### PR TITLE
fix: restore onboarding login/bootstrap flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -174,18 +174,28 @@ extension AppDelegate {
     /// 5s, so that assistant switches (which clear then re-bootstrap actor
     /// credentials) don't race with this method.
     func ensureLocalAssistantApiKey() {
-        guard !isCurrentAssistantManaged, !isCurrentAssistantRemote else { return }
-        guard authManager.isAuthenticated else { return }
+        guard !isCurrentAssistantManaged, !isCurrentAssistantRemote else {
+            log.debug("Skipping local assistant API key provisioning because current assistant is managed=\(self.isCurrentAssistantManaged, privacy: .public) remote=\(self.isCurrentAssistantRemote, privacy: .public)")
+            return
+        }
+        guard authManager.isAuthenticated else {
+            log.debug("Skipping local assistant API key provisioning because user is not authenticated")
+            return
+        }
 
         let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         guard let assistantId = storedId,
-              let assistant = LockfileAssistant.loadByName(assistantId) else { return }
+              let assistant = LockfileAssistant.loadByName(assistantId) else {
+            log.warning("Skipping local assistant API key provisioning because connectedAssistantId is missing from lockfile")
+            return
+        }
 
         // Resolve daemon HTTP endpoint from lockfile, with env override and fallback
         let daemonPort = assistant.daemonPort
             ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
             ?? 7821
         let daemonBaseURL = "http://localhost:\(daemonPort)"
+        log.info("Starting local assistant API key provisioning for \(assistant.assistantId, privacy: .public) at \(daemonBaseURL, privacy: .public)")
 
         Task {
             // Wait for actor token with retries — initial bootstrap may take

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -70,6 +70,7 @@ extension AppDelegate {
     func configureDaemonTransport(for assistant: LockfileAssistant?) {
         isCurrentAssistantRemote = assistant?.isRemote ?? false
         isCurrentAssistantManaged = assistant?.isManaged ?? false
+        let launchEnvironment = ProcessInfo.processInfo.environment
 
         // Managed assistant: use platform proxy URLs with session token auth.
         if let assistant, assistant.isManaged {
@@ -95,7 +96,8 @@ extension AppDelegate {
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant — use HTTP transport to the local daemon.
             // Bearer token is nil; resolved lazily at connect time.
-            let port = assistant?.resolvedDaemonPort() ?? (Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "") ?? 7821)
+            let port = assistant?.resolvedDaemonPort(environment: launchEnvironment)
+                ?? (Int(launchEnvironment["RUNTIME_HTTP_PORT"] ?? "") ?? 7821)
             let baseURL = "http://localhost:\(port)"
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
             let instanceDir = assistant?.instanceDir
@@ -130,13 +132,16 @@ extension AppDelegate {
         hasSetupDaemon = true
 
         let assistant = loadAssistantFromLockfile()
+        let launchEnvironment = ProcessInfo.processInfo.environment
 
         // Ensure the daemon starts its runtime HTTP server so the
-        // gateway can proxy iOS traffic to it. Use the lockfile's allocated
-        // daemon port when available (multi-instance), otherwise default to 7821.
-        if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-            let daemonPort = assistant?.resolvedDaemonPort() ?? 7821
-            setenv("RUNTIME_HTTP_PORT", String(daemonPort), 0)
+        // gateway can proxy iOS traffic to it. When a local assistant has a
+        // lockfile-assigned daemon port, use that instead of the generic default.
+        if let assistant, !assistant.isRemote {
+            let port = assistant.resolvedDaemonPort(environment: launchEnvironment)
+            setenv("RUNTIME_HTTP_PORT", String(port), 1)
+        } else if launchEnvironment["RUNTIME_HTTP_PORT"] == nil {
+            setenv("RUNTIME_HTTP_PORT", "7821", 0)
         }
 
         // Start the keychain broker before the daemon so it is listening

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -95,10 +95,7 @@ extension AppDelegate {
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant — use HTTP transport to the local daemon.
             // Bearer token is nil; resolved lazily at connect time.
-            // Prefer the lockfile's allocated daemon port (multi-instance), then env override, then default.
-            let port = assistant?.daemonPort
-                ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
-                ?? 7821
+            let port = assistant?.resolvedDaemonPort() ?? (Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "") ?? 7821)
             let baseURL = "http://localhost:\(port)"
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
             let instanceDir = assistant?.instanceDir
@@ -138,7 +135,7 @@ extension AppDelegate {
         // gateway can proxy iOS traffic to it. Use the lockfile's allocated
         // daemon port when available (multi-instance), otherwise default to 7821.
         if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-            let daemonPort = assistant?.daemonPort ?? 7821
+            let daemonPort = assistant?.resolvedDaemonPort() ?? 7821
             setenv("RUNTIME_HTTP_PORT", String(daemonPort), 0)
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -286,6 +286,23 @@ struct LockfileAssistant {
         }
     }
 
+    /// Resolve the assistant's local runtime HTTP port from the lockfile when
+    /// available, otherwise fall back to the current process environment.
+    func resolvedDaemonPort(environment: [String: String]? = nil) -> Int {
+        if let daemonPort {
+            return daemonPort
+        }
+
+        let env = environment ?? ProcessInfo.processInfo.environment
+        let rawPort = env["RUNTIME_HTTP_PORT"]
+            ?? getenv("RUNTIME_HTTP_PORT").map { String(cString: $0) }
+        return rawPort.flatMap(Int.init) ?? 7821
+    }
+
+    var localRuntimeBaseURL: String {
+        "http://localhost:\(resolvedDaemonPort())"
+    }
+
     static func loadLatest() -> LockfileAssistant? {
         loadAll().first
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -293,9 +293,14 @@ struct LockfileAssistant {
             return daemonPort
         }
 
-        let env = environment ?? ProcessInfo.processInfo.environment
-        let rawPort = env["RUNTIME_HTTP_PORT"]
-            ?? getenv("RUNTIME_HTTP_PORT").map { String(cString: $0) }
+        let rawPort: String?
+        if let environment {
+            rawPort = environment["RUNTIME_HTTP_PORT"]
+        } else {
+            let env = ProcessInfo.processInfo.environment
+            rawPort = env["RUNTIME_HTTP_PORT"]
+                ?? getenv("RUNTIME_HTTP_PORT").map { String(cString: $0) }
+        }
         return rawPort.flatMap(Int.init) ?? 7821
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "OnboardingFlowView")
 
 @MainActor
 struct OnboardingFlowView: View {
@@ -13,8 +16,6 @@ struct OnboardingFlowView: View {
     @State private var isAdvancingFromWakeUp = false
     @State private var isBootstrappingManaged = false
     @State private var managedBootstrapError: String?
-    @State private var isBootstrappingLocal = false
-    @State private var localBootstrapError: String?
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -66,8 +67,6 @@ struct OnboardingFlowView: View {
                     Group {
                         if isBootstrappingManaged {
                             managedBootstrapView
-                        } else if isBootstrappingLocal {
-                            localBootstrapView
                         } else {
                             switch state.currentStep {
                             case 0:
@@ -104,7 +103,7 @@ struct OnboardingFlowView: View {
                             removal: .opacity.combined(with: .offset(y: -8))
                         )
                     )
-                    .id(isBootstrappingManaged ? -1 : isBootstrappingLocal ? -2 : state.currentStep)
+                    .id(isBootstrappingManaged ? -1 : state.currentStep)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
@@ -140,10 +139,10 @@ struct OnboardingFlowView: View {
                             await performManagedBootstrap()
                         }
                     } else if !assistant.isRemote {
-                        Task {
-                            await performLocalBootstrap(assistant: assistant)
-                        }
+                        log.info("Auth completed for local assistant \(assistant.assistantId, privacy: .public) — deferring local registration until app startup")
+                        onComplete()
                     } else {
+                        log.info("Auth completed for remote assistant \(assistant.assistantId, privacy: .public) — proceeding to app")
                         onComplete()
                     }
                 } else if managedBootstrapEnabled {
@@ -151,6 +150,7 @@ struct OnboardingFlowView: View {
                         await performManagedBootstrap()
                     }
                 } else {
+                    log.info("Auth completed with no lockfile assistant — proceeding to app")
                     onComplete()
                 }
             }
@@ -240,81 +240,6 @@ struct OnboardingFlowView: View {
             managedBootstrapError = error.localizedDescription
         }
     }
-
-    // MARK: - Local Bootstrap
-
-    @ViewBuilder
-    private var localBootstrapView: some View {
-        VStack(spacing: VSpacing.lg) {
-            if localBootstrapError == nil {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                        .progressViewStyle(.circular)
-                    Text("Registering your assistant...")
-                        .font(VFont.monoMedium)
-                        .foregroundColor(VColor.textSecondary)
-                }
-            } else {
-                Text("Registration failed")
-                    .font(VFont.title)
-                    .foregroundColor(VColor.textPrimary)
-
-                if let error = localBootstrapError {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.error)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 280)
-                }
-
-                OnboardingButton(title: "Try again", style: .primary) {
-                    Task {
-                        if let assistant = LockfileAssistant.loadLatest(), !assistant.isRemote {
-                            await performLocalBootstrap(assistant: assistant)
-                        }
-                    }
-                }
-                .frame(maxWidth: 280)
-            }
-        }
-
-        Spacer()
-    }
-
-    private func performLocalBootstrap(assistant: LockfileAssistant) async {
-        isBootstrappingLocal = true
-        localBootstrapError = nil
-
-        // Resolve the daemon's HTTP base URL and bearer token
-        let daemonBaseURL = assistant.localRuntimeBaseURL
-
-        guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {
-            localBootstrapError = "No assistant credentials available. Please restart the assistant and try again."
-            return
-        }
-
-        do {
-            let bootstrapService = LocalAssistantBootstrapService(credentialStorage: KeychainCredentialStorage())
-            let outcome = try await bootstrapService.bootstrap(
-                runtimeAssistantId: assistant.assistantId,
-                clientPlatform: "macos",
-                daemonBaseURL: daemonBaseURL,
-                daemonToken: daemonToken
-            )
-
-            switch outcome {
-            case .registeredWithExistingKey, .registeredAndProvisioned:
-                UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
-            }
-
-            isBootstrappingLocal = false
-            onComplete()
-        } catch {
-            localBootstrapError = error.localizedDescription
-        }
-    }
-
 }
 
 #Preview {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -286,12 +286,8 @@ struct OnboardingFlowView: View {
         isBootstrappingLocal = true
         localBootstrapError = nil
 
-        // Resolve the daemon's HTTP base URL and bearer token.
-        // Prefer the lockfile's allocated daemon port (multi-instance), then env override, then default.
-        let port = assistant.daemonPort
-            ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
-            ?? 7821
-        let daemonBaseURL = "http://localhost:\(port)"
+        // Resolve the daemon's HTTP base URL and bearer token
+        let daemonBaseURL = assistant.localRuntimeBaseURL
 
         guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {
             localBootstrapError = "No assistant credentials available. Please restart the assistant and try again."

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -131,10 +131,14 @@ struct OnboardingFlowView: View {
             }
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
+            let currentAssistant = LockfileAssistant.loadLatest()
+            log.info(
+                "Observed auth state change in onboarding: isAuthenticated=\(isAuthenticated, privacy: .public) managedBootstrapEnabled=\(self.managedBootstrapEnabled, privacy: .public) lockfileAssistantId=\(currentAssistant?.assistantId ?? "<none>", privacy: .public)"
+            )
             if isAuthenticated {
-                let currentAssistant = LockfileAssistant.loadLatest()
                 if let assistant = currentAssistant {
                     if assistant.isManaged {
+                        log.info("Authenticated with managed assistant \(assistant.assistantId, privacy: .public); starting managed bootstrap")
                         Task {
                             await performManagedBootstrap()
                         }
@@ -146,6 +150,7 @@ struct OnboardingFlowView: View {
                         onComplete()
                     }
                 } else if managedBootstrapEnabled {
+                    log.info("Authenticated with no lockfile assistant; starting managed bootstrap")
                     Task {
                         await performManagedBootstrap()
                     }
@@ -204,6 +209,7 @@ struct OnboardingFlowView: View {
     private func performManagedBootstrap() async {
         isBootstrappingManaged = true
         managedBootstrapError = nil
+        log.info("Beginning managed assistant bootstrap")
 
         do {
             let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
@@ -212,8 +218,10 @@ struct OnboardingFlowView: View {
             switch outcome {
             case .reusedExisting(let existing):
                 assistant = existing
+                log.info("Managed bootstrap reused existing assistant \(assistant.id, privacy: .public)")
             case .createdNew(let created):
                 assistant = created
+                log.info("Managed bootstrap created new assistant \(assistant.id, privacy: .public)")
             }
 
             let runtimeUrl = AuthService.shared.baseURL
@@ -229,14 +237,17 @@ struct OnboardingFlowView: View {
 
             guard success else {
                 managedBootstrapError = "Failed to save assistant configuration. Please try again."
+                log.error("Managed bootstrap failed to persist lockfile entry for assistant \(assistant.id, privacy: .public)")
                 return
             }
 
             UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
 
             isBootstrappingManaged = false
+            log.info("Managed bootstrap completed for assistant \(assistant.id, privacy: .public); proceeding to app")
             onComplete()
         } catch {
+            log.error("Managed bootstrap failed: \(error.localizedDescription)")
             managedBootstrapError = error.localizedDescription
         }
     }

--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -258,6 +258,48 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertFalse(assistant.isRemote)
     }
 
+    func testResolvedDaemonPortPrefersLockfileValueOverEnvironment() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: 9911,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+
+        XCTAssertEqual(assistant.resolvedDaemonPort(environment: ["RUNTIME_HTTP_PORT": "7821"]), 9911)
+        XCTAssertEqual(assistant.localRuntimeBaseURL, "http://localhost:9911")
+    }
+
+    func testResolvedDaemonPortFallsBackToEnvironmentThenDefault() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+
+        XCTAssertEqual(assistant.resolvedDaemonPort(environment: ["RUNTIME_HTTP_PORT": "8811"]), 8811)
+        XCTAssertEqual(assistant.resolvedDaemonPort(environment: [:]), 7821)
+    }
+
     func testIsRemoteReturnsTrueForVellum() {
         let assistant = LockfileAssistant(
             assistantId: "test-id",

--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -300,6 +300,37 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(assistant.resolvedDaemonPort(environment: [:]), 7821)
     }
 
+    func testResolvedDaemonPortUsesProcessEnvironmentOnlyWhenNoEnvironmentIsInjected() {
+        let assistant = LockfileAssistant(
+            assistantId: "test-id",
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+
+        let previous = getenv("RUNTIME_HTTP_PORT").map { String(cString: $0) }
+        setenv("RUNTIME_HTTP_PORT", "9912", 1)
+        defer {
+            if let previous {
+                setenv("RUNTIME_HTTP_PORT", previous, 1)
+            } else {
+                unsetenv("RUNTIME_HTTP_PORT")
+            }
+        }
+
+        XCTAssertEqual(assistant.resolvedDaemonPort(environment: [:]), 7821)
+        XCTAssertEqual(assistant.resolvedDaemonPort(), 9912)
+    }
+
     func testIsRemoteReturnsTrueForVellum() {
         let assistant = LockfileAssistant(
             assistantId: "test-id",

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -69,6 +69,7 @@ public final class AuthManager {
     public func startWorkOSLogin() async {
         isSubmitting = true
         errorMessage = nil
+        defer { isSubmitting = false }
 
         do {
             let config = try await authService.getConfig()
@@ -134,17 +135,39 @@ public final class AuthManager {
                 accessToken: tokenResponse.access_token
             )
 
-            if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
-                state = .authenticated(user)
+            log.info(
+                "Provider-token auth completed with status=\(response.status, privacy: .public) isAuthenticated=\(response.meta?.is_authenticated == true, privacy: .public) hasUser=\(response.data?.user != nil, privacy: .public)"
+            )
+
+            if response.status == 200, response.meta?.is_authenticated != false {
+                if let user = response.data?.user {
+                    state = .authenticated(user)
+                    log.info("WorkOS login completed from provider-token response for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                } else {
+                    log.info("Provider-token auth returned no user payload; validating session via auth/session")
+                    let session = try await authService.getSession()
+                    if session.status == 200, session.meta?.is_authenticated != false, let user = session.data?.user {
+                        state = .authenticated(user)
+                        log.info("WorkOS login completed after session revalidation for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                    } else {
+                        log.error(
+                            "Session revalidation after provider-token auth did not return an authenticated user. status=\(session.status, privacy: .public) isAuthenticated=\(session.meta?.is_authenticated == true, privacy: .public) hasUser=\(session.data?.user != nil, privacy: .public)"
+                        )
+                        errorMessage = "Authentication was not completed. Please try again."
+                    }
+                }
             } else {
+                log.error(
+                    "Provider-token auth did not complete authentication. status=\(response.status, privacy: .public) isAuthenticated=\(response.meta?.is_authenticated == true, privacy: .public)"
+                )
                 errorMessage = "Authentication was not completed. Please try again."
             }
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
             log.info("User cancelled WorkOS login")
         } catch {
+            log.error("WorkOS login failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
         }
-        isSubmitting = false
     }
 
     public func logout() async {

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -16,7 +16,7 @@ public enum SessionTokenManager {
 
     /// Path to the platform token file the daemon reads.
     private static var platformTokenPath: String {
-        resolveVellumDir() + "/platform-token"
+        platformTokenPath(environment: connectedAssistantEnvironment())
     }
 
     public static func getToken() -> String? {
@@ -36,6 +36,26 @@ public enum SessionTokenManager {
     }
 
     // MARK: - Platform token file bridge
+
+    private static func platformTokenPath(environment: [String: String]?) -> String {
+        resolveVellumDir(environment: environment) + "/platform-token"
+    }
+
+    /// Scope platform-token writes to the active assistant instance when the
+    /// current lockfile entry exposes an instanceDir.
+    private static func connectedAssistantEnvironment() -> [String: String]? {
+        guard let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              let json = LockfilePaths.read(),
+              let assistants = json["assistants"] as? [[String: Any]],
+              let assistant = assistants.first(where: { ($0["assistantId"] as? String) == connectedAssistantId }),
+              let resources = assistant["resources"] as? [String: Any],
+              let instanceDir = resources["instanceDir"] as? String,
+              !instanceDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        return ["BASE_DATA_DIR": instanceDir]
+    }
 
     private static func writePlatformTokenFile(_ token: String) {
         let path = platformTokenPath

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -16,7 +16,7 @@ public enum SessionTokenManager {
 
     /// Path to the platform token file the daemon reads.
     private static var platformTokenPath: String {
-        platformTokenPath(environment: connectedAssistantEnvironment())
+        connectedAssistantPlatformTokenPath() ?? defaultPlatformTokenPath()
     }
 
     public static func getToken() -> String? {
@@ -37,24 +37,46 @@ public enum SessionTokenManager {
 
     // MARK: - Platform token file bridge
 
-    private static func platformTokenPath(environment: [String: String]?) -> String {
-        resolveVellumDir(environment: environment) + "/platform-token"
-    }
-
     /// Scope platform-token writes to the active assistant instance when the
-    /// current lockfile entry exposes an instanceDir.
-    private static func connectedAssistantEnvironment() -> [String: String]? {
+    /// current lockfile entry exposes assistant-specific storage paths.
+    private static func connectedAssistantPlatformTokenPath() -> String? {
         guard let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
               let json = LockfilePaths.read(),
               let assistants = json["assistants"] as? [[String: Any]],
-              let assistant = assistants.first(where: { ($0["assistantId"] as? String) == connectedAssistantId }),
-              let resources = assistant["resources"] as? [String: Any],
-              let instanceDir = resources["instanceDir"] as? String,
-              !instanceDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+              let assistant = assistants.first(where: { ($0["assistantId"] as? String) == connectedAssistantId }) else {
             return nil
         }
 
-        return ["BASE_DATA_DIR": instanceDir]
+        if let baseDataDir = assistant["baseDataDir"] as? String {
+            let trimmed = baseDataDir.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed + "/platform-token"
+            }
+        }
+
+        if let resources = assistant["resources"] as? [String: Any],
+           let instanceDir = resources["instanceDir"] as? String {
+            let trimmed = instanceDir.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed + "/.vellum/platform-token"
+            }
+        }
+
+        return nil
+    }
+
+    private static func defaultPlatformTokenPath() -> String {
+        let launchEnvironment = ProcessInfo.processInfo.environment
+        if let baseDir = launchEnvironment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !baseDir.isEmpty {
+            let resolved = baseDir == "~"
+                ? NSHomeDirectory()
+                : (baseDir.hasPrefix("~/")
+                    ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2))
+                    : baseDir)
+            return resolved + "/.vellum/platform-token"
+        }
+        return NSHomeDirectory() + "/.vellum/platform-token"
     }
 
     private static func writePlatformTokenFile(_ token: String) {

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -68,6 +68,7 @@ public enum SessionTokenManager {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 _ = APIKeyManager.shared.setAPIKey(token, provider: provider)
+                writePlatformTokenFile(token)
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: .sessionTokenDidChange, object: nil)
                 }
@@ -80,6 +81,7 @@ public enum SessionTokenManager {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 _ = APIKeyManager.shared.deleteAPIKey(provider: provider)
+                removePlatformTokenFile()
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: .sessionTokenDidChange, object: nil)
                 }


### PR DESCRIPTION
## Summary
- honor the selected local assistant's lockfile daemon port when configuring local HTTP transport
- defer local assistant platform registration until normal app startup after sign-in
- complete managed onboarding after provider-token auth by revalidating `auth/session` when the provider-token response has no `data.user`
- add targeted logs around auth state changes and managed bootstrap, and keep the async session-token bridge file in sync

## Regression background
`0.4.43` regressed login/bootstrap behavior after `45195ebf5` (`refactor: remove Unix domain socket transport from Swift clients (#14430)`). That left three broken paths:
- local assistants could reconnect/bootstrap against the wrong localhost port
- local assistant registration could run too early, before actor credentials existed
- no-assistant WorkOS sign-in could return to the Welcome screen because auth only transitioned when `/_allauth/app/v1/auth/provider/token` returned `data.user` immediately

## Testing
- `swift build --target VellumAssistantLib`
- pre-push `swift build` in `clients/`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
