### PR TITLE
fix: restore prompt-by-default behavior for host_bash trust rule

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -649,8 +649,8 @@ describe("Permission Checker", () => {
 
     test("plain rm (without -rf) is high risk and prompts despite default allow rule", async () => {
       // Validates that ALL rm commands are escalated to High risk, not just rm -rf.
-      // The default allow rule for host_bash auto-approves Low/Medium risk but
-      // High risk always prompts.
+      // The default ask rule for host_bash prompts regardless of risk level.
+      // High risk also prompts.
       const result = await check(
         "host_bash",
         { command: "rm single-file.txt" },
@@ -807,11 +807,11 @@ describe("Permission Checker", () => {
       expect(result.matchedRule?.id).toBe("default:ask-host_file_edit-global");
     });
 
-    test("host_bash auto-allows low risk via default allow rule", async () => {
+    test("host_bash prompts low risk via default ask rule", async () => {
       const result = await check("host_bash", { command: "ls" }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Matched trust rule");
-      expect(result.matchedRule?.id).toBe("default:allow-host_bash-global");
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("ask rule");
+      expect(result.matchedRule?.id).toBe("default:ask-host_bash-global");
     });
 
     test("scaffold_managed_skill prompts by default via managed skill ask rule", async () => {
@@ -2232,11 +2232,12 @@ describe("Permission Checker", () => {
       expect(result.matchedRule?.id).toBe("default:allow-bash-global");
     });
 
-    test("host_bash auto-allows low risk in strict mode (default allow rule is a matching rule)", async () => {
+    test("host_bash prompts low risk in strict mode (default ask rule matches)", async () => {
       testConfig.permissions.mode = "strict";
       const result = await check("host_bash", { command: "ls" }, "/tmp");
-      expect(result.decision).toBe("allow");
-      expect(result.matchedRule?.id).toBe("default:allow-host_bash-global");
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("ask rule");
+      expect(result.matchedRule?.id).toBe("default:ask-host_bash-global");
     });
 
     test("high-risk host_bash (rm) with no matching rule returns prompt in strict mode", async () => {
@@ -3570,15 +3571,16 @@ describe("Permission Checker", () => {
         expect(result.matchedRule?.id).toBe("default:allow-bash-global");
       });
 
-      test("low-risk host_bash auto-allows in strict mode (default allow rule is a matching rule)", async () => {
+      test("low-risk host_bash prompts in strict mode (default ask rule matches)", async () => {
         testConfig.permissions.mode = "strict";
         const result = await check(
           "host_bash",
           { command: "echo hello" },
           "/tmp",
         );
-        expect(result.decision).toBe("allow");
-        expect(result.matchedRule?.id).toBe("default:allow-host_bash-global");
+        expect(result.decision).toBe("prompt");
+        expect(result.reason).toContain("ask rule");
+        expect(result.matchedRule?.id).toBe("default:ask-host_bash-global");
       });
 
       test("low-risk file_read with no rule prompts in strict mode", async () => {
@@ -3660,10 +3662,11 @@ describe("Permission Checker", () => {
     //    target-scoped. ───────────────────────────────────────────────
 
     describe("Invariant 4: host execution approvals are explicit and target-scoped", () => {
-      test("host_bash auto-allows low risk via default allow rule", async () => {
+      test("host_bash prompts low risk via default ask rule", async () => {
         const result = await check("host_bash", { command: "ls" }, "/tmp");
-        expect(result.decision).toBe("allow");
-        expect(result.matchedRule?.id).toBe("default:allow-host_bash-global");
+        expect(result.decision).toBe("prompt");
+        expect(result.reason).toContain("ask rule");
+        expect(result.matchedRule?.id).toBe("default:ask-host_bash-global");
       });
 
       test("host_file_read prompts by default (no implicit allow)", async () => {
@@ -3740,7 +3743,7 @@ describe("Permission Checker", () => {
         expect(matchResult.matchedRule?.id).toBe("inv4-target-scoped");
 
         // Different target — the target-scoped rule should NOT match;
-        // falls back to the default host_bash allow rule (auto-allows medium risk)
+        // falls back to the default host_bash ask rule (prompts medium risk)
         const noMatchResult = await check(
           "host_bash",
           { command: "run script.js" },
@@ -4310,7 +4313,7 @@ describe("bash network_mode=proxied — no special-casing", () => {
 
   test("proxied bash follows normal rules (auto-allowed by default rule)", async () => {
     // Proxied bash is no longer force-prompted — the default allow-bash rule
-    // auto-allows low/medium risk commands regardless of network_mode.
+    // prompts low/medium risk commands regardless of network_mode.
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },
@@ -4722,10 +4725,10 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.reason).toContain("ask rule");
   });
 
-  test("host_bash → allow (default allow rule matches)", async () => {
+  test("host_bash → prompt (default ask rule matches)", async () => {
     const result = await check("host_bash", { command: "ls" }, workspaceDir);
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Matched trust rule");
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("ask rule");
   });
 
   // ── explicit rules still take precedence in workspace mode ──

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -874,13 +874,13 @@ describe("Trust Store", () => {
       );
     });
 
-    test("findHighestPriorityRule matches default allow for host_bash", () => {
+    test("findHighestPriorityRule matches default ask for host_bash", () => {
       const match = findHighestPriorityRule("host_bash", ["ls"], "/tmp");
       expect(match).not.toBeNull();
-      expect(match!.id).toBe("default:allow-host_bash-global");
-      expect(match!.decision).toBe("allow");
+      expect(match!.id).toBe("default:ask-host_bash-global");
+      expect(match!.decision).toBe("ask");
       expect(match!.priority).toBe(
-        DEFAULT_PRIORITY_BY_ID.get("default:allow-host_bash-global")!,
+        DEFAULT_PRIORITY_BY_ID.get("default:ask-host_bash-global")!,
       );
     });
 

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -58,14 +58,14 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
   }));
 
   // host_bash command candidates are raw commands ("ls", "npm test"), so the
-  // global default ask rule uses "**" (globstar) instead of a "tool:*" prefix
+  // global default rule uses "**" (globstar) instead of a "tool:*" prefix
   // because commands often contain "/" (e.g. "cat /etc/hosts").
   const hostShellRule: DefaultRuleTemplate = {
-    id: "default:allow-host_bash-global",
+    id: "default:ask-host_bash-global",
     tool: "host_bash",
     pattern: "**",
     scope: "everywhere",
-    decision: "allow",
+    decision: "ask",
     priority: 50,
   };
 


### PR DESCRIPTION
### Motivation
- A recent change made the default `host_bash` trust rule a global `allow`, which auto-approved low/medium-risk host shell commands and introduced a security regression by bypassing explicit user prompts. 
- The intent of this PR is to restore conservative, prompt-first behavior for host shell execution to prevent untrusted input from causing silent host reads or actions.

### Description
- Reverted the default host shell template in `assistant/src/permissions/defaults.ts` from `id: "default:allow-host_bash-global"` / `decision: "allow"` to `id: "default:ask-host_bash-global"` / `decision: "ask"` so host shell commands prompt by default. 
- Updated permission checker expectations and comments in `assistant/src/__tests__/checker.test.ts` to assert `prompt`/`ask rule` behavior for low-risk `host_bash` scenarios (standard, strict, and workspace invariants). 
- Updated trust-store expectations in `assistant/src/__tests__/trust-store.test.ts` to expect the `default:ask-host_bash-global` rule and `ask` decision when matching host_bash candidates. 
- Kept sandboxed `bash` behavior unchanged (sandbox `allow` rule remains unchanged) and made only the minimal test and template edits necessary to restore the prior security posture.

### Testing
- Attempted to run the relevant unit tests with `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/checker.test.ts src/__tests__/trust-store.test.ts`, but `bun` is not available in this environment and automatic installation failed due to network/download restrictions, so the test runner could not be executed here. 
- Performed repository checks with `rg`/search to verify removal of the old `default:allow-host_bash-global` occurrences and updated tests now reference `default:ask-host_bash-global`, confirming the code and test expectations are consistent. 
- Changes committed: updated files `assistant/src/permissions/defaults.ts`, `assistant/src/__tests__/checker.test.ts`, and `assistant/src/__tests__/trust-store.test.ts` and committed with message `fix: require prompt for default host_bash trust rule`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae954f09948323b7f35d037b8b39f6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
