### PR TITLE
fix: align checker tests with host_bash default ask rule

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -637,27 +637,26 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("prompt");
     });
 
-    test("host_bash rm is always high risk → prompt", async () => {
+    test("host_bash rm is always prompted via default ask rule", async () => {
       const result = await check(
         "host_bash",
         { command: "rm file.txt" },
         "/tmp",
       );
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("ask rule");
     });
 
-    test("plain rm (without -rf) is high risk and prompts despite default allow rule", async () => {
-      // Validates that ALL rm commands are escalated to High risk, not just rm -rf.
-      // The default ask rule for host_bash prompts regardless of risk level.
-      // High risk also prompts.
+    test("plain rm (without -rf) prompts via default ask rule", async () => {
+      // The default ask rule for host_bash prompts ALL commands regardless
+      // of risk level — rm commands are no exception.
       const result = await check(
         "host_bash",
         { command: "rm single-file.txt" },
         "/tmp",
       );
       expect(result.decision).toBe("prompt");
-      expect(result.reason).toContain("High risk");
+      expect(result.reason).toContain("ask rule");
 
       // Also verify rm -rf still prompts
       const rfResult = await check(
@@ -666,7 +665,7 @@ describe("Permission Checker", () => {
         "/tmp",
       );
       expect(rfResult.decision).toBe("prompt");
-      expect(rfResult.reason).toContain("High risk");
+      expect(rfResult.reason).toContain("ask rule");
     });
 
     test("rm is high risk even with matching trust rule → prompt", async () => {
@@ -3743,7 +3742,7 @@ describe("Permission Checker", () => {
         expect(matchResult.matchedRule?.id).toBe("inv4-target-scoped");
 
         // Different target — the target-scoped rule should NOT match;
-        // falls back to the default host_bash ask rule (prompts medium risk)
+        // falls back to the default host_bash ask rule (prompts)
         const noMatchResult = await check(
           "host_bash",
           { command: "run script.js" },
@@ -3752,8 +3751,9 @@ describe("Permission Checker", () => {
             executionTarget: "/usr/local/bin/bun",
           },
         );
-        expect(noMatchResult.decision).toBe("allow");
-        expect(noMatchResult.matchedRule?.id).not.toBe("inv4-target-scoped");
+        expect(noMatchResult.decision).toBe("prompt");
+        expect(noMatchResult.reason).toContain("ask rule");
+        expect(noMatchResult.matchedRule?.id).toBe("default:ask-host_bash-global");
       });
     });
 


### PR DESCRIPTION
## Summary
- Update 3 tests in `checker.test.ts` that were missed when the default host_bash rule was changed from `allow` to `ask` in #14615
- `rm` command tests now expect "ask rule" reason instead of "High risk" (the ask rule matches first)
- Target-scoped fallback test now expects `prompt` instead of `allow`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22869192231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
