### PR TITLE
Use VDropdown for active assistant picker in account settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -304,12 +304,11 @@ struct SettingsAccountTab: View {
                         .font(VFont.inputLabel)
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
-                    Picker("", selection: $selectedAssistantId) {
-                        ForEach(awakeAssistants, id: \.assistantId) { assistant in
-                            Text(assistant.assistantId).tag(assistant.assistantId)
-                        }
-                    }
-                    .labelsHidden()
+                    VDropdown(
+                        placeholder: "",
+                        selection: $selectedAssistantId,
+                        options: awakeAssistants.map { (label: $0.assistantId, value: $0.assistantId) }
+                    )
                     .frame(maxWidth: 200)
                 }
             }


### PR DESCRIPTION
## Summary
- Replace native SwiftUI `Picker` with `VDropdown` component for the active assistant dropdown in account settings
- Keeps the same `maxWidth: 200` frame for consistent sizing

## Original prompt
change active assistant dropdown in account setting to use VDropdown component, make it same width as it's current dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
