### PR TITLE
M1: Add Sentry test trigger buttons to Settings panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,6 +12,7 @@ enum SettingsTab: String {
     case privacy = "Privacy"
     case contacts = "Contacts"
     case advanced = "Advanced"
+    case debug = "Debug"
 
     /// Tabs shown in the sidebar. Contacts requires a feature flag; Advanced is only visible in dev mode.
     static func visibleTabs(isDevMode: Bool, contactsEnabled: Bool = false) -> [SettingsTab] {
@@ -24,6 +25,7 @@ enum SettingsTab: String {
         }
         if isDevMode {
             tabs.append(.advanced)
+            tabs.append(.debug)
         }
         return tabs
     }
@@ -52,6 +54,7 @@ enum SettingsTab: String {
         if tab == .contacts && !contactsEnabled { return nil }
         // Block dev-only tabs when dev mode is disabled
         if tab == .advanced && !isDevMode { return nil }
+        if tab == .debug && !isDevMode { return nil }
         return tab
     }
 }
@@ -267,6 +270,12 @@ struct SettingsPanel: View {
         case .advanced:
             if store.isDevMode {
                 SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
+            } else {
+                SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
+            }
+        case .debug:
+            if store.isDevMode {
+                SettingsDebugTab(store: store)
             } else {
                 SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -20,6 +20,9 @@ struct SettingsDebugTab: View {
         .onAppear {
             isSentryEnabled = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
         }
+        .onDisappear {
+            dismissTask?.cancel()
+        }
     }
 
     // MARK: - Sentry Testing Section
@@ -73,11 +76,7 @@ struct SettingsDebugTab: View {
                 // Test error
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     VButton(label: "Send Test Error", style: .secondary) {
-                        let event = Event(level: .error)
-                        event.message = SentryMessage(formatted: "Sentry test error from Settings debug tab")
-                        event.tags = ["source": "settings_debug"]
-                        MetricKitManager.captureSentryEvent(event)
-                        showStatus("Error event sent!")
+                        sendTestEvent(level: .error, label: "error")
                     }
                     Text("Captures a Sentry event with level .error")
                         .font(VFont.caption)
@@ -89,11 +88,7 @@ struct SettingsDebugTab: View {
                 // Test warning
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     VButton(label: "Send Test Warning", style: .secondary) {
-                        let event = Event(level: .warning)
-                        event.message = SentryMessage(formatted: "Sentry test warning from Settings debug tab")
-                        event.tags = ["source": "settings_debug"]
-                        MetricKitManager.captureSentryEvent(event)
-                        showStatus("Warning event sent!")
+                        sendTestEvent(level: .warning, label: "warning")
                     }
                     Text("Captures a Sentry event with level .warning")
                         .font(VFont.caption)
@@ -105,11 +100,7 @@ struct SettingsDebugTab: View {
                 // Test message
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     VButton(label: "Send Test Message", style: .secondary) {
-                        let event = Event(level: .info)
-                        event.message = SentryMessage(formatted: "Sentry test message from Settings debug tab")
-                        event.tags = ["source": "settings_debug"]
-                        MetricKitManager.captureSentryEvent(event)
-                        showStatus("Info message sent!")
+                        sendTestEvent(level: .info, label: "info message")
                     }
                     Text("Captures a Sentry event with level .info")
                         .font(VFont.caption)
@@ -123,7 +114,7 @@ struct SettingsDebugTab: View {
                     VButton(label: "Test Performance Transaction", style: .secondary) {
                         MetricKitManager.sentrySerialQueue.async {
                             guard SentrySDK.isEnabled else {
-                                DispatchQueue.main.async { showStatus("Sentry is disabled — transaction not sent.") }
+                                Task { @MainActor in showStatus("Sentry is disabled — transaction not sent.") }
                                 return
                             }
                             let transaction = SentrySDK.startTransaction(
@@ -131,7 +122,7 @@ struct SettingsDebugTab: View {
                                 operation: "test.transaction"
                             )
                             transaction.finish()
-                            DispatchQueue.main.async { showStatus("Performance transaction sent!") }
+                            Task { @MainActor in showStatus("Performance transaction sent!") }
                         }
                     }
                     Text("Starts and finishes a Sentry transaction to validate tracing.")
@@ -147,6 +138,18 @@ struct SettingsDebugTab: View {
     }
 
     // MARK: - Helpers
+
+    private func sendTestEvent(level: SentryLevel, label: String) {
+        guard isSentryEnabled else {
+            showStatus("Sentry is disabled — \(label) not sent.")
+            return
+        }
+        let event = Event(level: level)
+        event.message = SentryMessage(formatted: "Sentry test \(label) from Settings debug tab")
+        event.tags = ["source": "settings_debug"]
+        MetricKitManager.captureSentryEvent(event)
+        showStatus("\(label.capitalized) event sent!")
+    }
 
     private func showStatus(_ message: String) {
         dismissTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -10,6 +10,7 @@ struct SettingsDebugTab: View {
     @ObservedObject var store: SettingsStore
 
     @State private var lastStatus: String?
+    @State private var dismissTask: Task<Void, Never>?
     @State private var isSentryEnabled: Bool = true
 
     var body: some View {
@@ -148,9 +149,11 @@ struct SettingsDebugTab: View {
     // MARK: - Helpers
 
     private func showStatus(_ message: String) {
+        dismissTask?.cancel()
         withAnimation { lastStatus = message }
-        // Auto-dismiss after a few seconds
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation {
                 if lastStatus == message { lastStatus = nil }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+@preconcurrency import Sentry
+import VellumAssistantShared
+
+/// Debug settings tab — provides buttons to trigger various Sentry event types
+/// for validating that the Sentry DSN is receiving reports correctly.
+/// Only visible when dev mode is enabled.
+@MainActor
+struct SettingsDebugTab: View {
+    @ObservedObject var store: SettingsStore
+
+    @State private var lastStatus: String?
+    @State private var isSentryEnabled: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            sentryTestingSection
+        }
+        .onAppear {
+            isSentryEnabled = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
+        }
+    }
+
+    // MARK: - Sentry Testing Section
+
+    private var sentryTestingSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Sentry Testing")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Trigger test events to validate that Sentry is receiving reports from this app.")
+                    .font(VFont.sectionDescription)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            if !isSentryEnabled {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 12)
+                        .foregroundColor(VColor.warning)
+                    Text("Usage data collection is disabled. Non-fatal events will be silently dropped unless you enable \"Collect usage data\" in the Privacy tab.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            }
+
+            if let status = lastStatus {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundColor(VColor.success)
+                    Text(status)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
+                .transition(.opacity)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Fatal crash
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Trigger Fatal Crash", style: .danger) {
+                        fatalError("Sentry test crash")
+                    }
+                    Text("Calls fatalError() — will terminate the app immediately.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test error
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Error", style: .secondary) {
+                        let event = Event(level: .error)
+                        event.message = SentryMessage(formatted: "Sentry test error from Settings debug tab")
+                        event.tags = ["source": "settings_debug"]
+                        MetricKitManager.captureSentryEvent(event)
+                        showStatus("Error event sent!")
+                    }
+                    Text("Captures a Sentry event with level .error")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test warning
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Warning", style: .secondary) {
+                        let event = Event(level: .warning)
+                        event.message = SentryMessage(formatted: "Sentry test warning from Settings debug tab")
+                        event.tags = ["source": "settings_debug"]
+                        MetricKitManager.captureSentryEvent(event)
+                        showStatus("Warning event sent!")
+                    }
+                    Text("Captures a Sentry event with level .warning")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test message
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Message", style: .secondary) {
+                        let event = Event(level: .info)
+                        event.message = SentryMessage(formatted: "Sentry test message from Settings debug tab")
+                        event.tags = ["source": "settings_debug"]
+                        MetricKitManager.captureSentryEvent(event)
+                        showStatus("Info message sent!")
+                    }
+                    Text("Captures a Sentry event with level .info")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Performance transaction
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Test Performance Transaction", style: .secondary) {
+                        MetricKitManager.sentrySerialQueue.async {
+                            guard SentrySDK.isEnabled else {
+                                DispatchQueue.main.async { showStatus("Sentry is disabled — transaction not sent.") }
+                                return
+                            }
+                            let transaction = SentrySDK.startTransaction(
+                                name: "settings-debug-test",
+                                operation: "test.transaction"
+                            )
+                            transaction.finish()
+                            DispatchQueue.main.async { showStatus("Performance transaction sent!") }
+                        }
+                    }
+                    Text("Starts and finishes a Sentry transaction to validate tracing.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Helpers
+
+    private func showStatus(_ message: String) {
+        withAnimation { lastStatus = message }
+        // Auto-dismiss after a few seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            withAnimation {
+                if lastStatus == message { lastStatus = nil }
+            }
+        }
+    }
+}
+
+#Preview("SettingsDebugTab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        SettingsDebugTab(store: SettingsStore())
+            .frame(width: 480)
+            .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new **Debug** tab to the macOS Settings panel (dev-mode only) with buttons to trigger various Sentry event types for validating the new Sentry DSN
- Includes: Trigger Fatal Crash, Send Test Error, Send Test Warning, Send Test Message, and Test Performance Transaction buttons
- Shows status feedback after each action and a warning when usage data collection is disabled

## Test plan
- [ ] Enable dev mode, open Settings, verify the Debug tab appears
- [ ] Click each non-fatal button and verify "Event sent!" feedback appears
- [ ] Check Sentry dashboard to confirm events arrive
- [ ] Disable "Collect usage data" in Privacy tab, verify warning appears in Debug tab
- [ ] Click "Trigger Fatal Crash" to verify crash reporting (will terminate app)

Part of #14618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
