### PR TITLE
fix: kill stale gateway before restart to prevent zombie accumulation

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -816,6 +816,16 @@ export async function startGateway(
 ): Promise<string> {
   const effectiveGatewayPort = resources?.gatewayPort ?? GATEWAY_PORT;
 
+  // Kill any existing gateway process before spawning a new one.
+  // Without this, crashed/stale gateways accumulate as zombies — the old
+  // process holds the port (or lingers after losing it), and every restart
+  // attempt spawns yet another process that fails with EADDRINUSE.
+  const gwPidDir = resources
+    ? join(resources.instanceDir, ".vellum")
+    : join(homedir(), ".vellum");
+  const gwPidFile = join(gwPidDir, "gateway.pid");
+  await stopProcessByPidFile(gwPidFile, "gateway");
+
   const publicUrl = await discoverPublicUrl(effectiveGatewayPort);
   if (publicUrl) {
     console.log(`   Public URL: ${publicUrl}`);


### PR DESCRIPTION
## Summary
- `startGateway()` now kills any existing gateway process (via PID file) before spawning a new one
- Prevents zombie gateway processes from accumulating when the health monitor triggers restarts after crashes
- Mirrors the pre-flight lifecycle guard already used by `startLocalDaemon()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
