### PR TITLE
fix: disable LAN pairing URL advertisement by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -5,13 +5,13 @@ import VellumAssistantShared
 /// Displays a QR code containing the v4 connection payload for iOS pairing.
 ///
 /// v4 payload:
-/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","pairingSecret":"<32-byte-hex>","localLanUrl":"http://<lan-ip>:<gateway-port>"}`
+/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","<redacted>":"<redacted>"}`
 ///
 /// Key differences from v3:
 /// - No bearer token in QR code (secured by pairing secret + Mac approval)
 /// - Includes pairingRequestId + pairingSecret for the handshake
 /// - Pre-registers the pairing request with the daemon via local HTTP
-/// - localLanUrl is nullable (omitted when no LAN IP available)
+/// - localLanUrl is opt-in for explicit development/testing only
 @MainActor
 struct PairingQRCodeSheet: View {
     @Environment(\.dismiss) var dismiss
@@ -131,7 +131,7 @@ struct PairingQRCodeSheet: View {
         .frame(width: 380)
         .onAppear {
             hostId = Self.computeHostId()
-            localLanUrl = computeLocalLanUrl()
+            localLanUrl = shouldAdvertiseLocalLanUrl ? computeLocalLanUrl() : nil
             guard daemonClient != nil else { return }
             registerWithDaemon()
             startRefreshTimer()
@@ -277,6 +277,16 @@ struct PairingQRCodeSheet: View {
     private func computeLocalLanUrl() -> String? {
         guard let lanIP = LANIPHelper.currentLANAddress() else { return nil }
         return "http://\(lanIP):\(LockfilePaths.resolveGatewayPort())"
+    }
+
+    /// LAN pairing uses plaintext HTTP and can expose bearer tokens on a local
+    /// network. Keep this disabled by default and only allow explicit opt-in
+    /// for development/testing via environment variable.
+    private var shouldAdvertiseLocalLanUrl: Bool {
+        let value = ProcessInfo.processInfo.environment["VELLUM_ENABLE_INSECURE_LAN_PAIRING"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return value == "1" || value == "true" || value == "yes"
     }
 
     // MARK: - QR Generation


### PR DESCRIPTION
### Motivation
- The v4 pairing flow previously auto-included an HTTP `localLanUrl` in the QR/register payload when a LAN IP was present, which could cause the iOS client to receive bearer tokens over unencrypted LAN traffic and expose them to local attackers.
- The change aims to remove the insecure default while preserving the ability to opt in for development/testing when explicitly requested.

### Description
- Gate `localLanUrl` advertisement behind an explicit opt-in environment variable `VELLUM_ENABLE_INSECURE_LAN_PAIRING` so the macOS pairing sheet no longer advertises plaintext LAN URLs by default (change in `PairingQRCodeSheet.swift`).
- Update v4 payload documentation comment to reflect that `localLanUrl` is now opt-in for explicit development/testing only, and keep the rest of the registration/QR flow unchanged.

### Testing
- Attempted `cd clients/macos && ./build.sh lint`, but the lint/build step failed in this environment due to external dependency fetches being blocked (GitHub hosts Sparkle/Sentry returned CONNECT tunnel 403), so no compiled verification could be completed here.
- Static code review and local diffs confirm `localLanUrl` is no longer computed/advertised on appear unless `VELLUM_ENABLE_INSECURE_LAN_PAIRING` is set, and the QR payload logic still includes `localLanUrl` only when the opt-in is active.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aed6d52ffc832397e59911929ecd35)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
