### PR TITLE
refactor(twitter): remove strategy from daemon types and settings routes

### DIFF
--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -36,13 +36,10 @@ export interface TwitterIntegrationConfigRequest {
     | "set_mode"
     | "set_local_client"
     | "clear_local_client"
-    | "disconnect"
-    | "get_strategy"
-    | "set_strategy";
+    | "disconnect";
   mode?: "local_byo" | "managed";
   clientId?: string;
   clientSecret?: string;
-  strategy?: string;
 }
 
 export interface TelegramConfigRequest {
@@ -159,9 +156,6 @@ export interface TwitterIntegrationConfigResponse {
   localClientConfigured: boolean;
   connected: boolean;
   accountInfo?: string;
-  strategy?: "oauth" | "browser" | "auto";
-  /** Whether the user has explicitly set a strategy (vs. relying on the default 'auto'). */
-  strategyConfigured?: boolean;
   error?: string;
 }
 

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -460,13 +460,6 @@ function handleTwitterAuthStatus(): Response {
       "credential:integration:twitter:client_id",
     );
 
-    // Strategy
-    const strategyRaw = getNestedValue(raw, "twitter.strategy") as
-      | string
-      | undefined;
-    const strategy = strategyRaw ?? "auto";
-    const strategyConfigured = strategyRaw !== undefined;
-
     // In managed mode, connected is always false (auth goes through platform)
     const connected = mode === "managed" ? false : !!accessToken;
 
@@ -477,8 +470,6 @@ function handleTwitterAuthStatus(): Response {
       managedAvailable,
       managedPrerequisites,
       localClientConfigured,
-      strategy,
-      strategyConfigured,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Remove `strategy`, `strategyConfigured`, `get_strategy`, and `set_strategy` from Twitter integration config types
- Remove strategy computation and response fields from `handleTwitterAuthStatus()` settings route

Part of plan: rm-twitter-browser-auto.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
