### PR TITLE
refactor(twitter): clean up oauth-client browser fallback references

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
@@ -30,11 +30,11 @@ mock.module("../oauth-client.js", () => ({
     throw new Error("OAuth mock not configured");
   },
   UnsupportedOAuthOperationError: class UnsupportedOAuthOperationError extends Error {
-    public readonly suggestFallback = true;
-    public readonly fallbackPath = "browser" as const;
     public readonly operation: string;
     constructor(operation: string) {
-      super(`The "${operation}" operation is not available via the OAuth API.`);
+      super(
+        `The "${operation}" operation is not available via the OAuth API. Use managed mode instead.`,
+      );
       this.name = "UnsupportedOAuthOperationError";
       this.operation = operation;
     }

--- a/assistant/src/cli/commands/twitter/__tests__/oauth-client.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/oauth-client.test.ts
@@ -187,10 +187,9 @@ describe("Twitter OAuth client", () => {
       const err = new UnsupportedOAuthOperationError("search");
       expect(err.name).toBe("UnsupportedOAuthOperationError");
       expect(err.operation).toBe("search");
-      expect(err.suggestFallback).toBe(true);
-      expect(err.fallbackPath).toBe("browser");
       expect(err.message).toContain("search");
       expect(err.message).toContain("not available via the OAuth API");
+      expect(err.message).toContain("managed mode");
       expect(err).toBeInstanceOf(Error);
     });
   });

--- a/assistant/src/cli/commands/twitter/oauth-client.ts
+++ b/assistant/src/cli/commands/twitter/oauth-client.ts
@@ -2,9 +2,8 @@
  * OAuth-backed Twitter API client.
  *
  * Accepts an OAuth2 Bearer token as a parameter and uses it to execute
- * Twitter API v2 operations directly, without requiring a browser session.
- * Currently supports post and reply; all other operations fall back to the
- * browser-based CDP client.
+ * Twitter API v2 operations directly. Currently supports post and reply;
+ * all other operations require managed mode.
  */
 
 const TWITTER_API_BASE = "https://api.x.com/2";
@@ -20,18 +19,14 @@ export interface OAuthPostResult {
 
 export interface OAuthOperationError {
   message: string;
-  suggestFallback: boolean;
-  fallbackPath: "browser";
   operation: string;
 }
 
 export class UnsupportedOAuthOperationError extends Error {
-  public readonly suggestFallback = true;
-  public readonly fallbackPath = "browser" as const;
   public readonly operation: string;
   constructor(operation: string) {
     super(
-      `The "${operation}" operation is not available via the OAuth API. Use the browser path instead.`,
+      `The "${operation}" operation is not available via the OAuth API. Use managed mode instead.`,
     );
     this.name = "UnsupportedOAuthOperationError";
     this.operation = operation;
@@ -87,7 +82,7 @@ export function oauthIsAvailable(oauthToken: string | undefined): boolean {
 /**
  * Check whether a given operation is supported via the OAuth API path.
  * Only `post` and `reply` are currently supported; everything else
- * (timeline, search, bookmarks, etc.) requires the browser path.
+ * (timeline, search, bookmarks, etc.) requires managed mode.
  */
 export function oauthSupportsOperation(operation: string): boolean {
   return SUPPORTED_OPERATIONS.has(operation);


### PR DESCRIPTION
## Summary
- Remove `suggestFallback` and `fallbackPath` properties from `UnsupportedOAuthOperationError` and `OAuthOperationError`
- Update error message to suggest managed mode instead of browser path

Part of plan: rm-twitter-browser-auto.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
