### PR TITLE
Add Sentry test crash/error triggers for validation

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -104,6 +104,14 @@
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
       "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
+      "defaultEnabled": false
     }
   ]
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,10 +12,10 @@ enum SettingsTab: String {
     case privacy = "Privacy"
     case contacts = "Contacts"
     case advanced = "Advanced"
-    case debug = "Debug"
+    case sentryTesting = "Sentry Testing"
 
     /// Tabs shown in the sidebar. Contacts requires a feature flag; Advanced is only visible in dev mode.
-    static func visibleTabs(isDevMode: Bool, contactsEnabled: Bool = false) -> [SettingsTab] {
+    static func visibleTabs(isDevMode: Bool, contactsEnabled: Bool = false, sentryTestingEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [
             .account, .channels, .modelsAndServices, .voice,
             .automation, .appearance, .permissions, .privacy
@@ -25,7 +25,9 @@ enum SettingsTab: String {
         }
         if isDevMode {
             tabs.append(.advanced)
-            tabs.append(.debug)
+        }
+        if sentryTestingEnabled {
+            tabs.append(.sentryTesting)
         }
         return tabs
     }
@@ -33,7 +35,7 @@ enum SettingsTab: String {
     /// Maps legacy tab names (from IPC or saved state) to current tabs.
     /// The `isDevMode` parameter gates dev-only tabs so external callers
     /// (e.g. daemon IPC) cannot navigate to them when dev mode is off.
-    static func fromLegacyRawValue(_ value: String, isDevMode: Bool = false, contactsEnabled: Bool = false) -> SettingsTab? {
+    static func fromLegacyRawValue(_ value: String, isDevMode: Bool = false, contactsEnabled: Bool = false, sentryTestingEnabled: Bool = false) -> SettingsTab? {
         let tab: SettingsTab?
         // Try current values first
         if let direct = SettingsTab(rawValue: value) {
@@ -54,7 +56,7 @@ enum SettingsTab: String {
         if tab == .contacts && !contactsEnabled { return nil }
         // Block dev-only tabs when dev mode is disabled
         if tab == .advanced && !isDevMode { return nil }
-        if tab == .debug && !isDevMode { return nil }
+        if tab == .sentryTesting && !sentryTestingEnabled { return nil }
         return tab
     }
 }
@@ -95,6 +97,7 @@ struct SettingsPanel: View {
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var selectedTab: SettingsTab = .account
     @State private var isContactsEnabled: Bool = false
+    @State private var isSentryTestingEnabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("sentry_testing_enabled")
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
 
     var body: some View {
@@ -156,7 +159,7 @@ struct SettingsPanel: View {
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
             if let pending = store.pendingSettingsTab {
-                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled).contains(pending) {
+                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(pending) {
                     selectedTab = pending
                 }
                 store.pendingSettingsTab = nil
@@ -164,7 +167,7 @@ struct SettingsPanel: View {
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled).contains(tab) {
+                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(tab) {
                     selectedTab = tab
                 }
                 store.pendingSettingsTab = nil
@@ -175,7 +178,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
             if let tab = notification.object as? SettingsTab {
-                guard SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled).contains(tab) else { return }
+                guard SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(tab) else { return }
                 selectedTab = tab
             }
         }
@@ -233,7 +236,7 @@ struct SettingsPanel: View {
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled), id: \.self) { tab in
+            ForEach(SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
@@ -273,8 +276,8 @@ struct SettingsPanel: View {
             } else {
                 SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
             }
-        case .debug:
-            if store.isDevMode {
+        case .sentryTesting:
+            if MacOSClientFeatureFlagManager.shared.isEnabled("sentry_testing_enabled") {
                 SettingsDebugTab(store: store)
             } else {
                 SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,6 +12,7 @@ enum SettingsTab: String {
     case privacy = "Privacy"
     case contacts = "Contacts"
     case advanced = "Advanced"
+    case debug = "Debug"
 
     /// Tabs shown in the sidebar. Contacts requires a feature flag; Advanced is only visible in dev mode.
     static func visibleTabs(isDevMode: Bool, contactsEnabled: Bool = false) -> [SettingsTab] {
@@ -24,6 +25,7 @@ enum SettingsTab: String {
         }
         if isDevMode {
             tabs.append(.advanced)
+            tabs.append(.debug)
         }
         return tabs
     }
@@ -52,6 +54,7 @@ enum SettingsTab: String {
         if tab == .contacts && !contactsEnabled { return nil }
         // Block dev-only tabs when dev mode is disabled
         if tab == .advanced && !isDevMode { return nil }
+        if tab == .debug && !isDevMode { return nil }
         return tab
     }
 }
@@ -267,6 +270,12 @@ struct SettingsPanel: View {
         case .advanced:
             if store.isDevMode {
                 SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
+            } else {
+                SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
+            }
+        case .debug:
+            if store.isDevMode {
+                SettingsDebugTab(store: store)
             } else {
                 SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -282,11 +282,7 @@ struct SettingsPanel: View {
                 SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
             }
         case .sentryTesting:
-            if MacOSClientFeatureFlagManager.shared.isEnabled("sentry_testing_enabled") {
-                SettingsDebugTab(store: store)
-            } else {
-                SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
-            }
+            SettingsDebugTab()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -97,7 +97,7 @@ struct SettingsPanel: View {
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var selectedTab: SettingsTab = .account
     @State private var isContactsEnabled: Bool = false
-    @State private var isSentryTestingEnabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("sentry_testing_enabled")
+    @AppStorage("MacOSFeatureFlag.sentrytestingenabled") private var isSentryTestingEnabled: Bool = false
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
 
     var body: some View {
@@ -190,6 +190,11 @@ struct SettingsPanel: View {
                 if !enabled && selectedTab == .contacts {
                     selectedTab = .account
                 }
+            }
+        }
+        .onChange(of: isSentryTestingEnabled) { _, enabled in
+            if !enabled && selectedTab == .sentryTesting {
+                selectedTab = .account
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -2,13 +2,11 @@ import SwiftUI
 @preconcurrency import Sentry
 import VellumAssistantShared
 
-/// Debug settings tab — provides buttons to trigger various Sentry event types
+/// Sentry testing tab — provides buttons to trigger various Sentry event types
 /// for validating that the Sentry DSN is receiving reports correctly.
-/// Only visible when dev mode is enabled.
+/// Only visible when the `sentry_testing_enabled` feature flag is on.
 @MainActor
 struct SettingsDebugTab: View {
-    @ObservedObject var store: SettingsStore
-
     @State private var lastStatus: String?
     @State private var dismissTask: Task<Void, Never>?
     @State private var isSentryEnabled: Bool = true
@@ -112,6 +110,10 @@ struct SettingsDebugTab: View {
                 // Performance transaction
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     VButton(label: "Test Performance Transaction", style: .secondary) {
+                        guard isSentryEnabled else {
+                            showStatus("Sentry is disabled — transaction not sent.")
+                            return
+                        }
                         MetricKitManager.sentrySerialQueue.async {
                             guard SentrySDK.isEnabled else {
                                 Task { @MainActor in showStatus("Sentry is disabled — transaction not sent.") }
@@ -122,10 +124,12 @@ struct SettingsDebugTab: View {
                                 operation: "test.transaction"
                             )
                             transaction.finish()
-                            Task { @MainActor in showStatus("Performance transaction sent!") }
+                            Task { @MainActor in
+                                showStatus("Transaction finished (10% sample rate — may not appear in Sentry).")
+                            }
                         }
                     }
-                    Text("Starts and finishes a Sentry transaction to validate tracing.")
+                    Text("Starts and finishes a Sentry transaction. Only ~10% are sampled and sent.")
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                 }
@@ -167,7 +171,7 @@ struct SettingsDebugTab: View {
 #Preview("SettingsDebugTab") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        SettingsDebugTab(store: SettingsStore())
+        SettingsDebugTab()
             .frame(width: 480)
             .padding()
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDebugTab.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+@preconcurrency import Sentry
+import VellumAssistantShared
+
+/// Debug settings tab — provides buttons to trigger various Sentry event types
+/// for validating that the Sentry DSN is receiving reports correctly.
+/// Only visible when dev mode is enabled.
+@MainActor
+struct SettingsDebugTab: View {
+    @ObservedObject var store: SettingsStore
+
+    @State private var lastStatus: String?
+    @State private var dismissTask: Task<Void, Never>?
+    @State private var isSentryEnabled: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            sentryTestingSection
+        }
+        .onAppear {
+            isSentryEnabled = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
+        }
+        .onDisappear {
+            dismissTask?.cancel()
+        }
+    }
+
+    // MARK: - Sentry Testing Section
+
+    private var sentryTestingSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Sentry Testing")
+                    .font(VFont.sectionTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("Trigger test events to validate that Sentry is receiving reports from this app.")
+                    .font(VFont.sectionDescription)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            if !isSentryEnabled {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 12)
+                        .foregroundColor(VColor.warning)
+                    Text("Usage data collection is disabled. Non-fatal events will be silently dropped unless you enable \"Collect usage data\" in the Privacy tab.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.warning)
+                }
+            }
+
+            if let status = lastStatus {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundColor(VColor.success)
+                    Text(status)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
+                .transition(.opacity)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Fatal crash
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Trigger Fatal Crash", style: .danger) {
+                        fatalError("Sentry test crash")
+                    }
+                    Text("Calls fatalError() — will terminate the app immediately.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test error
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Error", style: .secondary) {
+                        sendTestEvent(level: .error, label: "error")
+                    }
+                    Text("Captures a Sentry event with level .error")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test warning
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Warning", style: .secondary) {
+                        sendTestEvent(level: .warning, label: "warning")
+                    }
+                    Text("Captures a Sentry event with level .warning")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Test message
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Send Test Message", style: .secondary) {
+                        sendTestEvent(level: .info, label: "info message")
+                    }
+                    Text("Captures a Sentry event with level .info")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                Divider().foregroundColor(VColor.divider)
+
+                // Performance transaction
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    VButton(label: "Test Performance Transaction", style: .secondary) {
+                        MetricKitManager.sentrySerialQueue.async {
+                            guard SentrySDK.isEnabled else {
+                                Task { @MainActor in showStatus("Sentry is disabled — transaction not sent.") }
+                                return
+                            }
+                            let transaction = SentrySDK.startTransaction(
+                                name: "settings-debug-test",
+                                operation: "test.transaction"
+                            )
+                            transaction.finish()
+                            Task { @MainActor in showStatus("Performance transaction sent!") }
+                        }
+                    }
+                    Text("Starts and finishes a Sentry transaction to validate tracing.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Helpers
+
+    private func sendTestEvent(level: SentryLevel, label: String) {
+        guard isSentryEnabled else {
+            showStatus("Sentry is disabled — \(label) not sent.")
+            return
+        }
+        let event = Event(level: level)
+        event.message = SentryMessage(formatted: "Sentry test \(label) from Settings debug tab")
+        event.tags = ["source": "settings_debug"]
+        MetricKitManager.captureSentryEvent(event)
+        showStatus("\(label.capitalized) event sent!")
+    }
+
+    private func showStatus(_ message: String) {
+        dismissTask?.cancel()
+        withAnimation { lastStatus = message }
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
+            withAnimation {
+                if lastStatus == message { lastStatus = nil }
+            }
+        }
+    }
+}
+
+#Preview("SettingsDebugTab") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        SettingsDebugTab(store: SettingsStore())
+            .frame(width: 480)
+            .padding()
+    }
+}

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -104,6 +104,14 @@
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
       "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -104,6 +104,14 @@
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
       "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Debug tab to the macOS Settings panel with buttons to trigger various Sentry event types (fatal crash, error, warning, info message, performance transaction) for validating that the new Sentry DSN is receiving reports correctly.

**This is a test branch — NOT intended to be merged to main.** It's for manual Sentry validation only.

## Changes
- New `SettingsDebugTab.swift` with 5 test buttons for different Sentry event types
- Debug tab added to `SettingsPanel.swift`, gated behind dev mode
- Shows accurate status feedback (success vs disabled) based on privacy settings
- Respects `collectUsageDataEnabled` flag — warns when Sentry is disabled

## Milestone PRs (merged into feature branch)
- #14621: M1: Add Sentry test trigger buttons to Settings panel

## Project issue
Closes #14618

## Test plan
- [ ] Enable dev mode, open Settings > Debug tab
- [ ] Click each test button and verify events appear in Sentry dashboard
- [ ] Disable "Collect usage data" and verify non-fatal buttons show disabled status
- [ ] Click "Trigger Fatal Crash" and verify crash report appears in Sentry

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
