### PR TITLE
refactor(twitter): remove strategy routing, route by integration mode

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
@@ -23,37 +23,6 @@ let mockManagedSearchRecentTweetsResult: {
 } | null = null;
 let mockManagedSearchRecentTweetsError: Error | null = null;
 
-let mockBrowserGetUserByScreenNameResult: {
-  userId: string;
-  screenName: string;
-  name: string;
-} | null = null;
-let mockBrowserGetUserByScreenNameError: Error | null = null;
-
-let mockBrowserGetUserTweetsResult: Array<{
-  tweetId: string;
-  text: string;
-  url: string;
-  createdAt: string;
-}> | null = null;
-let mockBrowserGetUserTweetsError: Error | null = null;
-
-let mockBrowserGetTweetDetailResult: Array<{
-  tweetId: string;
-  text: string;
-  url: string;
-  createdAt: string;
-}> | null = null;
-let mockBrowserGetTweetDetailError: Error | null = null;
-
-let mockBrowserSearchTweetsResult: Array<{
-  tweetId: string;
-  text: string;
-  url: string;
-  createdAt: string;
-}> | null = null;
-let mockBrowserSearchTweetsError: Error | null = null;
-
 // --- Mock TwitterProxyError ---
 
 class MockTwitterProxyError extends Error {
@@ -107,45 +76,12 @@ mock.module("../../../../twitter/platform-proxy-client.js", () => ({
   TwitterProxyError: MockTwitterProxyError,
 }));
 
-class MockSessionExpiredError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = "SessionExpiredError";
-  }
-}
-
 mock.module("../client.js", () => ({
-  postTweet: async () => {
-    throw new Error("Not used in read tests");
-  },
-  getUserByScreenName: async () => {
-    if (mockBrowserGetUserByScreenNameError)
-      throw mockBrowserGetUserByScreenNameError;
-    if (mockBrowserGetUserByScreenNameResult)
-      return mockBrowserGetUserByScreenNameResult;
-    throw new Error("Browser getUserByScreenName mock not configured");
-  },
-  getUserTweets: async () => {
-    if (mockBrowserGetUserTweetsError) throw mockBrowserGetUserTweetsError;
-    if (mockBrowserGetUserTweetsResult) return mockBrowserGetUserTweetsResult;
-    throw new Error("Browser getUserTweets mock not configured");
-  },
-  getTweetDetail: async () => {
-    if (mockBrowserGetTweetDetailError) throw mockBrowserGetTweetDetailError;
-    if (mockBrowserGetTweetDetailResult) return mockBrowserGetTweetDetailResult;
-    throw new Error("Browser getTweetDetail mock not configured");
-  },
-  searchTweets: async () => {
-    if (mockBrowserSearchTweetsError) throw mockBrowserSearchTweetsError;
-    if (mockBrowserSearchTweetsResult) return mockBrowserSearchTweetsResult;
-    throw new Error("Browser searchTweets mock not configured");
-  },
-  SessionExpiredError: MockSessionExpiredError,
+  // No browser functions needed — router no longer imports them
 }));
 
 mock.module("../oauth-client.js", () => ({
   oauthIsAvailable: () => false,
-  oauthSupportsOperation: () => false,
   oauthPostTweet: async () => {
     throw new Error("Not used in read tests");
   },
@@ -184,14 +120,6 @@ beforeEach(() => {
   mockManagedGetTweetError = null;
   mockManagedSearchRecentTweetsResult = null;
   mockManagedSearchRecentTweetsError = null;
-  mockBrowserGetUserByScreenNameResult = null;
-  mockBrowserGetUserByScreenNameError = null;
-  mockBrowserGetUserTweetsResult = null;
-  mockBrowserGetUserTweetsError = null;
-  mockBrowserGetTweetDetailResult = null;
-  mockBrowserGetTweetDetailError = null;
-  mockBrowserSearchTweetsResult = null;
-  mockBrowserSearchTweetsError = null;
 });
 
 describe("Twitter read routing", () => {
@@ -199,14 +127,14 @@ describe("Twitter read routing", () => {
   // User lookup
   // =========================================================================
   describe("routedGetUserByScreenName", () => {
-    test("managed strategy routes through proxy", async () => {
+    test("managed mode routes through proxy", async () => {
       mockManagedGetUserByUsernameResult = {
         data: { data: { id: "123", username: "testuser", name: "Test User" } },
         status: 200,
       };
 
       const { result, pathUsed } = await routedGetUserByScreenName("testuser", {
-        strategy: "managed",
+        mode: "managed",
       });
 
       expect(pathUsed).toBe("managed");
@@ -215,39 +143,20 @@ describe("Twitter read routing", () => {
       expect(result.name).toBe("Test User");
     });
 
-    test("browser strategy uses browser path", async () => {
-      mockBrowserGetUserByScreenNameResult = {
-        userId: "456",
-        screenName: "browseruser",
-        name: "Browser User",
-      };
-
-      const { result, pathUsed } = await routedGetUserByScreenName(
-        "browseruser",
-        { strategy: "browser" },
-      );
-
-      expect(pathUsed).toBe("browser");
-      expect(result.userId).toBe("456");
-      expect(result.screenName).toBe("browseruser");
+    test("oauth mode throws clear error for read operations", async () => {
+      try {
+        await routedGetUserByScreenName("testuser", { mode: "oauth" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain(
+          "Read operations are not supported via OAuth",
+        );
+        expect(e.pathUsed).toBe("oauth");
+      }
     });
 
-    test("auto strategy falls through to browser", async () => {
-      mockBrowserGetUserByScreenNameResult = {
-        userId: "789",
-        screenName: "autouser",
-        name: "Auto User",
-      };
-
-      const { result, pathUsed } = await routedGetUserByScreenName("autouser", {
-        strategy: "auto",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result.userId).toBe("789");
-    });
-
-    test("managed strategy surfaces proxy errors with metadata", async () => {
+    test("managed mode surfaces proxy errors with metadata", async () => {
       mockManagedGetUserByUsernameError = new MockTwitterProxyError(
         "Rate limit exceeded — retry later",
         "rate_limit",
@@ -256,7 +165,7 @@ describe("Twitter read routing", () => {
       );
 
       try {
-        await routedGetUserByScreenName("testuser", { strategy: "managed" });
+        await routedGetUserByScreenName("testuser", { mode: "managed" });
         expect(true).toBe(false);
       } catch (err) {
         const e = err as Error & {
@@ -276,7 +185,7 @@ describe("Twitter read routing", () => {
   // User tweets
   // =========================================================================
   describe("routedGetUserTweets", () => {
-    test("managed strategy routes through proxy", async () => {
+    test("managed mode routes through proxy", async () => {
       mockManagedGetUserTweetsResult = {
         data: {
           data: [
@@ -296,7 +205,7 @@ describe("Twitter read routing", () => {
       };
 
       const { result, pathUsed } = await routedGetUserTweets("123", 20, {
-        strategy: "managed",
+        mode: "managed",
       });
 
       expect(pathUsed).toBe("managed");
@@ -307,23 +216,17 @@ describe("Twitter read routing", () => {
       expect(result[1].tweetId).toBe("t2");
     });
 
-    test("browser strategy uses browser path", async () => {
-      mockBrowserGetUserTweetsResult = [
-        {
-          tweetId: "bt1",
-          text: "Browser tweet",
-          url: "https://x.com/user/status/bt1",
-          createdAt: "2025-01-01",
-        },
-      ];
-
-      const { result, pathUsed } = await routedGetUserTweets("456", 20, {
-        strategy: "browser",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result).toHaveLength(1);
-      expect(result[0].tweetId).toBe("bt1");
+    test("oauth mode throws clear error for read operations", async () => {
+      try {
+        await routedGetUserTweets("456", 20, { mode: "oauth" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain(
+          "Read operations are not supported via OAuth",
+        );
+        expect(e.pathUsed).toBe("oauth");
+      }
     });
   });
 
@@ -331,7 +234,7 @@ describe("Twitter read routing", () => {
   // Tweet detail
   // =========================================================================
   describe("routedGetTweetDetail", () => {
-    test("managed strategy routes through proxy", async () => {
+    test("managed mode routes through proxy", async () => {
       mockManagedGetTweetResult = {
         data: {
           data: {
@@ -344,7 +247,7 @@ describe("Twitter read routing", () => {
       };
 
       const { result, pathUsed } = await routedGetTweetDetail("tweet-123", {
-        strategy: "managed",
+        mode: "managed",
       });
 
       expect(pathUsed).toBe("managed");
@@ -353,31 +256,20 @@ describe("Twitter read routing", () => {
       expect(result[0].text).toBe("A specific tweet");
     });
 
-    test("browser strategy uses browser path", async () => {
-      mockBrowserGetTweetDetailResult = [
-        {
-          tweetId: "detail-1",
-          text: "Thread tweet 1",
-          url: "https://x.com/user/status/detail-1",
-          createdAt: "2025-01-01",
-        },
-        {
-          tweetId: "detail-2",
-          text: "Reply tweet",
-          url: "https://x.com/user/status/detail-2",
-          createdAt: "2025-01-01",
-        },
-      ];
-
-      const { result, pathUsed } = await routedGetTweetDetail("detail-1", {
-        strategy: "browser",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result).toHaveLength(2);
+    test("oauth mode throws clear error for read operations", async () => {
+      try {
+        await routedGetTweetDetail("tweet-123", { mode: "oauth" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain(
+          "Read operations are not supported via OAuth",
+        );
+        expect(e.pathUsed).toBe("oauth");
+      }
     });
 
-    test("managed strategy surfaces proxy errors", async () => {
+    test("managed mode surfaces proxy errors", async () => {
       mockManagedGetTweetError = new MockTwitterProxyError(
         "Forbidden: insufficient permissions",
         "forbidden",
@@ -386,7 +278,7 @@ describe("Twitter read routing", () => {
       );
 
       try {
-        await routedGetTweetDetail("tweet-123", { strategy: "managed" });
+        await routedGetTweetDetail("tweet-123", { mode: "managed" });
         expect(true).toBe(false);
       } catch (err) {
         const e = err as Error & {
@@ -403,7 +295,7 @@ describe("Twitter read routing", () => {
   // Search
   // =========================================================================
   describe("routedSearchTweets", () => {
-    test("managed strategy routes through proxy", async () => {
+    test("managed mode routes through proxy", async () => {
       mockManagedSearchRecentTweetsResult = {
         data: {
           data: [
@@ -420,7 +312,7 @@ describe("Twitter read routing", () => {
       const { result, pathUsed } = await routedSearchTweets(
         "AI agents",
         "Top",
-        { strategy: "managed" },
+        { mode: "managed" },
       );
 
       expect(pathUsed).toBe("managed");
@@ -429,50 +321,24 @@ describe("Twitter read routing", () => {
       expect(result[0].text).toBe("Search result 1");
     });
 
-    test("browser strategy uses browser path", async () => {
-      mockBrowserSearchTweetsResult = [
-        {
-          tweetId: "bs1",
-          text: "Browser search result",
-          url: "https://x.com/user/status/bs1",
-          createdAt: "2025-01-01",
-        },
-      ];
-
-      const { result, pathUsed } = await routedSearchTweets(
-        "test query",
-        "Latest",
-        { strategy: "browser" },
-      );
-
-      expect(pathUsed).toBe("browser");
-      expect(result).toHaveLength(1);
-      expect(result[0].tweetId).toBe("bs1");
+    test("oauth mode throws clear error for read operations", async () => {
+      try {
+        await routedSearchTweets("test query", "Latest", { mode: "oauth" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & { pathUsed: string };
+        expect(e.message).toContain(
+          "Read operations are not supported via OAuth",
+        );
+        expect(e.pathUsed).toBe("oauth");
+      }
     });
 
-    test("auto strategy falls through to browser for search", async () => {
-      mockBrowserSearchTweetsResult = [
-        {
-          tweetId: "auto-s1",
-          text: "Auto search result",
-          url: "https://x.com/user/status/auto-s1",
-          createdAt: "2025-01-01",
-        },
-      ];
-
-      const { result, pathUsed } = await routedSearchTweets("test", "Top", {
-        strategy: "auto",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result[0].tweetId).toBe("auto-s1");
-    });
-
-    test("managed strategy re-throws non-proxy errors", async () => {
+    test("managed mode re-throws non-proxy errors", async () => {
       mockManagedSearchRecentTweetsError = new Error("Network failure");
 
       try {
-        await routedSearchTweets("test", "Top", { strategy: "managed" });
+        await routedSearchTweets("test", "Top", { mode: "managed" });
         expect(true).toBe(false);
       } catch (err) {
         expect((err as Error).message).toBe("Network failure");

--- a/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
@@ -8,19 +8,12 @@ let mockOauthPostResult: {
   url?: string;
 } | null = null;
 let mockOauthPostError: Error | null = null;
-let mockBrowserPostResult: {
-  tweetId: string;
-  text: string;
-  url: string;
-} | null = null;
-let mockBrowserPostError: Error | null = null;
 let mockManagedPostResult: { data: unknown; status: number } | null = null;
 let mockManagedPostError: Error | null = null;
 
 // Mock the OAuth client
 mock.module("../oauth-client.js", () => ({
   oauthIsAvailable: (token?: string) => token != null && token.length > 0,
-  oauthSupportsOperation: (op: string) => op === "post" || op === "reply",
   oauthPostTweet: async (
     _text: string,
     _opts: { inReplyToTweetId?: string; oauthToken: string },
@@ -28,16 +21,6 @@ mock.module("../oauth-client.js", () => ({
     if (mockOauthPostError) throw mockOauthPostError;
     if (mockOauthPostResult) return mockOauthPostResult;
     throw new Error("OAuth mock not configured");
-  },
-  UnsupportedOAuthOperationError: class UnsupportedOAuthOperationError extends Error {
-    public readonly suggestFallback = true;
-    public readonly fallbackPath = "browser" as const;
-    public readonly operation: string;
-    constructor(operation: string) {
-      super(`The "${operation}" operation is not available via the OAuth API.`);
-      this.name = "UnsupportedOAuthOperationError";
-      this.operation = operation;
-    }
   },
 }));
 
@@ -70,23 +53,8 @@ mock.module("../../../../twitter/platform-proxy-client.js", () => ({
   TwitterProxyError: MockTwitterProxyError,
 }));
 
-// Create a SessionExpiredError class that matches the real one
-class MockSessionExpiredError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = "SessionExpiredError";
-  }
-}
-
-// Mock the browser client
-mock.module("../client.js", () => ({
-  postTweet: async (_text: string, _opts?: { inReplyToTweetId?: string }) => {
-    if (mockBrowserPostError) throw mockBrowserPostError;
-    if (mockBrowserPostResult) return mockBrowserPostResult;
-    throw new Error("Browser mock not configured");
-  },
-  SessionExpiredError: MockSessionExpiredError,
-}));
+// Mock the browser client — no longer used by router
+mock.module("../client.js", () => ({}));
 
 // Mock the logger to silence output
 mock.module("../../../../util/logger.js", () => ({
@@ -111,114 +79,25 @@ import { routedPostTweet } from "../router.js";
 beforeEach(() => {
   mockOauthPostResult = null;
   mockOauthPostError = null;
-  mockBrowserPostResult = null;
-  mockBrowserPostError = null;
   mockManagedPostResult = null;
   mockManagedPostError = null;
 });
 
-describe("Twitter strategy router", () => {
-  describe("auto strategy", () => {
-    test("uses OAuth when available and supported", async () => {
-      mockOauthPostResult = {
-        tweetId: "111",
-        text: "hello",
-        url: "https://x.com/u/status/111",
-      };
-
-      const { result, pathUsed } = await routedPostTweet("hello", {
-        strategy: "auto",
-        oauthToken: "test-token",
-      });
-
-      expect(pathUsed).toBe("oauth");
-      expect(result.tweetId).toBe("111");
-      expect(result.text).toBe("hello");
-      expect(result.url).toBe("https://x.com/u/status/111");
-    });
-
-    test("falls back to browser when OAuth is unavailable", async () => {
-      mockBrowserPostResult = {
-        tweetId: "222",
-        text: "hello",
-        url: "https://x.com/u/status/222",
-      };
-
-      const { result, pathUsed } = await routedPostTweet("hello", {
-        strategy: "auto",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result.tweetId).toBe("222");
-    });
-
-    test("falls back to browser when OAuth fails", async () => {
-      mockOauthPostError = new Error("OAuth token expired");
-      mockBrowserPostResult = {
-        tweetId: "333",
-        text: "hello",
-        url: "https://x.com/u/status/333",
-      };
-
-      const { result, pathUsed } = await routedPostTweet("hello", {
-        strategy: "auto",
-        oauthToken: "test-token",
-      });
-
-      expect(pathUsed).toBe("browser");
-      expect(result.tweetId).toBe("333");
-    });
-
-    test("constructs URL from tweetId when OAuth result has no url", async () => {
-      mockOauthPostResult = { tweetId: "444", text: "no url" };
-
-      const { result, pathUsed } = await routedPostTweet("no url", {
-        strategy: "auto",
-        oauthToken: "test-token",
-      });
-
-      expect(pathUsed).toBe("oauth");
-      expect(result.url).toBe("https://x.com/i/status/444");
-    });
-
-    test("throws combined error when both OAuth and browser fail with SessionExpiredError", async () => {
-      mockOauthPostError = new Error("OAuth failed");
-      mockBrowserPostError = new MockSessionExpiredError(
-        "Browser session expired",
-      );
-
-      try {
-        await routedPostTweet("will fail", {
-          strategy: "auto",
-          oauthToken: "test-token",
-        });
-        expect(true).toBe(false); // should not reach
-      } catch (err) {
-        const e = err as Error & { pathUsed: string; oauthError?: string };
-        expect(e).toBeInstanceOf(MockSessionExpiredError);
-        expect(e.message).toBe("Browser session expired");
-        expect(e.pathUsed).toBe("auto");
-        expect(e.oauthError).toBe("OAuth failed");
-      }
-    });
-  });
-
-  describe("explicit oauth strategy", () => {
+describe("Twitter mode router", () => {
+  describe("explicit oauth mode", () => {
     test("fails with helpful error when OAuth is not configured", async () => {
       try {
-        await routedPostTweet("hello", { strategy: "oauth" });
+        await routedPostTweet("hello", { mode: "oauth" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & {
           pathUsed: string;
-          suggestAlternative: string;
         };
         expect(e.message).toContain("OAuth is not configured");
         expect(e.message).toContain(
-          "assistant config set twitter.operationStrategy browser",
+          "Connect your X developer credentials to set up OAuth",
         );
         expect(e.pathUsed).toBe("oauth");
-        expect(e.suggestAlternative).toBe("browser");
       }
     });
 
@@ -226,63 +105,28 @@ describe("Twitter strategy router", () => {
       mockOauthPostResult = { tweetId: "555", text: "oauth post" };
 
       const { result, pathUsed } = await routedPostTweet("oauth post", {
-        strategy: "oauth",
+        mode: "oauth",
         oauthToken: "test-token",
       });
 
       expect(pathUsed).toBe("oauth");
       expect(result.tweetId).toBe("555");
     });
-  });
 
-  describe("explicit browser strategy", () => {
-    test("uses browser directly, ignoring OAuth availability", async () => {
-      mockBrowserPostResult = {
-        tweetId: "666",
-        text: "browser post",
-        url: "https://x.com/u/status/666",
-      };
+    test("constructs URL from tweetId when OAuth result has no url", async () => {
+      mockOauthPostResult = { tweetId: "444", text: "no url" };
 
-      const { result, pathUsed } = await routedPostTweet("browser post", {
-        strategy: "browser",
-        oauthToken: "test-token", // available but should be ignored
+      const { result, pathUsed } = await routedPostTweet("no url", {
+        mode: "oauth",
+        oauthToken: "test-token",
       });
 
-      expect(pathUsed).toBe("browser");
-      expect(result.tweetId).toBe("666");
-    });
-
-    test("preserves SessionExpiredError type with router metadata", async () => {
-      mockBrowserPostError = new MockSessionExpiredError("Session expired");
-
-      try {
-        await routedPostTweet("will fail", { strategy: "browser" });
-        expect(true).toBe(false); // should not reach
-      } catch (err) {
-        const e = err as Error & {
-          pathUsed: string;
-          suggestAlternative: string;
-        };
-        expect(e).toBeInstanceOf(MockSessionExpiredError);
-        expect(e.message).toBe("Session expired");
-        expect(e.pathUsed).toBe("browser");
-        expect(e.suggestAlternative).toBe("oauth");
-      }
-    });
-
-    test("re-throws non-session errors without wrapping", async () => {
-      mockBrowserPostError = new Error("Network failure");
-
-      try {
-        await routedPostTweet("will fail", { strategy: "browser" });
-        expect(true).toBe(false); // should not reach
-      } catch (err) {
-        expect((err as Error).message).toBe("Network failure");
-      }
+      expect(pathUsed).toBe("oauth");
+      expect(result.url).toBe("https://x.com/i/status/444");
     });
   });
 
-  describe("managed strategy", () => {
+  describe("managed mode", () => {
     test("routes post through platform proxy", async () => {
       mockManagedPostResult = {
         data: { data: { id: "managed-1" } },
@@ -290,7 +134,7 @@ describe("Twitter strategy router", () => {
       };
 
       const { result, pathUsed } = await routedPostTweet("managed post", {
-        strategy: "managed",
+        mode: "managed",
       });
 
       expect(pathUsed).toBe("managed");
@@ -305,7 +149,7 @@ describe("Twitter strategy router", () => {
       };
 
       const { result, pathUsed } = await routedPostTweet("reply text", {
-        strategy: "managed",
+        mode: "managed",
         inReplyToTweetId: "original-tweet-123",
       });
 
@@ -322,7 +166,7 @@ describe("Twitter strategy router", () => {
       );
 
       try {
-        await routedPostTweet("will fail", { strategy: "managed" });
+        await routedPostTweet("will fail", { mode: "managed" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & {
@@ -348,7 +192,7 @@ describe("Twitter strategy router", () => {
       );
 
       try {
-        await routedPostTweet("will fail", { strategy: "managed" });
+        await routedPostTweet("will fail", { mode: "managed" });
         expect(true).toBe(false);
       } catch (err) {
         const e = err as Error & {
@@ -366,7 +210,7 @@ describe("Twitter strategy router", () => {
       mockManagedPostError = new Error("Network failure");
 
       try {
-        await routedPostTweet("will fail", { strategy: "managed" });
+        await routedPostTweet("will fail", { mode: "managed" });
         expect(true).toBe(false);
       } catch (err) {
         expect((err as Error).message).toBe("Network failure");
@@ -376,7 +220,7 @@ describe("Twitter strategy router", () => {
   });
 
   describe("reply routing", () => {
-    test("auto strategy routes reply through OAuth when available", async () => {
+    test("oauth mode routes reply through OAuth when available", async () => {
       mockOauthPostResult = {
         tweetId: "777",
         text: "reply text",
@@ -385,7 +229,7 @@ describe("Twitter strategy router", () => {
 
       const { result, pathUsed } = await routedPostTweet("reply text", {
         inReplyToTweetId: "100",
-        strategy: "auto",
+        mode: "oauth",
         oauthToken: "test-token",
       });
 
@@ -393,19 +237,18 @@ describe("Twitter strategy router", () => {
       expect(result.tweetId).toBe("777");
     });
 
-    test("browser strategy routes reply through browser", async () => {
-      mockBrowserPostResult = {
-        tweetId: "888",
-        text: "reply text",
-        url: "https://x.com/u/status/888",
+    test("managed mode routes reply through platform proxy", async () => {
+      mockManagedPostResult = {
+        data: { data: { id: "888" } },
+        status: 200,
       };
 
       const { result, pathUsed } = await routedPostTweet("reply text", {
         inReplyToTweetId: "200",
-        strategy: "browser",
+        mode: "managed",
       });
 
-      expect(pathUsed).toBe("browser");
+      expect(pathUsed).toBe("managed");
       expect(result.tweetId).toBe("888");
     });
   });

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -24,7 +24,7 @@ import {
   getUserMedia,
   SessionExpiredError,
 } from "./client.js";
-import type { TwitterStrategy } from "./router.js";
+import type { TwitterMode } from "./router.js";
 import {
   routedGetTweetDetail,
   routedGetUserByScreenName,
@@ -430,19 +430,14 @@ Examples:
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const strategy = opts.strategy as TwitterStrategy;
-          if (
-            strategy !== "oauth" &&
-            strategy !== "browser" &&
-            strategy !== "auto" &&
-            strategy !== "managed"
-          ) {
+          const mode = opts.strategy as TwitterMode;
+          if (mode !== "oauth" && mode !== "managed") {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
             );
           }
           const { result, pathUsed } = await routedPostTweet(text, {
-            strategy,
+            mode,
             oauthToken: opts.oauthToken,
           });
           return {
@@ -464,11 +459,11 @@ Examples:
     .argument("<text>", "Reply text")
     .requiredOption(
       "--strategy <strategy>",
-      "Operation strategy: oauth, browser, auto, or managed",
+      "Operation strategy: oauth or managed",
     )
     .option(
       "--oauth-token <token>",
-      "OAuth access token (required when strategy is oauth or auto)",
+      "OAuth access token (required when mode is oauth)",
     )
     .addHelpText(
       "after",
@@ -494,15 +489,10 @@ Examples:
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const strategy = opts.strategy as TwitterStrategy;
-          if (
-            strategy !== "oauth" &&
-            strategy !== "browser" &&
-            strategy !== "auto" &&
-            strategy !== "managed"
-          ) {
+          const mode = opts.strategy as TwitterMode;
+          if (mode !== "oauth" && mode !== "managed") {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
             );
           }
           // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL
@@ -513,7 +503,7 @@ Examples:
           const inReplyToTweetId = idMatch[1];
           const { result, pathUsed } = await routedPostTweet(text, {
             inReplyToTweetId,
-            strategy,
+            mode,
             oauthToken: opts.oauthToken,
           });
           return {
@@ -560,25 +550,20 @@ Examples:
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
-          if (
-            strategy !== "oauth" &&
-            strategy !== "browser" &&
-            strategy !== "auto" &&
-            strategy !== "managed"
-          ) {
+          const mode = (opts.strategy ?? "managed") as TwitterMode;
+          if (mode !== "oauth" && mode !== "managed") {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
             );
           }
           const { result: user, pathUsed } = await routedGetUserByScreenName(
             screenName.replace(/^@/, ""),
-            { strategy },
+            { mode },
           );
           const { result: tweets } = await routedGetUserTweets(
             user.userId,
             parseInt(opts.count, 10),
-            { strategy },
+            { mode },
           );
           return { user, tweets, pathUsed };
         });
@@ -622,20 +607,15 @@ Examples:
           const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
           if (!idMatch)
             throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
-          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
-          if (
-            strategy !== "oauth" &&
-            strategy !== "browser" &&
-            strategy !== "auto" &&
-            strategy !== "managed"
-          ) {
+          const mode = (opts.strategy ?? "managed") as TwitterMode;
+          if (mode !== "oauth" && mode !== "managed") {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
             );
           }
           const { result: tweets, pathUsed } = await routedGetTweetDetail(
             idMatch[1],
-            { strategy },
+            { mode },
           );
           return { tweets, pathUsed };
         });
@@ -682,22 +662,17 @@ Examples:
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
-          if (
-            strategy !== "oauth" &&
-            strategy !== "browser" &&
-            strategy !== "auto" &&
-            strategy !== "managed"
-          ) {
+          const mode = (opts.strategy ?? "managed") as TwitterMode;
+          if (mode !== "oauth" && mode !== "managed") {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
             );
           }
           const product = opts.product as "Top" | "Latest" | "People" | "Media";
           const { result: tweets, pathUsed } = await routedSearchTweets(
             query,
             product,
-            { strategy },
+            { mode },
           );
           return { query, tweets, pathUsed };
         });

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -1,6 +1,6 @@
 /**
- * Strategy router for Twitter operations.
- * Selects managed proxy, OAuth, or browser path based on the caller-provided strategy.
+ * Mode router for Twitter operations.
+ * Selects managed proxy or OAuth path based on the caller-provided integration mode.
  */
 
 import {
@@ -12,46 +12,26 @@ import {
   TwitterProxyError,
 } from "../../../twitter/platform-proxy-client.js";
 import type { PostTweetResult, TweetEntry, UserInfo } from "./client.js";
-import {
-  getTweetDetail as browserGetTweetDetail,
-  getUserByScreenName as browserGetUserByScreenName,
-  getUserTweets as browserGetUserTweets,
-  postTweet as browserPostTweet,
-  searchTweets as browserSearchTweets,
-  SessionExpiredError,
-} from "./client.js";
-import {
-  oauthIsAvailable,
-  oauthPostTweet,
-  oauthSupportsOperation,
-} from "./oauth-client.js";
+import { oauthIsAvailable, oauthPostTweet } from "./oauth-client.js";
 
-export type TwitterStrategy = "oauth" | "browser" | "auto" | "managed";
+export type TwitterMode = "oauth" | "managed";
 
 export interface RoutedResult<T> {
   result: T;
-  pathUsed: TwitterStrategy;
-}
-
-export interface RoutedError {
-  message: string;
-  pathUsed: TwitterStrategy;
-  suggestAlternative?: TwitterStrategy;
-  alternativeSetupHint?: string;
+  pathUsed: TwitterMode;
 }
 
 export async function routedPostTweet(
   text: string,
   opts: {
     inReplyToTweetId?: string;
-    strategy: TwitterStrategy;
+    mode: TwitterMode;
     oauthToken?: string;
   },
 ): Promise<RoutedResult<PostTweetResult>> {
-  const strategy = opts.strategy;
-  const operation = opts.inReplyToTweetId ? "reply" : "post";
+  const mode = opts.mode;
 
-  if (strategy === "managed") {
+  if (mode === "managed") {
     // Route through platform proxy — the platform holds the OAuth credentials
     try {
       const response = await managedPostTweet(text, {
@@ -91,16 +71,15 @@ export async function routedPostTweet(
     }
   }
 
-  if (strategy === "oauth") {
+  if (mode === "oauth") {
     // User explicitly wants OAuth
     if (!oauthIsAvailable(opts.oauthToken)) {
       throw Object.assign(
         new Error(
-          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `assistant config set twitter.operationStrategy browser`.",
+          "OAuth is not configured. Connect your X developer credentials to set up OAuth.",
         ),
         {
           pathUsed: "oauth" as const,
-          suggestAlternative: "browser" as const,
         },
       );
     }
@@ -118,68 +97,9 @@ export async function routedPostTweet(
     };
   }
 
-  if (strategy === "browser") {
-    // User explicitly wants browser
-    try {
-      const result = await browserPostTweet(text, {
-        inReplyToTweetId: opts.inReplyToTweetId,
-      });
-      return { result, pathUsed: "browser" };
-    } catch (err) {
-      if (err instanceof SessionExpiredError) {
-        throw Object.assign(err, {
-          pathUsed: "browser" as const,
-          suggestAlternative: "oauth" as const,
-        });
-      }
-      throw err;
-    }
-  }
-
-  // auto strategy: try OAuth first if available and supported, fallback to browser
-  let oauthError: Error | undefined;
-  if (oauthIsAvailable(opts.oauthToken) && oauthSupportsOperation(operation)) {
-    try {
-      const result = await oauthPostTweet(text, {
-        inReplyToTweetId: opts.inReplyToTweetId,
-        oauthToken: opts.oauthToken!,
-      });
-      return {
-        result: {
-          tweetId: result.tweetId,
-          text: result.text,
-          url: result.url ?? `https://x.com/i/status/${result.tweetId}`,
-        },
-        pathUsed: "oauth",
-      };
-    } catch (err) {
-      oauthError = err instanceof Error ? err : new Error(String(err));
-      // Fall through to browser
-    }
-  }
-
-  // Fallback to browser
-  try {
-    const result = await browserPostTweet(text, {
-      inReplyToTweetId: opts.inReplyToTweetId,
-    });
-    return { result, pathUsed: "browser" };
-  } catch (err) {
-    if (err instanceof SessionExpiredError) {
-      throw Object.assign(err, {
-        pathUsed: "auto" as const,
-        oauthError: oauthError?.message,
-      });
-    }
-    if (oauthError) {
-      const browserError = err instanceof Error ? err : new Error(String(err));
-      throw Object.assign(browserError, {
-        pathUsed: "auto" as const,
-        oauthError: oauthError.message,
-      });
-    }
-    throw err;
-  }
+  // Exhaustive check — should never reach here
+  const _exhaustive: never = mode;
+  throw new Error(`Unknown mode: ${_exhaustive}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,13 +108,13 @@ export async function routedPostTweet(
 
 /**
  * Look up a user by screen name.
- * Managed mode uses GET /2/users/by/username/:username; browser mode uses GraphQL.
+ * Managed mode uses GET /2/users/by/username/:username.
  */
 export async function routedGetUserByScreenName(
   screenName: string,
-  opts: { strategy: TwitterStrategy },
+  opts: { mode: TwitterMode },
 ): Promise<RoutedResult<UserInfo>> {
-  if (opts.strategy === "managed") {
+  if (opts.mode === "managed") {
     try {
       const response = await managedGetUserByUsername(screenName, {
         "user.fields": "id,name,username",
@@ -228,21 +148,29 @@ export async function routedGetUserByScreenName(
     }
   }
 
-  // Browser path (used for browser, oauth, auto — read operations always go through browser)
-  const result = await browserGetUserByScreenName(screenName);
-  return { result, pathUsed: "browser" };
+  if (opts.mode === "oauth") {
+    throw Object.assign(
+      new Error(
+        "Read operations are not supported via OAuth. Use managed mode for read access.",
+      ),
+      { pathUsed: "oauth" as const },
+    );
+  }
+
+  const _exhaustive: never = opts.mode;
+  throw new Error(`Unknown mode: ${_exhaustive}`);
 }
 
 /**
  * Fetch a user's recent tweets.
- * Managed mode uses GET /2/users/:id/tweets; browser mode uses GraphQL.
+ * Managed mode uses GET /2/users/:id/tweets.
  */
 export async function routedGetUserTweets(
   userId: string,
   count: number,
-  opts: { strategy: TwitterStrategy },
+  opts: { mode: TwitterMode },
 ): Promise<RoutedResult<TweetEntry[]>> {
-  if (opts.strategy === "managed") {
+  if (opts.mode === "managed") {
     try {
       const response = await managedGetUserTweets(userId, {
         max_results: String(Math.min(count, 100)),
@@ -269,19 +197,28 @@ export async function routedGetUserTweets(
     }
   }
 
-  const result = await browserGetUserTweets(userId, count);
-  return { result, pathUsed: "browser" };
+  if (opts.mode === "oauth") {
+    throw Object.assign(
+      new Error(
+        "Read operations are not supported via OAuth. Use managed mode for read access.",
+      ),
+      { pathUsed: "oauth" as const },
+    );
+  }
+
+  const _exhaustive: never = opts.mode;
+  throw new Error(`Unknown mode: ${_exhaustive}`);
 }
 
 /**
  * Fetch a single tweet by ID.
- * Managed mode uses GET /2/tweets/:id; browser mode uses GraphQL TweetDetail.
+ * Managed mode uses GET /2/tweets/:id.
  */
 export async function routedGetTweetDetail(
   tweetId: string,
-  opts: { strategy: TwitterStrategy },
+  opts: { mode: TwitterMode },
 ): Promise<RoutedResult<TweetEntry[]>> {
-  if (opts.strategy === "managed") {
+  if (opts.mode === "managed") {
     try {
       const response = await managedGetTweet(tweetId, {
         "tweet.fields": "id,text,created_at,author_id,conversation_id",
@@ -340,20 +277,29 @@ export async function routedGetTweetDetail(
     }
   }
 
-  const result = await browserGetTweetDetail(tweetId);
-  return { result, pathUsed: "browser" };
+  if (opts.mode === "oauth") {
+    throw Object.assign(
+      new Error(
+        "Read operations are not supported via OAuth. Use managed mode for read access.",
+      ),
+      { pathUsed: "oauth" as const },
+    );
+  }
+
+  const _exhaustive: never = opts.mode;
+  throw new Error(`Unknown mode: ${_exhaustive}`);
 }
 
 /**
  * Search tweets.
- * Managed mode uses GET /2/tweets/search/recent; browser mode uses GraphQL SearchTimeline.
+ * Managed mode uses GET /2/tweets/search/recent.
  */
 export async function routedSearchTweets(
   query: string,
   product: "Top" | "Latest" | "People" | "Media",
-  opts: { strategy: TwitterStrategy },
+  opts: { mode: TwitterMode },
 ): Promise<RoutedResult<TweetEntry[]>> {
-  if (opts.strategy === "managed") {
+  if (opts.mode === "managed") {
     if (product === "People" || product === "Media") {
       throw Object.assign(
         new Error(
@@ -391,6 +337,15 @@ export async function routedSearchTweets(
     }
   }
 
-  const result = await browserSearchTweets(query, product);
-  return { result, pathUsed: "browser" };
+  if (opts.mode === "oauth") {
+    throw Object.assign(
+      new Error(
+        "Read operations are not supported via OAuth. Use managed mode for read access.",
+      ),
+      { pathUsed: "oauth" as const },
+    );
+  }
+
+  const _exhaustive: never = opts.mode;
+  throw new Error(`Unknown mode: ${_exhaustive}`);
 }


### PR DESCRIPTION
## Summary
- Replace `TwitterStrategy` type with `TwitterMode = "oauth" | "managed"` — routing is now by integration mode, not user-selectable strategy
- Remove all browser CDP client imports and auto/browser fallback logic from the router
- Read operations for oauth mode now throw a clear error instead of falling back to browser

Part of plan: rm-twitter-browser-auto.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
