### PR TITLE
M1: Create ImproveExperienceStepView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -7,7 +7,7 @@ struct ImproveExperienceStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
-    @State private var sharePerformanceMetrics: Bool = true
+    @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     var body: some View {
         VStack(spacing: VSpacing.xxl) {
@@ -53,7 +53,7 @@ struct ImproveExperienceStepView: View {
 
                 Button(action: { goBack() }) {
                     Text("Back")
-                        .font(.system(size: 13))
+                        .font(VFont.body)
                         .foregroundColor(VColor.textMuted)
                 }
                 .buttonStyle(.plain)
@@ -66,8 +66,10 @@ struct ImproveExperienceStepView: View {
         }
         .padding(.horizontal, VSpacing.xxl)
         .onAppear {
-            // Opt in by default during onboarding
-            UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+            // Opt in by default during onboarding, but preserve any existing choice
+            if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
+                UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+            }
 
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
@@ -85,7 +87,7 @@ struct ImproveExperienceStepView: View {
     }
 }
 
-#Preview {
+#Preview("ImproveExperienceStepView") {
     ZStack {
         VColor.background.ignoresSafeArea()
         ImproveExperienceStepView(state: {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -1,0 +1,98 @@
+import VellumAssistantShared
+import SwiftUI
+
+@MainActor
+struct ImproveExperienceStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showTitle = false
+    @State private var showContent = false
+    @State private var sharePerformanceMetrics: Bool = true
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxl) {
+            VStack(spacing: VSpacing.md) {
+                Text("Improve Experience")
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
+                    .font(VFont.onboardingSubtitle)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+
+            VStack(spacing: VSpacing.md) {
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Share performance metrics")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    VToggle(isOn: Binding(
+                        get: { sharePerformanceMetrics },
+                        set: { newValue in
+                            sharePerformanceMetrics = newValue
+                            UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                        }
+                    ))
+                }
+
+                OnboardingButton(
+                    title: "Continue",
+                    style: .primary
+                ) {
+                    state.isHatching = true
+                }
+
+                Button(action: { goBack() }) {
+                    Text("Back")
+                        .font(.system(size: 13))
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+            }
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .onAppear {
+            // Opt in by default during onboarding
+            UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+                showContent = true
+            }
+        }
+    }
+
+    private func goBack() {
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+            state.currentStep -= 1
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ImproveExperienceStepView(state: {
+            let s = OnboardingState()
+            s.currentStep = 1
+            return s
+        }())
+    }
+    .frame(width: 520, height: 500)
+}


### PR DESCRIPTION
## Summary
- Create new `ImproveExperienceStepView` onboarding step with "Improve Experience" title and subtitle
- Add performance metrics toggle (opted-in by default) that writes to `UserDefaults` key `sendPerformanceReports`
- Include Continue button (triggers hatching) and Back button (navigates to previous step)
- Follow existing step layout patterns with staggered fade-in animations

## Test plan
- [ ] Verify the view renders correctly in Xcode preview
- [ ] Verify toggle defaults to on and writes to `sendPerformanceReports` UserDefaults key
- [ ] Verify Continue button sets `state.isHatching = true`
- [ ] Verify Back button decrements `state.currentStep`
- [ ] Verify staggered fade-in animations work on appear

Closes #14629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
