### PR TITLE
fix: use lockfile daemon port instead of hardcoded 7821 in macOS app

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -95,8 +95,10 @@ extension AppDelegate {
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant — use HTTP transport to the local daemon.
             // Bearer token is nil; resolved lazily at connect time.
-            let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-            let port = Int(portString) ?? 7821
+            // Prefer the lockfile's allocated daemon port (multi-instance), then env override, then default.
+            let port = assistant?.daemonPort
+                ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+                ?? 7821
             let baseURL = "http://localhost:\(port)"
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
             let instanceDir = assistant?.instanceDir
@@ -133,9 +135,11 @@ extension AppDelegate {
         let assistant = loadAssistantFromLockfile()
 
         // Ensure the daemon starts its runtime HTTP server so the
-        // gateway can proxy iOS traffic to it.
+        // gateway can proxy iOS traffic to it. Use the lockfile's allocated
+        // daemon port when available (multi-instance), otherwise default to 7821.
         if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-            setenv("RUNTIME_HTTP_PORT", "7821", 0)
+            let daemonPort = assistant?.daemonPort ?? 7821
+            setenv("RUNTIME_HTTP_PORT", String(daemonPort), 0)
         }
 
         // Start the keychain broker before the daemon so it is listening

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -286,9 +286,11 @@ struct OnboardingFlowView: View {
         isBootstrappingLocal = true
         localBootstrapError = nil
 
-        // Resolve the daemon's HTTP base URL and bearer token
-        let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-        let port = Int(portString) ?? 7821
+        // Resolve the daemon's HTTP base URL and bearer token.
+        // Prefer the lockfile's allocated daemon port (multi-instance), then env override, then default.
+        let port = assistant.daemonPort
+            ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+            ?? 7821
         let daemonBaseURL = "http://localhost:\(port)"
 
         guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {


### PR DESCRIPTION
## Summary
- macOS app now reads `daemonPort` from lockfile resources instead of hardcoding port 7821
- Fixes connection failures when multi-instance port allocator assigns a different port (e.g. 7822 if 7821 was occupied at first hatch)
- Applied to `configureDaemonTransport`, `setupDaemonClient` env propagation, and `OnboardingFlowView` bootstrap
- Matches the fallback chain already used in `AppDelegate+AuthLifecycle.swift`: lockfile → env var → 7821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
