### PR TITLE
refactor(twitter): remove browser commands, strategy, and --strategy flag

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -1,29 +1,13 @@
 /**
  * CLI command group: `assistant twitter`
  *
- * Post tweets and manage Twitter sessions via the command line.
+ * Post tweets and interact with X via the command line.
  * All commands output JSON to stdout. Use --json for machine-readable output.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
 import { Command } from "commander";
 
-const execFileAsync = promisify(execFile);
-
 import { httpSend } from "../../http-client.js";
-import {
-  getBookmarks,
-  getFollowers,
-  getFollowing,
-  getHomeTimeline,
-  getLikes,
-  getNotifications,
-  getUserByScreenName,
-  getUserMedia,
-  SessionExpiredError,
-} from "./client.js";
 import type { TwitterMode } from "./router.js";
 import {
   routedGetTweetDetail,
@@ -32,11 +16,6 @@ import {
   routedPostTweet,
   routedSearchTweets,
 } from "./router.js";
-import {
-  clearSession,
-  importFromCredentialStore,
-  loadSession,
-} from "./session.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,50 +41,19 @@ function getJson(cmd: Command): boolean {
   return false;
 }
 
-const SESSION_EXPIRED_MSG =
-  "Your Twitter session has expired. Please sign in to Twitter in Chrome — " +
-  "run `assistant twitter refresh` to capture your session automatically.";
-
 async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
   try {
     const result = await fn();
     output({ ok: true, ...(result as Record<string, unknown>) }, getJson(cmd));
   } catch (err) {
     const meta = err as Record<string, unknown>;
-    if (err instanceof SessionExpiredError) {
-      // Preserve backward-compatible error code while surfacing router metadata
-      const payload: Record<string, unknown> = {
-        ok: false,
-        error: "session_expired",
-        message: SESSION_EXPIRED_MSG,
-      };
-      if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
-      if (meta.suggestAlternative !== undefined)
-        payload.suggestAlternative = meta.suggestAlternative;
-      if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
-      output(payload, getJson(cmd));
-      process.exitCode = 1;
-      return;
-    }
-    // For routed errors with any router metadata, emit structured JSON
-    // so callers can see dual-path diagnostics (pathUsed, oauthError, etc.)
-    if (
-      err instanceof Error &&
-      (meta.pathUsed !== undefined ||
-        meta.suggestAlternative !== undefined ||
-        meta.oauthError !== undefined ||
-        meta.proxyErrorCode !== undefined)
-    ) {
+    // For routed errors with managed-path metadata, emit structured JSON
+    if (err instanceof Error && meta.proxyErrorCode !== undefined) {
       const payload: Record<string, unknown> = {
         ok: false,
         error: err.message,
       };
-      if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
-      if (meta.suggestAlternative !== undefined)
-        payload.suggestAlternative = meta.suggestAlternative;
-      if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
-      if (meta.proxyErrorCode !== undefined)
-        payload.proxyErrorCode = meta.proxyErrorCode;
+      payload.proxyErrorCode = meta.proxyErrorCode;
       if (meta.retryable !== undefined) payload.retryable = meta.retryable;
       output(payload, getJson(cmd));
       process.exitCode = 1;
@@ -124,268 +72,81 @@ export function registerTwitterCommand(program: Command): void {
     .command("x")
     .alias("twitter")
     .description(
-      "Post on X and manage connections. Supports managed (platform proxy), OAuth (official API), and browser session paths.",
+      "Post on X and manage connections. Supports managed (platform proxy) and OAuth (official API) paths.",
     )
     .option("--json", "Machine-readable JSON output");
 
   tw.addHelpText(
     "after",
     `
-Twitter (X) supports multiple paths for interacting with the platform:
+Twitter (X) supports two paths for interacting with the platform:
 
   1. Managed (platform proxy) — routes Twitter API calls through the platform,
      which holds the OAuth credentials. Used when integrationMode is "managed".
   2. OAuth (official API) — uses an authenticated Twitter OAuth application for
      posting and replying. Requires a connected OAuth credential.
-  3. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
-     session to call Twitter's internal GraphQL API. Supports all read operations
-     and posting as a fallback.
 
-The strategy system controls which path is used for operations that support multiple:
-  managed  — route through the platform proxy (platform holds credentials)
-  oauth    — always use the OAuth API; fail if unavailable
-  browser  — always use the browser session; fail if unavailable
-  auto     — try OAuth first, fall back to browser session (default)
-
-Session management:
-  - "refresh" launches Chrome with CDP, navigates to x.com/login, and runs a
-    Ride Shotgun learn session to capture fresh cookies automatically
-  - "status" shows whether browser session and OAuth are active
-  - "logout" clears the saved browser session cookies
+Write operations (post, reply) default to OAuth. Pass --managed to route
+through the platform proxy instead. Read operations (timeline, tweet, search)
+always use managed mode.
 
 Examples:
   $ assistant x status
-  $ assistant x post "Hello world" --strategy managed
-  $ assistant x post "Hello world" --strategy auto
+  $ assistant x post "Hello world" --managed
+  $ assistant x post "Hello world" --oauth-token "$TOKEN"
   $ assistant x timeline elonmusk --count 10
-  $ assistant x search "from:vaborsh AI agents" --product Latest
-  $ assistant x strategy set oauth`,
+  $ assistant x search "from:vaborsh AI agents" --product Latest`,
   );
 
   // =========================================================================
-  // logout — clear saved session
-  // =========================================================================
-  tw.command("logout")
-    .description("Clear the saved Twitter session")
-    .addHelpText(
-      "after",
-      `
-Deletes all saved browser session cookies. After logout, browser-path commands
-will fail until a new session is captured via "refresh".
-OAuth credentials are not affected.
-
-Examples:
-  $ assistant x logout`,
-    )
-    .action(async (_opts: unknown, cmd: Command) => {
-      await clearSession();
-      output({ ok: true, message: "Session cleared" }, getJson(cmd));
-    });
-
-  // =========================================================================
-  // refresh — start Ride Shotgun learn to capture fresh cookies
-  // =========================================================================
-  tw.command("refresh")
-    .description(
-      "Start a Ride Shotgun learn session to capture fresh Twitter cookies. " +
-        "Opens x.com in Chrome — sign in when prompted. " +
-        "NOTE: Chrome will restart with debugging enabled; your tabs will be restored.",
-    )
-    .option("--duration <seconds>", "Recording duration in seconds", "180")
-    .addHelpText(
-      "after",
-      `
-Restarts Chrome with CDP (Chrome DevTools Protocol) enabled, navigates to
-x.com/login, and runs a Ride Shotgun learn session to capture fresh cookies.
-Sign in when Chrome opens — the session will be recorded automatically.
-
-The --duration flag sets how long (in seconds) the recording runs before
-stopping. Default is 180 seconds (3 minutes). After the recording completes,
-cookies are imported automatically and Chrome is minimized.
-
-Requires the assistant to be running (Ride Shotgun runs via the assistant).
-
-Examples:
-  $ assistant x refresh
-  $ assistant x refresh --duration 120
-  $ assistant x refresh --duration 300`,
-    )
-    .action(async (opts: { duration: string }, cmd: Command) => {
-      const json = getJson(cmd);
-      const duration = parseInt(opts.duration, 10);
-
-      try {
-        const result = await startLearnSession(duration);
-        if (result.recordingId) {
-          const session = await importFromCredentialStore("x.com");
-
-          // Hide Chrome after capturing session
-          try {
-            await minimizeChrome();
-          } catch {
-            /* best-effort */
-          }
-
-          output(
-            {
-              ok: true,
-              message: "Session refreshed successfully",
-              cookieCount: session.cookies.length,
-            },
-            json,
-          );
-        } else {
-          output(
-            {
-              ok: false,
-              error: "Recording completed but no recording ID returned",
-            },
-            json,
-          );
-          process.exitCode = 1;
-        }
-      } catch (err) {
-        outputError(err instanceof Error ? err.message : String(err));
-      }
-    });
-
-  // =========================================================================
-  // status — check session status + OAuth and strategy info
+  // status — check OAuth and managed mode info
   // =========================================================================
   tw.command("status")
-    .description("Check Twitter session, OAuth, and strategy status")
+    .description("Check Twitter OAuth and managed mode status")
     .addHelpText(
       "after",
       `
-Shows the current state of both authentication paths:
+Shows the current state of authentication:
 
-  Browser session — whether cookies are loaded and the cookie count.
-  OAuth — whether an OAuth credential is connected, the linked account, the
-    current strategy setting, and whether a strategy has been explicitly configured.
+  OAuth — whether an OAuth credential is connected and the linked account.
+  Managed — whether managed mode is available and prerequisite status.
 
-If the assistant is not running, OAuth fields will be reported as undefined.
+If the assistant is not running, fields will be reported as undefined.
 
 Examples:
   $ assistant x status
   $ assistant x status --json`,
     )
     .action(async (_opts: unknown, cmd: Command) => {
-      const session = await loadSession();
-      const browserInfo: Record<string, unknown> = session
-        ? {
-            browserSessionActive: true,
-            cookieCount: session.cookies.length,
-          }
-        : { browserSessionActive: false };
-
-      // Query daemon for OAuth / strategy config
+      // Query daemon for OAuth / managed config
       let oauthInfo: Record<string, unknown> = {};
       try {
         const r = await sendTwitterConfigRequest("get");
         oauthInfo = {
           oauthConnected: r.connected ?? false,
           oauthAccount: r.accountInfo ?? undefined,
-          preferredStrategy: r.strategy ?? "auto",
-          strategyConfigured: r.strategyConfigured ?? false,
+          managedAvailable: r.managedAvailable ?? false,
+          managedPrerequisites: r.managedPrerequisites ?? undefined,
+          localClientConfigured: r.localClientConfigured ?? false,
         };
       } catch {
-        // Daemon may not be running; report what we can from the local session
+        // Daemon may not be running; report what we can
         oauthInfo = {
           oauthConnected: undefined,
           oauthAccount: undefined,
-          preferredStrategy: undefined,
-          strategyConfigured: undefined,
+          managedAvailable: undefined,
+          managedPrerequisites: undefined,
+          localClientConfigured: undefined,
         };
       }
 
       output(
         {
           ok: true,
-          loggedIn: !!session,
-          ...browserInfo,
           ...oauthInfo,
         },
         getJson(cmd),
       );
-    });
-
-  // =========================================================================
-  // strategy — get or set the Twitter operation strategy
-  // =========================================================================
-  const strategyCli = tw
-    .command("strategy")
-    .description(
-      "Get or set the Twitter operation strategy (managed, oauth, browser, auto)",
-    )
-    .addHelpText(
-      "after",
-      `
-The strategy controls which authentication path is used for operations that
-support both OAuth and browser session:
-
-  managed  — route through the platform proxy (platform holds OAuth credentials).
-  oauth    — always use the official Twitter OAuth API. Fails if no OAuth
-             credential is connected. Best for reliable posting.
-  browser  — always use the browser session (captured cookies). Fails if no
-             session is loaded. Required for read-only endpoints not available
-             via OAuth (bookmarks, notifications, search).
-  auto     — try OAuth first, fall back to browser session. This is the default.
-
-Run without a subcommand to display the current strategy. Use "set" to change it.
-
-Examples:
-  $ assistant x strategy
-  $ assistant x strategy set oauth
-  $ assistant x strategy set auto`,
-    )
-    .action(async (_opts: unknown, cmd: Command) => {
-      const json = getJson(cmd);
-      try {
-        const r = await sendTwitterConfigRequest("get_strategy");
-        output({ ok: true, strategy: r.strategy ?? "auto" }, json);
-      } catch (err) {
-        outputError(err instanceof Error ? err.message : String(err));
-      }
-    });
-
-  strategyCli
-    .command("set")
-    .description("Set the Twitter operation strategy")
-    .argument("<value>", "Strategy value: oauth, browser, or auto")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  value   Strategy to use: "oauth", "browser", or "auto"
-
-Sets the preferred strategy for Twitter operations that support dual-path
-routing. The setting is persisted by the assistant and applies to all subsequent
-operations until changed. Note: "managed" is determined by integration mode
-and cannot be set manually.
-
-Examples:
-  $ assistant x strategy set oauth
-  $ assistant x strategy set browser
-  $ assistant x strategy set auto`,
-    )
-    .action(async (value: string, _opts: unknown, cmd: Command) => {
-      const json = getJson(cmd);
-      try {
-        const r = await sendTwitterConfigRequest("set_strategy", {
-          strategy: value,
-        });
-        if (r.success) {
-          output({ ok: true, strategy: r.strategy }, json);
-        } else {
-          output(
-            { ok: false, error: r.error ?? "Failed to set strategy" },
-            json,
-          );
-          process.exitCode = 1;
-        }
-      } catch (err) {
-        outputError(err instanceof Error ? err.message : String(err));
-      }
     });
 
   // =========================================================================
@@ -394,13 +155,10 @@ Examples:
   tw.command("post")
     .description("Post a tweet")
     .argument("<text>", "Tweet text")
-    .requiredOption(
-      "--strategy <strategy>",
-      "Operation strategy: oauth, browser, auto, or managed",
-    )
+    .option("--managed", "Route through the platform proxy (managed mode)")
     .option(
       "--oauth-token <token>",
-      "OAuth access token (required when strategy is oauth or auto)",
+      "OAuth access token (required for OAuth path)",
     )
     .addHelpText(
       "after",
@@ -408,34 +166,23 @@ Examples:
 Arguments:
   text   The tweet text to post (max 280 characters)
 
-Posts a new tweet using the routed system. The --strategy flag controls which
-path is used. The response includes the tweet ID, URL, and which path was used.
-
-Strategies:
-  oauth    — use the local OAuth token directly
-  browser  — use the browser session (CDP)
-  auto     — try OAuth first, fall back to browser
-  managed  — route through the platform proxy (platform holds OAuth credentials)
+Posts a new tweet. By default uses OAuth mode. Pass --managed to route through
+the platform proxy instead. The response includes the tweet ID, URL, and which
+path was used.
 
 Examples:
-  $ assistant x post "Hello world" --strategy browser
-  $ assistant x post "Hello world" --strategy oauth --oauth-token "$TOKEN"
-  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"
-  $ assistant x post "Hello world" --strategy managed`,
+  $ assistant x post "Hello world"
+  $ assistant x post "Hello world" --oauth-token "$TOKEN"
+  $ assistant x post "Hello world" --managed`,
     )
     .action(
       async (
         text: string,
-        opts: { strategy: string; oauthToken?: string },
+        opts: { managed?: boolean; oauthToken?: string },
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const mode = opts.strategy as TwitterMode;
-          if (mode !== "oauth" && mode !== "managed") {
-            throw new Error(
-              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
-            );
-          }
+          const mode: TwitterMode = opts.managed ? "managed" : "oauth";
           const { result, pathUsed } = await routedPostTweet(text, {
             mode,
             oauthToken: opts.oauthToken,
@@ -457,13 +204,10 @@ Examples:
     .description("Reply to a tweet")
     .argument("<tweetUrl>", "Tweet URL or tweet ID")
     .argument("<text>", "Reply text")
-    .requiredOption(
-      "--strategy <strategy>",
-      "Operation strategy: oauth or managed",
-    )
+    .option("--managed", "Route through the platform proxy (managed mode)")
     .option(
       "--oauth-token <token>",
-      "OAuth access token (required when mode is oauth)",
+      "OAuth access token (required for OAuth path)",
     )
     .addHelpText(
       "after",
@@ -474,27 +218,22 @@ Arguments:
 
 Posts a reply to the specified tweet. Accepts either a full tweet URL or a bare
 numeric tweet ID. The tweet ID is extracted from the last numeric segment of the
-URL. The --strategy flag controls which path is used.
+URL. By default uses OAuth mode. Pass --managed to route through the platform proxy.
 
 Examples:
-  $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!" --strategy browser
-  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"
-  $ assistant x reply 1234567890 "Nice!" --strategy managed`,
+  $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!"
+  $ assistant x reply 1234567890 "Interesting thread" --oauth-token "$TOKEN"
+  $ assistant x reply 1234567890 "Nice!" --managed`,
     )
     .action(
       async (
         tweetUrl: string,
         text: string,
-        opts: { strategy: string; oauthToken?: string },
+        opts: { managed?: boolean; oauthToken?: string },
         cmd: Command,
       ) => {
         await run(cmd, async () => {
-          const mode = opts.strategy as TwitterMode;
-          if (mode !== "oauth" && mode !== "managed") {
-            throw new Error(
-              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
-            );
-          }
+          const mode: TwitterMode = opts.managed ? "managed" : "oauth";
           // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL
           const idMatch = tweetUrl.match(/(\d+)\s*$/);
           if (!idMatch) {
@@ -523,39 +262,25 @@ Examples:
     .description("Fetch a user's recent tweets")
     .argument("<screenName>", "Twitter screen name (without @)")
     .option("--count <n>", "Number of tweets to fetch", "20")
-    .option(
-      "--strategy <strategy>",
-      "Operation strategy: managed or browser (default: browser)",
-    )
     .addHelpText(
       "after",
       `
 Arguments:
   screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
 
-Fetches a user's recent tweets. Resolves the screen name to a user ID first,
-then retrieves their tweet timeline. The --count flag controls how many tweets
-to return (default: 20). Use --strategy managed to route through the platform proxy.
+Fetches a user's recent tweets via managed mode. Resolves the screen name to a
+user ID first, then retrieves their tweet timeline. The --count flag controls
+how many tweets to return (default: 20).
 
 Examples:
   $ assistant x timeline elonmusk
   $ assistant x timeline vaborsh --count 50
-  $ assistant x timeline openai --count 10 --json
-  $ assistant x timeline elonmusk --strategy managed`,
+  $ assistant x timeline openai --count 10 --json`,
     )
     .action(
-      async (
-        screenName: string,
-        opts: { count: string; strategy?: string },
-        cmd: Command,
-      ) => {
+      async (screenName: string, opts: { count: string }, cmd: Command) => {
         await run(cmd, async () => {
-          const mode = (opts.strategy ?? "managed") as TwitterMode;
-          if (mode !== "oauth" && mode !== "managed") {
-            throw new Error(
-              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
-            );
-          }
+          const mode: TwitterMode = "managed";
           const { result: user, pathUsed } = await routedGetUserByScreenName(
             screenName.replace(/^@/, ""),
             { mode },
@@ -576,10 +301,6 @@ Examples:
   tw.command("tweet")
     .description("Fetch a tweet and its reply thread")
     .argument("<tweetIdOrUrl>", "Tweet ID or URL")
-    .option(
-      "--strategy <strategy>",
-      "Operation strategy: managed or browser (default: browser)",
-    )
     .addHelpText(
       "after",
       `
@@ -587,40 +308,28 @@ Arguments:
   tweetIdOrUrl   A bare tweet ID (e.g. 1234567890) or a full tweet URL
                  (e.g. https://x.com/user/status/1234567890)
 
-Fetches a single tweet and its reply thread. The tweet ID is extracted from the
-last numeric segment of the input. Returns an array of tweets representing the
-conversation thread. Use --strategy managed to route through the platform proxy.
+Fetches a single tweet and its reply thread via managed mode. The tweet ID is
+extracted from the last numeric segment of the input. Returns an array of tweets
+representing the conversation thread.
 
 Examples:
   $ assistant x tweet 1234567890
   $ assistant x tweet https://x.com/elonmusk/status/1234567890
-  $ assistant x tweet https://x.com/openai/status/9876543210 --json
-  $ assistant x tweet 1234567890 --strategy managed`,
+  $ assistant x tweet https://x.com/openai/status/9876543210 --json`,
     )
-    .action(
-      async (
-        tweetIdOrUrl: string,
-        opts: { strategy?: string },
-        cmd: Command,
-      ) => {
-        await run(cmd, async () => {
-          const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
-          if (!idMatch)
-            throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
-          const mode = (opts.strategy ?? "managed") as TwitterMode;
-          if (mode !== "oauth" && mode !== "managed") {
-            throw new Error(
-              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
-            );
-          }
-          const { result: tweets, pathUsed } = await routedGetTweetDetail(
-            idMatch[1],
-            { mode },
-          );
-          return { tweets, pathUsed };
-        });
-      },
-    );
+    .action(async (tweetIdOrUrl: string, _opts: unknown, cmd: Command) => {
+      await run(cmd, async () => {
+        const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
+        if (!idMatch)
+          throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
+        const mode: TwitterMode = "managed";
+        const { result: tweets, pathUsed } = await routedGetTweetDetail(
+          idMatch[1],
+          { mode },
+        );
+        return { tweets, pathUsed };
+      });
+    });
 
   // =========================================================================
   // search — search tweets
@@ -629,10 +338,6 @@ Examples:
     .description("Search tweets")
     .argument("<query>", "Search query")
     .option("--product <type>", "Top, Latest, People, or Media", "Top")
-    .option(
-      "--strategy <strategy>",
-      "Operation strategy: managed or browser (default: browser)",
-    )
     .addHelpText(
       "after",
       `
@@ -646,248 +351,23 @@ The --product flag selects the search result type:
   People   — user accounts matching the query
   Media    — tweets containing images or video
 
-Use --strategy managed to route through the platform proxy (uses Twitter's
-recent search API).
-
 Examples:
   $ assistant x search "AI agents"
   $ assistant x search "from:elonmusk SpaceX" --product Latest
-  $ assistant x search "machine learning" --product Media --json
-  $ assistant x search "AI agents" --strategy managed`,
+  $ assistant x search "machine learning" --product Media --json`,
     )
-    .action(
-      async (
-        query: string,
-        opts: { product: string; strategy?: string },
-        cmd: Command,
-      ) => {
-        await run(cmd, async () => {
-          const mode = (opts.strategy ?? "managed") as TwitterMode;
-          if (mode !== "oauth" && mode !== "managed") {
-            throw new Error(
-              `Invalid mode "${opts.strategy}". Must be oauth or managed.`,
-            );
-          }
-          const product = opts.product as "Top" | "Latest" | "People" | "Media";
-          const { result: tweets, pathUsed } = await routedSearchTweets(
-            query,
-            product,
-            { mode },
-          );
-          return { query, tweets, pathUsed };
-        });
-      },
-    );
-
-  // =========================================================================
-  // bookmarks — fetch bookmarks
-  // =========================================================================
-  tw.command("bookmarks")
-    .description("Fetch your bookmarks")
-    .option("--count <n>", "Number of bookmarks", "20")
-    .addHelpText(
-      "after",
-      `
-Fetches the authenticated user's bookmarked tweets via the browser session.
-The --count flag controls how many bookmarks to return (default: 20).
-
-Requires an active browser session. Bookmarks are private and only available
-for the logged-in account.
-
-Examples:
-  $ assistant x bookmarks
-  $ assistant x bookmarks --count 50
-  $ assistant x bookmarks --json`,
-    )
-    .action(async (opts: { count: string }, cmd: Command) => {
+    .action(async (query: string, opts: { product: string }, cmd: Command) => {
       await run(cmd, async () => {
-        const tweets = await getBookmarks(parseInt(opts.count, 10));
-        return { tweets };
+        const mode: TwitterMode = "managed";
+        const product = opts.product as "Top" | "Latest" | "People" | "Media";
+        const { result: tweets, pathUsed } = await routedSearchTweets(
+          query,
+          product,
+          { mode },
+        );
+        return { query, tweets, pathUsed };
       });
     });
-
-  // =========================================================================
-  // home — fetch home timeline
-  // =========================================================================
-  tw.command("home")
-    .description("Fetch your home timeline")
-    .option("--count <n>", "Number of tweets", "20")
-    .addHelpText(
-      "after",
-      `
-Fetches the authenticated user's home timeline (the "For You" feed) via the
-browser session. The --count flag controls how many tweets to return (default: 20).
-
-Requires an active browser session.
-
-Examples:
-  $ assistant x home
-  $ assistant x home --count 50
-  $ assistant x home --json`,
-    )
-    .action(async (opts: { count: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const tweets = await getHomeTimeline(parseInt(opts.count, 10));
-        return { tweets };
-      });
-    });
-
-  // =========================================================================
-  // notifications — fetch notifications
-  // =========================================================================
-  tw.command("notifications")
-    .description("Fetch your notifications")
-    .option("--count <n>", "Number of notifications", "20")
-    .addHelpText(
-      "after",
-      `
-Fetches the authenticated user's Twitter notifications (mentions, likes,
-retweets, follows, etc.) via the browser session. The --count flag controls
-how many notifications to return (default: 20).
-
-Requires an active browser session.
-
-Examples:
-  $ assistant x notifications
-  $ assistant x notifications --count 50
-  $ assistant x notifications --json`,
-    )
-    .action(async (opts: { count: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const notifications = await getNotifications(parseInt(opts.count, 10));
-        return { notifications };
-      });
-    });
-
-  // =========================================================================
-  // likes — fetch a user's liked tweets
-  // =========================================================================
-  tw.command("likes")
-    .description("Fetch a user's liked tweets")
-    .argument("<screenName>", "Twitter screen name (without @)")
-    .option("--count <n>", "Number of likes", "20")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
-
-Fetches tweets liked by the specified user via the browser session. Resolves the
-screen name to a user ID first. The --count flag controls how many liked tweets
-to return (default: 20).
-
-Examples:
-  $ assistant x likes elonmusk
-  $ assistant x likes vaborsh --count 50
-  $ assistant x likes openai --json`,
-    )
-    .action(
-      async (screenName: string, opts: { count: string }, cmd: Command) => {
-        await run(cmd, async () => {
-          const user = await getUserByScreenName(screenName.replace(/^@/, ""));
-          const tweets = await getLikes(user.userId, parseInt(opts.count, 10));
-          return { user, tweets };
-        });
-      },
-    );
-
-  // =========================================================================
-  // followers — fetch a user's followers
-  // =========================================================================
-  tw.command("followers")
-    .description("Fetch a user's followers")
-    .argument("<screenName>", "Twitter screen name (without @)")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
-
-Fetches the list of accounts following the specified user via the browser session.
-Resolves the screen name to a user ID first.
-
-Examples:
-  $ assistant x followers elonmusk
-  $ assistant x followers vaborsh --json`,
-    )
-    .action(async (screenName: string, _opts: unknown, cmd: Command) => {
-      await run(cmd, async () => {
-        const cleanName = screenName.replace(/^@/, "");
-        const user = await getUserByScreenName(cleanName);
-        const followers = await getFollowers(user.userId, cleanName);
-        return { user, followers };
-      });
-    });
-
-  // =========================================================================
-  // following — fetch who a user follows
-  // =========================================================================
-  tw.command("following")
-    .description("Fetch who a user follows")
-    .argument("<screenName>", "Twitter screen name (without @)")
-    .option("--count <n>", "Number of following", "20")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
-
-Fetches the list of accounts the specified user follows via the browser session.
-Resolves the screen name to a user ID first. The --count flag controls how many
-results to return (default: 20).
-
-Examples:
-  $ assistant x following elonmusk
-  $ assistant x following vaborsh --count 100
-  $ assistant x following openai --json`,
-    )
-    .action(
-      async (screenName: string, opts: { count: string }, cmd: Command) => {
-        await run(cmd, async () => {
-          const user = await getUserByScreenName(screenName.replace(/^@/, ""));
-          const following = await getFollowing(
-            user.userId,
-            parseInt(opts.count, 10),
-          );
-          return { user, following };
-        });
-      },
-    );
-
-  // =========================================================================
-  // media — fetch a user's media tweets
-  // =========================================================================
-  tw.command("media")
-    .description("Fetch a user's media tweets")
-    .argument("<screenName>", "Twitter screen name (without @)")
-    .option("--count <n>", "Number of media tweets", "20")
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
-
-Fetches tweets containing images or video from the specified user via the browser
-session. Resolves the screen name to a user ID first. The --count flag controls
-how many media tweets to return (default: 20).
-
-Examples:
-  $ assistant x media elonmusk
-  $ assistant x media nasa --count 50
-  $ assistant x media openai --json`,
-    )
-    .action(
-      async (screenName: string, opts: { count: string }, cmd: Command) => {
-        await run(cmd, async () => {
-          const user = await getUserByScreenName(screenName.replace(/^@/, ""));
-          const tweets = await getUserMedia(
-            user.userId,
-            parseInt(opts.count, 10),
-          );
-          return { user, tweets };
-        });
-      },
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -897,16 +377,13 @@ Examples:
 /**
  * Send a Twitter integration config request to the daemon via HTTP.
  *
- * Maps the old IPC `twitter_integration_config` message actions to HTTP
- * endpoints on the settings routes:
- *   - "get" / "get_strategy" → GET /v1/integrations/twitter/auth/status
- *   - "set_strategy"         → PUT /v1/settings/client (key=twitter.strategy)
+ * Maps the "get" action to HTTP:
+ *   - "get" → GET /v1/integrations/twitter/auth/status
  */
 async function sendTwitterConfigRequest(
   action: string,
-  extra?: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  if (action === "get" || action === "get_strategy") {
+  if (action === "get") {
     const response = await httpSend("/v1/integrations/twitter/auth/status", {
       method: "GET",
     });
@@ -921,8 +398,6 @@ async function sendTwitterConfigRequest(
       success: true,
       connected: data.connected ?? false,
       accountInfo: data.accountInfo,
-      strategy: data.strategy ?? "auto",
-      strategyConfigured: data.strategyConfigured ?? false,
       mode: data.mode,
       managedAvailable: data.managedAvailable ?? false,
       managedPrerequisites: data.managedPrerequisites,
@@ -930,179 +405,5 @@ async function sendTwitterConfigRequest(
     };
   }
 
-  if (action === "set_strategy") {
-    const strategy = extra?.strategy as string | undefined;
-    if (!strategy) throw new Error("strategy is required for set_strategy");
-    const response = await httpSend("/v1/settings/client", {
-      method: "PUT",
-      body: JSON.stringify({ key: "twitter.strategy", value: strategy }),
-    });
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`Assistant returned an error: ${text}`);
-    }
-    return {
-      type: "twitter_integration_config_response",
-      success: true,
-      strategy,
-    };
-  }
-
   throw new Error(`Unsupported twitter_integration_config action: ${action}`);
-}
-
-// ---------------------------------------------------------------------------
-// Chrome CDP helpers (via `assistant browser chrome` CLI)
-// ---------------------------------------------------------------------------
-
-async function launchChromeCdp(
-  startUrl?: string,
-): Promise<{ baseUrl: string }> {
-  const args = ["browser", "chrome", "launch"];
-  if (startUrl) args.push("--start-url", startUrl);
-  const { stdout } = await execFileAsync("assistant", args);
-  const result = JSON.parse(stdout) as {
-    ok: boolean;
-    baseUrl?: string;
-    error?: string;
-  };
-  if (!result.ok || !result.baseUrl) {
-    throw new Error(result.error ?? "Failed to launch Chrome with CDP");
-  }
-  return { baseUrl: result.baseUrl };
-}
-
-async function minimizeChrome(): Promise<void> {
-  try {
-    await execFileAsync("assistant", ["browser", "chrome", "minimize"]);
-  } catch {
-    // best-effort — same as the original
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Ride Shotgun learn session helper
-// ---------------------------------------------------------------------------
-
-interface LearnResult {
-  recordingId?: string;
-  recordingPath?: string;
-}
-
-async function navigateToX(cdpBase: string): Promise<void> {
-  try {
-    const res = await fetch(`${cdpBase}/json/list`);
-    if (!res.ok) return;
-    const targets = (await res.json()) as Array<{
-      id: string;
-      type: string;
-      url: string;
-    }>;
-    const tab = targets.find((t) => t.type === "page");
-    if (!tab) return;
-    await fetch(
-      `${cdpBase}/json/navigate?url=${encodeURIComponent(
-        "https://x.com/login",
-      )}&id=${tab.id}`,
-      { method: "PUT" },
-    );
-  } catch {
-    // best-effort
-  }
-}
-
-async function startLearnSession(
-  durationSeconds: number,
-): Promise<LearnResult> {
-  const cdpSession = await launchChromeCdp("https://x.com/login");
-  await navigateToX(cdpSession.baseUrl);
-
-  // Start ride shotgun via HTTP
-  const response = await httpSend("/v1/computer-use/ride-shotgun/start", {
-    method: "POST",
-    body: JSON.stringify({
-      durationSeconds,
-      intervalSeconds: 5,
-      mode: "learn",
-      targetDomain: "x.com",
-    }),
-  });
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(
-      `Cannot connect to assistant: ${response.status} ${body}. Is the assistant running?`,
-    );
-  }
-
-  const startResult = (await response.json()) as {
-    watchId?: string;
-    sessionId?: string;
-  };
-
-  if (!startResult.watchId) {
-    throw new Error("Ride-shotgun start response missing watchId");
-  }
-
-  // Poll the status endpoint using watchId to correlate completion
-  const { watchId } = startResult;
-  const timeoutMs = (durationSeconds + 30) * 1000;
-  const pollIntervalMs = 2000;
-  const startTime = Date.now();
-
-  return new Promise<LearnResult>((resolve, reject) => {
-    const tick = async () => {
-      if (Date.now() - startTime > timeoutMs) {
-        reject(
-          new Error(`Learn session timed out after ${durationSeconds + 30}s`),
-        );
-        return;
-      }
-
-      try {
-        const statusRes = await httpSend(
-          `/v1/computer-use/ride-shotgun/status/${watchId}`,
-          { method: "GET" },
-        );
-        if (!statusRes.ok) {
-          setTimeout(tick, pollIntervalMs);
-          return;
-        }
-
-        const status = (await statusRes.json()) as {
-          status: string;
-          recordingId?: string;
-          savedRecordingPath?: string;
-          bootstrapFailureReason?: string;
-        };
-
-        if (status.bootstrapFailureReason) {
-          reject(
-            new Error(`Learn session failed: ${status.bootstrapFailureReason}`),
-          );
-          return;
-        }
-
-        if (status.status === "completed") {
-          if (status.recordingId) {
-            resolve({
-              recordingId: status.recordingId,
-              recordingPath: status.savedRecordingPath,
-            });
-          } else {
-            reject(
-              new Error("Learn session completed but no recording was saved."),
-            );
-          }
-          return;
-        }
-      } catch {
-        // Status endpoint not reachable — continue polling
-      }
-
-      setTimeout(tick, pollIntervalMs);
-    };
-
-    setTimeout(tick, pollIntervalMs);
-  });
 }


### PR DESCRIPTION
## Summary
- Remove 11 CLI commands: logout, refresh, bookmarks, home, notifications, likes, followers, following, media, strategy, strategy set
- Replace `--strategy` flag with `--managed` boolean flag on post/reply; read commands always use managed mode
- Remove all browser session, Chrome CDP, Ride Shotgun, and strategy plumbing from the CLI

Part of plan: rm-twitter-browser-auto.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
