### PR TITLE
M2: Integrate ImproveExperienceStepView into onboarding flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -97,7 +97,7 @@ struct APIKeyStepView: View {
             }
         }
 
-        OnboardingFooter(currentStep: state.currentStep, totalSteps: userHostedEnabled ? 3 : 2)
+        OnboardingFooter(currentStep: state.currentStep, totalSteps: userHostedEnabled ? 4 : 3)
             .padding(.bottom, VSpacing.lg)
     }
 
@@ -199,7 +199,7 @@ struct APIKeyStepView: View {
 
     private var primaryButton: some View {
         OnboardingButton(
-            title: userHostedEnabled && hostingMode != .local && hostingMode != .docker ? "Continue" : "Hatch!",
+            title: "Continue",
             style: .primary,
             disabled: primaryButtonDisabled
         ) {
@@ -267,10 +267,10 @@ struct APIKeyStepView: View {
             if userHostedEnabled && hostingMode != .local && hostingMode != .docker {
                 state.advance()
             } else if userHostedEnabled {
-                state.isHatching = true
+                state.advance()
             } else {
                 state.cloudProvider = "local"
-                state.isHatching = true
+                state.advance()
             }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -58,7 +58,7 @@ struct CloudCredentialsStepView: View {
 
             backButton
 
-            OnboardingFooter(currentStep: state.currentStep, totalSteps: 3)
+            OnboardingFooter(currentStep: state.currentStep, totalSteps: 4)
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.bottom, VSpacing.lg)
@@ -429,7 +429,7 @@ struct CloudCredentialsStepView: View {
 
     private var continueButton: some View {
         OnboardingButton(
-            title: isCustomHardware ? "Pair!" : "Hatch!",
+            title: "Continue",
             style: .primary,
             disabled: continueDisabled
         ) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -491,7 +491,7 @@ struct CloudCredentialsStepView: View {
 
     private func saveAndContinue() {
         guard !continueDisabled else { return }
-        state.isHatching = true
+        state.advance()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -92,7 +92,7 @@ struct OnboardingFlowView: View {
                             case 1:
                                 APIKeyStepView(state: state)
                             case 2:
-                                if state.userHostedEnabled {
+                                if state.needsCloudCredentials {
                                     CloudCredentialsStepView(state: state)
                                 } else {
                                     ImproveExperienceStepView(state: state)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -22,7 +22,7 @@ struct OnboardingFlowView: View {
     }()
 
     private var maxOnboardingStep: Int {
-        state.userHostedEnabled ? 2 : 1
+        state.userHostedEnabled ? 3 : 2
     }
 
     var body: some View {
@@ -47,8 +47,8 @@ struct OnboardingFlowView: View {
                     )
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
                 // Trimmed onboarding flow.
-                // When userHostedEnabled: WakeUp → APIKey → CloudCredentials (steps 0–2)
-                // Otherwise: WakeUp → APIKey (steps 0–1)
+                // When userHostedEnabled: WakeUp → APIKey → CloudCredentials → ImproveExperience (steps 0–3)
+                // Otherwise: WakeUp → APIKey → ImproveExperience (steps 0–2)
                 VStack(spacing: 0) {
                     Spacer()
 
@@ -92,7 +92,13 @@ struct OnboardingFlowView: View {
                             case 1:
                                 APIKeyStepView(state: state)
                             case 2:
-                                CloudCredentialsStepView(state: state)
+                                if state.userHostedEnabled {
+                                    CloudCredentialsStepView(state: state)
+                                } else {
+                                    ImproveExperienceStepView(state: state)
+                                }
+                            case 3:
+                                ImproveExperienceStepView(state: state)
                             default:
                                 EmptyView()
                             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -41,6 +41,12 @@ final class OnboardingState {
     var cloudProvider: String = "local"
     var onboardingVariant: OnboardingVariant = .default
 
+    /// Whether the user's hosting choice requires cloud credentials (not local/docker).
+    var needsCloudCredentials: Bool {
+        let userHosted = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
+        return userHosted && cloudProvider != "local" && cloudProvider != "docker"
+    }
+
     /// When false, step changes are not written to UserDefaults (used by auth gate).
     var shouldPersist: Bool = true
 
@@ -136,7 +142,7 @@ final class OnboardingState {
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
         // has 4 steps (0–3); otherwise it stays at 3 steps (0–2).
-        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local"
+        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local" && cloudProvider != "docker"
         let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 3 : 2)
         if currentStep > maxStep {
             currentStep = maxStep

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -27,7 +27,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 8
+    private static let currentFlowVersion = 9
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -135,9 +135,9 @@ final class OnboardingState {
         // conversation entry point (step 2). Prevent stale persisted indices
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
-        // has 3 steps (0–2); otherwise it stays at 2 steps (0–1).
+        // has 4 steps (0–3); otherwise it stays at 3 steps (0–2).
         let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local"
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 2 : 1)
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 3 : 2)
         if currentStep > maxStep {
             currentStep = maxStep
         }


### PR DESCRIPTION
## Summary
- Wire ImproveExperienceStepView into the onboarding flow as the second-to-last step before hatching
- Default path: WakeUp → APIKey → ImproveExperience → Hatching
- User-hosted path: WakeUp → APIKey → CloudCredentials → ImproveExperience → Hatching
- Bump flow version 8→9 to reset stale persisted step indices

## Test plan
- [ ] Verify default onboarding flow shows ImproveExperience step after API key entry
- [ ] Verify user-hosted flow shows ImproveExperience after CloudCredentials
- [ ] Verify "Continue" button on ImproveExperience triggers hatching
- [ ] Verify flow version bump resets stale step indices on app update

Closes #14630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
