### PR TITLE
test(twitter): update tests for strategy-less routing model

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
@@ -76,10 +76,6 @@ mock.module("../../../../twitter/platform-proxy-client.js", () => ({
   TwitterProxyError: MockTwitterProxyError,
 }));
 
-mock.module("../client.js", () => ({
-  // No browser functions needed — router no longer imports them
-}));
-
 mock.module("../oauth-client.js", () => ({
   oauthIsAvailable: () => false,
   oauthPostTweet: async () => {

--- a/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
@@ -53,9 +53,6 @@ mock.module("../../../../twitter/platform-proxy-client.js", () => ({
   TwitterProxyError: MockTwitterProxyError,
 }));
 
-// Mock the browser client — no longer used by router
-mock.module("../client.js", () => ({}));
-
 // Mock the logger to silence output
 mock.module("../../../../util/logger.js", () => ({
   getLogger: () => ({


### PR DESCRIPTION
## Summary
- Update cli-routing, cli-read-routing, and oauth-client tests for strategy-less model
- Remove all browser/auto/strategy test references
- Ensure all tests pass with the new TwitterMode routing

Part of plan: rm-twitter-browser-auto.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
