### PR TITLE
Add 'Improve Experience' onboarding step with performance metrics toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -97,7 +97,7 @@ struct APIKeyStepView: View {
             }
         }
 
-        OnboardingFooter(currentStep: state.currentStep, totalSteps: userHostedEnabled ? 3 : 2)
+        OnboardingFooter(currentStep: state.currentStep, totalSteps: userHostedEnabled ? 4 : 3)
             .padding(.bottom, VSpacing.lg)
     }
 
@@ -197,7 +197,7 @@ struct APIKeyStepView: View {
 
     private var primaryButton: some View {
         OnboardingButton(
-            title: userHostedEnabled && hostingMode != .local && hostingMode != .docker ? "Continue" : "Hatch!",
+            title: "Continue",
             style: .primary,
             disabled: primaryButtonDisabled
         ) {
@@ -261,10 +261,10 @@ struct APIKeyStepView: View {
             if userHostedEnabled && hostingMode != .local && hostingMode != .docker {
                 state.advance()
             } else if userHostedEnabled {
-                state.isHatching = true
+                state.advance()
             } else {
                 state.cloudProvider = "local"
-                state.isHatching = true
+                state.advance()
             }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -58,7 +58,7 @@ struct CloudCredentialsStepView: View {
 
             backButton
 
-            OnboardingFooter(currentStep: state.currentStep, totalSteps: 3)
+            OnboardingFooter(currentStep: state.currentStep, totalSteps: 4)
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.bottom, VSpacing.lg)
@@ -421,7 +421,7 @@ struct CloudCredentialsStepView: View {
 
     private var continueButton: some View {
         OnboardingButton(
-            title: isCustomHardware ? "Pair!" : "Hatch!",
+            title: "Continue",
             style: .primary,
             disabled: continueDisabled
         ) {
@@ -481,7 +481,7 @@ struct CloudCredentialsStepView: View {
 
     private func saveAndContinue() {
         guard !continueDisabled else { return }
-        state.isHatching = true
+        state.advance()
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -72,8 +72,9 @@ struct ImproveExperienceStepView: View {
             }
 
             // Reset stale cloud provider when the user didn't go through CloudCredentials
-            // (e.g., user_hosted_enabled was turned off after a previous session set cloudProvider to "aws")
-            if !state.needsCloudCredentials {
+            // (e.g., user_hosted_enabled was turned off after a previous session set cloudProvider to "aws").
+            // Preserve "docker" since Docker users intentionally chose that path.
+            if !state.needsCloudCredentials && state.cloudProvider != "local" && state.cloudProvider != "docker" {
                 state.cloudProvider = "local"
             }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -10,61 +10,68 @@ struct ImproveExperienceStepView: View {
     @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     var body: some View {
-        VStack(spacing: VSpacing.xxl) {
-            VStack(spacing: VSpacing.md) {
-                Text("Improve Experience")
-                    .font(VFont.onboardingTitle)
-                    .foregroundColor(VColor.textPrimary)
+        Text("Improve Experience")
+            .font(VFont.onboardingTitle)
+            .foregroundColor(VColor.textPrimary)
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+            .padding(.bottom, VSpacing.md)
 
-                Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
-                    .font(VFont.onboardingSubtitle)
-                    .foregroundColor(VColor.textSecondary)
-                    .multilineTextAlignment(.center)
-            }
+        Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
+            .font(VFont.onboardingSubtitle)
+            .foregroundColor(VColor.textSecondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, VSpacing.xxl)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
 
-            VStack(spacing: VSpacing.md) {
-                HStack {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Share performance metrics")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textSecondary)
-                        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    Spacer()
-                    VToggle(isOn: Binding(
-                        get: { sharePerformanceMetrics },
-                        set: { newValue in
-                            sharePerformanceMetrics = newValue
-                            UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
-                        }
-                    ))
-                }
-
-                OnboardingButton(
-                    title: "Continue",
-                    style: .primary
-                ) {
-                    state.isHatching = true
-                }
-
-                Button(action: { goBack() }) {
-                    Text("Back")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .onHover { hovering in
-                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                }
+        HStack {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Share performance metrics")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
             }
-            .opacity(showContent ? 1 : 0)
-            .offset(y: showContent ? 0 : 12)
+            Spacer()
+            VToggle(isOn: Binding(
+                get: { sharePerformanceMetrics },
+                set: { newValue in
+                    sharePerformanceMetrics = newValue
+                    UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                }
+            ))
         }
         .padding(.horizontal, VSpacing.xxl)
+        .padding(.top, VSpacing.xl)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
+
+        Spacer()
+
+        VStack(spacing: VSpacing.md) {
+            OnboardingButton(
+                title: "Continue",
+                style: .primary
+            ) {
+                state.isHatching = true
+            }
+
+            Button(action: { goBack() }) {
+                Text("Back")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .padding(.bottom, VSpacing.lg)
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
         .onAppear {
             // Opt in by default during onboarding, but preserve any existing choice
             if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
@@ -85,6 +92,9 @@ struct ImproveExperienceStepView: View {
                 showContent = true
             }
         }
+
+        OnboardingFooter(currentStep: state.currentStep, totalSteps: state.needsCloudCredentials ? 4 : 3)
+            .padding(.bottom, VSpacing.lg)
     }
 
     private func goBack() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -1,0 +1,100 @@
+import VellumAssistantShared
+import SwiftUI
+
+@MainActor
+struct ImproveExperienceStepView: View {
+    @Bindable var state: OnboardingState
+
+    @State private var showTitle = false
+    @State private var showContent = false
+    @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxl) {
+            VStack(spacing: VSpacing.md) {
+                Text("Improve Experience")
+                    .font(VFont.onboardingTitle)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
+                    .font(VFont.onboardingSubtitle)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .opacity(showTitle ? 1 : 0)
+            .offset(y: showTitle ? 0 : 8)
+
+            VStack(spacing: VSpacing.md) {
+                HStack {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Share performance metrics")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textSecondary)
+                        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textMuted)
+                    }
+                    Spacer()
+                    VToggle(isOn: Binding(
+                        get: { sharePerformanceMetrics },
+                        set: { newValue in
+                            sharePerformanceMetrics = newValue
+                            UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                        }
+                    ))
+                }
+
+                OnboardingButton(
+                    title: "Continue",
+                    style: .primary
+                ) {
+                    state.isHatching = true
+                }
+
+                Button(action: { goBack() }) {
+                    Text("Back")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .onHover { hovering in
+                    if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+            }
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
+        }
+        .padding(.horizontal, VSpacing.xxl)
+        .onAppear {
+            // Opt in by default during onboarding, but preserve any existing choice
+            if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
+                UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+            }
+
+            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                showTitle = true
+            }
+            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+                showContent = true
+            }
+        }
+    }
+
+    private func goBack() {
+        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+            state.currentStep -= 1
+        }
+    }
+}
+
+#Preview("ImproveExperienceStepView") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ImproveExperienceStepView(state: {
+            let s = OnboardingState()
+            s.currentStep = 1
+            return s
+        }())
+    }
+    .frame(width: 520, height: 500)
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -64,9 +64,7 @@ struct ImproveExperienceStepView: View {
                     .foregroundColor(VColor.textMuted)
             }
             .buttonStyle(.plain)
-            .onHover { hovering in
-                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            .pointerCursor()
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.bottom, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -71,6 +71,12 @@ struct ImproveExperienceStepView: View {
                 UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
             }
 
+            // Reset stale cloud provider when the user didn't go through CloudCredentials
+            // (e.g., user_hosted_enabled was turned off after a previous session set cloudProvider to "aws")
+            if !state.needsCloudCredentials {
+                state.cloudProvider = "local"
+            }
+
             withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
                 showTitle = true
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,7 +23,7 @@ struct OnboardingFlowView: View {
     }()
 
     private var maxOnboardingStep: Int {
-        state.userHostedEnabled ? 2 : 1
+        state.userHostedEnabled ? 3 : 2
     }
 
     var body: some View {
@@ -48,8 +48,8 @@ struct OnboardingFlowView: View {
                     )
             } else if (0...maxOnboardingStep).contains(state.currentStep) {
                 // Trimmed onboarding flow.
-                // When userHostedEnabled: WakeUp → APIKey → CloudCredentials (steps 0–2)
-                // Otherwise: WakeUp → APIKey (steps 0–1)
+                // When userHostedEnabled: WakeUp → APIKey → CloudCredentials → ImproveExperience (steps 0–3)
+                // Otherwise: WakeUp → APIKey → ImproveExperience (steps 0–2)
                 VStack(spacing: 0) {
                     Spacer()
 
@@ -91,7 +91,13 @@ struct OnboardingFlowView: View {
                             case 1:
                                 APIKeyStepView(state: state)
                             case 2:
-                                CloudCredentialsStepView(state: state)
+                                if state.needsCloudCredentials {
+                                    CloudCredentialsStepView(state: state)
+                                } else {
+                                    ImproveExperienceStepView(state: state)
+                                }
+                            case 3:
+                                ImproveExperienceStepView(state: state)
                             default:
                                 EmptyView()
                             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -27,7 +27,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 8
+    private static let currentFlowVersion = 9
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -40,6 +40,12 @@ final class OnboardingState {
     var interviewCompleted: Bool = false
     var cloudProvider: String = "local"
     var onboardingVariant: OnboardingVariant = .default
+
+    /// Whether the user's hosting choice requires cloud credentials (not local/docker).
+    var needsCloudCredentials: Bool {
+        let userHosted = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
+        return userHosted && cloudProvider != "local" && cloudProvider != "docker"
+    }
 
     /// When false, step changes are not written to UserDefaults (used by auth gate).
     var shouldPersist: Bool = true
@@ -135,9 +141,9 @@ final class OnboardingState {
         // conversation entry point (step 2). Prevent stale persisted indices
         // from reopening legacy permission-request steps.
         // When userHostedEnabled is on and a cloud provider is selected, the flow
-        // has 3 steps (0–2); otherwise it stays at 2 steps (0–1).
-        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local"
-        let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 2 : 1)
+        // has 4 steps (0–3); otherwise it stays at 3 steps (0–2).
+        let hasCloudStep = MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled") && cloudProvider != "local" && cloudProvider != "docker"
+        let maxStep = onboardingVariant == .firstMeeting ? 4 : (hasCloudStep ? 3 : 2)
         if currentStep > maxStep {
             currentStep = maxStep
         }


### PR DESCRIPTION
## Summary
- Adds a new "Improve Experience" onboarding step with an opt-in toggle for sharing performance metrics
- The step is always the second-to-last step (right before hatching), regardless of hosting mode
- Default path: WakeUp → APIKey → ImproveExperience → Hatching (steps 0-2)
- User-hosted cloud path: WakeUp → APIKey → CloudCredentials → ImproveExperience → Hatching (steps 0-3)
- User-hosted local/docker path: same as default (skips CloudCredentials)

## Changes
- Created `ImproveExperienceStepView.swift` with title, subtitle, metrics toggle, continue/back buttons
- Modified `OnboardingFlowView.swift` to route ImproveExperience as the second-to-last step
- Modified `OnboardingState.swift` to add `needsCloudCredentials` computed property and update step counts
- Modified `APIKeyStepView.swift` to change button label to "Continue" and update footer totalSteps
- Modified `CloudCredentialsStepView.swift` to advance to next step instead of hatching directly, updated button label and footer

## Milestone PRs (merged into feature branch)
- #14631: M1 - Create ImproveExperienceStepView
- #14637: M2 - Integrate ImproveExperienceStepView into onboarding flow

## Project issue
Closes #14628

## Test plan
- [ ] Complete onboarding in default mode — verify ImproveExperience step appears before hatching
- [ ] Toggle metrics off, verify it persists via UserDefaults key `sendPerformanceReports`
- [ ] With `user_hosted_enabled` flag on, select AWS/GCP — verify flow: APIKey → CloudCredentials → ImproveExperience → Hatching
- [ ] With `user_hosted_enabled` flag on, select local/docker — verify flow: APIKey → ImproveExperience → Hatching (no CloudCredentials)
- [ ] Verify back button works on ImproveExperience step
- [ ] Verify OnboardingFooter shows correct step count in all paths

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
