### PR TITLE
M1: Attach crash report files as Sentry attachments in Send Report flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct CrashReportView: View {
     let crashURL: URL
     let crashLog: String
+    let companionFiles: [URL]
     let onDismiss: () -> Void
 
     @State private var isSending = false
@@ -96,20 +97,33 @@ struct CrashReportView: View {
         let crashFileName = crashURL.lastPathComponent
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let urlCopy = crashURL
+        let companions = companionFiles
 
         Task.detached {
             let event = Event(level: .fatal)
             event.message = SentryMessage(formatted: "Crash report: \(crashFileName)")
             event.tags = ["source": "crash_log", "app_version": appVersion]
             // Truncate to ~8 KB to stay within Sentry's event size limits.
+            // Kept as a fallback for quick viewing in Sentry.
             let truncated = logContent.count > 8_192
                 ? String(logContent.prefix(8_192)) + "\n[truncated]"
                 : logContent
             event.extra = ["crash_log": truncated, "crash_file": crashFileName]
 
+            // Attach the full crash log file and any companion files (e.g. spindump
+            // .tar.gz archives) so they are available in Sentry for download.
+            var attachments: [Attachment] = [
+                Attachment(path: urlCopy.path, filename: urlCopy.lastPathComponent),
+            ]
+            for companion in companions {
+                attachments.append(
+                    Attachment(path: companion.path, filename: companion.lastPathComponent)
+                )
+            }
+
             // Await completion so UI confirms delivery only after flush finishes.
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                MetricKitManager.sendManualReport(event) {
+                MetricKitManager.sendManualReport(event, attachments: attachments) {
                     continuation.resume()
                 }
             }
@@ -135,7 +149,7 @@ extension AppDelegate {
     /// Opens a crash report window if a crash log from the previous session exists.
     /// Call early in `applicationDidFinishLaunching`, before `recordLaunch()`.
     func checkForPreviousCrash() {
-        guard let (url, content) = CrashReporter.pendingCrashLog() else {
+        guard let (url, content, companionFiles) = CrashReporter.pendingCrashLog() else {
             CrashReporter.recordLaunch()
             return
         }
@@ -143,10 +157,10 @@ extension AppDelegate {
         // Record now so a second launch doesn't surface the same crash again
         // even if the user force-quits before dismissing the sheet.
         CrashReporter.recordLaunch()
-        showCrashReportWindow(url: url, content: content)
+        showCrashReportWindow(url: url, content: content, companionFiles: companionFiles)
     }
 
-    func showCrashReportWindow(url: URL, content: String) {
+    func showCrashReportWindow(url: URL, content: String, companionFiles: [URL] = []) {
         let dismiss: () -> Void = { [weak self] in
             self?.dismissCrashReportWindow()
         }
@@ -154,6 +168,7 @@ extension AppDelegate {
         let view = CrashReportView(
             crashURL: url,
             crashLog: content,
+            companionFiles: companionFiles,
             onDismiss: dismiss
         )
 
@@ -227,6 +242,7 @@ extension AppDelegate {
         0   vellum-assistant    0x0000000100abc123 main + 0
         1   dyld                0x00007fff6bc123ab start + 1
         """,
+        companionFiles: [],
         onDismiss: {}
     )
 }

--- a/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
@@ -13,7 +13,9 @@ enum CrashReporter {
     }
 
     /// Returns the most recent unseen crash log from the previous session, or nil.
-    static func pendingCrashLog() -> (url: URL, content: String)? {
+    /// Also returns companion file URLs (e.g. `.tar.gz`, `.diag`) that macOS may
+    /// generate alongside the crash log with matching base name prefixes.
+    static func pendingCrashLog() -> (url: URL, content: String, companionFiles: [URL])? {
         let diagURL = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Logs/DiagnosticReports")
         guard let items = try? FileManager.default.contentsOfDirectory(
@@ -61,7 +63,17 @@ enum CrashReporter {
               let content = try? String(contentsOf: mostRecent, encoding: .utf8)
         else { return nil }
 
-        return (url: mostRecent, content: content)
+        // Look for companion files that macOS generates alongside crash logs
+        // (e.g. .tar.gz spindump archives, .diag files) by matching the base
+        // name prefix before the extension.
+        let crashBaseName = mostRecent.deletingPathExtension().lastPathComponent
+        let companionFiles = items.filter { url in
+            let name = url.lastPathComponent
+            guard name != mostRecent.lastPathComponent else { return false }
+            return name.hasPrefix(crashBaseName)
+        }
+
+        return (url: mostRecent, content: content, companionFiles: companionFiles)
     }
 
     /// Marks a crash log as seen so it is not surfaced again on future launches.

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -90,9 +90,14 @@ import os
                 }
             }
 
+            // Always flush when attachments are present so large files are
+            // delivered before the user quits the app. When Sentry was temporarily
+            // started (user opted out), also close it afterward.
             if wasDisabled {
                 SentrySDK.flush(timeout: 5)
                 SentrySDK.close()
+            } else if !attachments.isEmpty {
+                SentrySDK.flush(timeout: 5)
             }
             completion?()
         }

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -56,6 +56,7 @@ import os
     /// `nonisolated` so the Settings sheet can call it from a detached Task.
     nonisolated static func sendManualReport(
         _ event: Event,
+        attachments: [Attachment] = [],
         completion: (@Sendable () -> Void)? = nil
     ) {
         sentrySerialQueue.async {
@@ -70,7 +71,25 @@ import os
                     options.enableAutoSessionTracking = false
                 }
             }
+
+            // Attach files to the scope before capturing the event.
+            if !attachments.isEmpty {
+                SentrySDK.configureScope { scope in
+                    for attachment in attachments {
+                        scope.addAttachment(attachment)
+                    }
+                }
+            }
+
             SentrySDK.capture(event: event)
+
+            // Clean up attachments so they don't leak into subsequent events.
+            if !attachments.isEmpty {
+                SentrySDK.configureScope { scope in
+                    scope.clearAttachments()
+                }
+            }
+
             if wasDisabled {
                 SentrySDK.flush(timeout: 5)
                 SentrySDK.close()

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -91,13 +91,17 @@ import os
             }
 
             // Always flush when attachments are present so large files are
-            // delivered before the user quits the app. When Sentry was temporarily
-            // started (user opted out), also close it afterward.
+            // delivered before the user quits the app. Use a longer timeout
+            // when attachments are present since companion archives (e.g.
+            // spindump .tar.gz) can be several MB on slow connections.
+            // When Sentry was temporarily started (user opted out), also
+            // close it afterward.
+            let flushTimeout: TimeInterval = attachments.isEmpty ? 5 : 15
             if wasDisabled {
-                SentrySDK.flush(timeout: 5)
+                SentrySDK.flush(timeout: flushTimeout)
                 SentrySDK.close()
             } else if !attachments.isEmpty {
-                SentrySDK.flush(timeout: 5)
+                SentrySDK.flush(timeout: flushTimeout)
             }
             completion?()
         }


### PR DESCRIPTION
## Summary
- Update CrashReporter to find companion files (.tar.gz, .diag) alongside crash logs
- Use Sentry Attachment API to attach full crash files when sending reports
- Update MetricKitManager.sendManualReport to support attachments
- Pass companion files through CrashReportView

Closes #14642
Part of #14641
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
