### PR TITLE
fix: restore pathUsed metadata in Twitter CLI error output

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -47,7 +47,7 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
     output({ ok: true, ...(result as Record<string, unknown>) }, getJson(cmd));
   } catch (err) {
     const meta = err as Record<string, unknown>;
-    // For routed errors with managed-path metadata, emit structured JSON
+    // For routed errors with proxy error codes, emit structured JSON
     if (err instanceof Error && meta.proxyErrorCode !== undefined) {
       const payload: Record<string, unknown> = {
         ok: false,
@@ -55,7 +55,19 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       };
       payload.proxyErrorCode = meta.proxyErrorCode;
       if (meta.retryable !== undefined) payload.retryable = meta.retryable;
+      if (meta.pathUsed !== undefined) payload.pathUsed = meta.pathUsed;
       output(payload, getJson(cmd));
+      process.exitCode = 1;
+      return;
+    }
+    // For routed errors with pathUsed but no proxy error code (e.g. OAuth
+    // not configured, user not found, unsupported product type), preserve
+    // the pathUsed metadata in structured output.
+    if (err instanceof Error && meta.pathUsed !== undefined) {
+      output(
+        { ok: false, error: err.message, pathUsed: meta.pathUsed },
+        getJson(cmd),
+      );
       process.exitCode = 1;
       return;
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-twitter-browser-auto.md.

**Gap:** run() error handler drops pathUsed metadata from non-proxy errors
**What was expected:** Errors with pathUsed metadata should include it in structured JSON output
**What was found:** Only errors with proxyErrorCode get structured output; non-proxy errors with pathUsed fall through to generic error handler

**Fix:** Added pathUsed to proxy error branch output, and added a second branch for non-proxy errors that have pathUsed metadata (e.g. OAuth not configured, user not found, unsupported product type). These now emit structured JSON with pathUsed instead of losing it.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
