### PR TITLE
fix(http): route Twitter config status to correct HTTP endpoint

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -182,7 +182,11 @@ extension HTTPTransport {
                 return true
             }
             if let msg = message as? TwitterIntegrationConfigRequestMessage {
-                Task { await self.sendEncodablePost(.integrationsTwitterAuthStart, body: msg, label: "twitter_integration_config") }
+                if msg.action == "get" {
+                    Task { await self.fetchTwitterAuthStatus() }
+                } else {
+                    Task { await self.sendEncodablePost(.integrationsTwitterAuthStart, body: msg, label: "twitter_integration_config") }
+                }
                 return true
             }
 
@@ -234,6 +238,43 @@ extension HTTPTransport {
             }
 
             return false
+        }
+    }
+
+    // MARK: - Twitter Auth Status
+
+    /// Fetch Twitter auth status via GET and route the response through the message router.
+    func fetchTwitterAuthStatus() async {
+        guard let url = buildURL(for: .integrationsTwitterAuthStatus) else {
+            log.error("Failed to build URL for twitter_auth_status")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                log.error("twitter_auth_status failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+                return
+            }
+
+            // Wrap the HTTP response with the IPC envelope fields the router expects.
+            guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                log.error("twitter_auth_status: unexpected response shape")
+                return
+            }
+            json["type"] = "twitter_integration_config_response"
+            json["success"] = true
+
+            let wrappedData = try JSONSerialization.data(withJSONObject: json)
+            let message = try JSONDecoder().decode(TwitterIntegrationConfigResponseMessage.self, from: wrappedData)
+            self.onMessage?(.twitterIntegrationConfigResponse(message))
+        } catch {
+            log.error("twitter_auth_status error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixed `TwitterIntegrationConfigRequestMessage` with `action: "get"` being sent to `POST /v1/integrations/twitter/auth/start` (OAuth flow start) instead of `GET /v1/integrations/twitter/auth/status`
- The generic `sendEncodablePost` helper discarded response bodies, so the status never reached the UI — causing "Managed Twitter status is unavailable." permanently
- Added `fetchTwitterAuthStatus()` that sends a GET to the correct endpoint, wraps the response with IPC envelope fields (`type`, `success`), and routes it through `onMessage` to the `SettingsStore` callback

## Test plan
- [x] Verified `GET /v1/integrations/twitter/auth/status` returns correct prerequisites
- [x] Verified the Connect button enables when all managed prerequisites are met
- [ ] Verify switching between Local (BYO App) and Managed modes updates the UI correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
