### PR TITLE
fix: remove dead oauthSupportsOperation code

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/oauth-client.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/oauth-client.test.ts
@@ -19,12 +19,7 @@ mock.module("../../../../util/logger.js", () => ({
   }),
 }));
 
-import {
-  oauthIsAvailable,
-  oauthPostTweet,
-  oauthSupportsOperation,
-  UnsupportedOAuthOperationError,
-} from "../oauth-client.js";
+import { oauthIsAvailable, oauthPostTweet } from "../oauth-client.js";
 
 // --- Global fetch mock ---
 
@@ -151,46 +146,6 @@ describe("Twitter OAuth client", () => {
 
     test("returns false when token is empty string", () => {
       expect(oauthIsAvailable("")).toBe(false);
-    });
-  });
-
-  describe("oauthSupportsOperation", () => {
-    test("returns true for post", () => {
-      expect(oauthSupportsOperation("post")).toBe(true);
-    });
-
-    test("returns true for reply", () => {
-      expect(oauthSupportsOperation("reply")).toBe(true);
-    });
-
-    test("returns false for unsupported operations", () => {
-      const unsupported = [
-        "timeline",
-        "search",
-        "bookmarks",
-        "home",
-        "notifications",
-        "likes",
-        "followers",
-        "following",
-        "media",
-        "tweet",
-      ];
-      for (const op of unsupported) {
-        expect(oauthSupportsOperation(op)).toBe(false);
-      }
-    });
-  });
-
-  describe("UnsupportedOAuthOperationError", () => {
-    test("has correct properties", () => {
-      const err = new UnsupportedOAuthOperationError("search");
-      expect(err.name).toBe("UnsupportedOAuthOperationError");
-      expect(err.operation).toBe("search");
-      expect(err.message).toContain("search");
-      expect(err.message).toContain("not available via the OAuth API");
-      expect(err.message).toContain("managed mode");
-      expect(err).toBeInstanceOf(Error);
     });
   });
 });

--- a/assistant/src/cli/commands/twitter/oauth-client.ts
+++ b/assistant/src/cli/commands/twitter/oauth-client.ts
@@ -2,35 +2,15 @@
  * OAuth-backed Twitter API client.
  *
  * Accepts an OAuth2 Bearer token as a parameter and uses it to execute
- * Twitter API v2 operations directly. Currently supports post and reply;
- * all other operations require managed mode.
+ * Twitter API v2 operations directly (post and reply).
  */
 
 const TWITTER_API_BASE = "https://api.x.com/2";
-
-/** Operations that the OAuth client can handle natively. */
-const SUPPORTED_OPERATIONS = new Set(["post", "reply"]);
 
 export interface OAuthPostResult {
   tweetId: string;
   text: string;
   url?: string;
-}
-
-export interface OAuthOperationError {
-  message: string;
-  operation: string;
-}
-
-export class UnsupportedOAuthOperationError extends Error {
-  public readonly operation: string;
-  constructor(operation: string) {
-    super(
-      `The "${operation}" operation is not available via the OAuth API. Use managed mode instead.`,
-    );
-    this.name = "UnsupportedOAuthOperationError";
-    this.operation = operation;
-  }
 }
 
 /**
@@ -77,13 +57,4 @@ export async function oauthPostTweet(
  */
 export function oauthIsAvailable(oauthToken: string | undefined): boolean {
   return oauthToken != null && oauthToken.length > 0;
-}
-
-/**
- * Check whether a given operation is supported via the OAuth API path.
- * Only `post` and `reply` are currently supported; everything else
- * (timeline, search, bookmarks, etc.) requires managed mode.
- */
-export function oauthSupportsOperation(operation: string): boolean {
-  return SUPPORTED_OPERATIONS.has(operation);
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-twitter-browser-auto.md.

**Gap:** oauthSupportsOperation is dead code — exported and tested but never called in production
**What was expected:** Dead code from strategy removal should be cleaned up
**What was found:** oauthSupportsOperation, SUPPORTED_OPERATIONS, and OAuthOperationError still exist but are never called

Removed from `oauth-client.ts`:
- `SUPPORTED_OPERATIONS` constant
- `OAuthOperationError` interface
- `UnsupportedOAuthOperationError` class
- `oauthSupportsOperation` function

Removed from `oauth-client.test.ts`:
- `oauthSupportsOperation` test suite
- `UnsupportedOAuthOperationError` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
