### PR TITLE
fix: match Local Gateway Target input style to Gateway URL input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -32,16 +32,18 @@ struct GatewaySettingsCard: View {
 
             HStack(spacing: VSpacing.sm) {
                 Text(store.localGatewayTarget)
-                    .font(VFont.mono)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                     .textSelection(.enabled)
-                    .padding(VSpacing.md)
+                    .padding(.horizontal, VSpacing.md)
+                    .padding(.vertical, VSpacing.xs)
+                    .frame(height: 28, alignment: .leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(VColor.surface.opacity(0.5))
+                    .background(VColor.inputBackground)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.3), lineWidth: 1)
+                            .stroke(VColor.surfaceBorder, lineWidth: 1)
                     )
 
                 Button {


### PR DESCRIPTION
## Summary
- Match the Local Gateway Target read-only text field to the same height (28pt), font (VFont.body), padding, background (VColor.inputBackground), and border style as the Gateway URL text field which uses `.vInputStyle()`

## Original prompt
make Local Gateway Target Input same height (size) and use same font as Gateway URL Input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
