### PR TITLE
Attach crash report files when sending reports or diagnostics

### DIFF
--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -11,6 +11,7 @@ import {
   createWriteStream,
   mkdirSync,
   readdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -404,13 +405,22 @@ async function handleDiagnosticsExport(body: {
         archive.pipe(output);
         archive.directory(tempDir, false);
 
-        // Add recent crash report files under crash-reports/
+        // Add recent crash report files under crash-reports/.
+        // Text-based crash files (.crash, .ips, .diag) are redacted using the
+        // same patterns as conversation data. Binary archives (.tar.gz) are
+        // added as-is since they can't be meaningfully text-redacted.
         const crashReportFiles = findRecentCrashReports();
         for (const filePath of crashReportFiles) {
           try {
-            archive.file(filePath, {
-              name: "crash-reports/" + basename(filePath),
-            });
+            const fileName = basename(filePath);
+            if (fileName.toLowerCase().endsWith(CRASH_REPORT_TAR_GZ)) {
+              archive.file(filePath, { name: "crash-reports/" + fileName });
+            } else {
+              const content = readFileSync(filePath, "utf-8");
+              archive.append(redact(content), {
+                name: "crash-reports/" + fileName,
+              });
+            }
           } catch {
             // Skip files that can't be read
           }

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -7,9 +7,16 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { createWriteStream, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  createWriteStream,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import archiver from "archiver";
 import { and, desc, eq, gte, lte } from "drizzle-orm";
@@ -102,6 +109,58 @@ function redactDeep(value: unknown): unknown {
     return out;
   }
   return value;
+}
+
+// ---------------------------------------------------------------------------
+// Crash report discovery
+// ---------------------------------------------------------------------------
+
+const CRASH_REPORT_EXTENSIONS = new Set([".crash", ".ips", ".diag"]);
+const CRASH_REPORT_TAR_GZ = ".tar.gz";
+const CRASH_REPORT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function findRecentCrashReports(): string[] {
+  const diagnosticReportsDir = join(
+    homedir(),
+    "Library",
+    "Logs",
+    "DiagnosticReports",
+  );
+
+  try {
+    const entries = readdirSync(diagnosticReportsDir);
+    const now = Date.now();
+    const results: string[] = [];
+
+    for (const entry of entries) {
+      // Case-insensitive prefix match for "vellum-assistant"
+      if (!entry.toLowerCase().startsWith("vellum-assistant")) continue;
+
+      // Check extension
+      const lowerEntry = entry.toLowerCase();
+      const hasValidExt =
+        CRASH_REPORT_EXTENSIONS.has(
+          lowerEntry.slice(lowerEntry.lastIndexOf(".")),
+        ) || lowerEntry.endsWith(CRASH_REPORT_TAR_GZ);
+
+      if (!hasValidExt) continue;
+
+      const filePath = join(diagnosticReportsDir, entry);
+      try {
+        const stat = statSync(filePath);
+        if (!stat.isFile()) continue;
+        if (now - stat.mtimeMs > CRASH_REPORT_MAX_AGE_MS) continue;
+        results.push(filePath);
+      } catch {
+        // Skip files we can't stat
+      }
+    }
+
+    return results;
+  } catch {
+    // Directory doesn't exist or can't be read — not an error
+    return [];
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -344,6 +403,19 @@ async function handleDiagnosticsExport(body: {
 
         archive.pipe(output);
         archive.directory(tempDir, false);
+
+        // Add recent crash report files under crash-reports/
+        const crashReportFiles = findRecentCrashReports();
+        for (const filePath of crashReportFiles) {
+          try {
+            archive.file(filePath, {
+              name: "crash-reports/" + basename(filePath),
+            });
+          } catch {
+            // Skip files that can't be read
+          }
+        }
+
         archive.finalize();
       });
 
@@ -382,9 +454,7 @@ const MAX_WINDOW_TITLE_LENGTH = 100;
 
 function sanitizeWindowTitle(title: string | undefined): string {
   if (!title) return "";
-  return title
-    .replace(/[<>]/g, "")
-    .slice(0, MAX_WINDOW_TITLE_LENGTH);
+  return title.replace(/[<>]/g, "").slice(0, MAX_WINDOW_TITLE_LENGTH);
 }
 
 interface DictationBody {
@@ -469,10 +539,7 @@ function buildCombinedDictationPrompt(
   return sections.join("\n");
 }
 
-function buildCommandPrompt(
-  body: DictationBody,
-  stylePrompt?: string,
-): string {
+function buildCommandPrompt(body: DictationBody, stylePrompt?: string): string {
   const sections = [
     "You are a text transformation assistant. The user has selected text and given a voice command to transform it.",
     "",
@@ -559,7 +626,10 @@ async function handleDictation(body: DictationBody): Promise<Response> {
   const stylePrompt = profile.stylePrompt || undefined;
 
   // Command mode: selected text present
-  if (body.context.selectedText && body.context.selectedText.trim().length > 0) {
+  if (
+    body.context.selectedText &&
+    body.context.selectedText.trim().length > 0
+  ) {
     log.info({ mode: "command" }, "Command mode (selected text present)");
     return handleCommandMode(body, profile, profileMeta, stylePrompt);
   }
@@ -669,10 +739,7 @@ async function handleDictation(body: DictationBody): Promise<Response> {
           });
         }
         const cleanedText = input.text?.trim() || transcription;
-        const normalizedText = applyDictionary(
-          cleanedText,
-          profile.dictionary,
-        );
+        const normalizedText = applyDictionary(cleanedText, profile.dictionary);
         return Response.json({
           text: normalizedText,
           mode: "dictation",

--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct CrashReportView: View {
     let crashURL: URL
     let crashLog: String
+    let companionFiles: [URL]
     let onDismiss: () -> Void
 
     @State private var isSending = false
@@ -96,20 +97,33 @@ struct CrashReportView: View {
         let crashFileName = crashURL.lastPathComponent
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let urlCopy = crashURL
+        let companions = companionFiles
 
         Task.detached {
             let event = Event(level: .fatal)
             event.message = SentryMessage(formatted: "Crash report: \(crashFileName)")
             event.tags = ["source": "crash_log", "app_version": appVersion]
             // Truncate to ~8 KB to stay within Sentry's event size limits.
+            // Kept as a fallback for quick viewing in Sentry.
             let truncated = logContent.count > 8_192
                 ? String(logContent.prefix(8_192)) + "\n[truncated]"
                 : logContent
             event.extra = ["crash_log": truncated, "crash_file": crashFileName]
 
+            // Attach the full crash log file and any companion files (e.g. spindump
+            // .tar.gz archives) so they are available in Sentry for download.
+            var attachments: [Attachment] = [
+                Attachment(path: urlCopy.path, filename: urlCopy.lastPathComponent),
+            ]
+            for companion in companions {
+                attachments.append(
+                    Attachment(path: companion.path, filename: companion.lastPathComponent)
+                )
+            }
+
             // Await completion so UI confirms delivery only after flush finishes.
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                MetricKitManager.sendManualReport(event) {
+                MetricKitManager.sendManualReport(event, attachments: attachments) {
                     continuation.resume()
                 }
             }
@@ -135,7 +149,7 @@ extension AppDelegate {
     /// Opens a crash report window if a crash log from the previous session exists.
     /// Call early in `applicationDidFinishLaunching`, before `recordLaunch()`.
     func checkForPreviousCrash() {
-        guard let (url, content) = CrashReporter.pendingCrashLog() else {
+        guard let (url, content, companionFiles) = CrashReporter.pendingCrashLog() else {
             CrashReporter.recordLaunch()
             return
         }
@@ -143,10 +157,10 @@ extension AppDelegate {
         // Record now so a second launch doesn't surface the same crash again
         // even if the user force-quits before dismissing the sheet.
         CrashReporter.recordLaunch()
-        showCrashReportWindow(url: url, content: content)
+        showCrashReportWindow(url: url, content: content, companionFiles: companionFiles)
     }
 
-    func showCrashReportWindow(url: URL, content: String) {
+    func showCrashReportWindow(url: URL, content: String, companionFiles: [URL] = []) {
         let dismiss: () -> Void = { [weak self] in
             self?.dismissCrashReportWindow()
         }
@@ -154,6 +168,7 @@ extension AppDelegate {
         let view = CrashReportView(
             crashURL: url,
             crashLog: content,
+            companionFiles: companionFiles,
             onDismiss: dismiss
         )
 
@@ -227,6 +242,7 @@ extension AppDelegate {
         0   vellum-assistant    0x0000000100abc123 main + 0
         1   dyld                0x00007fff6bc123ab start + 1
         """,
+        companionFiles: [],
         onDismiss: {}
     )
 }

--- a/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
+++ b/clients/macos/vellum-assistant/Telemetry/CrashReporter.swift
@@ -13,7 +13,9 @@ enum CrashReporter {
     }
 
     /// Returns the most recent unseen crash log from the previous session, or nil.
-    static func pendingCrashLog() -> (url: URL, content: String)? {
+    /// Also returns companion file URLs (e.g. `.tar.gz`, `.diag`) that macOS may
+    /// generate alongside the crash log with matching base name prefixes.
+    static func pendingCrashLog() -> (url: URL, content: String, companionFiles: [URL])? {
         let diagURL = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Logs/DiagnosticReports")
         guard let items = try? FileManager.default.contentsOfDirectory(
@@ -61,7 +63,17 @@ enum CrashReporter {
               let content = try? String(contentsOf: mostRecent, encoding: .utf8)
         else { return nil }
 
-        return (url: mostRecent, content: content)
+        // Look for companion files that macOS generates alongside crash logs
+        // (e.g. .tar.gz spindump archives, .diag files) by matching the base
+        // name prefix before the extension.
+        let crashBaseName = mostRecent.deletingPathExtension().lastPathComponent
+        let companionFiles = items.filter { url in
+            let name = url.lastPathComponent
+            guard name != mostRecent.lastPathComponent else { return false }
+            return name.hasPrefix(crashBaseName)
+        }
+
+        return (url: mostRecent, content: content, companionFiles: companionFiles)
     }
 
     /// Marks a crash log as seen so it is not surfaced again on future launches.

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -56,6 +56,7 @@ import os
     /// `nonisolated` so the Settings sheet can call it from a detached Task.
     nonisolated static func sendManualReport(
         _ event: Event,
+        attachments: [Attachment] = [],
         completion: (@Sendable () -> Void)? = nil
     ) {
         sentrySerialQueue.async {
@@ -70,10 +71,37 @@ import os
                     options.enableAutoSessionTracking = false
                 }
             }
+
+            // Attach files to the scope before capturing the event.
+            if !attachments.isEmpty {
+                SentrySDK.configureScope { scope in
+                    for attachment in attachments {
+                        scope.addAttachment(attachment)
+                    }
+                }
+            }
+
             SentrySDK.capture(event: event)
+
+            // Clean up attachments so they don't leak into subsequent events.
+            if !attachments.isEmpty {
+                SentrySDK.configureScope { scope in
+                    scope.clearAttachments()
+                }
+            }
+
+            // Always flush when attachments are present so large files are
+            // delivered before the user quits the app. Use a longer timeout
+            // when attachments are present since companion archives (e.g.
+            // spindump .tar.gz) can be several MB on slow connections.
+            // When Sentry was temporarily started (user opted out), also
+            // close it afterward.
+            let flushTimeout: TimeInterval = attachments.isEmpty ? 5 : 15
             if wasDisabled {
-                SentrySDK.flush(timeout: 5)
+                SentrySDK.flush(timeout: flushTimeout)
                 SentrySDK.close()
+            } else if !attachments.isEmpty {
+                SentrySDK.flush(timeout: flushTimeout)
             }
             completion?()
         }


### PR DESCRIPTION
## Summary
When the app crashes and the user clicks "Send Report", or when the user exports diagnostics, crash report files and companion archives are now properly attached instead of just embedding truncated text.

## Changes
- **CrashReporter.swift**: Updated `pendingCrashLog()` to find companion files (.tar.gz, .diag) alongside crash logs by matching base name prefixes in DiagnosticReports directory
- **MetricKitManager.swift**: Updated `sendManualReport()` to accept Sentry `Attachment` objects, add them to scope before capture, and clean up after. Uses 15s flush timeout for attachments (vs 5s for plain events)
- **CrashReportView.swift**: Creates Sentry `Attachment` objects for the crash file and any companions, passes them through the send flow. Added `companionFiles` property
- **diagnostics-routes.ts**: Added `findRecentCrashReports()` to scan DiagnosticReports for recent vellum-assistant crash files. Includes .crash, .ips, .tar.gz, .diag files from last 7 days under `crash-reports/` subdirectory in the export ZIP

## Milestone PRs (merged into feature branch)
- #14645: M1: Attach crash report files as Sentry attachments in Send Report flow
- #14651: M2: Include crash report files in diagnostics export ZIP

## Project issue
Closes #14641

## Test plan
- [ ] Trigger a crash (Settings > Debug > Trigger Fatal Crash), relaunch, verify "Send Report" attaches files in Sentry
- [ ] Export diagnostics from Debug Panel, verify ZIP contains crash-reports/ directory with any recent crash files
- [ ] Verify export still works when no crash files exist (graceful skip)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
