### PR TITLE
fix: resolve sentry testing flag via full flag manager instead of @AppStorage

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -97,8 +97,9 @@ struct SettingsPanel: View {
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var selectedTab: SettingsTab = .account
     @State private var isContactsEnabled: Bool = false
-    @AppStorage("MacOSFeatureFlag.sentrytestingenabled") private var isSentryTestingEnabled: Bool = false
+    @State private var isSentryTestingEnabled: Bool = false
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
+    private static let sentryTestingFeatureFlagKey = "sentry_testing_enabled"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -147,9 +148,10 @@ struct SettingsPanel: View {
         .background(VColor.backgroundSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .task {
-            // Refresh permission status and contacts feature flag when the view appears
+            // Refresh permission status and feature flags when the view appears
             await refreshPermissionStatus()
             await loadContactsFeatureFlag()
+            isSentryTestingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.sentryTestingFeatureFlagKey)
         }
         .onAppear {
             store.refreshAPIKeyState()
@@ -184,17 +186,18 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
-               let enabled = notification.userInfo?["enabled"] as? Bool,
-               key == Self.contactsFeatureFlagKey {
-                isContactsEnabled = enabled
-                if !enabled && selectedTab == .contacts {
-                    selectedTab = .account
+               let enabled = notification.userInfo?["enabled"] as? Bool {
+                if key == Self.contactsFeatureFlagKey {
+                    isContactsEnabled = enabled
+                    if !enabled && selectedTab == .contacts {
+                        selectedTab = .account
+                    }
+                } else if key == Self.sentryTestingFeatureFlagKey {
+                    isSentryTestingEnabled = enabled
+                    if !enabled && selectedTab == .sentryTesting {
+                        selectedTab = .account
+                    }
                 }
-            }
-        }
-        .onChange(of: isSentryTestingEnabled) { _, enabled in
-            if !enabled && selectedTab == .sentryTesting {
-                selectedTab = .account
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in


### PR DESCRIPTION
## Summary
- Replace `@AppStorage` with `@State` + `MacOSClientFeatureFlagManager.isEnabled()` for the sentry testing flag, matching the contacts flag pattern
- This ensures env vars (`VELLUM_FLAG_SENTRY_TESTING_ENABLED=1`) and registry defaults are respected, not just UserDefaults
- Fold flag change handling into the existing `.assistantFeatureFlagDidChange` notification handler

## Original prompt
Fix sentry testing flag to use MacOSClientFeatureFlagManager instead of @AppStorage, matching the contacts flag pattern. Addresses Codex review feedback on PR #14626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
