### PR TITLE
fix(oauth): redirect to desktop-complete page after managed Twitter OAuth

### DIFF
--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -93,7 +93,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
     ]
 
     /// The redirect path the platform navigates to after OAuth completes.
-    public static let redirectAfterConnect = "/"
+    public static let redirectAfterConnect = "/account/oauth/desktop-complete"
 
     /// Creates a new service instance.
     ///


### PR DESCRIPTION
## Summary
- Change `redirectAfterConnect` from `"/"` to `"/account/oauth/desktop-complete"` so after managed Twitter OAuth completes, the browser shows "Connection Successful — return to the desktop app" instead of the platform home page

## Test plan
- [ ] Complete managed Twitter OAuth flow and verify browser lands on the desktop-complete page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
