### PR TITLE
fix: post flag change notification for macOS-scope flags in Advanced tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -174,6 +174,11 @@ struct SettingsAdvancedDevTab: View {
             set: { newValue in
                 macOSFlagStates[index].enabled = newValue
                 MacOSClientFeatureFlagManager.shared.setOverride(entry.key, enabled: newValue)
+                NotificationCenter.default.post(
+                    name: .assistantFeatureFlagDidChange,
+                    object: nil,
+                    userInfo: ["key": entry.key, "enabled": newValue]
+                )
             }
         )
         return HStack {


### PR DESCRIPTION
## Summary
- Add `.assistantFeatureFlagDidChange` notification post to `macOSFlagRow` setter in `SettingsAdvancedDevTab`, matching the pattern already used by `assistantFlagRow`
- This fixes the regression from #14656 where toggling macOS-scope flags (like sentry-testing) in the Advanced tab didn't reactively update the SettingsPanel sidebar

## Original prompt
Add notification post for macOS-scope flag changes. Addresses review feedback on PR #14656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
