### PR TITLE
fix: sync command palette icons and make identity sidebar responsive

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -293,25 +293,25 @@ extension AppDelegate {
             CommandPaletteAction(id: "settings", icon: VIcon.settings.rawValue, label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
                 self?.mainWindow?.windowState.togglePanel(.settings)
             },
-            CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "App Directory", shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Things", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showAppsPanel()
             },
             CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.togglePanel(.intelligence)
             },
-            CommandPaletteAction(id: "navigate-back", icon: "chevron.left", label: "Back", shortcutHint: "\u{2318}[") { [weak self] in
+            CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in
                 self?.mainWindow?.windowState.navigateBack()
             },
-            CommandPaletteAction(id: "navigate-forward", icon: "chevron.right", label: "Forward", shortcutHint: "\u{2318}]") { [weak self] in
+            CommandPaletteAction(id: "navigate-forward", icon: VIcon.chevronRight.rawValue, label: "Forward", shortcutHint: "\u{2318}]") { [weak self] in
                 self?.mainWindow?.windowState.navigateForward()
             },
-            CommandPaletteAction(id: "zoom-in", icon: "plus.magnifyingglass", label: "Zoom In", shortcutHint: "\u{2318}+") { [weak self] in
+            CommandPaletteAction(id: "zoom-in", icon: VIcon.zoomIn.rawValue, label: "Zoom In", shortcutHint: "\u{2318}+") { [weak self] in
                 self?.zoomManager.zoomIn()
             },
-            CommandPaletteAction(id: "zoom-out", icon: "minus.magnifyingglass", label: "Zoom Out", shortcutHint: "\u{2318}-") { [weak self] in
+            CommandPaletteAction(id: "zoom-out", icon: VIcon.zoomOut.rawValue, label: "Zoom Out", shortcutHint: "\u{2318}-") { [weak self] in
                 self?.zoomManager.zoomOut()
             },
-            CommandPaletteAction(id: "zoom-reset", icon: "magnifyingglass", label: "Actual Size", shortcutHint: "\u{2318}0") { [weak self] in
+            CommandPaletteAction(id: "zoom-reset", icon: VIcon.search.rawValue, label: "Actual Size", shortcutHint: "\u{2318}0") { [weak self] in
                 self?.zoomManager.resetZoom()
             },
         ]

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -208,7 +208,7 @@ struct CommandPaletteView: View {
 
     private func actionRow(_ action: CommandPaletteAction, isSelected: Bool) -> some View {
         HStack(spacing: VSpacing.md) {
-            VIconView(SFSymbolMapping.icon(forSFSymbol: action.icon, fallback: .puzzle), size: 13)
+            VIconView(.resolve(action.icon), size: 13)
                 .foregroundColor(VColor.textSecondary)
                 .frame(width: 20, alignment: .center)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -342,18 +342,6 @@ struct MainWindowView: View {
     private var topBarView: some View {
         HStack(spacing: VSpacing.sm) {
             if !isSettingsOpen {
-                VIconButton(label: "Back", icon: VIcon.chevronLeft.rawValue, iconOnly: true, tooltip: "Back (\u{2318}[)") {
-                    windowState.navigateBack()
-                }
-                .disabled(!windowState.navigationHistory.canGoBack)
-                .opacity(windowState.navigationHistory.canGoBack ? 1 : 0.35)
-
-                VIconButton(label: "Forward", icon: VIcon.chevronRight.rawValue, iconOnly: true, tooltip: "Forward (\u{2318}])") {
-                    windowState.navigateForward()
-                }
-                .disabled(!windowState.navigationHistory.canGoForward)
-                .opacity(windowState.navigationHistory.canGoForward ? 1 : 0.35)
-
                 VIconButton(label: "Sidebar", icon: VIcon.panelLeft.rawValue, iconOnly: true, tooltip: sidebarExpanded ? "Collapse sidebar" : "Expand sidebar") {
                     withAnimation(VAnimation.panel) {
                         sidebarExpanded.toggle()
@@ -362,6 +350,20 @@ struct MainWindowView: View {
 
                 VIconButton(label: "Search", icon: VIcon.search.rawValue, iconOnly: true, tooltip: "Search (\u{2318}K)") {
                     AppDelegate.shared?.toggleCommandPalette()
+                }
+
+                HStack(spacing: 0) {
+                    VIconButton(label: "Back", icon: VIcon.chevronLeft.rawValue, iconOnly: true, tooltip: "Back (\u{2318}[)") {
+                        windowState.navigateBack()
+                    }
+                    .disabled(!windowState.navigationHistory.canGoBack)
+                    .opacity(windowState.navigationHistory.canGoBack ? 1 : 0.35)
+
+                    VIconButton(label: "Forward", icon: VIcon.chevronRight.rawValue, iconOnly: true, tooltip: "Forward (\u{2318}])") {
+                        windowState.navigateForward()
+                    }
+                    .disabled(!windowState.navigationHistory.canGoForward)
+                    .opacity(windowState.navigationHistory.canGoForward ? 1 : 0.35)
                 }
             }
             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -17,7 +17,9 @@ struct IdentityPanel: View {
     @State private var isFullscreen: Bool = false
     @State private var showAvatarSheet: Bool = false
 
-    private let sidebarWidth: CGFloat = 260
+    private let sidebarMinWidth: CGFloat = 200
+    private let sidebarMaxWidth: CGFloat = 280
+    private let sidebarFraction: CGFloat = 0.3
 
     private let panelPadding: CGFloat = VSpacing.xl
 
@@ -31,61 +33,64 @@ struct IdentityPanel: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            // Left sidebar: title, avatar, ID card — hidden in fullscreen
-            if !isFullscreen {
-                VStack(spacing: 0) {
+        GeometryReader { geo in
+            let computedSidebarWidth = min(sidebarMaxWidth, max(sidebarMinWidth, geo.size.width * sidebarFraction))
+            let avatarSize = min(180, computedSidebarWidth - VSpacing.lg * 2)
+            HStack(alignment: .top, spacing: 0) {
+                // Left sidebar: title, avatar, ID card — hidden in fullscreen
+                if !isFullscreen {
                     VStack(spacing: 0) {
-                        // "I'm [name]!" heading
-                        Text("I'm \(assistantDisplayName)!")
-                            .font(.system(size: 22, weight: .regular, design: .rounded))
-                            .foregroundColor(VColor.textPrimary)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.top, VSpacing.xxl)
-                            .padding(.horizontal, VSpacing.lg)
+                        VStack(spacing: 0) {
+                            // "I'm [name]!" heading
+                            Text("I'm \(assistantDisplayName)!")
+                                .font(.system(size: 22, weight: .regular, design: .rounded))
+                                .foregroundColor(VColor.textPrimary)
+                                .multilineTextAlignment(.center)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, VSpacing.xxl)
+                                .padding(.horizontal, VSpacing.lg)
 
-                        Spacer()
+                            Spacer()
 
-                        // Large centered avatar
-                        Image(nsImage: appearance.fullAvatarImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 180, height: 180)
-                            .clipShape(Circle())
-                            .frame(maxWidth: .infinity, alignment: .center)
+                            // Large centered avatar
+                            Image(nsImage: appearance.fullAvatarImage)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: avatarSize, height: avatarSize)
+                                .clipShape(Circle())
+                                .frame(maxWidth: .infinity, alignment: .center)
 
-                        Spacer()
+                            // Update Avatar button
+                            VButton(label: "Update Avatar", style: .secondary) { showAvatarSheet = true }
+                                .padding(.top, VSpacing.md)
 
-                        // Update Avatar button
-                        VButton(label: "Update Avatar", style: .primary) { showAvatarSheet = true }
-                            .padding(.horizontal, VSpacing.lg)
-                            .padding(.bottom, VSpacing.xl)
+                            Spacer()
 
-                        // Divider
-                        Divider().background(adaptiveColor(light: Moss._50, dark: Moss._500))
+                            // Divider
+                            Divider().background(adaptiveColor(light: Moss._50, dark: Moss._500))
 
-                        // Role + Hatched date
-                        VStack(alignment: .leading, spacing: VSpacing.lg) {
-                            let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
-                            if let role, !role.isEmpty {
-                                identityInfoRow(label: "Role", value: role)
+                            // Role + Hatched date
+                            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                                let role = remoteIdentity?.role.nilIfEmpty ?? identity?.role
+                                if let role, !role.isEmpty {
+                                    identityInfoRow(label: "Role", value: role)
+                                }
+                                if let date = metadata?.createdAt {
+                                    identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
+                                }
                             }
-                            if let date = metadata?.createdAt {
-                                identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
-                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, VSpacing.lg)
+                            .padding(.vertical, VSpacing.lg)
                         }
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.vertical, VSpacing.lg)
+                        .frame(maxHeight: .infinity)
+                        .background(VColor.inputBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                     }
-                    .frame(maxHeight: .infinity)
-                    .background(VColor.inputBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .frame(width: computedSidebarWidth)
+                    .padding(.trailing, VSpacing.lg)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
                 }
-                .frame(width: sidebarWidth)
-                .padding(.trailing, VSpacing.lg)
-                .transition(.move(edge: .leading).combined(with: .opacity))
-            }
 
             // Hex grid fills the rest of the space — card when not fullscreen
             ConstellationView(
@@ -104,56 +109,57 @@ struct IdentityPanel: View {
                 RoundedRectangle(cornerRadius: isFullscreen ? 0 : VRadius.lg)
                     .stroke(isFullscreen ? Color.clear : VColor.surfaceBorder, lineWidth: 1)
             )
-            .padding(.trailing, 0)
-        }
-        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
-        .overlay {
-            if let path = viewingFilePath {
-                // Dismiss backdrop
-                Color.black.opacity(0.4)
-                    .ignoresSafeArea()
-                    .onTapGesture { viewingFilePath = nil }
+                .padding(.trailing, 0)
+            }
+            .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
+            .overlay {
+                if let path = viewingFilePath {
+                    // Dismiss backdrop
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture { viewingFilePath = nil }
 
-                WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
-                    .frame(width: 600, height: 500)
+                    WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
+                        .frame(width: 600, height: 500)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                        .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
+                        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                }
+            }
+            .animation(VAnimation.standard, value: viewingFilePath != nil)
+            .overlay {
+                if showAvatarSheet {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture { showAvatarSheet = false }
+
+                    AvatarManagementSheet(
+                        onClose: { showAvatarSheet = false },
+                        onEditAvatar: {
+                            showAvatarSheet = false
+                            onEditAvatar()
+                        }
+                    )
+                    .frame(width: 360)
+                    .fixedSize(horizontal: false, vertical: true)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
                     .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
                     .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                }
             }
-        }
-        .animation(VAnimation.standard, value: viewingFilePath != nil)
-        .overlay {
-            if showAvatarSheet {
-                Color.black.opacity(0.4)
-                    .ignoresSafeArea()
-                    .onTapGesture { showAvatarSheet = false }
+            .animation(VAnimation.standard, value: showAvatarSheet)
+            .onAppear {
+                identity = IdentityInfo.load()
+                metadata = AssistantMetadata.load()
+                lockfileAssistant = LockfileAssistant.loadLatest()
+                workspaceFiles = WorkspaceFileNode.scan()
+                fetchSkills()
 
-                AvatarManagementSheet(
-                    onClose: { showAvatarSheet = false },
-                    onEditAvatar: {
-                        showAvatarSheet = false
-                        onEditAvatar()
+                // For remote assistants without local IDENTITY.md, fetch from daemon
+                if identity == nil, lockfileAssistant?.isRemote == true {
+                    Task {
+                        remoteIdentity = await daemonClient.fetchRemoteIdentity()
                     }
-                )
-                .frame(width: 360)
-                .fixedSize(horizontal: false, vertical: true)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-                .shadow(color: .black.opacity(0.5), radius: 20, y: 8)
-                .transition(.opacity.combined(with: .scale(scale: 0.95)))
-            }
-        }
-        .animation(VAnimation.standard, value: showAvatarSheet)
-        .onAppear {
-            identity = IdentityInfo.load()
-            metadata = AssistantMetadata.load()
-            lockfileAssistant = LockfileAssistant.loadLatest()
-            workspaceFiles = WorkspaceFileNode.scan()
-            fetchSkills()
-
-            // For remote assistants without local IDENTITY.md, fetch from daemon
-            if identity == nil, lockfileAssistant?.isRemote == true {
-                Task {
-                    remoteIdentity = await daemonClient.fetchRemoteIdentity()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Use VIcon raw values instead of SF Symbol names for command palette actions, resolve with `VIcon.resolve()` instead of `SFSymbolMapping`
- Rename "App Directory" to "Things" in command palette to match sidebar
- Reorder top bar: sidebar toggle, search, then back/forward grouped with no gap
- Make identity sidebar proportional (30%, 200-280pt) instead of fixed 260pt
- Move Update Avatar button under avatar with secondary style, left-align role/hatched section

## Test plan
- [ ] Command palette (⌘K) shows correct Lucide icons for all actions
- [ ] "Things" label matches sidebar
- [ ] Top bar order: sidebar, search, back/forward
- [ ] Identity tab sidebar scales with window size
- [ ] Update Avatar button appears under avatar with secondary style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
