### PR TITLE
fix: sync CLI help reference with twitter command description

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -32,7 +32,7 @@ Commands:
   oauth [options]                          Manage OAuth tokens for connected integrations
   skills                                   Browse and install skills from the Vellum catalog
   browser                                  Browser automation, extension relay, and Chrome CDP management
-  x|twitter [options]                      Post on X and manage connections. Supports managed (platform proxy), OAuth (official API), and browser session paths.
+  x|twitter [options]                      Post on X and manage connections. Supports managed (platform proxy) and OAuth (official API) paths.
   map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
   sequence [options]                       Manage email sequences
 `;


### PR DESCRIPTION
## Summary
- Update `CLI_HELP_REFERENCE` in `reference.ts` to match the current twitter command description which no longer mentions "browser session paths"
- Fixes failing `cli-help-reference-sync.test.ts` on main

## Original prompt
Fix CI test failures on main — cli-help-reference-sync.test.ts was failing because the reference string was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
