### PR TITLE
feat: generate dSYM debug symbols during release builds

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -902,6 +902,18 @@ codesign "${APP_SIGN_FLAGS[@]}" "$APP_DIR"
 
 echo "Built: $APP_DIR"
 
+# Generate dSYM debug symbol bundles for Sentry crash symbolication (release only)
+if [ "$CONFIG" = "release" ]; then
+    echo "Generating dSYM debug symbols..."
+    dsymutil "$MACOS_DIR/$BUNDLE_DISPLAY_NAME" -o "$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
+    echo "Generated dSYM: dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
+
+    if [ -f "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" ]; then
+        dsymutil "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" -o "$SCRIPT_DIR/dist/Sentry.framework.dSYM"
+        echo "Generated dSYM: dist/Sentry.framework.dSYM"
+    fi
+fi
+
 # 7. Run if requested
 if [ "$CMD" = "run" ]; then
     echo "Launching..."


### PR DESCRIPTION
## Summary
- Add dsymutil step to build.sh after release code signing to generate .dSYM bundles
- Generates dSYMs for the main Vellum executable and the Sentry framework
- Only runs for release builds (not debug)
- dSYMs are placed in dist/ alongside the .app bundle

Part of #14662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
