### PR TITLE
chore: add git hook to block new tool registrations

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -27,9 +27,11 @@ Automatically checks for plain text keys and secrets before allowing a commit.
 2. **Prettier formatting** — Runs `prettier --check` on staged files in `assistant/`, `cli/`, and `gateway/`
 3. **ESLint** — Runs `eslint` on staged source files in `assistant/`, `cli/`, and `gateway/`
 4. **IPC contract verification** — When IPC contract files are staged, verifies generated Swift models, inventory snapshot, and decoder sync are up to date
+5. **Tool registration guard** — Blocks new tool registrations in `assistant/src/tools/` (requires Team Jarvis approval, see `assistant/src/tools/AGENTS.md`)
 
 **Behavior:**
 - Blocks commits containing potential secrets
+- Blocks new tool files containing `implements Tool` or `registerTool()` patterns
 - Provides detailed feedback on what was detected and where
 - Allows clean commits to proceed without interruption
 - Avoids known false positives for architecture/db identifier strings like `assistant_auth_tokens` and migration checkpoint keys

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -903,13 +903,30 @@ while IFS= read -r -d '' FILE; do
         fi
     fi
 
-    # Check for modifications to tool-manifest.ts that add new imports or tool entries
+    # Check for modifications to tool-manifest.ts that ADD new tools (not refactoring/removal)
     if [[ "$FILE" == "assistant/src/tools/tool-manifest.ts" ]]; then
-        # Get the diff and check for added lines with tool registration patterns
-        ADDED_LINES=$(git diff --cached -- "$FILE" | grep '^+' | grep -v '^+++')
-        if printf '%s\n' "$ADDED_LINES" | grep -qE '(import[[:space:]]|explicitTools|eagerModuleToolNames|lazyTools)'; then
+        # Compare tool counts between HEAD and staged version
+        # Only trigger if the count INCREASED (new tools added)
+        HEAD_CONTENT=$(git show HEAD:"$FILE" 2>/dev/null || echo "")
+        STAGED_CONTENT=$(git show ":$FILE" 2>/dev/null)
+
+        # Count side-effect imports (lines like `import "./foo/bar.js";`)
+        HEAD_IMPORTS=$(printf '%s\n' "$HEAD_CONTENT" | grep -cE '^import[[:space:]]+"\./' 2>/dev/null || echo 0)
+        STAGED_IMPORTS=$(printf '%s\n' "$STAGED_CONTENT" | grep -cE '^import[[:space:]]+"\./' 2>/dev/null || echo 0)
+
+        # Count entries in eagerModuleToolNames array
+        HEAD_EAGER=$(printf '%s\n' "$HEAD_CONTENT" | grep -cE '^[[:space:]]+"[a-z_]+",' 2>/dev/null || echo 0)
+        STAGED_EAGER=$(printf '%s\n' "$STAGED_CONTENT" | grep -cE '^[[:space:]]+"[a-z_]+",' 2>/dev/null || echo 0)
+
+        # Count tool imports (lines like `import { fooTool } from "./foo/bar.js";`)
+        HEAD_TOOL_IMPORTS=$(printf '%s\n' "$HEAD_CONTENT" | grep -cE '^import[[:space:]]+\{.*\}[[:space:]]+from' 2>/dev/null || echo 0)
+        STAGED_TOOL_IMPORTS=$(printf '%s\n' "$STAGED_CONTENT" | grep -cE '^import[[:space:]]+\{.*\}[[:space:]]+from' 2>/dev/null || echo 0)
+
+        if [ "$STAGED_IMPORTS" -gt "$HEAD_IMPORTS" ] || \
+           [ "$STAGED_EAGER" -gt "$HEAD_EAGER" ] || \
+           [ "$STAGED_TOOL_IMPORTS" -gt "$HEAD_TOOL_IMPORTS" ]; then
             TOOL_VIOLATIONS=$((TOOL_VIOLATIONS + 1))
-            TOOL_VIOLATION_FILES+=("$FILE (tool manifest modification)")
+            TOOL_VIOLATION_FILES+=("$FILE (new tool entries added)")
         fi
     fi
 done < "$STAGED_ACM_FILE"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -893,7 +893,7 @@ while IFS= read -r -d '' FILE; do
         esac
 
         # Check if this is a new file (not a modification)
-        if ! git ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
+        if ! git cat-file -e HEAD:"$FILE" 2>/dev/null; then
             # New file — check if it contains tool registration patterns
             STAGED_CONTENT=$(git show ":$FILE" 2>/dev/null)
             if printf '%s\n' "$STAGED_CONTENT" | grep -qE '(implements[[:space:]]+Tool[^a-zA-Z]|registerTool\()'; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -866,4 +866,78 @@ if [ $COMMAND_VIOLATIONS -gt 0 ]; then
     echo ""
 fi
 
+# --- New tool registration check ---
+# Block creation of new tools registered on the assistant. New tools must be
+# approved by Team Jarvis. Use --no-verify to bypass if you have approval.
+#
+# Detects:
+# 1. New .ts files in assistant/src/tools/ containing `implements Tool` or `registerTool`
+# 2. Modifications to tool-manifest.ts that add new tool registrations
+
+TOOL_VIOLATIONS=0
+TOOL_VIOLATION_FILES=()
+
+while IFS= read -r -d '' FILE; do
+    # Check for new files in the tools directory
+    if [[ "$FILE" == assistant/src/tools/*.ts ]]; then
+        # Skip allowed files
+        case "$FILE" in
+            assistant/src/tools/types.ts|\
+            assistant/src/tools/registry.ts|\
+            assistant/src/tools/tool-manifest.ts|\
+            assistant/src/tools/shared/*|\
+            *.test.ts|\
+            *.spec.ts)
+                continue
+                ;;
+        esac
+
+        # Check if this is a new file (not a modification)
+        if ! git ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
+            # New file — check if it contains tool registration patterns
+            STAGED_CONTENT=$(git show ":$FILE" 2>/dev/null)
+            if printf '%s\n' "$STAGED_CONTENT" | grep -qE '(implements[[:space:]]+Tool[^a-zA-Z]|registerTool\()'; then
+                TOOL_VIOLATIONS=$((TOOL_VIOLATIONS + 1))
+                TOOL_VIOLATION_FILES+=("$FILE (new tool file)")
+            fi
+        fi
+    fi
+
+    # Check for modifications to tool-manifest.ts that add new imports or tool entries
+    if [[ "$FILE" == "assistant/src/tools/tool-manifest.ts" ]]; then
+        # Get the diff and check for added lines with tool registration patterns
+        ADDED_LINES=$(git diff --cached -- "$FILE" | grep '^+' | grep -v '^+++')
+        if printf '%s\n' "$ADDED_LINES" | grep -qE '(import[[:space:]]|explicitTools|eagerModuleToolNames|lazyTools)'; then
+            TOOL_VIOLATIONS=$((TOOL_VIOLATIONS + 1))
+            TOOL_VIOLATION_FILES+=("$FILE (tool manifest modification)")
+        fi
+    fi
+done < "$STAGED_ACM_FILE"
+
+if [ $TOOL_VIOLATIONS -gt 0 ]; then
+    echo ""
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}COMMIT REJECTED: New tool registration detected!${NC}"
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "Adding new tools to the assistant requires approval from Team Jarvis."
+    echo "The tool registration system is being phased out in favor of skills."
+    echo ""
+    echo "Detected tool registration in:"
+    for F in "${TOOL_VIOLATION_FILES[@]}"; do
+        echo "  - $F"
+    done
+    echo ""
+    echo "Instead of creating a new tool, consider:"
+    echo "  1. Creating a skill in assistant/src/config/bundled-skills/"
+    echo "  2. Teaching the assistant to use existing CLI tools via skills"
+    echo ""
+    echo "See assistant/src/tools/AGENTS.md for more information."
+    echo ""
+    echo "If you have approval from Team Jarvis, bypass with:"
+    echo "  git commit --no-verify"
+    echo ""
+    exit 1
+fi
+
 exit 0

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -60,4 +60,4 @@ tools/
 
 ## Questions?
 
-Contact Team Jarvis before starting work on a new tool.
+Contact Team Jarvis before shipping a new tool.

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -1,0 +1,63 @@
+# Tools — Agent Instructions
+
+## No New Tools Policy
+
+**New tool registrations require approval from Team Jarvis.**
+
+The tool registration system (`class ... implements Tool` + `registerTool()`) is being phased out in favor of skill-based approaches. Before adding a new tool, contact Team Jarvis for approval.
+
+## Why This Policy Exists
+
+1. **Skills are preferred** — The project direction is to teach the assistant CLI tools via skills rather than hardcoding tool implementations. Skills are portable, self-contained, and don't require daemon changes.
+
+2. **Context overhead** — Each registered tool adds to the system prompt and increases token usage for every conversation.
+
+3. **Maintenance burden** — Tools require ongoing maintenance, testing, and security review. Skills can be iterated on independently.
+
+## What To Do Instead
+
+Instead of creating a new tool, consider:
+
+1. **Create a bundled skill** in `assistant/src/config/bundled-skills/` — Skills teach the assistant to use existing CLI tools and are the preferred approach for new functionality.
+
+2. **Use existing tools** — Many capabilities can be achieved by combining existing tools (bash, file operations, network tools) with skill instructions.
+
+3. **External CLI tools** — If you need new functionality, consider whether it can be exposed as a CLI tool that the assistant can invoke via bash.
+
+## If You Have Approval
+
+If Team Jarvis has approved your new tool:
+
+1. The pre-commit hook will block your commit by default
+2. Use `git commit --no-verify` to bypass the hook
+3. Include the approval context in your PR description
+
+## Directory Structure
+
+```
+tools/
+├── AGENTS.md              # This file
+├── types.ts               # Tool interface definitions
+├── registry.ts            # Tool registration machinery
+├── tool-manifest.ts       # Declarative list of registered tools
+├── shared/                # Shared utilities (not tools)
+└── <category>/            # Tool implementations by category
+    └── <tool>.ts          # Individual tool files
+```
+
+## Existing Tool Categories
+
+- `apps/` — App proxy tools
+- `assets/` — Asset management
+- `browser/` — Headless browser tools
+- `credentials/` — Credential management
+- `filesystem/` — File read/write/edit
+- `memory/` — Memory operations
+- `network/` — Web fetch and search
+- `skills/` — Skill management
+- `system/` — System settings and permissions
+- `terminal/` — Shell operations
+
+## Questions?
+
+Contact Team Jarvis before starting work on a new tool.

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -8,7 +8,7 @@ The tool registration system (`class ... implements Tool` + `registerTool()`) is
 
 ## Why This Policy Exists
 
-1. **Skills are preferred** — The project direction is to teach the assistant CLI tools via skills rather than hardcoding tool implementations. Skills are portable, self-contained, and don't require daemon changes.
+1. **Skills are preferred** — The project direction is to teach the assistant CLI tools via skills rather than hardcoding tool implementations. Skills are progressively disclosed into context, are more portable, and are often self-contained.
 
 2. **Context overhead** — Each registered tool adds to the system prompt and increases token usage for every conversation.
 

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -32,31 +32,6 @@ If Team Jarvis has approved your new tool:
 2. Use `git commit --no-verify` to bypass the hook
 3. Include the approval context in your PR description
 
-## Directory Structure
-
-```
-tools/
-├── AGENTS.md              # This file
-├── types.ts               # Tool interface definitions
-├── registry.ts            # Tool registration machinery
-├── tool-manifest.ts       # Declarative list of registered tools
-├── shared/                # Shared utilities (not tools)
-└── <category>/            # Tool implementations by category
-    └── <tool>.ts          # Individual tool files
-```
-
-## Existing Tool Categories
-
-- `apps/` — App proxy tools
-- `assets/` — Asset management
-- `browser/` — Headless browser tools
-- `credentials/` — Credential management
-- `filesystem/` — File read/write/edit
-- `memory/` — Memory operations
-- `network/` — Web fetch and search
-- `skills/` — Skill management
-- `system/` — System settings and permissions
-- `terminal/` — Shell operations
 
 ## Questions?
 

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -18,7 +18,7 @@ The tool registration system (`class ... implements Tool` + `registerTool()`) is
 
 Instead of creating a new tool, consider:
 
-1. **Create a bundled skill** in `assistant/src/config/bundled-skills/` — Skills teach the assistant to use existing CLI tools and are the preferred approach for new functionality.
+1. **Create a skill**
 
 2. **Use existing tools** — Many capabilities can be achieved by combining existing tools (bash, file operations, network tools) with skill instructions.
 


### PR DESCRIPTION
## Summary

- Adds a pre-commit hook check that blocks creation of new tools in `assistant/src/tools/`
- New tool registrations now require approval from Team Jarvis
- Uses `--no-verify` as an escape hatch for approved changes
- Adds `AGENTS.md` in the tools directory to instruct coding agents about this policy

## What the hook detects

1. **New `.ts` files** in `assistant/src/tools/` containing `implements Tool` or `registerTool()` patterns
2. **Modifications to `tool-manifest.ts`** that add new imports or tool entries

## Why

The tool registration system is being phased out in favor of skills. This hook ensures new capabilities are added as skills rather than tools, and requires human approval for any exceptions.

## Test plan

- [ ] Try to add a new tool file — should be blocked
- [ ] Try to modify tool-manifest.ts with new imports — should be blocked
- [ ] Existing commits without tool changes — should pass normally
- [ ] Bypass with `--no-verify` — should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
