### PR TITLE
feat: upload dSYMs to Sentry during release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -720,6 +720,14 @@ jobs:
           echo "Main executable architecture:"
           file "$APP_PATH/Contents/MacOS/Vellum"
 
+      - name: Upload dSYMs to Sentry
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
+
       - name: Free disk space
         run: |
           rm -rf .build daemon-bin cli-bin gateway-bin
@@ -1051,6 +1059,14 @@ jobs:
 
           echo "Main executable architecture:"
           file "$APP_PATH/Contents/MacOS/Vellum"
+
+      - name: Upload dSYMs to Sentry
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
 
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary
- Add sentry-cli dSYM upload step to both arm64 and x64 release build jobs
- Installs sentry-cli, uploads all .dSYM bundles from dist/ to Sentry
- Uses SENTRY_AUTH_TOKEN secret for authentication
- Step is continue-on-error to avoid breaking releases if Sentry is down

Part of #14662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
