### PR TITLE
Add dSYM generation and Sentry upload for crash symbolication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -720,6 +720,14 @@ jobs:
           echo "Main executable architecture:"
           file "$APP_PATH/Contents/MacOS/Vellum"
 
+      - name: Upload dSYMs to Sentry
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
+
       - name: Free disk space
         run: |
           rm -rf .build daemon-bin cli-bin gateway-bin
@@ -1051,6 +1059,14 @@ jobs:
 
           echo "Main executable architecture:"
           file "$APP_PATH/Contents/MacOS/Vellum"
+
+      - name: Upload dSYMs to Sentry
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
 
       - name: Free disk space
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1065,7 +1065,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          curl -sL https://sentry.io/get-cli/ | bash
+          npm install -g @sentry/cli@2.42.2
           sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
 
       - name: Free disk space

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -725,7 +725,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          curl -sL https://sentry.io/get-cli/ | bash
+          npm install -g @sentry/cli@2.42.2
           sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
 
       - name: Free disk space

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -908,10 +908,9 @@ if [ "$CONFIG" = "release" ]; then
     dsymutil "$MACOS_DIR/$BUNDLE_DISPLAY_NAME" -o "$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
     echo "Generated dSYM: dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
 
-    if [ -f "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" ]; then
-        dsymutil "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" -o "$SCRIPT_DIR/dist/Sentry.framework.dSYM"
-        echo "Generated dSYM: dist/Sentry.framework.dSYM"
-    fi
+    # Note: Sentry.framework is a pre-built binary from SPM and does not contain
+    # the .o object files needed by dsymutil. Sentry distributes their own dSYMs
+    # separately via their SDK integration — no need to run dsymutil on it.
 fi
 
 # 7. Run if requested

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -902,6 +902,18 @@ codesign "${APP_SIGN_FLAGS[@]}" "$APP_DIR"
 
 echo "Built: $APP_DIR"
 
+# Generate dSYM debug symbol bundles for Sentry crash symbolication (release only)
+if [ "$CONFIG" = "release" ]; then
+    echo "Generating dSYM debug symbols..."
+    dsymutil "$MACOS_DIR/$BUNDLE_DISPLAY_NAME" -o "$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
+    echo "Generated dSYM: dist/$BUNDLE_DISPLAY_NAME.app.dSYM"
+
+    if [ -f "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" ]; then
+        dsymutil "$FRAMEWORKS_DIR/Sentry.framework/Versions/A/Sentry" -o "$SCRIPT_DIR/dist/Sentry.framework.dSYM"
+        echo "Generated dSYM: dist/Sentry.framework.dSYM"
+    fi
+fi
+
 # 7. Run if requested
 if [ "$CMD" = "run" ]; then
     echo "Launching..."


### PR DESCRIPTION
## Summary
Add dSYM debug symbol generation to release builds and automatic upload to Sentry, enabling full crash report symbolication for the macOS app.

## Changes
- Add `dsymutil` step to `build.sh` after release code signing to generate `.dSYM` bundles for the Vellum executable and Sentry framework
- Add `sentry-cli` upload step to both arm64 and x64 release jobs in the GitHub Actions workflow
- Upload step uses `SENTRY_AUTH_TOKEN` secret and is `continue-on-error` to avoid blocking releases

## Milestone PRs (merged into feature branch)
- #14665: feat: generate dSYM debug symbols during release builds
- #14668: feat: upload dSYMs to Sentry during release builds

## Project issue
Closes #14662

## Test plan
- [ ] Verify next release build generates `.dSYM` files in `dist/`
- [ ] Verify `sentry-cli` upload step runs in the release workflow (may need SENTRY_AUTH_TOKEN secret configured)
- [ ] Trigger a test crash and verify Sentry symbolicates the stack trace

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
