### PR TITLE
managed oauth: use ASWebAuthenticationSession for managed Twitter OAuth

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AuthenticationServices
 import Carbon.HIToolbox
 import Combine
 import Foundation
@@ -1060,8 +1061,12 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    /// Starts the managed Twitter OAuth connect flow: calls the platform to get
-    /// an authorization URL and opens it in the default browser.
+    /// Holds the active web auth session to prevent deallocation.
+    private var twitterWebAuthSession: ASWebAuthenticationSession?
+
+    /// Starts the managed Twitter OAuth connect flow using ASWebAuthenticationSession.
+    /// The platform redirects back to vellum-assistant://oauth/twitter/callback after
+    /// authorization, which ASWebAuthenticationSession intercepts and returns to the app.
     func connectManagedTwitter() {
         managedTwitterConnectInProgress = true
         managedTwitterError = nil
@@ -1079,15 +1084,58 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let url = URL(string: response.connectUrl) {
-                    NSWorkspace.shared.open(url)
-                } else {
+                guard let authURL = URL(string: response.connectUrl) else {
                     managedTwitterError = "Invalid authorization URL received."
+                    return
                 }
+
+                let callbackURL = try await performManagedTwitterWebAuth(url: authURL)
+
+                // Parse oauth_status from the callback URL
+                let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+                let oauthStatus = components?.queryItems?.first(where: { $0.name == "oauth_status" })?.value
+
+                if oauthStatus == "connected" {
+                    log.info("Managed Twitter OAuth completed successfully")
+                    refreshManagedTwitterStatus()
+                } else {
+                    let errorCode = components?.queryItems?.first(where: { $0.name == "oauth_code" })?.value
+                    managedTwitterError = "Twitter connection failed\(errorCode.map { ": \($0)" } ?? "")."
+                }
+            } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
+                log.info("User cancelled managed Twitter OAuth")
+                // No error — user intentionally dismissed
             } catch {
                 log.error("Failed to start managed Twitter connect: \(error)")
                 managedTwitterError = error.localizedDescription
             }
+        }
+    }
+
+    /// Presents an ASWebAuthenticationSession for managed Twitter OAuth and waits for the callback.
+    private func performManagedTwitterWebAuth(url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: PlatformTwitterOAuthService.callbackURLScheme
+            ) { [weak self] callbackURL, error in
+                self?.twitterWebAuthSession = nil
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: NSError(
+                        domain: "ManagedTwitterOAuth",
+                        code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "No callback URL received."]
+                    ))
+                }
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = WebAuthPresentationContext.shared
+            self.twitterWebAuthSession = session
+            session.start()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1135,7 +1135,14 @@ public final class SettingsStore: ObservableObject {
             session.prefersEphemeralWebBrowserSession = false
             session.presentationContextProvider = WebAuthPresentationContext.shared
             self.twitterWebAuthSession = session
-            session.start()
+            if !session.start() {
+                self.twitterWebAuthSession = nil
+                continuation.resume(throwing: NSError(
+                    domain: "ManagedTwitterOAuth",
+                    code: -2,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to start the authentication session."]
+                ))
+            }
         }
     }
 

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -220,10 +220,10 @@ public final class AuthManager {
     }
 }
 
-final class WebAuthPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
-    static let shared = WebAuthPresentationContext()
+public final class WebAuthPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+    public static let shared = WebAuthPresentationContext()
 
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         #if os(macOS)
         NSApp.keyWindow ?? NSApp.windows.first ?? ASPresentationAnchor()
         #elseif os(iOS)

--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -92,8 +92,11 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         "offline.access",
     ]
 
-    /// The redirect path the platform navigates to after OAuth completes.
-    public static let redirectAfterConnect = "/account/oauth/desktop-complete"
+    /// The URL scheme callback the platform redirects to after OAuth completes.
+    /// Uses the app's custom URL scheme so ASWebAuthenticationSession can intercept
+    /// the redirect and return control to the app automatically.
+    public static let callbackURLScheme = "vellum-assistant"
+    public static let redirectAfterConnect = "vellum-assistant://oauth/twitter/callback"
 
     /// Creates a new service instance.
     ///


### PR DESCRIPTION
## Summary
- Uses `ASWebAuthenticationSession` for managed Twitter OAuth instead of opening a plain browser window
- The auth flow intercepts the `vellum-assistant://` callback URL scheme, returning control to the app automatically (like Slack's desktop OAuth)
- Makes `WebAuthPresentationContext` public so the macOS target can reuse it

## Platform-side changes needed
This POC requires corresponding platform changes (separate repo):
- `serializers.py`: Allow `vellum-assistant://` URL scheme in `redirect_after_connect` validation
- `views.py`: Prepend `HEADLESS_BASE_URL` for relative redirect paths in `_build_redirect_url`

## Test plan
- [ ] Build succeeds on macOS
- [ ] Connect managed Twitter → opens auth sheet (not a browser tab)
- [ ] After authorizing, control returns to the app automatically
- [ ] Cancel/dismiss the auth sheet → no error, no leftover browser tab
- [ ] Disconnect flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
