### PR TITLE
fix: use VIconButton for iOS InputBarView chat input buttons

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -126,11 +126,12 @@ struct InputBarView: View {
     private var standardInputRow: some View {
         HStack(spacing: VSpacing.md) {
             // Attachment button — tap opens photo library (most common), long-press shows both options
-            Button(action: { showPhotosPicker = true }) {
-                VIconView(.paperclip, size: 16)
-                    .foregroundColor(VColor.textSecondary)
-            }
-            .accessibilityLabel("Attach file")
+            VIconButton(
+                label: "Attach file",
+                icon: VIcon.paperclip.rawValue,
+                iconOnly: true,
+                action: { showPhotosPicker = true }
+            )
             .contextMenu {
                 Button {
                     showPhotosPicker = true
@@ -184,36 +185,34 @@ struct InputBarView: View {
 
             // Stop button (shown while generating but not yet cancelling)
             if isGenerating && !isCancelling {
-                Button(action: onStop) {
-                    ZStack {
-                        Circle()
-                            .fill(VColor.buttonNeutral)
-                            .frame(width: 32, height: 32)
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(VColor.background)
-                            .frame(width: 11, height: 11)
-                    }
-                }
-                .accessibilityLabel("Stop generation")
+                VIconButton(
+                    label: "Stop generation",
+                    icon: VIcon.square.rawValue,
+                    iconOnly: true,
+                    variant: .neutral,
+                    action: onStop
+                )
             } else {
                 // Mic button — tap to expand the animated voice orb
-                Button(action: toggleVoiceInput) {
-                    VIconView(.mic, size: 22)
-                        .foregroundColor(VColor.textMuted)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Start voice input")
+                VIconButton(
+                    label: "Start voice input",
+                    icon: VIcon.mic.rawValue,
+                    iconOnly: true,
+                    action: toggleVoiceInput
+                )
 
                 // Send button
-                Button(action: {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    onSend()
-                }) {
-                    VIconView(.circleArrowUp, size: 32)
-                        .foregroundColor(canSend ? VColor.accent : VColor.textMuted)
-                }
+                VIconButton(
+                    label: "Send message",
+                    icon: VIcon.arrowUp.rawValue,
+                    iconOnly: true,
+                    variant: .primary,
+                    action: {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        onSend()
+                    }
+                )
                 .disabled(!canSend)
-                .accessibilityLabel("Send message")
             }
         }
         .padding(VSpacing.md)


### PR DESCRIPTION
## Summary
- Replace raw `Button` + `VIconView` with `VIconButton` for attach, stop, mic, and send buttons in iOS `InputBarView`
- Ensures consistency with the design system and matches macOS ComposerView conventions

## Test plan
- [ ] Verify attach, mic, send, and stop buttons render correctly on iOS
- [ ] Confirm button hover/press states match VIconButton styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
