### PR TITLE
feat: add cross-platform ContactsStore to shared library

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -1,9 +1,11 @@
+import Combine
 import Foundation
 import SwiftUI
 import VellumAssistantShared
 
 /// ViewModel for the contacts list, providing daemon IPC integration
-/// for loading and filtering contacts.
+/// for loading and filtering contacts. Delegates data operations to
+/// the shared ContactsStore.
 @MainActor
 final class ContactsViewModel: ObservableObject {
 
@@ -16,16 +18,23 @@ final class ContactsViewModel: ObservableObject {
 
     // MARK: - Dependencies
 
-    private let daemonClient: DaemonClient?
-
-    /// Debounce task for contacts_changed events, avoiding races with
-    /// in-progress channel update response handling in ContactDetailView.
-    private var contactsChangedTask: Task<Void, Never>?
+    let contactsStore: ContactsStore?
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 
     init(daemonClient: DaemonClient?) {
-        self.daemonClient = daemonClient
+        if let daemonClient {
+            let store = ContactsStore(daemonClient: daemonClient)
+            self.contactsStore = store
+
+            store.$contacts
+                .assign(to: &$contacts)
+            store.$isLoading
+                .assign(to: &$isLoading)
+        } else {
+            self.contactsStore = nil
+        }
     }
 
     // MARK: - Computed Properties
@@ -68,36 +77,6 @@ final class ContactsViewModel: ObservableObject {
 
     /// Request the list of contacts from the daemon.
     func loadContacts() {
-        guard let daemonClient else { return }
-        isLoading = true
-
-        daemonClient.onContactsResponse = { [weak self] response in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.isLoading = false
-                if response.success, let contacts = response.contacts {
-                    self.contacts = contacts
-                }
-            }
-        }
-
-        daemonClient.onContactsChanged = { [weak self] _ in
-            guard let self else { return }
-            // Debounce to let in-flight channel update responses
-            // (consumed by ContactDetailView.updateChannelStatus) settle
-            // before we fire a new list request.
-            self.contactsChangedTask?.cancel()
-            self.contactsChangedTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 500_000_000)
-                guard !Task.isCancelled else { return }
-                self?.loadContacts()
-            }
-        }
-
-        do {
-            try daemonClient.sendListContacts(limit: 500)
-        } catch {
-            isLoading = false
-        }
+        contactsStore?.loadContacts()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -19,7 +19,6 @@ final class ContactsViewModel: ObservableObject {
     // MARK: - Dependencies
 
     let contactsStore: ContactsStore?
-    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -63,6 +63,9 @@ public final class ContactsStore: ObservableObject {
 
             for await message in stream {
                 if case .contactsResponse(let response) = message {
+                    // Only handle list responses (contacts array present);
+                    // skip unrelated get/update/delete responses.
+                    guard response.contacts != nil || !response.success else { continue }
                     if response.success, let contacts = response.contacts {
                         self.contacts = contacts
                     }
@@ -87,6 +90,9 @@ public final class ContactsStore: ObservableObject {
 
             for await message in stream {
                 if case .contactsResponse(let response) = message {
+                    // Only handle single-contact responses (contact field present);
+                    // skip unrelated list/update/delete responses.
+                    guard response.contact != nil || !response.success else { continue }
                     if response.success, let contact = response.contact {
                         // Update the contact in-place if it exists
                         if let index = contacts.firstIndex(where: { $0.id == contact.id }) {

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -1,0 +1,160 @@
+import Combine
+import Foundation
+
+/// Cross-platform store for contacts data operations.
+///
+/// Encapsulates all daemon communication for listing, getting, updating,
+/// and deleting contacts. Platform-specific UI state (search filtering,
+/// panel presentation, etc.) remains in the platform view model that
+/// delegates here.
+@MainActor
+public final class ContactsStore: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published public var contacts: [ContactPayload] = []
+    @Published public var isLoading = false
+
+    // MARK: - Computed Properties
+
+    /// The guardian contact, if present.
+    public var guardianContact: ContactPayload? {
+        contacts.first { $0.role == "guardian" }
+    }
+
+    /// All non-guardian contacts.
+    public var otherContacts: [ContactPayload] {
+        contacts.filter { $0.role != "guardian" }
+    }
+
+    // MARK: - Private State
+
+    private let daemonClient: DaemonClient
+    private var contactsChangedTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    public init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        subscribeToContactsChanged()
+    }
+
+    // MARK: - Actions
+
+    /// Request the list of contacts from the daemon.
+    public func loadContacts() {
+        isLoading = true
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendListContacts(limit: 500)
+            } catch {
+                isLoading = false
+                return
+            }
+
+            for await message in stream {
+                if case .contactsResponse(let response) = message {
+                    if response.success, let contacts = response.contacts {
+                        self.contacts = contacts
+                    }
+                    isLoading = false
+                    return
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    /// Request a single contact by ID.
+    public func getContact(id: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendGetContact(contactId: id)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .contactsResponse(let response) = message {
+                    if response.success, let contact = response.contact {
+                        // Update the contact in-place if it exists
+                        if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
+                            contacts[index] = contact
+                        }
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Update a contact channel's status and/or policy.
+    public func updateContactChannel(channelId: String, status: String? = nil, policy: String? = nil, reason: String? = nil) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendUpdateContactChannel(channelId: channelId, status: status, policy: policy, reason: reason)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .contactsResponse(let response) = message {
+                    if response.success {
+                        // Reload contacts to reflect the update
+                        loadContacts()
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Request deletion of a contact by ID.
+    public func deleteContact(id: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendDeleteContact(contactId: id)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .contactsResponse(let response) = message {
+                    if response.success {
+                        contacts.removeAll { $0.id == id }
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Subscribe to contactsChanged broadcasts with 500ms debounce.
+    private func subscribeToContactsChanged() {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            for await message in stream {
+                if case .contactsChanged = message {
+                    contactsChangedTask?.cancel()
+                    contactsChangedTask = Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        guard !Task.isCancelled else { return }
+                        self?.loadContacts()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -31,12 +31,18 @@ public final class ContactsStore: ObservableObject {
 
     private let daemonClient: DaemonClient
     private var contactsChangedTask: Task<Void, Never>?
+    private var subscriptionTask: Task<Void, Never>?
 
     // MARK: - Init
 
     public init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
         subscribeToContactsChanged()
+    }
+
+    deinit {
+        subscriptionTask?.cancel()
+        contactsChangedTask?.cancel()
     }
 
     // MARK: - Actions
@@ -142,13 +148,15 @@ public final class ContactsStore: ObservableObject {
 
     /// Subscribe to contactsChanged broadcasts with 500ms debounce.
     private func subscribeToContactsChanged() {
-        Task {
+        subscriptionTask = Task { [weak self] in
+            guard let self else { return }
             let stream = daemonClient.subscribe()
 
             for await message in stream {
+                guard !Task.isCancelled else { return }
                 if case .contactsChanged = message {
-                    contactsChangedTask?.cancel()
-                    contactsChangedTask = Task { @MainActor [weak self] in
+                    self.contactsChangedTask?.cancel()
+                    self.contactsChangedTask = Task { @MainActor [weak self] in
                         try? await Task.sleep(nanoseconds: 500_000_000)
                         guard !Task.isCancelled else { return }
                         self?.loadContacts()

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -149,11 +149,11 @@ public final class ContactsStore: ObservableObject {
     /// Subscribe to contactsChanged broadcasts with 500ms debounce.
     private func subscribeToContactsChanged() {
         subscriptionTask = Task { [weak self] in
-            guard let self else { return }
+            guard let daemonClient = self?.daemonClient else { return }
             let stream = daemonClient.subscribe()
 
             for await message in stream {
-                guard !Task.isCancelled else { return }
+                guard let self, !Task.isCancelled else { return }
                 if case .contactsChanged = message {
                     self.contactsChangedTask?.cancel()
                     self.contactsChangedTask = Task { @MainActor [weak self] in

--- a/clients/shared/Features/Contacts/ContactsStore.swift
+++ b/clients/shared/Features/Contacts/ContactsStore.swift
@@ -64,11 +64,9 @@ public final class ContactsStore: ObservableObject {
             for await message in stream {
                 if case .contactsResponse(let response) = message {
                     // Only handle list responses (contacts array present);
-                    // skip unrelated get/update/delete responses.
-                    guard response.contacts != nil || !response.success else { continue }
-                    if response.success, let contacts = response.contacts {
-                        self.contacts = contacts
-                    }
+                    // skip unrelated get/update/delete responses and their errors.
+                    guard response.contacts != nil else { continue }
+                    self.contacts = response.contacts ?? []
                     isLoading = false
                     return
                 }
@@ -91,9 +89,9 @@ public final class ContactsStore: ObservableObject {
             for await message in stream {
                 if case .contactsResponse(let response) = message {
                     // Only handle single-contact responses (contact field present);
-                    // skip unrelated list/update/delete responses.
-                    guard response.contact != nil || !response.success else { continue }
-                    if response.success, let contact = response.contact {
+                    // skip unrelated list/update/delete responses and their errors.
+                    guard response.contact != nil else { continue }
+                    if let contact = response.contact {
                         // Update the contact in-place if it exists
                         if let index = contacts.firstIndex(where: { $0.id == contact.id }) {
                             contacts[index] = contact
@@ -118,6 +116,9 @@ public final class ContactsStore: ObservableObject {
 
             for await message in stream {
                 if case .contactsResponse(let response) = message {
+                    // Only handle single-contact responses (update returns contact);
+                    // skip unrelated list/get/delete responses.
+                    guard response.contact != nil || !response.success else { continue }
                     if response.success {
                         // Reload contacts to reflect the update
                         loadContacts()
@@ -141,6 +142,9 @@ public final class ContactsStore: ObservableObject {
 
             for await message in stream {
                 if case .contactsResponse(let response) = message {
+                    // Only handle delete acknowledgements (no contact/contacts fields);
+                    // skip unrelated list/get/update responses.
+                    guard response.contact == nil && response.contacts == nil || !response.success else { continue }
                     if response.success {
                         contacts.removeAll { $0.id == id }
                     }


### PR DESCRIPTION
## Summary
Extracts contacts data operations from macOS ContactsViewModel into a shared ContactsStore ObservableObject. The store handles list, get, update channel, and delete operations using existing DaemonClient methods. Includes 500ms debounced reactive updates via contactsChanged broadcasts. macOS ContactsViewModel now delegates to ContactsStore.

## Implementation
- New `ContactsStore` in `clients/shared/Features/Contacts/` follows the exact same patterns as `SkillsStore`
- Uses `daemonClient.subscribe()` stream-based pattern for all IPC operations
- Subscribes to `.contactsChanged` broadcasts with 500ms debounce for reactive updates
- macOS `ContactsViewModel` forwards `contacts` and `isLoading` from store via Combine `assign(to:)`
- macOS-specific UI state (searchQuery, filteredContacts, hasNonGuardianContacts) stays in the ViewModel

## Key Technical Choices
- Kept `guardianContact` and `otherContacts` computed properties on both the store (unfiltered) and ViewModel (filtered by search) since they serve different purposes
- Used `assign(to: &$property)` pattern for forwarding published properties, avoiding retain cycle issues

## Test plan
- [ ] Verify contacts list loads correctly on macOS
- [ ] Verify search filtering still works
- [ ] Verify guardian contact appears separately
- [ ] Verify contactsChanged debounce triggers reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
