### PR TITLE
fix: send empty response on HTTP failure in fetchSharedAppsList

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -489,7 +489,12 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchSharedAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchSharedAppsList(isRetry: true)
+                        return
+                    }
+                    // Auth refresh failed - send empty response
+                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
                     return
                 }
                 guard http.statusCode == 200 else {

--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -475,7 +475,10 @@ extension HTTPTransport {
     }
 
     private func fetchSharedAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsShared) else { return }
+        guard let url = buildURL(for: .appsShared) else {
+            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -491,6 +494,7 @@ extension HTTPTransport {
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch shared apps list failed (\(http.statusCode))")
+                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
                     return
                 }
             }
@@ -499,6 +503,7 @@ extension HTTPTransport {
             onMessage?(.sharedAppsListResponse(decoded))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
+            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
         }
     }
 


### PR DESCRIPTION
Fixes Things folder loading forever when HTTP requests fail (404 etc). Sends an empty sharedAppsListResponse in all error paths so isLoadingShared is always reset.

Part of #14695, Closes #14696
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
