### PR TITLE
Fix Things Folder Loading Forever (JARVIS-84)

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -475,7 +475,10 @@ extension HTTPTransport {
     }
 
     private func fetchSharedAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsShared) else { return }
+        guard let url = buildURL(for: .appsShared) else {
+            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -486,11 +489,17 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchSharedAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchSharedAppsList(isRetry: true)
+                        return
+                    }
+                    // Auth refresh failed - send empty response
+                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
                     return
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch shared apps list failed (\(http.statusCode))")
+                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
                     return
                 }
             }
@@ -499,6 +508,7 @@ extension HTTPTransport {
             onMessage?(.sharedAppsListResponse(decoded))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
+            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: [])))
         }
     }
 


### PR DESCRIPTION
## Summary
Fix the Things folder UI showing a loading spinner forever when HTTP requests fail. The `/v1/apps/shared` endpoint returning 404 (or any error) caused `fetchSharedAppsList()` to return without calling `onMessage`, leaving `isLoadingShared` stuck at true.

## Changes
- Modified `fetchSharedAppsList()` in `HTTPDaemonClient+Apps.swift` to send an empty `sharedAppsListResponse` in all error paths:
  - URL construction failure
  - Non-200 HTTP status
  - 401 auth refresh failure
  - Network/decode exceptions

## Milestone PRs (merged into feature branch)
- #14697: fix: send empty response on HTTP failure in fetchSharedAppsList

## Project issue
Closes #14695

## Test plan
- [ ] Build and run the macOS app
- [ ] Navigate to the Things folder
- [ ] Verify spinner disappears (shows empty state or apps list)
- [ ] Stop the daemon (`vellum sleep`) to simulate HTTP failure
- [ ] Verify the spinner still resolves (shows empty state, not infinite loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
