### PR TITLE
Add check-design-tokens.sh guardrail script with ratchet mode

### DIFF
--- a/clients/scripts/check-design-tokens.sh
+++ b/clients/scripts/check-design-tokens.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Design token guardrail script
+# Detects raw color usage that should go through the design token system.
+# Usage: check-design-tokens.sh --mode=ratchet|strict
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLIENTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASELINE_FILE="$SCRIPT_DIR/design-token-guard-baseline.txt"
+
+MODE=""
+for arg in "$@"; do
+  case "$arg" in
+    --mode=*) MODE="${arg#--mode=}" ;;
+    *) echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" ]] || [[ "$MODE" != "ratchet" && "$MODE" != "strict" ]]; then
+  echo "Usage: $0 --mode=ratchet|strict"
+  exit 1
+fi
+
+# Run grep from CLIENTS_DIR so paths are relative (e.g., macos/foo/bar.swift:42:...)
+cd "$CLIENTS_DIR"
+
+VIOLATIONS=""
+
+# Rule A: Color(hex:) outside token files
+RULE_A=$(grep -rn 'Color(hex:' . --include='*.swift' | grep -v 'shared/DesignSystem/Tokens/' | sed 's|^\./||' || true)
+if [[ -n "$RULE_A" ]]; then
+  VIOLATIONS="${VIOLATIONS}${RULE_A}"$'\n'
+fi
+
+# Rule B: adaptiveColor( outside token files
+RULE_B=$(grep -rn 'adaptiveColor(' . --include='*.swift' | grep -v 'shared/DesignSystem/Tokens/' | sed 's|^\./||' || true)
+if [[ -n "$RULE_B" ]]; then
+  VIOLATIONS="${VIOLATIONS}${RULE_B}"$'\n'
+fi
+
+# Rule C: Legacy CSS variable names without --v- prefix
+RULE_C=$(grep -rn -E '\-\-(bg|bg-subtle|text|text-secondary|border|accent|accent-text):' . --include='*.swift' | sed 's|^\./||' || true)
+if [[ -n "$RULE_C" ]]; then
+  VIOLATIONS="${VIOLATIONS}${RULE_C}"$'\n'
+fi
+
+# Normalize: trim trailing newlines, sort, deduplicate
+VIOLATIONS=$(echo "$VIOLATIONS" | sed '/^$/d' | sort -u)
+
+if [[ -z "$VIOLATIONS" ]]; then
+  echo "No design token violations found."
+  exit 0
+fi
+
+VIOLATION_COUNT=$(echo "$VIOLATIONS" | wc -l | tr -d ' ')
+
+if [[ "$MODE" == "strict" ]]; then
+  echo "=== STRICT MODE: $VIOLATION_COUNT violation(s) found ==="
+  echo "$VIOLATIONS"
+  exit 1
+fi
+
+# Ratchet mode: compare against baseline
+if [[ ! -f "$BASELINE_FILE" ]]; then
+  echo "ERROR: Baseline file not found at $BASELINE_FILE"
+  echo "Run in strict mode first and capture output to create a baseline."
+  exit 1
+fi
+
+BASELINE=$(sort -u "$BASELINE_FILE")
+
+# Find new violations not in baseline
+NEW_VIOLATIONS=""
+while IFS= read -r line; do
+  if ! echo "$BASELINE" | grep -qxF "$line"; then
+    NEW_VIOLATIONS="${NEW_VIOLATIONS}${line}"$'\n'
+  fi
+done <<< "$VIOLATIONS"
+
+NEW_VIOLATIONS=$(echo "$NEW_VIOLATIONS" | sed '/^$/d')
+
+# Count remaining baseline violations (informational)
+REMAINING_BASELINE=0
+while IFS= read -r line; do
+  if echo "$VIOLATIONS" | grep -qxF "$line"; then
+    REMAINING_BASELINE=$((REMAINING_BASELINE + 1))
+  fi
+done <<< "$BASELINE"
+
+echo "=== RATCHET MODE ==="
+echo "Total violations: $VIOLATION_COUNT"
+echo "Baseline violations remaining: $REMAINING_BASELINE"
+
+if [[ -n "$NEW_VIOLATIONS" ]]; then
+  NEW_COUNT=$(echo "$NEW_VIOLATIONS" | wc -l | tr -d ' ')
+  echo ""
+  echo "FAIL: $NEW_COUNT NEW violation(s) found (not in baseline):"
+  echo "$NEW_VIOLATIONS"
+  exit 1
+else
+  echo "PASS: No new violations found."
+  exit 0
+fi

--- a/clients/scripts/design-token-guard-baseline.txt
+++ b/clients/scripts/design-token-guard-baseline.txt
@@ -1,0 +1,89 @@
+macos/vellum-assistant/Features/Chat/ComposerBridge.swift:192:                    .foregroundColor(isRecording ? VColor.error : adaptiveColor(light: Forest._500, dark: Moss._400))
+macos/vellum-assistant/Features/Chat/ComposerView.swift:104:                    .fill(adaptiveColor(light: Moss._200, dark: Moss._700))
+macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift:47:        adaptiveColor(light: Moss._50, dark: Moss._950).ignoresSafeArea()
+macos/vellum-assistant/Features/MainWindow/MainWindow.swift:400:        window.backgroundColor = NSColor(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/MainWindowView.swift:434:        .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:112:        .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:245:                                        .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:278:                                .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:315:                                                .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:349:                                                    .fill(Color(hex: 0xE86B40))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:395:                                                        .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:428:                                    .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:504:                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:517:                                .fill(Color(hex: 0xE86B40))
+macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift:287:                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift:448:            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift:480:            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift:807:                    .foregroundColor(adaptiveColor(light: VColor.textPrimary, dark: VColor.textSecondary))
+macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift:878:                adaptiveColor(light: Moss._50, dark: Moss._950)
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:31:        case .communication: return Color(hex: 0x8B5DAA) // purple
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:32:        case .productivity: return Color(hex: 0x4682B4)   // steel blue
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:33:        case .development: return Color(hex: 0xC1421B)    // red
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:34:        case .media: return Color(hex: 0xD4A017)          // gold
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:35:        case .automation: return Color(hex: 0x2E8B57)     // sea green
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:36:        case .webSocial: return Color(hex: 0xCD853F)      // peru/tan
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:37:        case .knowledge: return Color(hex: 0x6B8E23)      // olive
+macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift:38:        case .integration: return Color(hex: 0x708090)    // slate gray
+macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift:70:                            Divider().background(adaptiveColor(light: Moss._50, dark: Moss._500))
+macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift:36:                                    ? adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift:42:                                    ? adaptiveColor(light: Color(hex: 0xD3DECF), dark: Forest._800)
+macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift:56:            .background(adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700))
+macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift:21:                    .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift:36:                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift:17:                .foregroundColor(Color(hex: 0xA1A096))
+macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift:86:                                .fill(adaptiveColor(
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:241:                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:250:                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:269:                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:286:                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:295:                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:335:                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Forest._600))
+macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift:354:                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3)), lineWidth: 1)
+macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift:101:                                .fill(adaptiveColor(
+macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift:119:                                .fill(adaptiveColor(
+macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift:60:                            .fill(adaptiveColor(
+macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift:112:                            adaptiveColor(light: Stone._100, dark: Moss._900),
+macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift:113:                            adaptiveColor(light: Stone._200, dark: Moss._950)
+macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift:40:                                adaptiveColor(light: Moss._100, dark: Moss._900),
+macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift:41:                                adaptiveColor(light: Moss._200, dark: Moss._950)
+macos/vellum-assistant/Features/Onboarding/WelcomeStepView.swift:49:                        .fill(adaptiveColor(
+macos/vellum-assistant/Features/QuickInput/QuickInputView.swift:173:                                .foregroundColor(adaptiveColor(light: Forest._500, dark: Moss._400))
+macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift:268:                    style.textContent = ':root { --bg: #ffffff; --bg-subtle: #f8f9fa; --text: #1a1a2e; --text-secondary: #6b7280; --border: #e5e7eb; --accent: #6366f1; --accent-text: #ffffff; --success: #10b981; --warning: #f59e0b; --error: #ef4444; } @media (prefers-color-scheme: dark) { :root { --bg: #0f172a; --bg-subtle: #1e293b; --text: #f1f5f9; --text-secondary: #94a3b8; --border: #334155; --accent: #818cf8; --accent-text: #ffffff; --success: #34d399; --warning: #fbbf24; --error: #f87171; } }';
+shared/DesignSystem/Components/Display/VThreadIcon.swift:104:        return Color(hex: Self.backgroundHexValues[index])
+shared/DesignSystem/Core/Buttons/VButton.swift:150:            if isPressed { return Color(hex: 0xE0745A) }
+shared/DesignSystem/Core/Buttons/VButton.swift:151:            if isHovered { return Color(hex: 0xD4582F) }
+shared/DesignSystem/Core/Buttons/VButton.swift:152:            return Color(hex: 0xC1421B)
+shared/DesignSystem/Core/Buttons/VButton.swift:164:            if isPressed { return adaptiveColor(light: Forest._400, dark: Forest._700) }
+shared/DesignSystem/Core/Buttons/VButton.swift:165:            if isHovered { return adaptiveColor(light: Forest._300, dark: Forest._800) }
+shared/DesignSystem/Core/Buttons/VButton.swift:166:            return adaptiveColor(light: Forest._200, dark: Forest._900)
+shared/DesignSystem/Core/Buttons/VButton.swift:174:        case .secondary: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+shared/DesignSystem/Core/Buttons/VButton.swift:176:        case .ghost: return Color(hex: 0x537D53)
+shared/DesignSystem/Core/Buttons/VButton.swift:178:        case .success: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
+shared/DesignSystem/Core/Buttons/VIconButton.swift:170:                return isActive ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear
+shared/DesignSystem/Core/Buttons/VIconButton.swift:173:                if isPressed { return adaptiveColor(light: Moss._200, dark: Moss._600) }
+shared/DesignSystem/Core/Buttons/VIconButton.swift:174:                if isHovered { return adaptiveColor(light: Moss._200, dark: Moss._600) }
+shared/DesignSystem/Core/Buttons/VIconButton.swift:175:                return adaptiveColor(light: Moss._100, dark: Moss._700)
+shared/DesignSystem/Core/Buttons/VIconButton.swift:177:                if isPressed { return adaptiveColor(light: Moss._200, dark: Moss._600) }
+shared/DesignSystem/Core/Buttons/VIconButton.swift:178:                if isHovered { return adaptiveColor(light: Moss._100, dark: Moss._700) }
+shared/DesignSystem/Core/Buttons/VIconButton.swift:77:            return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
+shared/DesignSystem/Core/Buttons/VIconButton.swift:79:        return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+shared/DesignSystem/Core/Feedback/VShortcutTag.swift:11:    private let tagColor = Color(hex: 0xA1A096)
+shared/DesignSystem/Core/Feedback/VShortcutTag.swift:12:    private let borderColor = Color(hex: 0xE8E6DA)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:34:            case .core: return Color(hex: 0x2A2A28)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:35:            case .installed: return Color(hex: 0x3A6B3A)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:36:            case .created: return Color(hex: 0x3A4A6B)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:37:            case .extra: return Color(hex: 0x6B6B5E)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:44:            case .core: return Color(hex: 0xE8E6DA)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:45:            case .installed: return Color(hex: 0xD4E8D4)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:46:            case .created: return Color(hex: 0xD4DCE8)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:47:            case .extra: return Color(hex: 0xDDDBCE)
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:74:                foreground: Color(hex: 0x6B6B5E),
+shared/DesignSystem/Core/Feedback/VSkillTypePill.swift:75:                background: Color(hex: 0xDDDBCE)
+shared/DesignSystem/Core/Inputs/VSlider.swift:77:                .fill(adaptiveColor(light: Moss._100, dark: Moss._700))
+shared/DesignSystem/Core/Inputs/VSlider.swift:82:                .fill(adaptiveColor(light: Forest._300, dark: Forest._500))
+shared/Features/Chat/SkillInvocationChip.swift:34:        .background(adaptiveColor(light: Moss._100, dark: Moss._700))
+shared/Features/Chat/SkillInvocationChip.swift:38:                .stroke(adaptiveColor(light: Amber._400, dark: Amber._600).opacity(0.6), lineWidth: 2)
+shared/Features/Chat/SubagentStatusChip.swift:12:        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
+shared/Features/Chat/SubagentThreadView.swift:116:                    .foregroundColor(isHovered ? VColor.iconAccent : adaptiveColor(light: Forest._600, dark: Forest._400))
+shared/Features/Chat/SubagentThreadView.swift:25:        default: return adaptiveColor(light: Forest._600, dark: Forest._400)


### PR DESCRIPTION
## Summary
- Add `clients/scripts/check-design-tokens.sh` with ratchet and strict modes to enforce design token usage
- Rule A blocks Color(hex:) outside token files, Rule B blocks adaptiveColor(...) outside token files, Rule C blocks legacy CSS variable injection
- Generate baseline file capturing current debt so ratchet mode passes today while blocking new violations

Part of plan: design-token-consolidation.md (PR 1 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
