### PR TITLE
Wire design token guard into pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -245,6 +245,31 @@ if [ -n "$CHANGED_FILES" ]; then
         _debug_log "$lint_pkg: lint done (passed)"
     done
 
+    # --- Design token guard for clients/ ---
+    # When Swift files under clients/ are changed, verify design tokens are
+    # consolidated (ratchet mode: only flag new violations, not pre-existing ones).
+    if [ -n "$SWIFT_CHANGED_FILES" ] && [ "$SKIP_SWIFT_BUILD" != "1" ]; then
+        if [ -x "${REPO_ROOT}/clients/scripts/check-design-tokens.sh" ]; then
+            echo ""
+            echo "🔍 Checking design tokens in clients/..."
+            _debug_log "design token guard start"
+            if ! "${REPO_ROOT}/clients/scripts/check-design-tokens.sh" --mode=ratchet 2>&1; then
+                echo ""
+                echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo -e "${RED}Design token violations in clients/ — push blocked${NC}"
+                echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+                echo ""
+                echo "Fix the design token violations or push with --no-verify to skip."
+                _debug_log "design token guard done (FAILED)"
+                exit 1
+            fi
+            echo -e "  ${GREEN}✅ Design token guard OK${NC}"
+            _debug_log "design token guard done (passed)"
+        else
+            _debug_log "clients/scripts/check-design-tokens.sh not found — skipping design token guard"
+        fi
+    fi
+
     # Temp dir for capturing test output
     RESULTS_DIR="$(mktemp -d)"
     trap 'rm -rf "${RESULTS_DIR}"' EXIT


### PR DESCRIPTION
## Summary
- Add design token guardrail check to pre-push hook after lint checks
- Runs check-design-tokens.sh in ratchet mode when Swift files under clients/ are changed
- Respects SKIP_SWIFT_BUILD env var for bypass

Part of plan: design-token-consolidation.md (PR 2 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
