### PR TITLE
Add design token guard step to CI workflows

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Design token guard
+        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+
       - name: Cache SPM artifacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Design token guard
+        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+
       - name: Cache SPM build artifacts
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Clear stale SPM artifact cache
         run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
 
+      - name: Design token guard
+        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+
       - name: Build for simulator
         working-directory: clients/ios
         run: ./build.sh

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -98,6 +98,9 @@ jobs:
         with:
           bun-version: '1.3.9'
 
+      - name: Design token guard
+        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+
       - name: Build binaries
         run: ./build.sh binaries
 


### PR DESCRIPTION
## Summary
- Add design token guard step to pr-macos, pr-ios, ci-main-macos, and ci-main-ios workflows
- Uses ratchet mode so existing debt doesn't block CI while new violations fail

Part of plan: design-token-consolidation.md (PR 3 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
