### PR TITLE
Migrate sidebar files to use VColor tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -242,7 +242,7 @@ extension MainWindowView {
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                 if sidebar.dropTargetThreadId == thread.id {
                                     Rectangle()
-                                        .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                        .fill(VColor.iconAccent)
                                         .frame(height: 2)
                                         .transition(.opacity)
                                 }
@@ -275,7 +275,7 @@ extension MainWindowView {
                         } label: {
                             Text(sidebar.showAllThreads ? "Show less" : "Show more")
                                 .font(VFont.caption)
-                                .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
+                                .foregroundColor(VColor.buttonSecondaryText)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.leading, VSpacing.sm + VSpacing.xs + 20 + VSpacing.xs)
                                 .padding(.top, VSpacing.sm)
@@ -312,7 +312,7 @@ extension MainWindowView {
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                         if sidebar.dropTargetThreadId == thread.id {
                                             Rectangle()
-                                                .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                                .fill(VColor.iconAccent)
                                                 .frame(height: 2)
                                                 .transition(.opacity)
                                         }
@@ -346,7 +346,7 @@ extension MainWindowView {
                                                 .animation(VAnimation.fast, value: isGroupExpanded)
                                             if hasUnread {
                                                 Circle()
-                                                    .fill(Color(hex: 0xE86B40))
+                                                    .fill(VColor.unreadIndicator)
                                                     .frame(width: 6, height: 6)
                                                     .transition(.opacity)
                                             }
@@ -392,7 +392,7 @@ extension MainWindowView {
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                                 if sidebar.dropTargetThreadId == thread.id {
                                                     Rectangle()
-                                                        .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
+                                                        .fill(VColor.iconAccent)
                                                         .frame(height: 2)
                                                         .transition(.opacity)
                                                 }
@@ -425,7 +425,7 @@ extension MainWindowView {
                             } label: {
                                 Text(sidebar.showAllScheduleThreads ? "Show less" : "Show more")
                                     .font(VFont.caption)
-                                    .foregroundColor(adaptiveColor(light: Forest._600, dark: Forest._400))
+                                    .foregroundColor(VColor.buttonSecondaryText)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.leading, VSpacing.sm + VSpacing.xs + 20 + VSpacing.xs)
                                     .padding(.top, VSpacing.sm)
@@ -501,7 +501,7 @@ extension MainWindowView {
                     ZStack(alignment: .bottomTrailing) {
                         Text(switcher.badgeText)
                             .font(.system(size: 11, weight: .semibold))
-                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                            .foregroundColor(VColor.buttonSecondaryText)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
                             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
@@ -514,7 +514,7 @@ extension MainWindowView {
 
                         if switcher.switchTargets.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
                             Circle()
-                                .fill(Color(hex: 0xE86B40))
+                                .fill(VColor.unreadIndicator)
                                 .frame(width: 8, height: 8)
                                 .offset(x: 4, y: 4)
                         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift
@@ -33,13 +33,13 @@ struct DrawerThemeToggle: View {
                         VIconView(SFSymbolMapping.icon(forSFSymbol: option.icon, fallback: .puzzle), size: 12)
                             .foregroundColor(
                                 isSelected
-                                    ? adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+                                    ? VColor.buttonSecondaryText
                                     : VColor.textMuted
                             )
                             .frame(width: 30, height: 24)
                             .background(
                                 isSelected
-                                    ? adaptiveColor(light: Color(hex: 0xD3DECF), dark: Forest._800)
+                                    ? VColor.themeToggleSelected
                                     : Color.clear
                             )
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
@@ -53,7 +53,7 @@ struct DrawerThemeToggle: View {
                 }
             }
             .padding(3)
-            .background(adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700))
+            .background(VColor.themeToggleBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -18,7 +18,7 @@ struct SidebarPrimaryRow: View {
         Button(action: action) {
             HStack(spacing: isExpanded ? VSpacing.xs : 0) {
                 VIconView(.resolve(icon), size: 13)
-                    .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                    .foregroundColor(VColor.buttonSecondaryText)
                     .frame(width: SidebarLayoutMetrics.iconSlotSize, height: SidebarLayoutMetrics.iconSlotSize)
                 Text(label)
                     .font(VFont.body)
@@ -33,7 +33,7 @@ struct SidebarPrimaryRow: View {
                     Spacer()
                     if let trailingIcon {
                         VIconView(.resolve(trailingIcon), size: 10)
-                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                            .foregroundColor(VColor.buttonSecondaryText)
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
@@ -14,7 +14,7 @@ struct ThreadSwitcherDrawer: View {
         VStack(spacing: 0) {
             Text("\(regularThreads.count) threads")
                 .font(VFont.caption)
-                .foregroundColor(Color(hex: 0xA1A096))
+                .foregroundColor(VColor.tagText)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.top, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Replace Color(hex:) and adaptiveColor(...) in MainWindowView+Sidebar, SidebarPrimaryRow, ThreadSwitcherDrawer, DrawerThemeToggle with VColor tokens
- Covers unread indicators, button text, icon accents, and theme toggle colors

Part of plan: design-token-consolidation.md (PR 9 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
