### PR TITLE
Migrate VButton, VIconButton, VShortcutTag to use VColor tokens

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -147,9 +147,9 @@ private struct VButtonStyle: ButtonStyle {
             if isHovered { return VColor.buttonSecondaryBgHover }
             return VColor.buttonSecondaryBg
         case .danger:
-            if isPressed { return Color(hex: 0xE0745A) }
-            if isHovered { return Color(hex: 0xD4582F) }
-            return Color(hex: 0xC1421B)
+            if isPressed { return VColor.buttonDangerPressed }
+            if isHovered { return VColor.buttonDangerHover }
+            return VColor.buttonDanger
         case .tertiary:
             if isPressed { return VColor.ghostPressed }
             if isHovered { return VColor.ghostHover }
@@ -171,11 +171,11 @@ private struct VButtonStyle: ButtonStyle {
         switch style {
         case .primary: return .white
         case .tertiary: return VColor.buttonSecondaryText
-        case .secondary: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+        case .secondary: return VColor.buttonSecondaryText
         case .danger: return .white
-        case .ghost: return Color(hex: 0x537D53)
+        case .ghost: return VColor.buttonPrimary
         case .outlined: return VColor.buttonSecondaryText
-        case .success: return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
+        case .success: return VColor.iconAccent
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -74,9 +74,9 @@ public struct VIconButton: View {
 
     private var iconForegroundColor: Color {
         if isActive {
-            return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
+            return VColor.iconAccent
         }
-        return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+        return VColor.buttonSecondaryText
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -8,8 +8,8 @@ public struct VShortcutTag: View {
 
     @State private var isHovered = false
 
-    private let tagColor = Color(hex: 0xA1A096)
-    private let borderColor = Color(hex: 0xE8E6DA)
+    private let tagColor = VColor.tagText
+    private let borderColor = VColor.tagBorder
 
     public init(_ text: String, icon: String? = nil, action: (() -> Void)? = nil) {
         self.text = text


### PR DESCRIPTION
## Summary
- Replace all Color(hex:) and adaptiveColor(...) in VButton, VIconButton, VShortcutTag with VColor semantic tokens
- Behavior-preserving: exact same color values, just referenced via tokens

Part of plan: design-token-consolidation.md (PR 5 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
