### PR TITLE
Migrate VSlider to use VColor tokens

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -74,12 +74,12 @@ public struct VSlider: View {
         ZStack(alignment: .leading) {
             // Unfilled track (edge-to-edge)
             Rectangle()
-                .fill(adaptiveColor(light: Moss._100, dark: Moss._700))
+                .fill(VColor.sliderTrack)
                 .frame(height: trackHeight)
 
             // Filled track (from left edge to thumb center)
             Rectangle()
-                .fill(adaptiveColor(light: Forest._300, dark: Forest._500))
+                .fill(VColor.sliderFill)
                 .frame(width: thumbOffset + thumbWidth / 2, height: trackHeight)
         }
         .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))


### PR DESCRIPTION
## Summary
- Replace adaptiveColor(...) calls in VSlider with VColor.sliderTrack and VColor.sliderFill tokens

Part of plan: design-token-consolidation.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
