### PR TITLE
Migrate shared chat feature files to use VColor tokens

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -291,4 +291,8 @@ public enum VColor {
     // Slider
     public static let sliderTrack = adaptiveColor(light: Moss._100, dark: Moss._700)
     public static let sliderFill = adaptiveColor(light: Forest._300, dark: Forest._500)
+
+    // Subagent / skill chip
+    public static let statusRunning = adaptiveColor(light: Forest._600, dark: Forest._400)
+    public static let skillChipBorder = adaptiveColor(light: Amber._400, dark: Amber._600)
 }

--- a/clients/shared/Features/Chat/SkillInvocationChip.swift
+++ b/clients/shared/Features/Chat/SkillInvocationChip.swift
@@ -31,11 +31,11 @@ public struct SkillInvocationChip: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .background(adaptiveColor(light: Moss._100, dark: Moss._700))
+        .background(VColor.inputBackground)
         .clipShape(PixelBorderShape())
         .overlay(
             PixelBorderShape()
-                .stroke(adaptiveColor(light: Amber._400, dark: Amber._600).opacity(0.6), lineWidth: 2)
+                .stroke(VColor.skillChipBorder.opacity(0.6), lineWidth: 2)
         )
     }
 }

--- a/clients/shared/Features/Chat/SubagentStatusChip.swift
+++ b/clients/shared/Features/Chat/SubagentStatusChip.swift
@@ -9,7 +9,7 @@ public struct SubagentStatusChip: View {
         switch subagent.status {
         case .completed: return VColor.success
         case .failed, .aborted: return VColor.error
-        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
+        default: return VColor.statusRunning
         }
     }
 

--- a/clients/shared/Features/Chat/SubagentThreadView.swift
+++ b/clients/shared/Features/Chat/SubagentThreadView.swift
@@ -22,7 +22,7 @@ public struct SubagentThreadView: View {
         switch subagent.status {
         case .completed: return VColor.success
         case .failed, .aborted: return VColor.error
-        default: return adaptiveColor(light: Forest._600, dark: Forest._400)
+        default: return VColor.statusRunning
         }
     }
 
@@ -113,7 +113,7 @@ public struct SubagentThreadView: View {
             if replyCount > 0 {
                 Text("\(replyCount) repl\(replyCount == 1 ? "y" : "ies")")
                     .font(VFont.captionMedium)
-                    .foregroundColor(isHovered ? VColor.iconAccent : adaptiveColor(light: Forest._600, dark: Forest._400))
+                    .foregroundColor(isHovered ? VColor.iconAccent : VColor.statusRunning)
             } else if isRunning {
                 Text("Working...")
                     .font(VFont.caption)


### PR DESCRIPTION
## Summary
- Replace all adaptiveColor(...) in SkillInvocationChip, SubagentThreadView, SubagentStatusChip with VColor tokens
- Add two new tokens: VColor.statusRunning and VColor.skillChipBorder to ColorTokens.swift

Part of plan: design-token-consolidation.md (PR 12 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
