### PR TITLE
Migrate remaining macOS feature files to use VColor tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -189,7 +189,7 @@ struct MicrophoneButton: View {
 
                 VIconView(.mic, size: 16)
                     .frame(width: 18, height: 18)
-                    .foregroundColor(isRecording ? VColor.error : adaptiveColor(light: Forest._500, dark: Moss._400))
+                    .foregroundColor(isRecording ? VColor.error : VColor.micIcon)
             }
         }
         .buttonStyle(VIconButtonStyle(isHovered: isHovered, isFocused: isFocused, size: size))

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -101,7 +101,7 @@ struct ComposerView: View {
             .padding(.trailing, VSpacing.lg)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(adaptiveColor(light: Moss._200, dark: Moss._700))
+                    .fill(VColor.composerBackground)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
             .overlay(

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -44,7 +44,7 @@ struct DaemonLoadingThreadsSkeleton: View {
 
 #Preview("DaemonLoadingThreadsSkeleton") {
     ZStack {
-        adaptiveColor(light: Moss._50, dark: Moss._950).ignoresSafeArea()
+        VColor.backgroundSubtle.ignoresSafeArea()
         DaemonLoadingThreadsSkeleton()
     }
     .frame(width: 240, height: 300)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -397,7 +397,7 @@ public final class MainWindow {
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
-        window.backgroundColor = NSColor(adaptiveColor(light: Moss._50, dark: Moss._950))
+        window.backgroundColor = NSColor(VColor.backgroundSubtle)
         window.isReleasedWhenClosed = false
         window.contentMinSize = NSSize(width: 800, height: 600)
         window.setFrame(windowRect, display: false)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -431,7 +431,7 @@ struct MainWindowView: View {
         .padding(.leading, trafficLightPadding)
         .padding(.trailing, VSpacing.lg)
         .frame(height: 36)
-        .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+        .background(VColor.backgroundSubtle)
     }
 
     /// Core layout extracted to break up type-checker complexity.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -284,7 +284,7 @@ extension MainWindowView {
                     }
                 )
                 .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                .background(VColor.backgroundSubtle)
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -445,7 +445,7 @@ extension MainWindowView {
                 }
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
-            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+            .background(VColor.backgroundSubtle)
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
@@ -477,7 +477,7 @@ extension MainWindowView {
                 daemonClient: daemonClient
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
-            .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+            .background(VColor.backgroundSubtle)
         case .usageDashboard:
             UsageDashboardPanel(
                 store: usageDashboardStore,
@@ -804,7 +804,7 @@ struct DynamicWorkspaceWrapper: View {
 
                 Text(surface.title ?? data.preview?.title ?? "App")
                     .font(VFont.bodyMedium)
-                    .foregroundColor(adaptiveColor(light: VColor.textPrimary, dark: VColor.textSecondary))
+                    .foregroundColor(VColor.contextualText)
                     .lineLimit(1)
 
                 Spacer(minLength: 0)
@@ -875,7 +875,7 @@ struct DynamicWorkspaceWrapper: View {
             .padding(.trailing, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
             .background(
-                adaptiveColor(light: Moss._50, dark: Moss._950)
+                VColor.backgroundSubtle
             )
 
             if let error = sharing.publishError {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -67,7 +67,7 @@ struct IdentityPanel: View {
                             Spacer()
 
                             // Divider
-                            Divider().background(adaptiveColor(light: Moss._50, dark: Moss._500))
+                            Divider().background(VColor.panelDivider)
 
                             // Role + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {

--- a/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
+++ b/clients/macos/vellum-assistant/Features/QuickInput/QuickInputView.swift
@@ -170,7 +170,7 @@ struct QuickInputView: View {
                     Button(action: { onMicrophoneToggle?() }) {
                         ZStack {
                             VIconView(.mic, size: 14)
-                                .foregroundColor(adaptiveColor(light: Forest._500, dark: Moss._400))
+                                .foregroundColor(VColor.micIcon)
                         }
                         .frame(width: 32, height: 32)
                     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -295,4 +295,16 @@ public enum VColor {
     // Subagent / skill chip
     public static let statusRunning = adaptiveColor(light: Forest._600, dark: Forest._400)
     public static let skillChipBorder = adaptiveColor(light: Amber._400, dark: Amber._600)
+
+    // Contextual text — primary in light, secondary in dark
+    public static let contextualText = adaptiveColor(light: Stone._900, dark: Moss._400)
+
+    // Panel divider — used in identity panel sidebar
+    public static let panelDivider = adaptiveColor(light: Moss._50, dark: Moss._500)
+
+    // Composer background fill
+    public static let composerBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
+
+    // Microphone icon color
+    public static let micIcon = adaptiveColor(light: Forest._500, dark: Moss._400)
 }


### PR DESCRIPTION
## Summary
- Replace all adaptiveColor(...) in PanelCoordinator, MainWindowView, MainWindow, DaemonLoadingOverlay, IdentityPanel, ComposerView, ComposerBridge, QuickInputView with VColor tokens
- Add new semantic tokens (contextualText, panelDivider, composerBackground, micIcon) where existing ones don't match

Part of plan: design-token-consolidation.md (PR 10 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
