### PR TITLE
Migrate onboarding files to use VColor tokens

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
@@ -83,10 +83,7 @@ struct AvatarRevealStepView: View {
                         .padding(.vertical, VSpacing.lg)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(
-                                    light: Stone._900,
-                                    dark: Forest._600
-                                ))
+                                .fill(VColor.onboardingStepBackground)
                         )
                 }
                 .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -238,7 +238,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.aws.amazon.com/iam/home#/roles")!) {
                 Text("Open AWS IAM Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
+                    .foregroundColor(VColor.onboardingLink)
             }
             .pointerCursor()
         }
@@ -247,7 +247,7 @@ struct CloudCredentialsStepView: View {
         .textSelection(.enabled)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+                .fill(VColor.codeBlockBackground)
         )
     }
 
@@ -266,7 +266,7 @@ struct CloudCredentialsStepView: View {
         .textSelection(.enabled)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+                .fill(VColor.codeBlockBackground)
         )
     }
 
@@ -283,7 +283,7 @@ struct CloudCredentialsStepView: View {
             Link(destination: URL(string: "https://console.cloud.google.com/iam-admin/serviceaccounts")!) {
                 Text("Open Google Cloud Console")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: VColor.accent, dark: Forest._400))
+                    .foregroundColor(VColor.onboardingLink)
             }
             .pointerCursor()
         }
@@ -292,7 +292,7 @@ struct CloudCredentialsStepView: View {
         .textSelection(.enabled)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(adaptiveColor(light: Color(nsColor: NSColor(red: 0.95, green: 0.95, blue: 0.97, alpha: 1)), dark: VColor.surface.opacity(0.5)))
+                .fill(VColor.codeBlockBackground)
         )
     }
 
@@ -332,7 +332,7 @@ struct CloudCredentialsStepView: View {
         } else {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.file, size: 14)
-                    .foregroundColor(adaptiveColor(light: Stone._900, dark: Forest._600))
+                    .foregroundColor(VColor.onboardingStepBackground)
                 Text(fileName)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)
@@ -351,7 +351,7 @@ struct CloudCredentialsStepView: View {
             .padding(.vertical, VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3)), lineWidth: 1)
+                    .stroke(VColor.onboardingBorderStroke, lineWidth: 1)
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FnKeyStepView.swift
@@ -98,10 +98,7 @@ struct FnKeyStepView: View {
                         .padding(.vertical, VSpacing.lg)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(
-                                    light: Stone._900,
-                                    dark: Forest._600
-                                ))
+                                .fill(VColor.onboardingStepBackground)
                         )
                 }
                 .buttonStyle(.plain)
@@ -116,10 +113,7 @@ struct FnKeyStepView: View {
                         .padding(.vertical, VSpacing.lg)
                         .background(
                             RoundedRectangle(cornerRadius: VRadius.lg)
-                                .fill(adaptiveColor(
-                                    light: Stone._900,
-                                    dark: Forest._600
-                                ))
+                                .fill(VColor.onboardingStepBackground)
                         )
                 }
                 .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -57,10 +57,7 @@ struct ModelSelectionStepView: View {
                     .padding(.vertical, VSpacing.lg)
                     .background(
                         RoundedRectangle(cornerRadius: VRadius.lg)
-                            .fill(adaptiveColor(
-                                light: Stone._900,
-                                dark: Forest._600
-                            ))
+                            .fill(VColor.onboardingStepBackground)
                     )
             }
             .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -37,8 +37,8 @@ struct OnboardingFlowView: View {
                     .background(
                         RadialGradient(
                             colors: [
-                                adaptiveColor(light: Moss._100, dark: Moss._900),
-                                adaptiveColor(light: Moss._200, dark: Moss._950)
+                                VColor.background,
+                                VColor.onboardingHatchGradientOuter
                             ],
                             center: .center,
                             startRadius: 0,
@@ -109,8 +109,8 @@ struct OnboardingFlowView: View {
                 .background(
                     RadialGradient(
                         colors: [
-                            adaptiveColor(light: Stone._100, dark: Moss._900),
-                            adaptiveColor(light: Stone._200, dark: Moss._950)
+                            VColor.onboardingGradientEdge,
+                            VColor.onboardingGradientOuter
                         ],
                         center: .center,
                         startRadius: 0,

--- a/clients/macos/vellum-assistant/Features/Onboarding/WelcomeStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WelcomeStepView.swift
@@ -46,10 +46,7 @@ struct WelcomeStepView: View {
                 .padding(.vertical, VSpacing.lg)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(adaptiveColor(
-                            light: Stone._900,
-                            dark: Forest._600
-                        ))
+                        .fill(VColor.onboardingStepBackground)
                 )
         }
         .buttonStyle(.plain)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -285,6 +285,14 @@ public enum VColor {
     public static let themeToggleSelected = adaptiveColor(light: Color(hex: 0xD3DECF), dark: Forest._800)
     public static let themeToggleBackground = adaptiveColor(light: Moss._100, dark: Moss._700)
 
+    // Onboarding
+    public static let onboardingGradientEdge = adaptiveColor(light: Stone._100, dark: Moss._900)
+    public static let onboardingGradientOuter = adaptiveColor(light: Stone._200, dark: Moss._950)
+    public static let onboardingHatchGradientOuter = adaptiveColor(light: Moss._200, dark: Moss._950)
+    public static let onboardingStepBackground = adaptiveColor(light: Stone._900, dark: Forest._600)
+    public static let onboardingLink = adaptiveColor(light: Color(hex: 0x262624), dark: Forest._400)
+    public static let onboardingBorderStroke = adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3))
+
     // Onboarding code block
     public static let codeBlockBackground = adaptiveColor(light: Color(hex: 0xF2F2F7), dark: Color(hex: 0x3A3A37).opacity(0.5))
 


### PR DESCRIPTION
## Summary
- Replace all adaptiveColor(...) in OnboardingFlowView, WelcomeStepView, FnKeyStepView, ModelSelectionStepView, AvatarRevealStepView, CloudCredentialsStepView with VColor tokens
- Add new onboarding-specific tokens to ColorTokens.swift

Part of plan: design-token-consolidation.md (PR 11 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
