### PR TITLE
Migrate VSkillTypePill and VThreadIcon to use VColor tokens

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
+++ b/clients/shared/DesignSystem/Components/Display/VThreadIcon.swift
@@ -66,17 +66,8 @@ public struct VThreadIcon: View {
 
     // MARK: - Color Palette
 
-    /// Muted, dark-theme-friendly hex values that complement the Moss/Forest palette.
-    private static let backgroundHexValues: [UInt] = [
-        0x4B6845, // forest green
-        0x4A5568, // slate blue-gray
-        0x5B4E3A, // warm brown
-        0x3D5A5B, // teal
-        0x6B4C5A, // muted mauve
-        0x4E5D3E, // olive
-        0x5A4A6B, // dusty purple
-        0x5C6B4A, // sage
-    ]
+    /// Thread icon background colors from the design token palette.
+    private static let backgrounds: [Color] = VColor.threadIconBackgrounds
 
     // MARK: - Hash
 
@@ -100,8 +91,8 @@ public struct VThreadIcon: View {
 
     private var backgroundColor: Color {
         let hash = Self.stableHash(title)
-        let index = Int(hash % UInt64(Self.backgroundHexValues.count))
-        return Color(hex: Self.backgroundHexValues[index])
+        let index = Int(hash % UInt64(Self.backgrounds.count))
+        return Self.backgrounds[index]
     }
 
     // MARK: - Body

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -31,20 +31,20 @@ public struct VSkillTypePill: View {
 
         var foregroundColor: Color {
             switch self {
-            case .core: return Color(hex: 0x2A2A28)
-            case .installed: return Color(hex: 0x3A6B3A)
-            case .created: return Color(hex: 0x3A4A6B)
-            case .extra: return Color(hex: 0x6B6B5E)
+            case .core: return VColor.skillCoreForeground
+            case .installed: return VColor.skillInstalledForeground
+            case .created: return VColor.skillCreatedForeground
+            case .extra: return VColor.skillExtraForeground
             case .custom(_, _, let fg, _): return fg
             }
         }
 
         var backgroundColor: Color {
             switch self {
-            case .core: return Color(hex: 0xE8E6DA)
-            case .installed: return Color(hex: 0xD4E8D4)
-            case .created: return Color(hex: 0xD4DCE8)
-            case .extra: return Color(hex: 0xDDDBCE)
+            case .core: return VColor.skillCoreBackground
+            case .installed: return VColor.skillInstalledBackground
+            case .created: return VColor.skillCreatedBackground
+            case .extra: return VColor.skillExtraBackground
             case .custom(_, _, _, let bg): return bg
             }
         }
@@ -71,8 +71,8 @@ public struct VSkillTypePill: View {
             self.type = .custom(
                 label: source.replacingOccurrences(of: "-", with: " ").capitalized,
                 icon: VIcon.puzzle.rawValue,
-                foreground: Color(hex: 0x6B6B5E),
-                background: Color(hex: 0xDDDBCE)
+                foreground: VColor.skillExtraForeground,
+                background: VColor.skillExtraBackground
             )
         }
     }


### PR DESCRIPTION
## Summary
- Replace all Color(hex:) in VSkillTypePill with VColor.skill* semantic tokens
- Replace VThreadIcon backgroundHexValues array with VColor.threadIconBackgrounds

Part of plan: design-token-consolidation.md (PR 6 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
