### PR TITLE
Unify web CSS token injection into single shared helper

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import WebKit
 import os
+import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DocumentEditor")
 
@@ -235,26 +236,7 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
   <style media="(prefers-color-scheme: light)">\(githubCSS)</style>
 
   <style>
-    :root {
-      --v-bg: #FFFFFF;
-      --v-surface: #FFFFFF;
-      --v-surface-border: #E7E5E4;
-      --v-text: #292524;
-      --v-text-secondary: #78716C;
-      --v-text-muted: #97918B;
-      --v-accent: #262624;
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --v-bg: #262624;
-        --v-surface: #2F2F2D;
-        --v-surface-border: #3A3A37;
-        --v-text: #F5F3EB;
-        --v-text-secondary: #A1A096;
-        --v-text-muted: #6B6B65;
-        --v-accent: #216C37;
-      }
-    }
+    \(WebTokenInjector.cssTokenBlock())
     /* Invert toolbar icons in dark mode — target both the JS-applied class and the media query */
     .toastui-editor-dark .toastui-editor-toolbar-icons { filter: invert(1) brightness(0.85) !important; }
     @media (prefers-color-scheme: dark) {

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -265,16 +265,10 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 (function() {
                     var style = document.createElement('style');
                     style.setAttribute('data-vellum-injected', '1');
-                    style.textContent = ':root { --bg: #ffffff; --bg-subtle: #f8f9fa; --text: #1a1a2e; --text-secondary: #6b7280; --border: #e5e7eb; --accent: #6366f1; --accent-text: #ffffff; --success: #10b981; --warning: #f59e0b; --error: #ef4444; } @media (prefers-color-scheme: dark) { :root { --bg: #0f172a; --bg-subtle: #1e293b; --text: #f1f5f9; --text-secondary: #94a3b8; --border: #334155; --accent: #818cf8; --accent-text: #ffffff; --success: #34d399; --warning: #fbbf24; --error: #f87171; } }';
+                    style.textContent = '\(WebTokenInjector.cssTokenBlock().replacingOccurrences(of: "'", with: "\\'").replacingOccurrences(of: "\n", with: " "))';
                     (document.head || document.documentElement).appendChild(style);
 
-                    window.vellum.theme = {
-                        mode: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-                    };
-                    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
-                        window.vellum.theme.mode = e.matches ? 'dark' : 'light';
-                        window.dispatchEvent(new CustomEvent('vellum-theme-change', { detail: window.vellum.theme }));
-                    });
+                    \(WebTokenInjector.themeEventScript())
                 })();
                 """,
             injectionTime: .atDocumentStart,

--- a/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-edit-animator.js
@@ -23,7 +23,7 @@
       '.vellum-cursor {',
       '  display: inline;',
       '  animation: vellum-blink 0.6s step-end infinite;',
-      '  color: var(--v-accent, #6366f1);',
+      '  color: var(--v-accent, #537D53);',
       '}',
       '@keyframes vellum-blink { 50% { opacity: 0; } }'
     ].join('\n');

--- a/clients/macos/vellum-assistant/Resources/vellum-widgets.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-widgets.js
@@ -16,9 +16,9 @@
   // ─── SVG Chart Defaults ──────────────────────────────────────
 
   var defaultColors = {
-    line: 'var(--v-accent, #8A5BE0)',
-    fill: 'var(--v-accent, #8A5BE0)',
-    bar: 'var(--v-accent, #8A5BE0)',
+    line: 'var(--v-accent, #537D53)',
+    fill: 'var(--v-accent, #537D53)',
+    bar: 'var(--v-accent, #537D53)',
     grid: 'var(--v-surface-border, #334155)',
     text: 'var(--v-text-secondary, #94A3B8)',
     bg: 'transparent'

--- a/clients/shared/DesignSystem/Tokens/WebTokenInjector.swift
+++ b/clients/shared/DesignSystem/Tokens/WebTokenInjector.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Single source of truth for CSS custom-property tokens and theme-change JS
+/// injected into WKWebViews (DynamicPageSurfaceView and DocumentEditorView).
+public enum WebTokenInjector {
+
+    /// Returns a `<style>` -safe CSS block that declares all `--v-*` semantic
+    /// tokens under `:root`, with light-mode defaults and a
+    /// `@media (prefers-color-scheme: dark)` override.
+    ///
+    /// Hex values are resolved from the Moss / Forest / Stone palettes so the
+    /// block is self-contained (no dependency on palette custom properties).
+    public static func cssTokenBlock() -> String {
+        """
+        :root {
+          --v-bg: #FFFFFF;
+          --v-surface: #F5F5F7;
+          --v-surface-border: #D2D2D7;
+          --v-text: #1D1D1F;
+          --v-text-secondary: #86868B;
+          --v-text-muted: #AEAEB2;
+          --v-accent: #657D5B;
+          --v-accent-hover: #516748;
+        }
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --v-bg: #20201E;
+            --v-surface: #3A3A37;
+            --v-surface-border: #4A4A46;
+            --v-text: #F5F3EB;
+            --v-text-secondary: #A1A096;
+            --v-text-muted: #6B6B65;
+            --v-accent: #657D5B;
+            --v-accent-hover: #516748;
+          }
+        }
+        """
+    }
+
+    /// Returns a JS snippet that sets `window.vellum.theme.mode` to the
+    /// current colour-scheme and dispatches a `vellum-theme-change`
+    /// CustomEvent whenever the system appearance changes.
+    public static func themeEventScript() -> String {
+        """
+        window.vellum.theme = {
+            mode: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        };
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+            window.vellum.theme.mode = e.matches ? 'dark' : 'light';
+            window.dispatchEvent(new CustomEvent('vellum-theme-change', { detail: window.vellum.theme }));
+        });
+        """
+    }
+}


### PR DESCRIPTION
## Summary
- Create WebTokenInjector.swift with shared CSS token block and theme event JS
- Replace inline token definitions in DynamicPageSurfaceView and DocumentEditorView with shared helper
- Remove legacy non-prefixed CSS variable injection (--bg, --text, --accent)
- Update JS fallback colors to match green app palette

Part of plan: design-token-consolidation.md (PR 13 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
