### PR TITLE
fix: update CI workflows to use strict mode for design token guard

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -26,7 +26,7 @@ jobs:
         run: brew install xcodegen
 
       - name: Design token guard
-        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+        run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Cache SPM artifacts
         uses: actions/cache@v4

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -22,7 +22,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Design token guard
-        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+        run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Cache SPM build artifacts
         uses: actions/cache@v4

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -33,7 +33,7 @@ jobs:
         run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
 
       - name: Design token guard
-        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+        run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Build for simulator
         working-directory: clients/ios

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -99,7 +99,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Design token guard
-        run: bash clients/scripts/check-design-tokens.sh --mode=ratchet
+        run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Build binaries
         run: ./build.sh binaries


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** CI workflows still use --mode=ratchet after baseline file was deleted
**What was expected:** CI should use strict mode
**What was found:** All four workflows still pass --mode=ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
