### PR TITLE
fix: correct design token guard path in pr-macos.yaml

### DIFF
--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -99,6 +99,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Design token guard
+        working-directory: .
         run: bash clients/scripts/check-design-tokens.sh --mode=strict
 
       - name: Build binaries


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** pr-macos.yaml design token guard uses wrong path due to working-directory default
**What was expected:** Script should run from repo root
**What was found:** Job default working-directory is clients/macos, making the path resolve incorrectly
**Fix:** Added `working-directory: .` to the Design token guard step to override the job default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
