### PR TITLE
fix: guard loadDisplayName() against nil instanceDir

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -368,7 +368,7 @@ struct LockfileAssistant {
     /// Returns `nil` if the file doesn't exist, the name hasn't been set yet,
     /// or the name is the generic "Assistant" placeholder.
     func loadDisplayName() -> String? {
-        let base = instanceDir ?? NSHomeDirectory()
+        guard let base = instanceDir else { return nil }
         let identityPath = base + "/.vellum/workspace/IDENTITY.md"
         guard let info = IdentityInfo.load(from: identityPath) else { return nil }
         guard let resolved = AssistantDisplayName.firstUserFacing(from: [info.name]),


### PR DESCRIPTION
## Summary
- Guard `loadDisplayName()` to return nil when `instanceDir` is nil
- Previously fell back to `NSHomeDirectory()`, causing multiple assistants without per-instance dirs to show the same display name
- Now returns nil so the UI falls back to the assistant ID instead

## Test plan
- [ ] Verify assistants without instanceDir show their ID instead of a shared display name
- [ ] Verify assistants with instanceDir still show their display name from IDENTITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
