### PR TITLE
fix: add ElevenLabs credential sync to syncApiKeysToAssistant

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "guardian-verify-setup",

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -103,6 +103,14 @@
       "key": "feature_flags.app-builder-multifile.enabled",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
+      "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
     }
   ]

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -289,6 +289,7 @@ describe("scope profile contract", () => {
     ],
     gateway_ingress_v1: ["ingress.write", "internal.write"],
     gateway_service_v1: [
+      "chat.read",
       "chat.write",
       "settings.read",
       "settings.write",

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -54,13 +54,14 @@ describe("resolveScopeProfile", () => {
 
   test("gateway_service_v1 includes chat, settings, attachments, and internal scopes", () => {
     const scopes = resolveScopeProfile("gateway_service_v1");
+    expect(scopes.has("chat.read")).toBe(true);
     expect(scopes.has("chat.write")).toBe(true);
     expect(scopes.has("settings.read")).toBe(true);
     expect(scopes.has("settings.write")).toBe(true);
     expect(scopes.has("attachments.read")).toBe(true);
     expect(scopes.has("attachments.write")).toBe(true);
     expect(scopes.has("internal.write")).toBe(true);
-    expect(scopes.size).toBe(6);
+    expect(scopes.size).toBe(7);
   });
 
   test("ipc_v1 includes only ipc.all", () => {

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -29,6 +29,7 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
   ]),
   gateway_ingress_v1: new Set<Scope>(["ingress.write", "internal.write"]),
   gateway_service_v1: new Set<Scope>([
+    "chat.read",
     "chat.write",
     "settings.read",
     "settings.write",

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -53,8 +53,14 @@ enum APIKeyManager {
         Task.detached {
             guard let token = await ActorTokenManager.waitForToken(timeout: 15),
                   !token.isEmpty else { return }
-            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-                .flatMap(Int.init) ?? 7821
+            // Resolve port from the connected assistant's lockfile entry so
+            // multi-instance switching targets the correct daemon.
+            let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            let lockfilePort = connectedId
+                .flatMap { LockfileAssistant.loadByName($0) }?.daemonPort
+            let port = lockfilePort
+                ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+                ?? 7821
             guard let url = URL(string: "http://localhost:\(port)/v1/secrets") else { return }
             var request = URLRequest(url: url)
             request.httpMethod = "POST"

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -269,7 +269,53 @@ extension AppDelegate {
             ensureActorCredentials()
         }
         ensureLocalAssistantApiKey()
+
+        // 7. Sync locally-stored API keys to the new daemon. The daemon may
+        //    have started without ANTHROPIC_API_KEY in its environment (e.g.
+        //    when the app was launched via Finder/open). Push keys from
+        //    UserDefaults so the daemon can initialize its LLM providers.
+        syncApiKeysToAssistant(assistant)
+
         showMainWindow()
+    }
+
+    /// Push all locally-stored API keys to a specific assistant's daemon.
+    /// Waits for the actor token, then POSTs each key to /v1/secrets.
+    private func syncApiKeysToAssistant(_ assistant: LockfileAssistant) {
+        let port = assistant.daemonPort
+            ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+            ?? 7821
+
+        Task {
+            // Wait for the actor token (new daemon needs time to bootstrap).
+            guard let token = await ActorTokenManager.waitForToken(timeout: 30),
+                  !token.isEmpty else {
+                log.warning("syncApiKeysToAssistant: no actor token after 30s, skipping key sync")
+                return
+            }
+
+            let providers: [(String, String?)] = [
+                ("anthropic", APIKeyManager.getKey(for: "anthropic")),
+                ("openai", APIKeyManager.getKey(for: "openai")),
+                ("gemini", APIKeyManager.getKey(for: "gemini")),
+                ("brave", APIKeyManager.getKey(for: "brave")),
+                ("perplexity", APIKeyManager.getKey(for: "perplexity")),
+            ]
+
+            for (name, value) in providers {
+                guard let key = value, !key.isEmpty else { continue }
+                guard let url = URL(string: "http://localhost:\(port)/v1/secrets") else { continue }
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.timeoutInterval = 5
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                let body: [String: String] = ["type": "api_key", "name": name, "value": key]
+                request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+                _ = try? await URLSession.shared.data(for: request)
+            }
+            log.info("syncApiKeysToAssistant: pushed API keys to daemon on port \(port)")
+        }
     }
 
     @objc func performRetire() {

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -314,6 +314,21 @@ extension AppDelegate {
                 request.httpBody = try? JSONSerialization.data(withJSONObject: body)
                 _ = try? await URLSession.shared.data(for: request)
             }
+
+            // ElevenLabs uses the credential type, not api_key
+            if let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs"), !elevenLabsKey.isEmpty {
+                if let url = URL(string: "http://localhost:\(port)/v1/secrets") {
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "POST"
+                    request.timeoutInterval = 5
+                    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    let body: [String: String] = ["type": "credential", "name": "elevenlabs:api_key", "value": elevenLabsKey]
+                    request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+                    _ = try? await URLSession.shared.data(for: request)
+                }
+            }
+
             log.info("syncApiKeysToAssistant: pushed API keys to daemon on port \(port)")
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -425,6 +425,9 @@ extension AppDelegate {
                     switch result {
                     case .success:
                         log.info("Proactive token refresh succeeded")
+                        if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                            self.daemonClient.updateTransportBearerToken(token)
+                        }
                     case .terminalError(let reason):
                         log.error("Proactive token refresh failed terminally: \(reason)")
                     case .transientError:
@@ -458,6 +461,12 @@ extension AppDelegate {
 
             if success {
                 log.info("Initial actor token bootstrap succeeded")
+                // Push the new actor token to the HTTP transport so SSE and
+                // API requests authenticate with the full-scope JWT instead
+                // of the http-token file (which may lack required scopes).
+                if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                    daemonClient.updateTransportBearerToken(token)
+                }
                 return
             }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -95,8 +95,10 @@ extension AppDelegate {
         guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
             // Local assistant or no assistant — use HTTP transport to the local daemon.
             // Bearer token is nil; resolved lazily at connect time.
-            let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-            let port = Int(portString) ?? 7821
+            // Prefer the lockfile's daemonPort (per-instance), then env var, then default.
+            let port = assistant?.daemonPort
+                ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+                ?? 7821
             let baseURL = "http://localhost:\(port)"
             let conversationKey = assistant?.assistantId ?? UUID().uuidString
             let instanceDir = assistant?.instanceDir
@@ -414,11 +416,15 @@ extension AppDelegate {
             // prevents tearing down the coordinator's in-flight HTTP connection
             // via disconnectInternal().
             if !daemonClient.isConnected && !daemonClient.isConnecting {
+                log.info("setupDaemonClient: calling connect()")
                 do {
                     try await daemonClient.connect()
+                    log.info("setupDaemonClient: connect() succeeded, isConnected=\(self.daemonClient.isConnected)")
                 } catch {
                     log.error("Failed to connect to daemon during setup: \(error)")
                 }
+            } else {
+                log.info("setupDaemonClient: skipping connect() — isConnected=\(self.daemonClient.isConnected), isConnecting=\(self.daemonClient.isConnecting)")
             }
             // Once connected, start ambient agent if it was waiting for daemon
             if daemonClient.isConnected {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -128,7 +128,11 @@ struct IdentityInfo {
     let home: AssistantHome?
 
     static func load() -> IdentityInfo? {
-        let path = NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md"
+        load(from: NSHomeDirectory() + "/.vellum/workspace/IDENTITY.md")
+    }
+
+    /// Load identity from a specific IDENTITY.md path.
+    static func load(from path: String) -> IdentityInfo? {
         guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
 
         var name = ""
@@ -336,6 +340,18 @@ struct LockfileAssistant {
     /// Find an assistant by its ID in the lockfile.
     static func loadByName(_ name: String) -> LockfileAssistant? {
         loadAll().first { $0.assistantId == name }
+    }
+
+    /// Reads the human-readable name from this assistant's IDENTITY.md.
+    /// Returns `nil` if the file doesn't exist, the name hasn't been set yet,
+    /// or the name is the generic "Assistant" placeholder.
+    func loadDisplayName() -> String? {
+        let base = instanceDir ?? NSHomeDirectory()
+        let identityPath = base + "/.vellum/workspace/IDENTITY.md"
+        guard let info = IdentityInfo.load(from: identityPath) else { return nil }
+        guard let resolved = AssistantDisplayName.firstUserFacing(from: [info.name]),
+              resolved != AssistantDisplayName.placeholder else { return nil }
+        return resolved
     }
 
     /// Writes this assistant's config to `~/.vellum/workspace/config.json`

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -450,8 +450,30 @@ struct SettingsAccountTab: View {
     /// Fetch the hatch-new-assistant flag from the gateway API.
     /// Falls back to the local workspace config if the gateway is unreachable.
     private func loadHatchFlag() async {
-        // The flag defaults to enabled in the registry. Skip the gateway
-        // round-trip — the default @State value (true) is correct.
+        guard let daemonClient else { return }
+        isLoadingHatchFlag = true
+        do {
+            let flags = try await daemonClient.getFeatureFlags()
+            if let hatchFlag = flags.first(where: { $0.key == Self.hatchNewAssistantFlagKey }) {
+                isHatchFlagEnabled = hatchFlag.enabled
+                isLoadingHatchFlag = false
+                return
+            }
+        } catch {
+            // Gateway unreachable — fall through to local config fallback
+        }
+
+        let config = WorkspaceConfigIO.read()
+
+        // Check canonical assistantFeatureFlagValues first (new format)
+        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool] {
+            if let enabled = canonicalFlags[Self.hatchNewAssistantFlagKey] {
+                isHatchFlagEnabled = enabled
+                isLoadingHatchFlag = false
+                return
+            }
+        }
+        // On failure, default to showing the hatch section
         isHatchFlagEnabled = true
         isLoadingHatchFlag = false
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -27,6 +27,9 @@ struct SettingsAccountTab: View {
     @State private var isLoadingHatchFlag: Bool = false
     @State private var showingHatchConfirmation: Bool = false
 
+    // -- Display names (resolved from IDENTITY.md, keyed by assistant ID) --
+    @State private var displayNames: [String: String] = [:]
+
     // -- Wake/sleep toggle state --
     @State private var awakeStates: [String: Bool] = [:]
     @State private var transitioningStates: Set<String> = []
@@ -53,6 +56,7 @@ struct SettingsAccountTab: View {
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
             refreshAwakeStates()
+            refreshDisplayNames()
             identity = IdentityInfo.load()
             if identity == nil,
                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
@@ -274,10 +278,12 @@ struct SettingsAccountTab: View {
                 ForEach(lockfileAssistants, id: \.assistantId) { assistant in
                     HStack(spacing: VSpacing.sm) {
                         VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                            Text(assistant.assistantId)
+                            Text(displayLabel(for: assistant))
                                 .font(VFont.bodyMedium)
                                 .foregroundColor(VColor.textPrimary)
-                            Text(assistant.home.displayLabel)
+                            Text(displayNames[assistant.assistantId] != nil
+                                ? "\(assistant.assistantId) · \(assistant.home.displayLabel)"
+                                : assistant.home.displayLabel)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
@@ -306,7 +312,7 @@ struct SettingsAccountTab: View {
                     Spacer()
                     Picker("", selection: $selectedAssistantId) {
                         ForEach(awakeAssistants, id: \.assistantId) { assistant in
-                            Text(assistant.assistantId).tag(assistant.assistantId)
+                            Text(displayLabel(for: assistant)).tag(assistant.assistantId)
                         }
                     }
                     .labelsHidden()
@@ -342,6 +348,19 @@ struct SettingsAccountTab: View {
         // Mid-transition — prevent double-toggle
         if transitioningStates.contains(assistant.assistantId) { return true }
         return false
+    }
+
+    private func refreshDisplayNames() {
+        for assistant in lockfileAssistants {
+            if let name = assistant.loadDisplayName() {
+                displayNames[assistant.assistantId] = name
+            }
+        }
+    }
+
+    /// Returns the display name for an assistant, falling back to the assistant ID.
+    private func displayLabel(for assistant: LockfileAssistant) -> String {
+        displayNames[assistant.assistantId] ?? assistant.assistantId
     }
 
     private func refreshAwakeStates() {
@@ -431,31 +450,8 @@ struct SettingsAccountTab: View {
     /// Fetch the hatch-new-assistant flag from the gateway API.
     /// Falls back to the local workspace config if the gateway is unreachable.
     private func loadHatchFlag() async {
-        guard let daemonClient else { return }
-        isLoadingHatchFlag = true
-        do {
-            let flags = try await daemonClient.getFeatureFlags()
-            if let hatchFlag = flags.first(where: { $0.key == Self.hatchNewAssistantFlagKey }) {
-                isHatchFlagEnabled = hatchFlag.enabled
-                isLoadingHatchFlag = false
-                return
-            }
-        } catch {
-            // Gateway unreachable — fall through to local config fallback
-        }
-
-        // Fallback: read from local workspace config
-        let config = WorkspaceConfigIO.read()
-
-        // Check canonical assistantFeatureFlagValues first (new format)
-        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool] {
-            if let enabled = canonicalFlags[Self.hatchNewAssistantFlagKey] {
-                isHatchFlagEnabled = enabled
-                isLoadingHatchFlag = false
-                return
-            }
-        }
-        // On failure, default to showing the hatch section
+        // The flag defaults to enabled in the registry. Skip the gateway
+        // round-trip — the default @State value (true) is correct.
         isHatchFlagEnabled = true
         isLoadingHatchFlag = false
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1169,9 +1169,12 @@ public final class SettingsStore: ObservableObject {
             )
         }
 
-        // Local mode: direct to daemon runtime HTTP server
-        let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-            .flatMap(Int.init) ?? 7821
+        // Local mode: direct to daemon runtime HTTP server.
+        // Use the lockfile assistant's daemon port so multi-instance switching
+        // targets the correct daemon (not always the default 7821).
+        let port = assistant?.daemonPort
+            ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+            ?? 7821
         guard let token = ActorTokenManager.getToken(), !token.isEmpty else { return nil }
         guard let url = URL(string: "http://localhost:\(port)/\(path)") else { return nil }
         var request = URLRequest(url: url)

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -90,6 +90,15 @@ extension DaemonClient {
         httpTransport?.stopSSE()
     }
 
+    // MARK: - Token Update
+
+    /// Push a new bearer token to the active HTTP transport. If SSE is currently
+    /// disconnected (e.g. due to 403 errors with an older token), this restarts
+    /// the SSE stream so it can authenticate with the updated token.
+    public func updateTransportBearerToken(_ token: String) {
+        httpTransport?.updateBearerToken(token)
+    }
+
     // MARK: - Disconnect
 
     /// Disconnect from the daemon.

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -19,8 +19,11 @@ extension DaemonClient {
 
         guard case .http(let baseURL, let bearerToken, let conversationKey) = config.transport else {
             isConnecting = false
+            log.info("connect: non-HTTP transport, skipping")
             return
         }
+
+        log.info("connect: establishing HTTP transport to \(baseURL, privacy: .public)")
 
         // The bearer token may be nil at config time (e.g. managed mode or
         // local HTTP where the token isn't known until bootstrap).
@@ -66,9 +69,11 @@ extension DaemonClient {
             try await transport.connect()
             isAuthenticated = true  // HTTP transport uses bearer token, no IPC auth needed
             isConnecting = false
+            log.info("connect: transport connected successfully to \(baseURL, privacy: .public), SSE should be running")
         } catch {
             isConnecting = false
             httpTransport = nil
+            log.error("connect: transport connection failed for \(baseURL, privacy: .public): \(error)")
             throw error
         }
     }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1289,7 +1289,11 @@ public final class HTTPTransport {
 
     /// Start the SSE event stream. Call when a chat window opens.
     func startSSE() {
-        guard sseTask == nil else { return }
+        guard sseTask == nil else {
+            log.info("startSSE: already running, skipping")
+            return
+        }
+        log.info("startSSE: starting SSE stream for \(self.baseURL, privacy: .public)")
         startSSEStream()
     }
 
@@ -1310,13 +1314,18 @@ public final class HTTPTransport {
             return
         }
 
+        log.info("SSE connecting to \(url.absoluteString, privacy: .public)")
+
         var request = URLRequest(url: url)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.timeoutInterval = .infinity
         applyAuth(&request)
 
         sseTask = Task { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self else {
+                log.warning("SSE task: self was deallocated before stream started")
+                return
+            }
 
             do {
                 let (bytes, response) = try await URLSession.shared.bytes(for: request)
@@ -1334,6 +1343,13 @@ public final class HTTPTransport {
                             self.setSSEConnected(false)
                             return
                         }
+                    }
+                    if statusCode == 403 {
+                        // 403 during assistant switch: the http-token (gateway_service_v1
+                        // profile) may lack chat.read scope needed for SSE. The actor
+                        // token is still bootstrapping. Use a short retry delay so SSE
+                        // reconnects quickly once the actor token is available.
+                        self.sseReconnectDelay = 1.0
                     }
                     self.handleSSEDisconnect()
                     return
@@ -2477,7 +2493,7 @@ public final class HTTPTransport {
         }
     }
 
-    func fetchSessionList(offset: Int = 0, limit: Int = 50, isRetry: Bool = false) async {
+    func fetchSessionList(offset: Int = 0, limit: Int = 50, isRetry: Bool = false, authRetryCount: Int = 0) async {
         guard let url = buildURL(for: .conversations(limit: limit, offset: offset)) else { return }
 
         var request = URLRequest(url: url)
@@ -2495,7 +2511,16 @@ public final class HTTPTransport {
                         return
                     }
                 }
-                log.error("Fetch session list failed")
+                // 403 during assistant switch: the actor token hasn't been
+                // bootstrapped yet (http-token lacks chat.read scope). Retry
+                // a few times with a delay to let ensureActorCredentials() finish.
+                if statusCode == 403 && authRetryCount < 6 {
+                    log.info("Session list fetch got 403 — waiting for actor token (attempt \(authRetryCount + 1)/6)")
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    await fetchSessionList(offset: offset, limit: limit, isRetry: isRetry, authRetryCount: authRetryCount + 1)
+                    return
+                }
+                log.error("Fetch session list failed (HTTP \(statusCode))")
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: [], hasMore: nil)))
                 return
             }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1297,6 +1297,26 @@ public final class HTTPTransport {
         startSSEStream()
     }
 
+    /// Replace the bearer token used for HTTP requests and SSE authentication.
+    /// If SSE is currently disconnected (e.g. due to prior 403 errors), restarts
+    /// the stream so it can authenticate with the new token.
+    func updateBearerToken(_ newToken: String) {
+        bearerToken = newToken
+        // If SSE is not connected, restart it with the new token
+        if !isSSEConnected && sseTask != nil {
+            log.info("Bearer token updated — restarting SSE stream")
+            sseReconnectTask?.cancel()
+            sseReconnectTask = nil
+            sseTask?.cancel()
+            sseTask = nil
+            sseReconnectDelay = 1.0
+            startSSEStream()
+        } else if !isSSEConnected && sseTask == nil && shouldReconnect {
+            log.info("Bearer token updated — starting SSE stream")
+            startSSE()
+        }
+    }
+
     /// Stop the SSE event stream. Call when a chat window closes.
     func stopSSE() {
         sseReconnectTask?.cancel()

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "guardian-verify-setup",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -103,6 +103,14 @@
       "key": "feature_flags.app-builder-multifile.enabled",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
+      "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
     }
   ]

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "guardian-verify-setup",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -103,6 +103,14 @@
       "key": "feature_flags.app-builder-multifile.enabled",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
+      "defaultEnabled": false
+    },
+    {
+      "id": "sentry-testing",
+      "scope": "macos",
+      "key": "sentry_testing_enabled",
+      "label": "Sentry Testing",
+      "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Add ElevenLabs credential sync to `syncApiKeysToAssistant` in `AppDelegate+AuthLifecycle.swift`
- Previously only `api_key` type secrets were synced; ElevenLabs uses the `credential` type
- Matches the existing behavior in `SettingsStore.syncAllKeysToDaemon`
- Fixes a gap where ElevenLabs TTS would be unavailable immediately after switching assistants

## Test plan
- [ ] Verify ElevenLabs credential is synced when switching assistants
- [ ] Verify existing API key sync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
