### PR TITLE
fix: sync chat.read scope to gateway_service_v1 profile

### DIFF
--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -29,6 +29,7 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
   ]),
   gateway_ingress_v1: new Set<Scope>(["ingress.write", "internal.write"]),
   gateway_service_v1: new Set<Scope>([
+    "chat.read",
     "chat.write",
     "settings.read",
     "settings.write",


### PR DESCRIPTION
## Summary
- Add `chat.read` to the `gateway_service_v1` scope profile in `gateway/src/auth/scopes.ts` to match the assistant-side definition
- This was missed in PR #14698 which added the scope to the assistant side only
- Without this fix, gateway would return 403 for `chat.read`-scoped routes when authenticating with a `gateway_service_v1` token

## Test plan
- [ ] Verify gateway scope profile includes `chat.read`
- [ ] Verify assistant and gateway scope profiles are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
