### PR TITLE
fix: correct skillCatDevelopment token to use original hex value

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -262,7 +262,7 @@ public enum VColor {
     // Skill category colors (constellation)
     public static let skillCatCommunication = Color(hex: 0x8B5DAA)
     public static let skillCatProductivity = Color(hex: 0x4682B4)
-    public static let skillCatDevelopment = Danger._700
+    public static let skillCatDevelopment = Color(hex: 0xC1421B)
     public static let skillCatMedia = Color(hex: 0xD4A017)
     public static let skillCatAutomation = Color(hex: 0x2E8B57)
     public static let skillCatWebSocial = Color(hex: 0xCD853F)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** skillCatDevelopment uses Danger._700 (0xDA491A) instead of original 0xC1421B
**What was expected:** Exact color match with original inline value
**What was found:** Token mapped to wrong palette entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
