### PR TITLE
fix: restore Forest._300 dark-mode foreground for success buttons and active icons

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -175,7 +175,7 @@ private struct VButtonStyle: ButtonStyle {
         case .danger: return .white
         case .ghost: return VColor.buttonPrimary
         case .outlined: return VColor.buttonSecondaryText
-        case .success: return VColor.iconAccent
+        case .success: return VColor.activeIconForeground
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -74,7 +74,7 @@ public struct VIconButton: View {
 
     private var iconForegroundColor: Color {
         if isActive {
-            return VColor.iconAccent
+            return VColor.activeIconForeground
         }
         return VColor.buttonSecondaryText
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -183,6 +183,9 @@ public enum VColor {
     // Icon & button accent
     public static let iconAccent = adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._500)
 
+    // Active/highlighted icon foreground — lighter green in dark mode for better contrast
+    public static let activeIconForeground = adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
+
     // Send button — always green
     public static let sendButton = Color(hex: 0x216C37)
     public static let accentSubtle = adaptiveColor(light: Forest._100, dark: Forest._900)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** VButton success and VIconButton active foreground regressed from Forest._300 to Forest._500 in dark mode
**What was expected:** Forest._300 (lighter, more readable) in dark mode
**What was found:** Forest._500 (darker, less contrast) via iconAccent token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
