### PR TITLE
fix: restore sidebar drop indicator and action text colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -242,7 +242,7 @@ extension MainWindowView {
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                 if sidebar.dropTargetThreadId == thread.id {
                                     Rectangle()
-                                        .fill(VColor.iconAccent)
+                                        .fill(VColor.dropIndicator)
                                         .frame(height: 2)
                                         .transition(.opacity)
                                 }
@@ -275,7 +275,7 @@ extension MainWindowView {
                         } label: {
                             Text(sidebar.showAllThreads ? "Show less" : "Show more")
                                 .font(VFont.caption)
-                                .foregroundColor(VColor.buttonSecondaryText)
+                                .foregroundColor(VColor.sidebarActionText)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.leading, VSpacing.sm + VSpacing.xs + 20 + VSpacing.xs)
                                 .padding(.top, VSpacing.sm)
@@ -312,7 +312,7 @@ extension MainWindowView {
                                     .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                         if sidebar.dropTargetThreadId == thread.id {
                                             Rectangle()
-                                                .fill(VColor.iconAccent)
+                                                .fill(VColor.dropIndicator)
                                                 .frame(height: 2)
                                                 .transition(.opacity)
                                         }
@@ -392,7 +392,7 @@ extension MainWindowView {
                                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                                 if sidebar.dropTargetThreadId == thread.id {
                                                     Rectangle()
-                                                        .fill(VColor.iconAccent)
+                                                        .fill(VColor.dropIndicator)
                                                         .frame(height: 2)
                                                         .transition(.opacity)
                                                 }
@@ -425,7 +425,7 @@ extension MainWindowView {
                             } label: {
                                 Text(sidebar.showAllScheduleThreads ? "Show less" : "Show more")
                                     .font(VFont.caption)
-                                    .foregroundColor(VColor.buttonSecondaryText)
+                                    .foregroundColor(VColor.sidebarActionText)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.leading, VSpacing.sm + VSpacing.xs + 20 + VSpacing.xs)
                                     .padding(.top, VSpacing.sm)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -325,4 +325,10 @@ public enum VColor {
     public static let iconGhostActiveBg = adaptiveColor(light: Moss._100, dark: Moss._700)
     public static let iconGhostActivePressed = adaptiveColor(light: Moss._200, dark: Moss._600)
     public static let iconGhostActiveDisabled = adaptiveColor(light: Moss._100, dark: Moss._700)
+
+    // Sidebar drop indicator
+    public static let dropIndicator = adaptiveColor(light: Forest._500, dark: Forest._400)
+
+    // Sidebar action text (Show more / Show less)
+    public static let sidebarActionText = adaptiveColor(light: Forest._600, dark: Forest._400)
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** Sidebar drop indicators and Show more text colors regressed
**What was expected:** Original Forest._500/_400 for drop indicators, Forest._600/_400 for action text
**What was found:** VColor.iconAccent and VColor.buttonSecondaryText have different values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
