### PR TITLE
fix: restore DocumentEditorView original CSS token values

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentEditorView.swift
@@ -236,7 +236,26 @@ private func generateEditorHTML(title: String, initialContent: String) -> String
   <style media="(prefers-color-scheme: light)">\(githubCSS)</style>
 
   <style>
-    \(WebTokenInjector.cssTokenBlock())
+    :root {
+      --v-bg: #FFFFFF;
+      --v-surface: #FFFFFF;
+      --v-surface-border: #E7E5E4;
+      --v-text: #292524;
+      --v-text-secondary: #78716C;
+      --v-text-muted: #97918B;
+      --v-accent: #262624;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --v-bg: #262624;
+        --v-surface: #2F2F2D;
+        --v-surface-border: #3A3A37;
+        --v-text: #F5F3EB;
+        --v-text-secondary: #A1A096;
+        --v-text-muted: #6B6B65;
+        --v-accent: #216C37;
+      }
+    }
     /* Invert toolbar icons in dark mode — target both the JS-applied class and the media query */
     .toastui-editor-dark .toastui-editor-toolbar-icons { filter: invert(1) brightness(0.85) !important; }
     @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** DocumentEditorView CSS token values changed when migrated to WebTokenInjector
**What was expected:** Editor should keep its original Stone-palette CSS values
**What was found:** WebTokenInjector provides different values causing visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
