### PR TITLE
fix: add ElevenLabs credential sync to syncApiKeysToAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -328,6 +328,21 @@ extension AppDelegate {
                 request.httpBody = try? JSONSerialization.data(withJSONObject: body)
                 _ = try? await URLSession.shared.data(for: request)
             }
+
+            // ElevenLabs uses the credential type, not api_key
+            if let elevenLabsKey = APIKeyManager.getKey(for: "elevenlabs"), !elevenLabsKey.isEmpty {
+                if let url = URL(string: "http://localhost:\(port)/v1/secrets") {
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "POST"
+                    request.timeoutInterval = 5
+                    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    let body: [String: String] = ["type": "credential", "name": "elevenlabs:api_key", "value": elevenLabsKey]
+                    request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+                    _ = try? await URLSession.shared.data(for: request)
+                }
+            }
+
             log.info("syncApiKeysToAssistant: pushed API keys to daemon on port \(port)")
         }
     }


### PR DESCRIPTION
## Summary
- Add ElevenLabs credential sync to `syncApiKeysToAssistant` in `AppDelegate+AuthLifecycle.swift`
- Previously only `api_key` type secrets were synced; ElevenLabs uses the `credential` type
- Matches the existing behavior in `SettingsStore.syncAllKeysToDaemon`
- Fixes a gap where ElevenLabs TTS would be unavailable immediately after switching assistants

## Test plan
- [ ] Verify ElevenLabs credential is synced when switching assistants
- [ ] Verify existing API key sync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
