### PR TITLE
fix: update vellum-widgets.js fallback colors to match moss palette

### DIFF
--- a/clients/macos/vellum-assistant/Resources/vellum-widgets.js
+++ b/clients/macos/vellum-assistant/Resources/vellum-widgets.js
@@ -16,11 +16,11 @@
   // ─── SVG Chart Defaults ──────────────────────────────────────
 
   var defaultColors = {
-    line: 'var(--v-accent, #537D53)',
-    fill: 'var(--v-accent, #537D53)',
-    bar: 'var(--v-accent, #537D53)',
-    grid: 'var(--v-surface-border, #334155)',
-    text: 'var(--v-text-secondary, #94A3B8)',
+    line: 'var(--v-accent, #657D5B)',
+    fill: 'var(--v-accent, #657D5B)',
+    bar: 'var(--v-accent, #657D5B)',
+    grid: 'var(--v-surface-border, #4A4A46)',
+    text: 'var(--v-text-secondary, #A1A096)',
     bg: 'transparent'
   };
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** vellum-widgets.js CSS fallback colors use stale slate palette values
**What was expected:** Fallback colors matching the app's green/moss palette
**What was found:** Slate-blue fallback values (#334155, #94A3B8) instead of moss values

- Updated `--v-accent` fallbacks from `#537D53` to `#657D5B` (matching WebTokenInjector dark-mode accent)
- Updated `--v-surface-border` fallback from `#334155` to `#4A4A46` (moss/stone dark-mode border)
- Updated `--v-text-secondary` fallback from `#94A3B8` to `#A1A096` (moss/stone dark-mode secondary text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
