### PR TITLE
fix: align daemon editor-template.ts CSS tokens with app palette

### DIFF
--- a/assistant/src/tools/document/editor-template.ts
+++ b/assistant/src/tools/document/editor-template.ts
@@ -39,17 +39,19 @@ export function generateEditorHTML(
       --v-text: #1D1D1F;
       --v-text-secondary: #86868B;
       --v-text-muted: #AEAEB2;
-      --v-accent: #8A5BE0;
+      --v-accent: #657D5B;
+      --v-accent-hover: #516748;
     }
     @media (prefers-color-scheme: dark) {
       :root {
-        --v-bg: #070D19;
-        --v-surface: #1E293B;
-        --v-surface-border: #334155;
-        --v-text: #F8FAFC;
-        --v-text-secondary: #94A3B8;
-        --v-text-muted: #64748B;
-        --v-accent: #8A5BE0;
+        --v-bg: #20201E;
+        --v-surface: #3A3A37;
+        --v-surface-border: #4A4A46;
+        --v-text: #F5F3EB;
+        --v-text-secondary: #A1A096;
+        --v-text-muted: #6B6B65;
+        --v-accent: #657D5B;
+        --v-accent-hover: #516748;
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** Daemon editor-template.ts has stale purple/slate CSS token values
**What was expected:** CSS tokens matching the app's green/moss palette
**What was found:** Purple/slate values diverging from client-side WebTokenInjector

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
