### PR TITLE
fix: add dedicated onboardingFileIcon token for foreground use

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -119,6 +119,11 @@ declare -a SAFE_LINE_PATTERNS=(
     # Also covers ternary expressions with no string literals
     # (e.g. `clientSecret: twitterClientSecret.isEmpty ? nil : twitterClientSecret`).
     "[Cc]lient[Ss]ecret:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*([[:space:]]*$|[[:space:]]+[?][[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*$)"
+    # Swift/JS: assignment of privateKey variable to empty string
+    # (e.g. `state.sshPrivateKey = ""`)
+    "[Pp]rivate[Kk]ey[[:space:]]*=[[:space:]]*['\"]['\"][[:space:]]*$"
+    # Swift: assignment of privateKey to a variable (e.g. `state.sshPrivateKey = contents`)
+    "[Pp]rivate[Kk]ey[[:space:]]*=[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*$"
     # Swift: named argument passing a variable for privateKey (e.g. `sshPrivateKey: state.sshPrivateKey,`)
     "[Pp]rivate[Kk]ey:[[:space:]]*[a-zA-Z_][a-zA-Z0-9_.]*[[:space:]]*[,)][[:space:]]*$"
     # Swift/Kotlin: constant declaration whose value is a camelCase identifier
@@ -272,6 +277,10 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_NAMED_ARG='                clientSecret: trimmedSecret'
     # Swift named argument passing a variable for privateKey (false positive to whitelist)
     SAFE_SWIFT_PRIVATE_KEY_ARG='            sshPrivateKey: state.sshPrivateKey,'
+    # Swift assignment of privateKey to empty string (false positive to whitelist)
+    SAFE_SWIFT_PRIVATE_KEY_EMPTY='                state.sshPrivateKey = ""'
+    # Swift assignment of privateKey to a variable (false positive to whitelist)
+    SAFE_SWIFT_PRIVATE_KEY_VAR='                state.sshPrivateKey = contents'
     # TS type assertion of clientSecret from dotted property (false positive to whitelist)
     SAFE_TS_TYPE_ASSERTION_SECRET='  const clientSecret = meta?.oauth2ClientSecret as string | undefined;'
     # AWS well-known example key (false positive to whitelist)
@@ -535,6 +544,14 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG" && ! matches_safe_line_pattern "$SAFE_SWIFT_PRIVATE_KEY_ARG"; then
         echo -e "${RED}Self-test failed:${NC} Swift named argument sshPrivateKey false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_PRIVATE_KEY_EMPTY" && ! matches_safe_line_pattern "$SAFE_SWIFT_PRIVATE_KEY_EMPTY"; then
+        echo -e "${RED}Self-test failed:${NC} Swift sshPrivateKey empty string assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_SWIFT_PRIVATE_KEY_VAR" && ! matches_safe_line_pattern "$SAFE_SWIFT_PRIVATE_KEY_VAR"; then
+        echo -e "${RED}Self-test failed:${NC} Swift sshPrivateKey variable assignment false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then

--- a/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/CloudCredentialsStepView.swift
@@ -332,7 +332,7 @@ struct CloudCredentialsStepView: View {
         } else {
             HStack(spacing: VSpacing.sm) {
                 VIconView(.file, size: 14)
-                    .foregroundColor(VColor.onboardingStepBackground)
+                    .foregroundColor(VColor.onboardingFileIcon)
                 Text(fileName)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundColor(VColor.textPrimary)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -293,6 +293,7 @@ public enum VColor {
     public static let onboardingGradientOuter = adaptiveColor(light: Stone._200, dark: Moss._950)
     public static let onboardingHatchGradientOuter = adaptiveColor(light: Moss._200, dark: Moss._950)
     public static let onboardingStepBackground = adaptiveColor(light: Stone._900, dark: Forest._600)
+    public static let onboardingFileIcon = adaptiveColor(light: Stone._900, dark: Forest._600)
     public static let onboardingLink = adaptiveColor(light: Color(hex: 0x262624), dark: Forest._400)
     public static let onboardingBorderStroke = adaptiveColor(light: Stone._900.opacity(0.3), dark: Forest._600.opacity(0.3))
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for design-token-consolidation.md.

**Gap:** VColor.onboardingStepBackground misused as icon foreground color
**What was expected:** Semantic tokens used according to their purpose
**What was found:** Background token used as .foregroundColor for a file icon

Also adds pre-commit hook safe-line patterns for `sshPrivateKey` variable assignments (false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
