### PR TITLE
feat: add cross-platform DirectoryStore to shared library

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
@@ -15,22 +15,14 @@ enum DirectoryTab: String, CaseIterable {
     }
 }
 
-struct DocumentItem: Identifiable {
-    let id: String  // surfaceId
-    let title: String
-    let wordCount: Int
-    let updatedAt: Date
-}
-
 struct DirectoryPanel: View {
     var onClose: () -> Void
     @ObservedObject var documentManager: DocumentManager
     @ObservedObject var threadManager: ThreadManager
     @ObservedObject var appListManager: AppListManager
+    @ObservedObject var directoryStore: DirectoryStore
     let daemonClient: DaemonClient
     @State private var selectedTab: DirectoryTab = .documents
-    @State private var savedDocuments: [DocumentItem] = []
-    @State private var isLoadingDocuments = false
 
     var body: some View {
         VSidePanel(title: "Directory", onClose: onClose, pinnedContent: { EmptyView() }) {
@@ -157,10 +149,7 @@ struct DirectoryPanel: View {
 
     private var documentsContent: some View {
         Group {
-            if isLoadingDocuments {
-                ProgressView("Loading documents...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if savedDocuments.isEmpty {
+            if directoryStore.documents.isEmpty {
                 VEmptyState(
                     title: "No saved documents",
                     subtitle: "Documents you save will appear here",
@@ -170,7 +159,7 @@ struct DirectoryPanel: View {
             } else {
                 ScrollView {
                     VStack(spacing: VSpacing.sm) {
-                        ForEach(savedDocuments) { doc in
+                        ForEach(directoryStore.documents) { doc in
                             documentRow(doc)
                         }
                     }
@@ -179,14 +168,14 @@ struct DirectoryPanel: View {
             }
         }
         .onAppear {
-            loadDocuments()
+            directoryStore.fetchDocuments()
         }
     }
 
-    private func documentRow(_ doc: DocumentItem) -> some View {
+    private func documentRow(_ doc: DocumentListItem) -> some View {
         Button(action: {
             // Load and open this document
-            try? daemonClient.sendDocumentLoad(surfaceId: doc.id)
+            directoryStore.loadDocument(surfaceId: doc.id)
         }) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text(doc.title)
@@ -222,33 +211,14 @@ struct DirectoryPanel: View {
         return formatter.localizedString(for: date, relativeTo: Date())
     }
 
-    private func loadDocuments() {
-        isLoadingDocuments = true
-
-        // Request document list from daemon
-        daemonClient.onDocumentListResponse = { [self] response in
-            Task { @MainActor in
-                self.savedDocuments = response.documents.map { doc in
-                    DocumentItem(
-                        id: doc.surfaceId,
-                        title: doc.title,
-                        wordCount: doc.wordCount,
-                        updatedAt: Date(timeIntervalSince1970: TimeInterval(doc.updatedAt) / 1000.0)
-                    )
-                }
-                self.isLoadingDocuments = false
-            }
-        }
-
-        try? daemonClient.sendDocumentList(conversationId: nil)  // nil = all documents
-    }
 }
 
 #Preview {
     let documentManager = DocumentManager()
-    let threadManager = ThreadManager(daemonClient: DaemonClient())
-    let appListManager = AppListManager()
     let daemonClient = DaemonClient()
+    let threadManager = ThreadManager(daemonClient: daemonClient)
+    let appListManager = AppListManager()
+    let directoryStore = DirectoryStore(daemonClient: daemonClient)
 
     return ZStack {
         VColor.background.ignoresSafeArea()
@@ -257,6 +227,7 @@ struct DirectoryPanel: View {
             documentManager: documentManager,
             threadManager: threadManager,
             appListManager: appListManager,
+            directoryStore: directoryStore,
             daemonClient: daemonClient
         )
         .frame(width: 400, height: 600)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
@@ -149,7 +149,10 @@ struct DirectoryPanel: View {
 
     private var documentsContent: some View {
         Group {
-            if directoryStore.documents.isEmpty {
+            if directoryStore.isLoadingDocuments {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if directoryStore.documents.isEmpty {
                 VEmptyState(
                     title: "No saved documents",
                     subtitle: "Documents you save will appear here",

--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -1,0 +1,233 @@
+import Combine
+import Foundation
+
+/// Cross-platform store for directory data operations (local apps, shared apps, documents).
+///
+/// Encapsulates all daemon communication for listing, opening, deleting, and sharing
+/// apps and documents. Platform-specific UI (tabs, navigation, presentation) remains
+/// in the platform view that delegates here.
+@MainActor
+public final class DirectoryStore: ObservableObject {
+
+    // MARK: - Published State
+
+    @Published public var localApps: [AppItem] = []
+    @Published public var sharedApps: [SharedAppItem] = []
+    @Published public var documents: [DocumentListItem] = []
+    @Published public var isLoading = false
+
+    // MARK: - Private State
+
+    private let daemonClient: DaemonClient
+    private var appFilesChangedTask: Task<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    public init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        subscribeToAppFilesChanged()
+    }
+
+    deinit {
+        appFilesChangedTask?.cancel()
+        debounceTask?.cancel()
+    }
+
+    // MARK: - Local Apps
+
+    /// Fetch the list of local apps from the daemon.
+    public func fetchApps() {
+        isLoading = true
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendAppsList()
+            } catch {
+                isLoading = false
+                return
+            }
+
+            for await message in stream {
+                if case .appsListResponse(let response) = message {
+                    self.localApps = response.apps
+                    self.isLoading = false
+                    return
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    /// Open a local app by ID.
+    public func openApp(id: String) {
+        try? daemonClient.sendAppOpen(appId: id)
+    }
+
+    /// Delete a local app by ID.
+    public func deleteApp(id: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendAppDelete(appId: id)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .appDeleteResponse(let response) = message {
+                    if response.success {
+                        localApps.removeAll { $0.id == id }
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Share a local app to the cloud.
+    public func shareAppCloud(id: String) {
+        try? daemonClient.sendShareAppCloud(appId: id)
+    }
+
+    // MARK: - Shared Apps
+
+    /// Fetch the list of shared apps from the daemon.
+    public func fetchSharedApps() {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendSharedAppsList()
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .sharedAppsListResponse(let response) = message {
+                    self.sharedApps = response.apps
+                    return
+                }
+            }
+        }
+    }
+
+    /// Delete a shared app by UUID.
+    public func deleteSharedApp(uuid: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendSharedAppDelete(uuid: uuid)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .sharedAppDeleteResponse(let response) = message {
+                    if response.success {
+                        sharedApps.removeAll { $0.uuid == uuid }
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Fork a shared app by UUID.
+    public func forkSharedApp(uuid: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendForkSharedApp(uuid: uuid)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .forkSharedAppResponse = message {
+                    return
+                }
+            }
+        }
+    }
+
+    /// Bundle a local app for sharing.
+    public func bundleApp(id: String) {
+        try? daemonClient.sendBundleApp(appId: id)
+    }
+
+    // MARK: - Documents
+
+    /// Fetch the list of documents from the daemon.
+    public func fetchDocuments(conversationId: String? = nil) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendDocumentList(conversationId: conversationId)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .documentListResponse(let response) = message {
+                    self.documents = response.documents.map { doc in
+                        DocumentListItem(
+                            id: doc.surfaceId,
+                            title: doc.title,
+                            wordCount: doc.wordCount,
+                            updatedAt: Date(timeIntervalSince1970: TimeInterval(doc.updatedAt) / 1000.0)
+                        )
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    /// Load a specific document by surface ID.
+    public func loadDocument(surfaceId: String) {
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendDocumentLoad(surfaceId: surfaceId)
+            } catch {
+                return
+            }
+
+            for await message in stream {
+                if case .documentLoadResponse = message {
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Subscribe to appFilesChanged broadcasts with debounce, then refresh local apps.
+    private func subscribeToAppFilesChanged() {
+        appFilesChangedTask = Task { [weak self] in
+            guard let daemonClient = self?.daemonClient else { return }
+            let stream = daemonClient.subscribe()
+
+            for await message in stream {
+                guard let self, !Task.isCancelled else { return }
+                if case .appFilesChanged = message {
+                    self.debounceTask?.cancel()
+                    self.debounceTask = Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        guard !Task.isCancelled else { return }
+                        self?.fetchApps()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -14,7 +14,9 @@ public final class DirectoryStore: ObservableObject {
     @Published public var localApps: [AppItem] = []
     @Published public var sharedApps: [SharedAppItem] = []
     @Published public var documents: [DocumentListItem] = []
-    @Published public var isLoading = false
+    @Published public var isLoadingApps = false
+    @Published public var isLoadingSharedApps = false
+    @Published public var isLoadingDocuments = false
 
     // MARK: - Private State
 
@@ -38,7 +40,7 @@ public final class DirectoryStore: ObservableObject {
 
     /// Fetch the list of local apps from the daemon.
     public func fetchApps() {
-        isLoading = true
+        isLoadingApps = true
 
         Task {
             let stream = daemonClient.subscribe()
@@ -46,18 +48,18 @@ public final class DirectoryStore: ObservableObject {
             do {
                 try daemonClient.sendAppsList()
             } catch {
-                isLoading = false
+                isLoadingApps = false
                 return
             }
 
             for await message in stream {
                 if case .appsListResponse(let response) = message {
                     self.localApps = response.apps
-                    self.isLoading = false
+                    self.isLoadingApps = false
                     return
                 }
             }
-            isLoading = false
+            isLoadingApps = false
         }
     }
 
@@ -80,7 +82,7 @@ public final class DirectoryStore: ObservableObject {
             for await message in stream {
                 if case .appDeleteResponse(let response) = message {
                     if response.success {
-                        localApps.removeAll { $0.id == id }
+                        fetchApps()
                     }
                     return
                 }
@@ -97,21 +99,26 @@ public final class DirectoryStore: ObservableObject {
 
     /// Fetch the list of shared apps from the daemon.
     public func fetchSharedApps() {
+        isLoadingSharedApps = true
+
         Task {
             let stream = daemonClient.subscribe()
 
             do {
                 try daemonClient.sendSharedAppsList()
             } catch {
+                isLoadingSharedApps = false
                 return
             }
 
             for await message in stream {
                 if case .sharedAppsListResponse(let response) = message {
                     self.sharedApps = response.apps
+                    self.isLoadingSharedApps = false
                     return
                 }
             }
+            isLoadingSharedApps = false
         }
     }
 
@@ -129,7 +136,7 @@ public final class DirectoryStore: ObservableObject {
             for await message in stream {
                 if case .sharedAppDeleteResponse(let response) = message {
                     if response.success {
-                        sharedApps.removeAll { $0.uuid == uuid }
+                        fetchSharedApps()
                     }
                     return
                 }
@@ -165,12 +172,15 @@ public final class DirectoryStore: ObservableObject {
 
     /// Fetch the list of documents from the daemon.
     public func fetchDocuments(conversationId: String? = nil) {
+        isLoadingDocuments = true
+
         Task {
             let stream = daemonClient.subscribe()
 
             do {
                 try daemonClient.sendDocumentList(conversationId: conversationId)
             } catch {
+                isLoadingDocuments = false
                 return
             }
 
@@ -184,9 +194,11 @@ public final class DirectoryStore: ObservableObject {
                             updatedAt: Date(timeIntervalSince1970: TimeInterval(doc.updatedAt) / 1000.0)
                         )
                     }
+                    self.isLoadingDocuments = false
                     return
                 }
             }
+            isLoadingDocuments = false
         }
     }
 

--- a/clients/shared/Features/Directory/DocumentListItem.swift
+++ b/clients/shared/Features/Directory/DocumentListItem.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A cross-platform model representing a document in the directory listing.
+public struct DocumentListItem: Identifiable {
+    public let id: String  // surfaceId
+    public let title: String
+    public let wordCount: Int
+    public let updatedAt: Date
+
+    public init(id: String, title: String, wordCount: Int, updatedAt: Date) {
+        self.id = id
+        self.title = title
+        self.wordCount = wordCount
+        self.updatedAt = updatedAt
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -310,9 +310,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `document_save_response` message.
     public var onDocumentSaveResponse: ((DocumentSaveResponseMessage) -> Void)?
 
-    /// Called when the daemon sends a `document_list_response` message.
-    public var onDocumentListResponse: ((DocumentListResponseMessage) -> Void)?
-
     /// Called when the daemon sends a `document_load_response` message.
     public var onDocumentLoadResponse: ((DocumentLoadResponseMessage) -> Void)?
 

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -56,8 +56,6 @@ extension DaemonClient {
             onDocumentSaveResponse?(msg)
         case .documentLoadResponse(let msg):
             onDocumentLoadResponse?(msg)
-        case .documentListResponse(let msg):
-            onDocumentListResponse?(msg)
         case .uiLayoutConfig(let msg):
             onLayoutConfig?(msg)
         case .appFilesChanged(let msg):


### PR DESCRIPTION
## Summary
Extract directory data operations (local apps, shared apps, documents) into a shared DirectoryStore for cross-platform reuse. Refactor macOS DirectoryPanel to delegate to the store. Move DocumentListItem to shared library.

## Implementation
- **DirectoryStore** (`clients/shared/Features/Directory/DirectoryStore.swift`): A `@MainActor` ObservableObject that manages local apps, shared apps, and documents via DaemonClient stream subscriptions. Follows the same patterns as ContactsStore (weak self in long-lived tasks, debounced broadcast subscriptions, task cancellation in deinit).
- **DocumentListItem** (`clients/shared/Features/Directory/DocumentListItem.swift`): Shared Identifiable model for document listings, extracted from the macOS-only DirectoryPanel.
- **DirectoryPanel refactor**: Removed local `DocumentItem` struct and `loadDocuments()` callback-based method. Panel now delegates document fetching and loading to DirectoryStore.

## Key Technical Choices
- Used the stream-based subscribe pattern (matching ContactsStore) rather than the callback pattern that was in DirectoryPanel's `loadDocuments()`. This is consistent with the codebase direction and avoids retain cycle concerns.
- Kept macOS-specific UI (tabs, navigation, AppListManager usage) in DirectoryPanel. Only data operations moved to the shared store.
- New files are automatically included in VellumAssistantShared via SPM path-based discovery (no Package.swift changes needed).

## Files Changed
- **New**: `clients/shared/Features/Directory/DirectoryStore.swift`
- **New**: `clients/shared/Features/Directory/DocumentListItem.swift`
- **Modified**: `clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift`

## Testing
- Verify DirectoryPanel still renders with the documents tab delegating to DirectoryStore
- Verify document list loads on tab appear via the store's stream subscription
- Verify document row tap triggers `loadDocument` through the store

## Deferred Work
- Apps tab still uses AppListManager directly (not DirectoryStore) — can be migrated separately
- iOS DirectoryPanel integration will use DirectoryStore in a future task
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
