### PR TITLE
fix: decode REST app list responses without IPC type discriminator

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -64,6 +64,13 @@ extension HTTPTransport {
 
     // MARK: - Apps HTTP Endpoints
 
+    /// REST shape returned by `/v1/apps`. The HTTP endpoint doesn't include
+    /// the `type` discriminator that IPC messages use, so we decode into this
+    /// intermediate struct and map to the IPC envelope.
+    private struct RESTAppsListResponse: Decodable {
+        let apps: [IPCAppsListResponseApp]
+    }
+
     private func fetchAppsList(isRetry: Bool = false) async {
         guard let url = buildURL(for: .appsList) else { return }
 
@@ -85,8 +92,10 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppsListResponse.self, from: data)
-            onMessage?(.appsListResponse(decoded))
+            // REST returns { apps: [...] } — wrap into IPC envelope with type
+            let rest = try decoder.decode(RESTAppsListResponse.self, from: data)
+            let ipcResponse = IPCAppsListResponse(type: "apps_list_response", apps: rest.apps)
+            onMessage?(.appsListResponse(ipcResponse))
         } catch {
             log.error("Fetch apps list error: \(error.localizedDescription)")
         }
@@ -474,6 +483,12 @@ extension HTTPTransport {
         }
     }
 
+    /// REST shape returned by `/v1/apps/shared`. The HTTP endpoint doesn't include
+    /// the `type` discriminator that IPC messages use.
+    private struct RESTSharedAppsListResponse: Decodable {
+        let apps: [IPCSharedAppsListResponseApp]
+    }
+
     private func fetchSharedAppsList(isRetry: Bool = false) async {
         guard let url = buildURL(for: .appsShared) else { return }
 
@@ -495,8 +510,10 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCSharedAppsListResponse.self, from: data)
-            onMessage?(.sharedAppsListResponse(decoded))
+            // REST returns { apps: [...] } — wrap into IPC envelope with type
+            let rest = try decoder.decode(RESTSharedAppsListResponse.self, from: data)
+            let ipcResponse = IPCSharedAppsListResponse(type: "shared_apps_list_response", apps: rest.apps)
+            onMessage?(.sharedAppsListResponse(ipcResponse))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
- **Apps not appearing in Things tab**: The HTTP endpoints `/v1/apps` and `/v1/apps/shared` return `{ apps: [...] }` without the `type` field that IPC message types require. The Swift client was trying to decode directly into `IPCAppsListResponse` and `IPCSharedAppsListResponse`, which both have a required `type` field. This caused silent decode failures, so `syncFromDaemon` was never called and apps never appeared in the sidebar.

### Root Cause
This is a regression from #14431 (IPC removal). The pattern used by other HTTP handlers like `handleAppOpen()` (which uses a private `RESTAppOpenResponse` struct to decode the REST shape, then maps to the IPC envelope) was not applied to the app list endpoints.

### Fix
Added intermediate `RESTAppsListResponse` and `RESTSharedAppsListResponse` structs without the `type` field, then map to the IPC envelope with a hardcoded type value.

Related to: #14701 (surfaces HTTP transport fix)

## Test plan
- [ ] Launch app, verify Things tab shows existing apps
- [ ] Create a new app via the assistant, verify it appears in Things tab
- [ ] Verify shared apps also appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
