### PR TITLE
feat(ios): add Models & Services, Privacy, and Channels/Guardian settings

### DIFF
--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -120,6 +120,7 @@ struct ChannelsGuardianSection: View {
                     .foregroundColor(VColor.error)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Revoke channel")
         }
     }
 

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -1,0 +1,194 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Settings section for viewing guardian status and approved contact channel policies.
+struct ChannelsGuardianSection: View {
+    @ObservedObject var channelTrustStore: ChannelTrustStore
+    @ObservedObject var contactsStore: ContactsStore
+    @State private var showRevokeConfirmation = false
+    @State private var channelToRevoke: ContactChannelPayload?
+
+    var body: some View {
+        Form {
+            // MARK: - Guardian
+
+            Section {
+                if let guardian = channelTrustStore.guardianContact {
+                    guardianRow(guardian)
+                } else {
+                    Text("No guardian configured")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+            } header: {
+                Text("Guardian")
+            } footer: {
+                Text("The guardian contact can approve or deny sensitive assistant actions on your behalf.")
+            }
+
+            // MARK: - Guardian Channels
+
+            if !channelTrustStore.guardianChannels.isEmpty {
+                Section("Guardian Channels") {
+                    ForEach(channelTrustStore.guardianChannels) { channel in
+                        guardianChannelRow(channel)
+                    }
+                }
+            }
+
+            // MARK: - Approved Contacts
+
+            Section {
+                if contactsStore.otherContacts.isEmpty {
+                    Text("No approved contacts")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(contactsStore.otherContacts) { contact in
+                        contactRow(contact)
+                    }
+                }
+            } header: {
+                Text("Approved Contacts")
+            } footer: {
+                Text("Manage contacts and their channel policies in the Intelligence tab.")
+            }
+        }
+        .navigationTitle("Channels & Guardian")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            contactsStore.loadContacts()
+        }
+        .alert("Revoke Channel", isPresented: $showRevokeConfirmation, presenting: channelToRevoke) { channel in
+            Button("Revoke", role: .destructive) {
+                channelTrustStore.revokeGuardian(channelId: channel.id)
+                channelToRevoke = nil
+            }
+            Button("Cancel", role: .cancel) {
+                channelToRevoke = nil
+            }
+        } message: { channel in
+            Text("Revoke guardian access for \(channel.address)? This cannot be undone.")
+        }
+    }
+
+    // MARK: - Guardian Row
+
+    @ViewBuilder
+    private func guardianRow(_ guardian: ContactPayload) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                VIconView(.shieldCheck, size: 14)
+                    .foregroundColor(VColor.success)
+                Text(guardian.displayName)
+                    .font(.body)
+            }
+            if let channelCount = guardian.channels.first {
+                Text("\(guardian.channels.count) channel\(guardian.channels.count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let verifiedAt = channelCount.verifiedAt {
+                    Text("Verified \(DateFormatting.relativeTimestamp(fromMilliseconds: verifiedAt) ?? "unknown")")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Guardian Channel Row
+
+    @ViewBuilder
+    private func guardianChannelRow(_ channel: ContactChannelPayload) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(channel.address)
+                    .font(.body)
+                HStack(spacing: 6) {
+                    policyBadge(channel.policy)
+                    statusBadge(channel.status)
+                }
+            }
+            Spacer()
+            Button {
+                channelToRevoke = channel
+                showRevokeConfirmation = true
+            } label: {
+                VIconView(.circleX, size: 14)
+                    .foregroundColor(VColor.error)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Contact Row
+
+    @ViewBuilder
+    private func contactRow(_ contact: ContactPayload) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(contact.displayName)
+                .font(.body)
+            if !contact.channels.isEmpty {
+                HStack(spacing: 6) {
+                    ForEach(contact.channels) { channel in
+                        policyBadge(channel.policy)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Badges
+
+    @ViewBuilder
+    private func policyBadge(_ policy: String) -> some View {
+        let (color, label): (Color, String) = {
+            switch policy {
+            case "allow": return (VColor.success, "Allow")
+            case "deny": return (VColor.error, "Deny")
+            case "escalate": return (VColor.warning, "Escalate")
+            default: return (VColor.textMuted, policy.capitalized)
+            }
+        }()
+        Text(label)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+
+    @ViewBuilder
+    private func statusBadge(_ status: String) -> some View {
+        let (color, label): (Color, String) = {
+            switch status {
+            case "active": return (VColor.success, "Active")
+            case "revoked": return (VColor.error, "Revoked")
+            case "pending": return (VColor.warning, "Pending")
+            default: return (VColor.textMuted, status.capitalized)
+            }
+        }()
+        Text(label)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    let client = DaemonClient(config: .fromUserDefaults())
+    let contactsStore = ContactsStore(daemonClient: client)
+    let trustStore = ChannelTrustStore(daemonClient: client, contactsStore: contactsStore)
+    NavigationStack {
+        ChannelsGuardianSection(channelTrustStore: trustStore, contactsStore: contactsStore)
+    }
+}
+#endif

--- a/clients/ios/Views/Settings/ModelsServicesSection.swift
+++ b/clients/ios/Views/Settings/ModelsServicesSection.swift
@@ -1,0 +1,205 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Settings section for managing API keys and the active LLM model.
+struct ModelsServicesSection: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    @State private var currentModel: String?
+    @State private var modelInput: String = ""
+    @State private var selectedProvider: APIKeyProvider?
+    @State private var loading = false
+
+    /// The two API key providers currently supported by `APIKeyManager`.
+    private let providers: [APIKeyProvider] = [
+        APIKeyProvider(id: "anthropic", displayName: "Claude (Anthropic)"),
+        APIKeyProvider(id: "elevenlabs", displayName: "ElevenLabs"),
+    ]
+
+    var body: some View {
+        Form {
+            // MARK: - Model Selection
+
+            Section {
+                if loading {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                } else if let model = currentModel {
+                    LabeledContent("Active Model", value: model)
+                } else {
+                    Text("Not connected")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+
+                HStack {
+                    TextField("Model ID", text: $modelInput)
+                        .textContentType(.none)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+
+                    Button("Set") {
+                        let trimmed = modelInput.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        setModel(trimmed)
+                    }
+                    .disabled(modelInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            } header: {
+                Text("Model")
+            } footer: {
+                Text("The model ID used by the assistant for text generation (e.g. claude-sonnet-4-20250514).")
+            }
+
+            // MARK: - API Key Providers
+
+            Section {
+                ForEach(providers) { provider in
+                    providerRow(provider)
+                }
+            } header: {
+                Text("API Keys")
+            } footer: {
+                Text("Keys are stored securely in the iOS Keychain and never sent to Vellum servers.")
+            }
+        }
+        .navigationTitle("Models & Services")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { fetchModel() }
+        .onChange(of: clientProvider.isConnected) { _, connected in
+            if connected { fetchModel() }
+        }
+        .sheet(item: $selectedProvider) { provider in
+            APIKeyDetailSheet(provider: provider)
+        }
+    }
+
+    // MARK: - Provider Row
+
+    @ViewBuilder
+    private func providerRow(_ provider: APIKeyProvider) -> some View {
+        let hasKey = APIKeyManager.shared.getAPIKey(provider: provider.id) != nil
+        Button {
+            selectedProvider = provider
+        } label: {
+            HStack {
+                Text(provider.displayName)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                VIconView(hasKey ? .circleCheck : .info, size: 14)
+                    .foregroundColor(hasKey ? VColor.success : VColor.textMuted)
+            }
+        }
+    }
+
+    // MARK: - Daemon Communication
+
+    private func fetchModel() {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        loading = true
+        daemon.onModelInfo = { info in
+            currentModel = info.model
+            loading = false
+        }
+        do {
+            try daemon.sendModelGet()
+        } catch {
+            loading = false
+        }
+    }
+
+    private func setModel(_ model: String) {
+        guard let daemon = clientProvider.client as? DaemonClient else { return }
+        loading = true
+        daemon.onModelInfo = { info in
+            currentModel = info.model
+            modelInput = ""
+            loading = false
+        }
+        do {
+            try daemon.sendModelSet(model: model)
+        } catch {
+            loading = false
+        }
+    }
+}
+
+// MARK: - Supporting Types
+
+struct APIKeyProvider: Identifiable {
+    let id: String
+    let displayName: String
+}
+
+// MARK: - API Key Detail Sheet
+
+private struct APIKeyDetailSheet: View {
+    let provider: APIKeyProvider
+    @Environment(\.dismiss) private var dismiss
+    @State private var keyText: String = ""
+    @State private var hasExistingKey: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    if hasExistingKey {
+                        HStack {
+                            VIconView(.circleCheck, size: 16)
+                                .foregroundColor(VColor.success)
+                            Text("API key saved")
+                            Spacer()
+                        }
+                    } else {
+                        SecureField("API Key", text: $keyText)
+                            .textContentType(.password)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                } header: {
+                    Text(provider.displayName)
+                }
+
+                Section {
+                    if hasExistingKey {
+                        Button("Clear Key", role: .destructive) {
+                            _ = APIKeyManager.shared.deleteAPIKey(provider: provider.id)
+                            hasExistingKey = false
+                            keyText = ""
+                        }
+                    } else {
+                        Button("Save") {
+                            let trimmed = keyText.trimmingCharacters(in: .whitespacesAndNewlines)
+                            guard !trimmed.isEmpty else { return }
+                            _ = APIKeyManager.shared.setAPIKey(trimmed, provider: provider.id)
+                            hasExistingKey = true
+                            keyText = ""
+                        }
+                        .disabled(keyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+            .navigationTitle(provider.displayName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onAppear {
+                hasExistingKey = APIKeyManager.shared.getAPIKey(provider: provider.id) != nil
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ModelsServicesSection()
+            .environmentObject(ClientProvider(client: DaemonClient(config: .fromUserDefaults())))
+    }
+}
+#endif

--- a/clients/ios/Views/Settings/ModelsServicesSection.swift
+++ b/clients/ios/Views/Settings/ModelsServicesSection.swift
@@ -69,6 +69,11 @@ struct ModelsServicesSection: View {
         .navigationTitle("Models & Services")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { fetchModel() }
+        .onDisappear {
+            if let daemon = clientProvider.client as? DaemonClient {
+                daemon.onModelInfo = nil
+            }
+        }
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { fetchModel() }
         }

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -1,0 +1,118 @@
+#if canImport(UIKit)
+import AVFoundation
+import SwiftUI
+import UserNotifications
+import VellumAssistantShared
+
+/// Settings section showing system permission statuses for privacy-sensitive APIs.
+struct PrivacySection: View {
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var micStatus: PermissionStatus = .notDetermined
+    @State private var speechStatus: PermissionStatus = .notDetermined
+    @State private var cameraStatus: PermissionStatus = .notDetermined
+    @State private var notificationStatus: PermissionStatus = .notDetermined
+
+    var body: some View {
+        Form {
+            Section {
+                permissionRow(name: "Microphone", status: micStatus)
+                permissionRow(name: "Speech Recognition", status: speechStatus)
+                permissionRow(name: "Camera", status: cameraStatus)
+                permissionRow(name: "Notifications", status: notificationStatus)
+            } header: {
+                Text("Permissions")
+            } footer: {
+                Text("Tap a denied or undetermined permission to open iOS Settings where you can grant access.")
+            }
+        }
+        .navigationTitle("Privacy")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { refreshAll() }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active { refreshAll() }
+        }
+    }
+
+    // MARK: - Permission Row
+
+    @ViewBuilder
+    private func permissionRow(name: String, status: PermissionStatus) -> some View {
+        Button {
+            if status == .denied || status == .notDetermined {
+                openSettings()
+            }
+        } label: {
+            HStack {
+                Text(name)
+                    .foregroundColor(VColor.textPrimary)
+                Spacer()
+                statusBadge(status)
+            }
+        }
+        .disabled(status == .granted)
+    }
+
+    // MARK: - Status Badge
+
+    @ViewBuilder
+    private func statusBadge(_ status: PermissionStatus) -> some View {
+        let (color, label): (Color, String) = {
+            switch status {
+            case .granted: return (VColor.success, "Granted")
+            case .denied: return (VColor.error, "Denied")
+            case .notDetermined: return (VColor.warning, "Not Set")
+            }
+        }()
+        Text(label)
+            .font(.caption2)
+            .fontWeight(.medium)
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+
+    // MARK: - Refresh
+
+    private func refreshAll() {
+        micStatus = PermissionManager.shared.status(for: .microphone)
+        speechStatus = PermissionManager.shared.status(for: .speechRecognition)
+        refreshCamera()
+        Task { await refreshNotifications() }
+    }
+
+    private func refreshCamera() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: cameraStatus = .granted
+        case .denied, .restricted: cameraStatus = .denied
+        case .notDetermined: cameraStatus = .notDetermined
+        @unknown default: cameraStatus = .notDetermined
+        }
+    }
+
+    @MainActor
+    private func refreshNotifications() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral: notificationStatus = .granted
+        case .denied: notificationStatus = .denied
+        case .notDetermined: notificationStatus = .notDetermined
+        @unknown default: notificationStatus = .notDetermined
+        }
+    }
+
+    private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PrivacySection()
+    }
+}
+#endif

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -12,6 +12,20 @@ struct SettingsView: View {
     /// manage private threads without creating a second store that races on UserDefaults.
     var threadStore: IOSThreadStore
 
+    /// Lazily builds the Channels & Guardian destination, creating the
+    /// shared stores from the current DaemonClient.
+    @ViewBuilder
+    private var channelsGuardianDestination: some View {
+        if let daemon = clientProvider.client as? DaemonClient {
+            let contactsStore = ContactsStore(daemonClient: daemon)
+            let trustStore = ChannelTrustStore(daemonClient: daemon, contactsStore: contactsStore)
+            ChannelsGuardianSection(channelTrustStore: trustStore, contactsStore: contactsStore)
+        } else {
+            Text("Not connected")
+                .foregroundStyle(.secondary)
+        }
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -29,6 +43,11 @@ struct SettingsView: View {
                         Label { Text("Connect") } icon: { VIconView(.monitor, size: 14) }
                     }
                     NavigationLink {
+                        ModelsServicesSection()
+                    } label: {
+                        Label { Text("Models & Services") } icon: { VIconView(.cpu, size: 14) }
+                    }
+                    NavigationLink {
                         TwilioSettingsSection()
                     } label: {
                         Label { Text("Twilio") } icon: { VIconView(.phone, size: 14) }
@@ -37,6 +56,11 @@ struct SettingsView: View {
                         IntegrationsSection()
                     } label: {
                         Label { Text("Integrations") } icon: { VIconView(.link, size: 14) }
+                    }
+                    NavigationLink {
+                        channelsGuardianDestination
+                    } label: {
+                        Label { Text("Channels & Guardian") } icon: { VIconView(.shieldCheck, size: 14) }
                     }
                     NavigationLink {
                         SchedulesSection()
@@ -79,6 +103,11 @@ struct SettingsView: View {
                 Section("Permissions") {
                     PermissionRowView(permission: .microphone)
                     PermissionRowView(permission: .speechRecognition)
+                    NavigationLink {
+                        PrivacySection()
+                    } label: {
+                        Label { Text("Privacy") } icon: { VIconView(.eye, size: 14) }
+                    }
                 }
 
                 Section("About") {

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -8,18 +8,18 @@ struct SettingsView: View {
     @AppStorage(UserDefaultsKeys.developerModeEnabled) private var developerModeEnabled: Bool = false
     @Binding var navigateToConnect: Bool
     @State private var versionTapCount: Int = 0
+    @State private var contactsStore: ContactsStore?
+    @State private var channelTrustStore: ChannelTrustStore?
     /// Shared thread store — passed through so PrivateThreadsSection can show and
     /// manage private threads without creating a second store that races on UserDefaults.
     var threadStore: IOSThreadStore
 
-    /// Lazily builds the Channels & Guardian destination, creating the
-    /// shared stores from the current DaemonClient.
+    /// Lazily builds the Channels & Guardian destination using the
+    /// pre-created stores from `@State` properties.
     @ViewBuilder
     private var channelsGuardianDestination: some View {
-        if let daemon = clientProvider.client as? DaemonClient {
-            let contactsStore = ContactsStore(daemonClient: daemon)
-            let trustStore = ChannelTrustStore(daemonClient: daemon, contactsStore: contactsStore)
-            ChannelsGuardianSection(channelTrustStore: trustStore, contactsStore: contactsStore)
+        if let trustStore = channelTrustStore, let contacts = contactsStore {
+            ChannelsGuardianSection(channelTrustStore: trustStore, contactsStore: contacts)
         } else {
             Text("Not connected")
                 .foregroundStyle(.secondary)
@@ -101,8 +101,6 @@ struct SettingsView: View {
                 }
 
                 Section("Permissions") {
-                    PermissionRowView(permission: .microphone)
-                    PermissionRowView(permission: .speechRecognition)
                     NavigationLink {
                         PrivacySection()
                     } label: {
@@ -139,6 +137,15 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationDestination(isPresented: $navigateToConnect) {
                 DaemonConnectionSection()
+            }
+            .task(id: clientProvider.isConnected) {
+                if let daemon = clientProvider.client as? DaemonClient {
+                    if contactsStore == nil {
+                        let contacts = ContactsStore(daemonClient: daemon)
+                        contactsStore = contacts
+                        channelTrustStore = ChannelTrustStore(daemonClient: daemon, contactsStore: contacts)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add three new iOS settings sections for API key management, privacy permissions, and guardian/channel trust
- Wire up NavigationLinks in SettingsView with VIconView labels

## Implementation
- **ModelsServicesSection**: Shows active model from daemon (`sendModelGet`/`sendModelSet`), lists API key providers (Anthropic, ElevenLabs) with status icons, tap for detail sheet with SecureField save/clear
- **PrivacySection**: Consolidated view of microphone, speech recognition, camera, and notification permission statuses using PermissionManager + direct system API checks; refreshes on scenePhase change; taps open iOS Settings
- **ChannelsGuardianSection**: Displays guardian contact from ChannelTrustStore, guardian channels with policy/status badges, revoke with confirmation alert, approved contacts list from ContactsStore

## Key Technical Choices
- Camera and Notifications permissions checked via system APIs directly since PermissionManager only supports microphone and speechRecognition
- ChannelTrustStore/ContactsStore created lazily in a computed property to avoid holding references when not navigated to
- Follows existing patterns from RemindersSection (daemon callback pattern) and VoiceSettingsSection (API key management)

## Files Changed
- `clients/ios/Views/Settings/ModelsServicesSection.swift` (new)
- `clients/ios/Views/Settings/PrivacySection.swift` (new)
- `clients/ios/Views/Settings/ChannelsGuardianSection.swift` (new)
- `clients/ios/Views/SettingsView.swift` (modified — added NavigationLinks + helper)

## Testing
- Verify Models & Services section shows model info when connected to daemon
- Verify API key save/clear works for both providers
- Verify Privacy section shows correct permission statuses
- Verify Channels & Guardian section loads guardian and contacts data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
