### PR TITLE
feat(ios): add Things tab with Apps, Shared Apps, and Documents views

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
         _threadStore = StateObject(wrappedValue: IOSThreadStore(daemonClient: daemonClient))
     }
 
-    private enum Tab { case chats, tasks, intelligence, settings }
+    private enum Tab { case chats, tasks, things, intelligence, settings }
 
     private enum ConnectPhase {
         case initial    // Haven't attempted connection yet
@@ -237,6 +237,14 @@ struct ContentView: View {
                 .tag(Tab.tasks)
                 .tabItem {
                     Label { Text("Tasks") } icon: { VIconView(.clipboardList, size: 12) }
+                }
+
+            ThingsTabView(onConnectTapped: navigateToConnectSettings)
+                .environmentObject(clientProvider)
+                .id(ObjectIdentifier(clientProvider.client as AnyObject))
+                .tag(Tab.things)
+                .tabItem {
+                    Label { Text("Things") } icon: { VIconView(.layoutGrid, size: 12) }
                 }
 
             IdentityView(onConnectTapped: navigateToConnectSettings)

--- a/clients/ios/Views/Things/AppsGridView.swift
+++ b/clients/ios/Views/Things/AppsGridView.swift
@@ -1,0 +1,144 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Grid view of the user's local apps with 2-column layout.
+struct AppsGridView: View {
+    @ObservedObject var directoryStore: DirectoryStore
+    @State private var appToDelete: AppItem?
+
+    private let columns = [
+        GridItem(.flexible(), spacing: VSpacing.md),
+        GridItem(.flexible(), spacing: VSpacing.md)
+    ]
+
+    var body: some View {
+        Group {
+            if directoryStore.isLoadingApps && directoryStore.localApps.isEmpty {
+                loadingView
+            } else if directoryStore.localApps.isEmpty {
+                emptyView
+            } else {
+                gridContent
+            }
+        }
+        .alert("Delete App", isPresented: Binding(
+            get: { appToDelete != nil },
+            set: { if !$0 { appToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { appToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let app = appToDelete {
+                    directoryStore.deleteApp(id: app.id)
+                    appToDelete = nil
+                }
+            }
+        } message: {
+            if let app = appToDelete {
+                Text("Are you sure you want to delete \"\(app.name)\"? This action cannot be undone.")
+            }
+        }
+    }
+
+    // MARK: - Grid Content
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: VSpacing.md) {
+                ForEach(directoryStore.localApps, id: \.id) { app in
+                    appCard(app)
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+        }
+        .refreshable {
+            directoryStore.fetchApps()
+        }
+    }
+
+    // MARK: - App Card
+
+    private func appCard(_ app: AppItem) -> some View {
+        Button {
+            directoryStore.openApp(id: app.id)
+        } label: {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                Text(app.icon ?? "\u{1F4F1}")
+                    .font(.system(size: 32))
+
+                Text(app.name)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                if let description = app.description {
+                    Text(description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .lineLimit(2)
+                }
+
+                Text(formattedDate(app.createdAt))
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(VSpacing.md)
+            .background(VColor.surface)
+            .cornerRadius(12)
+        }
+        .contextMenu {
+            Button {
+                directoryStore.openApp(id: app.id)
+            } label: {
+                Label("Open", systemImage: "arrow.up.forward")
+            }
+            Button {
+                directoryStore.shareAppCloud(id: app.id)
+            } label: {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+            Divider()
+            Button(role: .destructive) {
+                appToDelete = app
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading apps...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: VSpacing.md) {
+            VIconView(.layoutGrid, size: 48)
+                .foregroundColor(VColor.textMuted)
+            Text("No apps yet")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func formattedDate(_ timestamp: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}
+#endif

--- a/clients/ios/Views/Things/AppsGridView.swift
+++ b/clients/ios/Views/Things/AppsGridView.swift
@@ -54,6 +54,11 @@ struct AppsGridView: View {
         }
         .refreshable {
             directoryStore.fetchApps()
+            // fetchApps() fires an internal Task; await loading completion
+            // so the pull-to-refresh spinner stays visible until data arrives.
+            while directoryStore.isLoadingApps {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
         }
     }
 
@@ -86,24 +91,24 @@ struct AppsGridView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(VSpacing.md)
             .background(VColor.surface)
-            .cornerRadius(12)
+            .cornerRadius(VRadius.lg)
         }
         .contextMenu {
             Button {
                 directoryStore.openApp(id: app.id)
             } label: {
-                Label("Open", systemImage: "arrow.up.forward")
+                Label { Text("Open") } icon: { VIconView(.externalLink, size: 14) }
             }
             Button {
                 directoryStore.shareAppCloud(id: app.id)
             } label: {
-                Label("Share", systemImage: "square.and.arrow.up")
+                Label { Text("Share") } icon: { VIconView(.share, size: 14) }
             }
             Divider()
             Button(role: .destructive) {
                 appToDelete = app
             } label: {
-                Label("Delete", systemImage: "trash")
+                Label { Text("Delete") } icon: { VIconView(.trash, size: 14) }
             }
         }
     }

--- a/clients/ios/Views/Things/DocumentsListView.swift
+++ b/clients/ios/Views/Things/DocumentsListView.swift
@@ -57,6 +57,9 @@ struct DocumentsListView: View {
         .searchable(text: $searchText, prompt: "Search documents")
         .refreshable {
             directoryStore.fetchDocuments()
+            while directoryStore.isLoadingDocuments {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
         }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -68,7 +71,7 @@ struct DocumentsListView: View {
                             HStack {
                                 Text("Sort by \(order.rawValue)")
                                 if sortOrder == order {
-                                    Image(systemName: "checkmark")
+                                    VIconView(.check, size: 12)
                                 }
                             }
                         }

--- a/clients/ios/Views/Things/DocumentsListView.swift
+++ b/clients/ios/Views/Things/DocumentsListView.swift
@@ -1,0 +1,145 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Searchable list of documents with sort options.
+struct DocumentsListView: View {
+    @ObservedObject var directoryStore: DirectoryStore
+    @State private var searchText = ""
+    @State private var sortOrder: SortOrder = .byDate
+
+    private enum SortOrder: String, CaseIterable {
+        case byDate = "Date"
+        case byTitle = "Title"
+    }
+
+    private var filteredDocuments: [DocumentListItem] {
+        let filtered: [DocumentListItem]
+        if searchText.isEmpty {
+            filtered = directoryStore.documents
+        } else {
+            filtered = directoryStore.documents.filter {
+                $0.title.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        switch sortOrder {
+        case .byDate:
+            return filtered.sorted { $0.updatedAt > $1.updatedAt }
+        case .byTitle:
+            return filtered.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        }
+    }
+
+    var body: some View {
+        Group {
+            if directoryStore.isLoadingDocuments && directoryStore.documents.isEmpty {
+                loadingView
+            } else if directoryStore.documents.isEmpty {
+                emptyView
+            } else {
+                listContent
+            }
+        }
+    }
+
+    // MARK: - List Content
+
+    private var listContent: some View {
+        List(filteredDocuments) { doc in
+            Button {
+                directoryStore.loadDocument(surfaceId: doc.id)
+            } label: {
+                documentRow(doc)
+            }
+        }
+        .listStyle(.plain)
+        .searchable(text: $searchText, prompt: "Search documents")
+        .refreshable {
+            directoryStore.fetchDocuments()
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    ForEach(SortOrder.allCases, id: \.self) { order in
+                        Button {
+                            sortOrder = order
+                        } label: {
+                            HStack {
+                                Text("Sort by \(order.rawValue)")
+                                if sortOrder == order {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    VIconView(.arrowDown, size: 14)
+                }
+                .accessibilityLabel("Sort documents")
+            }
+        }
+    }
+
+    // MARK: - Row
+
+    private func documentRow(_ doc: DocumentListItem) -> some View {
+        HStack(spacing: VSpacing.md) {
+            VIconView(.fileText, size: 24)
+                .foregroundColor(VColor.textMuted)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(doc.title)
+                    .font(VFont.bodyBold)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+
+                HStack(spacing: VSpacing.sm) {
+                    Text("\(doc.wordCount) words")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+
+                    Text(formattedDate(doc.updatedAt))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, VSpacing.xs)
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading documents...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: VSpacing.md) {
+            VIconView(.fileText, size: 48)
+                .foregroundColor(VColor.textMuted)
+            Text("No documents yet")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}
+#endif

--- a/clients/ios/Views/Things/SharedAppsListView.swift
+++ b/clients/ios/Views/Things/SharedAppsListView.swift
@@ -53,6 +53,9 @@ struct SharedAppsListView: View {
         .listStyle(.plain)
         .refreshable {
             directoryStore.fetchSharedApps()
+            while directoryStore.isLoadingSharedApps {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
         }
     }
 
@@ -175,13 +178,13 @@ struct SharedAppsListView: View {
                         directoryStore.forkSharedApp(uuid: app.uuid)
                         selectedApp = nil
                     } label: {
-                        Label("Fork App", systemImage: "arrow.branch")
+                        Label { Text("Fork App") } icon: { VIconView(.gitBranch, size: 14) }
                     }
 
                     Button(role: .destructive) {
                         appToDelete = app
                     } label: {
-                        Label("Delete App", systemImage: "trash")
+                        Label { Text("Delete App") } icon: { VIconView(.trash, size: 14) }
                     }
                 }
             }

--- a/clients/ios/Views/Things/SharedAppsListView.swift
+++ b/clients/ios/Views/Things/SharedAppsListView.swift
@@ -1,0 +1,233 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// List view of shared apps with detail sheet for fork/delete actions.
+struct SharedAppsListView: View {
+    @ObservedObject var directoryStore: DirectoryStore
+    @State private var selectedApp: SharedAppItem?
+    @State private var appToDelete: SharedAppItem?
+
+    var body: some View {
+        Group {
+            if directoryStore.isLoadingSharedApps && directoryStore.sharedApps.isEmpty {
+                loadingView
+            } else if directoryStore.sharedApps.isEmpty {
+                emptyView
+            } else {
+                listContent
+            }
+        }
+        .sheet(item: $selectedApp) { app in
+            sharedAppDetail(app)
+        }
+        .alert("Delete Shared App", isPresented: Binding(
+            get: { appToDelete != nil },
+            set: { if !$0 { appToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { appToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let app = appToDelete {
+                    directoryStore.deleteSharedApp(uuid: app.uuid)
+                    appToDelete = nil
+                    selectedApp = nil
+                }
+            }
+        } message: {
+            if let app = appToDelete {
+                Text("Are you sure you want to delete \"\(app.name)\"? This action cannot be undone.")
+            }
+        }
+    }
+
+    // MARK: - List Content
+
+    private var listContent: some View {
+        List(directoryStore.sharedApps, id: \.uuid) { app in
+            Button {
+                selectedApp = app
+            } label: {
+                sharedAppRow(app)
+            }
+        }
+        .listStyle(.plain)
+        .refreshable {
+            directoryStore.fetchSharedApps()
+        }
+    }
+
+    // MARK: - Row
+
+    private func sharedAppRow(_ app: SharedAppItem) -> some View {
+        HStack(spacing: VSpacing.md) {
+            Text(app.icon ?? "\u{1F4E6}")
+                .font(.system(size: 28))
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: VSpacing.xs) {
+                    Text(app.name)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.textPrimary)
+                        .lineLimit(1)
+
+                    if app.updateAvailable == true {
+                        Text("Update")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.accent)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(VColor.accent.opacity(0.15))
+                            .cornerRadius(4)
+                    }
+                }
+
+                if let signer = app.signerDisplayName {
+                    HStack(spacing: VSpacing.xs) {
+                        Text(signer)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        trustBadge(app.trustTier)
+                    }
+                }
+            }
+
+            Spacer()
+
+            VIconView(.chevronRight, size: 14)
+                .foregroundColor(VColor.textMuted)
+        }
+        .padding(.vertical, VSpacing.xs)
+    }
+
+    // MARK: - Trust Badge
+
+    private func trustBadge(_ tier: String) -> some View {
+        Text(tier.capitalized)
+            .font(VFont.caption)
+            .foregroundColor(trustColor(tier))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(trustColor(tier).opacity(0.15))
+            .cornerRadius(4)
+    }
+
+    private func trustColor(_ tier: String) -> Color {
+        switch tier.lowercased() {
+        case "trusted": return .green
+        case "verified": return .blue
+        case "community": return .orange
+        default: return VColor.textMuted
+        }
+    }
+
+    // MARK: - Detail Sheet
+
+    private func sharedAppDetail(_ app: SharedAppItem) -> some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        Text(app.icon ?? "\u{1F4E6}")
+                            .font(.system(size: 48))
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text(app.name)
+                                .font(VFont.title)
+                                .foregroundColor(VColor.textPrimary)
+                            if let signer = app.signerDisplayName {
+                                Text("by \(signer)")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textSecondary)
+                            }
+                        }
+                    }
+                }
+
+                if let description = app.description {
+                    Section("Description") {
+                        Text(description)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                    }
+                }
+
+                Section("Details") {
+                    LabeledContent("Trust Tier") {
+                        trustBadge(app.trustTier)
+                    }
+                    LabeledContent("Bundle Size") {
+                        Text(formattedSize(app.bundleSizeBytes))
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    LabeledContent("Installed") {
+                        Text(app.installedAt)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                    if let version = app.version {
+                        LabeledContent("Version") {
+                            Text(version)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                    }
+                }
+
+                Section {
+                    Button {
+                        directoryStore.forkSharedApp(uuid: app.uuid)
+                        selectedApp = nil
+                    } label: {
+                        Label("Fork App", systemImage: "arrow.branch")
+                    }
+
+                    Button(role: .destructive) {
+                        appToDelete = app
+                    } label: {
+                        Label("Delete App", systemImage: "trash")
+                    }
+                }
+            }
+            .navigationTitle("Shared App")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { selectedApp = nil }
+                }
+            }
+        }
+    }
+
+    // MARK: - States
+
+    private var loadingView: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading shared apps...")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: VSpacing.md) {
+            VIconView(.package, size: 48)
+                .foregroundColor(VColor.textMuted)
+            Text("No shared apps")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func formattedSize(_ bytes: Int) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(bytes))
+    }
+}
+
+// MARK: - SharedAppItem Identifiable conformance for .sheet(item:)
+// The Identifiable conformance via uuid is already declared in IPCMessages.swift
+
+#endif

--- a/clients/ios/Views/Things/ThingsTabView.swift
+++ b/clients/ios/Views/Things/ThingsTabView.swift
@@ -1,0 +1,57 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Entry point for the Things tab — gates on daemon connectivity before
+/// showing the main ThingsView with DirectoryStore.
+struct ThingsTabView: View {
+    @EnvironmentObject var clientProvider: ClientProvider
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        if let daemon = clientProvider.client as? DaemonClient, clientProvider.isConnected {
+            ThingsView(directoryStore: DirectoryStore(daemonClient: daemon))
+                .environmentObject(clientProvider)
+        } else {
+            ThingsDisconnectedView(onConnectTapped: onConnectTapped)
+        }
+    }
+}
+
+struct ThingsDisconnectedView: View {
+    var onConnectTapped: (() -> Void)?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: VSpacing.lg) {
+                VIconView(.layoutGrid, size: 48)
+                    .foregroundColor(VColor.textMuted)
+                    .accessibilityHidden(true)
+                Text("Things Require Connection")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+                Text("Connect to your Assistant to browse apps, shared apps, and documents.")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, VSpacing.xl)
+                if onConnectTapped != nil {
+                    Button {
+                        onConnectTapped?()
+                    } label: {
+                        Text("Go to Settings")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("Things")
+        }
+    }
+}
+
+#Preview {
+    ThingsDisconnectedView()
+        .environmentObject(ClientProvider(client: DaemonClient(config: .default)))
+}
+#endif

--- a/clients/ios/Views/Things/ThingsTabView.swift
+++ b/clients/ios/Views/Things/ThingsTabView.swift
@@ -8,13 +8,31 @@ struct ThingsTabView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     var onConnectTapped: (() -> Void)?
 
+    /// Lazily created once by SwiftUI; survives re-renders of this view.
+    @StateObject private var directoryStore = LazyDirectoryStore()
+
     var body: some View {
         if let daemon = clientProvider.client as? DaemonClient, clientProvider.isConnected {
-            ThingsView(directoryStore: DirectoryStore(daemonClient: daemon))
+            ThingsView(directoryStore: directoryStore.resolve(daemon: daemon))
                 .environmentObject(clientProvider)
         } else {
             ThingsDisconnectedView(onConnectTapped: onConnectTapped)
         }
+    }
+}
+
+/// Wrapper that lazily creates a `DirectoryStore` once and holds onto it,
+/// avoiding repeated allocation on every SwiftUI body evaluation.
+private final class LazyDirectoryStore: ObservableObject {
+    private var store: DirectoryStore?
+    private weak var lastDaemon: DaemonClient?
+
+    func resolve(daemon: DaemonClient) -> DirectoryStore {
+        if let store, lastDaemon === daemon { return store }
+        let newStore = DirectoryStore(daemonClient: daemon)
+        self.store = newStore
+        self.lastDaemon = daemon
+        return newStore
     }
 }
 

--- a/clients/ios/Views/Things/ThingsView.swift
+++ b/clients/ios/Views/Things/ThingsView.swift
@@ -1,0 +1,52 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// Main container for the Things tab — shows a segmented picker switching
+/// between My Apps, Shared Apps, and Documents.
+struct ThingsView: View {
+    @StateObject var directoryStore: DirectoryStore
+
+    private enum Segment: String, CaseIterable {
+        case myApps = "My Apps"
+        case shared = "Shared"
+        case documents = "Documents"
+    }
+
+    @State private var selectedSegment: Segment = .myApps
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker("Section", selection: $selectedSegment) {
+                    ForEach(Segment.allCases, id: \.self) { segment in
+                        Text(segment.rawValue).tag(segment)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+
+                switch selectedSegment {
+                case .myApps:
+                    AppsGridView(directoryStore: directoryStore)
+                case .shared:
+                    SharedAppsListView(directoryStore: directoryStore)
+                case .documents:
+                    DocumentsListView(directoryStore: directoryStore)
+                }
+            }
+            .navigationTitle("Things")
+            .onAppear {
+                directoryStore.fetchApps()
+                directoryStore.fetchSharedApps()
+                directoryStore.fetchDocuments()
+            }
+        }
+    }
+}
+
+#Preview {
+    ThingsView(directoryStore: DirectoryStore(daemonClient: DaemonClient(config: .default)))
+}
+#endif


### PR DESCRIPTION
Add new Things tab to iOS with segmented control for My Apps grid, Shared Apps list, and Documents list. All data operations use shared DirectoryStore.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
