### PR TITLE
M11: macOS URL deep-link send handler

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -10,6 +10,12 @@ extension AppDelegate {
 
     public func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
+            // Handle vellum://send?message=... deep links
+            if url.scheme == "vellum" || url.scheme == "vellum-assistant" {
+                handleDeepLink(url)
+                continue
+            }
+
             guard url.pathExtension == "vellum" else { continue }
             log.info("Opening .vellum file: \(url.path, privacy: .private)")
 
@@ -29,6 +35,24 @@ extension AppDelegate {
                 }
             }
         }
+    }
+
+    /// Handle `vellum://send?message=...` deep links by buffering the message
+    /// in `DeepLinkManager` for the active `ChatViewModel` to consume,
+    /// then bringing the main window to front.
+    private func handleDeepLink(_ url: URL) {
+        guard url.host == "send" else { return }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let messageItem = components.queryItems?.first(where: { $0.name == "message" }),
+              let message = messageItem.value, !message.isEmpty else { return }
+
+        log.info("Received deep link send message (\(message.count) chars)")
+        DeepLinkManager.pendingMessage = message
+
+        // Bring the main window to front and consume the pending message
+        // in the active thread's view model.
+        showMainWindow()
+        mainWindow?.threadManager.activeViewModel?.consumeDeepLinkIfNeeded()
     }
 
     // MARK: - Bundle Open Handling

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -692,6 +692,12 @@ struct MainWindowView: View {
             }
             threadManager.activeViewModel?.activeSurfaceId = windowState.isDynamicExpanded ? windowState.activeDynamicSurface?.surfaceId : nil
             threadManager.activeViewModel?.isChatDockedToSide = windowState.isDynamicExpanded && windowState.isChatDockOpen
+            // Consume any buffered deep-link message now that a thread is active.
+            // Mirrors the iOS pattern (ChatTabView.onAppear, ThreadListView.onAppear)
+            // where consumeDeepLinkIfNeeded() is called when the view model becomes
+            // visible. Without this, deep links arriving before the window/thread is
+            // fully initialized are silently dropped on macOS.
+            threadManager.activeViewModel?.consumeDeepLinkIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -10,6 +10,18 @@
     <string>Vellum needs microphone access to transcribe voice commands.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>vellum</string>
+                <string>vellum-assistant</string>
+            </array>
+        </dict>
+    </array>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -946,15 +946,13 @@ public final class ChatViewModel: ObservableObject {
     // MARK: - Deep Link
 
     /// Check for a buffered deep-link message and apply it to `inputText`.
-    /// Called by the iOS view layer when this `ChatViewModel` becomes the
+    /// Called by the view layer when this `ChatViewModel` becomes the
     /// active/visible thread, ensuring only one VM ever consumes the message.
-    #if os(iOS)
     public func consumeDeepLinkIfNeeded() {
         guard let message = DeepLinkManager.pendingMessage else { return }
         DeepLinkManager.pendingMessage = nil
         inputText = message
     }
-    #endif
 
     // MARK: - Sending
 


### PR DESCRIPTION
Register vellum URL scheme on macOS and handle vellum://send?message=... deep links to bring the app to front and send messages to the active thread. Follows the same pattern as iOS deep-link handling.

## Summary
- Register `vellum` and `vellum-assistant` URL schemes in macOS Info.plist (CFBundleURLTypes), matching the iOS configuration
- Extend `application(_:open:)` in AppDelegate+BundleHandling to intercept `vellum://send?message=...` URLs alongside existing `.vellum` bundle handling
- Buffer the URL-decoded message in the shared `DeepLinkManager`, bring the main window to front, and have the active `ChatViewModel` consume it
- Widen `consumeDeepLinkIfNeeded()` from `#if os(iOS)` to cross-platform so macOS can use the same method

## Files Changed
- `clients/macos/vellum-assistant/Resources/Info.plist` — added CFBundleURLTypes with vellum/vellum-assistant schemes
- `clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift` — added deep link URL routing and `handleDeepLink(_:)` method
- `clients/shared/Features/Chat/ChatViewModel.swift` — removed `#if os(iOS)` guard from `consumeDeepLinkIfNeeded()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
