### PR TITLE
Remove redundant request_file tool alias

### DIFF
--- a/assistant/src/__tests__/session-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/session-surfaces-task-progress.test.ts
@@ -145,6 +145,40 @@ describe("task_progress surface compatibility", () => {
     });
   });
 
+  test("ui_show supports file_upload surfaces directly", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "file_upload",
+      title: "Upload a receipt",
+      data: {
+        prompt: "Share the receipt PDF",
+        acceptedTypes: ["application/pdf"],
+        maxFiles: 1,
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBe(true);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "file_upload") return;
+
+    expect(showMessage.title).toBe("Upload a receipt");
+    expect(showMessage.data).toEqual({
+      prompt: "Share the receipt PDF",
+      acceptedTypes: ["application/pdf"],
+      maxFiles: 1,
+    });
+    expect(ctx.pendingSurfaceActions.get(showMessage.surfaceId)).toEqual({
+      surfaceType: "file_upload",
+    });
+  });
+
   test("ui_show dynamic_page uses data.html when properly nested", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);

--- a/assistant/src/__tests__/ui-file-upload-surface.test.ts
+++ b/assistant/src/__tests__/ui-file-upload-surface.test.ts
@@ -6,80 +6,9 @@ import type {
 } from "../daemon/message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
 import {
-  requestFileTool,
+  allUiSurfaceTools,
   uiShowTool,
 } from "../tools/ui-surface/definitions.js";
-
-// ---------------------------------------------------------------------------
-// request_file tool definition
-// ---------------------------------------------------------------------------
-
-describe("requestFileTool definition", () => {
-  test("has the correct name and category", () => {
-    expect(requestFileTool.name).toBe("request_file");
-    expect(requestFileTool.category).toBe("ui-surface");
-    expect(requestFileTool.executionMode).toBe("proxy");
-  });
-
-  test("getDefinition returns correct input_schema", () => {
-    const definition = requestFileTool.getDefinition();
-
-    expect(definition.name).toBe("request_file");
-    expect(definition.description).toContain("file");
-
-    const schema = definition.input_schema as {
-      type: string;
-      properties: Record<string, unknown>;
-      required: string[];
-    };
-
-    expect(schema.type).toBe("object");
-    expect(schema.required).toEqual(["prompt"]);
-    expect(schema.properties).toHaveProperty("prompt");
-    expect(schema.properties).toHaveProperty("accepted_types");
-    expect(schema.properties).toHaveProperty("max_files");
-  });
-
-  test("prompt property is a string type", () => {
-    const definition = requestFileTool.getDefinition();
-    const props = (
-      definition.input_schema as {
-        properties: Record<string, { type: string }>;
-      }
-    ).properties;
-
-    expect(props.prompt.type).toBe("string");
-  });
-
-  test("accepted_types property is an array of strings", () => {
-    const definition = requestFileTool.getDefinition();
-    const props = (
-      definition.input_schema as {
-        properties: Record<string, { type: string; items?: { type: string } }>;
-      }
-    ).properties;
-
-    expect(props.accepted_types.type).toBe("array");
-    expect(props.accepted_types.items).toEqual({ type: "string" });
-  });
-
-  test("max_files property is a number type", () => {
-    const definition = requestFileTool.getDefinition();
-    const props = (
-      definition.input_schema as {
-        properties: Record<string, { type: string }>;
-      }
-    ).properties;
-
-    expect(props.max_files.type).toBe("number");
-  });
-
-  test("execute throws proxy error", () => {
-    expect(() => requestFileTool.execute({}, {} as never)).toThrow(
-      "Proxy tool: execution must be forwarded to the connected client",
-    );
-  });
-});
 
 // ---------------------------------------------------------------------------
 // FileUploadSurfaceData shape
@@ -162,5 +91,15 @@ describe("ui_show tool includes file_upload", () => {
   test("description mentions file_upload", () => {
     const definition = uiShowTool.getDefinition();
     expect(definition.description).toContain("file_upload");
+  });
+});
+
+describe("UI surface tool registration", () => {
+  test("registers only the base UI surface tools", () => {
+    expect(allUiSurfaceTools.map((tool) => tool.name)).toEqual([
+      "ui_show",
+      "ui_update",
+      "ui_dismiss",
+    ]);
   });
 });

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -29,7 +29,6 @@ import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import type {
   CuObservation,
-  FileUploadSurfaceData,
   ServerMessage,
   SurfaceData,
   SurfaceType,
@@ -360,9 +359,7 @@ export class ComputerUseSession {
 
     const toolDefs: ToolDefinition[] = [
       ...cuToolDefs,
-      ...allUiSurfaceTools
-        .filter((t) => t.name !== "request_file")
-        .map((t) => t.getDefinition()),
+      ...allUiSurfaceTools.map((t) => t.getDefinition()),
     ];
 
     this.prompter = new PermissionPrompter(this.sendToClient);
@@ -459,42 +456,6 @@ export class ComputerUseSession {
         this.pendingSurfaceActions.delete(surfaceId);
         this.surfaceState.delete(surfaceId);
         return { content: "Surface dismissed", isError: false };
-      }
-
-      // ── File request proxying ──────────────────────────────────────
-      if (toolName === "request_file") {
-        const surfaceId = uuid();
-        const prompt =
-          typeof input.prompt === "string"
-            ? input.prompt
-            : "Please share a file";
-        const acceptedTypes = Array.isArray(input.accepted_types)
-          ? (input.accepted_types as string[])
-          : undefined;
-        const maxFiles =
-          typeof input.max_files === "number" ? input.max_files : 1;
-
-        const data: FileUploadSurfaceData = {
-          prompt,
-          acceptedTypes,
-          maxFiles,
-        };
-
-        this.surfaceState.set(surfaceId, { surfaceType: "file_upload", data });
-
-        this.sendToClient({
-          type: "ui_surface_show",
-          sessionId: this.sessionId,
-          surfaceId,
-          surfaceType: "file_upload",
-          title: "File Request",
-          data,
-        } as UiSurfaceShow);
-
-        // Always await — file upload is interactive
-        return new Promise<ToolExecutionResult>((resolve) => {
-          this.pendingSurfaceActions.set(surfaceId, { resolve });
-        });
       }
 
       // ── Computer-use tool proxying ─────────────────────────────────

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -7,7 +7,6 @@ import { isPlainObject } from "../util/object.js";
 import type {
   CardSurfaceData,
   DynamicPageSurfaceData,
-  FileUploadSurfaceData,
   ListSurfaceData,
   ServerMessage,
   SurfaceData,
@@ -959,7 +958,7 @@ export function buildUserFacingLabel(
 
 /**
  * Resolve a proxy tool call that targets a UI surface.
- * Handles ui_show, ui_update, ui_dismiss, request_file, computer_use_request_control, and app_open.
+ * Handles ui_show, ui_update, ui_dismiss, computer_use_request_control, and app_open.
  */
 export async function surfaceProxyResolver(
   ctx: SurfaceSessionContext,
@@ -978,56 +977,6 @@ export async function surfaceProxyResolver(
         isError: true,
       };
     }
-  }
-
-  if (toolName === "request_file") {
-    const surfaceId = uuid();
-    const prompt =
-      typeof input.prompt === "string" ? input.prompt : "Please share a file";
-    const acceptedTypes = Array.isArray(input.accepted_types)
-      ? (input.accepted_types as string[])
-      : undefined;
-    const maxFiles = typeof input.max_files === "number" ? input.max_files : 1;
-
-    const data: FileUploadSurfaceData = {
-      prompt,
-      acceptedTypes,
-      maxFiles,
-    };
-
-    ctx.surfaceState.set(surfaceId, { surfaceType: "file_upload", data });
-
-    ctx.sendToClient({
-      type: "ui_surface_show",
-      sessionId: ctx.conversationId,
-      surfaceId,
-      surfaceType: "file_upload",
-      title: "File Request",
-      data,
-    } as UiSurfaceShow);
-
-    // Track surface for persistence
-    ctx.currentTurnSurfaces.push({
-      surfaceId,
-      surfaceType: "file_upload",
-      title: "File Request",
-      data,
-    });
-
-    // Non-blocking: return immediately, user action arrives as follow-up message
-    ctx.pendingSurfaceActions.set(surfaceId, {
-      surfaceType: "file_upload" as SurfaceType,
-    });
-    return {
-      content: JSON.stringify({
-        surfaceId,
-        status: "awaiting_user_action",
-        message:
-          "File upload dialog displayed and the user can see it. The uploaded file data will arrive as a follow-up message. Do not output any waiting message — just stop here.",
-      }),
-      isError: false,
-      yieldToUser: true,
-    };
   }
 
   if (toolName === "ui_show") {

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -218,63 +218,8 @@ export const uiDismissTool: Tool = {
   execute: proxyExecute,
 };
 
-// ---------------------------------------------------------------------------
-// request_file
-// ---------------------------------------------------------------------------
-
-export const requestFileTool: Tool = {
-  name: "request_file",
-  description:
-    "Request a file or image from the user. Shows a file upload dialog where the user can drag-and-drop or browse for files. " +
-    "Use this when you need the user to share a file (image, document, PDF, etc.) to continue the conversation. " +
-    "The result contains the uploaded file data including base64 content and MIME type.",
-  category: "ui-surface",
-  defaultRiskLevel: RiskLevel.Low,
-  executionMode: "proxy",
-
-  getDefinition(): ToolDefinition {
-    return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          prompt: {
-            type: "string",
-            description:
-              'What to ask the user for, e.g. "Please share the design file you\'d like me to review"',
-          },
-          accepted_types: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              'MIME type filters, e.g. ["image/*", "application/pdf"]. If omitted, all supported file types are accepted.',
-          },
-          max_files: {
-            type: "number",
-            description: "Maximum number of files to accept. Defaults to 1.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are requesting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
-        },
-        required: ["prompt"],
-      },
-    };
-  },
-
-  execute: proxyExecute,
-};
-
-// ---------------------------------------------------------------------------
-// All tools exported as array for convenience
-// ---------------------------------------------------------------------------
-
 export const allUiSurfaceTools: Tool[] = [
   uiShowTool,
   uiUpdateTool,
   uiDismissTool,
-  requestFileTool,
 ];

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1012,8 +1012,6 @@ public struct ToolCallData: Identifiable, Equatable {
             return "Updated the panel"
         case "ui_dismiss":
             return "Closed the panel"
-        case "request_file":
-            return "Requested a file"
         case "playbook_create":
             return "Created a playbook"
         case "playbook_update":

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1140,7 +1140,7 @@ extension ChatViewModel {
             flushStreamingBuffer()
             lastToolUseReceivedAt = Date()
             // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
-            if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" || msg.toolName == "request_file" {
+            if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" {
                 break
             }
             // Tool chip is now visible — hide the thinking indicator


### PR DESCRIPTION
## Summary
- remove the redundant `request_file` alias and keep `file_upload` available only through `ui_show`
- delete duplicate assistant-side proxy handling and shared client-side tool-name special cases
- replace the alias-specific test with direct `ui_show(file_upload)` regression coverage

## Verification
- `cd assistant && bun test src/__tests__/ui-file-upload-surface.test.ts src/__tests__/session-surfaces-task-progress.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ChatViewModelTests/(testSuppressedToolsDoNotCreateSegmentBoundary|testSuppressedToolDoesNotClearThinking)'`  
  - one filtered macOS test failed: `ChatViewModelTests/testSuppressedToolsDoNotCreateSegmentBoundary`

🤖 Generated with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
