### PR TITLE
LUM-138 Fix Things page infinite loading

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -25,6 +25,7 @@ struct AppsGridView: View {
     @State private var isLoadingShared = false
     @State private var hasFetchedShared = false
     @State private var sharedAppsTask: Task<Void, Never>?
+    @State private var sharedAppsTaskGeneration = 0
 
     /// Cache of lazily-loaded preview screenshots keyed by app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
@@ -484,22 +485,34 @@ struct AppsGridView: View {
         guard sharedAppsTask == nil else { return }
 
         isLoadingShared = true
-        sharedAppsTask = Task { @MainActor in
+        sharedAppsTaskGeneration += 1
+        let generation = sharedAppsTaskGeneration
+
+        let task = Task { @MainActor in
+            // Ignore cleanup from cancelled predecessors once a newer load starts.
+            defer {
+                if sharedAppsTaskGeneration == generation {
+                    sharedAppsTask = nil
+                }
+            }
+
             do {
-                sharedApps = try await SharedAppsLoader.load(using: daemonClient)
+                let apps = try await SharedAppsLoader.load(using: daemonClient)
+                guard sharedAppsTaskGeneration == generation else { return }
+                sharedApps = apps
                 hasFetchedShared = true
                 isLoadingShared = false
-                sharedAppsTask = nil
             } catch is CancellationError {
+                guard sharedAppsTaskGeneration == generation else { return }
                 isLoadingShared = false
-                sharedAppsTask = nil
             } catch {
+                guard sharedAppsTaskGeneration == generation else { return }
                 sharedApps = []
                 hasFetchedShared = true
                 isLoadingShared = false
-                sharedAppsTask = nil
             }
         }
+        sharedAppsTask = task
     }
 
     // MARK: - Sections

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -24,6 +24,7 @@ struct AppsGridView: View {
     @State private var sharedApps: [SharedAppItem] = []
     @State private var isLoadingShared = false
     @State private var hasFetchedShared = false
+    @State private var sharedAppsTask: Task<Void, Never>?
 
     /// Cache of lazily-loaded preview screenshots keyed by app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
@@ -63,6 +64,8 @@ struct AppsGridView: View {
             if !hasFetchedShared { fetchSharedApps() }
         }
         .onDisappear {
+            sharedAppsTask?.cancel()
+            sharedAppsTask = nil
             for task in previewTasks.values { task.cancel() }
             previewTasks.removeAll()
         }
@@ -478,20 +481,24 @@ struct AppsGridView: View {
     // MARK: - Daemon Data Fetching
 
     private func fetchSharedApps() {
+        guard sharedAppsTask == nil else { return }
+
         isLoadingShared = true
-        let previousHandler = daemonClient.onSharedAppsListResponse
-        daemonClient.onSharedAppsListResponse = { response in
-            daemonClient.onSharedAppsListResponse = previousHandler
-            self.sharedApps = response.apps
-            self.isLoadingShared = false
-            self.hasFetchedShared = true
-        }
-        do {
-            try daemonClient.sendSharedAppsList()
-        } catch {
-            isLoadingShared = false
-            hasFetchedShared = true
-            daemonClient.onSharedAppsListResponse = previousHandler
+        sharedAppsTask = Task { @MainActor in
+            do {
+                sharedApps = try await SharedAppsLoader.load(using: daemonClient)
+                hasFetchedShared = true
+                isLoadingShared = false
+                sharedAppsTask = nil
+            } catch is CancellationError {
+                isLoadingShared = false
+                sharedAppsTask = nil
+            } catch {
+                sharedApps = []
+                hasFetchedShared = true
+                isLoadingShared = false
+                sharedAppsTask = nil
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedAppsLoader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedAppsLoader.swift
@@ -1,0 +1,43 @@
+import Foundation
+import VellumAssistantShared
+
+@MainActor
+enum SharedAppsLoader {
+    enum LoadError: Error, Equatable {
+        case timedOut
+    }
+
+    static func load(
+        using daemonClient: DaemonClientProtocol,
+        timeoutNanoseconds: UInt64 = 10_000_000_000
+    ) async throws -> [SharedAppItem] {
+        let stream = daemonClient.subscribe()
+        try daemonClient.send(SharedAppsListRequestMessage())
+
+        return try await withThrowingTaskGroup(of: [SharedAppItem].self) { group in
+            group.addTask {
+                for await message in stream {
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+                    if case .sharedAppsListResponse(let response) = message {
+                        return response.apps
+                    }
+                }
+
+                throw LoadError.timedOut
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                throw LoadError.timedOut
+            }
+
+            defer { group.cancelAll() }
+            guard let apps = try await group.next() else {
+                throw LoadError.timedOut
+            }
+            return apps
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/SharedAppsLoaderTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedAppsLoaderTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+private final class SharedAppsTestClient: DaemonClientProtocol {
+    var isConnected: Bool = true
+    var sentMessages: [Any] = []
+    private var continuations: [AsyncStream<ServerMessage>.Continuation] = []
+
+    func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func send<T: Encodable>(_ message: T) throws {
+        sentMessages.append(message)
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func startSSE() {}
+    func stopSSE() {}
+
+    func emit(_ message: ServerMessage) {
+        for continuation in continuations {
+            continuation.yield(message)
+        }
+    }
+}
+
+@MainActor
+private final class ThrowingSharedAppsClient: DaemonClientProtocol {
+    struct ExpectedError: Error, Equatable {}
+
+    var isConnected: Bool = true
+
+    func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { _ in }
+    }
+
+    func send<T: Encodable>(_ message: T) throws {
+        throw ExpectedError()
+    }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func startSSE() {}
+    func stopSSE() {}
+}
+
+@MainActor
+final class SharedAppsLoaderTests: XCTestCase {
+    func testLoadReturnsAppsFromSharedAppsResponse() async throws {
+        let client = SharedAppsTestClient()
+
+        let loadTask = Task {
+            try await SharedAppsLoader.load(
+                using: client,
+                timeoutNanoseconds: 1_000_000_000
+            )
+        }
+
+        await Task.yield()
+        client.emit(.sharedAppsListResponse(IPCSharedAppsListResponse(
+            type: "shared_apps_list_response",
+            apps: [
+                IPCSharedAppsListResponseApp(
+                    uuid: "shared-1",
+                    name: "Shared Things",
+                    description: "Shared app",
+                    icon: "📱",
+                    preview: nil,
+                    entry: "index.html",
+                    trustTier: "trusted",
+                    signerDisplayName: "Aaron",
+                    bundleSizeBytes: 1024,
+                    installedAt: "2026-03-09T00:00:00Z",
+                    version: "1.0.0",
+                    contentId: "cid-1",
+                    updateAvailable: true
+                )
+            ]
+        )))
+
+        let apps = try await loadTask.value
+        XCTAssertEqual(apps.count, 1)
+        XCTAssertEqual(apps[0].uuid, "shared-1")
+        XCTAssertTrue(client.sentMessages.first is SharedAppsListRequestMessage)
+    }
+
+    func testLoadIgnoresUnrelatedMessages() async throws {
+        let client = SharedAppsTestClient()
+
+        let loadTask = Task {
+            try await SharedAppsLoader.load(
+                using: client,
+                timeoutNanoseconds: 1_000_000_000
+            )
+        }
+
+        await Task.yield()
+        client.emit(.appsListResponse(IPCAppsListResponse(
+            type: "apps_list_response",
+            apps: [
+                IPCAppsListResponseApp(
+                    id: "local-1",
+                    name: "Local Things",
+                    description: nil,
+                    icon: nil,
+                    preview: nil,
+                    createdAt: 123
+                )
+            ]
+        )))
+        client.emit(.sharedAppsListResponse(IPCSharedAppsListResponse(
+            type: "shared_apps_list_response",
+            apps: [
+                IPCSharedAppsListResponseApp(
+                    uuid: "shared-2",
+                    name: "Shared Followup",
+                    description: nil,
+                    icon: nil,
+                    preview: nil,
+                    entry: "index.html",
+                    trustTier: "trusted",
+                    signerDisplayName: nil,
+                    bundleSizeBytes: 512,
+                    installedAt: "2026-03-09T00:00:00Z"
+                )
+            ]
+        )))
+
+        let apps = try await loadTask.value
+        XCTAssertEqual(apps.count, 1)
+        XCTAssertEqual(apps[0].uuid, "shared-2")
+    }
+
+    func testLoadTimesOutWhenNoSharedAppsResponseArrives() async {
+        let client = SharedAppsTestClient()
+
+        do {
+            _ = try await SharedAppsLoader.load(
+                using: client,
+                timeoutNanoseconds: 1_000_000
+            )
+            XCTFail("Expected SharedAppsLoader.load to time out")
+        } catch let error as SharedAppsLoader.LoadError {
+            XCTAssertEqual(error, .timedOut)
+        } catch {
+            XCTFail("Expected SharedAppsLoader.LoadError, got \(error)")
+        }
+    }
+
+    func testLoadPropagatesSendFailure() async {
+        let client = ThrowingSharedAppsClient()
+
+        do {
+            _ = try await SharedAppsLoader.load(using: client)
+            XCTFail("Expected SharedAppsLoader.load to throw")
+        } catch is ThrowingSharedAppsClient.ExpectedError {
+            // Expected.
+        } catch {
+            XCTFail("Expected send failure, got \(error)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -62,6 +62,43 @@ extension HTTPTransport {
         }
     }
 
+    // MARK: - REST Response Shapes
+
+    private struct HTTPAppsListResponse: Decodable {
+        let apps: [HTTPAppsListItem]
+    }
+
+    private struct HTTPAppsListItem: Decodable {
+        let id: String
+        let name: String
+        let description: String?
+        let icon: String?
+        let preview: String?
+        let createdAt: Int
+        let version: String?
+        let contentId: String?
+    }
+
+    private struct HTTPSharedAppsListResponse: Decodable {
+        let apps: [HTTPSharedAppsListItem]
+    }
+
+    private struct HTTPSharedAppsListItem: Decodable {
+        let uuid: String
+        let name: String
+        let description: String?
+        let icon: String?
+        let preview: String?
+        let entry: String
+        let trustTier: String
+        let signerDisplayName: String?
+        let bundleSizeBytes: Int
+        let installedAt: String
+        let version: String?
+        let contentId: String?
+        let updateAvailable: Bool?
+    }
+
     // MARK: - Apps HTTP Endpoints
 
     private func fetchAppsList(isRetry: Bool = false) async {
@@ -85,8 +122,23 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppsListResponse.self, from: data)
-            onMessage?(.appsListResponse(decoded))
+            let decoded = try decoder.decode(HTTPAppsListResponse.self, from: data)
+            let apps = decoded.apps.map { app in
+                IPCAppsListResponseApp(
+                    id: app.id,
+                    name: app.name,
+                    description: app.description,
+                    icon: app.icon,
+                    preview: app.preview,
+                    createdAt: app.createdAt,
+                    version: app.version,
+                    contentId: app.contentId
+                )
+            }
+            onMessage?(.appsListResponse(IPCAppsListResponse(
+                type: "apps_list_response",
+                apps: apps
+            )))
         } catch {
             log.error("Fetch apps list error: \(error.localizedDescription)")
         }
@@ -489,14 +541,42 @@ extension HTTPTransport {
                     if case .success = result { await fetchSharedAppsList(isRetry: true) }
                     return
                 }
+                if http.statusCode == 404 {
+                    // Older assistants may not expose the shared-apps route yet.
+                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(
+                        type: "shared_apps_list_response",
+                        apps: []
+                    )))
+                    return
+                }
                 guard http.statusCode == 200 else {
                     log.error("Fetch shared apps list failed (\(http.statusCode))")
                     return
                 }
             }
 
-            let decoded = try decoder.decode(IPCSharedAppsListResponse.self, from: data)
-            onMessage?(.sharedAppsListResponse(decoded))
+            let decoded = try decoder.decode(HTTPSharedAppsListResponse.self, from: data)
+            let apps = decoded.apps.map { app in
+                IPCSharedAppsListResponseApp(
+                    uuid: app.uuid,
+                    name: app.name,
+                    description: app.description,
+                    icon: app.icon,
+                    preview: app.preview,
+                    entry: app.entry,
+                    trustTier: app.trustTier,
+                    signerDisplayName: app.signerDisplayName,
+                    bundleSizeBytes: app.bundleSizeBytes,
+                    installedAt: app.installedAt,
+                    version: app.version,
+                    contentId: app.contentId,
+                    updateAvailable: app.updateAvailable
+                )
+            }
+            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(
+                type: "shared_apps_list_response",
+                apps: apps
+            )))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
         }

--- a/clients/shared/Tests/HTTPTransportAppsListResponseTests.swift
+++ b/clients/shared/Tests/HTTPTransportAppsListResponseTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class MockAppsURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class HTTPTransportAppsListResponseTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MockAppsURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockAppsURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockAppsURLProtocol.self)
+        MockAppsURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testAppsListResponseWrapsRawHTTPPayloadIntoIPCMessage() async throws {
+        let responseExpectation = expectation(description: "apps list response")
+
+        MockAppsURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://example.com/v1/apps")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {"apps":[{"id":"app-1","name":"Things","description":"A task app","icon":"📱","preview":"preview-data","createdAt":123,"version":"1.0.0","contentId":"cid-1"}]}
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        transport.onMessage = { message in
+            guard case .appsListResponse(let response) = message else { return }
+            XCTAssertEqual(response.type, "apps_list_response")
+            XCTAssertEqual(response.apps.count, 1)
+            XCTAssertEqual(response.apps[0].id, "app-1")
+            XCTAssertEqual(response.apps[0].name, "Things")
+            XCTAssertEqual(response.apps[0].version, "1.0.0")
+            responseExpectation.fulfill()
+        }
+
+        try transport.send(AppsListRequestMessage())
+
+        await fulfillment(of: [responseExpectation], timeout: 1.0)
+    }
+
+    func testSharedAppsListResponseWrapsRawHTTPPayloadIntoIPCMessage() async throws {
+        let responseExpectation = expectation(description: "shared apps list response")
+
+        MockAppsURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.absoluteString, "https://example.com/v1/apps/shared")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {"apps":[{"uuid":"shared-1","name":"Shared Things","description":"Shared app","icon":"📱","preview":"preview-data","entry":"index.html","trustTier":"trusted","signerDisplayName":"Aaron","bundleSizeBytes":2048,"installedAt":"2026-03-09T00:00:00Z","version":"2.0.0","contentId":"cid-2","updateAvailable":true}]}
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        transport.onMessage = { message in
+            guard case .sharedAppsListResponse(let response) = message else { return }
+            XCTAssertEqual(response.type, "shared_apps_list_response")
+            XCTAssertEqual(response.apps.count, 1)
+            XCTAssertEqual(response.apps[0].uuid, "shared-1")
+            XCTAssertEqual(response.apps[0].name, "Shared Things")
+            XCTAssertEqual(response.apps[0].updateAvailable, true)
+            responseExpectation.fulfill()
+        }
+
+        try transport.send(SharedAppsListRequestMessage())
+
+        await fulfillment(of: [responseExpectation], timeout: 1.0)
+    }
+
+    func testSharedAppsList404ReturnsEmptyResponseForOlderAssistants() async throws {
+        let responseExpectation = expectation(description: "shared apps list fallback response")
+
+        MockAppsURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"error":{"code":"NOT_FOUND","message":"Not found"}}"#.utf8)
+            return (response, data)
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        transport.onMessage = { message in
+            guard case .sharedAppsListResponse(let response) = message else { return }
+            XCTAssertEqual(response.type, "shared_apps_list_response")
+            XCTAssertTrue(response.apps.isEmpty)
+            responseExpectation.fulfill()
+        }
+
+        try transport.send(SharedAppsListRequestMessage())
+
+        await fulfillment(of: [responseExpectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- decode raw HTTP app list responses into local HTTP DTOs and wrap them into the IPC messages the client expects
- add a stale-assistant fallback for `/v1/apps/shared` and a request-scoped shared-app loader with a bounded timeout
- add transport and loader regression tests for success, fallback, and timeout behavior

## Original prompt
please look at this PR https://github.com/vellum-ai/vellum-assistant/pull/14701

and make a plan to fix the Things page based on patterns in those changes, such that the Things page no longer infinitely loads as it currently is

we are migrating away from using IPC so we should probably make a new type for this. do we have a place to store those new types already?

that works for me, lets go with your recommendation. please implement this in a feature branch based off of main in a git worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
