### PR TITLE
M3: Update prompt, docs, and tests for the CLI workflow

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -40,12 +40,12 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 
 **Subject patterns:**
 
-| Pattern                                  | Principal Type | Description                                 |
-| ---------------------------------------- | -------------- | ------------------------------------------- |
-| `actor:<assistantId>:<actorPrincipalId>` | `actor`        | Desktop, iOS, or CLI client                 |
-| `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks)         |
-| `svc:internal:<assistantId>:<sessionId>` | `svc_internal` | Internal service connections                |
-| `svc:daemon:<identifier>`                | `svc_daemon`   | Daemon service token (local)                |
+| Pattern                                  | Principal Type | Description                         |
+| ---------------------------------------- | -------------- | ----------------------------------- |
+| `actor:<assistantId>:<actorPrincipalId>` | `actor`        | Desktop, iOS, or CLI client         |
+| `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks) |
+| `svc:internal:<assistantId>:<sessionId>` | `svc_internal` | Internal service connections        |
+| `svc:daemon:<identifier>`                | `svc_daemon`   | Daemon service token (local)        |
 
 **Scope profiles:**
 
@@ -1036,9 +1036,9 @@ Key behaviors:
 
 ---
 
-## Dynamic Skill Authoring — Tool Flow
+## Dynamic Skill Authoring — CLI Flow
 
-The assistant can author, test, and persist new skills at runtime through a three-tool workflow. All operations target `~/.vellum/workspace/skills/` (managed skills directory) and require explicit user confirmation.
+The assistant can author, test, and persist new skills at runtime through a bash + CLI workflow. All operations target `~/.vellum/workspace/skills/` (managed skills directory) and require explicit user confirmation.
 
 ```mermaid
 graph TB
@@ -1051,8 +1051,9 @@ graph TB
         RESULT["JSON result:<br/>ok, exitCode, result,<br/>stdout, stderr,<br/>durationMs, timeout"]
     end
 
-    subgraph "2. Persist (Filesystem)"
-        SCAFFOLD["scaffold_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
+    subgraph "2. Persist (CLI)"
+        CREATE["assistant skills create<br/>───────────────<br/>Requires user consent"]
+        CLI_CREATE["createSkillLocally()<br/>───────────────<br/>reads body file or stdin"]
         MANAGED_STORE["managed-store.ts<br/>───────────────<br/>validateManagedSkillId()<br/>buildSkillMarkdown()<br/>createManagedSkill()<br/>upsertSkillsIndexEntry()"]
         SKILL_DIR["~/.vellum/workspace/skills/&lt;id&gt;/<br/>SKILL.md (frontmatter + body)"]
         INDEX["~/.vellum/workspace/skills/<br/>SKILLS.md (index)"]
@@ -1064,7 +1065,8 @@ graph TB
     end
 
     subgraph "4. Delete"
-        DELETE["delete_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
+        DELETE["assistant skills uninstall<br/>───────────────<br/>Requires user consent"]
+        CLI_DELETE["uninstallSkillLocally()<br/>───────────────<br/>rmSync + removeSkillsIndexEntry()"]
         RM_DIR["rmSync skill directory"]
         RM_INDEX["removeSkillsIndexEntry()"]
     end
@@ -1079,9 +1081,10 @@ graph TB
     TEMP --> WRAPPER
     WRAPPER --> SANDBOX
     SANDBOX --> RESULT
-    RESULT -->|"ok=true + user consent"| SCAFFOLD
+    RESULT -->|"ok=true + user consent"| CREATE
 
-    SCAFFOLD --> MANAGED_STORE
+    CREATE --> CLI_CREATE
+    CLI_CREATE --> MANAGED_STORE
     MANAGED_STORE --> SKILL_DIR
     MANAGED_STORE --> INDEX
 
@@ -1092,8 +1095,9 @@ graph TB
     SKILL_DIR --> SKILL_LOAD
     SKILL_LOAD --> SESSION
 
-    DELETE --> RM_DIR
-    DELETE --> RM_INDEX
+    DELETE --> CLI_DELETE
+    CLI_DELETE --> RM_DIR
+    CLI_DELETE --> RM_INDEX
     RM_DIR --> WATCHER
 ```
 
@@ -1101,7 +1105,8 @@ graph TB
 
 - `evaluate_typescript_code` always forces `sandbox.enabled = true` regardless of global config.
 - Snippet contract: must export `default` or `run` with signature `(input: unknown) => unknown | Promise<unknown>`.
-- Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` or `SKILLS.md` files.
+- `assistant skills create` delegates to `createManagedSkill()`, which writes `SKILL.md` and `SKILLS.md` atomically (tmp file + rename).
+- `assistant skills uninstall` removes the skill directory and deletes its `SKILLS.md` entry.
 - After persist or delete, the file watcher triggers session eviction; the next turn runs in a fresh session. The model's system prompt instructs it to continue normally.
 - macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
 - `skill_load` validates the recursive include graph (via `include-graph.ts`) before emitting output. Missing children and cycles produce `isError: true` with no `<loaded_skill>` marker. Valid includes produce an "Included Skills (immediate)" metadata section showing child ID, name, description, and path.
@@ -1373,7 +1378,6 @@ The `classifyRisk()` function determines the risk level for each tool invocation
 | `file_write`, `file_edit` targeting skill source paths           | **High**                    | `isSkillSourcePath()` detects managed/bundled/workspace/extra skill roots                    |
 | `host_file_write`, `host_file_edit` targeting skill source paths | **High**                    | Same path classification, host variant                                                       |
 | `bash`, `host_bash`                                              | Varies                      | Parsed via tree-sitter: low-risk programs = Low, high-risk programs = High, unknown = Medium |
-| `scaffold_managed_skill`, `delete_managed_skill`                 | High                        | Skill lifecycle mutations always high-risk                                                   |
 | `evaluate_typescript_code`                                       | High                        | Arbitrary code execution                                                                     |
 | Skill-origin tools with no matching rule                         | Prompted regardless of risk | Even Low-risk skill tools default to `ask`                                                   |
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -86,7 +86,6 @@ The `classifyRisk()` function determines the risk level for each tool invocation
 | `file_write`, `file_edit` targeting skill source paths           | **High**                    | `isSkillSourcePath()` detects managed/bundled/workspace/extra skill roots                    |
 | `host_file_write`, `host_file_edit` targeting skill source paths | **High**                    | Same path classification, host variant                                                       |
 | `bash`, `host_bash`                                              | Varies                      | Parsed via tree-sitter: low-risk programs = Low, high-risk programs = High, unknown = Medium |
-| `scaffold_managed_skill`, `delete_managed_skill`                 | High                        | Skill lifecycle mutations always high-risk                                                   |
 | `evaluate_typescript_code`                                       | High                        | Arbitrary code execution                                                                     |
 | Skill-origin tools with no matching rule                         | Prompted regardless of risk | Even Low-risk skill tools default to `ask`                                                   |
 

--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -4,7 +4,7 @@ This document describes the security model for the Vellum Assistant skill system
 
 ## Overview
 
-Skills extend the assistant's capabilities by providing instructions (via `SKILL.md`) and optional custom tools (via `TOOLS.json`). Skills can be **bundled** (shipped with the application), **managed** (user-installed via `scaffold_managed_skill`), **workspace** (project-local), or **extra** (additional directories configured by the user).
+Skills extend the assistant's capabilities by providing instructions (via `SKILL.md`) and optional custom tools (via `TOOLS.json`). Skills can be **bundled** (shipped with the application), **managed** (stored under `~/.vellum/workspace/skills/`, typically via `assistant skills create` or `assistant skills install`), **workspace** (project-local), or **extra** (additional directories configured by the user).
 
 Because skills can introduce arbitrary tool behavior, they are subject to stricter permission defaults than core tools.
 

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -89,12 +89,12 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("## Dynamic Skill Authoring Workflow");
   });
 
-  test("workflow section mentions scaffold and delete tools and bun run workflow", () => {
+  test("workflow section mentions the skills CLI and bun run workflow", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
     expect(result).toContain("bun run /tmp/vellum-eval/snippet.ts");
-    expect(result).toContain("scaffold_managed_skill");
-    expect(result).toContain("delete_managed_skill");
+    expect(result).toContain("assistant skills create");
+    expect(result).toContain("assistant skills uninstall");
   });
 
   test("workflow section includes user confirmation warning", () => {

--- a/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
+++ b/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
@@ -54,7 +54,7 @@ bash command="rm -rf /tmp/vellum-eval/"
 ## Guidelines
 
 - **Iteration limit:** Max 3 attempts before asking the user for guidance.
-- **After successful test:** Persist with `scaffold_managed_skill` only after explicit user consent.
+- **After successful test:** After explicit user consent, persist with `assistant skills create <skill-id> --name "<name>" --description "<description>" --body-file <path-or-->`.
 - **Timeout:** Use `timeout_seconds=10` (or up to 20 for complex snippets).
 - **Error handling:** Read stdout/stderr from the bash output to diagnose failures.
-- **Never persist or delete skills without explicit user confirmation.**
+- **Never persist or delete skills without explicit user confirmation.** Remove skills with `assistant skills uninstall <skill-id>`.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -898,10 +898,10 @@ function buildDynamicSkillWorkflowSection(
     "1. Validate the gap — confirm no existing tool/skill covers it.",
     "2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).",
     '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
-    "4. Persist with `scaffold_managed_skill` only after user consent.",
+    '4. After user consent, persist the final skill body with `assistant skills create <skill-id> --name "<name>" --description "<description>" --body-file <path-or-->`.',
     "5. Load with `skill_load` before use.",
     "",
-    "**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.",
+    "**Never persist or delete skills without explicit user confirmation.** To remove: `assistant skills uninstall <skill-id>`.",
     "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
   ];
 


### PR DESCRIPTION
## Summary
- rewrite the dynamic skill authoring prompt to use `assistant skills create` and `assistant skills uninstall`
- update the bundled `typescript-eval` guidance and prompt coverage test to match the CLI workflow
- refresh skills/security/architecture docs so they no longer describe the deleted tool-based lifecycle

## Verification
- `cd assistant && bun test src/__tests__/dynamic-skill-workflow-prompt.test.ts`
- `cd assistant && bun run lint src/prompts/system-prompt.ts src/__tests__/dynamic-skill-workflow-prompt.test.ts`
- `cd assistant && bunx tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
