### PR TITLE
M12: Cross-platform polish, accessibility, and documentation

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -813,3 +813,93 @@ When `integrationMode` is `managed`, the daemon's `handleTwitterAuthStart` handl
 | `assistant/src/config/bundled-skills/twitter/SKILL.md` | Skill documentation including managed mode architecture |
 
 ---
+
+## Shared Feature Stores
+
+Cross-platform `ObservableObject` stores in `clients/shared/Features/` encapsulate daemon communication and state management. Platform views delegate data operations to these stores while owning their own UI presentation state.
+
+| Store | Location | Purpose |
+|-------|----------|---------|
+| `SkillsStore` | `shared/Features/Skills/SkillsStore.swift` | Skills CRUD: list, search, inspect, install, uninstall, enable/disable, configure, draft, and create. Caches inspect results and uses generation counters to handle stale responses. |
+| `ContactsStore` | `shared/Features/Contacts/ContactsStore.swift` | Contacts CRUD: list, get, update channel policy, delete. Auto-refreshes on `contactsChanged` daemon broadcasts with 500ms debounce. |
+| `DirectoryStore` | `shared/Features/Directory/DirectoryStore.swift` | Directory data: local apps, shared apps, documents. Supports open, delete, share-to-cloud, fork, and bundle operations. Auto-refreshes on `appFilesChanged` broadcasts. |
+| `ChannelTrustStore` | `shared/Features/ChannelTrust/ChannelTrustStore.swift` | Guardian state and channel trust management. Composes `ContactsStore` for guardian contact data, manages pending guardian action prompts via daemon IPC. |
+
+### Store Patterns
+
+All shared stores follow the same async pattern for daemon communication:
+
+1. Subscribe to the daemon's `AsyncStream` via `daemonClient.subscribe()`
+2. Send a request message via the appropriate `DaemonClient` method
+3. Iterate the stream with `for await`, matching on the expected response case
+4. Update `@Published` state on the main actor
+5. Cancel subscription tasks in `deinit` to prevent leaks
+
+Stores use `[weak self]` in all `Task` closures and background subscriptions. Platform views own stores via `@ObservedObject` or `@StateObject` and pass them down to child views.
+
+---
+
+## iOS Feature Flows
+
+### Intelligence Tab (M6)
+
+The Intelligence tab is the iOS hub for skills and contacts management, gated on daemon connectivity.
+
+| View | File | Purpose |
+|------|------|---------|
+| `InstalledSkillsView` | `ios/Views/Intelligence/InstalledSkillsView.swift` | List of installed skills with enable/disable swipe actions and uninstall |
+| `CommunitySkillsView` | `ios/Views/Intelligence/CommunitySkillsView.swift` | Searchable community skill browser with debounced search |
+| `SkillDetailView` | `ios/Views/Intelligence/SkillDetailView.swift` | Skill details with ClaWhub inspect data, enable/disable/uninstall actions |
+| `ContactsListView` | `ios/Views/Intelligence/ContactsListView.swift` | Searchable contacts list with guardian section and delete swipe actions |
+| `ContactDetailView` | `ios/Views/Intelligence/ContactDetailView.swift` | Contact details with channel list and policy editing via confirmation dialog |
+
+### Things Tab (M8-M9)
+
+The Things tab provides access to local apps, shared apps, and documents via a segmented picker.
+
+| View | File | Purpose |
+|------|------|---------|
+| `ThingsView` | `ios/Views/Things/ThingsView.swift` | Segmented container switching between My Apps, Shared, and Documents |
+| `AppsGridView` | `ios/Views/Things/AppsGridView.swift` | 2-column LazyVGrid of local apps with pin, share, bundle, and delete context menu actions |
+| `SharedAppsListView` | `ios/Views/Things/SharedAppsListView.swift` | List of shared apps with detail sheet for fork/delete |
+| `DocumentsListView` | `ios/Views/Things/DocumentsListView.swift` | Searchable, sortable document list |
+
+### Settings Parity (M7)
+
+New settings sections brought to iOS for feature parity with macOS:
+
+| View | File | Purpose |
+|------|------|---------|
+| `ModelsServicesSection` | `ios/Views/Settings/ModelsServicesSection.swift` | Active model display/set, API key management via Keychain |
+| `PrivacySection` | `ios/Views/Settings/PrivacySection.swift` | System permission status display with deep-link to iOS Settings |
+| `ChannelsGuardianSection` | `ios/Views/Settings/ChannelsGuardianSection.swift` | Guardian status, guardian channel management, approved contacts overview |
+
+---
+
+## macOS Task Queue (M10)
+
+The Task Queue panel is a macOS side panel for managing one-shot work items.
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `TaskQueuePanel` | `macos/.../Panels/TaskQueuePanel.swift` | Side panel with filter strip, task list, output/preflight sheet presentation |
+| `TaskQueueRow` | (private in TaskQueuePanel.swift) | Individual task row with status badge, priority menu, run/stop/result actions |
+| `TaskQueueViewModel` | `macos/.../Panels/TaskQueueViewModel.swift` | Centralized state: items, filters, run/cancel/timeout tracking, daemon callbacks |
+| `TaskPreflightView` | `macos/.../Panels/TaskPreflightView.swift` | Permission approval sheet with toggleable tool permissions and risk badges |
+| `TaskOutputView` | `macos/.../Panels/TaskOutputView.swift` | Output detail sheet with status, summary, highlights, and copy-to-clipboard |
+
+### Task Queue Data Flow
+
+1. `TaskQueueViewModel` sets up daemon callbacks in `init` and fetches the initial item list
+2. Filter strip controls which status subset is displayed (`All`, `Active`, `Completed`, `Failed`)
+3. Running a task triggers a preflight check; if permissions are needed, `TaskPreflightView` is presented
+4. Run requests include a timeout (10s); if the daemon doesn't respond, the task shows a "No response" warning
+5. Status changes from the daemon trigger debounced list refreshes (300ms)
+
+---
+
+## macOS Deep-Link Send (M11)
+
+The macOS app registers a `vellum://send?message=...` URL scheme handler. When invoked, it creates or reuses a conversation and sends the message through the daemon. This enables external tools, scripts, and iOS Shortcuts to trigger assistant actions on the Mac.
+
+---

--- a/clients/README.md
+++ b/clients/README.md
@@ -17,6 +17,10 @@ clients/
 ├── shared/                    # VellumAssistantShared - cross-platform code
 │   ├── IPC/                   # Daemon communication (DaemonClient, DaemonConfig, IPCMessages)
 │   ├── Features/Chat/         # Shared chat UI (ChatViewModel, MessageBubbleView, InputBarView, etc.)
+│   ├── Features/Skills/       # SkillsStore — cross-platform skills data operations
+│   ├── Features/Contacts/     # ContactsStore — cross-platform contacts data operations
+│   ├── Features/Directory/    # DirectoryStore — cross-platform apps and documents operations
+│   ├── Features/ChannelTrust/ # ChannelTrustStore — guardian state and channel trust management
 │   ├── Features/Surfaces/     # Shared surface rendering (confirmation, form)
 │   ├── DesignSystem/          # Design tokens and components (VColor, VFont, VSpacing, etc.)
 │   ├── Utilities/             # Shared utilities (APIKeyManager, PermissionManager)
@@ -29,7 +33,9 @@ clients/
 ├── ios/                       # iOS-specific code
 │   ├── App/                   # App lifecycle (VellumAssistantApp, AppDelegate, VellumIntents, etc.)
 │   ├── Views/                 # iOS-specific SwiftUI views (ChatTabView, ThreadListView, etc.)
-│   │   └── Settings/          # Decomposed settings sections (Integrations, TrustRules, etc.)
+│   │   ├── Intelligence/      # Skills and contacts views (InstalledSkills, CommunitySkills, Contacts)
+│   │   ├── Things/            # Apps, shared apps, and documents views
+│   │   └── Settings/          # Decomposed settings sections (Integrations, TrustRules, Models, Privacy, etc.)
 │   ├── Tests/                 # iOS integration tests
 │   └── Resources/             # Assets, Info.plist, background.png
 └── chrome-extension/          # Chrome browser extension
@@ -54,6 +60,7 @@ clients/
     types that need Swift-specific logic (e.g. typed enums, polymorphic `AnyCodable` data)
 - **Shared chat features** (`ChatViewModel`, `ChatMessage`, `MessageBubbleView`, `InputBarView`, `AttachmentStripView`, `MarkdownRenderer`, `CurrentStepIndicator`, inline widgets)
 - **Design system** (`VColor`, `VFont`, `VSpacing`, `VRadius`, `VShadow`, `VAnimation`, and all `V`-prefixed components)
+- **Shared feature stores** (`SkillsStore`, `ContactsStore`, `DirectoryStore`, `ChannelTrustStore` — cross-platform data operations for skills, contacts, apps, documents, and guardian trust)
 - **Shared utilities** (`APIKeyManager` for Keychain credential storage, `PermissionManager`, `MacOSClientFeatureFlagManager`)
 - **Shared app utilities** (signing identity management)
 
@@ -133,6 +140,9 @@ See [clients/ios/README.md](ios/README.md) for full build, packaging, and config
 - ✅ Deep linking (`vellum://send?message=...`)
 - ✅ Responsive typography/spacing (compact scaling for iPhone, full size on iPad)
 - ✅ Integration tests (ChatViewModel, threads, attachments, formatting, usage dashboard)
+- ✅ Intelligence tab — installed skills management, community skill browser, contacts with channel policy editing
+- ✅ Things tab — local apps grid with pin/share/bundle, shared apps with fork, searchable documents list
+- ✅ Settings parity — Models & Services, Privacy permissions, Channels & Guardian sections
 
 Depends only on `VellumAssistantShared` (no macOS frameworks).
 

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -24,6 +24,9 @@ The iOS app is built via a native Xcode project (`vellum-assistant-ios.xcodeproj
 - Siri Shortcuts integration — "Ask Vellum..." via AppIntents framework
 - Deep linking via `vellum://send?message=...` URL scheme
 - Responsive typography and spacing that scales down for iPhone compact width
+- Intelligence tab — installed skills management, community skill browser with debounced search, contacts with channel policy editing
+- Things tab — local apps grid (2-column LazyVGrid) with pin/share/bundle, shared apps with fork, searchable/sortable documents list
+- Settings parity — Models & Services (model selection, API key management), Privacy (system permission status), Channels & Guardian (guardian status, channel trust)
 
 ---
 

--- a/clients/ios/Views/Intelligence/CommunitySkillsView.swift
+++ b/clients/ios/Views/Intelligence/CommunitySkillsView.swift
@@ -100,7 +100,8 @@ struct CommunitySkillsView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Skill: \(item.name) by \(item.author)")
+        .accessibilityLabel("Skill: \(item.name) by \(item.author)\(item.isVellum ? ", Vellum verified" : "")\(item.stars > 0 ? ", \(item.stars) stars" : "")")
+        .accessibilityHint("Opens skill details")
     }
 
     // MARK: - States
@@ -132,6 +133,8 @@ struct CommunitySkillsView: View {
                 .padding(.horizontal, VSpacing.xl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No results. No skills found matching \(searchQuery). Try a different search term.")
     }
 
     private var browsePromptState: some View {

--- a/clients/ios/Views/Intelligence/ContactDetailView.swift
+++ b/clients/ios/Views/Intelligence/ContactDetailView.swift
@@ -168,7 +168,8 @@ struct ContactDetailView: View {
             showPolicySheet = true
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Channel: \(channel.type), \(channel.address), status: \(channel.status), policy: \(channel.policy)")
+        .accessibilityLabel("Channel: \(channel.type), \(channel.address), status: \(channel.status), policy: \(channel.policy)\(channel.isPrimary ? ", primary" : "")")
+        .accessibilityHint("Double-tap to change channel policy")
     }
 
     // MARK: - Badges

--- a/clients/ios/Views/Intelligence/ContactsListView.swift
+++ b/clients/ios/Views/Intelligence/ContactsListView.swift
@@ -122,7 +122,8 @@ struct ContactsListView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Contact: \(contact.displayName), \(contact.role)")
+        .accessibilityLabel("Contact: \(contact.displayName), \(contact.role)\(contact.interactionCount > 0 ? ", \(contact.interactionCount) interactions" : "")")
+        .accessibilityHint("Opens contact details")
     }
 
     // MARK: - Initials
@@ -198,6 +199,8 @@ struct ContactsListView: View {
                 .padding(.horizontal, VSpacing.xl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No contacts. Contacts will appear here as people interact with your assistant.")
     }
 
     private var loadingState: some View {

--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -113,6 +113,7 @@ struct InstalledSkillsView: View {
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Skill: \(skill.name), \(skill.state)\(skill.degraded ? ", degraded" : "")")
+        .accessibilityHint("Opens skill details")
     }
 
     // MARK: - State Badge
@@ -153,6 +154,8 @@ struct InstalledSkillsView: View {
                 .padding(.horizontal, VSpacing.xl)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No skills installed. Browse the community to discover and install skills for your assistant.")
     }
 
     private var loadingState: some View {

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -180,6 +180,8 @@ struct SkillDetailView: View {
                         .font(VFont.caption)
                 }
                 .foregroundColor(.orange)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Skill is degraded")
             }
 
             if skill.updateAvailable {
@@ -189,6 +191,8 @@ struct SkillDetailView: View {
                         .font(VFont.caption)
                 }
                 .foregroundColor(VColor.accent)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Update available for this skill")
             }
         }
         .frame(maxWidth: .infinity)

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -96,6 +96,8 @@ struct ChannelsGuardianSection: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Guardian: \(guardian.displayName), \(guardian.channels.count) channel\(guardian.channels.count == 1 ? "" : "s")")
     }
 
     // MARK: - Guardian Channel Row
@@ -120,8 +122,11 @@ struct ChannelsGuardianSection: View {
                     .foregroundColor(VColor.error)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Revoke channel")
+            .accessibilityLabel("Revoke channel \(channel.address)")
+            .accessibilityHint("Revokes guardian access for this channel")
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Guardian channel: \(channel.address), policy: \(channel.policy), status: \(channel.status)")
     }
 
     // MARK: - Contact Row
@@ -139,6 +144,8 @@ struct ChannelsGuardianSection: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Contact: \(contact.displayName)\(!contact.channels.isEmpty ? ", \(contact.channels.count) channel\(contact.channels.count == 1 ? "" : "s")" : "")")
     }
 
     // MARK: - Badges

--- a/clients/ios/Views/Settings/ModelsServicesSection.swift
+++ b/clients/ios/Views/Settings/ModelsServicesSection.swift
@@ -98,6 +98,8 @@ struct ModelsServicesSection: View {
                     .foregroundColor(hasKey ? VColor.success : VColor.textMuted)
             }
         }
+        .accessibilityLabel("\(provider.displayName), \(hasKey ? "key saved" : "no key set")")
+        .accessibilityHint("Opens API key management")
     }
 
     // MARK: - Daemon Communication

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -38,6 +38,13 @@ struct PrivacySection: View {
 
     @ViewBuilder
     private func permissionRow(name: String, status: PermissionStatus) -> some View {
+        let statusLabel: String = {
+            switch status {
+            case .granted: return "granted"
+            case .denied: return "denied"
+            case .notDetermined: return "not set"
+            }
+        }()
         Button {
             if status == .denied || status == .notDetermined {
                 openSettings()
@@ -51,6 +58,8 @@ struct PrivacySection: View {
             }
         }
         .disabled(status == .granted)
+        .accessibilityLabel("\(name), \(statusLabel)")
+        .accessibilityHint(status == .granted ? "" : "Opens iOS Settings to grant access")
     }
 
     // MARK: - Status Badge

--- a/clients/ios/Views/Things/AppsGridView.swift
+++ b/clients/ios/Views/Things/AppsGridView.swift
@@ -210,6 +210,9 @@ struct AppsGridView: View {
             .background(VColor.surface)
             .cornerRadius(VRadius.lg)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(app.name)\(isPinned(app.id) ? ", pinned" : "")\(app.description != nil ? ", \(app.description!)" : "")")
+        .accessibilityHint("Opens app. Long press for more options.")
         .contextMenu {
             Button {
                 directoryStore.openApp(id: app.id)
@@ -284,11 +287,14 @@ struct AppsGridView: View {
         VStack(spacing: VSpacing.md) {
             VIconView(.layoutGrid, size: 48)
                 .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
             Text("No apps yet")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No apps yet")
     }
 
     // MARK: - Helpers

--- a/clients/ios/Views/Things/DocumentsListView.swift
+++ b/clients/ios/Views/Things/DocumentsListView.swift
@@ -111,6 +111,9 @@ struct DocumentsListView: View {
             Spacer()
         }
         .padding(.vertical, VSpacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(doc.title), \(doc.wordCount) words, updated \(formattedDate(doc.updatedAt))")
+        .accessibilityHint("Opens document")
     }
 
     // MARK: - States
@@ -129,11 +132,14 @@ struct DocumentsListView: View {
         VStack(spacing: VSpacing.md) {
             VIconView(.fileText, size: 48)
                 .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
             Text("No documents yet")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No documents yet")
     }
 
     // MARK: - Helpers

--- a/clients/ios/Views/Things/SharedAppsListView.swift
+++ b/clients/ios/Views/Things/SharedAppsListView.swift
@@ -110,6 +110,9 @@ struct SharedAppsListView: View {
                 .foregroundColor(VColor.textMuted)
         }
         .padding(.vertical, VSpacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(app.name)\(app.signerDisplayName != nil ? " by \(app.signerDisplayName!)" : ""), trust: \(app.trustTier)\(app.updateAvailable == true ? ", update available" : "")")
+        .accessibilityHint("Opens shared app details")
     }
 
     // MARK: - Trust Badge
@@ -265,11 +268,14 @@ struct SharedAppsListView: View {
         VStack(spacing: VSpacing.md) {
             VIconView(.package, size: 48)
                 .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
             Text("No shared apps")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No shared apps")
     }
 
     // MARK: - Helpers

--- a/clients/ios/Views/Things/ThingsView.swift
+++ b/clients/ios/Views/Things/ThingsView.swift
@@ -26,6 +26,7 @@ struct ThingsView: View {
                 .pickerStyle(.segmented)
                 .padding(.horizontal, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
+                .accessibilityLabel("Things section picker")
 
                 switch selectedSegment {
                 case .myApps:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskOutputView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskOutputView.swift
@@ -102,6 +102,7 @@ struct TaskOutputView: View {
             .padding(.vertical, 4)
             .background(statusColor(for: output.status).opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            .accessibilityLabel("Status: \(statusLabel(for: output.status))")
 
             if let completedAt = output.completedAt {
                 HStack(spacing: 4) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskPreflightView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskPreflightView.swift
@@ -172,6 +172,9 @@ struct TaskPreflightView: View {
             }
         }
         .padding(.vertical, VSpacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(permission.tool), \(permission.description), risk: \(permission.riskLevel), \(isApproved ? "approved" : "not approved")")
+        .accessibilityHint("Double-tap to \(isApproved ? "revoke" : "approve") this permission")
     }
 
     private func riskBadge(for level: String) -> some View {
@@ -210,6 +213,8 @@ struct TaskPreflightView: View {
             }
             .buttonStyle(.plain)
             .disabled(approvedTools.isEmpty)
+            .accessibilityLabel("Approve and run")
+            .accessibilityHint(approvedTools.isEmpty ? "Select at least one permission first" : "Runs the task with \(approvedTools.count) approved permissions")
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
@@ -72,6 +72,8 @@ struct TaskQueuePanel: View {
                         .cornerRadius(6)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Filter: \(filter.rawValue)")
+                .accessibilityHint(viewModel.statusFilter == filter ? "Currently selected" : "Double-tap to filter by \(filter.rawValue.lowercased())")
             }
             Spacer()
             Button {
@@ -132,7 +134,7 @@ struct TaskQueuePanel: View {
     // MARK: - Task List
 
     private var taskList: some View {
-        VStack(spacing: 0) {
+        LazyVStack(spacing: 0) {
             ForEach(viewModel.filteredItems, id: \.id) { item in
                 TaskQueueRow(
                     item: item,
@@ -183,6 +185,8 @@ private struct TaskQueueRow: View {
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
         .contextMenu { contextMenuItems }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Task: \(item.title), status: \(TasksTableContract.statusStyle(for: status).label)")
     }
 
     // MARK: - Title Row


### PR DESCRIPTION
## Summary
Accessibility pass on all new iOS and macOS views from M6-M11, performance verification (LazyVStack conversion), and documentation updates for the iOS-macOS parity v3 feature set.

## Implementation

### Accessibility Pass
- **iOS Intelligence views** (M6): Added `accessibilityHint` to skill rows, contact rows, and channel rows. Added combined accessibility labels to empty states. Enhanced community skill row labels to include star count and Vellum verification status. Added labels to degraded/update-available badges in SkillDetailView.
- **iOS Settings sections** (M7): Added accessibility labels and hints to ModelsServicesSection provider rows, PrivacySection permission rows (with status and hint to open Settings), and ChannelsGuardianSection guardian/channel/contact rows.
- **iOS Things views** (M8-M9): Added accessibility labels and hints to AppsGridView app cards, SharedAppsListView rows, DocumentsListView document rows. Added `accessibilityHidden(true)` to decorative icons in empty states.
- **macOS Task Queue** (M10): Added accessibility labels and hints to filter strip buttons, task rows, permission preflight rows (with approve/revoke hints), and the Approve & Run button. Added status label to TaskOutputView metadata badge.

### Performance
- Converted TaskQueuePanel task list from eager `VStack` to `LazyVStack` for better performance with large task lists.
- Verified all other new views already use lazy containers (LazyVGrid in AppsGridView, List in other views).
- Verified `[weak self]` usage in all shared stores and TaskQueueViewModel — no retain cycles found.

### Documentation
- **ARCHITECTURE.md**: Added sections for Shared Feature Stores (SkillsStore, ContactsStore, DirectoryStore, ChannelTrustStore), iOS Feature Flows (Intelligence, Things, Settings), macOS Task Queue architecture, and deep-link send.
- **clients/README.md**: Updated directory layout, VellumAssistantShared contents, and iOS feature list.
- **clients/ios/README.md**: Added Intelligence tab, Things tab, and Settings parity features.

## Files Changed
- 5 iOS Intelligence views (accessibility additions)
- 3 iOS Settings views (accessibility additions)
- 4 iOS Things views (accessibility additions)
- 1 iOS ThingsView (accessibility label on picker)
- 3 macOS Task Queue files (accessibility + LazyVStack)
- 3 documentation files (ARCHITECTURE.md, README.md, ios/README.md)

## Note
Pre-existing Swift build errors in ChatViewModel.swift and APIKeyManager.swift (UserDefaults.standard) are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
