### PR TITLE
Skip wake-up bootstrap for reused managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -424,7 +424,9 @@ extension AppDelegate {
             // By this point the user has either entered an API key (steps 0→1→2)
             // or authenticated via Vellum Account (WorkOS). Proceed directly —
             // don't re-check auth, which would show the auth gate again.
-            self?.proceedToApp(isFirstLaunch: true)
+            self?.proceedToApp(
+                isFirstLaunch: state.shouldSendWakeUpGreetingAfterOnboarding
+            )
         }
         onboarding.onDismiss = { [weak self] in
             self?.onboardingWindow = nil

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -4,6 +4,34 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "OnboardingFlowView")
 
+struct ManagedBootstrapCompletionMetadata {
+    let shouldSendWakeUpGreeting: Bool
+    let hatchedAt: String
+}
+
+func deriveManagedBootstrapCompletionMetadata(
+    outcome: ManagedBootstrapOutcome,
+    existingHatchedAt: String?,
+    fallbackDate: Date = Date()
+) -> ManagedBootstrapCompletionMetadata {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let fallbackHatchedAt = formatter.string(from: fallbackDate)
+
+    switch outcome {
+    case .createdNew(let assistant):
+        return ManagedBootstrapCompletionMetadata(
+            shouldSendWakeUpGreeting: true,
+            hatchedAt: assistant.created_at ?? fallbackHatchedAt
+        )
+    case .reusedExisting(let assistant):
+        return ManagedBootstrapCompletionMetadata(
+            shouldSendWakeUpGreeting: false,
+            hatchedAt: existingHatchedAt ?? assistant.created_at ?? fallbackHatchedAt
+        )
+    }
+}
+
 @MainActor
 struct OnboardingFlowView: View {
     @Bindable var state: OnboardingState
@@ -209,6 +237,7 @@ struct OnboardingFlowView: View {
     private func performManagedBootstrap() async {
         isBootstrappingManaged = true
         managedBootstrapError = nil
+        state.shouldSendWakeUpGreetingAfterOnboarding = false
         log.info("Beginning managed assistant bootstrap")
 
         do {
@@ -225,14 +254,16 @@ struct OnboardingFlowView: View {
             }
 
             let runtimeUrl = AuthService.shared.baseURL
-            let isoFormatter = ISO8601DateFormatter()
-            isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            let hatchedAt = isoFormatter.string(from: Date())
+            let existingManagedAssistant = LockfileAssistant.loadByName(assistant.id)
+            let completionMetadata = deriveManagedBootstrapCompletionMetadata(
+                outcome: outcome,
+                existingHatchedAt: existingManagedAssistant?.hatchedAt
+            )
 
             let success = LockfileAssistant.upsertManagedEntry(
                 assistantId: assistant.id,
                 runtimeUrl: runtimeUrl,
-                hatchedAt: hatchedAt
+                hatchedAt: completionMetadata.hatchedAt
             )
 
             guard success else {
@@ -241,6 +272,7 @@ struct OnboardingFlowView: View {
                 return
             }
 
+            state.shouldSendWakeUpGreetingAfterOnboarding = completionMetadata.shouldSendWakeUpGreeting
             UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
 
             isBootstrappingManaged = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -67,6 +67,10 @@ final class OnboardingState {
     var firstTaskCandidate: String? = nil
     var observationDurationMinutes: Int = 5
     var observationInsights: [String] = []
+    /// Controls whether completing onboarding should enter the first-launch
+    /// bootstrap that sends the wake-up greeting. Local onboarding defaults to
+    /// true; managed bootstrap flips this off when it reuses an existing assistant.
+    var shouldSendWakeUpGreetingAfterOnboarding: Bool = true
 
     var anyPermissionDenied: Bool {
         !speechGranted || !accessibilityGranted || !screenGranted

--- a/clients/macos/vellum-assistantTests/ManagedBootstrapCompletionMetadataTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedBootstrapCompletionMetadataTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ManagedBootstrapCompletionMetadataTests: XCTestCase {
+    func testCreatedNewAssistantTriggersWakeUpGreeting() {
+        let assistant = PlatformAssistant(
+            id: "assistant-new",
+            created_at: "2024-01-02T03:04:05Z"
+        )
+
+        let result = deriveManagedBootstrapCompletionMetadata(
+            outcome: .createdNew(assistant),
+            existingHatchedAt: "2023-12-01T00:00:00Z"
+        )
+
+        XCTAssertTrue(result.shouldSendWakeUpGreeting)
+        XCTAssertEqual(result.hatchedAt, "2024-01-02T03:04:05Z")
+    }
+
+    func testReusedExistingAssistantSkipsWakeUpGreetingAndPreservesLockfileTimestamp() {
+        let assistant = PlatformAssistant(
+            id: "assistant-existing",
+            created_at: "2024-01-02T03:04:05Z"
+        )
+
+        let result = deriveManagedBootstrapCompletionMetadata(
+            outcome: .reusedExisting(assistant),
+            existingHatchedAt: "2023-12-01T00:00:00Z"
+        )
+
+        XCTAssertFalse(result.shouldSendWakeUpGreeting)
+        XCTAssertEqual(result.hatchedAt, "2023-12-01T00:00:00Z")
+    }
+
+    func testReusedExistingAssistantFallsBackToPlatformCreatedAtWhenLockfileMissing() {
+        let assistant = PlatformAssistant(
+            id: "assistant-existing",
+            created_at: "2024-01-02T03:04:05Z"
+        )
+
+        let result = deriveManagedBootstrapCompletionMetadata(
+            outcome: .reusedExisting(assistant),
+            existingHatchedAt: nil
+        )
+
+        XCTAssertFalse(result.shouldSendWakeUpGreeting)
+        XCTAssertEqual(result.hatchedAt, "2024-01-02T03:04:05Z")
+    }
+
+    func testFallsBackToCurrentDateWhenNoTimestampExists() {
+        let assistant = PlatformAssistant(id: "assistant-no-date")
+        let fallbackDate = Date(timeIntervalSince1970: 1_704_153_600)
+
+        let result = deriveManagedBootstrapCompletionMetadata(
+            outcome: .reusedExisting(assistant),
+            existingHatchedAt: nil,
+            fallbackDate: fallbackDate
+        )
+
+        XCTAssertFalse(result.shouldSendWakeUpGreeting)
+        XCTAssertEqual(result.hatchedAt, "2024-01-02T00:00:00.000Z")
+    }
+}


### PR DESCRIPTION
## Summary
- carry managed-bootstrap outcome through onboarding so reused hosted assistants do not enter first-launch wake-up bootstrap
- preserve the existing managed assistant `hatchedAt` value when onboarding reconnects to an existing assistant
- add focused tests for the managed bootstrap wake-up decision helper

## Testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path /tmp/vellum-assistant-no-wakeup/clients --filter ManagedBootstrapCompletionMetadataTests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
