### PR TITLE
feat(auth): use connectedAssistantId as source of truth in managed bootstrap

### DIFF
--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -271,11 +271,13 @@ public final class AuthService {
 
         log.debug("Platform request GET assistants/\(id)/ -> \(statusCode)")
 
-        if statusCode == 404 {
+        // 404 = deleted, 403 = access revoked. Both mean this specific
+        // assistant is no longer available to the current user.
+        if statusCode == 404 || statusCode == 403 {
             return .notFound
         }
 
-        if statusCode == 401 || statusCode == 403 {
+        if statusCode == 401 {
             throw PlatformAPIError.authenticationRequired
         }
 

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -240,6 +240,58 @@ public final class AuthService {
         }
     }
 
+    /// Retrieve a specific managed assistant by ID.
+    public func getAssistant(id: String, organizationId: String) async throws -> PlatformAssistantResult {
+        let urlString = "\(baseURL)/v1/assistants/\(id)/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET assistants/\(id)/ -> \(statusCode)")
+
+        if statusCode == 404 {
+            return .notFound
+        }
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            let assistant = try JSONDecoder().decode(PlatformAssistant.self, from: data)
+            return .found(assistant)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     /// Create a new managed assistant via the platform hatch endpoint.
     public func hatchAssistant(
         organizationId: String,

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -80,7 +80,10 @@ public final class ManagedAssistantBootstrapService {
                 log.info("Retrieved connected assistant: \(assistant.id, privacy: .public)")
                 return .reusedExisting(assistant)
             case .notFound:
-                log.error("Connected assistant \(connectedId, privacy: .public) not found (404)")
+                // Clear the stale ID so retries fall through to current/ + hatch
+                // instead of hitting the same 404 in a loop.
+                log.error("Connected assistant \(connectedId, privacy: .public) not found — clearing stale ID")
+                UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
                 throw ManagedBootstrapError.assistantUnavailable(connectedId)
             }
         }

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -17,6 +17,7 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
     case hatchFailed(String)
     case unexpectedResponse(String)
     case multipleOrganizations
+    case assistantUnavailable(String)
 
     public var errorDescription: String? {
         switch self {
@@ -32,6 +33,8 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
             return "Unexpected response format: \(message)"
         case .multipleOrganizations:
             return "Multiple organizations found. Multi-org support is not yet available — please contact support."
+        case .assistantUnavailable(let id):
+            return "Selected assistant \(id) is no longer available. Please sign out and sign in again to set up a new assistant."
         }
     }
 }
@@ -39,8 +42,9 @@ public enum ManagedBootstrapError: LocalizedError, Sendable {
 /// Orchestrates discovery or creation of a managed assistant on the platform.
 ///
 /// The bootstrap flow:
-/// 1. Try to fetch the current user's managed assistant.
-/// 2. If one exists (200), return it as `.reusedExisting`.
+/// 1. If a `connectedAssistantId` exists, fetch that specific assistant via GET /assistants/{id}/.
+///    If it returns 404/403, surface an error instead of silently hatching a replacement.
+/// 2. Otherwise, fall back to GET /assistants/current/ to discover the user's assistant.
 /// 3. If none exists (404), create one via hatch and return `.createdNew`.
 /// 4. Any other error is surfaced as a typed `ManagedBootstrapError`.
 @MainActor
@@ -58,30 +62,31 @@ public final class ManagedAssistantBootstrapService {
         description: String? = nil,
         anthropicApiKey: String? = nil
     ) async throws -> ManagedBootstrapOutcome {
-        // Resolve the user's organization ID first — required for all platform API calls.
-        // Prefer the persisted org to avoid ambiguity for multi-org users.
-        let organizationId: String
-        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
-            organizationId = persistedOrgId
-            log.info("Using persisted organization: \(organizationId, privacy: .public)")
-        } else {
+        let organizationId = try await resolveOrganizationId()
+
+        // If we already have a selected managed assistant, retrieve it directly.
+        // Do NOT fall back to current/ or hatch/ — surface an error if unavailable.
+        if let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+            log.info("Found connectedAssistantId: \(connectedId, privacy: .public), retrieving directly")
+            let result: PlatformAssistantResult
             do {
-                let orgs = try await authService.getOrganizations()
-                switch orgs.count {
-                case 0:
-                    throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
-                case 1:
-                    organizationId = orgs[0].id
-                default:
-                    throw ManagedBootstrapError.multipleOrganizations
-                }
-                UserDefaults.standard.set(organizationId, forKey: "connectedOrganizationId")
-                log.info("Resolved organization: \(organizationId, privacy: .public)")
+                result = try await authService.getAssistant(id: connectedId, organizationId: organizationId)
             } catch let error as PlatformAPIError {
                 throw mapPlatformError(error)
             }
+
+            switch result {
+            case .found(let assistant):
+                log.info("Retrieved connected assistant: \(assistant.id, privacy: .public)")
+                return .reusedExisting(assistant)
+            case .notFound:
+                log.error("Connected assistant \(connectedId, privacy: .public) not found (404)")
+                throw ManagedBootstrapError.assistantUnavailable(connectedId)
+            }
         }
 
+        // No selected assistant — discover via current/ or hatch a new one.
+        log.info("No connectedAssistantId set, falling back to current/ discovery")
         let currentResult: PlatformAssistantResult
         do {
             currentResult = try await authService.getCurrentAssistant(organizationId: organizationId)
@@ -109,6 +114,31 @@ public final class ManagedAssistantBootstrapService {
             }
             log.info("Created new managed assistant: \(newAssistant.id, privacy: .public)")
             return .createdNew(newAssistant)
+        }
+    }
+
+    /// Resolve the organization ID, preferring the persisted value.
+    private func resolveOrganizationId() async throws -> String {
+        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+            log.info("Using persisted organization: \(persistedOrgId, privacy: .public)")
+            return persistedOrgId
+        }
+
+        do {
+            let orgs = try await authService.getOrganizations()
+            switch orgs.count {
+            case 0:
+                throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
+            case 1:
+                let orgId = orgs[0].id
+                UserDefaults.standard.set(orgId, forKey: "connectedOrganizationId")
+                log.info("Resolved organization: \(orgId, privacy: .public)")
+                return orgId
+            default:
+                throw ManagedBootstrapError.multipleOrganizations
+            }
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `getAssistant(id:organizationId:)` to `AuthService` to retrieve a specific assistant via `GET /v1/assistants/{id}/`
- Updates `ManagedAssistantBootstrapService.ensureManagedAssistant()` to check `connectedAssistantId` first, retrieving that specific assistant instead of always calling `current/`
- If the selected assistant returns 404, surfaces an "assistant unavailable" error instead of silently hatching a replacement
- Only falls back to `current/` + hatch flow when no `connectedAssistantId` exists

## Test plan
- [ ] Sign in with managed account that has an existing assistant → should reuse via `GET /assistants/{id}/`
- [ ] Sign in fresh (no `connectedAssistantId`) → should fall back to `current/` discovery, then hatch if needed
- [ ] Delete the assistant on the platform, then re-bootstrap → should show "assistant unavailable" error instead of silently creating a new one
- [ ] Build succeeds on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
