### PR TITLE
M3: remove stale account_manage UI mappings from client

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -451,7 +451,6 @@ public struct ToolConfirmationData: Equatable {
         case "web_fetch":                             return "Fetch URL"
         case "web_search":                            return "Web Search"
         case "credential_store":                      return "Secure Storage"
-        case "account_manage":                        return "Account"
         case _ where toolName.hasPrefix("browser_"):  return "Browser"
         case _ where toolName.hasPrefix("schedule_"): return "Scheduling"
         case _ where toolName.hasPrefix("watcher_"):  return "Watcher"
@@ -479,7 +478,6 @@ public struct ToolConfirmationData: Equatable {
         case "web_fetch":                             return .circleArrowDown
         case "web_search":                            return .search
         case "credential_store":                      return .shield
-        case "account_manage":                        return .circleUser
         case _ where toolName.hasPrefix("browser_"):  return .globe
         case _ where toolName.hasPrefix("schedule_"): return .calendar
         case _ where toolName.hasPrefix("watcher_"):  return .eye


### PR DESCRIPTION
## Summary

- Removes dead code for the removed `account_manage` tool from the iOS/macOS client `ChatMessage.swift`
- The tool category label and icon mappings are no longer needed after M1 removed the daemon tool
- Only intentional migration-comment references remain in the assistant package

## Test plan

- [ ] No practical local client test to run for this change (UI mapping code paths)
- [ ] The remaining `account_manage` references are intentional migration comments in `assistant/src/memory/`

Closes #14758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
