### PR TITLE
Fix bug icon diagnostics export not showing results

### DIFF
--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -434,7 +434,7 @@ async function handleDiagnosticsExport(body: {
         "Diagnostics export completed via HTTP",
       );
 
-      return Response.json({ ok: true, filePath: zipPath });
+      return Response.json({ success: true, filePath: zipPath });
     } finally {
       try {
         rmSync(tempDir, { recursive: true, force: true });

--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -66,7 +66,7 @@ extension HTTPTransport {
 
             // --- Diagnostics ---
             if let msg = message as? DiagnosticsExportRequestMessage {
-                Task { await self.sendEncodablePost(.diagnosticsExport, body: msg, label: "diagnostics_export") }
+                Task { await self.sendDiagnosticsExport(msg) }
                 return true
             }
             if message is EnvVarsRequestMessage {
@@ -275,6 +275,68 @@ extension HTTPTransport {
             self.onMessage?(.twitterIntegrationConfigResponse(message))
         } catch {
             log.error("twitter_auth_status error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Diagnostics Export
+
+    /// Send a diagnostics export request and route the response through the message router.
+    func sendDiagnosticsExport(_ msg: DiagnosticsExportRequestMessage) async {
+        guard let url = buildURL(for: .diagnosticsExport) else {
+            log.error("Failed to build URL for diagnostics_export")
+            self.onMessage?(.diagnosticsExportResponse(DiagnosticsExportResponseMessage(
+                success: false,
+                filePath: nil,
+                error: "Failed to build URL"
+            )))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(msg)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                log.error("diagnostics_export failed: no HTTP response")
+                self.onMessage?(.diagnosticsExportResponse(DiagnosticsExportResponseMessage(
+                    success: false,
+                    filePath: nil,
+                    error: "No HTTP response"
+                )))
+                return
+            }
+
+            if (200...299).contains(http.statusCode) {
+                // Parse successful response
+                let responseMessage = try JSONDecoder().decode(DiagnosticsExportResponseMessage.self, from: data)
+                log.debug("diagnostics_export succeeded")
+                self.onMessage?(.diagnosticsExportResponse(responseMessage))
+            } else {
+                // Try to parse error message from response
+                var errorMessage = "HTTP \(http.statusCode)"
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let error = json["error"] as? [String: Any],
+                   let message = error["message"] as? String {
+                    errorMessage = message
+                }
+                log.error("diagnostics_export failed: \(errorMessage)")
+                self.onMessage?(.diagnosticsExportResponse(DiagnosticsExportResponseMessage(
+                    success: false,
+                    filePath: nil,
+                    error: errorMessage
+                )))
+            }
+        } catch {
+            log.error("diagnostics_export error: \(error.localizedDescription)")
+            self.onMessage?(.diagnosticsExportResponse(DiagnosticsExportResponseMessage(
+                success: false,
+                filePath: nil,
+                error: error.localizedDescription
+            )))
         }
     }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2001,6 +2001,12 @@ public struct DiagnosticsExportResponseMessage: Decodable, Sendable {
     public let success: Bool
     public let filePath: String?
     public let error: String?
+
+    public init(success: Bool, filePath: String?, error: String?) {
+        self.success = success
+        self.filePath = filePath
+        self.error = error
+    }
 }
 
 /// Request daemon environment variables (debug only).


### PR DESCRIPTION
## Summary
- The bug icon on chat messages was silently failing because the HTTP response was discarded
- Added proper response parsing that routes success/error to the toast notification system
- Now shows "Report exported successfully" toast with "Reveal in Finder" action on success

## Original prompt
investigate and fix the "bug" icon breaking. up until recently, it would help export logs that we could use for debugging. maybe it broke when we started using Sentry more and added opt-in usage reporting today. idk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
