### PR TITLE
M1: Remove voice mode toggle from toolbar, wire mic button to voice mode

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
     static let queryAppPinState = Notification.Name("MainWindow.queryAppPinState")
     static let appPreviewImageCaptured = Notification.Name("MainWindow.appPreviewImageCaptured")
     static let requestAppPreview = Notification.Name("MainWindow.requestAppPreview")
+    static let stopPTTRecording = Notification.Name("VoiceInput.stopPTTRecording")
     static let assistantFeatureFlagDidChange = Notification.Name("assistantFeatureFlagDidChange")
 }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -450,9 +450,6 @@ extension AppDelegate {
     func ensureMainWindowExists(isFirstLaunch: Bool = false) -> MainWindow {
         if let existing = mainWindow { return existing }
         let main = MainWindow(services: services, isFirstLaunch: isFirstLaunch)
-        main.onMicrophoneToggle = { [weak self] in
-            self?.voiceInput?.toggleRecording()
-        }
         main.threadManager.onInlineConfirmationResponse = { [weak self] requestId, decision in
             guard let self else { return }
             self.toolConfirmationNotificationService.handleInlineResponse(requestId: requestId)

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -127,7 +127,17 @@ final class VoiceInputManager {
                 self.otherKeyPressedDuringHold = false
             }
         }
-        appSwitchObservers = [workspaceObserver, resignObserver, spaceObserver]
+        let stopPTTObserver = NotificationCenter.default.addObserver(
+            forName: .stopPTTRecording,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.isRecording else { return }
+                self.stopRecording()
+            }
+        }
+        appSwitchObservers = [workspaceObserver, resignObserver, spaceObserver, stopPTTObserver]
 
         // Wire the dictation response callback to insert text and manage the overlay
         if onDictationResponse == nil {

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -130,7 +130,7 @@ final class VoiceInputManager {
         let stopPTTObserver = NotificationCenter.default.addObserver(
             forName: .stopPTTRecording,
             object: nil,
-            queue: .main
+            queue: nil
         ) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self, self.isRecording else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -221,7 +221,6 @@ public final class MainWindow {
     let usageDashboardStore: UsageDashboardStore
     public let windowState = MainWindowState()
     let documentManager = DocumentManager()
-    var onMicrophoneToggle: (() -> Void)?
     let voiceModeManager = VoiceModeManager()
 
     /// Wake-up greeting to auto-send after the "coming alive" transition completes.
@@ -373,7 +372,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -404,17 +404,6 @@ struct MainWindowView: View {
                 windowState.selection = .panel(.settings)
             }
             if windowState.isConversationVisible {
-                // Voice mode toggle
-                VIconButton(
-                    label: "Voice Mode",
-                    icon: voiceModeManager.state != .off ? "waveform.circle.fill" : "waveform.circle",
-                    isActive: voiceModeManager.state != .off,
-                    iconOnly: true,
-                    tooltip: voiceModeManager.state != .off ? "Exit voice mode" : "Voice mode"
-                ) {
-                    toggleVoiceMode()
-                }
-
                 // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
                 // only visible on normal threads when no messages exist yet
                 if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -42,7 +42,6 @@ struct MainWindowView: View {
     let settingsStore: SettingsStore
     let authManager: AuthManager
     @ObservedObject var documentManager: DocumentManager
-    let onMicrophoneToggle: () -> Void
     @ObservedObject var voiceModeManager: VoiceModeManager
 
     /// Callback to send the wake-up greeting after the "coming alive" transition.
@@ -56,7 +55,7 @@ struct MainWindowView: View {
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
@@ -70,7 +69,6 @@ struct MainWindowView: View {
         self.authManager = authManager
         self.windowState = windowState
         self.documentManager = documentManager
-        self.onMicrophoneToggle = onMicrophoneToggle
         self.voiceModeManager = voiceModeManager
         self.onSendWakeUp = onSendWakeUp
         self._showComingAlive = State(initialValue: onSendWakeUp != nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -376,7 +376,7 @@ extension MainWindowView {
                 daemonClient: daemonClient,
                 ambientAgent: ambientAgent,
                 settingsStore: settingsStore,
-                onMicrophoneToggle: onMicrophoneToggle,
+                onMicrophoneToggle: toggleVoiceMode,
                 isTemporaryChat: activeThread?.kind == .private,
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceModeManager.openAIVoiceService,
@@ -531,7 +531,7 @@ extension MainWindowView {
                         }
                     }
                 },
-                onMicrophoneToggle: onMicrophoneToggle
+                onMicrophoneToggle: toggleVoiceMode
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -530,8 +530,7 @@ extension MainWindowView {
                             enterAppEditing(appId: appId)
                         }
                     }
-                },
-                onMicrophoneToggle: toggleVoiceMode
+                }
             )
         }
     }
@@ -601,7 +600,7 @@ struct ActiveChatViewWrapper: View {
                 windowState.selection = .panel(.settings)
             },
             onSend: {
-                if viewModel.isRecording { onMicrophoneToggle() }
+                if viewModel.isRecording { voiceModeManager?.deactivate() }
                 viewModel.sendMessage()
             },
             onStop: viewModel.stopGenerating,
@@ -769,7 +768,6 @@ struct DynamicWorkspaceWrapper: View {
     let onBundleAndShare: (String) -> Void
     let isChatDockOpen: Bool
     let onToggleChatDock: () -> Void
-    let onMicrophoneToggle: () -> Void
 
     @State private var showVersionHistory = false
     @State private var publishUrlCopied = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -600,7 +600,10 @@ struct ActiveChatViewWrapper: View {
                 windowState.selection = .panel(.settings)
             },
             onSend: {
-                if viewModel.isRecording { voiceModeManager?.deactivate() }
+                if viewModel.isRecording {
+                    voiceModeManager?.deactivate()
+                    NotificationCenter.default.post(name: .stopPTTRecording, object: nil)
+                }
                 viewModel.sendMessage()
             },
             onStop: viewModel.stopGenerating,


### PR DESCRIPTION
## Summary
- Remove the voice mode toggle VIconButton from the NavigationToolbar
- Wire the composer's MicrophoneButton to activate/deactivate voice mode (VoiceModeManager) instead of PTT recording
- PTT hold-to-talk (Fn/Ctrl key) continues to work unchanged via VoiceInputManager

Closes #14781
Part of #14780
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
