### PR TITLE
M1: Align AssistantProgressView header padding with StepDetailRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -176,7 +176,7 @@ struct AssistantProgressView: View {
             // Code preview (streaming code phase)
             if phase == .streamingCode, let code = streamingCodePreview {
                 CodePreviewView(code: code)
-                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.xs)
             }
         }
@@ -260,7 +260,7 @@ struct AssistantProgressView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
+        .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.xs)
     }
 


### PR DESCRIPTION
Update header row and code preview horizontal padding from VSpacing.sm (8pt) to VSpacing.lg (16pt) to match StepDetailRow's effective horizontal inset (sm+sm = 16pt), so status icons align vertically when expanded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
