### PR TITLE
Align AssistantProgressView padding with tool rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -170,7 +170,7 @@ struct AssistantProgressView: View {
             // Expanded content
             if isExpanded {
                 expandedContent
-                    .padding(.bottom, VSpacing.xs)
+                    .padding(.bottom, VSpacing.sm)
             }
 
             // Code preview (streaming code phase)
@@ -261,7 +261,7 @@ struct AssistantProgressView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Status Icon

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -176,7 +176,7 @@ struct AssistantProgressView: View {
             // Code preview (streaming code phase)
             if phase == .streamingCode, let code = streamingCodePreview {
                 CodePreviewView(code: code)
-                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.xs)
             }
         }
@@ -260,7 +260,7 @@ struct AssistantProgressView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
+        .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.xs)
     }
 


### PR DESCRIPTION
## Summary
Updates AssistantProgressView header and code preview horizontal padding from `VSpacing.sm` (8pt) to `VSpacing.lg` (16pt) so that status icons align vertically with the individual StepDetailRow content when the view is expanded.

## Changes
- Header row horizontal padding: `VSpacing.sm` → `VSpacing.lg`
- Code preview horizontal padding: `VSpacing.sm` → `VSpacing.lg`

## Milestone PRs (merged into feature branch)
- #14793: M1: Align AssistantProgressView header padding with StepDetailRow

## Project issue
Closes #14791

## Test plan
- [ ] Open the app and trigger tool calls
- [ ] Expand the progress view — verify status icons in the header align with status icons in individual step rows
- [ ] Trigger streaming code preview — verify code preview section aligns with expanded content

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
