### PR TITLE
fix: remove transition-out delay from navigation hover effects

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1037,7 +1037,7 @@ private struct SettingsNavRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 (isSelected ? VColor.navActive : isHovered ? VColor.navHover : .clear)
-                    .animation(VAnimation.fast, value: isHovered)
+                    .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -44,7 +44,7 @@ struct SidebarPrimaryRow: View {
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
             .background(
                 (isActive ? VColor.navActive : isHovered ? VColor.navHover : .clear)
-                    .animation(VAnimation.fast, value: isHovered)
+                    .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -125,7 +125,7 @@ struct SidebarThreadItem: View {
             }
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .animation(VAnimation.fast, value: isHovered)
+            .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
         }
         .onTapGesture {
             selectThread()


### PR DESCRIPTION
## Summary
Remove the transition-out animation from navigation hover backgrounds so hover-out is instant while hover-in remains animated. This eliminates the "double highlight" ghosting effect when moving between adjacent nav items.

## Changes
- Use asymmetric animation for nav hover backgrounds: `isHovered ? VAnimation.fast : .linear(duration: 0)`
- Applied to SettingsNavRow, SidebarPrimaryRow, and SidebarThreadItem

## Milestone PRs (merged into feature branch)
- #14798: fix: remove transition-out delay from nav hover effects

## Project issue
Closes #14796

## Test plan
- [ ] Hover over Settings nav items and move between them — no ghosting/double-highlight
- [ ] Hover over Sidebar nav items and move between them — instant hover-out
- [ ] Hover over thread items in sidebar — same instant hover-out behavior

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
