### PR TITLE
M2: Add inverse voice composer color tokens

### DIFF
--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -320,6 +320,12 @@ public enum VColor {
     // Composer background fill
     public static let composerBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
 
+    // Voice composer — inverse/high-contrast tokens for voice mode
+    public static let voiceComposerBackground = adaptiveColor(light: Slate._900, dark: Slate._100)
+    public static let voiceComposerTextPrimary = adaptiveColor(light: .white, dark: Slate._900)
+    public static let voiceComposerTextSecondary = adaptiveColor(light: Slate._300, dark: Slate._600)
+    public static let voiceComposerControlBackground = adaptiveColor(light: Slate._800, dark: Slate._200)
+
     // Microphone icon color
     public static let micIcon = adaptiveColor(light: Forest._500, dark: Moss._400)
 


### PR DESCRIPTION
## Summary
- Add voiceComposerBackground, voiceComposerTextPrimary, voiceComposerTextSecondary, voiceComposerControlBackground tokens
- Uses adaptiveColor with Slate scale for inverse light/dark treatment
- No existing tokens modified

Part of #14799
Closes #14801
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
