### PR TITLE
Fix signed-in managed hatch flow

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -263,7 +263,11 @@ extension AppDelegate {
         // Clear persisted step so replay always starts at step 0
         OnboardingState.clearPersistedState()
 
-        let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
+        let onboarding = OnboardingWindow(
+            daemonClient: daemonClient,
+            authManager: authManager,
+            forceCreateNewManagedAssistant: true
+        )
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -265,8 +265,7 @@ extension AppDelegate {
 
         let onboarding = OnboardingWindow(
             daemonClient: daemonClient,
-            authManager: authManager,
-            forceCreateNewManagedAssistant: true
+            authManager: authManager
         )
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -84,7 +84,7 @@ struct OnboardingFlowView: View {
                                     },
                                     onContinueWithVellum: {
                                         Task {
-                                            await authManager.startWorkOSLogin()
+                                            await continueWithManagedAssistant()
                                         }
                                     }
                                 )
@@ -128,6 +128,11 @@ struct OnboardingFlowView: View {
         }
         }
         .ignoresSafeArea()
+        .task {
+            if !authManager.isAuthenticated {
+                await authManager.checkSession()
+            }
+        }
         .onChange(of: state.currentStep) { _, newStep in
             if newStep == 0 {
                 isAdvancingFromWakeUp = false
@@ -174,6 +179,15 @@ struct OnboardingFlowView: View {
     }
 
     // MARK: - Managed Bootstrap
+
+    private func continueWithManagedAssistant() async {
+        switch onboardingManagedContinuationAction(isAuthenticated: authManager.isAuthenticated) {
+        case .startLogin:
+            await authManager.startWorkOSLogin()
+        case .bootstrap:
+            await performManagedBootstrap()
+        }
+    }
 
     @ViewBuilder
     private var managedBootstrapView: some View {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum OnboardingManagedContinuationAction: Equatable {
+    case startLogin
+    case bootstrap
+}
+
+func onboardingPrimaryButtonTitle(isAuthenticated: Bool) -> String {
+    isAuthenticated ? "Talk to your assistant" : "Sign in"
+}
+
+func onboardingManagedContinuationAction(isAuthenticated: Bool) -> OnboardingManagedContinuationAction {
+    if isAuthenticated {
+        return .bootstrap
+    }
+    return .startLogin
+}

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -24,6 +24,10 @@ struct WakeUpStepView: View {
     @State private var showSubtext = false
     @State private var showButtons = false
 
+    private var primaryButtonTitle: String {
+        onboardingPrimaryButtonTitle(isAuthenticated: authManager?.isAuthenticated == true)
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -46,7 +50,17 @@ struct WakeUpStepView: View {
 
         // Buttons
         VStack(spacing: VSpacing.sm) {
-            if authManager?.isSubmitting == true {
+            if authManager?.isLoading == true {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                    Text("Checking...")
+                        .font(VFont.monoMedium)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .frame(height: 36)
+            } else if authManager?.isSubmitting == true {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
                         .controlSize(.small)
@@ -57,7 +71,7 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else {
-                OnboardingButton(title: "Sign in", style: .primary) {
+                OnboardingButton(title: primaryButtonTitle, style: .primary) {
                     onContinueWithVellum()
                 }
                 .accessibilityLabel("Sign in")

--- a/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class OnboardingManagedAuthStateTests: XCTestCase {
+    func testPrimaryButtonTitleShowsSignInWhenUnauthenticated() {
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false), "Sign in")
+    }
+
+    func testPrimaryButtonTitleShowsContinueLabelWhenAuthenticated() {
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: true), "Talk to your assistant")
+    }
+
+    func testContinuationActionStartsLoginWhenUnauthenticated() {
+        XCTAssertEqual(
+            onboardingManagedContinuationAction(isAuthenticated: false),
+            .startLogin
+        )
+    }
+
+    func testContinuationActionBootstrapsWhenAuthenticated() {
+        XCTAssertEqual(onboardingManagedContinuationAction(isAuthenticated: true), .bootstrap)
+    }
+}


### PR DESCRIPTION
## Summary
- make the onboarding auth gate detect an existing signed-in session when the welcome screen opens
- change the primary CTA to `Talk to your assistant` for signed-in users and continue directly into managed bootstrap instead of reopening sign-in
- keep `Settings > Hatch` on the normal managed-assistant reuse path instead of forcing a brand-new assistant
- add focused macOS tests for the onboarding auth-state decision logic

## Testing
- `./build.sh test --filter OnboardingManagedAuthStateTests`
- `./build.sh lint`

## Apple refs checked (2026-03-10)
- https://developer.apple.com/documentation/SwiftUI/View/task%28priority%3A_%3A%29
- https://developer.apple.com/jp/documentation/authenticationservices/authenticating_a_user_through_a_web_service/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->