### PR TITLE
M4: Add recordingAmplitude to ChatMessageManager/ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -33,6 +33,7 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var pendingQueuedCount: Int = 0
     @Published public var suggestion: String?
     @Published public var isRecording: Bool = false
+    @Published public var recordingAmplitude: Float = 0
 
     // MARK: - Workspace refinement
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -164,6 +164,10 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.isRecording }
         set { messageManager.isRecording = newValue }
     }
+    public var recordingAmplitude: Float {
+        get { messageManager.recordingAmplitude }
+        set { messageManager.recordingAmplitude = newValue }
+    }
     public var isWorkspaceRefinementInFlight: Bool {
         get { messageManager.isWorkspaceRefinementInFlight }
         set { messageManager.isWorkspaceRefinementInFlight = newValue }


### PR DESCRIPTION
## Summary
- Add @Published recordingAmplitude: Float to ChatMessageManager
- Add computed proxy in ChatViewModel
- Data plumbing for amplitude-driven waveform visualization

Part of #14799
Closes #14803
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
