### PR TITLE
M5: Wire amplitude through AppDelegate+Voice

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -82,6 +82,9 @@ extension AppDelegate {
             log.info("Action mode triggered from voice dictation — submitting task")
             self.startSession(task: text, source: TaskSubmission.voiceActionSource)
         }
+        voiceInput?.onAmplitudeChanged = { [weak self] amplitude in
+            self?.recordingViewModel?.recordingAmplitude = amplitude
+        }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
             // Check if main window is actively in the foreground (not just existing behind other apps)
             let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
@@ -97,6 +100,7 @@ extension AppDelegate {
                 vm.isRecording = isRecording
             }
             if !isRecording {
+                self?.recordingViewModel?.recordingAmplitude = 0
                 self?.recordingViewModel = nil
             }
 


### PR DESCRIPTION
## Summary
- Wire onAmplitudeChanged callback to recordingViewModel.recordingAmplitude
- Reset amplitude to 0 on recording stop
- Amplitude now flows: audio tap → VoiceInputManager → AppDelegate → ChatViewModel

Part of #14799
Closes #14804
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
