### PR TITLE
M6: Suppress DictationOverlayWindow for chat-origin dictation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -114,7 +114,8 @@ extension AppDelegate {
                 )
                 let quickInputActive = self?.quickInputWindow?.isVisible ?? false
                 let isDictation = self?.voiceInput?.currentMode == .dictation
-                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation,
+                let isChatComposerOrigin = self?.voiceInput?.activeOrigin == .chatComposer
+                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation && !isChatComposerOrigin,
                    let manager = self?.mainWindow?.voiceModeManager {
                     let window = VoiceTranscriptionWindow(voiceModeManager: manager)
                     window.show()


### PR DESCRIPTION
## Summary
- Gate floating overlay display on activeOrigin != .chatComposer
- Chat-origin dictation renders inline in composer instead
- quickInput and hotkey origins continue showing floating overlay

Part of #14799
Closes #14805
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
