### PR TITLE
fix: move settings panel right/bottom padding inside scroll content (#14821)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -125,6 +125,7 @@ struct SettingsPanel: View {
             .padding(.bottom, VSpacing.md)
 
             VColor.surfaceBorder.frame(height: 1)
+                .padding(.trailing, VSpacing.xl)
 
             // Body: nav pinned left + centered content with max width
             HStack(alignment: .top, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -121,6 +121,7 @@ struct SettingsPanel: View {
 
                 Spacer()
             }
+            .padding(.trailing, VSpacing.xl)
             .padding(.bottom, VSpacing.md)
 
             VColor.surfaceBorder.frame(height: 1)
@@ -132,11 +133,16 @@ struct SettingsPanel: View {
 
                 if selectedTab == .contacts {
                     selectedTabContent
+                        .padding(.trailing, VSpacing.xl)
+                        .padding(.bottom, VSpacing.xl)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 } else {
                     ScrollView {
                         selectedTabContent
-                            .padding(VSpacing.lg)
+                            .padding(.top, VSpacing.lg)
+                            .padding(.leading, VSpacing.lg)
+                            .padding(.trailing, VSpacing.xl)
+                            .padding(.bottom, VSpacing.xl)
                             .frame(maxWidth: 700, alignment: .top)
                             .frame(maxWidth: .infinity)
                     }
@@ -144,7 +150,8 @@ struct SettingsPanel: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .padding(VSpacing.xl)
+        .padding(.top, VSpacing.xl)
+        .padding(.leading, VSpacing.xl)
         .background(VColor.backgroundSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .task {


### PR DESCRIPTION
## Summary
- Move right and bottom padding from the outer settings panel container to inside the scroll content area
- Scrollbar now sits flush against the right edge of the panel
- Bottom padding no longer clips scroll content

## Original prompt
Fix settings panel padding so scrollbar is flush right and content isn't clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
