### PR TITLE
fix: settings panel scrollbar flush right and content padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -121,9 +121,11 @@ struct SettingsPanel: View {
 
                 Spacer()
             }
+            .padding(.trailing, VSpacing.xl)
             .padding(.bottom, VSpacing.md)
 
             VColor.surfaceBorder.frame(height: 1)
+                .padding(.trailing, VSpacing.xl)
 
             // Body: nav pinned left + centered content with max width
             HStack(alignment: .top, spacing: 0) {
@@ -132,11 +134,16 @@ struct SettingsPanel: View {
 
                 if selectedTab == .contacts {
                     selectedTabContent
+                        .padding(.trailing, VSpacing.xl)
+                        .padding(.bottom, VSpacing.xl)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 } else {
                     ScrollView {
                         selectedTabContent
-                            .padding(VSpacing.lg)
+                            .padding(.top, VSpacing.lg)
+                            .padding(.leading, VSpacing.lg)
+                            .padding(.trailing, VSpacing.xl)
+                            .padding(.bottom, VSpacing.xl)
                             .frame(maxWidth: 700, alignment: .top)
                             .frame(maxWidth: .infinity)
                     }
@@ -144,7 +151,8 @@ struct SettingsPanel: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .padding(VSpacing.xl)
+        .padding(.top, VSpacing.xl)
+        .padding(.leading, VSpacing.xl)
         .background(VColor.backgroundSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .task {


### PR DESCRIPTION
## Summary
Fix the settings panel layout so the scrollbar sits flush against the right edge of the panel and bottom padding doesn't clip scroll content. Padding is moved from the outer container to inside the scroll content area.

## Changes
- Replace outer `.padding(VSpacing.xl)` with directional top/leading padding only
- Add trailing padding to header and divider to maintain original appearance
- Move right and bottom padding inside the ScrollView content
- Add equivalent padding to the non-scrolling contacts tab

## Milestone PRs (merged into feature branch)
- #14822: fix: move settings panel right/bottom padding inside scroll content

## Project issue
Closes #14820

## Test plan
- [ ] Open Settings panel — scrollbar should be flush against the right edge
- [ ] Scroll content — bottom content should not be clipped
- [ ] Verify divider and header alignment match original layout
- [ ] Check contacts tab layout (non-scrolling)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
