### PR TITLE
M8: Thread voice callbacks through chat view hierarchy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -25,6 +25,9 @@ struct ChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     @State private var visible = false
@@ -117,6 +120,9 @@ struct ChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
+                    recordingAmplitude: recordingAmplitude,
+                    onDictateToggle: onDictateToggle,
+                    onVoiceModeToggle: onVoiceModeToggle,
                     placeholderText: placeholder,
                     threadId: threadId
                 )
@@ -164,6 +170,9 @@ struct ChatTemporaryChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     var body: some View {
@@ -224,6 +233,9 @@ struct ChatTemporaryChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
+                    recordingAmplitude: recordingAmplitude,
+                    onDictateToggle: onDictateToggle,
+                    onVoiceModeToggle: onVoiceModeToggle,
                     placeholderText: "Ask anything...",
                     threadId: threadId
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -75,6 +75,9 @@ struct ChatView: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
@@ -139,6 +142,9 @@ struct ChatView: View {
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
                             onDismissError: onDismissError,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     } else {
@@ -161,6 +167,9 @@ struct ChatView: View {
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
                             onDismissError: onDismissError,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     }
@@ -254,6 +263,9 @@ struct ChatView: View {
                             voiceModeManager: voiceModeManager,
                             voiceService: voiceService,
                             onEndVoiceMode: onEndVoiceMode,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -41,6 +41,9 @@ struct ComposerSection: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     var body: some View {
@@ -96,6 +99,9 @@ struct ComposerSection: View {
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceService,
                 onEndVoiceMode: onEndVoiceMode,
+                recordingAmplitude: recordingAmplitude,
+                onDictateToggle: onDictateToggle,
+                onVoiceModeToggle: onVoiceModeToggle,
                 placeholderText: isSending ? "Working on it..." : "What would you like to do?",
                 threadId: threadId
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -92,7 +92,7 @@ struct MainWindowView: View {
         FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
     }
 
-    private func toggleVoiceMode() {
+    func toggleVoiceMode() {
         if voiceModeManager.state != .off {
             voiceModeManager.deactivate()
         } else {
@@ -404,17 +404,6 @@ struct MainWindowView: View {
                 windowState.selection = .panel(.settings)
             }
             if windowState.isConversationVisible {
-                // Voice mode toggle
-                VIconButton(
-                    label: "Voice Mode",
-                    icon: voiceModeManager.state != .off ? "waveform.circle.fill" : "waveform.circle",
-                    isActive: voiceModeManager.state != .off,
-                    iconOnly: true,
-                    tooltip: voiceModeManager.state != .off ? "Exit voice mode" : "Voice mode"
-                ) {
-                    toggleVoiceMode()
-                }
-
                 // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
                 // only visible on normal threads when no messages exist yet
                 if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -383,6 +383,12 @@ extension MainWindowView {
                 onEndVoiceMode: {
                     voiceModeManager.deactivate()
                 },
+                onDictateToggle: {
+                    (NSApp.delegate as? AppDelegate)?.voiceInput?.toggleRecording(origin: .chatComposer)
+                },
+                onVoiceModeToggle: {
+                    toggleVoiceMode()
+                },
                 threadId: threadManager.activeThreadId,
                 anchorMessageId: $threadManager.pendingAnchorMessageId
             )
@@ -573,6 +579,8 @@ struct ActiveChatViewWrapper: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
     @Binding var anchorMessageId: UUID?
 
@@ -695,6 +703,9 @@ struct ActiveChatViewWrapper: View {
             voiceModeManager: voiceModeManager,
             voiceService: voiceService,
             onEndVoiceMode: onEndVoiceMode,
+            recordingAmplitude: viewModel.recordingAmplitude,
+            onDictateToggle: onDictateToggle,
+            onVoiceModeToggle: onVoiceModeToggle,
             threadId: threadId,
             anchorMessageId: $anchorMessageId,
             displayedMessageCount: viewModel.displayedMessageCount,


### PR DESCRIPTION
## Summary
- Thread onDictateToggle, onVoiceModeToggle, and recordingAmplitude through ComposerSection, ChatView, ChatEmptyStateView, PanelCoordinator, and MainWindowView
- Wire onDictateToggle to voiceInput.toggleRecording(origin: .chatComposer)
- Wire onVoiceModeToggle to toggleVoiceMode()
- Wire recordingAmplitude from ChatViewModel
- Remove top-bar voice mode toggle button (now lives in composer)

Part of voice-composer-ux plan (M8 of 9)

Closes #14807
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
