### PR TITLE
Compact AssistantProgressView child rows with aligned time/chevron

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -397,7 +397,7 @@ struct AssistantProgressView: View {
             let overflow = resolved.count - visible.count
 
             ForEach(Array(visible.enumerated()), id: \.offset) { _, confirmation in
-                compactPermissionChip(confirmation)
+                CompactPermissionChip(state: confirmation.state, label: confirmation.toolCategory)
             }
 
             // +N overflow badge with popover
@@ -423,7 +423,7 @@ struct AssistantProgressView: View {
                 .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(Array(resolved.dropFirst(2).enumerated()), id: \.offset) { _, confirmation in
-                            compactPermissionChip(confirmation)
+                            CompactPermissionChip(state: confirmation.state, label: confirmation.toolCategory)
                         }
                     }
                     .padding(VSpacing.sm)
@@ -432,42 +432,6 @@ struct AssistantProgressView: View {
         }
     }
 
-    private func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
-        let isApproved = confirmation.state == .approved
-        let isDenied = confirmation.state == .denied
-        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
-
-        return HStack(spacing: VSpacing.xxs) {
-            Group {
-                switch confirmation.state {
-                case .approved:
-                    VIconView(.circleCheck, size: 10)
-                        .foregroundColor(chipColor)
-                case .denied:
-                    VIconView(.circleAlert, size: 10)
-                        .foregroundColor(chipColor)
-                case .timedOut:
-                    VIconView(.clock, size: 10)
-                        .foregroundColor(chipColor)
-                default:
-                    EmptyView()
-                }
-            }
-
-            Text(isApproved ? "\(confirmation.toolCategory) Allowed" :
-                 isDenied ? "\(confirmation.toolCategory) Denied" : "Timed Out")
-                .font(VFont.small)
-                .foregroundColor(chipColor)
-        }
-        .padding(.horizontal, VSpacing.xs)
-        .padding(.vertical, VSpacing.xxs)
-        .background(
-            Capsule().fill(Color.clear)
-        )
-        .overlay(
-            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
-        )
-    }
 }
 
 // MARK: - Step Detail Row
@@ -585,7 +549,7 @@ private struct StepDetailRow: View {
                     // Permission badge + duration + chevron (completed only)
                     HStack(spacing: VSpacing.xs) {
                         if let decision = toolCall.confirmationDecision {
-                            compactPermissionChip(
+                            CompactPermissionChip(
                                 state: decision,
                                 label: toolCall.confirmationLabel ?? toolCall.friendlyName
                             )
@@ -844,13 +808,26 @@ private struct StepDetailRow: View {
             : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
     }
 
-    /// Renders a compact permission chip from a confirmation state + label.
-    private func compactPermissionChip(state: ToolConfirmationState, label: String) -> some View {
-        let isApproved = state == .approved
-        let isDenied = state == .denied
-        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
+}
 
-        return HStack(spacing: VSpacing.xxs) {
+// MARK: - Compact Permission Chip
+
+/// Shared permission chip used in both the collapsed header (inline chips)
+/// and expanded step detail rows (per-tool-call badge).
+private struct CompactPermissionChip: View {
+    let state: ToolConfirmationState
+    let label: String
+
+    private var chipColor: Color {
+        switch state {
+        case .approved: VColor.iconAccent
+        case .denied: VColor.error
+        default: VColor.textMuted
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: VSpacing.xxs) {
             Group {
                 switch state {
                 case .approved:
@@ -867,7 +844,7 @@ private struct StepDetailRow: View {
                 }
             }
 
-            Text(isApproved || isDenied ? "\(label)" : "Timed Out")
+            Text(state == .approved || state == .denied ? label : "Timed Out")
                 .font(VFont.small)
                 .foregroundColor(chipColor)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -609,12 +609,11 @@ private struct StepDetailRow: View {
             }
             .buttonStyle(.plain)
             .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .fill(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.5) : .clear)
             )
-            .padding(.horizontal, VSpacing.sm)
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -92,10 +92,6 @@ struct AssistantProgressView: View {
         toolCalls.first(where: { !$0.isComplete })
     }
 
-    private var completedCount: Int {
-        toolCalls.filter(\.isComplete).count
-    }
-
     /// Single source of truth for denied state — used for both `.denied` phase gating
     /// and `.complete` warning styling/copy. Checks live confirmations and persisted per-tool data.
     private var hasDeniedTools: Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -296,7 +296,7 @@ struct AssistantProgressView: View {
                 processingLabel
             } else {
                 Text(headlineText)
-                    .font(VFont.bodyMedium)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: headlineText)
             }
@@ -322,7 +322,7 @@ struct AssistantProgressView: View {
 
             HStack(spacing: VSpacing.xs) {
                 Text(labels[labelIndex])
-                    .font(VFont.bodyMedium)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: labelIndex)
 
@@ -543,7 +543,7 @@ private struct StepDetailRow: View {
                                 }
                                 return toolCall.actionDescription
                             }())
-                                .font(VFont.bodyMedium)
+                                .font(VFont.caption)
                                 .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
@@ -558,7 +558,7 @@ private struct StepDetailRow: View {
                                     buildingStatus: toolCall.buildingStatus
                                 )
                             }())
-                            .font(VFont.bodyMedium)
+                            .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -573,7 +573,7 @@ private struct StepDetailRow: View {
                                     buildingStatus: toolCall.buildingStatus
                                 )
                             }())
-                            .font(VFont.bodyMedium)
+                            .font(VFont.caption)
                             .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -608,13 +608,15 @@ private struct StepDetailRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, VSpacing.sm)
+            .padding(.leading, VSpacing.sm)
+            .padding(.trailing, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .fill(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.5) : .clear)
             )
-            .padding(.horizontal, VSpacing.sm)
+            .padding(.leading, VSpacing.sm)
+            .padding(.trailing, VSpacing.xs)
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)
@@ -865,8 +867,7 @@ private struct StepDetailRow: View {
                 }
             }
 
-            Text(isApproved ? "\(label) Allowed" :
-                 isDenied ? "\(label) Denied" : "Timed Out")
+            Text(isApproved || isDenied ? "\(label)" : "Timed Out")
                 .font(VFont.small)
                 .foregroundColor(chipColor)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -30,6 +30,7 @@ struct AssistantProgressView: View {
     let decidedConfirmations: [ToolConfirmationData]
     var onRehydrate: (() -> Void)?
 
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var isExpanded: Bool = false
     @State private var startDate: Date = Date()
@@ -180,7 +181,7 @@ struct AssistantProgressView: View {
                     .padding(.bottom, VSpacing.xs)
             }
         }
-        .background(VColor.surface.opacity(0.5))
+        .background(colorScheme == .light ? Moss._50 : VColor.surface.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onChange(of: phase) { _, newPhase in
             if newPhase == .processing {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -614,6 +614,7 @@ private struct StepDetailRow: View {
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .fill(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.5) : .clear)
             )
+            .padding(.horizontal, VSpacing.sm)
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -92,8 +92,8 @@ extension ChatBubble {
                 }
             }
 
-            Text(isApproved ? "\(confirmation.toolCategory) Allowed" :
-                 isDenied ? "\(confirmation.toolCategory) Denied" : "Timed Out")
+            Text(isApproved || isDenied ? "\(confirmation.toolCategory)" :
+                 "Timed Out")
                 .font(VFont.captionMedium)
                 .foregroundColor(chipColor)
         }


### PR DESCRIPTION
## Summary
- Reduce StepDetailRow vertical padding and font size for a more compact, hierarchical look
- Align child row time labels and chevron icons vertically with the parent header
- Use leading-only outer indent so child rows are visually nested but right-aligned with parent

## Changes
- Parent headline font: `bodyMedium` → `body` (Medium → Regular, same 13pt)
- Child row text font: `bodyMedium` → `caption` (Medium 13pt → Regular 11pt)
- Child row padding: asymmetric inner (leading sm, trailing xs) + leading-only outer indent + trailing xs matching card bottom
- Child row vertical padding: `sm` → `xs` to match parent header
- Simplify permission chip labels

## Test plan
- [ ] Expand progress view — verify child time/chevron align vertically with parent
- [ ] Hover child rows — verify hover background looks balanced
- [ ] Check multiple tool calls with errors — verify error styling still works
- [ ] Test with permission chips — verify layout with badges

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
