### PR TITLE
M9: Add voice composer gallery entries and diagnostics logging

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -190,6 +190,7 @@ final class VoiceInputManager {
             stopRecording()
         } else {
             activeOrigin = origin
+            log.debug("Dictation started (origin: \(String(describing: origin)))")
             beginRecording()
         }
     }
@@ -565,7 +566,11 @@ final class VoiceInputManager {
         isRecording = true
         onRecordingStateChanged?(true)
         if currentMode == .dictation {
-            overlayWindow.show(state: .recording)
+            if activeOrigin == .chatComposer {
+                log.debug("Overlay suppressed for chatComposer origin")
+            } else {
+                overlayWindow.show(state: .recording)
+            }
         }
         log.info("Voice recording started")
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
+import os
 #if os(macOS)
 import AppKit
 #endif
+
+private let composerLog = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "Composer")
 
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 200
@@ -12,7 +15,7 @@ struct ComposerView: View {
     // MARK: - ComposerMode
 
     /// Three-mode state machine for the composer.
-    private enum ComposerMode {
+    private enum ComposerMode: Equatable {
         /// Normal text entry with attach/send buttons.
         case textEntry
         /// Inline dictation: text field visible with a recording strip below.
@@ -121,6 +124,9 @@ struct ComposerView: View {
         .onChange(of: threadId) {
             guard !hasPendingConfirmation else { return }
             composerFocus = true
+        }
+        .onChange(of: currentMode) {
+            composerLog.debug("Composer mode: \(String(describing: currentMode))")
         }
     }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 
 struct ChatGallerySection: View {
+    @State private var voiceComposerAmplitude: Float = 0.5
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
             // MARK: - Error Banners
@@ -33,6 +35,53 @@ struct ChatGallerySection: View {
                         message: "Your session has expired. Please start a new conversation.",
                         onDismiss: {}
                     )
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Voice Composer
+            GallerySectionHeader(
+                title: "Voice Composer",
+                description: "VStreamingWaveform in composer context. The composer has three modes: textEntry, dictationInline (with dictation-style waveform), and voiceConversation (with conversation-style waveform)."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    HStack {
+                        Text("Amplitude: \(String(format: "%.2f", voiceComposerAmplitude))")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Slider(value: $voiceComposerAmplitude, in: 0...1, step: 0.05)
+                            .frame(maxWidth: 200)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Conversation style (voice mode)")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+                    VStreamingWaveform(
+                        amplitude: voiceComposerAmplitude,
+                        isActive: true,
+                        style: .conversation,
+                        foregroundColor: VColor.accent
+                    )
+                    .frame(width: 120, height: 60)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Dictation style (inline dictation)")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+                    VStreamingWaveform(
+                        amplitude: voiceComposerAmplitude,
+                        isActive: true,
+                        style: .dictation,
+                        foregroundColor: VColor.accent
+                    )
+                    .frame(height: 24)
+                    .frame(maxWidth: .infinity)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add Voice Composer gallery section in ChatGallerySection with VStreamingWaveform demos in both conversation and dictation styles, with interactive amplitude slider
- Add os.Logger diagnostics in VoiceInputManager for dictation origin tracking and overlay suppression
- Add composer mode transition logging in ComposerView via onChange(of: currentMode)

Part of voice-composer-ux plan (M9 of 9)

Closes #14808
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
