### PR TITLE
fix(browser): sanitize download filenames and enforce downloads dir boundary

### DIFF
--- a/assistant/src/__tests__/browser-manager.test.ts
+++ b/assistant/src/__tests__/browser-manager.test.ts
@@ -15,6 +15,7 @@ mock.module("../util/logger.js", () => ({
 
 import {
   browserManager,
+  sanitizeDownloadFilename,
   setLaunchFn,
 } from "../tools/browser/browser-manager.js";
 
@@ -72,6 +73,27 @@ function createMockContext() {
     },
   };
 }
+
+describe("sanitizeDownloadFilename", () => {
+  test("keeps a normal filename", () => {
+    expect(sanitizeDownloadFilename("report.json")).toBe("report.json");
+  });
+
+  test("removes traversal segments and separators", () => {
+    expect(sanitizeDownloadFilename("../../.ssh/authorized_keys")).toBe(
+      "authorized_keys",
+    );
+    expect(
+      sanitizeDownloadFilename("..\\..\\windows\\system32\\drivers\\etc\\hosts"),
+    ).toBe("hosts");
+  });
+
+  test("falls back to safe default for empty or dot paths", () => {
+    expect(sanitizeDownloadFilename("   ")).toBe("download");
+    expect(sanitizeDownloadFilename(".")).toBe("download");
+    expect(sanitizeDownloadFilename("..")).toBe("download");
+  });
+});
 
 describe("BrowserManager", () => {
   let mockCtx: ReturnType<typeof createMockContext>;

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
@@ -58,6 +58,13 @@ function getDownloadsDir(): string {
   const dir = join(getDataDir(), "browser-downloads");
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+export function sanitizeDownloadFilename(filename: string): string {
+  const leaf = filename.replaceAll("\\", "/").split("/").pop() ?? "";
+  const stripped = leaf.replaceAll("\0", "").trim();
+  const safe = stripped.length > 0 ? stripped : "download";
+  return safe === "." || safe === ".." ? "download" : safe;
 }
 
 /** Wraps a promise with a timeout to prevent indefinite hangs. */
@@ -778,8 +785,13 @@ class BrowserManager {
         failure(): Promise<string | null>;
       };
       try {
-        const filename = dl.suggestedFilename();
-        const destPath = join(getDownloadsDir(), `${Date.now()}-${filename}`);
+        const filename = sanitizeDownloadFilename(dl.suggestedFilename());
+        const downloadsDir = getDownloadsDir();
+        const destPath = resolve(downloadsDir, `${Date.now()}-${filename}`);
+        const relPath = relative(resolve(downloadsDir), destPath);
+        if (relPath.startsWith("..") || isAbsolute(relPath)) {
+          throw new Error("Resolved download path escaped downloads directory");
+        }
         await withTimeout(dl.saveAs(destPath), 120_000, "Download save");
         const info: DownloadInfo = { path: destPath, filename };
 


### PR DESCRIPTION
### Motivation
- A path-traversal / arbitrary write risk existed where `download.suggestedFilename()` was used directly to build a destination path and saved into the filesystem, allowing an attacker-controlled filename to escape the downloads directory.
- The change prevents remote sites from specifying filenames that could overwrite arbitrary files on the host when Playwright reports a malicious `Content-Disposition` value.

### Description
- Add `sanitizeDownloadFilename()` in `assistant/src/tools/browser/browser-manager.ts` to strip path separators, null bytes, and dot-only names and to return a safe fallback filename (`download`).
- Use `resolve()` + `relative()` + `isAbsolute()` to compute the final `destPath` and enforce that the resolved path remains inside the downloads directory returned by `getDownloadsDir()` before calling `dl.saveAs(destPath)`.
- Export the sanitizer and add targeted unit tests for filename sanitization in `assistant/src/__tests__/browser-manager.test.ts` covering normal filenames, traversal-style inputs, and empty/dot fallbacks.

### Testing
- Added unit tests in `assistant/src/__tests__/browser-manager.test.ts` for `sanitizeDownloadFilename()` which exercise normal, traversal, and fallback cases, but the test suite could not be executed in this environment because `bun` is unavailable; attempted `cd assistant && bun test src/__tests__/browser-manager.test.ts` failed due to missing `bun`.
- No other automated test runs completed in this environment due to the same runtime limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aed76a6cf083239b8e4ce45625f2cb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
