### PR TITLE
feat: composer-integrated voice + dictation UX refresh

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -114,7 +114,8 @@ extension AppDelegate {
                 )
                 let quickInputActive = self?.quickInputWindow?.isVisible ?? false
                 let isDictation = self?.voiceInput?.currentMode == .dictation
-                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation,
+                let isChatComposerOrigin = self?.voiceInput?.activeOrigin == .chatComposer
+                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation && !isChatComposerOrigin,
                    let manager = self?.mainWindow?.voiceModeManager {
                     let window = VoiceTranscriptionWindow(voiceModeManager: manager)
                     window.show()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -82,6 +82,9 @@ extension AppDelegate {
             log.info("Action mode triggered from voice dictation — submitting task")
             self.startSession(task: text, source: TaskSubmission.voiceActionSource)
         }
+        voiceInput?.onAmplitudeChanged = { [weak self] amplitude in
+            self?.recordingViewModel?.recordingAmplitude = amplitude
+        }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
             // Check if main window is actively in the foreground (not just existing behind other apps)
             let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
@@ -97,6 +100,7 @@ extension AppDelegate {
                 vm.isRecording = isRecording
             }
             if !isRecording {
+                self?.recordingViewModel?.recordingAmplitude = 0
                 self?.recordingViewModel = nil
             }
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -190,6 +190,7 @@ final class VoiceInputManager {
             stopRecording()
         } else {
             activeOrigin = origin
+            log.debug("Dictation started (origin: \(String(describing: origin)))")
             beginRecording()
         }
     }
@@ -565,7 +566,11 @@ final class VoiceInputManager {
         isRecording = true
         onRecordingStateChanged?(true)
         if currentMode == .dictation {
-            overlayWindow.show(state: .recording)
+            if activeOrigin == .chatComposer {
+                log.debug("Overlay suppressed for chatComposer origin")
+            } else {
+                overlayWindow.show(state: .recording)
+            }
         }
         log.info("Voice recording started")
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -3,6 +3,7 @@ import AppKit
 import CoreGraphics
 import Speech
 import AVFoundation
+import Accelerate
 import os
 import VellumAssistantShared
 
@@ -13,6 +14,13 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 enum VoiceInputMode {
     case conversation  // existing behavior — transcription goes to chat
     case dictation     // transcription goes to daemon for cleanup, then inserted at cursor
+}
+
+/// Tracks the UI surface that initiated a voice recording session.
+enum VoiceInputOrigin {
+    case chatComposer
+    case quickInput
+    case hotkey
 }
 
 @MainActor
@@ -34,6 +42,21 @@ final class VoiceInputManager {
     /// Called when the daemon classifies dictation as an action (e.g. "Slack Alex about the standup").
     /// The callback receives the original transcription text for routing to a full agent session.
     var onActionModeTriggered: ((String) -> Void)?
+
+    /// Tracks which UI surface initiated the current recording session.
+    var activeOrigin: VoiceInputOrigin = .hotkey
+
+    /// Callback fired with smoothed amplitude values (~50ms intervals) during recording.
+    var onAmplitudeChanged: ((Float) -> Void)?
+
+    /// Mutable state for amplitude smoothing/throttling, captured by the audio tap closure
+    /// so reads and writes happen entirely on the audio thread (no cross-thread races).
+    private final class AmplitudeState {
+        var previousSmoothed: Float = 0
+        var lastEmissionTime: CFAbsoluteTime = 0
+        func reset() { previousSmoothed = 0; lastEmissionTime = 0 }
+    }
+    private let amplitudeState = AmplitudeState()
 
     /// Context captured at activation time, describing the frontmost app state.
     var currentDictationContext: DictationContext?
@@ -161,10 +184,12 @@ final class VoiceInputManager {
     }
 
     /// Directly toggle recording on/off — used by UI mic buttons that bypass the Fn-key hold flow.
-    func toggleRecording() {
+    /// The `origin` parameter tracks which UI surface initiated the recording.
+    func toggleRecording(origin: VoiceInputOrigin = .hotkey) {
         if isRecording {
             stopRecording()
         } else {
+            activeOrigin = origin
             beginRecording()
         }
     }
@@ -184,6 +209,10 @@ final class VoiceInputManager {
     func stopContinuousRecording() {
         guard isRecording else { return }
         log.info("Stopping continuous recording — waiting for final transcription")
+
+        activeOrigin = .hotkey
+        amplitudeState.reset()
+        onAmplitudeChanged?(0)
 
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
@@ -557,8 +586,31 @@ final class VoiceInputManager {
             return
         }
 
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+        let ampState = amplitudeState
+        ampState.reset()
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
             request.append(buffer)
+
+            // Compute amplitude from the audio buffer for visual feedback.
+            // All smoothing/throttling state lives in ampState (a reference type
+            // captured by this closure) so reads and writes stay on the audio thread.
+            guard let channelData = buffer.floatChannelData else { return }
+            let frameLength = Int(buffer.frameLength)
+            guard frameLength > 0 else { return }
+
+            let channelDataArray = Array(UnsafeBufferPointer(start: channelData[0], count: frameLength))
+            let rawRMS = vDSP.rootMeanSquare(channelDataArray)
+
+            let smoothed = 0.3 * rawRMS + 0.7 * ampState.previousSmoothed
+            ampState.previousSmoothed = smoothed
+
+            let now = CFAbsoluteTimeGetCurrent()
+            guard now - ampState.lastEmissionTime >= 0.05 else { return }
+            ampState.lastEmissionTime = now
+
+            DispatchQueue.main.async { [weak self] in
+                self?.onAmplitudeChanged?(smoothed)
+            }
         }
 
         recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
@@ -783,6 +835,9 @@ final class VoiceInputManager {
         isRecording = false
         onRecordingStateChanged?(false)
         currentDictationContext = nil
+        activeOrigin = .hotkey
+        amplitudeState.reset()
+        onAmplitudeChanged?(0)
         // Overlay stays visible if we're transitioning to processing state (dictation sent
         // to daemon). Otherwise dismiss it — recording stopped without producing a result.
         if !awaitingDaemonResponse {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -25,6 +25,9 @@ struct ChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     @State private var visible = false
@@ -117,6 +120,9 @@ struct ChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
+                    recordingAmplitude: recordingAmplitude,
+                    onDictateToggle: onDictateToggle,
+                    onVoiceModeToggle: onVoiceModeToggle,
                     placeholderText: placeholder,
                     threadId: threadId
                 )
@@ -164,6 +170,9 @@ struct ChatTemporaryChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     var body: some View {
@@ -224,6 +233,9 @@ struct ChatTemporaryChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
+                    recordingAmplitude: recordingAmplitude,
+                    onDictateToggle: onDictateToggle,
+                    onVoiceModeToggle: onVoiceModeToggle,
                     placeholderText: "Ask anything...",
                     threadId: threadId
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -75,6 +75,9 @@ struct ChatView: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
@@ -139,6 +142,9 @@ struct ChatView: View {
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
                             onDismissError: onDismissError,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     } else {
@@ -161,6 +167,9 @@ struct ChatView: View {
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
                             onDismissError: onDismissError,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     }
@@ -254,6 +263,9 @@ struct ChatView: View {
                             voiceModeManager: voiceModeManager,
                             voiceService: voiceService,
                             onEndVoiceMode: onEndVoiceMode,
+                            recordingAmplitude: recordingAmplitude,
+                            onDictateToggle: onDictateToggle,
+                            onVoiceModeToggle: onVoiceModeToggle,
                             threadId: threadId
                         )
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -41,6 +41,9 @@ struct ComposerSection: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
 
     var body: some View {
@@ -96,6 +99,9 @@ struct ComposerSection: View {
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceService,
                 onEndVoiceMode: onEndVoiceMode,
+                recordingAmplitude: recordingAmplitude,
+                onDictateToggle: onDictateToggle,
+                onVoiceModeToggle: onVoiceModeToggle,
                 placeholderText: isSending ? "Working on it..." : "What would you like to do?",
                 threadId: threadId
             )

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
+import os
 #if os(macOS)
 import AppKit
 #endif
+
+private let composerLog = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "Composer")
 
 struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 200
@@ -12,7 +15,7 @@ struct ComposerView: View {
     // MARK: - ComposerMode
 
     /// Three-mode state machine for the composer.
-    private enum ComposerMode {
+    private enum ComposerMode: Equatable {
         /// Normal text entry with attach/send buttons.
         case textEntry
         /// Inline dictation: text field visible with a recording strip below.
@@ -121,6 +124,9 @@ struct ComposerView: View {
         .onChange(of: threadId) {
             guard !hasPendingConfirmation else { return }
             composerFocus = true
+        }
+        .onChange(of: currentMode) {
+            composerLog.debug("Composer mode: \(String(describing: currentMode))")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -9,6 +9,29 @@ struct ComposerView: View {
     private let composerMaxHeight: CGFloat = 200
     private let composerActionButtonSize: CGFloat = 34
 
+    // MARK: - ComposerMode
+
+    /// Three-mode state machine for the composer.
+    private enum ComposerMode {
+        /// Normal text entry with attach/send buttons.
+        case textEntry
+        /// Inline dictation: text field visible with a recording strip below.
+        case dictationInline
+        /// Full voice conversation with inverse/high-contrast container.
+        case voiceConversation
+    }
+
+    /// The current mode derived from recording and voice-mode state.
+    private var currentMode: ComposerMode {
+        if voiceModeManager.map({ $0.state != .off }) ?? false {
+            return .voiceConversation
+        } else if isRecording {
+            return .dictationInline
+        } else {
+            return .textEntry
+        }
+    }
+
     @Binding var inputText: String
     let hasAPIKey: Bool
     let isSending: Bool
@@ -30,6 +53,9 @@ struct ComposerView: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var recordingAmplitude: Float = 0
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var placeholderText: String = "What would you like to do?"
     var composerCompactHeight: CGFloat = 34
     var threadId: UUID?
@@ -44,10 +70,6 @@ struct ComposerView: View {
     @State var slashSelectedIndex = 0
     @State var suppressSlashReopen = false
     @State private var avatarSeed: String = "default"
-
-    private var isVoiceModeActive: Bool {
-        voiceModeManager.map { $0.state != .off } ?? false
-    }
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -72,50 +94,17 @@ struct ComposerView: View {
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
-            // Composer box
-            VStack(spacing: 0) {
-                if !pendingAttachments.isEmpty {
-                    attachmentStrip
-                }
+            // Composer box — switches on the three-mode state machine
+            switch currentMode {
+            case .voiceConversation:
+                voiceConversationComposer
 
-                if isVoiceModeActive {
-                    // Voice mode: replace text field with live transcription + voice controls
-                    HStack(alignment: .center, spacing: VSpacing.md) {
-                        voiceModeContent
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        voiceModeActionButtons
-                            .frame(maxHeight: .infinity, alignment: .center)
-                    }
-                    .frame(height: compactRowHeight, alignment: .center)
-                } else {
-                    composerTextField
-                        .frame(minHeight: composerCompactHeight)
-                        .overlay(alignment: .bottomTrailing) {
-                            composerActionButtons
-                        }
-                }
+            case .dictationInline:
+                dictationInlineComposer
+
+            case .textEntry:
+                textEntryComposer
             }
-            .padding(.top, VSpacing.sm)
-            .padding(.bottom, VSpacing.sm)
-            .padding(.leading, VSpacing.lg)
-            .padding(.trailing, VSpacing.lg)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(VColor.composerBackground)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(
-                        isComposerFocused ? VColor.surfaceBorder : VColor.surfaceBorder.opacity(0.95),
-                        lineWidth: isComposerFocused ? 1.5 : 1
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .stroke(VColor.surfaceBorder.opacity(isComposerFocused ? 0.12 : 0), lineWidth: 3)
-            )
-            .shadow(color: .clear, radius: 0)
         }
         .fixedSize(horizontal: false, vertical: true)
         .animation(VAnimation.fast, value: showSlashMenu)
@@ -133,10 +122,6 @@ struct ComposerView: View {
             guard !hasPendingConfirmation else { return }
             composerFocus = true
         }
-    }
-
-    private var compactRowHeight: CGFloat {
-        composerActionButtonSize
     }
 
     /// The text overlays (slash highlighting, ghost text) rendered behind / on
@@ -384,6 +369,51 @@ struct ComposerView: View {
         #endif
     }
 
+    // MARK: - Text Entry Mode
+
+    /// Standard composer shell with border, used for textEntry and dictationInline modes.
+    @ViewBuilder
+    private func standardComposerShell<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) {
+            if !pendingAttachments.isEmpty {
+                attachmentStrip
+            }
+            content()
+        }
+        .padding(.top, VSpacing.sm)
+        .padding(.bottom, VSpacing.sm)
+        .padding(.leading, VSpacing.lg)
+        .padding(.trailing, VSpacing.lg)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.composerBackground)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(
+                    isComposerFocused ? VColor.surfaceBorder : VColor.surfaceBorder.opacity(0.95),
+                    lineWidth: isComposerFocused ? 1.5 : 1
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder.opacity(isComposerFocused ? 0.12 : 0), lineWidth: 3)
+        )
+        .shadow(color: .clear, radius: 0)
+    }
+
+    @ViewBuilder
+    private var textEntryComposer: some View {
+        standardComposerShell {
+            composerTextField
+                .frame(minHeight: composerCompactHeight)
+                .overlay(alignment: .bottomTrailing) {
+                    composerActionButtons
+                }
+        }
+    }
+
     @ViewBuilder
     private var composerActionButtons: some View {
         HStack(spacing: 2) {
@@ -418,6 +448,27 @@ struct ComposerView: View {
                         onSend()
                     }
                     .transition(.scale.combined(with: .opacity))
+                } else if inputText.isEmpty && !hasPendingConfirmation {
+                    // Empty input: show dictate + voice mode buttons
+                    VIconButton(
+                        label: "Dictate",
+                        icon: VIcon.mic.rawValue,
+                        iconOnly: true,
+                        size: composerActionButtonSize,
+                        action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                    )
+                    .disabled(!hasAPIKey)
+                    .transition(.scale.combined(with: .opacity))
+
+                    VIconButton(
+                        label: "Voice mode",
+                        icon: VIcon.audioWaveform.rawValue,
+                        iconOnly: true,
+                        size: composerActionButtonSize,
+                        action: { onVoiceModeToggle?() }
+                    )
+                    .disabled(!hasAPIKey)
+                    .transition(.scale.combined(with: .opacity))
                 } else {
                     MicrophoneButton(
                         isRecording: isRecording,
@@ -433,95 +484,132 @@ struct ComposerView: View {
         .animation(VAnimation.spring, value: canSend)
     }
 
-    // MARK: - Voice Mode Content
+    // MARK: - Dictation Inline Mode
+
+    @State private var dictationPulse = false
 
     @ViewBuilder
-    private var voiceModeContent: some View {
-        if let manager = voiceModeManager {
-            HStack(spacing: VSpacing.sm) {
-                // Waveform icon
-                VIconView(.audioWaveform, size: 14)
-                    .foregroundColor(voiceModeIconColor(manager))
+    private var dictationInlineComposer: some View {
+        standardComposerShell {
+            VStack(spacing: VSpacing.sm) {
+                // Text field remains visible for live transcription
+                composerTextField
+                    .frame(minHeight: composerCompactHeight)
 
-                if manager.state == .listening, !manager.liveTranscription.isEmpty {
-                    Text(manager.liveTranscription)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.head)
-                } else {
-                    Text(manager.stateLabel)
-                        .font(VFont.body)
+                // Inline recording strip
+                HStack(spacing: VSpacing.sm) {
+                    Text("Listening\u{2026}")
+                        .font(VFont.caption)
                         .foregroundColor(VColor.textSecondary)
+                        .opacity(dictationPulse ? 0.4 : 1.0)
+                        .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: dictationPulse)
+                        .onAppear { dictationPulse = true }
+                        .onDisappear { dictationPulse = false }
+
+                    VStreamingWaveform(
+                        amplitude: recordingAmplitude,
+                        isActive: true,
+                        style: .dictation,
+                        foregroundColor: VColor.accent
+                    )
+                    .frame(height: 24)
+                    .frame(maxWidth: .infinity)
+
+                    VIconButton(
+                        label: "Stop dictation",
+                        icon: VIcon.square.rawValue,
+                        iconOnly: true,
+                        variant: .neutral,
+                        size: composerActionButtonSize,
+                        action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                    )
                 }
             }
         }
     }
 
+    // MARK: - Voice Conversation Mode
+
     @ViewBuilder
-    private var voiceModeActionButtons: some View {
-        if let manager = voiceModeManager, let voiceService {
-            HStack(spacing: 2) {
-                // Waveform amplitude dots
-                voiceModeWaveform(manager: manager, voiceService: voiceService)
-                    .frame(width: 28, height: composerActionButtonSize)
+    private var voiceConversationComposer: some View {
+        if let manager = voiceModeManager {
+            VStack(spacing: 0) {
+                if !pendingAttachments.isEmpty {
+                    attachmentStrip
+                }
 
-                // Mute / unmute
-                VIconButton(
-                    label: manager.state == .listening ? "Mute" : "Unmute",
-                    icon: manager.state == .listening ? VIcon.mic.rawValue : VIcon.micOff.rawValue,
-                    iconOnly: true,
-                    size: composerActionButtonSize,
-                    action: { manager.toggleListening() }
-                )
-                .disabled(manager.state == .processing)
+            HStack(spacing: VSpacing.md) {
+                // Left section: state label + live transcription
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(manager.stateLabel)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.voiceComposerTextSecondary)
 
-                // End voice mode (red X)
-                VIconButton(
-                    label: "End voice mode",
-                    icon: VIcon.x.rawValue,
-                    iconOnly: true,
-                    variant: .danger,
-                    size: composerActionButtonSize,
-                    action: { onEndVoiceMode?() }
+                    if manager.state == .listening, !manager.liveTranscription.isEmpty {
+                        Text(manager.liveTranscription)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.voiceComposerTextPrimary)
+                            .lineLimit(2)
+                            .truncationMode(.tail)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                // Center: streaming waveform
+                VStreamingWaveform(
+                    amplitude: voiceConversationAmplitude(manager),
+                    isActive: manager.state == .listening || manager.state == .speaking,
+                    style: .conversation,
+                    foregroundColor: voiceConversationWaveformColor(manager)
                 )
+                .frame(width: 60, height: 32)
+
+                // Right: mute/unmute + end button
+                HStack(spacing: 2) {
+                    VIconButton(
+                        label: manager.state == .listening ? "Mute" : "Unmute",
+                        icon: manager.state == .listening ? VIcon.mic.rawValue : VIcon.micOff.rawValue,
+                        iconOnly: true,
+                        size: composerActionButtonSize,
+                        action: { manager.toggleListening() }
+                    )
+                    .disabled(manager.state == .processing)
+
+                    VIconButton(
+                        label: "End voice mode",
+                        icon: VIcon.x.rawValue,
+                        iconOnly: true,
+                        variant: .danger,
+                        size: composerActionButtonSize,
+                        action: { onEndVoiceMode?() }
+                    )
+                }
             }
-            .padding(.trailing, -(VSpacing.lg - VSpacing.sm))
+            .padding(.vertical, VSpacing.md)
+            .padding(.horizontal, VSpacing.lg)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.voiceComposerBackground)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         }
     }
 
-    private func voiceModeWaveform(manager: VoiceModeManager, voiceService: OpenAIVoiceService) -> some View {
-        HStack(spacing: 2) {
-            ForEach(0..<4, id: \.self) { i in
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(voiceModeIconColor(manager))
-                    .frame(width: 3, height: voiceModeBarHeight(index: i, manager: manager, voiceService: voiceService))
-                    .animation(.easeInOut(duration: 0.12), value: voiceService.amplitude)
-                    .animation(.easeInOut(duration: 0.3), value: voiceService.speakingAmplitude)
-            }
-        }
-    }
-
-    private func voiceModeBarHeight(index: Int, manager: VoiceModeManager, voiceService: OpenAIVoiceService) -> CGFloat {
-        let amp: Float
+    private func voiceConversationAmplitude(_ manager: VoiceModeManager) -> Float {
         switch manager.state {
-        case .listening: amp = voiceService.amplitude
-        case .speaking: amp = voiceService.speakingAmplitude
-        default: return 4
+        case .listening: return voiceService?.amplitude ?? 0
+        case .speaking: return voiceService?.speakingAmplitude ?? 0
+        default: return 0
         }
-        let base: CGFloat = 4
-        let maxExtra: CGFloat = 14
-        let offset = Float(index) * 0.2
-        let value = min(max(amp + offset * amp, 0), 1)
-        return base + CGFloat(value) * maxExtra
     }
 
-    private func voiceModeIconColor(_ manager: VoiceModeManager) -> Color {
+    private func voiceConversationWaveformColor(_ manager: VoiceModeManager) -> Color {
         switch manager.state {
         case .listening: return VColor.accent
         case .speaking: return VColor.success
         case .processing: return VColor.textSecondary
-        default: return Moss._500
+        default: return VColor.accent
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -92,7 +92,7 @@ struct MainWindowView: View {
         FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vellum/workspace/BOOTSTRAP.md")
     }
 
-    private func toggleVoiceMode() {
+    func toggleVoiceMode() {
         if voiceModeManager.state != .off {
             voiceModeManager.deactivate()
         } else {
@@ -404,17 +404,6 @@ struct MainWindowView: View {
                 windowState.selection = .panel(.settings)
             }
             if windowState.isConversationVisible {
-                // Voice mode toggle
-                VIconButton(
-                    label: "Voice Mode",
-                    icon: voiceModeManager.state != .off ? "waveform.circle.fill" : "waveform.circle",
-                    isActive: voiceModeManager.state != .off,
-                    iconOnly: true,
-                    tooltip: voiceModeManager.state != .off ? "Exit voice mode" : "Voice mode"
-                ) {
-                    toggleVoiceMode()
-                }
-
                 // Temporary chat toggle — always visible on private threads (so users can exit temp chat),
                 // only visible on normal threads when no messages exist yet
                 if threadManager.activeThread?.kind == .private || threadManager.activeViewModel?.messages.contains(where: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -383,6 +383,12 @@ extension MainWindowView {
                 onEndVoiceMode: {
                     voiceModeManager.deactivate()
                 },
+                onDictateToggle: {
+                    (NSApp.delegate as? AppDelegate)?.voiceInput?.toggleRecording(origin: .chatComposer)
+                },
+                onVoiceModeToggle: {
+                    toggleVoiceMode()
+                },
                 threadId: threadManager.activeThreadId,
                 anchorMessageId: $threadManager.pendingAnchorMessageId
             )
@@ -573,6 +579,8 @@ struct ActiveChatViewWrapper: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var onDictateToggle: (() -> Void)? = nil
+    var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
     @Binding var anchorMessageId: UUID?
 
@@ -695,6 +703,9 @@ struct ActiveChatViewWrapper: View {
             voiceModeManager: voiceModeManager,
             voiceService: voiceService,
             onEndVoiceMode: onEndVoiceMode,
+            recordingAmplitude: viewModel.recordingAmplitude,
+            onDictateToggle: onDictateToggle,
+            onVoiceModeToggle: onVoiceModeToggle,
             threadId: threadId,
             anchorMessageId: $anchorMessageId,
             displayedMessageCount: viewModel.displayedMessageCount,

--- a/clients/shared/DesignSystem/Components/Display/VStreamingWaveform.swift
+++ b/clients/shared/DesignSystem/Components/Display/VStreamingWaveform.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+// MARK: - Waveform Style
+
+/// Defines the visual style of the streaming waveform.
+public enum WaveformStyle {
+    /// Dense centered bars for voice mode.
+    case conversation
+    /// Subtler bottom-aligned bars for inline recording strip.
+    case dictation
+}
+
+// MARK: - VStreamingWaveform
+
+/// A streaming waveform visualizer that renders animated bars driven by an audio amplitude signal.
+///
+/// Uses `Canvas` + `TimelineView(.animation)` for smooth 60fps rendering isolated from
+/// broader view invalidations.
+public struct VStreamingWaveform: View {
+    /// Audio amplitude, clamped to 0...1.
+    public var amplitude: Float
+    /// Whether the waveform is actively receiving audio input.
+    public var isActive: Bool
+    /// Visual style of the waveform.
+    public var style: WaveformStyle
+    /// Bar color.
+    public var foregroundColor: Color
+    /// Number of bars to render.
+    public var barCount: Int
+    /// Width of each bar.
+    public var lineWidth: CGFloat
+
+    public init(
+        amplitude: Float,
+        isActive: Bool,
+        style: WaveformStyle = .conversation,
+        foregroundColor: Color = VColor.accent,
+        barCount: Int = 5,
+        lineWidth: CGFloat = 3
+    ) {
+        self.amplitude = amplitude
+        self.isActive = isActive
+        self.style = style
+        self.foregroundColor = foregroundColor
+        self.barCount = barCount
+        self.lineWidth = lineWidth
+    }
+
+    public var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let date = timeline.date.timeIntervalSinceReferenceDate
+                draw(context: context, size: size, time: date)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(isActive ? "Audio waveform, active" : "Audio waveform, inactive")
+    }
+
+    // MARK: - Drawing
+
+    private func draw(context: GraphicsContext, size: CGSize, time: TimeInterval) {
+        guard barCount > 0 else { return }
+
+        let clampedAmplitude = CGFloat(min(max(amplitude, 0), 1))
+        let totalBarWidth = CGFloat(barCount) * lineWidth
+        let totalSpacing = CGFloat(barCount - 1) * VSpacing.xs
+        let totalWidth = totalBarWidth + totalSpacing
+        let startX = (size.width - totalWidth) / 2
+
+        let isConversation = style == .conversation
+        let maxBarHeight: CGFloat = isConversation ? size.height * 0.8 : size.height * 0.5
+        let minBarHeight: CGFloat = isConversation ? lineWidth * 1.5 : lineWidth
+
+        for i in 0..<barCount {
+            let phaseOffset = Double(i) * 0.6
+            let wave = sin(time * 4.0 + phaseOffset) * 0.5 + 0.5 // 0...1
+
+            let activeHeight: CGFloat
+            if isActive {
+                let amplitudeContribution = clampedAmplitude * 0.7
+                let waveContribution = CGFloat(wave) * 0.3
+                let normalizedHeight = amplitudeContribution + waveContribution * clampedAmplitude
+                activeHeight = minBarHeight + normalizedHeight * (maxBarHeight - minBarHeight)
+            } else {
+                // Settle to baseline
+                let subtleWave = CGFloat(sin(time * 2.0 + phaseOffset) * 0.5 + 0.5) * 0.15
+                activeHeight = minBarHeight + subtleWave * minBarHeight
+            }
+
+            let barHeight = max(activeHeight, minBarHeight)
+            let x = startX + CGFloat(i) * (lineWidth + VSpacing.xs)
+
+            let barRect: CGRect
+            if isConversation {
+                // Centered vertically
+                let y = (size.height - barHeight) / 2
+                barRect = CGRect(x: x, y: y, width: lineWidth, height: barHeight)
+            } else {
+                // Bottom-aligned
+                let y = size.height - barHeight
+                barRect = CGRect(x: x, y: y, width: lineWidth, height: barHeight)
+            }
+
+            let cornerRadius = isConversation ? lineWidth / 2 : lineWidth / 3
+            let path = Path(roundedRect: barRect, cornerRadius: cornerRadius)
+            context.fill(path, with: .color(foregroundColor))
+        }
+    }
+}
+
+// MARK: - Preview
+
+private struct WaveformPreviewContainer: View {
+    @State private var amplitude: Float = 0.5
+    @State private var isActive: Bool = true
+
+    var body: some View {
+        VStack(spacing: VSpacing.xl) {
+            Text("Conversation Style")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            VStreamingWaveform(
+                amplitude: amplitude,
+                isActive: isActive,
+                style: .conversation
+            )
+            .frame(width: 120, height: 60)
+
+            Text("Dictation Style")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            VStreamingWaveform(
+                amplitude: amplitude,
+                isActive: isActive,
+                style: .dictation,
+                foregroundColor: VColor.textSecondary
+            )
+            .frame(width: 100, height: 30)
+
+            Divider()
+
+            HStack {
+                Text("Amplitude: \(String(format: "%.2f", amplitude))")
+                    .foregroundColor(VColor.textSecondary)
+                Slider(value: Binding(
+                    get: { Double(amplitude) },
+                    set: { amplitude = Float($0) }
+                ), in: 0...1)
+            }
+            .padding(.horizontal)
+
+            Toggle("Active", isOn: $isActive)
+                .padding(.horizontal)
+                .foregroundColor(VColor.textPrimary)
+        }
+        .padding()
+    }
+}
+
+#Preview("VStreamingWaveform") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        WaveformPreviewContainer()
+    }
+    .frame(width: 300, height: 350)
+}

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 
 struct ChatGallerySection: View {
+    @State private var voiceComposerAmplitude: Float = 0.5
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
             // MARK: - Error Banners
@@ -33,6 +35,53 @@ struct ChatGallerySection: View {
                         message: "Your session has expired. Please start a new conversation.",
                         onDismiss: {}
                     )
+                }
+            }
+
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - Voice Composer
+            GallerySectionHeader(
+                title: "Voice Composer",
+                description: "VStreamingWaveform in composer context. The composer has three modes: textEntry, dictationInline (with dictation-style waveform), and voiceConversation (with conversation-style waveform)."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    HStack {
+                        Text("Amplitude: \(String(format: "%.2f", voiceComposerAmplitude))")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Slider(value: $voiceComposerAmplitude, in: 0...1, step: 0.05)
+                            .frame(maxWidth: 200)
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Conversation style (voice mode)")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+                    VStreamingWaveform(
+                        amplitude: voiceComposerAmplitude,
+                        isActive: true,
+                        style: .conversation,
+                        foregroundColor: VColor.accent
+                    )
+                    .frame(width: 120, height: 60)
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    Text("Dictation style (inline dictation)")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+                    VStreamingWaveform(
+                        amplitude: voiceComposerAmplitude,
+                        isActive: true,
+                        style: .dictation,
+                        foregroundColor: VColor.accent
+                    )
+                    .frame(height: 24)
+                    .frame(maxWidth: .infinity)
                 }
             }
 

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 struct DisplayGallerySection: View {
     @State private var cardPadding: CGFloat = 24
+    @State private var waveformAmplitude: Float = 0.5
+    @State private var waveformActive: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
@@ -163,6 +165,61 @@ struct DisplayGallerySection: View {
                             .font(VFont.body)
                             .foregroundColor(VColor.textSecondary)
                     }
+                }
+            }
+            Divider().background(VColor.surfaceBorder).padding(.vertical, VSpacing.md)
+
+            // MARK: - VStreamingWaveform
+            GallerySectionHeader(
+                title: "VStreamingWaveform",
+                description: "Animated audio waveform driven by amplitude. Two styles: conversation (centered) and dictation (bottom-aligned)."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(spacing: VSpacing.sm) {
+                            Text("Conversation")
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+                            VStreamingWaveform(
+                                amplitude: waveformAmplitude,
+                                isActive: waveformActive,
+                                style: .conversation
+                            )
+                            .frame(width: 120, height: 60)
+                        }
+
+                        VStack(spacing: VSpacing.sm) {
+                            Text("Dictation")
+                                .font(VFont.captionMedium)
+                                .foregroundColor(VColor.textSecondary)
+                            VStreamingWaveform(
+                                amplitude: waveformAmplitude,
+                                isActive: waveformActive,
+                                style: .dictation,
+                                foregroundColor: VColor.textSecondary
+                            )
+                            .frame(width: 100, height: 30)
+                        }
+                    }
+
+                    Divider().background(VColor.surfaceBorder)
+
+                    HStack {
+                        Text("Amplitude: \(String(format: "%.2f", waveformAmplitude))")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                        Slider(value: Binding(
+                            get: { Double(waveformAmplitude) },
+                            set: { waveformAmplitude = Float($0) }
+                        ), in: 0...1)
+                        .frame(maxWidth: 200)
+                    }
+
+                    Toggle("Active", isOn: $waveformActive)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textPrimary)
                 }
             }
         }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -320,6 +320,12 @@ public enum VColor {
     // Composer background fill
     public static let composerBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
 
+    // Voice composer — inverse/high-contrast tokens for voice mode
+    public static let voiceComposerBackground = adaptiveColor(light: Slate._900, dark: Slate._100)
+    public static let voiceComposerTextPrimary = adaptiveColor(light: .white, dark: Slate._900)
+    public static let voiceComposerTextSecondary = adaptiveColor(light: Slate._300, dark: Slate._600)
+    public static let voiceComposerControlBackground = adaptiveColor(light: Slate._800, dark: Slate._200)
+
     // Microphone icon color
     public static let micIcon = adaptiveColor(light: Forest._500, dark: Moss._400)
 

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -33,6 +33,7 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var pendingQueuedCount: Int = 0
     @Published public var suggestion: String?
     @Published public var isRecording: Bool = false
+    @Published public var recordingAmplitude: Float = 0
 
     // MARK: - Workspace refinement
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -164,6 +164,10 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.isRecording }
         set { messageManager.isRecording = newValue }
     }
+    public var recordingAmplitude: Float {
+        get { messageManager.recordingAmplitude }
+        set { messageManager.recordingAmplitude = newValue }
+    }
     public var isWorkspaceRefinementInFlight: Bool {
         get { messageManager.isWorkspaceRefinementInFlight }
         set { messageManager.isWorkspaceRefinementInFlight = newValue }


### PR DESCRIPTION
## Summary
Redesign the macOS chat composer to be the single entry point for both Dictation (draft-first, manual send) and Voice Mode (seamless auto-send conversation), with a reusable streaming waveform component, three explicit composer states, amplitude-driven visualizations, and inverse/high-contrast styling for voice mode.

## Changes
- **VStreamingWaveform**: New Canvas+TimelineView design system component with `.conversation` and `.dictation` styles, amplitude-driven bar animation at 60fps
- **Inverse color tokens**: `voiceComposerBackground`, `voiceComposerTextPrimary`, `voiceComposerTextSecondary`, `voiceComposerControlBackground` with adaptive light/dark values
- **Audio amplitude pipeline**: RMS via vDSP → EMA smoothing (0.3/0.7) → 50ms throttled emission from VoiceInputManager → ChatViewModel
- **VoiceInputOrigin**: Enum tracking dictation source (`.chatComposer`, `.quickInput`, `.hotkey`) to conditionally suppress floating overlay for chat-origin dictation
- **Three-mode composer**: ComposerMode state machine (`.textEntry`, `.dictationInline`, `.voiceConversation`) replacing the old boolean voice mode branch
- **Inline dictation strip**: VStreamingWaveform + pulsing "Listening..." label + stop button below text field during recording
- **Inverse voice conversation UI**: Full-width inverse container with state label, live transcription, VStreamingWaveform, mute/end controls
- **Callback plumbing**: `onDictateToggle`, `onVoiceModeToggle`, `recordingAmplitude` threaded through ComposerSection → ChatView → ChatEmptyStateView → PanelCoordinator → MainWindowView
- **Gallery & diagnostics**: Voice Composer gallery section, os.Logger events for dictation origin and mode transitions

## Milestone PRs (merged into feature branch)
- #14809: M1 — Add VStreamingWaveform design system component
- #14813: M2 — Add inverse voice composer color tokens
- #14814: M3 — Extend VoiceInputManager with amplitude callback and origin tracking
- #14817: M4 — Add recordingAmplitude to ChatMessageManager and ChatViewModel
- #14818: M5 — Wire amplitude and origin through AppDelegate+Voice
- #14819: M6 — Suppress DictationOverlayWindow for chat-origin dictation
- #14823: M7 — Three-mode composer with inline dictation and inverse voice mode
- #14825: M8 — Thread voice callbacks through chat view hierarchy
- #14827: M9 — Add voice composer gallery entries and diagnostics logging

## Project issue
Closes #14799

## Test plan
- [ ] Verify VStreamingWaveform renders in gallery with both styles
- [ ] Verify dictation from composer shows inline strip (not floating overlay)
- [ ] Verify voice mode from composer shows inverse container with waveform
- [ ] Verify hotkey dictation still shows floating overlay
- [ ] Verify amplitude-driven waveform animation during recording
- [ ] Verify light/dark mode inverse token rendering
- [ ] Verify mode transition logging appears in Console.app at debug level

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
