### PR TITLE
fix: validate generate_clip output_format to prevent path traversal

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -73,6 +73,8 @@ const MIME_BY_FORMAT: Record<string, string> = {
   mov: "video/quicktime",
 };
 
+const ALLOWED_OUTPUT_FORMATS = new Set(Object.keys(MIME_BY_FORMAT));
+
 // ---------------------------------------------------------------------------
 // Tool entry point
 // ---------------------------------------------------------------------------
@@ -105,7 +107,16 @@ export async function run(
 
   const preRoll = (input.pre_roll as number) ?? 3;
   const postRoll = (input.post_roll as number) ?? 2;
-  const outputFormat = (input.output_format as string) ?? "mp4";
+  const outputFormatInput =
+    typeof input.output_format === "string" ? input.output_format : "mp4";
+  const outputFormat = outputFormatInput.toLowerCase();
+  if (!ALLOWED_OUTPUT_FORMATS.has(outputFormat)) {
+    return {
+      content:
+        "output_format must be one of: mp4, webm, mov (defaults to mp4).",
+      isError: true,
+    };
+  }
   const title = input.title as string | undefined;
 
   const asset = getMediaAssetById(assetId);


### PR DESCRIPTION
### Motivation
- Prevent a path traversal vulnerability where untrusted `output_format` was interpolated into the clip filename/path and could cause `ffmpeg -y` to overwrite or delete arbitrary files (vulnerable code lived in `assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts`).

### Description
- Add an `ALLOWED_OUTPUT_FORMATS` set derived from `MIME_BY_FORMAT`, normalize `input.output_format` to lowercase, and return an error when the value is not one of `mp4`, `webm`, or `mov`, so no unvalidated input is used when constructing the output filename/path (change made in `assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts`).

### Testing
- Attempted to run the TypeScript check via `cd assistant && bunx tsc --noEmit`, but the environment could not install `bun` so the type-check step failed to execute; pre-commit hooks reported bun-based lint/type checks were skipped and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aefa319694832385d87ca6b16c4b73)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
