### PR TITLE
fix: correct Sentry project name for dSYM upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,7 +726,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum-ai --project vellum-assistant-macos dist/*.dSYM
 
       - name: Free disk space
         run: |
@@ -1066,7 +1066,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum-ai --project vellum-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum-ai --project vellum-assistant-macos dist/*.dSYM
 
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary
- Fix Sentry dSYM upload failing with HTTP 404 by correcting the project name from `vellum-macos` to `vellum-assistant-macos`
- Both arm64 and x64 build jobs were affected (lines 729 and 1069 in release.yml)
- The upload step has `continue-on-error: true` so these failures were silent

## Original prompt
Fix Sentry dSYM upload 404 error: change --project vellum-macos to --project vellum-assistant-macos in .github/workflows/release.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
