### PR TITLE
fix: correct Sentry org slug for dSYM upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,7 +726,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum-ai --project vellum-assistant-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
 
       - name: Free disk space
         run: |
@@ -1066,7 +1066,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm install -g @sentry/cli@2.42.2
-          sentry-cli debug-files upload --org vellum-ai --project vellum-assistant-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
 
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary
- Fix Sentry org slug from `vellum-ai` to `vellum` in dSYM upload command
- Verified locally: `sentry-cli debug-files upload --org vellum --project vellum-assistant-macos` succeeds and uploads the dSYM file
- The previous fix (#14831) corrected the project name but the org was also wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
