### PR TITLE
feat: add Send Logs to Vellum menu item for Sentry upload (#14837)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -325,6 +325,11 @@ extension AppDelegate {
         exportLogsItem.image = VIcon.fileArchive.nsImage
         menu.addItem(exportLogsItem)
 
+        let sendLogsItem = NSMenuItem(title: "Send Logs to Vellum", action: #selector(sendLogsToSentry), keyEquivalent: "")
+        sendLogsItem.target = self
+        sendLogsItem.image = VIcon.upload.nsImage
+        menu.addItem(sendLogsItem)
+
         let restartItem = NSMenuItem(title: "Restart", action: #selector(performRestart), keyEquivalent: "")
         restartItem.target = self
         restartItem.image = VIcon.refreshCw.nsImage
@@ -518,6 +523,10 @@ extension AppDelegate {
 
     @objc public func exportAssistantLogs() {
         LogExporter.exportLogs()
+    }
+
+    @objc public func sendLogsToSentry() {
+        LogExporter.sendLogsToSentry()
     }
 
     func refreshSkillsCache() {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import os
+@preconcurrency import Sentry
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
@@ -47,6 +48,44 @@ enum LogExporter {
                 alert.alertStyle = .warning
                 alert.runModal()
             }
+        }
+    }
+
+    /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.
+    static func sendLogsToSentry() {
+        Task {
+            let fileManager = FileManager.default
+            let archiveURL = fileManager.temporaryDirectory
+                .appendingPathComponent("vellum-assistant-logs-\(UUID().uuidString).tar.gz")
+
+            do {
+                try await buildArchive(destination: archiveURL)
+            } catch {
+                log.error("Failed to build log archive for Sentry: \(error.localizedDescription)")
+                let alert = NSAlert()
+                alert.messageText = "Send Failed"
+                alert.informativeText = "Could not collect logs: \(error.localizedDescription)"
+                alert.alertStyle = .warning
+                alert.runModal()
+                return
+            }
+
+            let archiveName = defaultArchiveName()
+            let attachment = Attachment(path: archiveURL.path, filename: archiveName)
+            let event = Event(level: .info)
+            event.message = SentryMessage(formatted: "Manual log export")
+            event.tags = ["source": "manual_log_export"]
+
+            MetricKitManager.sendManualReport(event, attachments: [attachment]) {
+                try? FileManager.default.removeItem(at: archiveURL)
+            }
+
+            // Show immediate confirmation — the upload runs async in background
+            let alert = NSAlert()
+            alert.messageText = "Logs Sent"
+            alert.informativeText = "Log archive is being uploaded to Vellum. This may take a moment on slow connections."
+            alert.alertStyle = .informational
+            alert.runModal()
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 'Send Logs to Vellum' menu item next to 'Export Logs...' in status bar context menu
- Collects all log sources (session logs, daemon logs, debug state, etc.) into a .tar.gz archive
- Uploads the archive to Sentry as an attachment via MetricKitManager.sendManualReport()
- Works even when user has opted out of automatic crash reporting
- Shows confirmation alert after initiating upload

## Original prompt
Add Export to Vellum menu item that sends .tar log archive to Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
