### PR TITLE
feat: Send Logs to Vellum menu item for Sentry upload

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -22,6 +22,9 @@ struct VellumAssistantApp: App {
                 Button("Export Logs...") {
                     appDelegate.exportAssistantLogs()
                 }
+                Button("Send Logs to Vellum") {
+                    appDelegate.sendLogsToSentry()
+                }
             }
             // Replace the default Settings menu item (which opens the SwiftUI
             // Settings scene window) with one that opens the in-app panel.

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -325,6 +325,11 @@ extension AppDelegate {
         exportLogsItem.image = VIcon.fileArchive.nsImage
         menu.addItem(exportLogsItem)
 
+        let sendLogsItem = NSMenuItem(title: "Send Logs to Vellum", action: #selector(sendLogsToSentry), keyEquivalent: "")
+        sendLogsItem.target = self
+        sendLogsItem.image = VIcon.upload.nsImage
+        menu.addItem(sendLogsItem)
+
         let restartItem = NSMenuItem(title: "Restart", action: #selector(performRestart), keyEquivalent: "")
         restartItem.target = self
         restartItem.image = VIcon.refreshCw.nsImage
@@ -518,6 +523,10 @@ extension AppDelegate {
 
     @objc public func exportAssistantLogs() {
         LogExporter.exportLogs()
+    }
+
+    @objc public func sendLogsToSentry() {
+        LogExporter.sendLogsToSentry()
     }
 
     func refreshSkillsCache() {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -76,14 +76,16 @@ enum LogExporter {
             event.message = SentryMessage(formatted: "Manual log export")
             event.tags = ["source": "manual_log_export"]
 
-            MetricKitManager.sendManualReport(event, attachments: [attachment]) {
-                try? FileManager.default.removeItem(at: archiveURL)
+            await withCheckedContinuation { continuation in
+                MetricKitManager.sendManualReport(event, attachments: [attachment]) {
+                    try? FileManager.default.removeItem(at: archiveURL)
+                    continuation.resume()
+                }
             }
 
-            // Show immediate confirmation — the upload runs async in background
             let alert = NSAlert()
             alert.messageText = "Logs Sent"
-            alert.informativeText = "Log archive is being uploaded to Vellum. This may take a moment on slow connections."
+            alert.informativeText = "Log archive has been uploaded to Vellum."
             alert.alertStyle = .informational
             alert.runModal()
         }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import os
+@preconcurrency import Sentry
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
@@ -47,6 +48,44 @@ enum LogExporter {
                 alert.alertStyle = .warning
                 alert.runModal()
             }
+        }
+    }
+
+    /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.
+    static func sendLogsToSentry() {
+        Task {
+            let fileManager = FileManager.default
+            let archiveURL = fileManager.temporaryDirectory
+                .appendingPathComponent("vellum-assistant-logs-\(UUID().uuidString).tar.gz")
+
+            do {
+                try await buildArchive(destination: archiveURL)
+            } catch {
+                log.error("Failed to build log archive for Sentry: \(error.localizedDescription)")
+                let alert = NSAlert()
+                alert.messageText = "Send Failed"
+                alert.informativeText = "Could not collect logs: \(error.localizedDescription)"
+                alert.alertStyle = .warning
+                alert.runModal()
+                return
+            }
+
+            let archiveName = defaultArchiveName()
+            let attachment = Attachment(path: archiveURL.path, filename: archiveName)
+            let event = Event(level: .info)
+            event.message = SentryMessage(formatted: "Manual log export")
+            event.tags = ["source": "manual_log_export"]
+
+            MetricKitManager.sendManualReport(event, attachments: [attachment]) {
+                try? FileManager.default.removeItem(at: archiveURL)
+            }
+
+            // Show immediate confirmation — the upload runs async in background
+            let alert = NSAlert()
+            alert.messageText = "Logs Sent"
+            alert.informativeText = "Log archive is being uploaded to Vellum. This may take a moment on slow connections."
+            alert.alertStyle = .informational
+            alert.runModal()
         }
     }
 


### PR DESCRIPTION
## Summary
Adds a "Send Logs to Vellum" menu item in the status bar context menu (next to "Export Logs...") that creates a .tar.gz archive of all logs and uploads it to Sentry as an attachment on a manual problem report event. This enables developers to collect diagnostic logs from users experiencing issues without requiring them to manually export and send files.

## Changes
- Added `sendLogsToSentry()` method to `LogExporter` that builds a log archive and sends it via `MetricKitManager.sendManualReport()` with a Sentry `Attachment`
- Added "Send Logs to Vellum" menu item with upload icon in `AppDelegate+MenuBar.swift`
- Reuses existing `LogExporter.buildArchive()` for log collection and `MetricKitManager.sendManualReport()` for upload (works even when user has opted out of automatic crash reporting)

## Milestone PRs (merged into feature branch)
- #14838: M1 — Add sendLogsToSentry() to LogExporter and wire up menu item

## Project issue
Closes #14836

## Test plan
- [ ] Build and run the macOS app
- [ ] Right-click the status bar icon → verify "Send Logs to Vellum" appears below "Export Logs..."
- [ ] Click "Send Logs to Vellum" → verify success alert appears
- [ ] Check Sentry dashboard for the event with `source: manual_log_export` tag and attached .tar.gz

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
