### PR TITLE
fix: suggest browser skill when web_fetch returns sparse HTML content

### DIFF
--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -1605,4 +1605,42 @@ describe("web_fetch tool", () => {
     expect(result.content).toContain("<title>Fake Title</title>");
     expect(result.content).toContain("Regular markdown content.");
   });
+
+  test("suggests browser skill when HTML page returns very little text content", async () => {
+    const spaHtml =
+      '<!doctype html><html><head><title>My App</title></head><body><div id="root"></div><script src="/app.js"></script></body></html>';
+    const result = await executeWithMockFetch(
+      { url: "https://example.com/spa" },
+      {
+        resolveHostAddresses: async () => ["93.184.216.34"],
+        requestExecutor: async () =>
+          new Response(spaHtml, {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          }),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("browser skill");
+    expect(result.content).toContain("browser_navigate");
+  });
+
+  test("does not suggest browser skill when HTML page has substantial content", async () => {
+    const richHtml = `<!doctype html><html><head><title>Docs</title></head><body><p>${"Lorem ipsum dolor sit amet. ".repeat(20)}</p></body></html>`;
+    const result = await executeWithMockFetch(
+      { url: "https://example.com/docs" },
+      {
+        resolveHostAddresses: async () => ["93.184.216.34"],
+        requestExecutor: async () =>
+          new Response(richHtml, {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          }),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("browser skill");
+  });
 });

--- a/assistant/src/__tests__/web-fetch.test.ts
+++ b/assistant/src/__tests__/web-fetch.test.ts
@@ -1606,7 +1606,7 @@ describe("web_fetch tool", () => {
     expect(result.content).toContain("Regular markdown content.");
   });
 
-  test("suggests browser skill when HTML page returns very little text content", async () => {
+  test("suggests JS rendering may be needed when HTML page returns very little text content", async () => {
     const spaHtml =
       '<!doctype html><html><head><title>My App</title></head><body><div id="root"></div><script src="/app.js"></script></body></html>';
     const result = await executeWithMockFetch(
@@ -1622,8 +1622,8 @@ describe("web_fetch tool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("browser skill");
-    expect(result.content).toContain("browser_navigate");
+    expect(result.content).toContain("Extracted text content is very short");
+    expect(result.content).toContain("JavaScript rendering");
   });
 
   test("does not suggest browser skill when HTML page has substantial content", async () => {
@@ -1641,6 +1641,25 @@ describe("web_fetch tool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).not.toContain("browser skill");
+    expect(result.content).not.toContain("Extracted text content is very short");
+  });
+
+  test("does not suggest JS rendering notice in raw mode even for sparse HTML", async () => {
+    const spaHtml =
+      '<!doctype html><html><head><title>My App</title></head><body><div id="root"></div><script src="/app.js"></script></body></html>';
+    const result = await executeWithMockFetch(
+      { url: "https://example.com/spa", raw: true },
+      {
+        resolveHostAddresses: async () => ["93.184.216.34"],
+        requestExecutor: async () =>
+          new Response(spaHtml, {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          }),
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("Extracted text content is very short");
   });
 });

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -763,9 +763,9 @@ export async function executeWebFetch(
         `start_index (${startIndex}) exceeded available content length (${processed.length}).`,
       );
     }
-    if (html && processed.length < 200) {
+    if (html && !rawMode && processed.length < 200) {
       notices.push(
-        "This page returned very little text content and is likely a JavaScript-rendered single-page app. Use the browser skill (browser_navigate + browser_extract) to load and extract the full rendered content.",
+        `Extracted text content is very short (${processed.length} characters). The page may require JavaScript rendering for full content.`,
       );
     }
 

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -763,6 +763,11 @@ export async function executeWebFetch(
         `start_index (${startIndex}) exceeded available content length (${processed.length}).`,
       );
     }
+    if (html && processed.length < 200) {
+      notices.push(
+        "This page returned very little text content and is likely a JavaScript-rendered single-page app. Use the browser skill (browser_navigate + browser_extract) to load and extract the full rendered content.",
+      );
+    }
 
     const content = formatWebFetchOutput({
       requestedUrl: safeRequestedUrl,


### PR DESCRIPTION
## Summary
- When `web_fetch` encounters an HTML page that returns very little text content (<200 chars), it now includes a notice suggesting the browser skill (`browser_navigate` + `browser_extract`) for full rendered content
- This helps users who are trying to fetch JavaScript-rendered single-page apps that return minimal HTML shell content

## Test plan
- [x] Added test: SPA-style HTML with minimal text triggers the browser skill suggestion
- [x] Added test: HTML page with substantial content does not trigger the suggestion
- [x] All 74 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
