### PR TITLE
feat: scrolling waveform, improved dictation & voice mode UX

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -83,6 +83,11 @@ extension AppDelegate {
             self.startSession(task: text, source: TaskSubmission.voiceActionSource)
         }
         voiceInput?.onAmplitudeChanged = { [weak self] amplitude in
+            // Lazy-acquire recordingViewModel if it wasn't set during onRecordingStateChanged
+            // (can happen when dictation starts before the view model lookup resolves).
+            if self?.recordingViewModel == nil {
+                self?.recordingViewModel = self?.mainWindow?.activeViewModel
+            }
             self?.recordingViewModel?.recordingAmplitude = amplitude
         }
         voiceInput?.onRecordingStateChanged = { [weak self] isRecording in

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import Combine
 import CoreGraphics
 import Speech
 import AVFoundation
@@ -48,6 +49,10 @@ final class VoiceInputManager {
 
     /// Callback fired with smoothed amplitude values (~50ms intervals) during recording.
     var onAmplitudeChanged: ((Float) -> Void)?
+
+    /// Direct amplitude publisher that bypasses ChatViewModel's 100ms coalescing.
+    /// Views can subscribe via `onReceive` for real-time waveform updates.
+    static let amplitudeSubject = CurrentValueSubject<Float, Never>(0)
 
     /// Mutable state for amplitude smoothing/throttling, captured by the audio tap closure
     /// so reads and writes happen entirely on the audio thread (no cross-thread races).
@@ -213,6 +218,7 @@ final class VoiceInputManager {
 
         activeOrigin = .hotkey
         amplitudeState.reset()
+        Self.amplitudeSubject.send(0)
         onAmplitudeChanged?(0)
 
         audioEngine.stop()
@@ -543,8 +549,11 @@ final class VoiceInputManager {
         let speechStatus = SFSpeechRecognizer.authorizationStatus()
 
         if micStatus == .notDetermined || speechStatus == .notDetermined {
-            showPermissionPrompt(kind: .notDetermined)
+            // Skip custom overlay — go straight to the native system permission dialogs.
             currentDictationContext = nil
+            Task { @MainActor [weak self] in
+                await self?.requestPermissionsAndRecord()
+            }
             return
         }
         let micDenied = micStatus == .denied || micStatus == .restricted
@@ -558,7 +567,7 @@ final class VoiceInputManager {
             } else {
                 deniedPermission = .speechRecognition
             }
-            showPermissionPrompt(kind: .denied, deniedPermission: deniedPermission)
+            showDeniedPermissionPrompt(deniedPermission: deniedPermission)
             currentDictationContext = nil
             return
         }
@@ -606,15 +615,20 @@ final class VoiceInputManager {
             let channelDataArray = Array(UnsafeBufferPointer(start: channelData[0], count: frameLength))
             let rawRMS = vDSP.rootMeanSquare(channelDataArray)
 
-            let smoothed = 0.3 * rawRMS + 0.7 * ampState.previousSmoothed
+            let smoothed = 0.5 * rawRMS + 0.5 * ampState.previousSmoothed
             ampState.previousSmoothed = smoothed
 
+            // Scale amplitude to 0-1 range for waveform visualization.
+            // Speech RMS is typically 0.01-0.1; multiply to fill the visual range.
+            let scaled = min(smoothed * 14.0, 1.0)
+
             let now = CFAbsoluteTimeGetCurrent()
-            guard now - ampState.lastEmissionTime >= 0.05 else { return }
+            guard now - ampState.lastEmissionTime >= 0.033 else { return }
             ampState.lastEmissionTime = now
 
+            VoiceInputManager.amplitudeSubject.send(scaled)
             DispatchQueue.main.async { [weak self] in
-                self?.onAmplitudeChanged?(smoothed)
+                self?.onAmplitudeChanged?(scaled)
             }
         }
 
@@ -673,12 +687,6 @@ final class VoiceInputManager {
 
     // MARK: - Permission Prompt
 
-    /// Possible permission states that trigger a prompt overlay.
-    private enum PermissionPromptKind {
-        case notDetermined
-        case denied
-    }
-
     /// Display name for the currently configured activation key, for use in user-facing copy.
     private var activationKeyDisplayName: String {
         let current = activator
@@ -686,39 +694,16 @@ final class VoiceInputManager {
         return current.displayName
     }
 
-    /// Show the permission prompt overlay explaining why access is needed and providing
-    /// action buttons. After the user grants access, recording starts automatically.
-    private func showPermissionPrompt(
-        kind: PermissionPromptKind,
-        deniedPermission: PermissionPromptOverlay.DeniedPermission = .both
-    ) {
+    /// Show the denied-permission overlay directing the user to System Settings.
+    private func showDeniedPermissionPrompt(deniedPermission: PermissionPromptOverlay.DeniedPermission) {
         let keyName = activationKeyDisplayName
-
-        switch kind {
-        case .notDetermined:
-            permissionOverlay.show(
-                kind: .notDetermined(keyName: keyName),
-                onGrantAccess: { [weak self] in
-                    Task { @MainActor [weak self] in
-                        guard let self = self else { return }
-                        await self.requestPermissionsAndRecord()
-                    }
-                },
-                onDismiss: { [weak self] in
-                    log.info("User dismissed permission prompt")
-                    self?.permissionOverlay.dismiss()
-                }
-            )
-
-        case .denied:
-            permissionOverlay.show(
-                kind: .denied(keyName: keyName, deniedPermission: deniedPermission),
-                onGrantAccess: { },
-                onDismiss: { [weak self] in
-                    self?.permissionOverlay.dismiss()
-                }
-            )
-        }
+        permissionOverlay.show(
+            kind: deniedPermission,
+            keyName: keyName,
+            onDismiss: { [weak self] in
+                self?.permissionOverlay.dismiss()
+            }
+        )
     }
 
     /// Request both microphone and speech recognition permissions sequentially,
@@ -727,7 +712,7 @@ final class VoiceInputManager {
         let micGranted = await AVCaptureDevice.requestAccess(for: .audio)
         guard micGranted else {
             log.warning("Microphone access denied by user")
-            showPermissionPrompt(kind: .denied, deniedPermission: .microphone)
+            showDeniedPermissionPrompt(deniedPermission: .microphone)
             return
         }
 
@@ -738,7 +723,7 @@ final class VoiceInputManager {
         }
         guard speechGranted else {
             log.warning("Speech recognition access denied by user")
-            showPermissionPrompt(kind: .denied, deniedPermission: .speechRecognition)
+            showDeniedPermissionPrompt(deniedPermission: .speechRecognition)
             return
         }
 
@@ -842,6 +827,7 @@ final class VoiceInputManager {
         currentDictationContext = nil
         activeOrigin = .hotkey
         amplitudeState.reset()
+        Self.amplitudeSubject.send(0)
         onAmplitudeChanged?(0)
         // Overlay stays visible if we're transitioning to processing state (dictation sent
         // to daemon). Otherwise dismiss it — recording stopped without producing a result.

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
@@ -73,6 +74,10 @@ struct ComposerView: View {
     @State var slashSelectedIndex = 0
     @State var suppressSlashReopen = false
     @State private var avatarSeed: String = "default"
+    /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
+    @State private var preDictationText: String = ""
+    /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
+    @State private var liveAmplitude: Float = 0
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -127,6 +132,9 @@ struct ComposerView: View {
         }
         .onChange(of: currentMode) {
             composerLog.debug("Composer mode: \(String(describing: currentMode))")
+            if currentMode == .dictationInline {
+                preDictationText = inputText
+            }
         }
     }
 
@@ -466,13 +474,9 @@ struct ComposerView: View {
                     .disabled(!hasAPIKey)
                     .transition(.scale.combined(with: .opacity))
 
-                    VIconButton(
-                        label: "Voice mode",
-                        icon: VIcon.audioWaveform.rawValue,
-                        iconOnly: true,
-                        size: composerActionButtonSize,
-                        action: { onVoiceModeToggle?() }
-                    )
+                    VoiceModeButton(size: composerActionButtonSize) {
+                        onVoiceModeToggle?()
+                    }
                     .disabled(!hasAPIKey)
                     .transition(.scale.combined(with: .opacity))
                 } else {
@@ -492,7 +496,6 @@ struct ComposerView: View {
 
     // MARK: - Dictation Inline Mode
 
-    @State private var dictationPulse = false
 
     @ViewBuilder
     private var dictationInlineComposer: some View {
@@ -503,34 +506,49 @@ struct ComposerView: View {
                     .frame(minHeight: composerCompactHeight)
 
                 // Inline recording strip
-                HStack(spacing: VSpacing.sm) {
-                    Text("Listening\u{2026}")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .opacity(dictationPulse ? 0.4 : 1.0)
-                        .animation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true), value: dictationPulse)
-                        .onAppear { dictationPulse = true }
-                        .onDisappear { dictationPulse = false }
-
-                    VStreamingWaveform(
-                        amplitude: recordingAmplitude,
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+VStreamingWaveform(
+                        amplitude: liveAmplitude,
                         isActive: true,
-                        style: .dictation,
-                        foregroundColor: VColor.accent
+                        style: .scrolling,
+                        foregroundColor: VColor.textMuted,
+                        lineWidth: 2
                     )
-                    .frame(height: 24)
+                    .padding(.trailing, VSpacing.lg)
+                    .frame(height: 44)
                     .frame(maxWidth: .infinity)
 
+                    // Cancel: stop dictation and discard transcribed text
                     VIconButton(
-                        label: "Stop dictation",
-                        icon: VIcon.square.rawValue,
+                        label: "Cancel dictation",
+                        icon: VIcon.x.rawValue,
                         iconOnly: true,
-                        variant: .neutral,
+                        variant: .danger,
                         size: composerActionButtonSize,
-                        action: { (onDictateToggle ?? onMicrophoneToggle)() }
+                        action: {
+                            inputText = preDictationText
+                            preDictationText = ""
+                            (onDictateToggle ?? onMicrophoneToggle)()
+                        }
+                    )
+
+                    // Accept: stop dictation and keep transcribed text
+                    VIconButton(
+                        label: "Accept dictation",
+                        icon: VIcon.check.rawValue,
+                        iconOnly: true,
+                        variant: .primary,
+                        size: composerActionButtonSize,
+                        action: {
+                            preDictationText = ""
+                            (onDictateToggle ?? onMicrophoneToggle)()
+                        }
                     )
                 }
             }
+        }
+        .onReceive(VoiceInputManager.amplitudeSubject.receive(on: RunLoop.main)) { amp in
+            liveAmplitude = amp
         }
     }
 
@@ -544,38 +562,26 @@ struct ComposerView: View {
                     attachmentStrip
                 }
 
-            HStack(spacing: VSpacing.md) {
-                // Left section: state label + live transcription
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text(manager.stateLabel)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.voiceComposerTextSecondary)
-
-                    if manager.state == .listening, !manager.liveTranscription.isEmpty {
-                        Text(manager.liveTranscription)
-                            .font(VFont.body)
-                            .foregroundColor(VColor.voiceComposerTextPrimary)
-                            .lineLimit(2)
-                            .truncationMode(.tail)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                // Center: streaming waveform
+            HStack(spacing: VSpacing.sm) {
+                // Scrolling waveform — full width, inverse color
                 VStreamingWaveform(
                     amplitude: voiceConversationAmplitude(manager),
                     isActive: manager.state == .listening || manager.state == .speaking,
-                    style: .conversation,
-                    foregroundColor: voiceConversationWaveformColor(manager)
+                    style: .scrolling,
+                    foregroundColor: VColor.voiceComposerTextPrimary,
+                    lineWidth: 2
                 )
-                .frame(width: 60, height: 32)
+                .padding(.trailing, VSpacing.lg)
+                .frame(height: 44)
+                .frame(maxWidth: .infinity)
 
                 // Right: mute/unmute + end button
-                HStack(spacing: 2) {
+                HStack(spacing: VSpacing.xs) {
                     VIconButton(
                         label: manager.state == .listening ? "Mute" : "Unmute",
                         icon: manager.state == .listening ? VIcon.mic.rawValue : VIcon.micOff.rawValue,
                         iconOnly: true,
+                        variant: .neutral,
                         size: composerActionButtonSize,
                         action: { manager.toggleListening() }
                     )
@@ -583,7 +589,7 @@ struct ComposerView: View {
 
                     VIconButton(
                         label: "End voice mode",
-                        icon: VIcon.x.rawValue,
+                        icon: VIcon.phoneCall.rawValue,
                         iconOnly: true,
                         variant: .danger,
                         size: composerActionButtonSize,
@@ -603,11 +609,14 @@ struct ComposerView: View {
     }
 
     private func voiceConversationAmplitude(_ manager: VoiceModeManager) -> Float {
+        let raw: Float
         switch manager.state {
-        case .listening: return voiceService?.amplitude ?? 0
-        case .speaking: return voiceService?.speakingAmplitude ?? 0
-        default: return 0
+        case .listening: raw = voiceService?.amplitude ?? 0
+        case .speaking: raw = voiceService?.speakingAmplitude ?? 0
+        default: raw = 0
         }
+        // Amplify for more visible waveform spikes
+        return min(raw * 2.5, 1.0)
     }
 
     private func voiceConversationWaveformColor(_ manager: VoiceModeManager) -> Color {
@@ -627,4 +636,30 @@ struct ComposerView: View {
             && (!inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !pendingAttachments.isEmpty)
     }
 
+}
+
+// MARK: - Voice Mode Button
+
+/// Circle button with inverse colors for voice mode entry.
+private struct VoiceModeButton: View {
+    let size: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VIconView(.audioWaveform, size: 13)
+                .frame(width: 20, height: 20)
+                .foregroundColor(VColor.voiceComposerTextPrimary)
+        }
+        .buttonStyle(.plain)
+        .frame(width: size, height: size)
+        .background(
+            Circle()
+                .fill(VColor.voiceComposerBackground)
+                .frame(width: 28, height: 28)
+        )
+        .contentShape(Circle().size(width: size, height: size))
+        .pointerCursor()
+        .accessibilityLabel("Voice mode")
+    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -384,7 +384,7 @@ extension MainWindowView {
                     voiceModeManager.deactivate()
                 },
                 onDictateToggle: {
-                    (NSApp.delegate as? AppDelegate)?.voiceInput?.toggleRecording(origin: .chatComposer)
+                    AppDelegate.shared?.voiceInput?.toggleRecording(origin: .chatComposer)
                 },
                 onVoiceModeToggle: {
                     toggleVoiceMode()

--- a/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/PermissionPromptOverlay.swift
@@ -5,39 +5,27 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "PermissionPrompt")
 
-/// Lightweight overlay that explains why microphone/speech permissions are needed
-/// and provides action buttons to grant access or open System Settings.
+/// Overlay shown when microphone or speech recognition permissions have been denied,
+/// directing the user to System Settings.
 @MainActor
 final class PermissionPromptOverlay {
     private var panel: NSPanel?
 
-    /// Which permission(s) are currently denied, so the overlay can show the correct
-    /// guidance and open the right System Settings pane.
+    /// Which permission(s) are currently denied.
     enum DeniedPermission {
         case microphone
         case speechRecognition
         case both
     }
 
-    enum PromptKind {
-        /// Permission has never been requested — show explanation and "Grant Access" button.
-        case notDetermined(keyName: String)
-        /// Permission was denied — show guidance to System Settings.
-        case denied(keyName: String, deniedPermission: DeniedPermission)
-    }
-
-    /// Show the permission prompt overlay centered near the top of the screen.
-    /// - Parameters:
-    ///   - kind: Whether this is a first-ask or a denied state.
-    ///   - onGrantAccess: Called when the user taps "Grant Access" (notDetermined only).
-    ///   - onDismiss: Called when the user taps "Not Now" or the overlay is dismissed.
-    func show(kind: PromptKind, onGrantAccess: @escaping () -> Void, onDismiss: @escaping () -> Void) {
+    /// Show the denied-permission overlay centered on screen.
+    func show(kind: DeniedPermission, keyName: String, onDismiss: @escaping () -> Void) {
         dismiss()
 
         let width: CGFloat = 360
-        let height: CGFloat = 180
+        let height: CGFloat = 200
 
-        let contentView = buildContentView(kind: kind, onGrantAccess: onGrantAccess, onDismiss: onDismiss)
+        let contentView = buildContentView(deniedPermission: kind, keyName: keyName, onDismiss: onDismiss)
 
         let newPanel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: width, height: height),
@@ -52,6 +40,7 @@ final class PermissionPromptOverlay {
         newPanel.hasShadow = true
         newPanel.contentView = contentView
         newPanel.isMovableByWindowBackground = false
+        newPanel.appearance = NSAppearance(named: .darkAqua)
 
         if let screen = NSScreen.main {
             let screenFrame = screen.visibleFrame
@@ -63,7 +52,7 @@ final class PermissionPromptOverlay {
         self.panel = newPanel
         newPanel.orderFront(nil)
 
-        log.info("Showing permission prompt overlay: \(String(describing: kind))")
+        log.info("Showing denied-permission overlay: \(String(describing: kind))")
     }
 
     func dismiss() {
@@ -74,8 +63,8 @@ final class PermissionPromptOverlay {
     // MARK: - Content Building
 
     private func buildContentView(
-        kind: PromptKind,
-        onGrantAccess: @escaping () -> Void,
+        deniedPermission: DeniedPermission,
+        keyName: String,
         onDismiss: @escaping () -> Void
     ) -> NSView {
         let container = PermissionOverlayBackground()
@@ -84,18 +73,43 @@ final class PermissionPromptOverlay {
         let stack = NSStackView()
         stack.orientation = .vertical
         stack.alignment = .centerX
-        stack.spacing = 12
+        stack.spacing = VSpacing.md
         stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.edgeInsets = NSEdgeInsets(top: 20, left: 24, bottom: 20, right: 24)
+        stack.edgeInsets = NSEdgeInsets(top: VSpacing.xl, left: VSpacing.xl, bottom: VSpacing.xl, right: VSpacing.xl)
 
-        let (title, body, primaryTitle, primaryAction, secondaryTitle, secondaryAction) = content(
-            for: kind,
-            onGrantAccess: onGrantAccess,
-            onDismiss: onDismiss
-        )
+        let title: String
+        let body: String
+        let openSettings: () -> Void
+        let vicon: VIcon
+
+        switch deniedPermission {
+        case .microphone:
+            title = "Microphone Access Required"
+            body = "Dictation requires microphone access. Grant access in System Settings."
+            vicon = .micOff
+            openSettings = { PermissionManager.openMicrophoneSettings() }
+        case .speechRecognition:
+            title = "Speech Recognition Required"
+            body = "Dictation requires speech recognition access. Grant access in System Settings."
+            vicon = .audioWaveform
+            openSettings = { PermissionManager.openSpeechRecognitionSettings() }
+        case .both:
+            title = "Permissions Required"
+            body = "Dictation requires microphone and speech recognition access. Grant access in System Settings."
+            vicon = .micOff
+            openSettings = {
+                NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy")!)
+            }
+        }
 
         // Icon
-        let iconView = makeIconView(for: kind)
+        let imageView = NSImageView()
+        if let img = vicon.nsImage(size: 32) {
+            imageView.image = img
+            imageView.contentTintColor = NSColor(VColor.warning)
+        }
+        imageView.widthAnchor.constraint(equalToConstant: 32).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 32).isActive = true
 
         // Title
         let titleLabel = NSTextField(labelWithString: title)
@@ -114,15 +128,22 @@ final class PermissionPromptOverlay {
         // Buttons
         let buttonStack = NSStackView()
         buttonStack.orientation = .horizontal
-        buttonStack.spacing = 10
+        buttonStack.spacing = VSpacing.sm
 
-        let secondaryButton = makeButton(title: secondaryTitle, isPrimary: false, action: secondaryAction)
-        let primaryButton = makeButton(title: primaryTitle, isPrimary: true, action: primaryAction)
+        let dismissButton = makeButton(title: "Dismiss", isPrimary: false) { [weak self] in
+            self?.dismiss()
+            onDismiss()
+        }
+        let settingsButton = makeButton(title: "Open System Settings", isPrimary: true) { [weak self] in
+            self?.dismiss()
+            openSettings()
+            onDismiss()
+        }
 
-        buttonStack.addArrangedSubview(secondaryButton)
-        buttonStack.addArrangedSubview(primaryButton)
+        buttonStack.addArrangedSubview(dismissButton)
+        buttonStack.addArrangedSubview(settingsButton)
 
-        stack.addArrangedSubview(iconView)
+        stack.addArrangedSubview(imageView)
         stack.addArrangedSubview(titleLabel)
         stack.addArrangedSubview(bodyLabel)
         stack.addArrangedSubview(buttonStack)
@@ -138,108 +159,25 @@ final class PermissionPromptOverlay {
         return container
     }
 
-    private func content(
-        for kind: PromptKind,
-        onGrantAccess: @escaping () -> Void,
-        onDismiss: @escaping () -> Void
-    ) -> (title: String, body: String, primaryTitle: String, primaryAction: () -> Void, secondaryTitle: String, secondaryAction: () -> Void) {
-        switch kind {
-        case .notDetermined(let keyName):
-            return (
-                title: "Microphone Access Needed",
-                body: "Hold \(keyName) to dictate text or start a voice conversation. Vellum uses on-device speech recognition — nothing you say leaves your Mac.",
-                primaryTitle: "Grant Access",
-                primaryAction: { [weak self] in
-                    self?.dismiss()
-                    onGrantAccess()
-                },
-                secondaryTitle: "Not Now",
-                secondaryAction: { [weak self] in
-                    self?.dismiss()
-                    onDismiss()
-                }
-            )
-        case .denied(let keyName, let deniedPermission):
-            let title: String
-            let body: String
-            let openSettings: () -> Void
-
-            switch deniedPermission {
-            case .microphone:
-                title = "Microphone Access Required"
-                body = "Push-to-talk requires microphone access. You can grant access in System Settings. (Triggered by \(keyName) key)"
-                openSettings = { PermissionManager.openMicrophoneSettings() }
-            case .speechRecognition:
-                title = "Speech Recognition Required"
-                body = "Push-to-talk requires speech recognition access. You can grant access in System Settings. (Triggered by \(keyName) key)"
-                openSettings = { PermissionManager.openSpeechRecognitionSettings() }
-            case .both:
-                title = "Permissions Required"
-                body = "Push-to-talk requires microphone and speech recognition access. You can grant access in System Settings. (Triggered by \(keyName) key)"
-                openSettings = {
-                    NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy")!)
-                }
-            }
-
-            return (
-                title: title,
-                body: body,
-                primaryTitle: "Open System Settings",
-                primaryAction: { [weak self] in
-                    self?.dismiss()
-                    openSettings()
-                    onDismiss()
-                },
-                secondaryTitle: "Dismiss",
-                secondaryAction: { [weak self] in
-                    self?.dismiss()
-                    onDismiss()
-                }
-            )
-        }
-    }
-
-    private func makeIconView(for kind: PromptKind) -> NSView {
-        let vicon: VIcon
-        let color: NSColor
-
-        switch kind {
-        case .notDetermined:
-            vicon = .mic
-            color = .systemBlue
-        case .denied(_, let deniedPermission):
-            color = .systemOrange
-            switch deniedPermission {
-            case .microphone:
-                vicon = .micOff
-            case .speechRecognition:
-                vicon = .audioWaveform
-            case .both:
-                vicon = .micOff
-            }
-        }
-
-        let imageView = NSImageView()
-        if let img = vicon.nsImage(size: 36) {
-            imageView.image = img
-            imageView.contentTintColor = color
-        }
-        imageView.widthAnchor.constraint(equalToConstant: 36).isActive = true
-        imageView.heightAnchor.constraint(equalToConstant: 36).isActive = true
-        return imageView
-    }
-
     private func makeButton(title: String, isPrimary: Bool, action: @escaping () -> Void) -> NSButton {
         let button = OverlayActionButton(title: title, action: action)
-        button.bezelStyle = .rounded
-        button.font = NSFont.systemFont(ofSize: 12, weight: isPrimary ? .medium : .regular)
+        button.isBordered = false
+        button.wantsLayer = true
+        button.font = NSFont.systemFont(ofSize: 12, weight: .medium)
 
         if isPrimary {
             button.contentTintColor = .white
-            button.wantsLayer = true
             button.layer?.backgroundColor = NSColor(VColor.accent).cgColor
-            button.layer?.cornerRadius = VRadius.sm
+            button.layer?.cornerRadius = VRadius.md
+        } else {
+            button.contentTintColor = NSColor(VColor.textSecondary)
+            button.layer?.backgroundColor = NSColor(VColor.backgroundSubtle).cgColor
+            button.layer?.cornerRadius = VRadius.md
         }
+
+        let widthConstraint = button.widthAnchor.constraint(greaterThanOrEqualToConstant: 100)
+        let heightConstraint = button.heightAnchor.constraint(equalToConstant: 30)
+        NSLayoutConstraint.activate([widthConstraint, heightConstraint])
 
         return button
     }

--- a/clients/shared/DesignSystem/Components/Display/VStreamingWaveform.swift
+++ b/clients/shared/DesignSystem/Components/Display/VStreamingWaveform.swift
@@ -8,6 +8,32 @@ public enum WaveformStyle {
     case conversation
     /// Subtler bottom-aligned bars for inline recording strip.
     case dictation
+    /// Right-to-left scrolling amplitude history (like ChatGPT voice input).
+    case scrolling
+}
+
+// MARK: - Scrolling State
+
+/// Holds the amplitude sample history for the scrolling waveform style.
+/// Using a reference type so Canvas can append samples during draw without
+/// needing @State mutation (which isn't allowed inside Canvas closures).
+private final class ScrollingWaveformState {
+    var samples: [Float] = []
+    var lastSampleTime: TimeInterval = 0
+
+    func update(amplitude: Float, maxBars: Int, time: TimeInterval, sampleInterval: TimeInterval) {
+        guard time - lastSampleTime >= sampleInterval else { return }
+        lastSampleTime = time
+        samples.append(amplitude)
+        if samples.count > maxBars {
+            samples.removeFirst(samples.count - maxBars)
+        }
+    }
+
+    func reset() {
+        samples.removeAll()
+        lastSampleTime = 0
+    }
 }
 
 // MARK: - VStreamingWaveform
@@ -16,6 +42,9 @@ public enum WaveformStyle {
 ///
 /// Uses `Canvas` + `TimelineView(.animation)` for smooth 60fps rendering isolated from
 /// broader view invalidations.
+///
+/// In `.scrolling` style, new amplitude samples appear on the right and scroll left,
+/// building up a visual history of the audio input.
 public struct VStreamingWaveform: View {
     /// Audio amplitude, clamped to 0...1.
     public var amplitude: Float
@@ -25,10 +54,12 @@ public struct VStreamingWaveform: View {
     public var style: WaveformStyle
     /// Bar color.
     public var foregroundColor: Color
-    /// Number of bars to render.
+    /// Number of bars to render (ignored for `.scrolling` style, which fills available width).
     public var barCount: Int
     /// Width of each bar.
     public var lineWidth: CGFloat
+
+    @State private var scrollingState = ScrollingWaveformState()
 
     public init(
         amplitude: Float,
@@ -50,14 +81,94 @@ public struct VStreamingWaveform: View {
         TimelineView(.animation) { timeline in
             Canvas { context, size in
                 let date = timeline.date.timeIntervalSinceReferenceDate
-                draw(context: context, size: size, time: date)
+                if style == .scrolling {
+                    drawScrolling(context: context, size: size, time: date)
+                } else {
+                    draw(context: context, size: size, time: date)
+                }
+            }
+        }
+        .onChange(of: isActive) { _, active in
+            if !active {
+                scrollingState.reset()
             }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(isActive ? "Audio waveform, active" : "Audio waveform, inactive")
     }
 
-    // MARK: - Drawing
+    // MARK: - Scrolling Drawing
+
+    private func drawScrolling(context: GraphicsContext, size: CGSize, time: TimeInterval) {
+        let barSpacing: CGFloat = 2
+        let effectiveBarCount = max(1, Int(size.width / (lineWidth + barSpacing)))
+
+        // Push a new amplitude sample at ~30Hz
+        if isActive {
+            scrollingState.update(
+                amplitude: min(max(amplitude, 0), 1),
+                maxBars: effectiveBarCount,
+                time: time,
+                sampleInterval: 0.033
+            )
+        }
+
+        let samples = scrollingState.samples
+        guard !samples.isEmpty else {
+            // Draw baseline dots when no samples yet
+            drawScrollingBaseline(context: context, size: size, barCount: effectiveBarCount, barSpacing: barSpacing)
+            return
+        }
+
+        let maxBarHeight = size.height * 0.85
+        let minBarHeight = max(lineWidth, 2)
+        let cornerRadius = lineWidth / 2
+
+        // Draw bars right-aligned: newest sample on the right
+        let sampleCount = samples.count
+        for i in 0..<sampleCount {
+            let sampleValue = CGFloat(samples[i])
+            let barHeight = max(minBarHeight + sampleValue * (maxBarHeight - minBarHeight), minBarHeight)
+
+            // Position from the right
+            let barIndex = effectiveBarCount - sampleCount + i
+            guard barIndex >= 0 else { continue }
+            let x = CGFloat(barIndex) * (lineWidth + barSpacing)
+
+            // Centered vertically
+            let y = (size.height - barHeight) / 2
+            let barRect = CGRect(x: x, y: y, width: lineWidth, height: barHeight)
+            let path = Path(roundedRect: barRect, cornerRadius: cornerRadius)
+            context.fill(path, with: .color(foregroundColor))
+        }
+
+        // Draw faint baseline dots for unfilled positions
+        let filledStart = effectiveBarCount - sampleCount
+        if filledStart > 0 {
+            for i in 0..<filledStart {
+                let x = CGFloat(i) * (lineWidth + barSpacing)
+                let y = (size.height - minBarHeight) / 2
+                let barRect = CGRect(x: x, y: y, width: lineWidth, height: minBarHeight)
+                let path = Path(roundedRect: barRect, cornerRadius: cornerRadius)
+                context.fill(path, with: .color(foregroundColor.opacity(0.25)))
+            }
+        }
+    }
+
+    private func drawScrollingBaseline(context: GraphicsContext, size: CGSize, barCount: Int, barSpacing: CGFloat) {
+        let minBarHeight = max(lineWidth, 2)
+        let cornerRadius = lineWidth / 2
+
+        for i in 0..<barCount {
+            let x = CGFloat(i) * (lineWidth + barSpacing)
+            let y = (size.height - minBarHeight) / 2
+            let barRect = CGRect(x: x, y: y, width: lineWidth, height: minBarHeight)
+            let path = Path(roundedRect: barRect, cornerRadius: cornerRadius)
+            context.fill(path, with: .color(foregroundColor.opacity(0.25)))
+        }
+    }
+
+    // MARK: - Conversation / Dictation Drawing
 
     private func draw(context: GraphicsContext, size: CGSize, time: TimeInterval) {
         guard barCount > 0 else { return }
@@ -117,6 +228,18 @@ private struct WaveformPreviewContainer: View {
 
     var body: some View {
         VStack(spacing: VSpacing.xl) {
+            Text("Scrolling Style")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            VStreamingWaveform(
+                amplitude: amplitude,
+                isActive: isActive,
+                style: .scrolling,
+                foregroundColor: VColor.accent,
+                lineWidth: 2
+            )
+            .frame(height: 34)
+
             Text("Conversation Style")
                 .font(VFont.headline)
                 .foregroundColor(VColor.textPrimary)
@@ -163,5 +286,5 @@ private struct WaveformPreviewContainer: View {
         VColor.background.ignoresSafeArea()
         WaveformPreviewContainer()
     }
-    .frame(width: 300, height: 350)
+    .frame(width: 400, height: 450)
 }

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -5,6 +5,7 @@ public enum VIconButtonVariant {
     case primary
     case secondary
     case danger
+    case success
     case outlined
     case neutral
 }
@@ -65,7 +66,7 @@ public struct VIconButton: View {
 
     private var iconForegroundForVariant: Color {
         switch variant {
-        case .primary, .danger, .neutral:
+        case .primary, .danger, .success, .neutral:
             return .white
         case .ghost, .secondary, .outlined:
             return iconForegroundColor
@@ -148,6 +149,12 @@ public struct VIconButtonStyle: ButtonStyle {
             if isHovered { return VColor.buttonDangerHover }
             return VColor.buttonDanger
 
+        case .success:
+            guard isEnabled else { return VColor.buttonSuccessBg.opacity(0.5) }
+            if isPressed { return VColor.buttonSuccessBgPressed }
+            if isHovered { return VColor.buttonSuccessBgHover }
+            return VColor.buttonSuccessBg
+
         case .neutral:
             guard isEnabled else { return VColor.buttonNeutral.opacity(0.5) }
             if isPressed { return VColor.buttonNeutralPressed }
@@ -188,7 +195,7 @@ public struct VIconButtonStyle: ButtonStyle {
 
     private var borderColor: Color {
         switch variant {
-        case .primary, .danger, .neutral:
+        case .primary, .danger, .success, .neutral:
             return .clear
         case .outlined:
             return VColor.buttonSecondaryBorder

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -321,10 +321,10 @@ public enum VColor {
     public static let composerBackground = adaptiveColor(light: Moss._200, dark: Moss._700)
 
     // Voice composer — inverse/high-contrast tokens for voice mode
-    public static let voiceComposerBackground = adaptiveColor(light: Slate._900, dark: Slate._100)
+    public static let voiceComposerBackground = adaptiveColor(light: Slate._900, dark: Color(hex: 0xE8E6DA))
     public static let voiceComposerTextPrimary = adaptiveColor(light: .white, dark: Slate._900)
-    public static let voiceComposerTextSecondary = adaptiveColor(light: Slate._300, dark: Slate._600)
-    public static let voiceComposerControlBackground = adaptiveColor(light: Slate._800, dark: Slate._200)
+    public static let voiceComposerTextSecondary = adaptiveColor(light: Slate._300, dark: Slate._400)
+    public static let voiceComposerControlBackground = adaptiveColor(light: Slate._800, dark: Slate._800)
 
     // Microphone icon color
     public static let micIcon = adaptiveColor(light: Forest._500, dark: Moss._400)


### PR DESCRIPTION
## Summary
- Fix dictation button not working (AppDelegate.shared vs NSApp.delegate cast)
- Add scrolling right-to-left waveform style to VStreamingWaveform (like ChatGPT voice input)
- Redesign dictation inline UI: full-width scrolling waveform with cancel (X) and accept (checkmark) buttons
- Redesign voice mode composer: scrolling waveform with inverse colors (#E8E6DA background, dark content)
- Add VoiceModeButton with circular dark background
- Amplify audio amplitude for visible waveform bars (14x scaling, responsive EMA smoothing)
- Simplify PermissionPromptOverlay: remove unnecessary first-time prompt, style with VColor tokens
- Add success variant to VIconButton
- Update voice composer color tokens for proper dark mode contrast

## Test plan
- [ ] Click mic icon in composer — dictation starts, scrolling waveform animates as you speak
- [ ] Cancel (X) restores pre-dictation text, accept (checkmark) keeps transcribed text
- [ ] Voice mode shows scrolling waveform with dark content bars on light background
- [ ] Voice mode icon button has circular dark background with inverse icon
- [ ] Denied permission overlay appears styled in app theme
- [ ] Light mode: voice composer has dark background with white content
- [ ] Dark mode: voice composer has #E8E6DA background with dark content

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
