### PR TITLE
fix: correct stale comments for host_bash ask rule

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4313,7 +4313,7 @@ describe("bash network_mode=proxied — no special-casing", () => {
 
   test("proxied bash follows normal rules (auto-allowed by default rule)", async () => {
     // Proxied bash is no longer force-prompted — the default allow-bash rule
-    // prompts low/medium risk commands regardless of network_mode.
+    // auto-allows low/medium risk commands regardless of network_mode.
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -576,7 +576,7 @@ async function classifyRiskUncached(
 
       if (prog === "rm") {
         // Only downgrade rm of known safe workspace files for sandboxed bash.
-        // host_bash has a global allow rule that would auto-approve Medium-risk
+        // host_bash has a global ask rule that would prompt Medium-risk
         // commands, so rm on the host must always require explicit approval.
         if (toolName === "bash" && isRmOfKnownSafeFile(seg.args)) {
           maxRisk = RiskLevel.Medium;


### PR DESCRIPTION
Addresses review feedback from PR #14615.

- checker.ts: Updated comment from 'allow rule' to 'ask rule' to reflect the new host_bash default
- checker.test.ts: Fixed comment from 'prompts' to 'auto-allows' since the test is for sandboxed bash (not host_bash), which still has an allow rule
- trust.json migration: Verified existing backfillDefaults() already handles the renamed rule ID — old default:allow-host_bash-global is removed and replaced by default:ask-host_bash-global
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
