### PR TITLE
fix: always overwrite RUNTIME_HTTP_PORT on assistant switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -140,8 +140,8 @@ extension AppDelegate {
         if let assistant, !assistant.isRemote {
             let port = assistant.resolvedDaemonPort(environment: launchEnvironment)
             setenv("RUNTIME_HTTP_PORT", String(port), 1)
-        } else if launchEnvironment["RUNTIME_HTTP_PORT"] == nil {
-            setenv("RUNTIME_HTTP_PORT", "7821", 0)
+        } else {
+            setenv("RUNTIME_HTTP_PORT", "7821", 1)
         }
 
         // Start the keychain broker before the daemon so it is listening


### PR DESCRIPTION
Addresses review feedback from PR #14633. Changes the else-branch setenv to always overwrite RUNTIME_HTTP_PORT (flag 1 instead of 0) and removes the nil guard, preventing stale ports from persisting across assistant switches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
