### PR TITLE
M1: Use reason/reasonDescription in notification formatting

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1068,9 +1068,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.onToolCallsComplete = { [weak self, weak viewModel] toolCalls in
             guard let self, let service = self.activityNotificationService else { return }
             let sessionId = viewModel?.sessionId ?? ""
+            // Derive a human-friendly summary from the last tool call's reasonDescription
+            let summary: String
+            if let lastReason = toolCalls.last?.reasonDescription, !lastReason.isEmpty {
+                let capitalized = lastReason.prefix(1).uppercased() + lastReason.dropFirst()
+                summary = capitalized.count > 50 ? String(capitalized.prefix(47)) + "..." : String(capitalized)
+            } else {
+                let count = toolCalls.count
+                summary = "Completed \(count) action\(count == 1 ? "" : "s")"
+            }
             Task { @MainActor in
                 await service.notifySessionComplete(
-                    summary: "Tool execution completed",
+                    summary: summary,
                     steps: toolCalls.count,
                     toolCalls: toolCalls,
                     sessionId: sessionId

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -135,6 +135,12 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
 
         // Filter and format tool calls to be user-friendly
         let friendlyTools = toolCalls.compactMap { tc -> String? in
+            // Prefer the LLM-provided reasonDescription when available
+            if let reason = tc.reasonDescription, !reason.isEmpty {
+                let capitalized = reason.prefix(1).uppercased() + reason.dropFirst()
+                return String(capitalized)
+            }
+
             // Skip technical/internal tools that aren't user-facing
             let toolName = tc.toolName.lowercased()
             if toolName.contains("bash") || toolName.contains("command") {
@@ -216,6 +222,24 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
     /// Map technical tool names to user-friendly names
     private func friendlyToolName(_ toolName: String) -> String {
         switch toolName.lowercased() {
+        case "call_start":
+            return "Started call"
+        case "call_status":
+            return "Checked call"
+        case "call_end":
+            return "Ended call"
+        case "schedule_create":
+            return "Created schedule"
+        case "schedule_update":
+            return "Updated schedule"
+        case "schedule_delete":
+            return "Deleted schedule"
+        case "reminder_create":
+            return "Set reminder"
+        case "reminder_list":
+            return "Listed reminders"
+        case "reminder_cancel":
+            return "Cancelled reminder"
         case let name where name.contains("write"):
             return "Created file"
         case let name where name.contains("edit"):
@@ -233,7 +257,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         case let name where name.contains("type"):
             return "Typed text"
         default:
-            return toolName
+            return toolName.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
 }

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -133,6 +133,17 @@ public final class ToolConfirmationNotificationService {
             }
             return command.count > 200 ? String(command.prefix(197)) + "..." : command
         }
+        // For all other tools, prefer the human-readable reason
+        if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
+            let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
+            let preview = commandPreview(toolName: message.toolName, input: message.input)
+            if !preview.isEmpty {
+                let body = "\(capitalizedReason)\n\(preview)"
+                if body.count <= 200 { return body }
+                return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
+            }
+            return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
+        }
         let preview = commandPreview(toolName: message.toolName, input: message.input)
         if preview.count > 200 {
             return String(preview.prefix(197)) + "..."

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -136,11 +136,22 @@ public final class ToolConfirmationNotificationService {
         // For all other tools, prefer the human-readable reason
         if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
             let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
-            let preview = commandPreview(toolName: message.toolName, input: message.input)
+            // Filter out `reason` key so commandPreview doesn't duplicate it
+            let nonReasonInput = message.input.filter { $0.key != "reason" && $0.key != "reasoning" }
+            let preview = commandPreview(toolName: message.toolName, input: nonReasonInput)
             if !preview.isEmpty {
                 let body = "\(capitalizedReason)\n\(preview)"
                 if body.count <= 200 { return body }
-                return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
+                // Truncate reason first to preserve the target preview
+                let previewBudget = min(preview.count, 200)
+                let reasonBudget = 200 - previewBudget - 1 // 1 for newline
+                if reasonBudget >= 4 {
+                    let truncatedReason = String(capitalizedReason.prefix(reasonBudget - 3)) + "..."
+                    let truncatedBody = "\(truncatedReason)\n\(preview)"
+                    if truncatedBody.count <= 200 { return truncatedBody }
+                }
+                // Preview alone exceeds the limit — truncate it
+                return preview.count > 200 ? String(preview.prefix(197)) + "..." : preview
             }
             return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
         }


### PR DESCRIPTION
Use the LLM-provided reason fields in tool call notifications instead of raw tool names and UUIDs. Closes #14850.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
