### PR TITLE
docs: update remaining LAN pairing docs to reflect opt-in requirement

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -184,7 +184,7 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 ### iOS Gateway Networking
 - iOS connects to the assistant exclusively via the HTTP gateway
 - Pair via QR code (Settings → Connect on both devices); all pairings require Mac-side approval
-- LAN pairing works automatically when both devices are on the same network
+- LAN pairing is disabled by default for security. To enable, set `VELLUM_ENABLE_INSECURE_LAN_PAIRING=1` on the Mac; when enabled, the QR code includes the local gateway URL for direct LAN connections
 
 ### iOS Computer-Use
 - AXUIElement + CGEvent APIs are macOS-only (sandbox prevents on iOS)

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -93,7 +93,7 @@ Pair with a running assistant (local Mac or remote) via QR code. The iOS app con
 4. Tap **Approve Once** or **Always Allow** on the host
 5. The app auto-configures the gateway URL and bearer token
 
-The QR code uses a v4 payload with a one-time pairing secret (no bearer token in the QR). All pairings require Mac-side approval. Devices approved with "Always Allow" auto-approve on future pairings. LAN pairing works automatically when both devices are on the same network — the QR code includes the local gateway URL for direct LAN connections.
+The QR code uses a v4 payload with a one-time pairing secret (no bearer token in the QR). All pairings require Mac-side approval. Devices approved with "Always Allow" auto-approve on future pairings. LAN pairing is disabled by default for security. To enable, set `VELLUM_ENABLE_INSECURE_LAN_PAIRING=1` on the Mac; when enabled, the QR code includes the local gateway URL for direct LAN connections.
 
 **Note for simulator:** Keychain is unavailable for unsigned simulator builds. API keys and tokens are stored in `UserDefaults` instead, which works fine for development. On a real device, credentials are stored in the Keychain.
 


### PR DESCRIPTION
Updates clients/README.md and clients/ios/README.md to reflect that LAN pairing is disabled by default and requires VELLUM_ENABLE_INSECURE_LAN_PAIRING=1. This addresses the documentation drift flagged in PR #14846.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
