### PR TITLE
Fix SSL cert errors in proxied network mode without MITM

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -528,15 +528,13 @@ export function getSessionEnv(sessionId: ProxySessionId): ProxyEnvVars {
     NO_PROXY: "localhost,127.0.0.1,::1",
   };
 
-  if (managed.dataDir) {
+  // Only set cert env vars when the CA was actually initialized (MITM mode).
+  // Without this guard, NODE_EXTRA_CA_CERTS points to a nonexistent file
+  // when the proxy runs in pass-through mode (no credentials/MITM),
+  // causing Bun/BoringSSL to fail with SSL load errors.
+  if (managed.dataDir && managed.combinedCABundlePath) {
     env.NODE_EXTRA_CA_CERTS = getCAPath(managed.dataDir);
-    // Combined bundle lets non-Node clients (curl, Python, Go) trust
-    // the proxy CA alongside system roots via SSL_CERT_FILE.
-    // Only set when the bundle was actually created — pointing at a
-    // missing file would replace the system trust store with nothing.
-    if (managed.combinedCABundlePath) {
-      env.SSL_CERT_FILE = managed.combinedCABundlePath;
-    }
+    env.SSL_CERT_FILE = managed.combinedCABundlePath;
   }
 
   return env;


### PR DESCRIPTION
## Summary
- Fix SSL errors (`error:10000002:SSL routines:OPENSSL_internal:system library`) when the assistant runs proxied bash commands without MITM credentials
- `getSessionEnv()` was setting `NODE_EXTRA_CA_CERTS` to a nonexistent CA cert path in pass-through proxy mode — gate both cert env vars on `combinedCABundlePath` being set (only happens after MITM CA initialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
