### PR TITLE
fix: restore indentation on effort property in schema.ts

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -274,7 +274,7 @@ export const AssistantConfigSchema = z
       .int("maxTokens must be an integer")
       .positive("maxTokens must be a positive integer")
       .default(16000),
-effort: EffortSchema,
+    effort: EffortSchema,
     thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
     contextWindow: ContextWindowConfigSchema.default(
       ContextWindowConfigSchema.parse({}),


### PR DESCRIPTION
Fixes broken indentation on `effort: EffortSchema` line in the config schema object, introduced when `maxToolUseTurns` was removed in #14851.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
