### PR TITLE
Fix slash commands not intercepted via POST /v1/messages

### DIFF
--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for slash command interception in the POST /v1/messages handler.
+ *
+ * Validates that:
+ * - Built-in slash commands (/status, /model, /commands) are intercepted and
+ *   do NOT trigger the agent loop.
+ * - Skill slash commands are rewritten and forwarded to the agent loop with
+ *   preactivated skill IDs.
+ * - Regular messages pass through to the agent loop unchanged.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+import type { SlashResolution } from "../daemon/session-slash.js";
+
+const resolveSlashMock = mock(
+  (_content: string, _context?: unknown): SlashResolution => ({
+    kind: "passthrough",
+    content: _content,
+  }),
+);
+
+mock.module("../daemon/session-slash.js", () => ({
+  resolveSlash: resolveSlashMock,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "claude-opus-4-6",
+    provider: "anthropic",
+    apiKeys: { anthropic: "test-key" },
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+  }),
+}));
+
+const addMessageMock = mock(
+  async (
+    _conversationId: string,
+    role: string,
+    _content?: string,
+    _metadata?: Record<string, unknown>,
+  ) => ({
+    id: role === "user" ? "persisted-user-id" : "persisted-assistant-id",
+  }),
+);
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../memory/conversation-key-store.js", () => ({
+  getOrCreateConversation: () => ({ conversationId: "conv-slash-test" }),
+  getConversationByKey: () => null,
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  getAttachmentsByIds: () => [],
+}));
+
+mock.module("../runtime/guardian-reply-router.js", () => ({
+  routeGuardianReply: async () => ({
+    consumed: false,
+    decisionApplied: false,
+    type: "not_consumed",
+  }),
+}));
+
+mock.module("../memory/canonical-guardian-store.js", () => ({
+  createCanonicalGuardianRequest: () => ({
+    id: "canonical-id",
+    requestCode: "ABC123",
+  }),
+  generateCanonicalRequestCode: () => "ABC123",
+  listPendingCanonicalGuardianRequestsByDestinationConversation: () => [],
+  listCanonicalGuardianRequests: () => [],
+  listPendingRequestsByConversationScope: () => [],
+}));
+
+mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
+  bridgeConfirmationRequestToGuardian: async () => undefined,
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => addMessageMock(conversationId, role, content, metadata),
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  resolveLocalIpcTrustContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  }),
+}));
+
+mock.module("../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  }),
+  withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
+    ...(ctx as Record<string, unknown>),
+    sourceChannel,
+  }),
+}));
+
+import type { AuthContext } from "../runtime/auth/types.js";
+import { handleSendMessage } from "../runtime/routes/conversation-routes.js";
+
+const testAuthContext: AuthContext = {
+  subject: "actor:self:test-guardian",
+  principalType: "actor",
+  assistantId: "self",
+  actorPrincipalId: "test-guardian",
+  scopeProfile: "actor_client_v1",
+  scopes: new Set([
+    "chat.read",
+    "chat.write",
+    "approval.read",
+    "approval.write",
+    "settings.read",
+    "settings.write",
+    "attachments.read",
+    "attachments.write",
+    "calls.read",
+    "calls.write",
+    "feature_flags.read",
+    "feature_flags.write",
+  ]),
+  policyEpoch: 1,
+};
+
+function makeSession() {
+  const persistUserMessage = mock(
+    async (_content: string, _attachments: unknown[], _requestId?: string) =>
+      "persisted-user-id",
+  );
+  const runAgentLoop = mock(
+    async (
+      _content: string,
+      _messageId: string,
+      _onEvent: unknown,
+      _options?: unknown,
+    ) => undefined,
+  );
+  const setPreactivatedSkillIds = mock((_ids: string[] | undefined) => {});
+  const events: unknown[] = [];
+  const messages: unknown[] = [];
+  const session = {
+    setTrustContext: () => {},
+    updateClient: (_fn: unknown, _b: boolean) => {},
+    emitConfirmationStateChanged: () => {},
+    emitActivityState: () => {},
+    setTurnChannelContext: () => {},
+    setTurnInterfaceContext: () => {},
+    isProcessing: () => false,
+    hasAnyPendingConfirmation: () => false,
+    denyAllPendingConfirmations: () => {},
+    enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+    persistUserMessage,
+    runAgentLoop,
+    setPreactivatedSkillIds,
+    getMessages: () => messages,
+    assistantId: "self",
+    trustContext: undefined,
+    hasPendingConfirmation: () => false,
+    usageStats: {
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.05,
+    },
+  } as unknown as import("../daemon/session.js").Session;
+  return {
+    session,
+    persistUserMessage,
+    runAgentLoop,
+    setPreactivatedSkillIds,
+    events,
+    messages,
+  };
+}
+
+function makeRequest(content: string) {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      conversationKey: "slash-test-key",
+      content,
+      sourceChannel: "vellum",
+      interface: "macos",
+    }),
+  });
+}
+
+function makeDeps(session: import("../daemon/session.js").Session) {
+  return {
+    sendMessageDeps: {
+      getOrCreateSession: async () => session,
+      assistantEventHub: { publish: async () => {} } as any,
+      resolveAttachments: () => [],
+    },
+  };
+}
+
+describe("handleSendMessage slash command interception", () => {
+  beforeEach(() => {
+    resolveSlashMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  test("intercepts built-in slash commands (unknown kind) without calling agent loop", async () => {
+    resolveSlashMock.mockReturnValue({
+      kind: "unknown",
+      message: "Session Status\n\nContext: 5%",
+    });
+
+    const { session, persistUserMessage, runAgentLoop } = makeSession();
+    const res = await handleSendMessage(
+      makeRequest("/status"),
+      makeDeps(session),
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      accepted: boolean;
+      messageId?: string;
+    };
+    expect(body.accepted).toBe(true);
+    expect(body.messageId).toBe("persisted-user-id");
+
+    // Slash command was resolved
+    expect(resolveSlashMock).toHaveBeenCalledTimes(1);
+    expect(resolveSlashMock.mock.calls[0][0]).toBe("/status");
+
+    // User + assistant messages persisted, but agent loop NOT called
+    expect(addMessageMock).toHaveBeenCalledTimes(2);
+    const roles = addMessageMock.mock.calls.map((c) => c[1]);
+    expect(roles).toEqual(["user", "assistant"]);
+    expect(persistUserMessage).not.toHaveBeenCalled();
+    expect(runAgentLoop).not.toHaveBeenCalled();
+  });
+
+  test("rewrites skill slash commands and calls agent loop with rewritten content", async () => {
+    resolveSlashMock.mockReturnValue({
+      kind: "rewritten",
+      content: "[SKILL INVOCATION] Run the weather skill",
+      skillId: "weather",
+    });
+
+    const {
+      session,
+      persistUserMessage,
+      runAgentLoop,
+      setPreactivatedSkillIds,
+    } = makeSession();
+    const res = await handleSendMessage(
+      makeRequest("/weather San Diego"),
+      makeDeps(session),
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+
+    // Slash command was resolved
+    expect(resolveSlashMock).toHaveBeenCalledTimes(1);
+
+    // Skill IDs preactivated
+    expect(setPreactivatedSkillIds).toHaveBeenCalledWith(["weather"]);
+
+    // Agent loop called with rewritten content
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+    const loopContent = runAgentLoop.mock.calls[0][0];
+    expect(loopContent).toBe("[SKILL INVOCATION] Run the weather skill");
+
+    // addMessage NOT called (agent loop handles persistence)
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("passes regular messages through to agent loop unchanged", async () => {
+    resolveSlashMock.mockReturnValue({
+      kind: "passthrough",
+      content: "hello there",
+    });
+
+    const {
+      session,
+      persistUserMessage,
+      runAgentLoop,
+      setPreactivatedSkillIds,
+    } = makeSession();
+    const res = await handleSendMessage(
+      makeRequest("hello there"),
+      makeDeps(session),
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+
+    // Slash command was resolved but passed through
+    expect(resolveSlashMock).toHaveBeenCalledTimes(1);
+
+    // No skill preactivation
+    expect(setPreactivatedSkillIds).not.toHaveBeenCalled();
+
+    // Agent loop called with original content
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+    const loopContent = runAgentLoop.mock.calls[0][0];
+    expect(loopContent).toBe("hello there");
+  });
+
+  test("passes SlashContext with session usage stats", async () => {
+    resolveSlashMock.mockReturnValue({
+      kind: "passthrough",
+      content: "test",
+    });
+
+    const { session } = makeSession();
+    await handleSendMessage(
+      makeRequest("test"),
+      makeDeps(session),
+      testAuthContext,
+    );
+
+    expect(resolveSlashMock).toHaveBeenCalledTimes(1);
+    const context = resolveSlashMock.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(context).toMatchObject({
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCost: 0.05,
+      model: "claude-opus-4-6",
+      provider: "anthropic",
+      maxInputTokens: 200000,
+    });
+  });
+});

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -95,6 +95,30 @@ mock.module("../memory/conversation-crud.js", () => ({
     content: string,
     metadata?: Record<string, unknown>,
   ) => addMessageMock(conversationId, role, content, metadata),
+  getMessages: () => [],
+  provenanceFromTrustContext: (ctx: unknown) =>
+    ctx
+      ? { provenanceTrustClass: (ctx as Record<string, unknown>).trustClass }
+      : { provenanceTrustClass: "unknown" },
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+}));
+
+mock.module("../daemon/session-process.js", () => ({
+  buildModelInfoEvent: () => ({
+    type: "model_info",
+    model: "claude-opus-4-6",
+    provider: "anthropic",
+    configuredProviders: ["anthropic", "ollama"],
+  }),
+  isModelSlashCommand: (content: string) => {
+    const trimmed = content.trim();
+    return (
+      trimmed === "/model" ||
+      trimmed === "/models" ||
+      trimmed.startsWith("/model ")
+    );
+  },
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -196,6 +196,7 @@ function makeSession() {
     persistUserMessage,
     runAgentLoop,
     setPreactivatedSkillIds,
+    drainQueue: async () => {},
     getMessages: () => messages,
     assistantId: "self",
     trustContext: undefined,

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -188,6 +188,7 @@ function makeSession() {
     emitActivityState: () => {},
     setTurnChannelContext: () => {},
     setTurnInterfaceContext: () => {},
+    ensureActorScopedHistory: async () => {},
     isProcessing: () => false,
     hasAnyPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -36,7 +36,11 @@ import type {
 import type { MessageQueue } from "./session-queue-manager.js";
 import type { QueueDrainReason } from "./session-queue-manager.js";
 import type { TrustContext } from "./session-runtime-assembly.js";
-import { resolveSlash, type SlashContext } from "./session-slash.js";
+import {
+  isProviderShortcut,
+  resolveSlash,
+  type SlashContext,
+} from "./session-slash.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
@@ -326,7 +330,10 @@ export async function drainQueue(
 
       // Emit fresh model info before the text delta so the client has
       // up-to-date configuredProviders when rendering /model or /models UI.
-      if (isModelSlashCommand(next.content)) {
+      if (
+        isModelSlashCommand(next.content) ||
+        isProviderShortcut(next.content)
+      ) {
         next.onEvent(buildModelInfoEvent());
       }
       next.onEvent({ type: "assistant_text_delta", text: slashResult.message });
@@ -676,7 +683,7 @@ export async function processMessage(
 
     // Emit fresh model info before the text delta so the client has
     // up-to-date configuredProviders when rendering /model or /models UI.
-    if (isModelSlashCommand(content)) {
+    if (isModelSlashCommand(content) || isProviderShortcut(content)) {
       onEvent(buildModelInfoEvent());
     }
     onEvent({ type: "assistant_text_delta", text: slashResult.message });

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -43,7 +43,7 @@ import { resolveVerificationSessionIntent } from "./verification-session-intent.
 const log = getLogger("session-process");
 
 /** Build a model_info event with fresh config data. */
-function buildModelInfoEvent(): ServerMessage {
+export function buildModelInfoEvent(): ServerMessage {
   const config = getConfig();
   const configured = Object.keys(config.apiKeys).filter(
     (k) => !!config.apiKeys[k],
@@ -58,7 +58,7 @@ function buildModelInfoEvent(): ServerMessage {
 }
 
 /** True when the trimmed content is a /model or /models slash command. */
-function isModelSlashCommand(content: string): boolean {
+export function isModelSlashCommand(content: string): boolean {
   const trimmed = content.trim();
   return (
     trimmed === "/model" ||

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -121,6 +121,13 @@ const PROVIDER_MODEL_SHORTCUTS: Record<
   },
 };
 
+/** True when the trimmed content matches a provider shortcut like /opus, /gpt4, etc. */
+export function isProviderShortcut(content: string): boolean {
+  const match = content.trim().match(/^\/([a-z0-9-]+)(\s|$)/i);
+  if (!match) return false;
+  return match[1].toLowerCase() in PROVIDER_MODEL_SHORTCUTS;
+}
+
 /** Reverse lookup: model ID → provider, derived from PROVIDER_MODEL_SHORTCUTS. */
 export const MODEL_TO_PROVIDER: Record<string, string> = Object.fromEntries(
   Object.values(PROVIDER_MODEL_SHORTCUTS).map(({ model, provider }) => [

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -14,8 +14,10 @@ import {
   parseChannelId,
   parseInterfaceId,
 } from "../../channels/types.js";
+import { getConfig } from "../../config/loader.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { resolveSlash, type SlashContext } from "../../daemon/session-slash.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
@@ -670,16 +672,93 @@ export async function handleSendMessage(
     userMessageInterface: sourceInterface,
     assistantMessageInterface: sourceInterface,
   });
+
+  // Resolve slash commands before persisting or running the agent loop.
+  const rawContent = content ?? "";
+  const config = getConfig();
+  const slashContext: SlashContext = {
+    messageCount: session.getMessages().length,
+    inputTokens: session.usageStats.inputTokens,
+    outputTokens: session.usageStats.outputTokens,
+    maxInputTokens: config.contextWindow.maxInputTokens,
+    model: config.model,
+    provider: config.provider,
+    estimatedCost: session.usageStats.estimatedCost,
+  };
+  const slashResult = resolveSlash(rawContent, slashContext);
+
+  if (slashResult.kind === "unknown") {
+    const channelMeta = {
+      userMessageChannel: sourceChannel,
+      assistantMessageChannel: sourceChannel,
+      userMessageInterface: sourceInterface,
+      assistantMessageInterface: sourceInterface,
+    };
+    const userMsg = createUserMessage(rawContent, attachments);
+    const persisted = await addMessage(
+      mapping.conversationId,
+      "user",
+      JSON.stringify(userMsg.content),
+      channelMeta,
+    );
+    session.getMessages().push(userMsg);
+
+    // Emit fresh model info before the text delta so the client has
+    // up-to-date configuredProviders when rendering /model or /models UI.
+    const trimmed = rawContent.trim();
+    if (
+      trimmed === "/model" ||
+      trimmed === "/models" ||
+      trimmed.startsWith("/model ")
+    ) {
+      const configured = Object.keys(config.apiKeys).filter(
+        (k) => !!config.apiKeys[k],
+      );
+      if (!configured.includes("ollama")) configured.push("ollama");
+      onEvent({
+        type: "model_info",
+        model: config.model,
+        provider: config.provider,
+        configuredProviders: configured,
+      });
+    }
+
+    const assistantMsg = createAssistantMessage(slashResult.message);
+    await addMessage(
+      mapping.conversationId,
+      "assistant",
+      JSON.stringify(assistantMsg.content),
+      channelMeta,
+    );
+    session.getMessages().push(assistantMsg);
+
+    onEvent({ type: "assistant_text_delta", text: slashResult.message });
+    onEvent({
+      type: "message_complete",
+      sessionId: mapping.conversationId,
+    });
+
+    return Response.json(
+      { accepted: true, messageId: persisted.id },
+      { status: 202 },
+    );
+  }
+
+  const resolvedContent = slashResult.content;
+  if (slashResult.kind === "rewritten") {
+    session.setPreactivatedSkillIds([slashResult.skillId]);
+  }
+
   const requestId = crypto.randomUUID();
   const messageId = await session.persistUserMessage(
-    content ?? "",
+    resolvedContent,
     attachments,
     requestId,
   );
 
   // Fire-and-forget the agent loop; events flow to the hub via onEvent.
   session
-    .runAgentLoop(content ?? "", messageId, onEvent, {
+    .runAgentLoop(resolvedContent, messageId, onEvent, {
       isInteractive: isInteractiveInterface,
       isUserMessage: true,
     })

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -704,55 +704,63 @@ export async function handleSendMessage(
   const slashResult = resolveSlash(rawContent, slashContext);
 
   if (slashResult.kind === "unknown") {
-    const provenance = provenanceFromTrustContext(session.trustContext);
-    const channelMeta = {
-      ...provenance,
-      userMessageChannel: sourceChannel,
-      assistantMessageChannel: sourceChannel,
-      userMessageInterface: sourceInterface,
-      assistantMessageInterface: sourceInterface,
-    };
-    const userMsg = createUserMessage(rawContent, attachments);
-    const persisted = await addMessage(
-      mapping.conversationId,
-      "user",
-      JSON.stringify(userMsg.content),
-      channelMeta,
-    );
-    session.getMessages().push(userMsg);
+    session.processing = true;
+    try {
+      const provenance = provenanceFromTrustContext(session.trustContext);
+      const channelMeta = {
+        ...provenance,
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      };
+      const userMsg = createUserMessage(rawContent, attachments);
+      const persisted = await addMessage(
+        mapping.conversationId,
+        "user",
+        JSON.stringify(userMsg.content),
+        channelMeta,
+      );
+      session.getMessages().push(userMsg);
 
-    const assistantMsg = createAssistantMessage(slashResult.message);
-    await addMessage(
-      mapping.conversationId,
-      "assistant",
-      JSON.stringify(assistantMsg.content),
-      channelMeta,
-    );
-    session.getMessages().push(assistantMsg);
+      const assistantMsg = createAssistantMessage(slashResult.message);
+      await addMessage(
+        mapping.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        channelMeta,
+      );
+      session.getMessages().push(assistantMsg);
 
-    setConversationOriginChannelIfUnset(mapping.conversationId, sourceChannel);
-    setConversationOriginInterfaceIfUnset(
-      mapping.conversationId,
-      sourceInterface,
-    );
+      setConversationOriginChannelIfUnset(
+        mapping.conversationId,
+        sourceChannel,
+      );
+      setConversationOriginInterfaceIfUnset(
+        mapping.conversationId,
+        sourceInterface,
+      );
 
-    // Emit fresh model info before the text delta so the client has
-    // up-to-date configuredProviders when rendering /model, /models,
-    // and provider shortcut commands (/gpt4, /opus, etc.).
-    if (isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)) {
-      onEvent(buildModelInfoEvent());
+      // Emit fresh model info before the text delta so the client has
+      // up-to-date configuredProviders when rendering /model, /models,
+      // and provider shortcut commands (/gpt4, /opus, etc.).
+      if (isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)) {
+        onEvent(buildModelInfoEvent());
+      }
+
+      onEvent({ type: "assistant_text_delta", text: slashResult.message });
+      onEvent({
+        type: "message_complete",
+        sessionId: mapping.conversationId,
+      });
+
+      return Response.json(
+        { accepted: true, messageId: persisted.id },
+        { status: 202 },
+      );
+    } finally {
+      session.processing = false;
     }
-
-    onEvent({ type: "assistant_text_delta", text: slashResult.message });
-    onEvent({
-      type: "message_complete",
-      sessionId: mapping.conversationId,
-    });
-
-    return Response.json(
-      { accepted: true, messageId: persisted.id },
-      { status: 202 },
-    );
   }
 
   const resolvedContent = slashResult.content;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -21,7 +21,11 @@ import {
   buildModelInfoEvent,
   isModelSlashCommand,
 } from "../../daemon/session-process.js";
-import { resolveSlash, type SlashContext } from "../../daemon/session-slash.js";
+import {
+  isProviderShortcut,
+  resolveSlash,
+  type SlashContext,
+} from "../../daemon/session-slash.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
@@ -733,8 +737,9 @@ export async function handleSendMessage(
     );
 
     // Emit fresh model info before the text delta so the client has
-    // up-to-date configuredProviders when rendering /model or /models UI.
-    if (isModelSlashCommand(rawContent)) {
+    // up-to-date configuredProviders when rendering /model, /models,
+    // and provider shortcut commands (/gpt4, /opus, etc.).
+    if (isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)) {
       onEvent(buildModelInfoEvent());
     }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -683,6 +683,8 @@ export async function handleSendMessage(
     assistantMessageInterface: sourceInterface,
   });
 
+  await session.ensureActorScopedHistory();
+
   // Resolve slash commands before persisting or running the agent loop.
   const rawContent = content ?? "";
   const config = getConfig();
@@ -764,7 +766,7 @@ export async function handleSendMessage(
   } catch (err) {
     // Reset preactivated skill IDs so a stale activation doesn't leak
     // into the next message if persistence fails.
-    session.setPreactivatedSkillIds([]);
+    session.setPreactivatedSkillIds(undefined);
     throw err;
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -17,6 +17,10 @@ import {
 import { getConfig } from "../../config/loader.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
+import {
+  buildModelInfoEvent,
+  isModelSlashCommand,
+} from "../../daemon/session-process.js";
 import { resolveSlash, type SlashContext } from "../../daemon/session-slash.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
@@ -24,7 +28,13 @@ import {
   generateCanonicalRequestCode,
   listPendingRequestsByConversationScope,
 } from "../../memory/canonical-guardian-store.js";
-import { addMessage, getMessages } from "../../memory/conversation-crud.js";
+import {
+  addMessage,
+  getMessages,
+  provenanceFromTrustContext,
+  setConversationOriginChannelIfUnset,
+  setConversationOriginInterfaceIfUnset,
+} from "../../memory/conversation-crud.js";
 import {
   getConversationByKey,
   getOrCreateConversation,
@@ -688,7 +698,9 @@ export async function handleSendMessage(
   const slashResult = resolveSlash(rawContent, slashContext);
 
   if (slashResult.kind === "unknown") {
+    const provenance = provenanceFromTrustContext(session.trustContext);
     const channelMeta = {
+      ...provenance,
       userMessageChannel: sourceChannel,
       assistantMessageChannel: sourceChannel,
       userMessageInterface: sourceInterface,
@@ -703,26 +715,6 @@ export async function handleSendMessage(
     );
     session.getMessages().push(userMsg);
 
-    // Emit fresh model info before the text delta so the client has
-    // up-to-date configuredProviders when rendering /model or /models UI.
-    const trimmed = rawContent.trim();
-    if (
-      trimmed === "/model" ||
-      trimmed === "/models" ||
-      trimmed.startsWith("/model ")
-    ) {
-      const configured = Object.keys(config.apiKeys).filter(
-        (k) => !!config.apiKeys[k],
-      );
-      if (!configured.includes("ollama")) configured.push("ollama");
-      onEvent({
-        type: "model_info",
-        model: config.model,
-        provider: config.provider,
-        configuredProviders: configured,
-      });
-    }
-
     const assistantMsg = createAssistantMessage(slashResult.message);
     await addMessage(
       mapping.conversationId,
@@ -731,6 +723,18 @@ export async function handleSendMessage(
       channelMeta,
     );
     session.getMessages().push(assistantMsg);
+
+    setConversationOriginChannelIfUnset(mapping.conversationId, sourceChannel);
+    setConversationOriginInterfaceIfUnset(
+      mapping.conversationId,
+      sourceInterface,
+    );
+
+    // Emit fresh model info before the text delta so the client has
+    // up-to-date configuredProviders when rendering /model or /models UI.
+    if (isModelSlashCommand(rawContent)) {
+      onEvent(buildModelInfoEvent());
+    }
 
     onEvent({ type: "assistant_text_delta", text: slashResult.message });
     onEvent({
@@ -749,12 +753,20 @@ export async function handleSendMessage(
     session.setPreactivatedSkillIds([slashResult.skillId]);
   }
 
-  const requestId = crypto.randomUUID();
-  const messageId = await session.persistUserMessage(
-    resolvedContent,
-    attachments,
-    requestId,
-  );
+  let messageId: string;
+  try {
+    const requestId = crypto.randomUUID();
+    messageId = await session.persistUserMessage(
+      resolvedContent,
+      attachments,
+      requestId,
+    );
+  } catch (err) {
+    // Reset preactivated skill IDs so a stale activation doesn't leak
+    // into the next message if persistence fails.
+    session.setPreactivatedSkillIds([]);
+    throw err;
+  }
 
   // Fire-and-forget the agent loop; events flow to the hub via onEvent.
   session

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -760,6 +760,7 @@ export async function handleSendMessage(
       );
     } finally {
       session.processing = false;
+      session.drainQueue().catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary
- The `handleSendMessage` handler in `conversation-routes.ts` (the `POST /v1/messages` path used by the macOS app) was missing `resolveSlash()` — all slash commands (`/status`, `/model`, `/pair`, `/commands`, provider shortcuts, and skill invocations) went straight to the LLM instead of being intercepted
- The old IPC path that had proper slash interception is dead code (exported but never imported)
- Adds `resolveSlash()` handling for all three resolution kinds: `unknown` (built-in commands), `rewritten` (skill commands), and `passthrough` (regular messages)

## Test plan
- [x] Added unit tests covering all three slash resolution paths
- [ ] Manual: send `/status` from macOS app — should show session status, not LLM response
- [ ] Manual: send `/model` from macOS app — should show current model info
- [ ] Manual: send regular message — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
