### PR TITLE
fix: restore interactive permission prompts for desktop HTTP sessions

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -557,13 +557,14 @@ export async function handleSendMessage(
   }
 
   const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
-  // Desktop/CLI interfaces have an SSE client that can display permission
-  // prompts. Channel interfaces (telegram, slack, etc.) route approvals
-  // through the guardian system and have no interactive prompter UI.
+  // Desktop, CLI, and web interfaces have an SSE client that can display
+  // permission prompts. Channel interfaces (telegram, slack, etc.) route
+  // approvals through the guardian system and have no interactive prompter UI.
   const isInteractiveInterface =
     sourceInterface === "macos" ||
     sourceInterface === "ios" ||
-    sourceInterface === "cli";
+    sourceInterface === "cli" ||
+    sourceInterface === "vellum";
   // Wire sendToClient to the SSE hub so all subsystems (prompter, surface
   // resolver, notifiers, trace emitter) can reach the HTTP client.  The
   // IPC socket removal (PR #14431) left sendToClient as a no-op; this

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -557,11 +557,18 @@ export async function handleSendMessage(
   }
 
   const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
+  // Desktop/CLI interfaces have an SSE client that can display permission
+  // prompts. Channel interfaces (telegram, slack, etc.) route approvals
+  // through the guardian system and have no interactive prompter UI.
+  const isInteractiveInterface =
+    sourceInterface === "macos" ||
+    sourceInterface === "ios" ||
+    sourceInterface === "cli";
   // Wire sendToClient to the SSE hub so all subsystems (prompter, surface
   // resolver, notifiers, trace emitter) can reach the HTTP client.  The
   // IPC socket removal (PR #14431) left sendToClient as a no-op; this
   // restores the delivery path using the SSE hub instead.
-  session.updateClient(onEvent, true);
+  session.updateClient(onEvent, !isInteractiveInterface);
 
   const attachments = hasAttachments
     ? smDeps.resolveAttachments(attachmentIds)
@@ -648,7 +655,7 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
       },
-      { isInteractive: false },
+      { isInteractive: isInteractiveInterface },
     );
     if (result.rejected) {
       return httpError(
@@ -677,10 +684,9 @@ export async function handleSendMessage(
   );
 
   // Fire-and-forget the agent loop; events flow to the hub via onEvent.
-  // Mark non-interactive so conflict clarification doesn't block the turn.
   session
     .runAgentLoop(content ?? "", messageId, onEvent, {
-      isInteractive: false,
+      isInteractive: isInteractiveInterface,
       isUserMessage: true,
     })
     .catch((err) => {

--- a/worktrees/fix-apps-list-http/clients/.build
+++ b/worktrees/fix-apps-list-http/clients/.build
@@ -1,0 +1,1 @@
+/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/fix-apps-list-http/clients/.build

--- a/worktrees/no-tools-json/clients/.build
+++ b/worktrees/no-tools-json/clients/.build
@@ -1,0 +1,1 @@
+/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/no-tools-json/clients/.build

--- a/worktrees/remove-vellum-extensions/clients/.build
+++ b/worktrees/remove-vellum-extensions/clients/.build
@@ -1,0 +1,1 @@
+/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/remove-vellum-extensions/clients/.build

--- a/worktrees/weather-skill-cli/clients/.build
+++ b/worktrees/weather-skill-cli/clients/.build
@@ -1,0 +1,1 @@
+/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/weather-skill-cli/clients/.build


### PR DESCRIPTION
## Summary
- Desktop/CLI clients connecting via HTTP/SSE were silently auto-approving all tool permissions (host_bash, Write File, etc.) because `hasNoClient=true` and `isInteractive: false` were hardcoded for all HTTP sessions
- Root cause: PR #14431 (IPC socket removal) left `hasNoClient=true` for all HTTP sessions, and commit a60f752ed preserved this when wiring sendToClient to the SSE hub
- Fix: derive interactivity from `sourceInterface` — `macos`/`ios`/`cli` are interactive (can show permission prompts), channel interfaces remain non-interactive

## Original prompt
please fix the bug according to the fixes you suggested in this thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
