### PR TITLE
M1: Contract + feature flag + IPC types for tool preview lifecycle

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -112,6 +112,14 @@
       "label": "Sentry Testing",
       "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
+    },
+    {
+      "id": "tool-preview-lifecycle",
+      "scope": "assistant",
+      "key": "feature_flags.tool-preview-lifecycle.enabled",
+      "label": "Tool Preview Lifecycle",
+      "description": "Emit tool_use_preview_start events during LLM tool input streaming for immediate UI feedback",
+      "defaultEnabled": false
     }
   ]
 }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -95,11 +95,20 @@ export interface ToolOutputChunk {
   subToolId?: string;
 }
 
+export interface ToolUsePreviewStart {
+  type: "tool_use_preview_start";
+  toolUseId: string;
+  toolName: string;
+  sessionId?: string;
+}
+
 export interface ToolInputDelta {
   type: "tool_input_delta";
   toolName: string;
   content: string;
   sessionId?: string;
+  /** The tool_use block ID for client-side correlation. */
+  toolUseId?: string;
 }
 
 export interface ToolResult {
@@ -117,6 +126,8 @@ export interface ToolResult {
   sessionId?: string;
   /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot). */
   imageData?: string;
+  /** The tool_use block ID for client-side correlation. */
+  toolUseId?: string;
 }
 
 export interface ConfirmationRequest {
@@ -325,6 +336,7 @@ export type _MessagesServerMessages =
   | AssistantTextDelta
   | AssistantThinkingDelta
   | ToolUseStart
+  | ToolUsePreviewStart
   | ToolOutputChunk
   | ToolInputDelta
   | ToolResult

--- a/clients/shared/IPC/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/IPC/Generated/GeneratedAPITypes.swift
@@ -4783,12 +4783,15 @@ public struct IPCToolInputDelta: Codable, Sendable {
     public let toolName: String
     public let content: String
     public let sessionId: String?
+    /// The tool_use block ID for client-side correlation.
+    public let toolUseId: String?
 
-    public init(type: String, toolName: String, content: String, sessionId: String? = nil) {
+    public init(type: String, toolName: String, content: String, sessionId: String? = nil, toolUseId: String? = nil) {
         self.type = type
         self.toolName = toolName
         self.content = content
         self.sessionId = sessionId
+        self.toolUseId = toolUseId
     }
 }
 
@@ -4946,8 +4949,10 @@ public struct IPCToolResult: Codable, Sendable {
     public let sessionId: String?
     /// Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot).
     public let imageData: String?
+    /// The tool_use block ID for client-side correlation.
+    public let toolUseId: String?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: IPCToolResultDiff? = nil, status: String? = nil, sessionId: String? = nil, imageData: String? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: IPCToolResultDiff? = nil, status: String? = nil, sessionId: String? = nil, imageData: String? = nil, toolUseId: String? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4956,6 +4961,7 @@ public struct IPCToolResult: Codable, Sendable {
         self.status = status
         self.sessionId = sessionId
         self.imageData = imageData
+        self.toolUseId = toolUseId
     }
 }
 
@@ -4970,6 +4976,20 @@ public struct IPCToolResultDiff: Codable, Sendable {
         self.oldContent = oldContent
         self.newContent = newContent
         self.isNewFile = isNewFile
+    }
+}
+
+public struct IPCToolUsePreviewStart: Codable, Sendable {
+    public let type: String
+    public let toolUseId: String
+    public let toolName: String
+    public let sessionId: String?
+
+    public init(type: String, toolUseId: String, toolName: String, sessionId: String? = nil) {
+        self.type = type
+        self.toolUseId = toolUseId
+        self.toolName = toolName
+        self.sessionId = sessionId
     }
 }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1477,6 +1477,10 @@ public typealias WatchCompleteRequestMessage = IPCWatchCompleteRequest
 /// Backed by generated `IPCToolUseStart`.
 public typealias ToolUseStartMessage = IPCToolUseStart
 
+/// Tool use preview started (emitted during LLM tool input streaming for immediate UI feedback).
+/// Backed by generated `IPCToolUsePreviewStart`.
+public typealias ToolUsePreviewStartMessage = IPCToolUsePreviewStart
+
 /// Streaming tool input delta (e.g. partial JSON as tool input is generated).
 /// Backed by generated `IPCToolInputDelta`.
 public typealias ToolInputDeltaMessage = IPCToolInputDelta
@@ -2157,6 +2161,7 @@ public enum ServerMessage: Decodable, Sendable {
     case skillsDraftResponse(SkillsDraftResponseMessage)
     case suggestionResponse(SuggestionResponseMessage)
     case toolUseStart(ToolUseStartMessage)
+    case toolUsePreviewStart(ToolUsePreviewStartMessage)
     case toolInputDelta(ToolInputDeltaMessage)
     case toolOutputChunk(ToolOutputChunkMessage)
     case toolResult(ToolResultMessage)
@@ -2418,6 +2423,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "tool_use_start":
             let message = try ToolUseStartMessage(from: decoder)
             self = .toolUseStart(message)
+        case "tool_use_preview_start":
+            let message = try ToolUsePreviewStartMessage(from: decoder)
+            self = .toolUsePreviewStart(message)
         case "tool_input_delta":
             let message = try ToolInputDeltaMessage(from: decoder)
             self = .toolInputDelta(message)

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -112,6 +112,14 @@
       "label": "Sentry Testing",
       "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
+    },
+    {
+      "id": "tool-preview-lifecycle",
+      "scope": "assistant",
+      "key": "feature_flags.tool-preview-lifecycle.enabled",
+      "label": "Tool Preview Lifecycle",
+      "description": "Emit tool_use_preview_start events during LLM tool input streaming for immediate UI feedback",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -112,6 +112,14 @@
       "label": "Sentry Testing",
       "description": "Show the Sentry Testing tab in Settings for triggering test crash reports and error events",
       "defaultEnabled": false
+    },
+    {
+      "id": "tool-preview-lifecycle",
+      "scope": "assistant",
+      "key": "feature_flags.tool_preview_lifecycle.enabled",
+      "label": "Tool Preview Lifecycle",
+      "description": "Emit tool_use_preview_start events during LLM tool input streaming for immediate UI feedback",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -116,7 +116,7 @@
     {
       "id": "tool-preview-lifecycle",
       "scope": "assistant",
-      "key": "feature_flags.tool_preview_lifecycle.enabled",
+      "key": "feature_flags.tool-preview-lifecycle.enabled",
       "label": "Tool Preview Lifecycle",
       "description": "Emit tool_use_preview_start events during LLM tool input streaming for immediate UI feedback",
       "defaultEnabled": false


### PR DESCRIPTION
Add foundational types for tool preview lifecycle: tool_use_preview_start message, toolUseId on tool_input_delta and tool_result, feature flag, and Swift IPC types. Part of #14856.

## Changes

- **`assistant/src/daemon/message-types/messages.ts`**: Added `ToolUsePreviewStart` interface, added optional `toolUseId` to `ToolInputDelta` and `ToolResult`, added `ToolUsePreviewStart` to `_MessagesServerMessages` union
- **`meta/feature-flags/feature-flag-registry.json`**: Added `tool-preview-lifecycle` feature flag (default off)
- **`clients/shared/IPC/Generated/GeneratedAPITypes.swift`**: Added `IPCToolUsePreviewStart` struct, added `toolUseId` to `IPCToolInputDelta` and `IPCToolResult`
- **`clients/shared/IPC/IPCMessages.swift`**: Added `ToolUsePreviewStartMessage` typealias, `toolUsePreviewStart` case to `ServerMessage` enum, decoder case for `tool_use_preview_start`

All new fields are optional for backward compatibility.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
