### PR TITLE
Human-friendly tool call notifications

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1068,15 +1068,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.onToolCallsComplete = { [weak self, weak viewModel] toolCalls in
             guard let self, let service = self.activityNotificationService else { return }
             let sessionId = viewModel?.sessionId ?? ""
-            // Derive a human-friendly summary from the last tool call's reasonDescription
-            let summary: String
-            if let lastReason = toolCalls.last?.reasonDescription, !lastReason.isEmpty {
-                let capitalized = lastReason.prefix(1).uppercased() + lastReason.dropFirst()
-                summary = capitalized.count > 50 ? String(capitalized.prefix(47)) + "..." : String(capitalized)
-            } else {
-                let count = toolCalls.count
-                summary = "Completed \(count) action\(count == 1 ? "" : "s")"
-            }
+            // Pass empty summary so ActivityNotificationService derives the title
+            // from the tool calls themselves (friendly name + target for single tool,
+            // count-based for multiple tools)
+            let summary = ""
             Task { @MainActor in
                 await service.notifySessionComplete(
                     summary: summary,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1068,9 +1068,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         viewModel.onToolCallsComplete = { [weak self, weak viewModel] toolCalls in
             guard let self, let service = self.activityNotificationService else { return }
             let sessionId = viewModel?.sessionId ?? ""
+            // Derive a human-friendly summary from the last tool call's reasonDescription
+            let summary: String
+            if let lastReason = toolCalls.last?.reasonDescription, !lastReason.isEmpty {
+                let capitalized = lastReason.prefix(1).uppercased() + lastReason.dropFirst()
+                summary = capitalized.count > 50 ? String(capitalized.prefix(47)) + "..." : String(capitalized)
+            } else {
+                let count = toolCalls.count
+                summary = "Completed \(count) action\(count == 1 ? "" : "s")"
+            }
             Task { @MainActor in
                 await service.notifySessionComplete(
-                    summary: "Tool execution completed",
+                    summary: summary,
                     steps: toolCalls.count,
                     toolCalls: toolCalls,
                     sessionId: sessionId

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -62,7 +62,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
 
         // Format notification content
         let content = UNMutableNotificationContent()
-        content.title = formatTitle(summary: summary, steps: steps)
+        content.title = formatTitle(summary: summary, steps: steps, toolCalls: toolCalls)
         content.body = formatBody(toolCalls: toolCalls)
         content.categoryIdentifier = "ACTIVITY_COMPLETE"
         content.sound = .default
@@ -115,16 +115,33 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
 
     // MARK: - Private Helpers
 
-    private func formatTitle(summary: String, steps: Int) -> String {
+    private func formatTitle(summary: String, steps: Int, toolCalls: [ToolCallData]) -> String {
         // Use the summary if it's meaningful (not empty and not just "Task completed")
         let cleanSummary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
         if !cleanSummary.isEmpty && cleanSummary.lowercased() != "task completed" {
             return cleanSummary
         }
 
+        // For single tool, show the friendly action as the title
+        if toolCalls.count == 1, let tc = toolCalls.first {
+            let toolName = tc.toolName.lowercased()
+            if toolName.contains("bash") || toolName.contains("command") {
+                if !tc.inputSummary.isEmpty {
+                    let cmd = tc.inputSummary.count > 40 ? String(tc.inputSummary.prefix(37)) + "..." : tc.inputSummary
+                    return "Ran command: \(cmd)"
+                }
+                return "Ran command"
+            }
+            let friendlyName = friendlyToolName(tc.toolName)
+            if !tc.inputSummary.isEmpty && tc.inputSummary.count < 40 && !tc.inputSummary.contains("--") {
+                return "\(friendlyName): \(tc.inputSummary)"
+            }
+            return friendlyName
+        }
+
         // Fallback to step count
-        let stepWord = steps == 1 ? "step" : "steps"
-        return "Task completed (\(steps) \(stepWord))"
+        let count = toolCalls.isEmpty ? steps : toolCalls.count
+        return "Completed \(count) action\(count == 1 ? "" : "s")"
     }
 
     private func formatBody(toolCalls: [ToolCallData]) -> String {
@@ -134,15 +151,16 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         }
 
         // Filter and format tool calls to be user-friendly.
-        // For body text, show the target detail (tool name + input) rather than the
-        // reasonDescription, since the title already shows the reason. For multi-tool
-        // notifications where only some have reasons, use the reason as the label.
+        // For single-tool notifications, the title shows the tool action so the body
+        // shows the reason. For multi-tool notifications, use reasons as labels.
         let isSingleWithReason = toolCalls.count == 1
             && toolCalls.first?.reasonDescription?.isEmpty == false
+        if isSingleWithReason, let reason = toolCalls.first?.reasonDescription, !reason.isEmpty {
+            let capitalized = reason.prefix(1).uppercased() + reason.dropFirst()
+            return String(capitalized)
+        }
         let friendlyTools = toolCalls.compactMap { tc -> String? in
-            // For single-tool notifications where the title already shows the reason,
-            // use the target detail (friendly name + input) for the body instead
-            if !isSingleWithReason, let reason = tc.reasonDescription, !reason.isEmpty {
+            if let reason = tc.reasonDescription, !reason.isEmpty {
                 let capitalized = reason.prefix(1).uppercased() + reason.dropFirst()
                 return String(capitalized)
             }
@@ -154,8 +172,8 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
                 if let action = extractBashAction(from: tc.inputSummary) {
                     return action
                 }
-                // Show the raw command if it's short enough
-                if !tc.inputSummary.isEmpty && tc.inputSummary.count < 50 {
+                // Show the command, let macOS truncate if needed
+                if !tc.inputSummary.isEmpty {
                     return "Ran command: \(tc.inputSummary)"
                 }
                 return "Ran command"

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -133,10 +133,16 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
             return "Your task has finished successfully."
         }
 
-        // Filter and format tool calls to be user-friendly
+        // Filter and format tool calls to be user-friendly.
+        // For body text, show the target detail (tool name + input) rather than the
+        // reasonDescription, since the title already shows the reason. For multi-tool
+        // notifications where only some have reasons, use the reason as the label.
+        let isSingleWithReason = toolCalls.count == 1
+            && toolCalls.first?.reasonDescription?.isEmpty == false
         let friendlyTools = toolCalls.compactMap { tc -> String? in
-            // Prefer the LLM-provided reasonDescription when available
-            if let reason = tc.reasonDescription, !reason.isEmpty {
+            // For single-tool notifications where the title already shows the reason,
+            // use the target detail (friendly name + input) for the body instead
+            if !isSingleWithReason, let reason = tc.reasonDescription, !reason.isEmpty {
                 let capitalized = reason.prefix(1).uppercased() + reason.dropFirst()
                 return String(capitalized)
             }
@@ -145,7 +151,14 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
             let toolName = tc.toolName.lowercased()
             if toolName.contains("bash") || toolName.contains("command") {
                 // For bash commands, try to extract what was done
-                return extractBashAction(from: tc.inputSummary)
+                if let action = extractBashAction(from: tc.inputSummary) {
+                    return action
+                }
+                // Show the raw command if it's short enough
+                if !tc.inputSummary.isEmpty && tc.inputSummary.count < 50 {
+                    return "Ran command: \(tc.inputSummary)"
+                }
+                return "Ran command"
             }
 
             // Map tool names to friendly descriptions

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -135,6 +135,12 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
 
         // Filter and format tool calls to be user-friendly
         let friendlyTools = toolCalls.compactMap { tc -> String? in
+            // Prefer the LLM-provided reasonDescription when available
+            if let reason = tc.reasonDescription, !reason.isEmpty {
+                let capitalized = reason.prefix(1).uppercased() + reason.dropFirst()
+                return String(capitalized)
+            }
+
             // Skip technical/internal tools that aren't user-facing
             let toolName = tc.toolName.lowercased()
             if toolName.contains("bash") || toolName.contains("command") {
@@ -216,6 +222,24 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
     /// Map technical tool names to user-friendly names
     private func friendlyToolName(_ toolName: String) -> String {
         switch toolName.lowercased() {
+        case "call_start":
+            return "Started call"
+        case "call_status":
+            return "Checked call"
+        case "call_end":
+            return "Ended call"
+        case "schedule_create":
+            return "Created schedule"
+        case "schedule_update":
+            return "Updated schedule"
+        case "schedule_delete":
+            return "Deleted schedule"
+        case "reminder_create":
+            return "Set reminder"
+        case "reminder_list":
+            return "Listed reminders"
+        case "reminder_cancel":
+            return "Cancelled reminder"
         case let name where name.contains("write"):
             return "Created file"
         case let name where name.contains("edit"):
@@ -233,7 +257,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         case let name where name.contains("type"):
             return "Typed text"
         default:
-            return toolName
+            return toolName.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
 }

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -133,6 +133,28 @@ public final class ToolConfirmationNotificationService {
             }
             return command.count > 200 ? String(command.prefix(197)) + "..." : command
         }
+        // For all other tools, prefer the human-readable reason
+        if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
+            let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
+            // Filter out `reason` key so commandPreview doesn't duplicate it
+            let nonReasonInput = message.input.filter { $0.key != "reason" && $0.key != "reasoning" }
+            let preview = commandPreview(toolName: message.toolName, input: nonReasonInput)
+            if !preview.isEmpty {
+                let body = "\(capitalizedReason)\n\(preview)"
+                if body.count <= 200 { return body }
+                // Truncate reason first to preserve the target preview
+                let previewBudget = min(preview.count, 200)
+                let reasonBudget = 200 - previewBudget - 1 // 1 for newline
+                if reasonBudget >= 4 {
+                    let truncatedReason = String(capitalizedReason.prefix(reasonBudget - 3)) + "..."
+                    let truncatedBody = "\(truncatedReason)\n\(preview)"
+                    if truncatedBody.count <= 200 { return truncatedBody }
+                }
+                // Preview alone exceeds the limit — truncate it
+                return preview.count > 200 ? String(preview.prefix(197)) + "..." : preview
+            }
+            return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
+        }
         let preview = commandPreview(toolName: message.toolName, input: message.input)
         if preview.count > 200 {
             return String(preview.prefix(197)) + "..."


### PR DESCRIPTION
## Summary
Make macOS tool call notifications more legible and human-friendly by using the LLM-provided `reason`/`reasonDescription` fields instead of raw tool names and UUIDs.

- Use `reasonDescription` as the primary notification text in completion notifications
- Use `reason` from tool input for all confirmation notifications (not just bash)
- Derive contextual summary title from tool calls instead of hardcoded "Tool execution completed"
- Add missing friendly name mappings and humanize unknown tool names

## Milestone PRs (merged into feature branch)
- #14852: M1: Use reason/reasonDescription in notification formatting

## Project issue
Closes #14849

## Test plan
- [ ] Trigger a tool call that requires permission (e.g., `call_status`) while app is in background — notification should show the LLM's reason text instead of raw tool name + UUID
- [ ] Trigger a completion notification — title should show last action's reason or "Completed N actions" instead of "Tool execution completed"
- [ ] Verify bash/host_bash confirmation notifications still show both reason and command preview
- [ ] Verify unknown tool names are humanized (underscores replaced, capitalized) instead of shown raw

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
