### PR TITLE
M2: Anthropic provider — emit preview-start and toolUseId on deltas

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -635,6 +635,7 @@ export class AnthropicProvider implements Provider {
 
         // Track which tool is currently streaming so we can attribute inputJson deltas.
         let currentStreamingToolName: string | undefined;
+        let currentStreamingToolUseId: string | undefined;
         let accumulatedInputJson = "";
         let lastInputJsonEmitMs = 0;
         let pendingInputJsonFlush: ReturnType<typeof setTimeout> | undefined;
@@ -664,8 +665,14 @@ export class AnthropicProvider implements Provider {
             event.content_block.type === "tool_use"
           ) {
             currentStreamingToolName = event.content_block.name;
+            currentStreamingToolUseId = event.content_block.id;
             accumulatedInputJson = "";
             lastInputJsonEmitMs = 0;
+            onEvent?.({
+              type: "tool_use_preview_start",
+              toolUseId: event.content_block.id,
+              toolName: event.content_block.name,
+            });
           }
           if (event.type === "content_block_stop") {
             if (pendingInputJsonFlush) {
@@ -676,10 +683,12 @@ export class AnthropicProvider implements Provider {
               onEvent?.({
                 type: "input_json_delta",
                 toolName: currentStreamingToolName,
+                toolUseId: currentStreamingToolUseId!,
                 accumulatedJson: accumulatedInputJson,
               });
             }
             currentStreamingToolName = undefined;
+            currentStreamingToolUseId = undefined;
             accumulatedInputJson = "";
           }
         });
@@ -697,10 +706,12 @@ export class AnthropicProvider implements Provider {
             onEvent?.({
               type: "input_json_delta",
               toolName: currentStreamingToolName,
+              toolUseId: currentStreamingToolUseId!,
               accumulatedJson: accumulatedInputJson,
             });
           } else if (!pendingInputJsonFlush) {
             const toolName = currentStreamingToolName;
+            const toolUseId = currentStreamingToolUseId!;
             pendingInputJsonFlush = setTimeout(() => {
               pendingInputJsonFlush = undefined;
               lastInputJsonEmitMs = Date.now();
@@ -708,6 +719,7 @@ export class AnthropicProvider implements Provider {
                 onEvent?.({
                   type: "input_json_delta",
                   toolName,
+                  toolUseId,
                   accumulatedJson: accumulatedInputJson,
                 });
               }

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -95,7 +95,13 @@ export interface ProviderResponse {
 export type ProviderEvent =
   | { type: "text_delta"; text: string }
   | { type: "thinking_delta"; thinking: string }
-  | { type: "input_json_delta"; toolName: string; accumulatedJson: string };
+  | { type: "tool_use_preview_start"; toolUseId: string; toolName: string }
+  | {
+      type: "input_json_delta";
+      toolName: string;
+      toolUseId: string;
+      accumulatedJson: string;
+    };
 
 export interface SendMessageConfig {
   model?: string;


### PR DESCRIPTION
Emit tool_use_preview_start on content_block_start for tool_use, and include toolUseId on all input_json_delta events. Part of #14856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
