### PR TITLE
M1: Add collect usage data toggle to ImproveExperienceStepView

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -450,19 +450,43 @@ extension AppDelegate {
     func checkAndApplyPrivacyFlag() {
         Task {
             do {
-                let flags = try await daemonClient.getFeatureFlags()
-                let collectUsageData = flags
-                    .first(where: { $0.key == "feature_flags.collect-usage-data.enabled" })
-                    .map { $0.enabled }
-                    ?? true
-                // Persist so MetricKitManager can check this flag synchronously
-                // during the startup window on the next launch, regardless of
-                // whether the user has visited the Privacy settings tab.
-                UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
-                if !collectUsageData {
-                    // Route through sentrySerialQueue to prevent races with
-                    // concurrent MetricKit captures or manual report sends.
-                    MetricKitManager.closeSentry()
+                let featureFlagKey = "feature_flags.collect-usage-data.enabled"
+
+                // Check if the user explicitly set the privacy preference during
+                // onboarding (before the daemon was available). If so, push that
+                // choice TO the daemon so it persists server-side, rather than
+                // letting the daemon's default (true) silently overwrite the
+                // user's opt-out.
+                if let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
+                    let flags = try await daemonClient.getFeatureFlags()
+                    let daemonValue = flags
+                        .first(where: { $0.key == featureFlagKey })
+                        .map { $0.enabled }
+                        ?? true
+
+                    if onboardingValue != daemonValue {
+                        try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                    }
+
+                    if !onboardingValue {
+                        MetricKitManager.closeSentry()
+                    }
+                } else {
+                    // No local preference set — use the daemon's value as before.
+                    let flags = try await daemonClient.getFeatureFlags()
+                    let collectUsageData = flags
+                        .first(where: { $0.key == featureFlagKey })
+                        .map { $0.enabled }
+                        ?? true
+                    // Persist so MetricKitManager can check this flag synchronously
+                    // during the startup window on the next launch, regardless of
+                    // whether the user has visited the Privacy settings tab.
+                    UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
+                    if !collectUsageData {
+                        // Route through sentrySerialQueue to prevent races with
+                        // concurrent MetricKit captures or manual report sends.
+                        MetricKitManager.closeSentry()
+                    }
                 }
             } catch {
                 // Flag check is best-effort; Sentry stays active when the flag

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -460,6 +460,19 @@ extension AppDelegate {
                 // UserDefaults key always non-nil and blocking daemon sync.
                 if UserDefaults.standard.bool(forKey: "collectUsageDataExplicitlySet"),
                    let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
+                    // Clear the explicit-set flag so subsequent reconnects
+                    // resume daemon-as-source-of-truth behavior.
+                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+
+                    // Always apply Sentry state locally first, regardless of
+                    // whether the daemon sync succeeds — the user's explicit
+                    // choice must take effect immediately.
+                    if !onboardingValue {
+                        MetricKitManager.closeSentry()
+                    }
+
+                    // Best-effort sync to daemon; failure is tolerable because
+                    // the local preference is already applied above.
                     let flags = try await daemonClient.getFeatureFlags()
                     let daemonValue = flags
                         .first(where: { $0.key == featureFlagKey })
@@ -468,14 +481,6 @@ extension AppDelegate {
 
                     if onboardingValue != daemonValue {
                         try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
-                    }
-
-                    // Clear the explicit-set flag so subsequent reconnects
-                    // resume daemon-as-source-of-truth behavior.
-                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
-
-                    if !onboardingValue {
-                        MetricKitManager.closeSentry()
                     }
                 } else {
                     // No explicit user interaction — use the daemon's value

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -452,12 +452,14 @@ extension AppDelegate {
             do {
                 let featureFlagKey = "feature_flags.collect-usage-data.enabled"
 
-                // Check if the user explicitly set the privacy preference during
-                // onboarding (before the daemon was available). If so, push that
-                // choice TO the daemon so it persists server-side, rather than
-                // letting the daemon's default (true) silently overwrite the
-                // user's opt-out.
-                if let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
+                // Check if the user explicitly interacted with the privacy
+                // toggle during onboarding. The `collectUsageDataExplicitlySet`
+                // flag is only written when the user actually touches the
+                // toggle, NOT when the onAppear block sets the default value.
+                // This prevents the auto-written default from making the
+                // UserDefaults key always non-nil and blocking daemon sync.
+                if UserDefaults.standard.bool(forKey: "collectUsageDataExplicitlySet"),
+                   let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
                     let flags = try await daemonClient.getFeatureFlags()
                     let daemonValue = flags
                         .first(where: { $0.key == featureFlagKey })
@@ -468,11 +470,16 @@ extension AppDelegate {
                         try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
                     }
 
+                    // Clear the explicit-set flag so subsequent reconnects
+                    // resume daemon-as-source-of-truth behavior.
+                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+
                     if !onboardingValue {
                         MetricKitManager.closeSentry()
                     }
                 } else {
-                    // No local preference set — use the daemon's value as before.
+                    // No explicit user interaction — use the daemon's value
+                    // as the source of truth.
                     let flags = try await daemonClient.getFeatureFlags()
                     let collectUsageData = flags
                         .first(where: { $0.key == featureFlagKey })

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -37,6 +37,7 @@ struct ImproveExperienceStepView: View {
                     set: { newValue in
                         collectUsageData = newValue
                         UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
+                        UserDefaults.standard.set(true, forKey: "collectUsageDataExplicitlySet")
                     }
                 ))
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -7,6 +7,7 @@ struct ImproveExperienceStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
     @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     var body: some View {
@@ -17,7 +18,7 @@ struct ImproveExperienceStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
+        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
             .font(VFont.onboardingSubtitle)
             .foregroundColor(VColor.textSecondary)
             .multilineTextAlignment(.center)
@@ -25,23 +26,34 @@ struct ImproveExperienceStepView: View {
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
 
-        HStack {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+        VStack(spacing: VSpacing.md) {
+            HStack {
+                Text("Collect usage data")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                VToggle(isOn: Binding(
+                    get: { collectUsageData },
+                    set: { newValue in
+                        collectUsageData = newValue
+                        UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
+                    }
+                ))
+            }
+
+            HStack {
                 Text("Share performance metrics")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
-                Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                Spacer()
+                VToggle(isOn: Binding(
+                    get: { sharePerformanceMetrics },
+                    set: { newValue in
+                        sharePerformanceMetrics = newValue
+                        UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                    }
+                ))
             }
-            Spacer()
-            VToggle(isOn: Binding(
-                get: { sharePerformanceMetrics },
-                set: { newValue in
-                    sharePerformanceMetrics = newValue
-                    UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
-                }
-            ))
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.top, VSpacing.xl)
@@ -72,6 +84,9 @@ struct ImproveExperienceStepView: View {
         .offset(y: showContent ? 0 : 12)
         .onAppear {
             // Opt in by default during onboarding, but preserve any existing choice
+            if UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
+                UserDefaults.standard.set(true, forKey: "collectUsageDataEnabled")
+            }
             if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
                 UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
             }


### PR DESCRIPTION
Add a Collect usage data toggle (opted in by default) to the onboarding improve experience step. Update subtitle text and simplify toggle rows to show only titles. Closes #14874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
