### PR TITLE
M4: Daemon handlers — emit IPC preview-start + activity state + toolUseId

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -281,6 +281,7 @@ export interface AssistantActivityState {
     | "thinking_delta"
     | "first_text_delta"
     | "tool_use_start"
+    | "preview_start"
     | "tool_result_received"
     | "confirmation_requested"
     | "confirmation_resolved"

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -13,6 +13,8 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import {
   addMessage,
   getMessageById,
@@ -304,6 +306,36 @@ export function handleToolUse(
   });
 }
 
+export function handleToolUsePreviewStart(
+  _state: EventHandlerState,
+  deps: EventHandlerDeps,
+  event: Extract<AgentEvent, { type: "tool_use_preview_start" }>,
+): void {
+  const config = getConfig();
+  if (
+    !isAssistantFeatureFlagEnabled(
+      "feature_flags.tool-preview-lifecycle.enabled",
+      config,
+    )
+  ) {
+    return;
+  }
+  deps.onEvent({
+    type: "tool_use_preview_start",
+    toolUseId: event.toolUseId,
+    toolName: event.toolName,
+    sessionId: deps.ctx.conversationId,
+  });
+  const statusText = `Preparing ${friendlyToolName(event.toolName)}...`;
+  deps.ctx.emitActivityState(
+    "tool_running",
+    "preview_start",
+    "assistant_turn",
+    deps.reqId,
+    statusText,
+  );
+}
+
 export function handleToolOutputChunk(
   _state: EventHandlerState,
   deps: EventHandlerDeps,
@@ -396,6 +428,7 @@ export function handleInputJsonDelta(
     toolName: event.toolName,
     content,
     sessionId: deps.ctx.conversationId,
+    toolUseId: event.toolUseId,
   });
 }
 
@@ -420,6 +453,7 @@ export function handleToolResult(
     status: event.status,
     sessionId: deps.ctx.conversationId,
     imageData: imageBlock?.source.data,
+    toolUseId: event.toolUseId,
   });
   state.pendingToolResults.set(event.toolUseId, {
     content: event.content,
@@ -780,6 +814,9 @@ export async function dispatchAgentEvent(
       break;
     case "tool_use":
       handleToolUse(state, deps, event);
+      break;
+    case "tool_use_preview_start":
+      handleToolUsePreviewStart(state, deps, event);
       break;
     case "tool_output_chunk":
       handleToolOutputChunk(state, deps, event);

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -226,6 +226,7 @@ export interface AgentLoopSessionContext {
       | "thinking_delta"
       | "first_text_delta"
       | "tool_use_start"
+      | "preview_start"
       | "tool_result_received"
       | "confirmation_requested"
       | "confirmation_resolved"

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -131,7 +131,8 @@ export interface ProcessSessionContext {
       | "confirmation_resolved"
       | "message_complete"
       | "generation_cancelled"
-      | "error_terminal",
+      | "error_terminal"
+      | "preview_start",
     anchor?: "assistant_turn" | "user_turn" | "global",
     requestId?: string,
     statusText?: string,


### PR DESCRIPTION
Add daemon handler for tool_use_preview_start, include toolUseId on tool_input_delta and tool_result IPC messages. Gated behind tool-preview-lifecycle feature flag. Part of #14856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
