### PR TITLE
Onboarding UX: update ImproveExperience toggles and Hatching text

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -63,7 +63,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "user-hosted-enabled",

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -460,10 +460,6 @@ extension AppDelegate {
                 // UserDefaults key always non-nil and blocking daemon sync.
                 if UserDefaults.standard.bool(forKey: "collectUsageDataExplicitlySet"),
                    let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
-                    // Clear the explicit-set flag so subsequent reconnects
-                    // resume daemon-as-source-of-truth behavior.
-                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
-
                     // Always apply Sentry state locally first, regardless of
                     // whether the daemon sync succeeds — the user's explicit
                     // choice must take effect immediately.
@@ -471,17 +467,23 @@ extension AppDelegate {
                         MetricKitManager.closeSentry()
                     }
 
-                    // Best-effort sync to daemon; failure is tolerable because
-                    // the local preference is already applied above.
-                    let flags = try await daemonClient.getFeatureFlags()
-                    let daemonValue = flags
-                        .first(where: { $0.key == featureFlagKey })
-                        .map { $0.enabled }
-                        ?? true
+                    // Best-effort sync to daemon. Use try? so failure doesn't
+                    // propagate to the outer catch and skip flag cleanup.
+                    if let flags = try? await daemonClient.getFeatureFlags() {
+                        let daemonValue = flags
+                            .first(where: { $0.key == featureFlagKey })
+                            .map { $0.enabled }
+                            ?? true
 
-                    if onboardingValue != daemonValue {
-                        try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                        if onboardingValue != daemonValue {
+                            try? await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                        }
                     }
+
+                    // Clear the explicit-set flag only after the sync attempt
+                    // completes (success or best-effort failure). This ensures
+                    // the flag persists if we never reach this point.
+                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
                 } else {
                     // No explicit user interaction — use the daemon's value
                     // as the source of truth.

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -450,19 +450,55 @@ extension AppDelegate {
     func checkAndApplyPrivacyFlag() {
         Task {
             do {
-                let flags = try await daemonClient.getFeatureFlags()
-                let collectUsageData = flags
-                    .first(where: { $0.key == "feature_flags.collect-usage-data.enabled" })
-                    .map { $0.enabled }
-                    ?? true
-                // Persist so MetricKitManager can check this flag synchronously
-                // during the startup window on the next launch, regardless of
-                // whether the user has visited the Privacy settings tab.
-                UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
-                if !collectUsageData {
-                    // Route through sentrySerialQueue to prevent races with
-                    // concurrent MetricKit captures or manual report sends.
-                    MetricKitManager.closeSentry()
+                let featureFlagKey = "feature_flags.collect-usage-data.enabled"
+
+                // Check if the user explicitly interacted with the privacy
+                // toggle during onboarding. The `collectUsageDataExplicitlySet`
+                // flag is only written when the user actually touches the
+                // toggle, NOT when the onAppear block sets the default value.
+                // This prevents the auto-written default from making the
+                // UserDefaults key always non-nil and blocking daemon sync.
+                if UserDefaults.standard.bool(forKey: "collectUsageDataExplicitlySet"),
+                   let onboardingValue = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool {
+                    // Clear the explicit-set flag so subsequent reconnects
+                    // resume daemon-as-source-of-truth behavior.
+                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+
+                    // Always apply Sentry state locally first, regardless of
+                    // whether the daemon sync succeeds — the user's explicit
+                    // choice must take effect immediately.
+                    if !onboardingValue {
+                        MetricKitManager.closeSentry()
+                    }
+
+                    // Best-effort sync to daemon; failure is tolerable because
+                    // the local preference is already applied above.
+                    let flags = try await daemonClient.getFeatureFlags()
+                    let daemonValue = flags
+                        .first(where: { $0.key == featureFlagKey })
+                        .map { $0.enabled }
+                        ?? true
+
+                    if onboardingValue != daemonValue {
+                        try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                    }
+                } else {
+                    // No explicit user interaction — use the daemon's value
+                    // as the source of truth.
+                    let flags = try await daemonClient.getFeatureFlags()
+                    let collectUsageData = flags
+                        .first(where: { $0.key == featureFlagKey })
+                        .map { $0.enabled }
+                        ?? true
+                    // Persist so MetricKitManager can check this flag synchronously
+                    // during the startup window on the next launch, regardless of
+                    // whether the user has visited the Privacy settings tab.
+                    UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
+                    if !collectUsageData {
+                        // Route through sentrySerialQueue to prevent races with
+                        // concurrent MetricKit captures or manual report sends.
+                        MetricKitManager.closeSentry()
+                    }
                 }
             } catch {
                 // Flag check is best-effort; Sentry stays active when the flag

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -467,8 +467,9 @@ extension AppDelegate {
                         MetricKitManager.closeSentry()
                     }
 
-                    // Best-effort sync to daemon. Use try? so failure doesn't
-                    // propagate to the outer catch and skip flag cleanup.
+                    // Best-effort sync to daemon. Only clear the explicit-set
+                    // flag when the sync succeeds so that a transient gateway
+                    // failure preserves the flag for retry on next reconnect.
                     if let flags = try? await daemonClient.getFeatureFlags() {
                         let daemonValue = flags
                             .first(where: { $0.key == featureFlagKey })
@@ -478,12 +479,11 @@ extension AppDelegate {
                         if onboardingValue != daemonValue {
                             try? await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
                         }
-                    }
 
-                    // Clear the explicit-set flag only after the sync attempt
-                    // completes (success or best-effort failure). This ensures
-                    // the flag persists if we never reach this point.
-                    UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+                        // Sync succeeded — clear the flag so subsequent
+                        // reconnects resume daemon-as-source-of-truth.
+                        UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+                    }
                 } else {
                     // No explicit user interaction — use the daemon's value
                     // as the source of truth.

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -476,13 +476,22 @@ extension AppDelegate {
                             .map { $0.enabled }
                             ?? true
 
+                        var syncSucceeded = true
                         if onboardingValue != daemonValue {
-                            try? await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                            do {
+                                try await daemonClient.setFeatureFlag(key: featureFlagKey, enabled: onboardingValue)
+                            } catch {
+                                syncSucceeded = false
+                                log.debug("Failed to sync onboarding privacy flag to daemon: \(error)")
+                            }
                         }
 
-                        // Sync succeeded — clear the flag so subsequent
-                        // reconnects resume daemon-as-source-of-truth.
-                        UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+                        // Only clear the flag when both read and write
+                        // succeeded so a failed write preserves the flag
+                        // for retry on next reconnect.
+                        if syncSucceeded {
+                            UserDefaults.standard.removeObject(forKey: "collectUsageDataExplicitlySet")
+                        }
                     }
                 } else {
                     // No explicit user interaction — use the daemon's value

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -18,18 +18,8 @@ struct HatchingStepView: View {
     @State private var hatchStartTime: Date?
     @State private var elapsedTime: TimeInterval = 0
     @State private var elapsedTimer: Timer?
-    @State private var progressMessageIndex: Int = 0
-    @State private var progressMessageTimer: Timer?
-    @State private var showTimeEstimate = false
     @State private var cliFinished = false
     @State private var failureReason: String?
-
-    private static let progressMessages = [
-        "Getting things ready\u{2026}",
-        "Making things cozy\u{2026}",
-        "Almost there\u{2026}",
-        "Just a moment longer\u{2026}",
-    ]
 
     private var isLocalFlow: Bool {
         state.cloudProvider == "local" || state.cloudProvider.isEmpty
@@ -40,15 +30,6 @@ struct HatchingStepView: View {
         isLocalFlow ? 45.0 : 180.0
     }
 
-    private var timeEstimateText: String {
-        if elapsedTime > expectedDuration * 1.5 {
-            return "Taking a bit longer than usual\u{2026}"
-        }
-        return isLocalFlow
-            ? "This usually takes less than a minute"
-            : "This usually takes a few minutes"
-    }
-
     var body: some View {
         VStack(spacing: VSpacing.lg) {
             Spacer()
@@ -57,11 +38,6 @@ struct HatchingStepView: View {
                 .padding(.bottom, VSpacing.xl)
 
             statusText
-
-            if !state.hatchFailed && !state.hatchCompleted {
-                progressMessageView
-                timeEstimateView
-            }
 
             if state.hatchFailed {
                 failureButtons
@@ -78,13 +54,6 @@ struct HatchingStepView: View {
             startWobble()
             hatchStartTime = Date()
             startElapsedTimer()
-            startProgressMessageRotation()
-            // Fade in time estimate after 2 seconds
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                withAnimation(.easeIn(duration: 0.5)) {
-                    showTimeEstimate = true
-                }
-            }
             if !hatchStarted {
                 hatchStarted = true
                 startHatching()
@@ -93,13 +62,11 @@ struct HatchingStepView: View {
         .onDisappear {
             wobbleTimer?.invalidate()
             elapsedTimer?.invalidate()
-            progressMessageTimer?.invalidate()
         }
         .onChange(of: state.hatchCompleted) { _, completed in
             if completed {
                 wobbleTimer?.invalidate()
                 elapsedTimer?.invalidate()
-                progressMessageTimer?.invalidate()
                 withAnimation(.spring(duration: 0.6, bounce: 0.3)) {
                     eggHatched = true
                 }
@@ -109,7 +76,6 @@ struct HatchingStepView: View {
             if failed {
                 wobbleTimer?.invalidate()
                 elapsedTimer?.invalidate()
-                progressMessageTimer?.invalidate()
             }
         }
     }
@@ -165,32 +131,22 @@ struct HatchingStepView: View {
                 Text(isCustomHardware ? "Your assistant is paired!" : "Your assistant has hatched!")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
-            } else {
-                Text(isCustomHardware ? "Pairing\u{2026}" : "Hatching\u{2026}")
+            } else if isCustomHardware {
+                Text("Pairing\u{2026}")
                     .font(.system(size: 24, weight: .regular, design: .serif))
                     .foregroundColor(VColor.textPrimary)
+            } else {
+                Text("Hatching...")
+                    .font(.system(size: 24, weight: .regular, design: .serif))
+                    .foregroundColor(VColor.textPrimary)
+                Text("Getting your assistant ready\u{2026}")
+                    .font(.system(size: 14))
+                    .foregroundColor(VColor.textSecondary)
+                Text("Your assistant will ask a few quick questions to get started.\nThis usually takes less than a minute.")
+                    .font(.system(size: 13))
+                    .foregroundColor(VColor.textMuted)
             }
         }
-    }
-
-    // MARK: - Progress Message
-
-    private var progressMessageView: some View {
-        Text(Self.progressMessages[progressMessageIndex])
-            .font(.system(size: 14))
-            .foregroundColor(VColor.textSecondary)
-            .id(progressMessageIndex)
-            .transition(.opacity)
-            .animation(.easeInOut(duration: 0.6), value: progressMessageIndex)
-    }
-
-    // MARK: - Time Estimate
-
-    private var timeEstimateView: some View {
-        Text(timeEstimateText)
-            .font(.system(size: 13))
-            .foregroundColor(VColor.textMuted)
-            .opacity(showTimeEstimate ? 1 : 0)
     }
 
     // MARK: - Failure Buttons
@@ -234,17 +190,6 @@ struct HatchingStepView: View {
                 // Time-based egg crack: crack at 50% of expected duration
                 if !eggCracked && elapsedTime >= expectedDuration * 0.5 {
                     triggerCrack()
-                }
-            }
-        }
-    }
-
-    private func startProgressMessageRotation() {
-        progressMessageTimer?.invalidate()
-        progressMessageTimer = Timer.scheduledTimer(withTimeInterval: 8.0, repeats: true) { _ in
-            Task { @MainActor in
-                withAnimation(.easeInOut(duration: 0.6)) {
-                    progressMessageIndex = (progressMessageIndex + 1) % Self.progressMessages.count
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -7,6 +7,7 @@ struct ImproveExperienceStepView: View {
 
     @State private var showTitle = false
     @State private var showContent = false
+    @State private var collectUsageData: Bool = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
     @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     var body: some View {
@@ -17,7 +18,7 @@ struct ImproveExperienceStepView: View {
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("To provide you the best experience, your assistant will ask you a couple of questions to get to know you better.")
+        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
             .font(VFont.onboardingSubtitle)
             .foregroundColor(VColor.textSecondary)
             .multilineTextAlignment(.center)
@@ -25,23 +26,35 @@ struct ImproveExperienceStepView: View {
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
 
-        HStack {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
+        VStack(spacing: VSpacing.md) {
+            HStack {
+                Text("Collect usage data")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                VToggle(isOn: Binding(
+                    get: { collectUsageData },
+                    set: { newValue in
+                        collectUsageData = newValue
+                        UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
+                        UserDefaults.standard.set(true, forKey: "collectUsageDataExplicitlySet")
+                    }
+                ))
+            }
+
+            HStack {
                 Text("Share performance metrics")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
-                Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
+                Spacer()
+                VToggle(isOn: Binding(
+                    get: { sharePerformanceMetrics },
+                    set: { newValue in
+                        sharePerformanceMetrics = newValue
+                        UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                    }
+                ))
             }
-            Spacer()
-            VToggle(isOn: Binding(
-                get: { sharePerformanceMetrics },
-                set: { newValue in
-                    sharePerformanceMetrics = newValue
-                    UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
-                }
-            ))
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.top, VSpacing.xl)
@@ -72,6 +85,9 @@ struct ImproveExperienceStepView: View {
         .offset(y: showContent ? 0 : 12)
         .onAppear {
             // Opt in by default during onboarding, but preserve any existing choice
+            if UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
+                UserDefaults.standard.set(true, forKey: "collectUsageDataEnabled")
+            }
             if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
                 UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -38,6 +38,10 @@ struct ImproveExperienceStepView: View {
                         collectUsageData = newValue
                         UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
                         UserDefaults.standard.set(true, forKey: "collectUsageDataExplicitlySet")
+                        if !newValue {
+                            sharePerformanceMetrics = false
+                            UserDefaults.standard.set(false, forKey: "sendPerformanceReports")
+                        }
                     }
                 ))
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -58,6 +58,7 @@ struct ImproveExperienceStepView: View {
                         UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
                     }
                 ))
+                .disabled(!collectUsageData)
             }
         }
         .padding(.horizontal, VSpacing.xxl)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -138,8 +138,14 @@ struct SettingsPrivacyTab: View {
                 MetricKitManager.closeSentry()
             }
         } catch {
-            // Revert the optimistic toggle on failure
+            // Revert the optimistic toggle on failure, including the
+            // cascaded performance metrics toggle if it was turned off.
             collectUsageData = !enabled
+            if !enabled {
+                // We had turned off sendPerformanceReports when disabling;
+                // revert it since the disable failed.
+                store.sendPerformanceReports = true
+            }
             loadError = "Could not save privacy setting: \(error.localizedDescription)"
         }
         isUpdating = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -61,11 +61,12 @@ struct SettingsPrivacyTab: View {
                 VToggle(isOn: Binding(
                     get: { collectUsageData },
                     set: { newValue in
+                        let previousPerfMetrics = store.sendPerformanceReports
                         collectUsageData = newValue
                         if !newValue {
                             store.sendPerformanceReports = false
                         }
-                        Task { await setCollectUsageData(newValue) }
+                        Task { await setCollectUsageData(newValue, previousPerfMetrics: previousPerfMetrics) }
                     }
                 ))
                 .disabled(isLoading || isUpdating || daemonClient == nil)
@@ -118,7 +119,7 @@ struct SettingsPrivacyTab: View {
         isLoading = false
     }
 
-    private func setCollectUsageData(_ enabled: Bool) async {
+    private func setCollectUsageData(_ enabled: Bool, previousPerfMetrics: Bool = false) async {
         guard let daemonClient else { return }
         isUpdating = true
         do {
@@ -139,12 +140,11 @@ struct SettingsPrivacyTab: View {
             }
         } catch {
             // Revert the optimistic toggle on failure, including the
-            // cascaded performance metrics toggle if it was turned off.
+            // cascaded performance metrics toggle — restore to its
+            // previous value rather than blindly setting true.
             collectUsageData = !enabled
             if !enabled {
-                // We had turned off sendPerformanceReports when disabling;
-                // revert it since the disable failed.
-                store.sendPerformanceReports = true
+                store.sendPerformanceReports = previousPerfMetrics
             }
             loadError = "Could not save privacy setting: \(error.localizedDescription)"
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -62,6 +62,9 @@ struct SettingsPrivacyTab: View {
                     get: { collectUsageData },
                     set: { newValue in
                         collectUsageData = newValue
+                        if !newValue {
+                            store.sendPerformanceReports = false
+                        }
                         Task { await setCollectUsageData(newValue) }
                     }
                 ))

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -294,9 +294,9 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Privacy
 
     /// Whether the user has opted in to sharing anonymised performance metrics (e.g. hang rate,
-    /// scroll speed). Defaults to `false`. Read by the MetricKit integration (M4) to decide
+    /// scroll speed). Defaults to `true`. Read by the MetricKit integration (M4) to decide
     /// whether to forward payloads.
-    @Published var sendPerformanceReports: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? false
+    @Published var sendPerformanceReports: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     // MARK: - Private
 

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -63,7 +63,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "user-hosted-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -63,7 +63,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "user-hosted-enabled",


### PR DESCRIPTION
## Summary
Update two onboarding step views with refined copy and an additional privacy toggle:
- Add a "Collect usage data" toggle to ImproveExperienceStepView (opted in by default), with proper daemon feature flag sync
- Update subtitle text and simplify toggle rows to show only titles
- Replace rotating progress messages in HatchingStepView with static descriptive text

## Changes
- Added `collectUsageData` toggle to `ImproveExperienceStepView` with UserDefaults persistence and explicit-set tracking
- Updated `checkAndApplyPrivacyFlag()` in `AppDelegate+DaemonSetup.swift` to respect onboarding privacy choices
- Updated HatchingStepView hatching text to "Hatching... / Getting your assistant ready… / Your assistant will ask a few quick questions to get started."
- Removed rotating progress messages and time estimate from HatchingStepView (66 lines deleted)

## Milestone PRs (merged into feature branch)
- #14877: M1: Add collect usage data toggle to ImproveExperienceStepView
- #14879: M2: Update HatchingStepView with new hatching text

## Project issue
Closes #14873

## Test plan
- [ ] Launch app with fresh onboarding, verify "Collect usage data" and "Share performance metrics" toggles appear with titles only
- [ ] Toggle "Collect usage data" off, complete onboarding, verify the opt-out persists after daemon connects
- [ ] Verify hatching step shows "Hatching..." with static descriptive text
- [ ] Verify custom hardware path still shows "Pairing…" text

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
