### PR TITLE
ci: disable macOS Performance Baselines on push

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -1,13 +1,6 @@
 name: CI – macOS Performance Baselines
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'clients/macos/**'
-      - 'clients/shared/**'
-      - '.github/workflows/ci-perf-macos.yaml'
-      - 'scripts/compare-perf-baselines.sh'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove push trigger from CI – macOS Performance Baselines workflow so it no longer runs automatically on every push to main
- Workflow remains available via manual dispatch (workflow_dispatch)

## Original prompt
disable CI - macOS Performance Baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
