### PR TITLE
M6: Cross-channel safety (CLI/Telegram/Voice)

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -513,6 +513,8 @@ export async function startVoiceTurn(
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input);
           }
+          // Note: tool_use_preview_start is intentionally not handled here.
+          // Voice only reacts to the definitive tool_use_start event.
         },
       );
       if (lastError) {

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -699,6 +699,10 @@ export async function startCli(): Promise<void> {
         prompt();
         break;
 
+      case "tool_use_preview_start":
+        // Early preview of tool use — ignored by CLI; full tool_use_start follows.
+        break;
+
       case "tool_use_start":
         toolStreaming = false;
         spinner.start(formatToolProgress(msg.toolName, msg.input));

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -44,6 +44,9 @@ export class TelegramStreamingDelivery {
       case "assistant_text_delta":
         this.onTextDelta(msg.text);
         break;
+      case "tool_use_preview_start":
+        // Early preview of tool use — ignored by Telegram; full tool_use_start follows.
+        break;
       case "tool_use_start":
         // Flush buffer and send an edit so the message is up-to-date before the tool runs
         if (this.buffer.length > 0 && this.currentMessageId) {


### PR DESCRIPTION
Ensure tool_use_preview_start events are handled gracefully across CLI, Telegram, and Voice channels. Part of #14856.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
