### PR TITLE
ci: fix UPDATE_BASELINE in macOS Performance Baselines workflow

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -2,6 +2,11 @@ name: CI – macOS Performance Baselines
 
 on:
   workflow_dispatch:
+    inputs:
+      update_baseline:
+        description: 'Update stored baselines (default: true on main)'
+        type: boolean
+        default: true
 
 jobs:
   perf-baselines:
@@ -62,7 +67,7 @@ jobs:
 
       - name: Compare baselines
         env:
-          UPDATE_BASELINE: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          UPDATE_BASELINE: ${{ inputs.update_baseline && 'true' || 'false' }}
         run: bash scripts/compare-perf-baselines.sh
 
       - name: Performance summary


### PR DESCRIPTION
## Summary
- Fix UPDATE_BASELINE always being 'false' since the push trigger was removed — it was still checking `github.event_name == 'push'`
- Add `update_baseline` input to workflow_dispatch (defaults to true) so baselines can be updated on manual runs
- Addresses review feedback from #14882

## Original prompt
address comments https://github.com/vellum-ai/vellum-assistant/pull/14882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
