### PR TITLE
ci: only update perf baselines when dispatched on main

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       update_baseline:
-        description: 'Update stored baselines (default: true on main)'
+        description: 'Update stored baselines (only effective on main branch)'
         type: boolean
         default: true
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Compare baselines
         env:
-          UPDATE_BASELINE: ${{ inputs.update_baseline && 'true' || 'false' }}
+          UPDATE_BASELINE: ${{ inputs.update_baseline && github.ref == 'refs/heads/main' && 'true' || 'false' }}
         run: bash scripts/compare-perf-baselines.sh
 
       - name: Performance summary


### PR DESCRIPTION
## Summary
- Gate UPDATE_BASELINE on both the input toggle AND `github.ref == 'refs/heads/main'` so dispatching from a feature branch never overwrites baselines
- Update input description to clarify the main-branch restriction
- Addresses review feedback from #14884

## Original prompt
address comments https://github.com/vellum-ai/vellum-assistant/pull/14884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
