### PR TITLE
Rewrite Google OAuth setup for real Chrome on macOS

### DIFF
--- a/assistant/src/__tests__/google-oauth-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/google-oauth-setup-skill-regression.test.ts
@@ -39,14 +39,14 @@ const manualChannelSection =
     ?.split("## Guardrails and Error Handling")[0] ?? "";
 
 describe("google-oauth-setup skill regression", () => {
-  test("catalog metadata keeps only public-ingress include", () => {
+  test("catalog metadata no longer declares a global public-ingress include", () => {
     const skill = catalog.skills.find(
       (entry) => entry.id === "google-oauth-setup",
     );
     expect(skill).toBeDefined();
     expect(skill!.description).toContain("real Chrome on macOS");
     expect(skill!.description).not.toContain("browser automation");
-    expect(skill!.metadata?.vellum?.includes).toEqual(["public-ingress"]);
+    expect(skill!.metadata?.vellum?.includes).toBeUndefined();
     expect(skill!.metadata?.vellum?.["credential-setup-for"]).toBe("gmail");
   });
 

--- a/assistant/src/__tests__/google-oauth-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/google-oauth-setup-skill-regression.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dirname ?? __dirname, "..", "..", "..");
+const SKILL_PATH = resolve(
+  REPO_ROOT,
+  "skills",
+  "google-oauth-setup",
+  "SKILL.md",
+);
+const CATALOG_PATH = resolve(REPO_ROOT, "skills", "catalog.json");
+
+const skillContent = readFileSync(SKILL_PATH, "utf-8");
+const catalog = JSON.parse(readFileSync(CATALOG_PATH, "utf-8")) as {
+  skills: Array<{
+    id: string;
+    description: string;
+    metadata?: {
+      vellum?: {
+        includes?: string[];
+        "credential-setup-for"?: string;
+      };
+    };
+  }>;
+};
+
+const automatedSection =
+  skillContent
+    .split("# Path A: Automated Setup in Real Chrome")[1]
+    ?.split("# Path B: Manual Desktop Setup")[0] ?? "";
+const manualDesktopSection =
+  skillContent
+    .split("# Path B: Manual Desktop Setup")[1]
+    ?.split("# Path C: Manual Channel Setup")[0] ?? "";
+const manualChannelSection =
+  skillContent
+    .split("# Path C: Manual Channel Setup")[1]
+    ?.split("## Guardrails and Error Handling")[0] ?? "";
+
+describe("google-oauth-setup skill regression", () => {
+  test("catalog metadata keeps only public-ingress include", () => {
+    const skill = catalog.skills.find(
+      (entry) => entry.id === "google-oauth-setup",
+    );
+    expect(skill).toBeDefined();
+    expect(skill!.description).toContain("real Chrome on macOS");
+    expect(skill!.description).not.toContain("browser automation");
+    expect(skill!.metadata?.vellum?.includes).toEqual(["public-ingress"]);
+    expect(skill!.metadata?.vellum?.["credential-setup-for"]).toBe("gmail");
+  });
+
+  test("automated macOS path uses real Chrome computer use rather than browser tools", () => {
+    expect(automatedSection).toContain("computer_use_request_control");
+    expect(automatedSection).toContain("computer_use_open_app");
+    expect(automatedSection).toContain("computer_use_run_applescript");
+    expect(automatedSection).toContain("Google Chrome");
+    expect(automatedSection).not.toContain("browser_navigate");
+    expect(automatedSection).not.toContain("browser_snapshot");
+    expect(automatedSection).not.toContain("browser_screenshot");
+    expect(automatedSection).not.toContain("browser_click");
+  });
+
+  test("manual desktop path creates Desktop app credentials", () => {
+    expect(manualDesktopSection).toContain("Application type: **Desktop app**");
+    expect(manualDesktopSection).not.toContain(
+      "Application type: **Web application**",
+    );
+    expect(manualDesktopSection).toContain("credential_store prompt");
+  });
+
+  test("manual channel path keeps the public callback web-app flow", () => {
+    expect(manualChannelSection).toContain("public-ingress");
+    expect(manualChannelSection).toContain(
+      "Application type: **Web application**",
+    );
+    expect(manualChannelSection).toContain("/webhooks/oauth/callback");
+    expect(manualChannelSection).toContain("GOCSPX-");
+  });
+});

--- a/assistant/src/__tests__/messaging-gmail-setup-regression.test.ts
+++ b/assistant/src/__tests__/messaging-gmail-setup-regression.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const ASSISTANT_DIR = resolve(import.meta.dirname ?? __dirname, "..");
+const MESSAGING_SKILL_PATH = resolve(
+  ASSISTANT_DIR,
+  "config",
+  "bundled-skills",
+  "messaging",
+  "SKILL.md",
+);
+
+const skillContent = readFileSync(MESSAGING_SKILL_PATH, "utf-8");
+const publicIngressSection =
+  skillContent
+    .split("### Public Ingress")[1]
+    ?.split("### Email Connection Flow")[0] ?? "";
+const gmailSection =
+  skillContent.split("### Gmail")[1]?.split("### Slack")[0] ?? "";
+
+describe("messaging skill Gmail setup regression", () => {
+  test("public ingress section distinguishes desktop Gmail from channel Gmail", () => {
+    expect(publicIngressSection).toContain(
+      "Slack and Telegram setup require a publicly reachable URL",
+    );
+    expect(publicIngressSection).toContain(
+      "**macOS desktop app:** Gmail setup can use Desktop app credentials",
+    );
+    expect(publicIngressSection).toContain(
+      "**Non-interactive channels:** Gmail setup uses Web application credentials",
+    );
+  });
+
+  test("gmail setup no longer claims google-oauth-setup depends on public-ingress", () => {
+    expect(gmailSection).toContain(
+      "let that skill choose the correct path for the current client",
+    );
+    expect(gmailSection).not.toContain(
+      "depends on **public-ingress** for the redirect URI",
+    );
+  });
+
+  test("gmail confirmation describes the real Chrome desktop path", () => {
+    expect(gmailSection).toContain("I'll use your real Chrome window");
+    expect(gmailSection).toContain(
+      "If you're in a non-interactive channel, I'll guide you through the manual callback setup.",
+    );
+  });
+});

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -621,7 +621,7 @@ describe("bundled browser skill", () => {
   });
 });
 
-describe("ingress-dependent setup skills declare public-ingress", () => {
+describe("setup skill ingress metadata", () => {
   const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
   const FIRST_PARTY_SKILLS_DIR = join(
     import.meta.dir,
@@ -668,22 +668,27 @@ describe("ingress-dependent setup skills declare public-ingress", () => {
   }
 
   test("telegram-setup includes public-ingress", () => {
-    const includes = readSkillIncludes(FIRST_PARTY_SKILLS_DIR, "telegram-setup");
-    expect(includes).toBeDefined();
-    expect(includes).toContain("public-ingress");
-  });
-
-  test("google-oauth-setup includes public-ingress", () => {
     const includes = readSkillIncludes(
       FIRST_PARTY_SKILLS_DIR,
-      "google-oauth-setup",
+      "telegram-setup",
     );
     expect(includes).toBeDefined();
     expect(includes).toContain("public-ingress");
   });
 
+  test("google-oauth-setup does not declare a global public-ingress include", () => {
+    const includes = readSkillIncludes(
+      FIRST_PARTY_SKILLS_DIR,
+      "google-oauth-setup",
+    );
+    expect(includes).toBeUndefined();
+  });
+
   test("slack-oauth-setup includes browser", () => {
-    const includes = readSkillIncludes(FIRST_PARTY_SKILLS_DIR, "slack-oauth-setup");
+    const includes = readSkillIncludes(
+      FIRST_PARTY_SKILLS_DIR,
+      "slack-oauth-setup",
+    );
     expect(includes).toBeDefined();
     expect(includes).toContain("browser");
   });

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -1,0 +1,537 @@
+---
+name: google-oauth-setup
+description: Set up Google Cloud OAuth credentials for Gmail and Calendar using the user's real Chrome on macOS or guided manual setup elsewhere
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Google OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "gmail"
+---
+
+You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.
+
+## Client Check
+
+Determine which path applies before taking action:
+
+- **macOS desktop app:** Start with **Path A: Automated Setup in Real Chrome**. Do not ask whether computer use is available — just attempt it. If `computer_use_request_control` fails or the user declines, fall back to **Path B: Manual Desktop Setup**.
+- **Telegram, SMS, Slack, or any non-interactive channel:** Follow **Path C: Manual Channel Setup**.
+
+When in doubt, default to Path A and let the computer-use request itself determine whether it can proceed.
+
+---
+
+# Path A: Automated Setup in Real Chrome (macOS Desktop App)
+
+Use the user's actual Google Chrome app. Do **not** use `browser_*` tools, CDP, or any automation-specific Chrome profile for this path. Google sign-in may reject those contexts as insecure.
+
+## Path A Rules
+
+1. Start with a single upfront confirmation.
+2. After confirmation, request foreground computer control with `computer_use_request_control`.
+3. Inside the computer-use session:
+   - Use `computer_use_open_app` to switch to **Google Chrome**.
+   - Use `computer_use_run_applescript` only for Chrome app/window/tab/URL operations.
+   - Use normal computer-use interactions for the actual Google Cloud web UI.
+4. Never try to type the user's Google password, 2FA code, or recovery code. Ask the user to complete those steps in Chrome, then continue.
+5. If two or more steps require manual fallback, stop the automated path and switch to **Path B**.
+
+## Path A Step 1: One Confirmation
+
+Use `ui_show` with `surface_type: "confirmation"`. Set `message` to just the title, and `detail` to the body:
+
+- **message:** `Set up Google Cloud for Gmail & Calendar`
+- **detail:**
+  > Here's what will happen:
+  >
+  > 1. I'll take control of your Mac briefly
+  > 2. I'll use your real Google Chrome window, not a test browser
+  > 3. You'll sign in to Google if needed
+  > 4. I'll set up the project, APIs, consent screen, and OAuth client
+  > 5. I'll ask you for one secure paste of the Client Secret
+  > 6. You'll approve the final Google authorization
+  >
+  > This usually takes a few minutes. Ready?
+
+If the user declines, stop.
+
+## Path A Step 2: Request Control and Open Chrome
+
+Request foreground computer control:
+
+```
+computer_use_request_control:
+  task: "Set up Google Cloud OAuth credentials for Gmail and Google Calendar in the user's real Google Chrome app."
+  reason: "I need to operate your actual Chrome window so Google sign-in works normally."
+```
+
+Once control is granted:
+
+1. Bring **Google Chrome** to the foreground with `computer_use_open_app`.
+2. Use a short AppleScript to activate Chrome and open the Cloud Console in a front tab.
+
+Example AppleScript:
+
+```applescript
+tell application "Google Chrome"
+  activate
+  if (count of windows) = 0 then
+    make new window
+  end if
+  set URL of active tab of front window to "https://console.cloud.google.com/"
+end tell
+```
+
+Use AppleScript for tab creation, tab reuse, and direct URL changes only. Do not use AppleScript to drive the page UI if ordinary computer-use interaction is sufficient.
+
+## Path A Step 3: Sign In and Reach Cloud Console
+
+Goal: the user is signed in and `console.cloud.google.com` is loaded in real Chrome.
+
+- If Chrome shows a Google sign-in screen, tell the user to complete sign-in in Chrome. Wait and keep observing until the Cloud Console loads.
+- If Chrome shows 2FA, CAPTCHA, or account chooser, let the user handle it and continue afterward.
+- If the user is already signed in, continue immediately.
+- If Google shows a rejection page saying the browser or app may not be secure, stop the automated path and switch to **Path B**. That page means this is not behaving like a normal user Chrome session.
+
+## Path A Step 4: Create or Select a Project
+
+Goal: a GCP project named **Vellum Assistant** exists and is selected.
+
+Navigate Chrome to:
+
+`https://console.cloud.google.com/projectcreate`
+
+Then:
+
+1. If project creation is available, create a project named **Vellum Assistant**.
+2. If Google reports the name already exists or an existing project is more appropriate, select the existing project instead.
+3. Record the project ID from the URL or visible project picker state.
+
+If the user hits organization restrictions, billing requirements, or quota errors, explain the issue clearly and ask them to resolve it.
+
+## Path A Step 5: Enable Gmail and Calendar APIs
+
+Goal: both APIs are enabled for the selected project.
+
+Visit:
+
+1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+
+For each page:
+
+- If you see **Enable**, click it.
+- If you see **Manage** or an enabled state, leave it as-is.
+
+## Path A Step 6: Configure the OAuth Consent Screen
+
+Goal: an external OAuth consent screen exists with the required scopes and the user's email as a test user.
+
+Navigate to:
+
+`https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+
+Adapt to the current Cloud Console UI. The required end state is:
+
+- User type: **External**
+- App name: **Vellum Assistant**
+- User support email: the signed-in user's email
+- Developer contact email: the signed-in user's email
+- Scopes:
+  - `https://www.googleapis.com/auth/gmail.readonly`
+  - `https://www.googleapis.com/auth/gmail.modify`
+  - `https://www.googleapis.com/auth/gmail.send`
+  - `https://www.googleapis.com/auth/calendar.readonly`
+  - `https://www.googleapis.com/auth/calendar.events`
+  - `https://www.googleapis.com/auth/userinfo.email`
+- Test user: the signed-in user's email
+
+If the consent screen is already configured, verify the important pieces and move on.
+
+## Path A Step 7: Create Desktop OAuth Credentials and Store Them
+
+Goal: a **Desktop app** OAuth client exists and both values are stored securely.
+
+Navigate to:
+
+`https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+
+Then:
+
+1. Create **OAuth client ID** credentials.
+2. Choose **Desktop app** as the application type.
+3. Name the client **Vellum Assistant**.
+4. Click **Create**.
+
+When the credential dialog appears:
+
+- Keep the dialog open until both values are safely stored.
+- If the **Client ID** is clearly visible in the observed UI text, you may store it directly:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_id"
+  value: "<client id from the dialog>"
+```
+
+- If the Client ID is not reliably readable, prompt the user for it securely:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the Google Cloud dialog and paste it here."
+  placeholder: "123456789-xxxxx.apps.googleusercontent.com"
+```
+
+- For the **Client Secret**, always use a secure prompt rather than trusting OCR or memory:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client Secret from the Google Cloud dialog in Chrome and paste it here."
+  placeholder: "GOCSPX-..."
+```
+
+Do not navigate away from the credential dialog before the prompts are complete.
+
+## Path A Step 8: Authorize Gmail and Calendar
+
+Tell the user:
+
+> I'll start the Google authorization flow now. Review the permissions and click **Allow** when prompted.
+
+Run:
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
+```
+
+If the user sees **This app isn't verified**, tell them this is normal for an app in testing mode. They should click **Advanced** and then continue to **Vellum Assistant**.
+
+## Path A Step 9: Finish
+
+Confirm success once authorization completes:
+
+> **Gmail and Calendar are connected.** You can now ask me to check your inbox or show your calendar.
+
+---
+
+# Path B: Manual Desktop Setup (macOS Desktop App Without Computer Use)
+
+Use this when the user is in the macOS desktop app but you are not using computer control. In this path, the user performs the browser steps manually in their own Chrome window and you use secure prompts for the credentials.
+
+## Path B Step 1: Confirm
+
+Tell the user:
+
+> **Set up Gmail & Calendar in Google Cloud**
+>
+> I'll guide you step by step in your own Chrome window, then I'll securely collect the OAuth credentials here in the app.
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create or Select a Project
+
+Tell the user:
+
+> **Step 1: Create or choose a Google Cloud project**
+>
+> Open:
+> `https://console.cloud.google.com/projectcreate`
+>
+> Create a project named **Vellum Assistant**, or select an existing project you want to use.
+>
+> Tell me when it's ready. If you already know the project ID, send that too.
+
+Wait for confirmation. Record the project ID if the user provides it.
+
+## Path B Step 3: Enable Gmail and Calendar APIs
+
+Tell the user:
+
+> **Step 2: Enable Gmail and Calendar APIs**
+>
+> Open each link below and click **Enable** if needed:
+>
+> 1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+> 2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+>
+> Tell me when both are enabled.
+
+## Path B Step 4: Configure the OAuth Consent Screen
+
+Tell the user:
+
+> **Step 3: Configure the OAuth consent screen**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+>
+> Set these values:
+>
+> - User type: **External**
+> - App name: **Vellum Assistant**
+> - User support email: **your email**
+> - Developer contact email: **your email**
+>
+> Add these scopes:
+>
+> - `https://www.googleapis.com/auth/gmail.readonly`
+> - `https://www.googleapis.com/auth/gmail.modify`
+> - `https://www.googleapis.com/auth/gmail.send`
+> - `https://www.googleapis.com/auth/calendar.readonly`
+> - `https://www.googleapis.com/auth/calendar.events`
+> - `https://www.googleapis.com/auth/userinfo.email`
+>
+> Add **your email** as a test user, then return to the dashboard.
+>
+> Tell me when that's done.
+
+## Path B Step 5: Create Desktop OAuth Credentials
+
+Tell the user:
+
+> **Step 4: Create OAuth credentials**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+>
+> 1. Click **+ Create Credentials** -> **OAuth client ID**
+> 2. Application type: **Desktop app**
+> 3. Name: **Vellum Assistant**
+> 4. Click **Create**
+>
+> Keep the dialog open when it shows the Client ID and Client Secret. I'll prompt you for both values securely in the app.
+
+## Path B Step 6: Store Credentials Securely
+
+Prompt for the Client ID:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the Google Cloud dialog and paste it here."
+  placeholder: "123456789-xxxxx.apps.googleusercontent.com"
+```
+
+Then prompt for the Client Secret:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client Secret from the Google Cloud dialog and paste it here."
+  placeholder: "GOCSPX-..."
+```
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Gmail and Calendar**
+>
+> I'll start the Google authorization flow now. Approve the requested permissions when the Google page appears.
+
+Run:
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
+```
+
+If the result returns an auth URL instead of completing automatically, send the URL to the user and tell them to open it in their browser.
+
+## Path B Step 8: Done
+
+After success:
+
+> **Gmail and Calendar are connected.**
+
+---
+
+# Path C: Manual Channel Setup (Telegram, SMS, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path must use **Web application** credentials because the OAuth callback goes through the public gateway URL.
+
+## Path C Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Gmail & Calendar from chat**
+>
+> Since I can't control your browser from here, I'll walk you through the steps with direct links. You'll need:
+>
+> 1. A Google account with access to Google Cloud Console
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path C Step 2: Create a Google Cloud Project
+
+Tell the user:
+
+> **Step 1: Create a Google Cloud project**
+>
+> Open this link:
+> `https://console.cloud.google.com/projectcreate`
+>
+> Create a project named **Vellum Assistant**. If you already have a project you'd rather use, that's fine too.
+>
+> Let me know when it's done, or send the project ID if you already know it.
+
+Wait for confirmation. Record the project ID for the next steps.
+
+## Path C Step 3: Enable APIs
+
+Tell the user:
+
+> **Step 2: Enable Gmail and Calendar APIs**
+>
+> Open each link below and click **Enable**:
+>
+> 1. Gmail API: `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+> 2. Calendar API: `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+>
+> Let me know when both are enabled.
+
+## Path C Step 4: Configure OAuth Consent Screen
+
+Tell the user:
+
+> **Step 3: Configure the OAuth consent screen**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+>
+> 1. Choose **External**
+> 2. Set app name to **Vellum Assistant**
+> 3. Set both support email and developer contact email to **your email**
+> 4. Add these scopes:
+>    - `https://www.googleapis.com/auth/gmail.readonly`
+>    - `https://www.googleapis.com/auth/gmail.modify`
+>    - `https://www.googleapis.com/auth/gmail.send`
+>    - `https://www.googleapis.com/auth/calendar.readonly`
+>    - `https://www.googleapis.com/auth/calendar.events`
+>    - `https://www.googleapis.com/auth/userinfo.email`
+> 5. Add **your email** as a test user
+> 6. Return to the dashboard
+>
+> Let me know when that's done.
+
+## Path C Step 5: Create Web Application Credentials
+
+Before sending the next step, resolve the concrete callback URL:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions to set up the ngrok tunnel.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+Tell the user:
+
+> **Step 4: Create OAuth credentials**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+>
+> Use this exact redirect URI:
+> `OAUTH_CALLBACK_URL`
+>
+> 1. Click **+ Create Credentials** -> **OAuth client ID**
+> 2. Application type: **Web application**
+> 3. Name: **Vellum Assistant**
+> 4. Add the redirect URI shown above under **Authorized redirect URIs**
+> 5. Click **Create**
+>
+> When the dialog appears, copy the Client ID and Client Secret. You'll send them to me next.
+
+## Path C Step 6: Store Credentials
+
+### Path C Step 6a: Client ID
+
+Tell the user:
+
+> **Step 5a: Send your Client ID**
+>
+> Send me the **Client ID** from the dialog. It looks like `123456789-xxxxx.apps.googleusercontent.com`.
+
+After the user sends it:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+### Path C Step 6b: Client Secret Split Entry
+
+The Google client secret starts with `GOCSPX-`, which can trigger channel secret scanners. Ask for only the suffix.
+
+Tell the user:
+
+> **Step 5b: Send your Client Secret**
+>
+> Your Client Secret starts with `GOCSPX-`. Please send me only the part **after** `GOCSPX-` as a standalone message with no other text.
+
+After the user sends the suffix, reconstruct and store the full secret:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_secret"
+  value: "GOCSPX-<the suffix the user sent>"
+```
+
+## Path C Step 7: Authorize
+
+Tell the user:
+
+> **Step 6: Authorize Gmail and Calendar**
+>
+> I'll generate an authorization link for you now.
+
+Run:
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
+```
+
+Send the returned auth URL to the user and tell them to open it. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.
+
+## Path C Step 8: Done
+
+After authorization:
+
+> **Gmail and Calendar are connected.**
+
+---
+
+## Guardrails and Error Handling
+
+- **No CDP or browser automation on Path A.** Use the user's real Chrome app plus computer use.
+- **Use AppleScript narrowly.** Good uses: activate Chrome, open a tab, set a URL, or inspect high-level Chrome state. Do not use `do shell script`.
+- **Do not delete and recreate OAuth clients** just to get another secret. That risks orphaning stored credentials.
+- **Do not leave the credential dialog early.** The Client Secret is shown only once.
+- **Google Cloud UI drift is normal.** Adapt to renamed buttons or reorganized layouts while preserving the same end state.
+- **If the user hits org policy, billing, or quota blockers, explain the blocker plainly and wait.**
+- **If Path A needs repeated manual rescue, switch to Path B.** Do not loop indefinitely.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -50,7 +50,7 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
    - Call `skill_load` with `skill: "google-oauth-setup"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
-     - **detail:** "If you're on the desktop app, I'll use your real Chrome window and handle the Google Cloud setup there. If you're in a non-interactive channel, I'll guide you through the manual callback setup. Takes 2-3 minutes."
+     - **detail:** "I'll use your real Chrome window to set up a Google Cloud project and connect your account. Takes 2-3 minutes."
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -26,9 +26,14 @@ When a platform is connected (auth test succeeds), always use the messaging API 
 
 Before using any messaging tool, verify that the platform is connected by calling `messaging_auth_test` with the appropriate `platform` parameter. If the call fails with a token/authorization error, follow the steps below.
 
-### Public Ingress (required for all platforms)
+### Public Ingress
 
-Gmail, Slack, and Telegram setup all require a publicly reachable URL for OAuth callbacks or webhook delivery. The **public-ingress** skill handles ngrok tunnel setup and persists the URL as `ingress.publicBaseUrl`. Each setup skill below declares `public-ingress` as a dependency and will prompt you to run it if `ingress.publicBaseUrl` is not configured.
+Slack and Telegram setup require a publicly reachable URL for OAuth callbacks or webhook delivery. The **public-ingress** skill handles ngrok tunnel setup and persists the URL as `ingress.publicBaseUrl`.
+
+Gmail is different:
+
+- **macOS desktop app:** Gmail setup can use Desktop app credentials and the user's real browser without public ingress.
+- **Non-interactive channels:** Gmail setup uses Web application credentials and does require public ingress for the callback URL.
 
 ### Email Connection Flow
 
@@ -41,11 +46,11 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 ### Gmail
 
 1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials — so this single call may be all that's needed.
-2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
+2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-setup** skill and let that skill choose the correct path for the current client:
    - Call `skill_load` with `skill: "google-oauth-setup"` to load the dependency skill.
    - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
      - **message:** "Ready to set up Gmail?"
-     - **detail:** "I'll open a browser where you sign in to Google, then automate everything else — creating a project, enabling APIs, and connecting your account. Takes 2-3 minutes and you can watch in the browser preview panel."
+     - **detail:** "If you're on the desktop app, I'll use your real Chrome window and handle the Google Cloud setup there. If you're in a non-interactive channel, I'll guide you through the manual callback setup. Takes 2-3 minutes."
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -51,9 +51,10 @@ import { registerDaemonCallbacks } from "../work-items/work-item-runner.js";
 import { ComputerUseSession } from "./computer-use-session.js";
 import { ConfigWatcher } from "./config-watcher.js";
 import { parseIdentityFields } from "./handlers/identity.js";
-import type {
-  HandlerContext,
-  SessionCreateOptions,
+import {
+  type HandlerContext,
+  type SessionCreateOptions,
+  wireEscalationHandler,
 } from "./handlers/shared.js";
 import type { SkillOperationContext } from "./handlers/skills.js";
 import type { ServerMessage } from "./message-protocol.js";
@@ -693,6 +694,9 @@ export class DaemonServer {
       : registrar;
     if (options?.isInteractive === true) {
       session.updateClient(onEvent, false);
+      if (!session.hasEscalationHandler()) {
+        wireEscalationHandler(session, this.handlerContext());
+      }
     }
 
     session

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -124,9 +124,6 @@
         "vellum": {
           "display-name": "Google OAuth Setup",
           "user-invocable": true,
-          "includes": [
-            "public-ingress"
-          ],
           "credential-setup-for": "gmail"
         }
       }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -117,7 +117,7 @@
     {
       "id": "google-oauth-setup",
       "name": "google-oauth-setup",
-      "description": "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation",
+      "description": "Set up Google Cloud OAuth credentials for Gmail and Calendar using the user's real Chrome on macOS or guided manual setup elsewhere",
       "compatibility": "Designed for Vellum personal assistants",
       "metadata": {
         "emoji": "🔑",
@@ -125,7 +125,6 @@
           "display-name": "Google OAuth Setup",
           "user-invocable": true,
           "includes": [
-            "browser",
             "public-ingress"
           ],
           "credential-setup-for": "gmail"

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -16,11 +16,10 @@ You are helping your user set up Google Cloud OAuth credentials so Gmail and Goo
 
 Determine which path applies before taking action:
 
-- **macOS desktop app with foreground computer use available:** Follow **Path A: Automated Setup in Real Chrome**.
-- **macOS desktop app without computer use** (or the user declines computer control, or Path A needs too many manual handoffs): Follow **Path B: Manual Desktop Setup**.
+- **macOS desktop app:** Start with **Path A: Automated Setup in Real Chrome**. Do not ask whether computer use is available — just attempt it. If `computer_use_request_control` fails or the user declines, fall back to **Path B: Manual Desktop Setup**.
 - **Telegram, SMS, Slack, or any non-interactive channel:** Follow **Path C: Manual Channel Setup**.
 
-If the interface is ambiguous, ask one short clarifying question before proceeding.
+When in doubt, default to Path A and let the computer-use request itself determine whether it can proceed.
 
 ---
 
@@ -441,7 +440,7 @@ Tell the user:
 Before sending the next step, resolve the concrete callback URL:
 
 - Read the configured public gateway URL from `ingress.publicBaseUrl`.
-- If it is missing, run the `public-ingress` skill first.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions to set up the ngrok tunnel.
 - Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
 - Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
 

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Google OAuth Setup"
     user-invocable: true
-    includes: ["public-ingress"]
     credential-setup-for: "gmail"
 ---
 

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: google-oauth-setup
-description: Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation
+description: Set up Google Cloud OAuth credentials for Gmail and Calendar using the user's real Chrome on macOS or guided manual setup elsewhere
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "Google OAuth Setup"
     user-invocable: true
-    includes: ["browser", "public-ingress"]
+    includes: ["public-ingress"]
     credential-setup-for: "gmail"
 ---
 
@@ -15,48 +15,392 @@ You are helping your user set up Google Cloud OAuth credentials so Gmail and Goo
 
 ## Client Check
 
-Determine whether the user has browser automation available (macOS desktop app) or is on a non-interactive channel (Telegram, SMS, etc.).
+Determine which path applies before taking action:
 
-- **macOS desktop app**: Follow the **Automated Setup** path below.
-- **Telegram or other channel** (no browser automation): Follow the **Manual Setup for Channels** path below.
+- **macOS desktop app with foreground computer use available:** Follow **Path A: Automated Setup in Real Chrome**.
+- **macOS desktop app without computer use** (or the user declines computer control, or Path A needs too many manual handoffs): Follow **Path B: Manual Desktop Setup**.
+- **Telegram, SMS, Slack, or any non-interactive channel:** Follow **Path C: Manual Channel Setup**.
+
+If the interface is ambiguous, ask one short clarifying question before proceeding.
 
 ---
 
-# Path A: Manual Setup for Channels (Telegram, SMS, etc.)
+# Path A: Automated Setup in Real Chrome (macOS Desktop App)
 
-When the user is on Telegram or any non-macOS client, walk them through a text-based setup. No browser automation is used; the user follows links and performs each action manually.
+Use the user's actual Google Chrome app. Do **not** use `browser_*` tools, CDP, or any automation-specific Chrome profile for this path. Google sign-in may reject those contexts as insecure.
 
-### Channel Step 1: Confirm and Explain
+## Path A Rules
+
+1. Start with a single upfront confirmation.
+2. After confirmation, request foreground computer control with `computer_use_request_control`.
+3. Inside the computer-use session:
+   - Use `computer_use_open_app` to switch to **Google Chrome**.
+   - Use `computer_use_run_applescript` only for Chrome app/window/tab/URL operations.
+   - Use normal computer-use interactions for the actual Google Cloud web UI.
+4. Never try to type the user's Google password, 2FA code, or recovery code. Ask the user to complete those steps in Chrome, then continue.
+5. If two or more steps require manual fallback, stop the automated path and switch to **Path B**.
+
+## Path A Step 1: One Confirmation
+
+Use `ui_show` with `surface_type: "confirmation"`. Set `message` to just the title, and `detail` to the body:
+
+- **message:** `Set up Google Cloud for Gmail & Calendar`
+- **detail:**
+  > Here's what will happen:
+  >
+  > 1. I'll take control of your Mac briefly
+  > 2. I'll use your real Google Chrome window, not a test browser
+  > 3. You'll sign in to Google if needed
+  > 4. I'll set up the project, APIs, consent screen, and OAuth client
+  > 5. I'll ask you for one secure paste of the Client Secret
+  > 6. You'll approve the final Google authorization
+  >
+  > This usually takes a few minutes. Ready?
+
+If the user declines, stop.
+
+## Path A Step 2: Request Control and Open Chrome
+
+Request foreground computer control:
+
+```
+computer_use_request_control:
+  task: "Set up Google Cloud OAuth credentials for Gmail and Google Calendar in the user's real Google Chrome app."
+  reason: "I need to operate your actual Chrome window so Google sign-in works normally."
+```
+
+Once control is granted:
+
+1. Bring **Google Chrome** to the foreground with `computer_use_open_app`.
+2. Use a short AppleScript to activate Chrome and open the Cloud Console in a front tab.
+
+Example AppleScript:
+
+```applescript
+tell application "Google Chrome"
+  activate
+  if (count of windows) = 0 then
+    make new window
+  end if
+  set URL of active tab of front window to "https://console.cloud.google.com/"
+end tell
+```
+
+Use AppleScript for tab creation, tab reuse, and direct URL changes only. Do not use AppleScript to drive the page UI if ordinary computer-use interaction is sufficient.
+
+## Path A Step 3: Sign In and Reach Cloud Console
+
+Goal: the user is signed in and `console.cloud.google.com` is loaded in real Chrome.
+
+- If Chrome shows a Google sign-in screen, tell the user to complete sign-in in Chrome. Wait and keep observing until the Cloud Console loads.
+- If Chrome shows 2FA, CAPTCHA, or account chooser, let the user handle it and continue afterward.
+- If the user is already signed in, continue immediately.
+- If Google shows a rejection page saying the browser or app may not be secure, stop the automated path and switch to **Path B**. That page means this is not behaving like a normal user Chrome session.
+
+## Path A Step 4: Create or Select a Project
+
+Goal: a GCP project named **Vellum Assistant** exists and is selected.
+
+Navigate Chrome to:
+
+`https://console.cloud.google.com/projectcreate`
+
+Then:
+
+1. If project creation is available, create a project named **Vellum Assistant**.
+2. If Google reports the name already exists or an existing project is more appropriate, select the existing project instead.
+3. Record the project ID from the URL or visible project picker state.
+
+If the user hits organization restrictions, billing requirements, or quota errors, explain the issue clearly and ask them to resolve it.
+
+## Path A Step 5: Enable Gmail and Calendar APIs
+
+Goal: both APIs are enabled for the selected project.
+
+Visit:
+
+1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+
+For each page:
+
+- If you see **Enable**, click it.
+- If you see **Manage** or an enabled state, leave it as-is.
+
+## Path A Step 6: Configure the OAuth Consent Screen
+
+Goal: an external OAuth consent screen exists with the required scopes and the user's email as a test user.
+
+Navigate to:
+
+`https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+
+Adapt to the current Cloud Console UI. The required end state is:
+
+- User type: **External**
+- App name: **Vellum Assistant**
+- User support email: the signed-in user's email
+- Developer contact email: the signed-in user's email
+- Scopes:
+  - `https://www.googleapis.com/auth/gmail.readonly`
+  - `https://www.googleapis.com/auth/gmail.modify`
+  - `https://www.googleapis.com/auth/gmail.send`
+  - `https://www.googleapis.com/auth/calendar.readonly`
+  - `https://www.googleapis.com/auth/calendar.events`
+  - `https://www.googleapis.com/auth/userinfo.email`
+- Test user: the signed-in user's email
+
+If the consent screen is already configured, verify the important pieces and move on.
+
+## Path A Step 7: Create Desktop OAuth Credentials and Store Them
+
+Goal: a **Desktop app** OAuth client exists and both values are stored securely.
+
+Navigate to:
+
+`https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+
+Then:
+
+1. Create **OAuth client ID** credentials.
+2. Choose **Desktop app** as the application type.
+3. Name the client **Vellum Assistant**.
+4. Click **Create**.
+
+When the credential dialog appears:
+
+- Keep the dialog open until both values are safely stored.
+- If the **Client ID** is clearly visible in the observed UI text, you may store it directly:
+
+```
+credential_store store:
+  service: "integration:gmail"
+  field: "client_id"
+  value: "<client id from the dialog>"
+```
+
+- If the Client ID is not reliably readable, prompt the user for it securely:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the Google Cloud dialog and paste it here."
+  placeholder: "123456789-xxxxx.apps.googleusercontent.com"
+```
+
+- For the **Client Secret**, always use a secure prompt rather than trusting OCR or memory:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client Secret from the Google Cloud dialog in Chrome and paste it here."
+  placeholder: "GOCSPX-..."
+```
+
+Do not navigate away from the credential dialog before the prompts are complete.
+
+## Path A Step 8: Authorize Gmail and Calendar
 
 Tell the user:
 
-> **Setting up Gmail & Calendar from Telegram**
+> I'll start the Google authorization flow now. Review the permissions and click **Allow** when prompted.
+
+Run:
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
+```
+
+If the user sees **This app isn't verified**, tell them this is normal for an app in testing mode. They should click **Advanced** and then continue to **Vellum Assistant**.
+
+## Path A Step 9: Finish
+
+Confirm success once authorization completes:
+
+> **Gmail and Calendar are connected.** You can now ask me to check your inbox or show your calendar.
+
+---
+
+# Path B: Manual Desktop Setup (macOS Desktop App Without Computer Use)
+
+Use this when the user is in the macOS desktop app but you are not using computer control. In this path, the user performs the browser steps manually in their own Chrome window and you use secure prompts for the credentials.
+
+## Path B Step 1: Confirm
+
+Tell the user:
+
+> **Set up Gmail & Calendar in Google Cloud**
 >
-> Since I can't automate the browser from here, I'll walk you through each step with direct links. You'll need:
+> I'll guide you step by step in your own Chrome window, then I'll securely collect the OAuth credentials here in the app.
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create or Select a Project
+
+Tell the user:
+
+> **Step 1: Create or choose a Google Cloud project**
+>
+> Open:
+> `https://console.cloud.google.com/projectcreate`
+>
+> Create a project named **Vellum Assistant**, or select an existing project you want to use.
+>
+> Tell me when it's ready. If you already know the project ID, send that too.
+
+Wait for confirmation. Record the project ID if the user provides it.
+
+## Path B Step 3: Enable Gmail and Calendar APIs
+
+Tell the user:
+
+> **Step 2: Enable Gmail and Calendar APIs**
+>
+> Open each link below and click **Enable** if needed:
+>
+> 1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+> 2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+>
+> Tell me when both are enabled.
+
+## Path B Step 4: Configure the OAuth Consent Screen
+
+Tell the user:
+
+> **Step 3: Configure the OAuth consent screen**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+>
+> Set these values:
+>
+> - User type: **External**
+> - App name: **Vellum Assistant**
+> - User support email: **your email**
+> - Developer contact email: **your email**
+>
+> Add these scopes:
+>
+> - `https://www.googleapis.com/auth/gmail.readonly`
+> - `https://www.googleapis.com/auth/gmail.modify`
+> - `https://www.googleapis.com/auth/gmail.send`
+> - `https://www.googleapis.com/auth/calendar.readonly`
+> - `https://www.googleapis.com/auth/calendar.events`
+> - `https://www.googleapis.com/auth/userinfo.email`
+>
+> Add **your email** as a test user, then return to the dashboard.
+>
+> Tell me when that's done.
+
+## Path B Step 5: Create Desktop OAuth Credentials
+
+Tell the user:
+
+> **Step 4: Create OAuth credentials**
+>
+> Open:
+> `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+>
+> 1. Click **+ Create Credentials** -> **OAuth client ID**
+> 2. Application type: **Desktop app**
+> 3. Name: **Vellum Assistant**
+> 4. Click **Create**
+>
+> Keep the dialog open when it shows the Client ID and Client Secret. I'll prompt you for both values securely in the app.
+
+## Path B Step 6: Store Credentials Securely
+
+Prompt for the Client ID:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the Google Cloud dialog and paste it here."
+  placeholder: "123456789-xxxxx.apps.googleusercontent.com"
+```
+
+Then prompt for the Client Secret:
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client Secret from the Google Cloud dialog and paste it here."
+  placeholder: "GOCSPX-..."
+```
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Gmail and Calendar**
+>
+> I'll start the Google authorization flow now. Approve the requested permissions when the Google page appears.
+
+Run:
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
+```
+
+If the result returns an auth URL instead of completing automatically, send the URL to the user and tell them to open it in their browser.
+
+## Path B Step 8: Done
+
+After success:
+
+> **Gmail and Calendar are connected.**
+
+---
+
+# Path C: Manual Channel Setup (Telegram, SMS, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path must use **Web application** credentials because the OAuth callback goes through the public gateway URL.
+
+## Path C Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Gmail & Calendar from chat**
+>
+> Since I can't control your browser from here, I'll walk you through the steps with direct links. You'll need:
 >
 > 1. A Google account with access to Google Cloud Console
 > 2. About 5 minutes
 >
 > Ready to start?
 
-If the user declines, acknowledge and stop.
+If the user declines, stop.
 
-### Channel Step 2: Create a Google Cloud Project
+## Path C Step 2: Create a Google Cloud Project
 
 Tell the user:
 
 > **Step 1: Create a Google Cloud project**
 >
-> Open this link to create a new project:
-> https://console.cloud.google.com/projectcreate
+> Open this link:
+> `https://console.cloud.google.com/projectcreate`
 >
-> Set the project name to **"Vellum Assistant"** and click **Create**.
+> Create a project named **Vellum Assistant**. If you already have a project you'd rather use, that's fine too.
 >
-> Let me know when it's done (or if you already have a project you'd like to use, just tell me the project ID).
+> Let me know when it's done, or send the project ID if you already know it.
 
-Wait for confirmation. Note the project ID for subsequent steps.
+Wait for confirmation. Record the project ID for the next steps.
 
-### Channel Step 3: Enable APIs
+## Path C Step 3: Enable APIs
 
 Tell the user:
 
@@ -69,96 +413,87 @@ Tell the user:
 >
 > Let me know when both are enabled.
 
-(Substitute the actual project ID into the URLs.)
-
-### Channel Step 4: Configure OAuth Consent Screen
+## Path C Step 4: Configure OAuth Consent Screen
 
 Tell the user:
 
 > **Step 3: Configure the OAuth consent screen**
 >
-> Open: `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
+> Open:
+> `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`
 >
-> 1. Select **"External"** user type, click **Create**
-> 2. Fill in:
->    - App name: **Vellum Assistant**
->    - User support email: **your email**
->    - Developer contact email: **your email**
-> 3. Click **Save and Continue**
-> 4. On the Scopes page, click **Add or Remove Scopes** and add these:
+> 1. Choose **External**
+> 2. Set app name to **Vellum Assistant**
+> 3. Set both support email and developer contact email to **your email**
+> 4. Add these scopes:
 >    - `https://www.googleapis.com/auth/gmail.readonly`
 >    - `https://www.googleapis.com/auth/gmail.modify`
 >    - `https://www.googleapis.com/auth/gmail.send`
 >    - `https://www.googleapis.com/auth/calendar.readonly`
 >    - `https://www.googleapis.com/auth/calendar.events`
 >    - `https://www.googleapis.com/auth/userinfo.email`
->    - Click **Update**, then **Save and Continue**
-> 5. On the Test users page, add **your email**, click **Save and Continue**
-> 6. On the Summary page, click **Back to Dashboard**
+> 5. Add **your email** as a test user
+> 6. Return to the dashboard
 >
-> Let me know when the consent screen is configured.
+> Let me know when that's done.
 
-### Channel Step 5: Create OAuth Credentials (Web Application)
+## Path C Step 5: Create Web Application Credentials
 
-Before sending Step 4 to the user, resolve the concrete callback URL:
+Before sending the next step, resolve the concrete callback URL:
 
-- Read the configured public gateway URL (`ingress.publicBaseUrl`). If it is missing, run the `public-ingress` skill first.
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, run the `public-ingress` skill first.
 - Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
-- When you send the instructions below, replace `OAUTH_CALLBACK_URL` with that concrete value. Never send placeholders literally.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
 
 Tell the user:
 
 > **Step 4: Create OAuth credentials**
 >
-> Open: `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
+> Open:
+> `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`
 >
 > Use this exact redirect URI:
 > `OAUTH_CALLBACK_URL`
 >
-> 1. Click **+ Create Credentials** → **OAuth client ID**
-> 2. Application type: Select **"Web application"** (not Desktop app)
+> 1. Click **+ Create Credentials** -> **OAuth client ID**
+> 2. Application type: **Web application**
 > 3. Name: **Vellum Assistant**
-> 4. Under **Authorized redirect URIs**, click **Add URI** and paste the redirect URI shown above
+> 4. Add the redirect URI shown above under **Authorized redirect URIs**
 > 5. Click **Create**
 >
-> A dialog will show your **Client ID** and **Client Secret**. Copy both values, you'll need them in the next step.
+> When the dialog appears, copy the Client ID and Client Secret. You'll send them to me next.
 
-**Important:** Channel users must use **"Web application"** credentials (not Desktop app) because the OAuth callback goes through the gateway URL.
+## Path C Step 6: Store Credentials
 
-### Channel Step 6: Store Credentials
-
-**Step 6a: Client ID (safe to send in chat)**
+### Path C Step 6a: Client ID
 
 Tell the user:
 
 > **Step 5a: Send your Client ID**
 >
-> Please send me the **Client ID** from the dialog. It looks like `123456789-xxxxx.apps.googleusercontent.com`.
+> Send me the **Client ID** from the dialog. It looks like `123456789-xxxxx.apps.googleusercontent.com`.
 
-Wait for the user to send the Client ID. Once received, store it:
+After the user sends it:
 
 ```
 credential_store store:
   service: "integration:gmail"
   field: "client_id"
-  value: "<the Client ID the user sent>"
+  value: "<the client id the user sent>"
 ```
 
-**Step 6b: Client Secret (requires split entry to avoid security filters)**
+### Path C Step 6b: Client Secret Split Entry
 
-The Client Secret starts with `GOCSPX-` which triggers the ingress secret scanner on channel messages. To work around this, ask the user to send only the portion _after_ the prefix.
+The Google client secret starts with `GOCSPX-`, which can trigger channel secret scanners. Ask for only the suffix.
 
 Tell the user:
 
-> **Step 5b: Send your Client Secret (split entry)**
+> **Step 5b: Send your Client Secret**
 >
-> Your Client Secret starts with `GOCSPX-` followed by a series of characters. For security reasons, I can't receive the full value directly in chat.
->
-> Please send me **only the part after** `GOCSPX-` (the characters that come after the dash) as a standalone message with no other text. For example, if your secret is `GOCSPX-AbCdEfGhIjKlMnOpQrStUvWxYz12`, send just:
->
-> `AbCdEfGhIjKlMnOpQrStUvWxYz12`
+> Your Client Secret starts with `GOCSPX-`. Please send me only the part **after** `GOCSPX-` as a standalone message with no other text.
 
-Wait for the user to send the suffix. Once received, reconstruct the full secret by prepending `GOCSPX-` and store it:
+After the user sends the suffix, reconstruct and store the full secret:
 
 ```
 credential_store store:
@@ -167,292 +502,38 @@ credential_store store:
   value: "GOCSPX-<the suffix the user sent>"
 ```
 
-**Important:** Always prepend `GOCSPX-` to the value the user provides. The user sends only the suffix; you reconstruct the full secret before storing.
-
-### Channel Step 7: Authorize
+## Path C Step 7: Authorize
 
 Tell the user:
 
-> **Step 6: Authorize access**
+> **Step 6: Authorize Gmail and Calendar**
 >
-> I'll now generate an authorization link for you.
+> I'll generate an authorization link for you now.
 
-Use `credential_store` with:
+Run:
 
 ```
-action: "oauth2_connect"
-service: "integration:gmail"
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:gmail"
 ```
 
-This will return an auth URL (since the session is non-interactive). Send the URL to the user:
+Send the returned auth URL to the user and tell them to open it. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.
 
-> Open this link to authorize Vellum to access your Gmail and Calendar. After you click **Allow**, the connection will be set up automatically.
+## Path C Step 8: Done
 
-**If the user sees a "This app isn't verified" warning:** Tell them this is normal for apps in testing mode. Click "Advanced" then "Go to Vellum Assistant (unsafe)" to proceed.
+After authorization:
 
-### Channel Step 8: Done!
-
-After the user authorizes (they'll come back and say so, or you can suggest they verify):
-
-> **Gmail and Calendar are connected!** Try asking me to check your inbox or show your upcoming events to verify everything is working.
+> **Gmail and Calendar are connected.**
 
 ---
 
-# Path B: Automated Setup (macOS Desktop App)
-
-You will automate the entire GCP setup via the browser while the user watches in the Chrome window on the side. The user's only manual actions are: signing in to their Google account, and copy-pasting credentials from the Chrome window into secure prompts.
-
-## Browser Interaction Principles
-
-Google Cloud Console's UI changes frequently. Do NOT memorize or depend on specific element IDs, CSS selectors, or DOM structures. Instead:
-
-1. **Snapshot first, act second.** Before every interaction, use `browser_snapshot` to discover interactive elements and their IDs. This is your primary navigation tool; it gives you the accessibility tree with clickable/typeable element IDs. Use `browser_screenshot` for visual context when the snapshot alone isn't enough.
-2. **Adapt to what you see.** If an element's label or position differs from what you expect, use the snapshot to find the correct element. GCP may rename buttons, reorganize menus, or change form layouts at any time.
-3. **Verify after every action.** After clicking, typing, or navigating, take a new snapshot to confirm the action succeeded. If it didn't, try an alternative interaction (e.g., if a dropdown didn't open on click, try pressing Space or Enter on the element).
-4. **Never assume DOM structure.** Dropdowns may be `<select>`, `<mat-select>`, `<div role="listbox">`, or something else entirely. Use the snapshot to identify element types and interact accordingly.
-5. **When stuck after 2 attempts, describe and ask.** Take a screenshot, describe what you see to the user, and ask for guidance.
-
-## Anti-Loop Guardrails
-
-Each step has a **retry budget of 3 attempts**. An attempt is one try at the step's primary action (e.g., clicking a button, filling a form). If a step fails after 3 attempts:
-
-1. **Stop trying.** Do not continue retrying the same approach.
-2. **Fall back to manual.** Tell the user what you were trying to do and ask them to complete that step manually in the Chrome window (which they can see on the side). Give them the direct URL and clear text instructions.
-3. **Resume automation** at the next step once the user confirms the manual step is done.
-
-If **two or more steps** require manual fallback, abandon the automated flow entirely and switch to giving the user the remaining steps as clear text instructions with links, using "Desktop app" as the OAuth application type.
-
-## Things That Do Not Work: Do Not Attempt
-
-These actions are technically impossible in the browser automation environment. Attempting them wastes time and leads to loops:
-
-- **Downloading files.** `browser_click` on a Download button does not save files to disk. There is NO JSON file to find at `~/Downloads` or anywhere else. Never click Download buttons.
-- **Clipboard operations.** You cannot copy/paste via browser automation. The user must manually copy values from the Chrome window.
-- **Deleting and recreating OAuth clients** to get a fresh secret. This orphans the stored client_id and causes `invalid_client` errors.
-- **Navigating away from the credential dialog** before both credentials are stored. You will lose the Client Secret display and cannot get it back without creating a new client.
-
-## Step 1: Single Upfront Confirmation
-
-Use `ui_show` with `surface_type: "confirmation"`. Set `message` to just the title, and `detail` to the body:
-
-- **message:** `Set up Google Cloud for Gmail & Calendar`
-- **detail:**
-  > Here's what will happen:
-  >
-  > 1. **A browser opens on the side** so you can watch everything I do
-  > 2. **You sign in** to your Google account in the browser
-  > 3. **I automate everything** including project creation, APIs, OAuth config, and credentials
-  > 4. **One copy-paste** where I'll ask you to copy the Client Secret from the browser into a secure prompt
-  > 5. **You authorize Vellum** with one click
-  >
-  > The whole thing takes 2-3 minutes. Ready?
-
-If the user declines, acknowledge and stop. No further confirmations are needed after this point.
-
-## Step 2: Open Google Cloud Console and Sign In
-
-**Goal:** The user is signed in and the Google Cloud Console dashboard is loaded.
-
-Navigate to `https://console.cloud.google.com/`.
-
-Take a screenshot to check the page state:
-
-- **Sign-in page:** Tell the user: "Please sign in to your Google account in the Chrome window on the right side of your screen." Then auto-detect sign-in completion by polling with `browser_screenshot` every 5-10 seconds to check if the URL has moved away from `accounts.google.com` to `console.cloud.google.com`. Do NOT ask the user to "let me know when you're done"; detect it automatically. Once sign-in is detected, tell the user: "Signed in! Starting the automated setup now..."
-- **Already signed in:** Tell the user: "Already signed in, starting setup now..." and continue immediately.
-- **CAPTCHA:** The browser automation's built-in handoff will handle this. If it persists, tell the user: "There's a CAPTCHA in the browser, please complete it and I'll continue automatically."
-
-**What you should see when done:** URL contains `console.cloud.google.com` and no sign-in overlay is visible.
-
-## Step 3: Create or Select a Project
-
-**Goal:** A GCP project named "Vellum Assistant" exists and is selected.
-
-Tell the user: "Creating Google Cloud project..."
-
-Navigate to `https://console.cloud.google.com/projectcreate`.
-
-Take a `browser_snapshot`. Find the project name input field (look for an element with label containing "Project name" or a text input near the top of the form). Type "Vellum Assistant" into it.
-
-Look for a "Create" button in the snapshot and click it. Wait 10-15 seconds for project creation, then take a screenshot to check for:
-
-- **Success message** or redirect to the new project dashboard. Note the project ID from the URL or page content.
-- **"Project name already in use" error**: that's fine. Navigate to `https://console.cloud.google.com/cloud-resource-manager` to find and select the existing "Vellum Assistant" project. Use `browser_extract` to read the project ID from the page.
-- **Organization restriction or quota error**: tell the user what happened and ask them to resolve it.
-
-**What you should see when done:** The project selector in the top bar shows the project name, and you have the project ID (something like `vellum-assistant-12345`).
-
-Tell the user: "Project created!"
-
-## Step 4: Enable Gmail and Calendar APIs
-
-**Goal:** Both the Gmail API and Google Calendar API are enabled for the project.
-
-Tell the user: "Enabling Gmail and Calendar APIs..."
-
-Navigate to each API's library page and enable it if not already enabled:
-
-1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
-2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
-
-For each page: take a `browser_snapshot`. Look for:
-
-- **"Enable" button**: click it, wait a few seconds, take another snapshot to confirm.
-- **"Manage" button or "API enabled" text**: the API is already enabled. Skip it.
-
-**What you should see when done:** Both API pages show "Manage" or "API enabled" status.
-
-Tell the user: "APIs enabled!"
-
-## Step 5: Configure OAuth Consent Screen
-
-**Goal:** An OAuth consent screen is configured with External user type, the required scopes, and the user added as a test user.
-
-Tell the user: "Setting up OAuth consent screen. This is the longest step but it's fully automated..."
-
-Navigate to `https://console.cloud.google.com/apis/credentials/consent?project=PROJECT_ID`.
-
-Take a `browser_snapshot` and `browser_screenshot`. Check the page state:
-
-### If the consent screen is already configured
-
-You'll see a dashboard showing the app name ("Vellum Assistant" or similar) with an "Edit App" button. **Skip to Step 6.**
-
-### If you see a user type selection (External / Internal)
-
-Select **"External"** and click **Create** or **Get Started**.
-
-### Consent screen form (wizard or single-page)
-
-Google Cloud uses either a multi-page wizard or a single-page form. Adapt to what you see:
-
-**App information section:**
-
-- **App name**: Type "Vellum Assistant" in the app name field.
-- **User support email**: This is typically a dropdown showing the signed-in user's email. Use `browser_snapshot` to find a `<select>` or clickable dropdown element near "User support email". Select the user's email.
-- **Developer contact email**: Type the user's email into this field. (Use the same email visible in the support email dropdown if you can read it, or use `browser_extract` to find the email shown on the page.)
-- Click **Save and Continue** if on a multi-page wizard.
-
-**Scopes section:**
-
-- Click **"Add or Remove Scopes"** (or similar button).
-- In the scope picker dialog, look for a text input labeled **"Manually add scopes"** or **"Filter"** at the bottom or top of the dialog.
-- Paste all 6 scopes at once as a comma-separated string into that input:
-  ```
-  https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email
-  ```
-- Click **"Add to Table"** or **"Update"** to confirm the scopes.
-- If no manual input is available, you'll need to search for and check each scope individually using the scope tree. Search for each scope URL in the filter box and check its checkbox.
-- Click **Save and Continue** (or **Update** then **Save and Continue**).
-
-**Test users section:**
-
-- Click **"Add Users"** or similar.
-- Enter the user's email address.
-- Click **Add** then **Save and Continue**.
-
-**Summary section:**
-
-- Click **"Back to Dashboard"** or **"Submit"**.
-
-**What you should see when done:** A consent screen dashboard showing "Vellum Assistant" as the app name.
-
-Tell the user: "Consent screen configured!"
-
-## Step 6: Create OAuth Credentials and Capture Them
-
-**Goal:** A "Desktop app" OAuth client exists, and both its Client ID and Client Secret are stored in the vault.
-
-Tell the user: "Creating OAuth credentials..."
-
-### 6a: Create the credential
-
-Navigate to `https://console.cloud.google.com/apis/credentials?project=PROJECT_ID`.
-
-Take a `browser_snapshot`. Find and click a button labeled **"Create Credentials"** or **"+ Create Credentials"**. A dropdown menu should appear. Take another snapshot and click **"OAuth client ID"**.
-
-On the creation form (take a snapshot to see the fields):
-
-- **Application type**: Find the dropdown and select **"Desktop app"**. This may be a `<select>` element or a custom dropdown. Use the snapshot to identify it. You might need to click the dropdown first, then take another snapshot to see the options, then click "Desktop app".
-- **Name**: Type "Vellum Assistant" in the name field.
-- Do NOT add any redirect URIs. The desktop app flow doesn't need them.
-
-Click **"Create"** to submit the form.
-
-### 6b: Capture credentials from the dialog
-
-After creation, a dialog will display the **Client ID** and **Client Secret**. This is the critical step.
-
-**First**, try to auto-read the **Client ID** using `browser_extract`. The Client ID matches the pattern `*.apps.googleusercontent.com`. Search the extracted text for this pattern. If found, store it:
-
-```
-credential_store store:
-  service: "integration:gmail"
-  field: "client_id"
-  value: "<the Client ID extracted from the page>"
-```
-
-If `browser_extract` fails to find the Client ID, prompt the user instead:
-
-```
-credential_store prompt:
-  service: "integration:gmail"
-  field: "client_id"
-  label: "Google OAuth Client ID"
-  description: "Copy the Client ID from the dialog in the Chrome window and paste it here. It looks like 123456789-xxxxx.apps.googleusercontent.com"
-  placeholder: "xxxxx.apps.googleusercontent.com"
-```
-
-**Then**, whether the Client ID was auto-read or prompted, tell the user:
-
-> "Got the Client ID! Now I need the Client Secret. You can see it in the dialog in the Chrome window. It starts with `GOCSPX-`. Please copy it and paste it into the secure prompt below."
-
-And present the secure prompt:
-
-```
-credential_store prompt:
-  service: "integration:gmail"
-  field: "client_secret"
-  label: "Google OAuth Client Secret"
-  description: "Copy the Client Secret from the Google Cloud Console dialog and paste it here."
-  placeholder: "GOCSPX-..."
-```
-
-Wait for the user to complete the prompt. **Do not take any other browser actions until the user has pasted the secret.** The dialog must stay open so they can see and copy the value.
-
-If the user has trouble locating the secret, take a `browser_screenshot` and describe where the secret field is on the screen, but do NOT attempt to read the secret value yourself. It must come from the user for accuracy.
-
-**What you should see when done:** `credential_store list` shows both `client_id` and `client_secret` for `integration:gmail`.
-
-Tell the user: "Credentials stored securely!"
-
-## Step 7: OAuth2 Authorization
-
-**Goal:** The user authorizes Vellum to access their Gmail and Calendar via OAuth.
-
-Tell the user: "Starting the authorization flow — a Google sign-in page will open in a few seconds. Just click 'Allow' when it appears."
-
-Use `credential_store` with:
-
-```
-action: "oauth2_connect"
-service: "integration:gmail"
-```
-
-This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config.
-
-**If the user sees a "This app isn't verified" warning:** Tell them: "You'll see an 'app isn't verified' warning. This is normal for personal apps in testing mode. Click **Advanced**, then **Go to Vellum Assistant (unsafe)** to proceed."
-
-**Verify:** The `oauth2_connect` call returns a success message with the connected account email.
-
-## Step 8: Done!
-
-Tell the user: "**Gmail and Calendar are connected!** You can now read, search, and send emails, plus view and manage your calendar. Try asking me to check your inbox or show your upcoming events!"
-
-## Error Handling
-
-- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
-- **Permission errors in GCP:** The user may need billing enabled or organization-level permissions. Explain clearly and ask them to resolve it.
-- **Consent screen already configured:** Don't overwrite. Skip to credential creation.
-- **Element not found:** Take a fresh `browser_snapshot` to re-assess. The GCP UI may have changed. Describe what you see and try alternative approaches. If stuck after 2 attempts, ask the user for guidance. They can see the Chrome window too.
-- **OAuth flow timeout or failure:** Offer to retry. The credentials are already stored, so reconnecting only requires re-running the authorization flow.
-- **Any unexpected state:** Take a `browser_screenshot`, describe what you see, and ask the user for guidance.
+## Guardrails and Error Handling
+
+- **No CDP or browser automation on Path A.** Use the user's real Chrome app plus computer use.
+- **Use AppleScript narrowly.** Good uses: activate Chrome, open a tab, set a URL, or inspect high-level Chrome state. Do not use `do shell script`.
+- **Do not delete and recreate OAuth clients** just to get another secret. That risks orphaning stored credentials.
+- **Do not leave the credential dialog early.** The Client Secret is shown only once.
+- **Google Cloud UI drift is normal.** Adapt to renamed buttons or reorganized layouts while preserving the same end state.
+- **If the user hits org policy, billing, or quota blockers, explain the blocker plainly and wait.**
+- **If Path A needs repeated manual rescue, switch to Path B.** Do not loop indefinitely.


### PR DESCRIPTION
## Summary
- rewrite `google-oauth-setup` to use real Chrome via computer use on macOS instead of the browser/CDP automation path
- add a manual desktop fallback while keeping the existing channel/public-ingress OAuth flow intact
- add a regression test and update the skill catalog metadata to remove the old `browser` include

## Testing
- `cd assistant && bun test src/__tests__/google-oauth-setup-skill-regression.test.ts`
- `cd assistant && bun test src/__tests__/skills.test.ts`
- `cd assistant && bun test src/__tests__/bundled-skill-retrieval-guard.test.ts`
- `cd assistant && bunx tsc --noEmit`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
