### PR TITLE
fix: hardcode daemon Sentry DSN

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -148,8 +148,11 @@ export function isMonitoringEnabled(): boolean {
   return getEnableMonitoring();
 }
 
-export function getSentryDsn(): string | undefined {
-  return str("SENTRY_DSN");
+const DEFAULT_SENTRY_DSN =
+  "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992";
+
+export function getSentryDsn(): string {
+  return str("SENTRY_DSN") ?? DEFAULT_SENTRY_DSN;
 }
 
 // ── Qdrant ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Hardcode the `vellum-assistant-brain` Sentry DSN as the default in `getSentryDsn()`, matching the pattern used by the macOS app (which hardcodes its own DSN in `AppDelegate.swift`)
- Previously the daemon only reported to Sentry if `SENTRY_DSN` was set in the environment, which was never the case for most users — making crash reporting effectively a no-op
- `SENTRY_DSN` env var still overrides the default for development

## Original prompt
Seeing a Processing Error / configuration issue on Sentry project VELLUM-ASSISTANT-BRAIN-1K. Investigated and found the daemon's Sentry DSN was never being set in production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
