### PR TITLE
Skip Platform API for skills list in dev mode

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -373,18 +373,14 @@ Examples:
     .option("--json", "Machine-readable JSON output")
     .action(async (opts: { json?: boolean }) => {
       try {
-        const catalog = await fetchCatalog();
-
-        // In dev mode, merge in skills from the repo-local skills/ directory
+        // In dev mode, use the local catalog as the source of truth
+        // and skip the remote Platform API entirely.
         const repoSkillsDir = getRepoSkillsDir();
+        let catalog: CatalogSkill[];
         if (repoSkillsDir) {
-          const localSkills = readLocalCatalog(repoSkillsDir);
-          const remoteIds = new Set(catalog.map((s) => s.id));
-          for (const local of localSkills) {
-            if (!remoteIds.has(local.id)) {
-              catalog.push(local);
-            }
-          }
+          catalog = readLocalCatalog(repoSkillsDir);
+        } else {
+          catalog = await fetchCatalog();
         }
 
         if (opts.json) {


### PR DESCRIPTION
## Summary
- In dev mode (`VELLUM_DEV=1`), `assistant skills list` now reads directly from the local `skills/catalog.json` instead of fetching from the Platform API first and merging
- Eliminates unnecessary network call that was failing through the outbound proxy due to SSL cert issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
