### PR TITLE
fix: remove tracked worktree files and gitignore worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage/
 dist
 
 # misc
+worktrees/
 .DS_Store
 .githooks/.githooks
 *.pem

--- a/worktrees/fix-apps-list-http/clients/.build
+++ b/worktrees/fix-apps-list-http/clients/.build
@@ -1,1 +1,0 @@
-/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/fix-apps-list-http/clients/.build

--- a/worktrees/no-tools-json/clients/.build
+++ b/worktrees/no-tools-json/clients/.build
@@ -1,1 +1,0 @@
-/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/no-tools-json/clients/.build

--- a/worktrees/remove-vellum-extensions/clients/.build
+++ b/worktrees/remove-vellum-extensions/clients/.build
@@ -1,1 +1,0 @@
-/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/remove-vellum-extensions/clients/.build

--- a/worktrees/weather-skill-cli/clients/.build
+++ b/worktrees/weather-skill-cli/clients/.build
@@ -1,1 +1,0 @@
-/Users/aaronlevin/Projects/VellumOrg/vellum-assistant/worktrees/weather-skill-cli/clients/.build


### PR DESCRIPTION
## Summary
- Removed four accidentally tracked `.build` symlinks under `worktrees/`
- Added `worktrees/` to `.gitignore` to prevent future tracking

## Test plan
- [x] Verify `git status` is clean after checkout
- [x] Confirm worktree directories are ignored going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
