### PR TITLE
M2: Replace spinners with ChatLoadingSkeleton

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -108,14 +108,9 @@ struct ChatView: View {
                     APIKeyBanner(onOpenSettings: onOpenSettings)
                 }
                 if messages.isEmpty && !isHistoryLoaded {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .controlSize(.small)
-                        Spacer()
-                    }
-                    Spacer()
+                    ChatLoadingSkeleton()
+                        .padding(VSpacing.lg)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if isEmptyState && isBootstrapping {
                     // During first-launch bootstrap, suppress the empty state
                     // and show a simple loading panel until the first assistant
@@ -404,21 +399,15 @@ private struct ChatBootstrapLoadingView: View {
     @State private var visible = false
 
     var body: some View {
-        VStack(spacing: VSpacing.lg) {
-            Spacer()
-            VLoadingIndicator(size: 24, color: VColor.accent)
-            Text("Getting ready...")
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .opacity(visible ? 1 : 0)
-        .onAppear {
-            withAnimation(VAnimation.standard) {
-                visible = true
+        ChatLoadingSkeleton()
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .opacity(visible ? 1 : 0)
+            .onAppear {
+                withAnimation(VAnimation.standard) {
+                    visible = true
+                }
             }
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -111,6 +111,8 @@ struct ChatView: View {
                     ChatLoadingSkeleton()
                         .padding(VSpacing.lg)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Loading chat history")
                 } else if isEmptyState && isBootstrapping {
                     // During first-launch bootstrap, suppress the empty state
                     // and show a simple loading panel until the first assistant
@@ -402,6 +404,8 @@ private struct ChatBootstrapLoadingView: View {
         ChatLoadingSkeleton()
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Getting ready")
             .opacity(visible ? 1 : 0)
             .onAppear {
                 withAnimation(VAnimation.standard) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Blank page with a centered loading spinner, shown over the chat area
-/// while waiting for the daemon to connect.
+/// Skeleton placeholder shown over the chat area while waiting for the
+/// daemon to connect.
 struct DaemonLoadingChatSkeleton: View {
     var body: some View {
         ZStack {

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -8,7 +8,8 @@ struct DaemonLoadingChatSkeleton: View {
         ZStack {
             VColor.backgroundSubtle
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-            VLoadingIndicator(size: 24, color: VColor.textMuted)
+            ChatLoadingSkeleton()
+                .padding(VSpacing.lg)
         }
         .accessibilityHidden(true)
     }


### PR DESCRIPTION
Replace ProgressView/VLoadingIndicator spinners with ChatLoadingSkeleton skeleton pattern in three locations: ChatView history loading, DaemonLoadingChatSkeleton, and ChatBootstrapLoadingView. Part of #14888.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
