### PR TITLE
fix: emit generation_cancelled immediately on abort

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -229,12 +229,13 @@ mock.module("../daemon/session-usage.js", () => ({
   recordUsage: recordUsageMock,
 }));
 
+const resolveAssistantAttachmentsMock = mock(async () => ({
+  assistantAttachments: [],
+  emittedAttachments: [],
+  directiveWarnings: [],
+}));
 mock.module("../daemon/session-attachments.js", () => ({
-  resolveAssistantAttachments: async () => ({
-    assistantAttachments: [],
-    emittedAttachments: [],
-    directiveWarnings: [],
-  }),
+  resolveAssistantAttachments: resolveAssistantAttachmentsMock,
   approveHostAttachmentRead: async () => true,
   formatAttachmentWarnings: () => "",
 }));
@@ -1505,6 +1506,46 @@ describe("session-agent-loop", () => {
       // Should NOT emit a session_error for user cancellation
       const sessionError = events.find((e) => e.type === "session_error");
       expect(sessionError).toBeUndefined();
+    });
+
+    test("skips resolveAssistantAttachments when cancelled", async () => {
+      const events: ServerMessage[] = [];
+      const abortController = new AbortController();
+      resolveAssistantAttachmentsMock.mockClear();
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "partial" }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 100,
+          outputTokens: 50,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+        // Simulate abort after processing
+        abortController.abort();
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "partial" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({ agentLoopRun, abortController });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      const cancelled = events.find((e) => e.type === "generation_cancelled");
+      expect(cancelled).toBeDefined();
+      // resolveAssistantAttachments should NOT have been called
+      expect(resolveAssistantAttachmentsMock).not.toHaveBeenCalled();
     });
   });
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1349,8 +1349,27 @@ export async function runAgentLoopImpl(
         });
       }
 
-      // Emit completion event
-      if (yieldedForHandoff) {
+      // Re-check: the user may have cancelled during attachment resolution
+      if (abortController.signal.aborted) {
+        ctx.emitActivityState(
+          "idle",
+          "generation_cancelled",
+          "global",
+          reqId,
+        );
+        ctx.traceEmitter.emit(
+          "generation_cancelled",
+          "Generation cancelled by user",
+          {
+            requestId: reqId,
+            status: "warning",
+          },
+        );
+        onEvent({
+          type: "generation_cancelled",
+          sessionId: ctx.conversationId,
+        });
+      } else if (yieldedForHandoff) {
         ctx.traceEmitter.emit(
           "generation_handoff",
           "Handing off to next queued message",

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1301,60 +1301,10 @@ export async function runAgentLoopImpl(
       sessionId: ctx.conversationId,
     });
 
-    // Resolve attachments
-    const attachmentResult = await resolveAssistantAttachments(
-      state.accumulatedDirectives,
-      state.accumulatedToolContentBlocks,
-      state.directiveWarnings,
-      ctx.workingDir,
-      async (filePath) =>
-        approveHostAttachmentRead(
-          filePath,
-          ctx.workingDir,
-          ctx.prompter,
-          ctx.conversationId,
-          ctx.hasNoClient,
-        ),
-      state.lastAssistantMessageId,
-      state.toolContentBlockToolNames,
-    );
-    const { assistantAttachments, emittedAttachments } = attachmentResult;
-
-    ctx.lastAssistantAttachments = assistantAttachments;
-    ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
-
-    const warningText = formatAttachmentWarnings(
-      attachmentResult.directiveWarnings,
-    );
-    if (warningText) {
-      onEvent({
-        type: "assistant_text_delta",
-        text: warningText,
-        sessionId: ctx.conversationId,
-      });
-    }
-
-    // Emit completion event
-    if (yieldedForHandoff) {
-      ctx.traceEmitter.emit(
-        "generation_handoff",
-        "Handing off to next queued message",
-        {
-          requestId: reqId,
-          status: "info",
-          attributes: { queuedCount: ctx.getQueueDepth() },
-        },
-      );
-      onEvent({
-        type: "generation_handoff",
-        sessionId: ctx.conversationId,
-        requestId: reqId,
-        queuedCount: ctx.getQueueDepth(),
-        ...(emittedAttachments.length > 0
-          ? { attachments: emittedAttachments }
-          : {}),
-      });
-    } else if (abortController.signal.aborted) {
+    // Fast-path: when the user cancelled, skip expensive post-loop work
+    // (attachment resolution) and emit the cancellation event immediately
+    // so the client can re-enable the UI without delay.
+    if (abortController.signal.aborted) {
       ctx.emitActivityState("idle", "generation_cancelled", "global", reqId);
       ctx.traceEmitter.emit(
         "generation_cancelled",
@@ -1366,18 +1316,77 @@ export async function runAgentLoopImpl(
       );
       onEvent({ type: "generation_cancelled", sessionId: ctx.conversationId });
     } else {
-      ctx.emitActivityState("idle", "message_complete", "global", reqId);
-      ctx.traceEmitter.emit("message_complete", "Message processing complete", {
-        requestId: reqId,
-        status: "success",
-      });
-      onEvent({
-        type: "message_complete",
-        sessionId: ctx.conversationId,
-        ...(emittedAttachments.length > 0
-          ? { attachments: emittedAttachments }
-          : {}),
-      });
+      // Resolve attachments (only when not cancelled — this is expensive async I/O)
+      const attachmentResult = await resolveAssistantAttachments(
+        state.accumulatedDirectives,
+        state.accumulatedToolContentBlocks,
+        state.directiveWarnings,
+        ctx.workingDir,
+        async (filePath) =>
+          approveHostAttachmentRead(
+            filePath,
+            ctx.workingDir,
+            ctx.prompter,
+            ctx.conversationId,
+            ctx.hasNoClient,
+          ),
+        state.lastAssistantMessageId,
+        state.toolContentBlockToolNames,
+      );
+      const { assistantAttachments, emittedAttachments } = attachmentResult;
+
+      ctx.lastAssistantAttachments = assistantAttachments;
+      ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
+
+      const warningText = formatAttachmentWarnings(
+        attachmentResult.directiveWarnings,
+      );
+      if (warningText) {
+        onEvent({
+          type: "assistant_text_delta",
+          text: warningText,
+          sessionId: ctx.conversationId,
+        });
+      }
+
+      // Emit completion event
+      if (yieldedForHandoff) {
+        ctx.traceEmitter.emit(
+          "generation_handoff",
+          "Handing off to next queued message",
+          {
+            requestId: reqId,
+            status: "info",
+            attributes: { queuedCount: ctx.getQueueDepth() },
+          },
+        );
+        onEvent({
+          type: "generation_handoff",
+          sessionId: ctx.conversationId,
+          requestId: reqId,
+          queuedCount: ctx.getQueueDepth(),
+          ...(emittedAttachments.length > 0
+            ? { attachments: emittedAttachments }
+            : {}),
+        });
+      } else {
+        ctx.emitActivityState("idle", "message_complete", "global", reqId);
+        ctx.traceEmitter.emit(
+          "message_complete",
+          "Message processing complete",
+          {
+            requestId: reqId,
+            status: "success",
+          },
+        );
+        onEvent({
+          type: "message_complete",
+          sessionId: ctx.conversationId,
+          ...(emittedAttachments.length > 0
+            ? { attachments: emittedAttachments }
+            : {}),
+        });
+      }
     }
 
     // Second title pass: after 3 completed turns, re-generate the title


### PR DESCRIPTION
## Summary
- Skip expensive `resolveAssistantAttachments()` async I/O when the user cancels generation, so the `generation_cancelled` event is emitted to the client immediately
- Previously, the post-loop cleanup (message history repair, usage stats, **attachment resolution**) all ran before the cancellation event was emitted — causing a noticeable delay between clicking Stop and the UI actually responding
- Now the abort check runs before attachment resolution; message history cleanup and usage stats still run (they're fast and needed for valid state)

## Test plan
- [x] Added test "skips resolveAssistantAttachments when cancelled" verifying the mock is never called when abort signal is set
- [x] All 32 existing session-agent-loop tests pass
- [ ] Manual: click Stop during generation and verify UI responds immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
