### PR TITLE
fix: upload dSYMs to both Sentry projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -727,6 +727,7 @@ jobs:
         run: |
           npm install -g @sentry/cli@2.42.2
           sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum --project vellum-assistant-brain dist/*.dSYM
 
       - name: Free disk space
         run: |
@@ -1067,6 +1068,7 @@ jobs:
         run: |
           npm install -g @sentry/cli@2.42.2
           sentry-cli debug-files upload --org vellum --project vellum-assistant-macos dist/*.dSYM
+          sentry-cli debug-files upload --org vellum --project vellum-assistant-brain dist/*.dSYM
 
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary
- Upload dSYMs to both `vellum-assistant-macos` and `vellum-assistant-brain` Sentry projects in the release workflow
- Old releases of the macOS app use the `vellum-assistant-brain` DSN (before Timur's DSN change in #14609), so events from users who haven't updated yet land in `vellum-assistant-brain` without dSYMs, causing "Processing Error" / "configuration issues" banners
- Once all users update to the new release, `vellum-assistant-brain` will stop receiving cocoa events and this extra upload becomes a harmless no-op

## Original prompt
Fix Sentry Processing Error on vellum-assistant-brain events by uploading dSYMs to the correct project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
