### PR TITLE
fix: remove stale QUEUE_FULL docs and dead rejected field

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -801,7 +801,6 @@ The daemon emits two distinct error message types via SSE:
 | `PROVIDER_NETWORK`          | Unable to reach the LLM provider (connection refused, timeout, DNS) | Yes       |
 | `PROVIDER_RATE_LIMIT`       | LLM provider rate-limited the request (HTTP 429)                    | Yes       |
 | `PROVIDER_API`              | Provider returned a server error (5xx)                              | Yes       |
-| `QUEUE_FULL`                | The message queue is full                                           | Yes       |
 | `SESSION_ABORTED`           | Non-user abort interrupted the request                              | Yes       |
 | `SESSION_PROCESSING_FAILED` | Catch-all for unexpected processing failures                        | No        |
 | `REGENERATE_FAILED`         | Failed to regenerate a previous response                            | Yes       |
@@ -813,7 +812,7 @@ The daemon classifies errors via `classifySessionError()` in `session-error.ts`.
 Classification uses a two-tier strategy:
 
 1. **Structured provider errors**: If the error is a `ProviderError` with a `statusCode`, the status code determines the category deterministically — `429` maps to `PROVIDER_RATE_LIMIT` (retryable), `5xx` to `PROVIDER_API` (retryable), other `4xx` to `PROVIDER_API` (not retryable).
-2. **Regex fallback**: For non-provider errors or `ProviderError` without a status code, regex pattern matching against the error message detects network failures, rate limits, and API errors. Phase-specific overrides handle queue and regeneration contexts.
+2. **Regex fallback**: For non-provider errors or `ProviderError` without a status code, regex pattern matching against the error message detects network failures, rate limits, and API errors. Phase-specific overrides handle regeneration contexts.
 
 Debug details are capped at 4,000 characters to prevent oversized payloads.
 

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -218,7 +218,6 @@ interface TestSession {
   denyAllPendingConfirmations: () => void;
   enqueueMessage: (...args: unknown[]) => {
     queued: boolean;
-    rejected?: boolean;
     requestId: string;
   };
   traceEmitter: { emit: (...args: unknown[]) => void };

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -91,7 +91,7 @@ function injectSubagent(
     messages: [],
     sendToClient: () => {},
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
-    enqueueMessage: () => ({ queued: false, rejected: false }),
+    enqueueMessage: () => ({ queued: false }),
     persistUserMessage: () => "msg-1",
     runAgentLoop: async () => {},
   };

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -214,7 +214,7 @@ export interface SurfaceSessionContext {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
-  ): { queued: boolean; rejected?: boolean; requestId: string };
+  ): { queued: boolean; requestId: string };
   getQueueDepth(): number;
   processMessage(
     content: string,


### PR DESCRIPTION
Address review feedback from #14868: remove QUEUE_FULL from ARCHITECTURE.md error codes table and clean up stale rejected?: boolean from interfaces and test mocks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
