### PR TITLE
Replace thread loading spinner with skeleton pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -38,12 +38,6 @@ struct ChatLoadingSkeleton: View {
             chatBone(height: 14)
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.45, alignment: .trailing)
         }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.md)
-        .background(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.textMuted.opacity(0.06))
-        )
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.65)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
@@ -63,12 +57,6 @@ struct ChatLoadingSkeleton: View {
                         )
                 }
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.md)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(VColor.textMuted.opacity(0.06))
-            )
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
             .overlay(alignment: .topLeading) {
                 Image(nsImage: appearance.chatAvatarImage)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -14,9 +14,9 @@ struct ChatLoadingSkeleton: View {
     /// Darker bone that uses a subtler shimmer to avoid the bright white sweep.
     private func chatBone(width: CGFloat? = nil, height: CGFloat = 14) -> some View {
         RoundedRectangle(cornerRadius: VRadius.sm)
-            .fill(VColor.surfaceBorder.opacity(0.7))
+            .fill(VColor.textMuted.opacity(0.15))
             .frame(width: width, height: height)
-            .vShimmer(highlightColor: VColor.surfaceBorder)
+            .vShimmer(highlightColor: VColor.textMuted.opacity(0.1))
     }
 
     var body: some View {
@@ -42,7 +42,7 @@ struct ChatLoadingSkeleton: View {
         .padding(.vertical, VSpacing.md)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surfaceBorder.opacity(0.25))
+                .fill(VColor.textMuted.opacity(0.06))
         )
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
         .frame(maxWidth: .infinity, alignment: .trailing)
@@ -67,7 +67,7 @@ struct ChatLoadingSkeleton: View {
             .padding(.vertical, VSpacing.md)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .fill(VColor.surfaceBorder.opacity(0.15))
+                    .fill(VColor.textMuted.opacity(0.06))
             )
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
             .overlay(alignment: .topLeading) {
@@ -78,7 +78,7 @@ struct ChatLoadingSkeleton: View {
                     .clipShape(Circle())
                     .overlay(
                         Circle()
-                            .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                            .strokeBorder(VColor.textMuted.opacity(0.2), lineWidth: 1)
                     )
                     .offset(x: -(28 + VSpacing.sm), y: 0)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -36,7 +36,7 @@ struct ChatLoadingSkeleton: View {
         VStack(alignment: .trailing, spacing: VSpacing.xs) {
             chatBone(height: 14)
             chatBone(height: 14)
-                .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.6, alignment: .trailing)
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.45, alignment: .trailing)
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -44,7 +44,7 @@ struct ChatLoadingSkeleton: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.textMuted.opacity(0.06))
         )
-        .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.65)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -32,7 +32,6 @@ struct ChatLoadingSkeleton: View {
                 }
             }
         }
-        .accessibilityHidden(true)
     }
 
     // MARK: - Assistant Row

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -11,6 +11,14 @@ struct ChatLoadingSkeleton: View {
     /// Varying lengths look more natural than uniform bones.
     private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
 
+    /// Darker bone that uses a subtler shimmer to avoid the bright white sweep.
+    private func chatBone(width: CGFloat? = nil, height: CGFloat = 14) -> some View {
+        RoundedRectangle(cornerRadius: VRadius.sm)
+            .fill(VColor.surfaceBorder.opacity(0.7))
+            .frame(width: width, height: height)
+            .vShimmer(highlightColor: VColor.surfaceBorder)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             userMessage
@@ -22,12 +30,12 @@ struct ChatLoadingSkeleton: View {
 
     // MARK: - User Message
 
-    /// Right-aligned user bubble with two short text lines inside,
+    /// Right-aligned user bubble with two text lines inside,
     /// matching real ChatBubble user styling (fill + padding + corner radius).
     private var userMessage: some View {
         VStack(alignment: .trailing, spacing: VSpacing.xs) {
-            VSkeletonBone(width: 180, height: 14, radius: VRadius.sm)
-            VSkeletonBone(width: 120, height: 14, radius: VRadius.sm)
+            chatBone(width: 280, height: 14)
+            chatBone(width: 200, height: 14)
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -47,14 +55,11 @@ struct ChatLoadingSkeleton: View {
         HStack(alignment: .top, spacing: 0) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 ForEach(assistantLineWidths.indices, id: \.self) { idx in
-                    VSkeletonBone(
-                        height: 14,
-                        radius: VRadius.sm
-                    )
-                    .frame(
-                        maxWidth: VSpacing.chatBubbleMaxWidth * assistantLineWidths[idx],
-                        alignment: .leading
-                    )
+                    chatBone(height: 14)
+                        .frame(
+                            maxWidth: VSpacing.chatBubbleMaxWidth * assistantLineWidths[idx],
+                            alignment: .leading
+                        )
                 }
             }
             .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -38,6 +38,12 @@ struct ChatLoadingSkeleton: View {
             chatBone(height: 14)
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.45, alignment: .trailing)
         }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.userBubble)
+        )
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.65)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Skeleton placeholder for the chat area while a thread is loading.
+/// Shows alternating assistant/user message bones that mimic the real
+/// `ChatBubble` layout, replacing a generic spinner with a content-aware preview.
+struct ChatLoadingSkeleton: View {
+    /// Defines a skeleton row: either an assistant or user message placeholder.
+    private struct SkeletonRow: Identifiable {
+        let id: Int
+        let isUser: Bool
+        /// Fraction of `chatBubbleMaxWidth` the main bone should occupy.
+        let widthFraction: CGFloat
+        /// Height of the main text bone.
+        let boneHeight: CGFloat
+    }
+
+    private let rows: [SkeletonRow] = [
+        SkeletonRow(id: 0, isUser: false, widthFraction: 0.75, boneHeight: 48),
+        SkeletonRow(id: 1, isUser: true,  widthFraction: 0.40, boneHeight: 20),
+        SkeletonRow(id: 2, isUser: false, widthFraction: 0.60, boneHeight: 32),
+        SkeletonRow(id: 3, isUser: true,  widthFraction: 0.35, boneHeight: 20),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            ForEach(rows) { row in
+                if row.isUser {
+                    userRow(row)
+                } else {
+                    assistantRow(row)
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Assistant Row
+
+    @ViewBuilder
+    private func assistantRow(_ row: SkeletonRow) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            // Avatar placeholder
+            VSkeletonBone(width: 28, height: 28, radius: VRadius.pill)
+
+            // Text bone
+            VSkeletonBone(height: row.boneHeight, radius: VRadius.lg)
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth * row.widthFraction)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - User Row
+
+    @ViewBuilder
+    private func userRow(_ row: SkeletonRow) -> some View {
+        VSkeletonBone(height: row.boneHeight, radius: VRadius.lg)
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth * row.widthFraction)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+}
+
+#if DEBUG
+#Preview("ChatLoadingSkeleton") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ChatLoadingSkeleton()
+            .padding(VSpacing.lg)
+    }
+    .frame(width: 700, height: 400)
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -2,60 +2,68 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Skeleton placeholder for the chat area while a thread is loading.
-/// Shows alternating assistant/user message bones that mimic the real
-/// `ChatBubble` layout, replacing a generic spinner with a content-aware preview.
+/// Mimics the real `ChatBubble` layout — a short user message followed by a
+/// multi-line assistant response — so the transition to real content feels seamless.
 struct ChatLoadingSkeleton: View {
-    /// Defines a skeleton row: either an assistant or user message placeholder.
-    private struct SkeletonRow: Identifiable {
-        let id: Int
-        let isUser: Bool
-        /// Fraction of `chatBubbleMaxWidth` the main bone should occupy.
-        let widthFraction: CGFloat
-        /// Height of the main text bone.
-        let boneHeight: CGFloat
-    }
-
-    private let rows: [SkeletonRow] = [
-        SkeletonRow(id: 0, isUser: false, widthFraction: 0.75, boneHeight: 48),
-        SkeletonRow(id: 1, isUser: true,  widthFraction: 0.40, boneHeight: 20),
-        SkeletonRow(id: 2, isUser: false, widthFraction: 0.60, boneHeight: 32),
-        SkeletonRow(id: 3, isUser: true,  widthFraction: 0.35, boneHeight: 20),
-    ]
+    /// Line widths for the multi-line assistant text block.
+    /// Varying lengths look more natural than uniform bones.
+    private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(rows) { row in
-                if row.isUser {
-                    userRow(row)
-                } else {
-                    assistantRow(row)
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            userMessage
+            assistantMessage
+        }
+        .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
+    }
+
+    // MARK: - User Message
+
+    /// Right-aligned user bubble with two short text lines inside,
+    /// matching real ChatBubble user styling (fill + padding + corner radius).
+    private var userMessage: some View {
+        VStack(alignment: .trailing, spacing: VSpacing.xs) {
+            VSkeletonBone(width: 180, height: 14, radius: VRadius.sm)
+            VSkeletonBone(width: 120, height: 14, radius: VRadius.sm)
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceBorder.opacity(0.25))
+        )
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .trailing)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    // MARK: - Assistant Message
+
+    /// Left-aligned assistant block with avatar placeholder and six text lines,
+    /// matching real ChatBubble assistant layout (28pt avatar + 8pt gap + content).
+    private var assistantMessage: some View {
+        HStack(alignment: .top, spacing: 0) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                ForEach(assistantLineWidths.indices, id: \.self) { idx in
+                    VSkeletonBone(
+                        height: 14,
+                        radius: VRadius.sm
+                    )
+                    .frame(
+                        maxWidth: VSpacing.chatBubbleMaxWidth * assistantLineWidths[idx],
+                        alignment: .leading
+                    )
                 }
             }
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+            .overlay(alignment: .topLeading) {
+                // Avatar bone positioned identically to real ChatBubble
+                VSkeletonBone(width: 28, height: 28, radius: VRadius.pill)
+                    .offset(x: -(28 + VSpacing.sm), y: 0)
+            }
+            .padding(.leading, 28 + VSpacing.sm)
+
+            Spacer(minLength: 0)
         }
-    }
-
-    // MARK: - Assistant Row
-
-    @ViewBuilder
-    private func assistantRow(_ row: SkeletonRow) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            // Avatar placeholder
-            VSkeletonBone(width: 28, height: 28, radius: VRadius.pill)
-
-            // Text bone
-            VSkeletonBone(height: row.boneHeight, radius: VRadius.lg)
-                .frame(maxWidth: VSpacing.chatBubbleMaxWidth * row.widthFraction)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - User Row
-
-    @ViewBuilder
-    private func userRow(_ row: SkeletonRow) -> some View {
-        VSkeletonBone(height: row.boneHeight, radius: VRadius.lg)
-            .frame(maxWidth: VSpacing.chatBubbleMaxWidth * row.widthFraction)
-            .frame(maxWidth: .infinity, alignment: .trailing)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -5,6 +5,8 @@ import VellumAssistantShared
 /// Mimics the real `ChatBubble` layout — a short user message followed by a
 /// multi-line assistant response — so the transition to real content feels seamless.
 struct ChatLoadingSkeleton: View {
+    @State private var appearance = AvatarAppearanceManager.shared
+
     /// Line widths for the multi-line assistant text block.
     /// Varying lengths look more natural than uniform bones.
     private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
@@ -13,6 +15,7 @@ struct ChatLoadingSkeleton: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             userMessage
             assistantMessage
+            Spacer(minLength: 0)
         }
         .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
     }
@@ -38,8 +41,8 @@ struct ChatLoadingSkeleton: View {
 
     // MARK: - Assistant Message
 
-    /// Left-aligned assistant block with avatar placeholder and six text lines,
-    /// matching real ChatBubble assistant layout (28pt avatar + 8pt gap + content).
+    /// Left-aligned assistant block with real avatar and six text lines inside
+    /// a subtle bubble, matching real ChatBubble assistant layout.
     private var assistantMessage: some View {
         HStack(alignment: .top, spacing: 0) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -54,10 +57,23 @@ struct ChatLoadingSkeleton: View {
                     )
                 }
             }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.md)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.surfaceBorder.opacity(0.15))
+            )
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
             .overlay(alignment: .topLeading) {
-                // Avatar bone positioned identically to real ChatBubble
-                VSkeletonBone(width: 28, height: 28, radius: VRadius.pill)
+                Image(nsImage: appearance.chatAvatarImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 28, height: 28)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                    )
                     .offset(x: -(28 + VSpacing.sm), y: 0)
             }
             .padding(.leading, 28 + VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -34,8 +34,9 @@ struct ChatLoadingSkeleton: View {
     /// matching real ChatBubble user styling (fill + padding + corner radius).
     private var userMessage: some View {
         VStack(alignment: .trailing, spacing: VSpacing.xs) {
-            chatBone(width: 280, height: 14)
-            chatBone(width: 200, height: 14)
+            chatBone(height: 14)
+            chatBone(height: 14)
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth * 0.6, alignment: .trailing)
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
@@ -43,7 +44,7 @@ struct ChatLoadingSkeleton: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .fill(VColor.surfaceBorder.opacity(0.25))
         )
-        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .trailing)
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -110,7 +110,7 @@ struct ChatView: View {
                 if messages.isEmpty && !isHistoryLoaded {
                     ChatLoadingSkeleton()
                         .padding(VSpacing.lg)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                         .accessibilityElement(children: .ignore)
                         .accessibilityLabel("Loading chat history")
                 } else if isEmptyState && isBootstrapping {
@@ -403,7 +403,7 @@ private struct ChatBootstrapLoadingView: View {
     var body: some View {
         ChatLoadingSkeleton()
             .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("Getting ready")
             .opacity(visible ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -108,14 +108,11 @@ struct ChatView: View {
                     APIKeyBanner(onOpenSettings: onOpenSettings)
                 }
                 if messages.isEmpty && !isHistoryLoaded {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .controlSize(.small)
-                        Spacer()
-                    }
-                    Spacer()
+                    ChatLoadingSkeleton()
+                        .padding(VSpacing.lg)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Loading chat history")
                 } else if isEmptyState && isBootstrapping {
                     // During first-launch bootstrap, suppress the empty state
                     // and show a simple loading panel until the first assistant
@@ -404,21 +401,17 @@ private struct ChatBootstrapLoadingView: View {
     @State private var visible = false
 
     var body: some View {
-        VStack(spacing: VSpacing.lg) {
-            Spacer()
-            VLoadingIndicator(size: 24, color: VColor.accent)
-            Text("Getting ready...")
-                .font(VFont.body)
-                .foregroundColor(VColor.textSecondary)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .opacity(visible ? 1 : 0)
-        .onAppear {
-            withAnimation(VAnimation.standard) {
-                visible = true
+        ChatLoadingSkeleton()
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Getting ready")
+            .opacity(visible ? 1 : 0)
+            .onAppear {
+                withAnimation(VAnimation.standard) {
+                    visible = true
+                }
             }
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DaemonLoadingOverlay.swift
@@ -1,14 +1,15 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Blank page with a centered loading spinner, shown over the chat area
-/// while waiting for the daemon to connect.
+/// Skeleton placeholder shown over the chat area while waiting for the
+/// daemon to connect.
 struct DaemonLoadingChatSkeleton: View {
     var body: some View {
         ZStack {
             VColor.backgroundSubtle
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-            VLoadingIndicator(size: 24, color: VColor.textMuted)
+            ChatLoadingSkeleton()
+                .padding(VSpacing.lg)
         }
         .accessibilityHidden(true)
     }


### PR DESCRIPTION
## Summary
Replace the spinning loading indicators in the chat area with content-aware skeleton placeholders that mimic the chat message layout, providing better perceived-performance UX when threads are loading.

## Changes
- Added `ChatLoadingSkeleton` component with alternating assistant/user skeleton message bubbles using `VSkeletonBone` + shimmer animation
- Replaced `ProgressView()` spinner in ChatView (history loading state) with `ChatLoadingSkeleton()`
- Replaced `VLoadingIndicator` in `DaemonLoadingChatSkeleton` with `ChatLoadingSkeleton()`
- Replaced `VLoadingIndicator` + "Getting ready..." in `ChatBootstrapLoadingView` with `ChatLoadingSkeleton()`
- Added VoiceOver accessibility labels for all skeleton loading states
- Uses adaptive `maxWidth` sizing so skeletons scale with narrow containers

## Milestone PRs (merged into feature branch)
- #14893: M1: Add ChatLoadingSkeleton component
- #14902: M2: Replace spinners with ChatLoadingSkeleton

## Project issue
Closes #14888

## Test plan
- [ ] Open the app and click on a thread — verify skeleton appears instead of spinner while messages load
- [ ] Kill the daemon and relaunch — verify skeleton appears in chat area during daemon connection
- [ ] Test first-launch bootstrap — verify skeleton with fade-in instead of spinner + "Getting ready..."
- [ ] Open a side panel to narrow the chat area — verify skeletons scale down without clipping
- [ ] Enable VoiceOver — verify "Loading chat history" / "Getting ready" labels are announced

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
