### PR TITLE
fix: prevent config backfill hot-loop that starves daemon requests

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -180,8 +180,16 @@ function backfillConfigDefaults(
     return;
   }
 
-  if (deepMergeMissing(raw as Record<string, unknown>, fullDefaults)) {
-    writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n");
+  deepMergeMissing(raw as Record<string, unknown>, fullDefaults);
+  // Compare serialized JSON to decide whether a write is needed.
+  // deepMergeMissing can report false-positive mutations (e.g. setting a key
+  // to a value identical to what was already there), so comparing the final
+  // JSON avoids a hot-loop where writing triggers the config-watcher which
+  // reloads and backfills again endlessly.
+  const newJson = JSON.stringify(raw, null, 2) + "\n";
+  const existingJson = readFileSync(configPath, "utf-8");
+  if (newJson !== existingJson) {
+    writeFileSync(configPath, newJson);
     log.info("Backfilled missing config defaults in %s", configPath);
   }
 }


### PR DESCRIPTION
## Summary
- `deepMergeMissing` can return `true` (claiming mutations) even when the serialized JSON is identical to what's on disk
- This caused an infinite cycle: backfill writes config.json → watcher fires → reload → backfill writes again, repeating every ~250ms
- The hot-loop starved the daemon, preventing it from serving thread list and other HTTP requests (app showed no threads)
- Fix: compare the final JSON against the existing file content instead of relying on `deepMergeMissing`'s return value

## Test plan
- [x] Existing `config-loader-backfill.test.ts` tests pass (11/11)
- [x] Verified fix stops the hot-loop in the running daemon
- [x] Verified threads load in macOS app after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
