### PR TITLE
Replace targetInputTokens with targetBudgetRatio for context window compaction

### DIFF
--- a/assistant/src/__tests__/compaction.benchmark.test.ts
+++ b/assistant/src/__tests__/compaction.benchmark.test.ts
@@ -4,8 +4,8 @@
  * Measures compaction cost with a mock provider:
  * - compaction latency under threshold pressure
  * - no-op fast path for below-threshold histories
- * - token reduction ratio after compaction
- * - summary call count within expected range
+ * - token reduction below target budget
+ * - single-pass summarization (exactly 1 call)
  * - severe pressure overriding cooldown
  */
 import { describe, expect, mock, test } from "bun:test";
@@ -73,9 +73,8 @@ function makeConfig() {
   return {
     ...DEFAULT_CONFIG.contextWindow,
     maxInputTokens: 6000,
-    targetInputTokens: 3200,
+    targetBudgetRatio: 0.58,
     compactThreshold: 0.6,
-    preserveRecentUserTurns: 8,
     summaryBudgetRatio: 0.05,
   };
 }
@@ -131,7 +130,7 @@ describe("Compaction benchmark", () => {
     expect(counter.calls).toBe(0);
   });
 
-  test("token reduction ratio exceeds 30% after compaction", async () => {
+  test("compaction reduces tokens below target budget", async () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
@@ -145,13 +144,17 @@ describe("Compaction benchmark", () => {
     const result = await manager.maybeCompact(messages);
 
     expect(result.compacted).toBe(true);
-    const reductionRatio =
-      (result.previousEstimatedInputTokens - result.estimatedInputTokens) /
-      result.previousEstimatedInputTokens;
-    expect(reductionRatio).toBeGreaterThan(0.3);
+    expect(result.estimatedInputTokens).toBeLessThan(
+      result.previousEstimatedInputTokens,
+    );
+    // Target is maxInputTokens * (targetBudgetRatio - summaryBudgetRatio)
+    const targetTokens = Math.floor(
+      config.maxInputTokens * (config.targetBudgetRatio - config.summaryBudgetRatio),
+    );
+    expect(result.estimatedInputTokens).toBeLessThanOrEqual(targetTokens);
   });
 
-  test("summary calls fall within 2-6 range", async () => {
+  test("single-pass summarization makes exactly 1 summary call", async () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
@@ -165,8 +168,7 @@ describe("Compaction benchmark", () => {
     const result = await manager.maybeCompact(messages);
 
     expect(result.compacted).toBe(true);
-    expect(result.summaryCalls).toBeGreaterThanOrEqual(2);
-    expect(result.summaryCalls).toBeLessThanOrEqual(6);
+    expect(result.summaryCalls).toBe(1);
     expect(result.summaryCalls).toBe(counter.calls);
   });
 
@@ -177,7 +179,7 @@ describe("Compaction benchmark", () => {
     const config = {
       ...makeConfig(),
       maxInputTokens: 4000,
-      targetInputTokens: 2000,
+      targetBudgetRatio: 0.55,
     };
     const manager = new ContextWindowManager({
       provider,

--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -17,10 +17,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 180000,
-      targetInputTokens: 110000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
   }),
   invalidateConfigCache: () => {},

--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -75,10 +75,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 180000,
-      targetInputTokens: 110000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
     assistantFeatureFlagValues: {},
   }),

--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -15,10 +15,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 180000,
-      targetInputTokens: 110000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
   }),
   invalidateConfigCache: () => {},

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -97,9 +97,8 @@ describe("AssistantConfigSchema", () => {
     expect(result.contextWindow).toEqual({
       enabled: true,
       maxInputTokens: 200000,
-      targetInputTokens: 110000,
+      targetBudgetRatio: 0.3,
       compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
       summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
@@ -321,18 +320,18 @@ describe("AssistantConfigSchema", () => {
     }
   });
 
-  test("rejects contextWindow targetInputTokens >= maxInputTokens", () => {
+  test("rejects contextWindow targetBudgetRatio >= compactThreshold", () => {
     const result = AssistantConfigSchema.safeParse({
-      contextWindow: { maxInputTokens: 1000, targetInputTokens: 1000 },
+      contextWindow: { targetBudgetRatio: 0.8, compactThreshold: 0.8 },
     });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(
         result.error.issues.some(
           (issue) =>
-            issue.path.join(".") === "contextWindow.targetInputTokens" &&
+            issue.path.join(".") === "contextWindow.targetBudgetRatio" &&
             issue.message.includes(
-              "must be less than contextWindow.maxInputTokens",
+              "must be less than contextWindow.compactThreshold",
             ),
         ),
       ).toBe(true);
@@ -1101,9 +1100,8 @@ describe("loadConfig with schema validation", () => {
     expect(config.contextWindow).toEqual({
       enabled: true,
       maxInputTokens: 200000,
-      targetInputTokens: 110000,
+      targetBudgetRatio: 0.3,
       compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
       summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
@@ -1194,11 +1192,11 @@ describe("loadConfig with schema validation", () => {
 
   test("falls back for invalid contextWindow relationship", () => {
     writeConfig({
-      contextWindow: { maxInputTokens: 1000, targetInputTokens: 1000 },
+      contextWindow: { targetBudgetRatio: 0.8, compactThreshold: 0.8 },
     });
     const config = loadConfig();
-    expect(config.contextWindow.maxInputTokens).toBe(200000);
-    expect(config.contextWindow.targetInputTokens).toBe(110000);
+    expect(config.contextWindow.targetBudgetRatio).toBe(0.3);
+    expect(config.contextWindow.compactThreshold).toBe(0.8);
   });
 
   test("falls back for invalid rateLimit values", () => {

--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -430,9 +430,8 @@ describe("Context + Memory E2E regression", () => {
       config: {
         ...DEFAULT_CONFIG.contextWindow,
         maxInputTokens: 5200,
-        targetInputTokens: 2600,
+        targetBudgetRatio: 0.55,
         compactThreshold: 0.55,
-        preserveRecentUserTurns: 6,
         summaryBudgetRatio: 0.05,
       },
     });

--- a/assistant/src/__tests__/context-overflow-reducer.test.ts
+++ b/assistant/src/__tests__/context-overflow-reducer.test.ts
@@ -57,9 +57,8 @@ function makeConfig(overrides?: Partial<ReducerConfig>): ReducerConfig {
     contextWindow: {
       enabled: true,
       maxInputTokens: 2000,
-      targetInputTokens: 1200,
+      targetBudgetRatio: 0.65,
       compactThreshold: 0.6,
-      preserveRecentUserTurns: 2,
       summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -20,9 +20,8 @@ function makeConfig(
   return {
     enabled: true,
     maxInputTokens: 450,
-    targetInputTokens: 300,
+    targetBudgetRatio: 0.67,
     compactThreshold: 0.6,
-    preserveRecentUserTurns: 2,
     summaryBudgetRatio: 0.05,
     overflowRecovery: {
       enabled: true,
@@ -84,7 +83,7 @@ describe("ContextWindowManager", () => {
     const manager = new ContextWindowManager({
       provider,
       systemPrompt: "system prompt",
-      config: makeConfig(),
+      config: makeConfig({ maxInputTokens: 600 }),
     });
     const long = "x".repeat(240);
     const history: Message[] = [
@@ -146,8 +145,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 7_000,
-        targetInputTokens: 2_500,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.41,
       }),
     });
     const long = "q".repeat(6_000);
@@ -186,8 +184,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 300,
-        targetInputTokens: 160,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.58,
       }),
     });
     const long = "y".repeat(220);
@@ -226,8 +223,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 260,
-        targetInputTokens: 140,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.59,
       }),
     });
     const long = "z".repeat(220);
@@ -265,8 +261,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 280,
-        targetInputTokens: 150,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.59,
       }),
     });
     const long = "f".repeat(220);
@@ -314,8 +309,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 320,
-        targetInputTokens: 170,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.58,
       }),
     });
     const long = "k".repeat(220);
@@ -362,8 +356,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 320,
-        targetInputTokens: 170,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.58,
       }),
     });
     const long = "k".repeat(220);
@@ -423,8 +416,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 2600,
-        targetInputTokens: 1500,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.63,
       }),
     });
     const long = "c".repeat(5000);
@@ -468,8 +460,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 260,
-        targetInputTokens: 180,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.74,
       }),
     });
     const long = "c".repeat(220);
@@ -498,8 +489,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 320,
-        targetInputTokens: 180,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.61,
       }),
     });
     const long = "p".repeat(340);
@@ -530,8 +520,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 260,
-        targetInputTokens: 180,
-        preserveRecentUserTurns: 1,
+        targetBudgetRatio: 0.74,
       }),
     });
     const long = "c".repeat(220);
@@ -564,9 +553,8 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 7000,
-        targetInputTokens: 5000,
+        targetBudgetRatio: 0.76,
         compactThreshold: 0.8,
-        preserveRecentUserTurns: 1,
       }),
     });
 
@@ -616,8 +604,7 @@ describe("ContextWindowManager", () => {
       systemPrompt: "system prompt",
       config: makeConfig({
         maxInputTokens: 260,
-        targetInputTokens: 60,
-        preserveRecentUserTurns: 2,
+        targetBudgetRatio: 0.28,
       }),
     });
     const long = "e".repeat(220);
@@ -632,7 +619,7 @@ describe("ContextWindowManager", () => {
       minKeepRecentUserTurns: 0,
     });
     expect(result.compacted).toBe(true);
-    // With minKeepRecentUserTurns=0 and a tight targetInputTokens budget,
+    // With minKeepRecentUserTurns=0 and a tight target budget,
     // pickKeepBoundary drops keepTurns all the way to 0.
     // All three messages are compacted into a single summary message.
     expect(result.compactedMessages).toBe(3);
@@ -712,8 +699,7 @@ describe("ContextWindowManager", () => {
     // Use generous default target so normal compaction would keep all 3 user turns.
     const config = makeConfig({
       maxInputTokens: 1200,
-      targetInputTokens: 1000,
-      preserveRecentUserTurns: 3,
+      targetBudgetRatio: 0.88,
     });
     const long = "t".repeat(220);
     const history: Message[] = [

--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -199,9 +199,8 @@ describe("Memory context benchmark", () => {
       config: {
         ...DEFAULT_CONFIG.contextWindow,
         maxInputTokens: 6000,
-        targetInputTokens: 3200,
+        targetBudgetRatio: 0.58,
         compactThreshold: 0.6,
-        preserveRecentUserTurns: 8,
         summaryBudgetRatio: 0.05,
       },
     });

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -32,10 +32,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 180000,
-      targetInputTokens: 110000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
   }),
   invalidateConfigCache: noop,

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -32,10 +32,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 180000,
-      targetInputTokens: 110000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
   }),
   invalidateConfigCache: noop,

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -102,10 +102,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -142,10 +142,8 @@ const mockConfig = {
   contextWindow: {
     enabled: true,
     maxInputTokens: 180000,
-    targetInputTokens: 110000,
-    compactThreshold: 0.8,
-    preserveRecentUserTurns: 8,
-    summaryBudgetRatio: 0.05,
+    targetBudgetRatio: 0.30,
+    compactThreshold: 0.8,    summaryBudgetRatio: 0.05,
   },
   thinking: { enabled: false },
 };

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -51,10 +51,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -36,10 +36,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 70000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 6,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,

--- a/assistant/src/__tests__/session-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/session-workspace-cache-state.test.ts
@@ -32,10 +32,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     apiKeys: {},

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -46,10 +46,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -44,10 +44,8 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetInputTokens: 80000,
-      compactThreshold: 0.8,
-      preserveRecentUserTurns: 8,
-      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.30,
+      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -329,16 +329,16 @@ export const AssistantConfigSchema = z
   })
   .superRefine((config, ctx) => {
     if (
-      config.contextWindow?.targetInputTokens != null &&
-      config.contextWindow?.maxInputTokens != null &&
-      config.contextWindow.targetInputTokens >=
-        config.contextWindow.maxInputTokens
+      config.contextWindow?.targetBudgetRatio != null &&
+      config.contextWindow?.compactThreshold != null &&
+      config.contextWindow.targetBudgetRatio >=
+        config.contextWindow.compactThreshold
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ["contextWindow", "targetInputTokens"],
+        path: ["contextWindow", "targetBudgetRatio"],
         message:
-          "contextWindow.targetInputTokens must be less than contextWindow.maxInputTokens",
+          "contextWindow.targetBudgetRatio must be less than contextWindow.compactThreshold",
       });
     }
     const segmentation = config.memory?.segmentation;

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -80,24 +80,18 @@ export const ContextWindowConfigSchema = z.object({
     .int("contextWindow.maxInputTokens must be an integer")
     .positive("contextWindow.maxInputTokens must be a positive integer")
     .default(200000),
-  targetInputTokens: z
-    .number({ error: "contextWindow.targetInputTokens must be a number" })
-    .int("contextWindow.targetInputTokens must be an integer")
-    .positive("contextWindow.targetInputTokens must be a positive integer")
-    .default(110000),
+  targetBudgetRatio: z
+    .number({ error: "contextWindow.targetBudgetRatio must be a number" })
+    .finite("contextWindow.targetBudgetRatio must be finite")
+    .gt(0, "contextWindow.targetBudgetRatio must be greater than 0")
+    .lte(1, "contextWindow.targetBudgetRatio must be less than or equal to 1")
+    .default(0.3),
   compactThreshold: z
     .number({ error: "contextWindow.compactThreshold must be a number" })
     .finite("contextWindow.compactThreshold must be finite")
     .gt(0, "contextWindow.compactThreshold must be greater than 0")
     .lte(1, "contextWindow.compactThreshold must be less than or equal to 1")
     .default(0.8),
-  preserveRecentUserTurns: z
-    .number({ error: "contextWindow.preserveRecentUserTurns must be a number" })
-    .int("contextWindow.preserveRecentUserTurns must be an integer")
-    .positive(
-      "contextWindow.preserveRecentUserTurns must be a positive integer",
-    )
-    .default(8),
   summaryBudgetRatio: z
     .number({ error: "contextWindow.summaryBudgetRatio must be a number" })
     .finite("contextWindow.summaryBudgetRatio must be finite")

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -435,6 +435,13 @@ export class ContextWindowManager {
     };
   }
 
+  private get targetInputTokens(): number {
+    return Math.floor(
+      this.config.maxInputTokens *
+        (this.config.targetBudgetRatio - this.config.summaryBudgetRatio),
+    );
+  }
+
   private pickKeepBoundary(
     messages: Message[],
     userTurnStarts: number[],
@@ -448,12 +455,10 @@ export class ContextWindowManager {
       userTurnStarts.length,
     );
     const targetTokens =
-      opts?.targetInputTokensOverride ?? this.config.targetInputTokens;
+      opts?.targetInputTokensOverride ?? this.targetInputTokens;
 
-    let keepTurns = Math.min(
-      this.config.preserveRecentUserTurns,
-      userTurnStarts.length,
-    );
+    // Start from all available turns and reduce until projected tokens fit.
+    let keepTurns = userTurnStarts.length;
     keepTurns = Math.max(minFloor, keepTurns);
 
     // When minFloor is 0 and there are no user turns to keep, keepFromIndex


### PR DESCRIPTION
## Summary
- Replace `targetInputTokens` (absolute token count, default 110K) and `preserveRecentUserTurns` (hard cap, default 8) with `targetBudgetRatio` (percentage of context window, default 30%)
- Compaction now preserves as many recent user/assistant turns as fit within the effective budget (`targetBudgetRatio - summaryBudgetRatio` = 25% by default), instead of capping at a fixed number of turns
- Cross-field validation updated: `targetBudgetRatio` must be less than `compactThreshold`

## Original prompt
Let's change targetInputTokens to a percentage of the context window (default 30%) and preserve as many user/assistant turns as we can while staying under that percentage (minus the summary % - so 25% in this case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
