### PR TITLE
Add Vertex provider entry to managed proxy constants

### DIFF
--- a/.codex-worktrees/signed-in-hatch-flow/clients/.build
+++ b/.codex-worktrees/signed-in-hatch-flow/clients/.build
@@ -1,0 +1,1 @@
+/Users/emmiekehoe/vellum/vellum-assistant/.codex-worktrees/signed-in-hatch-flow/clients/.build

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -46,6 +46,11 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
     managed: true,
     proxyPath: "/v1/runtime-proxy/openrouter",
   },
+  vertex: {
+    name: "vertex",
+    managed: true,
+    proxyPath: "/v1/runtime-proxy/vertex",
+  },
   ollama: { name: "ollama", managed: false },
 };
 


### PR DESCRIPTION
## Summary
- Add `vertex` entry to `MANAGED_PROVIDER_META` with `managed: true` and `proxyPath: "/v1/runtime-proxy/vertex"`
- This makes Vertex available as a managed proxy provider, used by the avatar generation refactor

Part of plan: managed-avatar-runtime-proxy.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
