### PR TITLE
feat: auto-start ngrok tunnel on startup for webhook integrations [JARVIS-87]

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -47,6 +47,7 @@ import {
   startGateway,
   stopLocalProcesses,
 } from "../lib/local";
+import { maybeStartNgrokTunnel } from "../lib/ngrok";
 import { isProcessAlive } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
@@ -266,7 +267,16 @@ function parseArgs(): HatchArgs {
     }
   }
 
-  return { species, detached, keepAlive, name, remote, daemonOnly, restart, watch };
+  return {
+    species,
+    detached,
+    keepAlive,
+    name,
+    remote,
+    daemonOnly,
+    restart,
+    watch,
+  };
 }
 
 function formatElapsed(ms: number): string {
@@ -731,7 +741,13 @@ async function hatchLocal(
     resources = await allocateLocalResources(instanceName);
   }
 
-  const logsDir = join(resources.instanceDir, ".vellum", "workspace", "data", "logs");
+  const logsDir = join(
+    resources.instanceDir,
+    ".vellum",
+    "workspace",
+    "data",
+    "logs",
+  );
   archiveLogFile("hatch.log", logsDir);
   resetLogFile("hatch.log");
 
@@ -752,6 +768,21 @@ async function hatchLocal(
     );
     await stopLocalProcesses(resources);
     throw error;
+  }
+
+  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
+  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
+  const prevBaseDataDir = process.env.BASE_DATA_DIR;
+  process.env.BASE_DATA_DIR = resources.instanceDir;
+  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+  if (ngrokChild?.pid) {
+    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+  }
+  if (prevBaseDataDir !== undefined) {
+    process.env.BASE_DATA_DIR = prevBaseDataDir;
+  } else {
+    delete process.env.BASE_DATA_DIR;
   }
 
   // Read the bearer token (JWT) written by the daemon so the CLI can
@@ -831,9 +862,7 @@ async function hatchLocal(
         consecutiveFailures++;
       }
       if (consecutiveFailures >= MAX_FAILURES) {
-        console.log(
-          "\n⚠️  Gateway stopped responding — shutting down.",
-        );
+        console.log("\n⚠️  Gateway stopped responding — shutting down.");
         await stopLocalProcesses(resources);
         process.exit(1);
       }
@@ -849,8 +878,16 @@ export async function hatch(): Promise<void> {
   const cliVersion = getCliVersion();
   console.log(`@vellumai/cli v${cliVersion}`);
 
-  const { species, detached, keepAlive, name, remote, daemonOnly, restart, watch } =
-    parseArgs();
+  const {
+    species,
+    detached,
+    keepAlive,
+    name,
+    remote,
+    daemonOnly,
+    restart,
+    watch,
+  } = parseArgs();
 
   if (restart && remote !== "local") {
     console.error(

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,9 +1,10 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import { startLocalDaemon, startGateway } from "../lib/local";
+import { maybeStartNgrokTunnel } from "../lib/ngrok";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
@@ -93,6 +94,21 @@ export async function wake(): Promise<void> {
     } else {
       await startGateway(undefined, watch, resources);
     }
+  }
+
+  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
+  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
+  const prevBaseDataDir = process.env.BASE_DATA_DIR;
+  process.env.BASE_DATA_DIR = resources.instanceDir;
+  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+  if (ngrokChild?.pid) {
+    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+  }
+  if (prevBaseDataDir !== undefined) {
+    process.env.BASE_DATA_DIR = prevBaseDataDir;
+  } else {
+    delete process.env.BASE_DATA_DIR;
   }
 
   console.log("Wake complete.");

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1046,4 +1046,7 @@ export async function stopLocalProcesses(
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
+
+  const ngrokPidFile = join(vellumDir, "ngrok.pid");
+  await stopProcessByPidFile(ngrokPidFile, "ngrok");
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -169,6 +169,88 @@ function clearIngressUrl(): void {
 }
 
 /**
+ * Check whether any webhook-based integrations (e.g. Telegram) are configured
+ * that require a public ingress URL.
+ */
+function hasWebhookIntegrationsConfigured(): boolean {
+  try {
+    const config = loadRawConfig();
+    const telegram = config.telegram as Record<string, unknown> | undefined;
+    if (telegram?.botUsername) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether a non-ngrok ingress URL is already configured (e.g. custom
+ * domain or cloud deployment), meaning ngrok is not needed.
+ */
+function hasNonNgrokIngressUrl(): boolean {
+  try {
+    const config = loadRawConfig();
+    const ingress = config.ingress as Record<string, unknown> | undefined;
+    const publicBaseUrl = ingress?.publicBaseUrl;
+    if (!publicBaseUrl || typeof publicBaseUrl !== "string") return false;
+    return !publicBaseUrl.includes("ngrok");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Auto-start an ngrok tunnel if webhook integrations are configured and no
+ * non-ngrok ingress URL is present. Designed to be called during daemon/gateway
+ * startup. Non-fatal: if ngrok is unavailable or fails, startup continues.
+ *
+ * Returns the spawned ngrok child process (for PID tracking) or null.
+ */
+export async function maybeStartNgrokTunnel(
+  targetPort: number,
+): Promise<ChildProcess | null> {
+  if (!hasWebhookIntegrationsConfigured()) return null;
+  if (hasNonNgrokIngressUrl()) return null;
+
+  const version = getNgrokVersion();
+  if (!version) return null;
+
+  // Reuse an existing tunnel if one is already running
+  const existingUrl = await findExistingTunnel(targetPort);
+  if (existingUrl) {
+    console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
+    saveIngressUrl(existingUrl);
+    return null;
+  }
+
+  console.log(`   Starting ngrok tunnel for webhook integrations...`);
+  const ngrokProcess = startNgrokProcess(targetPort);
+
+  // Pipe output for debugging but don't block on it
+  ngrokProcess.stdout?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.log(`[ngrok] ${line}`);
+  });
+  ngrokProcess.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.error(`[ngrok] ${line}`);
+  });
+
+  try {
+    const publicUrl = await waitForNgrokUrl();
+    saveIngressUrl(publicUrl);
+    console.log(`   Tunnel established: ${publicUrl}`);
+    return ngrokProcess;
+  } catch {
+    console.warn(
+      `   ⚠ Could not start ngrok tunnel. Webhook integrations may not work until you run \`vellum tunnel\`.`,
+    );
+    if (!ngrokProcess.killed) ngrokProcess.kill("SIGTERM");
+    return null;
+  }
+}
+
+/**
  * Run the ngrok tunnel workflow: check installation, find or start a tunnel,
  * save the public URL to config, and block until exit or signal.
  */


### PR DESCRIPTION
## Summary
- Auto-start ngrok tunnel during `hatch`/`wake` when webhook integrations (e.g. Telegram) are configured, so the gateway can re-register webhooks with the new public URL
- Track ngrok subprocess PID for clean shutdown alongside daemon and gateway
- Non-fatal: if ngrok is not installed or fails to start, startup continues normally and the user can manually run `vellum tunnel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
