### PR TITLE
Preserve all media in kept turns instead of fixed image cap

### DIFF
--- a/assistant/src/__tests__/session-media-retry.test.ts
+++ b/assistant/src/__tests__/session-media-retry.test.ts
@@ -60,88 +60,26 @@ describe("stripMediaPayloadsForRetry", () => {
     ).toContain("Image omitted");
   });
 
-  test("keeps images in summary message when it is the only user message", () => {
-    // This is the bug scenario: forced compaction with minKeepRecentUserTurns: 0
-    // compacts everything, preserving images into the summary message. Media
-    // stubbing should NOT strip those images since there's no other user message.
-    const img = makeImageBlock();
-    const summaryMsg = createContextSummaryMessage(
-      "Prior conversation summary",
-    );
-    summaryMsg.content.push(
-      {
-        type: "text",
-        text: "[The following images were uploaded by the user in earlier messages and are preserved for reference.]",
-      },
-      img,
-    );
-
-    const messages: Message[] = [summaryMsg];
-
-    const result = stripMediaPayloadsForRetry(messages);
-    expect(result.modified).toBe(false);
-    expect(result.replacedBlocks).toBe(0);
-    // The image should still be present
-    const imageBlocks = result.messages[0].content.filter(
-      (b) => b.type === "image",
-    );
-    expect(imageBlocks.length).toBe(1);
-  });
-
-  test("keeps images in summary message when only other user messages are tool-result-only", () => {
-    const img = makeImageBlock();
-    const summaryMsg = createContextSummaryMessage("Summary");
-    summaryMsg.content.push(img);
-
-    const toolResultMsg: Message = {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: "tool-1",
-          content: "result text",
-        },
-      ],
-    };
-
+  test("strips images from older user turns, keeps images in latest kept turn", () => {
+    // After compaction, images only exist in kept turns (not in summary messages).
+    // Media retry should keep images in the latest user message and strip older ones.
     const messages: Message[] = [
-      summaryMsg,
-      makeAssistantMessage({ type: "text", text: "ok" }),
-      toolResultMsg,
-    ];
-
-    const result = stripMediaPayloadsForRetry(messages);
-    expect(result.modified).toBe(false);
-    expect(result.replacedBlocks).toBe(0);
-  });
-
-  test("prefers non-summary user message over summary when both exist", () => {
-    const summaryImg = makeImageBlock("BBBB");
-    const summaryMsg = createContextSummaryMessage("Summary");
-    summaryMsg.content.push(summaryImg);
-
-    const userImg = makeImageBlock("CCCC");
-    const userMsg = makeUserMessage({ type: "text", text: "latest" }, userImg);
-
-    const messages: Message[] = [
-      summaryMsg,
+      createContextSummaryMessage("Summary"),
+      makeUserMessage({ type: "text", text: "older kept turn" }, makeImageBlock("AAAA")),
       makeAssistantMessage({ type: "text", text: "response" }),
-      userMsg,
+      makeUserMessage({ type: "text", text: "latest kept turn" }, makeImageBlock("BBBB")),
     ];
 
     const result = stripMediaPayloadsForRetry(messages);
-    // Summary image should be stripped, user image should be kept
     expect(result.modified).toBe(true);
     expect(result.replacedBlocks).toBe(1);
 
-    // Summary message image → stubbed
-    const summaryBlocks = result.messages[0].content;
-    const summaryImageBlocks = summaryBlocks.filter((b) => b.type === "image");
-    expect(summaryImageBlocks.length).toBe(0);
+    // Older kept turn image → stubbed
+    const olderBlocks = result.messages[1].content;
+    expect(olderBlocks.filter((b) => b.type === "image").length).toBe(0);
 
-    // Latest user message image → kept
-    const userBlocks = result.messages[2].content;
-    const userImageBlocks = userBlocks.filter((b) => b.type === "image");
-    expect(userImageBlocks.length).toBe(1);
+    // Latest kept turn image → kept
+    const latestBlocks = result.messages[3].content;
+    expect(latestBlocks.filter((b) => b.type === "image").length).toBe(1);
   });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -13,7 +13,6 @@ const COMPACTION_COOLDOWN_MS = 2 * 60 * 1000;
 const MIN_GAIN_TOKENS_DURING_COOLDOWN = 1200;
 const SEVERE_PRESSURE_RATIO = 0.95;
 const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
-const MAX_PRESERVED_IMAGE_BLOCKS = 5;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
 const SUMMARY_SYSTEM_PROMPT = [
@@ -350,49 +349,11 @@ export class ContextWindowManager {
     }
     const summaryCalls = 1;
 
-    // Extract user-uploaded image blocks from compacted messages so they
-    // remain accessible to the assistant in subsequent turns. Tool-result
-    // screenshots are NOT preserved — only top-level image blocks in user
-    // messages, which represent intentional user uploads.
-    // Also carry forward any images already preserved in the existing summary
-    // message so they survive multiple compaction cycles.
-    const preservedImageBlocks: ContentBlock[] = [];
-    if (existingSummary != null) {
-      const summaryMsg = messages[0];
-      for (const block of summaryMsg.content) {
-        if (block.type === "image") {
-          preservedImageBlocks.push(block);
-        }
-      }
-    }
-    for (const msg of compactableMessages) {
-      if (msg.role !== "user") continue;
-      for (const block of msg.content) {
-        if (block.type === "image") {
-          preservedImageBlocks.push(block);
-        }
-      }
-    }
-
-    // Cap preserved images to avoid unbounded accumulation across cycles.
-    // Older images (carried forward) are at the front; keep the most recent.
-    if (preservedImageBlocks.length > MAX_PRESERVED_IMAGE_BLOCKS) {
-      preservedImageBlocks.splice(
-        0,
-        preservedImageBlocks.length - MAX_PRESERVED_IMAGE_BLOCKS,
-      );
-    }
-
+    // Media (images, files) in kept turns is preserved naturally — those
+    // turns are carried forward as-is and their token cost is already
+    // accounted for by pickKeepBoundary's estimatePromptTokens call.
+    // Media in compacted turns is described textually in the summary transcript.
     const summaryMessage = createContextSummaryMessage(summary);
-    if (preservedImageBlocks.length > 0) {
-      summaryMessage.content.push(
-        {
-          type: "text",
-          text: "[The following images were uploaded by the user in earlier messages and are preserved for reference.]",
-        },
-        ...preservedImageBlocks,
-      );
-    }
 
     const compactedMessages = [
       summaryMessage,

--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -19,27 +19,13 @@ export function stripMediaPayloadsForRetry(messages: Message[]): {
   latestUserIndex: number | null;
 } {
   let latestUserIndex: number | null = null;
-  let lastSummaryUserIndex: number | null = null;
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
     if (msg.role !== "user") continue;
     if (isToolResultOnlyMessage(msg)) continue;
-    if (getSummaryFromContextMessage(msg) != null) {
-      // Track the last summary message as a fallback — after aggressive
-      // compaction (minKeepRecentUserTurns: 0), the summary may be the only
-      // user message left and it can contain preserved image blocks that
-      // should not be stripped.
-      if (lastSummaryUserIndex == null) lastSummaryUserIndex = i;
-      continue;
-    }
+    if (getSummaryFromContextMessage(msg) != null) continue;
     latestUserIndex = i;
     break;
-  }
-
-  // Fall back to the summary message when compaction consumed all user turns,
-  // so images preserved by compaction are not unconditionally stripped.
-  if (latestUserIndex == null && lastSummaryUserIndex != null) {
-    latestUserIndex = lastSummaryUserIndex;
   }
 
   let modified = false;


### PR DESCRIPTION
## Summary
- Remove `MAX_PRESERVED_IMAGE_BLOCKS` (5) cap and the logic that extracted images from compacted turns into the summary message
- Media in kept turns is already preserved naturally and its token cost is accounted for by `pickKeepBoundary`'s `estimatePromptTokens` call
- Remove dead summary-image fallback code from `session-media-retry.ts` and update tests to reflect the new behavior

## Original prompt
Instead of having a fixed number of preserved images, let's preserve all media in turns that are kept and account for that in our token calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
