### PR TITLE
Refactor managed avatar client to call Vertex runtime proxy instead of deleted endpoint

### DIFF
--- a/assistant/src/media/avatar-types.ts
+++ b/assistant/src/media/avatar-types.ts
@@ -1,4 +1,7 @@
-export type AvatarGenerationStrategy = "managed_required" | "managed_prefer" | "local_only";
+export type AvatarGenerationStrategy =
+  | "managed_required"
+  | "managed_prefer"
+  | "local_only";
 
 export interface ManagedAvatarImagePayload {
   mime_type: string;
@@ -55,6 +58,11 @@ export interface AvatarGenerationResult {
   correlationId?: string;
 }
 
-export const AVATAR_MIME_ALLOWLIST = new Set(["image/png", "image/jpeg", "image/webp"]);
+export const AVATAR_MIME_ALLOWLIST = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+]);
 export const AVATAR_MAX_DECODED_BYTES = 10 * 1024 * 1024;
 export const AVATAR_PROMPT_MAX_LENGTH = 2000;
+export const VERTEX_IMAGE_DEFAULT_MODEL = "imagen-3.0-generate-002";

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto";
+
 import { getPlatformBaseUrl } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import { getSecureKey } from "../security/secure-keys.js";
@@ -7,8 +9,8 @@ import {
   AVATAR_MIME_ALLOWLIST,
   AVATAR_PROMPT_MAX_LENGTH,
   ManagedAvatarError,
-  type ManagedAvatarErrorResponse,
   type ManagedAvatarResponse,
+  VERTEX_IMAGE_DEFAULT_MODEL,
 } from "./avatar-types.js";
 
 const log = getLogger("managed-avatar-client");
@@ -30,7 +32,7 @@ export function isManagedAvailable(): boolean {
 
 export async function generateManagedAvatar(
   prompt: string,
-  options?: { correlationId?: string; idempotencyKey?: string },
+  options?: { correlationId?: string; idempotencyKey?: string; model?: string },
 ): Promise<ManagedAvatarResponse> {
   if (prompt.length > AVATAR_PROMPT_MAX_LENGTH) {
     throw new ManagedAvatarError({
@@ -68,7 +70,8 @@ export async function generateManagedAvatar(
     });
   }
 
-  const url = `${baseUrl}/v1/assistants/avatar/generate/`;
+  const model = options?.model ?? VERTEX_IMAGE_DEFAULT_MODEL;
+  const url = `${baseUrl}/v1/runtime-proxy/vertex/v1/models/${model}:predict`;
   const idempotencyKey = options?.idempotencyKey ?? crypto.randomUUID();
   const correlationId = options?.correlationId ?? crypto.randomUUID();
 
@@ -79,13 +82,23 @@ export async function generateManagedAvatar(
     "X-Correlation-Id": correlationId,
   };
 
-  log.debug({ url, correlationId }, "Requesting managed avatar generation");
+  log.debug(
+    { url, correlationId, model },
+    "Requesting managed avatar generation",
+  );
 
   let response: Response;
   try {
     response = await fetch(url, {
       method: "POST",
-      body: JSON.stringify({ prompt }),
+      body: JSON.stringify({
+        instances: [{ prompt }],
+        parameters: {
+          sampleCount: 1,
+          aspectRatio: "1:1",
+          outputOptions: { mimeType: "image/png" },
+        },
+      }),
       signal: AbortSignal.timeout(60_000),
       headers,
     });
@@ -105,63 +118,89 @@ export async function generateManagedAvatar(
   }
 
   if (!response.ok) {
-    let errorBody: ManagedAvatarErrorResponse;
+    let detail = `HTTP ${response.status}`;
     try {
-      errorBody = (await response.json()) as ManagedAvatarErrorResponse;
+      const text = await response.text();
+      if (text) detail = `HTTP ${response.status}: ${text}`;
     } catch {
-      throw new ManagedAvatarError({
-        code: "upstream_error",
-        subcode: "unparseable_response",
-        detail: `HTTP ${response.status}: unable to parse error response`,
-        retryable: response.status >= 500 || response.status === 429,
-        correlationId,
-        statusCode: response.status,
-      });
+      // ignore parse failures
     }
 
     throw new ManagedAvatarError({
-      code: errorBody.code ?? "upstream_error",
-      subcode: errorBody.subcode ?? "unknown",
-      detail: errorBody.detail ?? `HTTP ${response.status}`,
-      retryable:
-        errorBody.retryable ??
-        (response.status >= 500 || response.status === 429),
-      correlationId: errorBody.correlation_id ?? correlationId,
+      code: "upstream_error",
+      subcode: "http_error",
+      detail,
+      retryable: response.status >= 500 || response.status === 429,
+      correlationId,
       statusCode: response.status,
     });
   }
 
-  let body: ManagedAvatarResponse;
   try {
-    body = (await response.json()) as ManagedAvatarResponse;
+    const vertexBody = (await response.json()) as {
+      predictions: Array<{ bytesBase64Encoded: string; mimeType: string }>;
+    };
 
-    if (!AVATAR_MIME_ALLOWLIST.has(body.image.mime_type)) {
+    const prediction = vertexBody.predictions?.[0];
+    if (!prediction) {
+      throw new ManagedAvatarError({
+        code: "upstream_error",
+        subcode: "empty_predictions",
+        detail: "Vertex response contained no predictions",
+        retryable: false,
+        correlationId,
+        statusCode: 0,
+      });
+    }
+
+    const mimeType = prediction.mimeType;
+    const dataBase64 = prediction.bytesBase64Encoded;
+
+    if (!AVATAR_MIME_ALLOWLIST.has(mimeType)) {
       throw new ManagedAvatarError({
         code: "validation_error",
         subcode: "disallowed_mime_type",
-        detail: `Response MIME type "${body.image.mime_type}" is not in the allowlist`,
+        detail: `Response MIME type "${mimeType}" is not in the allowlist`,
         retryable: false,
         correlationId,
         statusCode: 0,
       });
     }
 
-    const b64 = body.image.data_base64;
-    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
-    const estimatedDecodedBytes = Math.ceil((b64.length * 3) / 4) - padding;
-    if (
-      estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES ||
-      body.image.bytes > AVATAR_MAX_DECODED_BYTES
-    ) {
+    const padding = dataBase64.endsWith("==")
+      ? 2
+      : dataBase64.endsWith("=")
+        ? 1
+        : 0;
+    const estimatedDecodedBytes =
+      Math.ceil((dataBase64.length * 3) / 4) - padding;
+    if (estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES) {
       throw new ManagedAvatarError({
         code: "validation_error",
         subcode: "oversized_image",
-        detail: `Response image size ${Math.max(estimatedDecodedBytes, body.image.bytes)} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
+        detail: `Response image size ${estimatedDecodedBytes} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
         retryable: false,
         correlationId,
         statusCode: 0,
       });
     }
+
+    const sha256 = createHash("sha256")
+      .update(Buffer.from(dataBase64, "base64"))
+      .digest("hex");
+
+    const body: ManagedAvatarResponse = {
+      image: {
+        mime_type: mimeType,
+        data_base64: dataBase64,
+        bytes: estimatedDecodedBytes,
+        sha256,
+      },
+      usage: { billable: true, class_name: "image_generation" },
+      generation_source: "vertex",
+      profile: model,
+      correlation_id: correlationId,
+    };
 
     log.debug(
       {


### PR DESCRIPTION
## Summary
- Replace deleted `/v1/assistants/avatar/generate/` endpoint with `/v1/runtime-proxy/vertex/v1/models/{model}:predict`
- Add `VERTEX_IMAGE_DEFAULT_MODEL` constant (`imagen-3.0-generate-002`)
- Update request body to Vertex Imagen API format and response parsing from Vertex format
- Accept optional `model` parameter (platform-side allowlist handles validation)
- Replace old structured error parsing with generic HTTP error handling

Part of plan: managed-avatar-runtime-proxy.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
