### PR TITLE
Remove DEFAULT_MAX_WAIT_MS and dead message queue expiry code

### DIFF
--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -9,10 +9,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { getLogger } from "../util/logger.js";
 import type { ServerMessage, UserMessageAttachment } from "./message-protocol.js";
-
-const log = getLogger("session-queue");
 
 export interface QueuedMessage {
   content: string;
@@ -32,9 +29,6 @@ export interface QueuedMessage {
   displayContent?: string;
 }
 
-/** Messages older than this (ms) are auto-expired from the queue. */
-export const DEFAULT_MAX_WAIT_MS = 60_000;
-
 /**
  * Describes why a queued message was promoted from the queue.
  * - `loop_complete`: the agent loop finished normally and the next message was drained.
@@ -51,44 +45,22 @@ export interface QueuePolicy {
   checkpointHandoffEnabled: boolean;
 }
 
-export interface QueueMetrics {
-  currentDepth: number;
-  totalExpired: number;
-  /** Average wait time (ms) of dequeued messages. 0 when no messages have been dequeued. */
-  averageWaitMs: number;
-}
-
 /**
  * Typed wrapper around the queued-message array.
  *
- * Session owns one instance; the wrapper handles expiry, metrics,
- * and iteration so the rest of Session doesn't touch the raw array.
+ * Session owns one instance; the wrapper handles iteration
+ * so the rest of Session doesn't touch the raw array.
  */
 export class MessageQueue {
   private items: QueuedMessage[] = [];
-  private maxWaitMs: number;
-  private expiredCount = 0;
-  private totalWaitMs = 0;
-  private dequeuedCount = 0;
-
-  constructor(maxWaitMs: number = DEFAULT_MAX_WAIT_MS) {
-    this.maxWaitMs = maxWaitMs;
-  }
 
   push(item: QueuedMessage): void {
-    this.expireStale();
     item.queuedAt = Date.now();
     this.items.push(item);
   }
 
   shift(): QueuedMessage | undefined {
-    this.expireStale();
-    const item = this.items.shift();
-    if (item) {
-      this.dequeuedCount++;
-      this.totalWaitMs += Date.now() - item.queuedAt;
-    }
-    return item;
+    return this.items.shift();
   }
 
   clear(): void {
@@ -111,49 +83,6 @@ export class MessageQueue {
     const idx = this.items.findIndex((m) => m.requestId === requestId);
     if (idx === -1) return undefined;
     return this.items.splice(idx, 1)[0];
-  }
-
-  getMetrics(): QueueMetrics {
-    return {
-      currentDepth: this.items.length,
-      totalExpired: this.expiredCount,
-      averageWaitMs:
-        this.dequeuedCount > 0 ? this.totalWaitMs / this.dequeuedCount : 0,
-    };
-  }
-
-  /** Remove messages that have been waiting longer than maxWaitMs. */
-  private expireStale(): void {
-    const now = Date.now();
-    const cutoff = now - this.maxWaitMs;
-    const expired: QueuedMessage[] = [];
-    this.items = this.items.filter((item) => {
-      if (item.queuedAt < cutoff) {
-        this.expiredCount++;
-        expired.push(item);
-        return false;
-      }
-      return true;
-    });
-    for (const item of expired) {
-      log.warn(
-        { requestId: item.requestId, waitMs: now - item.queuedAt },
-        "Expiring stale queued message",
-      );
-      try {
-        item.onEvent({
-          type: "error",
-          message:
-            "Your queued message was dropped because it waited too long in the queue.",
-          category: "queue_expired",
-        });
-      } catch (e) {
-        log.debug(
-          { err: e, requestId: item.requestId },
-          "Failed to notify client of expired message",
-        );
-      }
-    }
   }
 
   [Symbol.iterator](): Iterator<QueuedMessage> {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -82,10 +82,7 @@ import {
   drainQueue as drainQueueImpl,
   processMessage as processMessageImpl,
 } from "./session-process.js";
-import type {
-  QueueDrainReason,
-  QueueMetrics,
-} from "./session-queue-manager.js";
+import type { QueueDrainReason } from "./session-queue-manager.js";
 import { MessageQueue } from "./session-queue-manager.js";
 import type {
   ChannelCapabilities,
@@ -460,10 +457,6 @@ export class Session {
 
   getQueueDepth(): number {
     return this.queue.length;
-  }
-
-  getQueueMetrics(): QueueMetrics {
-    return this.queue.getMetrics();
   }
 
   hasQueuedMessages(): boolean {


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_MAX_WAIT_MS` (60s stale-message expiry threshold) and cascade-remove all code made dead by its removal: `expireStale()`, `maxWaitMs` field, `QueueMetrics` interface, `getMetrics()`/`getQueueMetrics()`, metric tracking fields, and the logger import
- `QueuedMessage.queuedAt` is preserved as it's still set in `push()` and referenced by `session-messaging.ts`

## Original prompt
Remove DEFAULT_MAX_WAIT_MS and any code that is now dead as a result

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
