### PR TITLE
Pass model parameter through avatar router to managed client

### DIFF
--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -58,18 +58,23 @@ async function generateLocal(
 
 export async function routedGenerateAvatar(
   prompt: string,
-  options?: { correlationId?: string },
+  options?: { correlationId?: string; model?: string },
 ): Promise<AvatarGenerationResult> {
   const strategy = getAvatarStrategy();
   const correlationId = options?.correlationId;
+  const model = options?.model;
 
   if (strategy === "managed_required") {
-    const managed = await generateManagedAvatar(prompt, { correlationId });
+    const managed = await generateManagedAvatar(prompt, {
+      correlationId,
+      model,
+    });
     return {
       imageBase64: managed.image.data_base64,
       mimeType: managed.image.mime_type,
       pathUsed: "managed",
       correlationId: managed.correlation_id,
+      model,
     };
   }
 
@@ -80,12 +85,16 @@ export async function routedGenerateAvatar(
   // managed_prefer: try managed first if available, fall back to local
   if (isManagedAvailable()) {
     try {
-      const managed = await generateManagedAvatar(prompt, { correlationId });
+      const managed = await generateManagedAvatar(prompt, {
+        correlationId,
+        model,
+      });
       return {
         imageBase64: managed.image.data_base64,
         mimeType: managed.image.mime_type,
         pathUsed: "managed",
         correlationId: managed.correlation_id,
+        model,
       };
     } catch (err) {
       log.warn(

--- a/assistant/src/media/avatar-types.ts
+++ b/assistant/src/media/avatar-types.ts
@@ -56,6 +56,7 @@ export interface AvatarGenerationResult {
   mimeType: string;
   pathUsed: "managed" | "local";
   correlationId?: string;
+  model?: string;
 }
 
 export const AVATAR_MIME_ALLOWLIST = new Set([


### PR DESCRIPTION
## Summary
- Add optional `model` field to `AvatarGenerationResult` interface
- Thread `model` parameter through `routedGenerateAvatar()` to `generateManagedAvatar()`
- Include model in returned result for observability

Part of plan: managed-avatar-runtime-proxy.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
