### PR TITLE
Fix nav item hover transition flash

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1096,7 +1096,7 @@ private struct ShareDrawerRow: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(isHovered ? VColor.navHover : Color.clear)
+            .background(VColor.navHover.opacity(isHovered ? 1 : 0))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1044,8 +1044,8 @@ private struct SettingsNavRow: View {
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                (isSelected ? VColor.navActive : isHovered ? VColor.navHover : .clear)
-                    .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
+                (isSelected ? VColor.navActive : VColor.navHover.opacity(isHovered ? 1 : 0))
+                    .animation(VAnimation.fast, value: isHovered)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuItem.swift
@@ -33,7 +33,7 @@ struct DrawerMenuItem: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
-            .background(isHovered ? VColor.navHover : Color.clear)
+            .background(VColor.navHover.opacity(isHovered ? 1 : 0))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -43,8 +43,8 @@ struct SidebarPrimaryRow: View {
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
             .background(
-                (isActive ? VColor.navActive : isHovered ? VColor.navHover : .clear)
-                    .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
+                (isActive ? VColor.navActive : VColor.navHover.opacity(isHovered ? 1 : 0))
+                    .animation(VAnimation.fast, value: isHovered)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -120,12 +120,12 @@ struct SidebarThreadItem: View {
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
-                    Color.clear
+                    VColor.navHover.opacity(0)
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
-            .animation(isHovered ? VAnimation.fast : .linear(duration: 0), value: isHovered)
+            .animation(VAnimation.fast, value: isHovered)
         }
         .onTapGesture {
             selectThread()

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -160,7 +160,7 @@ struct AppSharePanelView: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(hoveredServiceIndex == index ? VColor.navHover : Color.clear)
+            .background(VColor.navHover.opacity(hoveredServiceIndex == index ? 1 : 0))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Sharing/SlackChannelPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/SlackChannelPickerView.swift
@@ -167,7 +167,7 @@ struct SlackChannelPickerView: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(hoveredChannelID == channel.id ? VColor.navHover : Color.clear)
+            .background(VColor.navHover.opacity(hoveredChannelID == channel.id ? 1 : 0))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/shared/DesignSystem/Core/Display/VListRow.swift
+++ b/clients/shared/DesignSystem/Core/Display/VListRow.swift
@@ -30,7 +30,7 @@ public struct VListRow<Content: View>: View {
             .padding(.vertical, VSpacing.sm)
             .padding(.horizontal, VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isHovered ? VColor.navHover : .clear)
+            .background(VColor.navHover.opacity(isHovered ? 1 : 0))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .onHover { hovering in
                 isHovered = hovering

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -33,7 +33,7 @@ public struct VTab: View {
         } else if isHovered {
             return VColor.navHover
         } else {
-            return .clear
+            return VColor.navHover.opacity(0)
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -78,6 +78,7 @@ public struct VTab: View {
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
                 .opacity(isSelected ? 1 : 0)
         )
+        .animation(VAnimation.fast, value: isHovered)
         .onHover { hovering in isHovered = hovering }
         .pointerCursor()
     }


### PR DESCRIPTION
## Summary
Fix the navigation item hover transition that briefly flashed a darker color before settling on the correct lighter hover gray. The root cause was SwiftUI interpolating RGB channels when animating from `.clear` to `VColor.navHover`, producing a dark intermediate color.

## Changes
- Replaced `.clear` / `Color.clear` with `VColor.navHover.opacity(0)` in all 9 nav hover backgrounds so only opacity animates (RGB channels stay constant)
- Simplified conditional animations (`isHovered ? VAnimation.fast : .linear(duration: 0)`) to a single `VAnimation.fast` for smoother hover-in and hover-out

## Milestone PRs (merged into feature branch)
- #14912: M1: Fix nav hover transition flash across all components

## Project issue
Closes #14909

## Test plan
- [ ] Hover over sidebar nav items — should see a smooth, single-step fade to light gray with no dark flash
- [ ] Hover over thread items in sidebar — same smooth transition
- [ ] Hover over settings nav rows — same behavior
- [ ] Hover over drawer menu items — same behavior
- [ ] Verify hover-out transition is also smooth (no snap)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
