### PR TITLE
Add byte budget to session message queue to prevent memory exhaustion

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -303,6 +303,7 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 
 import type { QueueDrainReason, QueuePolicy } from "../daemon/session.js";
 import { Session } from "../daemon/session.js";
+import { MessageQueue } from "../daemon/session-queue-manager.js";
 
 type SessionWithWorkspaceDeps = Session & {
   getWorkspaceGitService?: (_workspaceDir: string) => {
@@ -1751,4 +1752,95 @@ describe("Regression: cancel semantics and error channel split", () => {
       turnCommitHangForever = false;
     }
   }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// MessageQueue byte budget
+// ---------------------------------------------------------------------------
+
+describe("MessageQueue byte budget", () => {
+  function makeItem(
+    content: string,
+    requestId = "r",
+    attachments: { data: string }[] = [],
+  ) {
+    return {
+      content,
+      attachments: attachments.map((a) => ({
+        id: "a",
+        filename: "f",
+        mimeType: "text/plain",
+        data: a.data,
+      })),
+      requestId,
+      onEvent: () => {},
+      queuedAt: 0,
+    };
+  }
+
+  test("accepts messages within budget", () => {
+    const q = new MessageQueue(10_000);
+    expect(q.push(makeItem("hello", "r1"))).toBe(true);
+    expect(q.length).toBe(1);
+  });
+
+  test("rejects message that would exceed byte budget", () => {
+    // Budget of 2000 bytes — a single message with ~500 chars of content
+    // uses ~1512 bytes (500*2 + 512 overhead). A second should be rejected.
+    const q = new MessageQueue(2_000);
+    expect(q.push(makeItem("x".repeat(500), "r1"))).toBe(true);
+    expect(q.push(makeItem("y".repeat(500), "r2"))).toBe(false);
+    expect(q.length).toBe(1);
+  });
+
+  test("always accepts first message even if it alone exceeds budget", () => {
+    const q = new MessageQueue(100); // tiny budget
+    expect(q.push(makeItem("x".repeat(1000), "r1"))).toBe(true);
+    expect(q.length).toBe(1);
+  });
+
+  test("reclaims budget when messages are shifted", () => {
+    const q = new MessageQueue(3_000);
+    expect(q.push(makeItem("x".repeat(500), "r1"))).toBe(true);
+    expect(q.push(makeItem("y".repeat(500), "r2"))).toBe(false);
+
+    q.shift(); // free up space
+    expect(q.push(makeItem("y".repeat(500), "r2"))).toBe(true);
+    expect(q.length).toBe(1);
+  });
+
+  test("reclaims budget when messages are removed by requestId", () => {
+    const q = new MessageQueue(5_000);
+    expect(q.push(makeItem("a".repeat(500), "r1"))).toBe(true);
+    expect(q.push(makeItem("b".repeat(500), "r2"))).toBe(true);
+    expect(q.push(makeItem("c".repeat(500), "r3"))).toBe(false);
+
+    q.removeByRequestId("r1");
+    expect(q.push(makeItem("c".repeat(500), "r3"))).toBe(true);
+  });
+
+  test("clear resets byte budget to zero", () => {
+    const q = new MessageQueue(3_000);
+    q.push(makeItem("x".repeat(500), "r1"));
+    q.clear();
+    expect(q.totalBytes).toBe(0);
+    expect(q.push(makeItem("y".repeat(500), "r2"))).toBe(true);
+  });
+
+  test("accounts for attachment data in byte estimate", () => {
+    // 1000 chars content = 2512 bytes. Add a 2000 char attachment = +4000 bytes.
+    // Total ~6512 bytes. Budget of 5000 should reject.
+    const q = new MessageQueue(5_000);
+    expect(
+      q.push(
+        makeItem("x".repeat(1000), "r1", [{ data: "a".repeat(2000) }]),
+      ),
+    ).toBe(true); // first message always accepted
+    // Second message of same size should be rejected
+    expect(
+      q.push(
+        makeItem("y".repeat(100), "r2", [{ data: "b".repeat(100) }]),
+      ),
+    ).toBe(false);
+  });
 });

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -730,6 +730,9 @@ function buildDispatchUserMessage(params: {
       undefined,
       displayContent,
     );
+    if (result.rejected) {
+      return;
+    }
     if (result.queued) {
       const position = session.getQueueDepth();
       rlog.info({ source, position }, queuedDescription);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -291,7 +291,7 @@ export class DaemonServer {
         undefined,
         metadata,
       );
-      if (!enqueueResult.queued) {
+      if (!enqueueResult.queued && !enqueueResult.rejected) {
         const messageId = await parentSession.persistUserMessage(
           message,
           [],

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -212,7 +212,7 @@ export function enqueueMessage(
   metadata?: Record<string, unknown>,
   options?: { isInteractive?: boolean },
   displayContent?: string,
-): { queued: boolean; requestId: string } {
+): { queued: boolean; requestId: string; rejected?: boolean } {
   if (!ctx.processing) {
     return { queued: false, requestId };
   }
@@ -225,7 +225,7 @@ export function enqueueMessage(
     extractTurnInterfaceContext(metadata) ??
     ctx.getTurnInterfaceContext() ??
     undefined;
-  ctx.queue.push({
+  const accepted = ctx.queue.push({
     content,
     attachments,
     requestId,
@@ -239,6 +239,15 @@ export function enqueueMessage(
     queuedAt: Date.now(),
     displayContent,
   });
+  if (!accepted) {
+    onEvent({
+      type: "error",
+      message:
+        "The assistant is busy and cannot accept more messages right now. Please try again shortly.",
+      category: "queue_full",
+    });
+    return { queued: false, requestId, rejected: true };
+  }
   return { queued: true, requestId };
 }
 

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -9,7 +9,10 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { getLogger } from "../util/logger.js";
 import type { ServerMessage, UserMessageAttachment } from "./message-protocol.js";
+
+const log = getLogger("session-queue");
 
 export interface QueuedMessage {
   content: string;
@@ -28,6 +31,13 @@ export interface QueuedMessage {
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
   displayContent?: string;
 }
+
+/**
+ * Maximum total estimated bytes across all queued messages per session.
+ * Limits memory consumption when a sender floods messages while the
+ * session is busy.  50 MB is well above any legitimate usage.
+ */
+export const DEFAULT_MAX_QUEUE_BYTES = 50 * 1024 * 1024; // 50 MB
 
 /**
  * Describes why a queued message was promoted from the queue.
@@ -50,21 +60,55 @@ export interface QueuePolicy {
  *
  * Session owns one instance; the wrapper handles iteration
  * so the rest of Session doesn't touch the raw array.
+ *
+ * A byte budget caps total memory held by queued messages so a
+ * high-rate sender cannot exhaust the process.
  */
 export class MessageQueue {
   private items: QueuedMessage[] = [];
+  private currentBytes = 0;
+  private maxBytes: number;
 
-  push(item: QueuedMessage): void {
+  constructor(maxBytes: number = DEFAULT_MAX_QUEUE_BYTES) {
+    this.maxBytes = maxBytes;
+  }
+
+  /**
+   * Attempt to enqueue a message.
+   * Returns `true` if accepted, `false` if rejected (over budget).
+   */
+  push(item: QueuedMessage): boolean {
+    const itemBytes = estimateItemBytes(item);
+    if (this.currentBytes + itemBytes > this.maxBytes && this.items.length > 0) {
+      log.warn(
+        {
+          requestId: item.requestId,
+          queueDepth: this.items.length,
+          currentBytes: this.currentBytes,
+          itemBytes,
+          maxBytes: this.maxBytes,
+        },
+        "Rejecting queued message: queue byte budget exceeded",
+      );
+      return false;
+    }
     item.queuedAt = Date.now();
     this.items.push(item);
+    this.currentBytes += itemBytes;
+    return true;
   }
 
   shift(): QueuedMessage | undefined {
-    return this.items.shift();
+    const item = this.items.shift();
+    if (item) {
+      this.currentBytes -= estimateItemBytes(item);
+    }
+    return item;
   }
 
   clear(): void {
     this.items = [];
+    this.currentBytes = 0;
   }
 
   get length(): number {
@@ -75,6 +119,10 @@ export class MessageQueue {
     return this.items.length === 0;
   }
 
+  get totalBytes(): number {
+    return this.currentBytes;
+  }
+
   /**
    * Remove a queued message by its requestId.
    * Returns the removed message, or undefined if not found.
@@ -82,10 +130,28 @@ export class MessageQueue {
   removeByRequestId(requestId: string): QueuedMessage | undefined {
     const idx = this.items.findIndex((m) => m.requestId === requestId);
     if (idx === -1) return undefined;
-    return this.items.splice(idx, 1)[0];
+    const [removed] = this.items.splice(idx, 1);
+    this.currentBytes -= estimateItemBytes(removed);
+    return removed;
   }
 
   [Symbol.iterator](): Iterator<QueuedMessage> {
     return this.items[Symbol.iterator]();
   }
+}
+
+/**
+ * Estimate the in-memory byte cost of a queued message.
+ * Dominated by content text and attachment `data` (base64 strings).
+ */
+function estimateItemBytes(item: QueuedMessage): number {
+  let bytes = item.content.length * 2; // JS strings are UTF-16
+  for (const a of item.attachments) {
+    bytes += a.data.length * 2;
+    if (a.extractedText) bytes += a.extractedText.length * 2;
+  }
+  // Small fixed overhead for metadata, pointers, etc. (not worth
+  // measuring precisely — the content/attachment data dominates).
+  bytes += 512;
+  return bytes;
 }

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -214,7 +214,7 @@ export interface SurfaceSessionContext {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
-  ): { queued: boolean; requestId: string };
+  ): { queued: boolean; requestId: string; rejected?: boolean };
   getQueueDepth(): number;
   processMessage(
     content: string,
@@ -579,6 +579,10 @@ export function handleSurfaceAction(
       sessionId: ctx.conversationId,
     });
 
+    if (result.rejected) {
+      return;
+    }
+
     if (result.queued) {
       log.info(
         { surfaceId, actionId, requestId },
@@ -724,6 +728,9 @@ export function handleSurfaceAction(
     undefined,
     displayContent,
   );
+  if (result.rejected) {
+    return;
+  }
   if (result.queued) {
     const position = ctx.getQueueDepth();
     if (!retainPending) {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -440,7 +440,7 @@ export class Session {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
-  ): { queued: boolean; requestId: string } {
+  ): { queued: boolean; requestId: string; rejected?: boolean } {
     return enqueueMessageImpl(
       this,
       content,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -643,7 +643,7 @@ export async function handleSendMessage(
 
     // Queue the message so it's processed when the current turn completes
     const requestId = crypto.randomUUID();
-    session.enqueueMessage(
+    const enqueueResult = session.enqueueMessage(
       content ?? "",
       attachments,
       onEvent,
@@ -658,6 +658,12 @@ export async function handleSendMessage(
       },
       { isInteractive: isInteractiveInterface },
     );
+    if (enqueueResult.rejected) {
+      return Response.json(
+        { accepted: false, error: "queue_full" },
+        { status: 429 },
+      );
+    }
     return Response.json({ accepted: true, queued: true }, { status: 202 });
   }
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -398,6 +398,9 @@ export class SubagentManager {
       onEvent,
       requestId,
     );
+    if (result.rejected) {
+      return "sent"; // error event already delivered via onEvent
+    }
     if (!result.queued) {
       // Session is idle — send directly.  Fire-and-forget so we don't block.
       const messageId = await managed.session.persistUserMessage(trimmed, []);


### PR DESCRIPTION
## Summary
- Add a byte budget (50 MB default) to `MessageQueue` that estimates per-item memory cost from content and attachment data sizes, rejecting pushes that would exceed the budget
- `push()` now returns `boolean`; `enqueueMessage()` propagates a `rejected` flag and sends a `queue_full` error event to the client
- All callers across the codebase (session-user-message, server, session-surfaces, conversation-routes, subagent manager) handle the new rejection path
- Added unit tests for byte budget enforcement including acceptance, rejection, budget reclaim on shift/remove/clear, and attachment accounting

## Original prompt
Let's add a queue byte budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
