### PR TITLE
Fix MessageQueue byte budget test using wrong budget value

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1810,12 +1810,14 @@ describe("MessageQueue byte budget", () => {
   });
 
   test("reclaims budget when messages are removed by requestId", () => {
-    const q = new MessageQueue(5_000);
+    // Each 500-char item ≈ 1512 bytes (500*2 + 512 overhead).
+    // Budget of 4000 fits two items (3024) but not three (4536).
+    const q = new MessageQueue(4_000);
     expect(q.push(makeItem("a".repeat(500), "r1"))).toBe(true);
     expect(q.push(makeItem("b".repeat(500), "r2"))).toBe(true);
     expect(q.push(makeItem("c".repeat(500), "r3"))).toBe(false);
 
-    q.removeByRequestId("r1");
+    q.removeByRequestId("r1"); // frees 1512 bytes → 1512 remaining
     expect(q.push(makeItem("c".repeat(500), "r3"))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- The "reclaims budget when messages are removed by requestId" test used a budget of 5000 bytes, but each 500-char item only costs 1512 bytes (500×2 + 512 overhead), so three items (4536) fit within the budget — causing the third push to unexpectedly succeed.
- Changed budget from 5000 to 4000 so two items (3024) fit but three (4536) don't, matching the test's intent.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22925181412/job/66533649460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
