### PR TITLE
fix: add avatar router tests for model passthrough

### DIFF
--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -178,6 +178,43 @@ describe("avatar-router", () => {
     expect(getAvatarStrategy()).toBe("local_only");
   });
 
+  // 10. managed_required passes model to generateManagedAvatar
+  test("managed_required forwards model to generateManagedAvatar", async () => {
+    mockStrategy = "managed_required";
+    const result = await routedGenerateAvatar("a cute cat", {
+      model: "imagen-3.0-generate-002",
+    });
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateManagedAvatarFn).toHaveBeenCalledWith("a cute cat", {
+      correlationId: undefined,
+      model: "imagen-3.0-generate-002",
+    });
+    expect(result.model).toBe("imagen-3.0-generate-002");
+    expect(result.pathUsed).toBe("managed");
+  });
+
+  // 11. managed_prefer passes model to generateManagedAvatar on success
+  test("managed_prefer forwards model to generateManagedAvatar on success", async () => {
+    mockStrategy = "managed_prefer";
+    const result = await routedGenerateAvatar("a cute cat", {
+      model: "imagen-3.0-generate-002",
+    });
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateManagedAvatarFn).toHaveBeenCalledWith("a cute cat", {
+      correlationId: undefined,
+      model: "imagen-3.0-generate-002",
+    });
+    expect(result.model).toBe("imagen-3.0-generate-002");
+    expect(result.pathUsed).toBe("managed");
+  });
+
+  // 12. model is undefined in result when not provided
+  test("managed_required result has no model when none provided", async () => {
+    mockStrategy = "managed_required";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.model).toBeUndefined();
+  });
+
   // 9. Removed: Invalid strategy values are now rejected at config parse time
   // by the Zod schema, so they cannot reach getAvatarStrategy().
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-avatar-runtime-proxy.md.

**Gap:** Avatar router tests do not cover model passthrough
**What was expected:** Tests verifying model forwarding and result inclusion
**What was found:** Zero tests for model in avatar-router.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
