### PR TITLE
Truncate tool results in kept turns during compaction

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -688,6 +688,115 @@ describe("ContextWindowManager", () => {
     expect(result.estimatedTokens).toBe(0);
   });
 
+  test("truncates tool results in kept turns to preserve more conversation", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- truncation summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+    // Budget is tight enough that full 8K tool results would force dropping turns,
+    // but truncated results (≤6K chars) should allow more turns to be kept.
+    const config = makeConfig({
+      maxInputTokens: 4000,
+      targetBudgetRatio: 0.7,
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
+
+    const largeToolResult = "x".repeat(8000);
+    const history: Message[] = [
+      message("user", "u1"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "read_file",
+            input: { path: "/tmp/a" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: largeToolResult,
+          },
+        ],
+      },
+      message("assistant", "a1"),
+      message("user", "u2"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "t2",
+            name: "read_file",
+            input: { path: "/tmp/b" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t2",
+            content: largeToolResult,
+          },
+        ],
+      },
+      message("assistant", "a2"),
+      message("user", "u3"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "t3",
+            name: "read_file",
+            input: { path: "/tmp/c" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t3",
+            content: largeToolResult,
+          },
+        ],
+      },
+      message("assistant", "a3"),
+      message("user", "u4"),
+      message("assistant", "a4"),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+    });
+    expect(result.compacted).toBe(true);
+
+    // Verify tool results in output are truncated (should be < 8K chars each).
+    for (const msg of result.messages) {
+      for (const block of msg.content) {
+        if (block.type === "tool_result") {
+          expect(block.content.length).toBeLessThan(8000);
+        }
+      }
+    }
+  });
+
   test("targetInputTokensOverride reduces retained turns beyond normal compaction", async () => {
     const provider = createProvider(() => ({
       content: [{ type: "text", text: "## Goals\n- tight fit summary" }],

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -3,6 +3,7 @@ import type { ContextWindowConfig } from "../config/types.js";
 import type { ContentBlock, Message, Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import { estimatePromptTokens } from "./token-estimator.js";
+import { truncateToolResultsAcrossHistory } from "./tool-result-truncation.js";
 
 const log = getLogger("context-window");
 
@@ -12,6 +13,7 @@ const MAX_FALLBACK_SUMMARY_CHARS = 12000;
 const COMPACTION_COOLDOWN_MS = 2 * 60 * 1000;
 const MIN_GAIN_TOKENS_DURING_COOLDOWN = 1200;
 const SEVERE_PRESSURE_RATIO = 0.95;
+const COMPACTION_TOOL_RESULT_MAX_CHARS = 6_000;
 const MIN_COMPACTABLE_PERSISTED_MESSAGES = 2;
 const INTERNAL_CONTEXT_SUMMARY_MESSAGES = new WeakSet<Message>();
 
@@ -235,10 +237,15 @@ export class ContextWindowManager {
 
     const compactedPersistedMessages =
       countPersistedMessages(compactableMessages);
-    const projectedMessages = [
+    const rawProjectedMessages = [
       createContextSummaryMessage(existingSummary ?? "Projected summary"),
       ...messages.slice(keepPlan.keepFromIndex),
     ];
+    const { messages: projectedMessages } =
+      truncateToolResultsAcrossHistory(
+        rawProjectedMessages,
+        COMPACTION_TOOL_RESULT_MAX_CHARS,
+      );
     const projectedInputTokens = estimatePromptTokens(
       projectedMessages,
       this.systemPrompt,
@@ -355,10 +362,12 @@ export class ContextWindowManager {
     // Media in compacted turns is described textually in the summary transcript.
     const summaryMessage = createContextSummaryMessage(summary);
 
-    const compactedMessages = [
-      summaryMessage,
-      ...messages.slice(keepPlan.keepFromIndex),
-    ];
+    const { messages: truncatedKeptMessages } =
+      truncateToolResultsAcrossHistory(
+        messages.slice(keepPlan.keepFromIndex),
+        COMPACTION_TOOL_RESULT_MAX_CHARS,
+      );
+    const compactedMessages = [summaryMessage, ...truncatedKeptMessages];
     const estimatedInputTokens = estimatePromptTokens(
       compactedMessages,
       this.systemPrompt,
@@ -431,10 +440,15 @@ export class ContextWindowManager {
           messages.length);
 
     while (keepTurns > minFloor) {
-      const projectedMessages = [
+      const rawProjected = [
         createContextSummaryMessage("Projected summary"),
         ...messages.slice(keepFromIndex),
       ];
+      const { messages: projectedMessages } =
+        truncateToolResultsAcrossHistory(
+          rawProjected,
+          COMPACTION_TOOL_RESULT_MAX_CHARS,
+        );
       const projectedTokens = estimatePromptTokens(
         projectedMessages,
         this.systemPrompt,


### PR DESCRIPTION
## Summary
- Apply `truncateToolResultsAcrossHistory()` (6K char limit) to kept messages during compaction — in `pickKeepBoundary()` for accurate projections and in `maybeCompact()` for the output assembly
- Large tool results (often 10K+ tokens) are low-value relative to the conversational turns they displace; truncating them lets the same token budget fit more user/assistant turns
- Compactable messages passed to the summary LLM remain untruncated (already clamped by `serializeForSummary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
