### PR TITLE
feat: upload dSYMs to Sentry from local release builds

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -913,6 +913,13 @@ if [ "$CONFIG" = "release" ]; then
     # Note: Sentry.framework is a pre-built binary from SPM and does not contain
     # the .o object files needed by dsymutil. Sentry distributes their own dSYMs
     # separately via their SDK integration — no need to run dsymutil on it.
+
+    # Upload dSYMs to Sentry when auth token is available (local dev & CI)
+    if [ -n "${SENTRY_AUTH_TOKEN:-}" ] && command -v sentry-cli &>/dev/null; then
+        echo "Uploading dSYMs to Sentry..."
+        sentry-cli debug-files upload --org vellum --project vellum-assistant-macos "$SCRIPT_DIR/dist/"*.dSYM || echo "warning: dSYM upload failed (non-fatal)"
+        sentry-cli debug-files upload --org vellum --project vellum-assistant-brain "$SCRIPT_DIR/dist/"*.dSYM || echo "warning: dSYM upload failed (non-fatal)"
+    fi
 fi
 
 # 7. Run if requested


### PR DESCRIPTION
## Summary
- Add dSYM upload to `build.sh` after release builds, so local development builds also get symbolicated in Sentry
- Only runs when `SENTRY_AUTH_TOKEN` is set and `sentry-cli` is available — no-op otherwise
- Uploads to both `vellum-assistant-macos` and `vellum-assistant-brain` projects (matching the CI workflow)
- Failures are non-fatal (prints warning, doesn't break the build)

## Original prompt
The CI release workflow uploads dSYMs but local dev builds don't, so locally-built crashes show "Processing Error" in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
