### PR TITLE
fix: use per-thread conversationKey so each thread gets its own backend conversation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -33,11 +33,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Switching to a real thread discards any draft
                 draftViewModel = nil
 
-                // Scope the HTTP transport's conversationKey to this thread so
-                // SSE events and outgoing messages target the correct backend
-                // conversation instead of sharing a single global one.
-                daemonClient.switchConversationKey(activeThreadId.uuidString)
-
                 let activeViewModel = getOrCreateViewModel(for: activeThreadId)
                 activeViewModel?.ensureMessageLoopStarted()
                 sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
@@ -50,6 +45,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Notify the daemon so it rebinds the socket to this thread's session.
                 // Without this, socketToSession stays stale after thread switches,
                 // causing ownership checks (e.g. subagent abort) to fail.
+                // Send session switch BEFORE switchConversationKey so the backend
+                // registers the key before the SSE stream reconnects.
                 if let sessionId = activeViewModel?.sessionId {
                     do {
                         try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
@@ -57,6 +54,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                         log.error("Failed to send session switch request: \(error)")
                     }
                 }
+
+                // Scope the HTTP transport's conversationKey to this thread so
+                // SSE events and outgoing messages target the correct backend
+                // conversation instead of sharing a single global one.
+                // Use sessionId as conversationKey for restored threads (stable across restarts),
+                // fall back to thread UUID for new threads without a session yet.
+                let conversationKey = activeViewModel?.sessionId ?? activeThreadId.uuidString
+                daemonClient.switchConversationKey(conversationKey)
             } else {
                 // Only clear the persisted thread ID outside of restoration.
                 // During init, enterDraftMode() sets activeThreadId = nil before

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -42,26 +42,31 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 if !isRestoringThreads {
                     lastActiveThreadIdString = activeThreadId.uuidString
                 }
-                // Notify the daemon so it rebinds the socket to this thread's session.
-                // Without this, socketToSession stays stale after thread switches,
-                // causing ownership checks (e.g. subagent abort) to fail.
-                // Send session switch BEFORE switchConversationKey so the backend
-                // registers the key before the SSE stream reconnects.
-                if let sessionId = activeViewModel?.sessionId {
-                    do {
-                        try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
-                    } catch {
-                        log.error("Failed to send session switch request: \(error)")
+                // Skip session switch and conversation key updates during
+                // startup restoration — threads are being bulk-loaded and the
+                // backend hasn't mapped their keys yet.
+                if !isRestoringThreads {
+                    // Notify the daemon so it rebinds the socket to this thread's session.
+                    // Without this, socketToSession stays stale after thread switches,
+                    // causing ownership checks (e.g. subagent abort) to fail.
+                    // Send session switch BEFORE switchConversationKey so the backend
+                    // registers the key before the SSE stream reconnects.
+                    if let sessionId = activeViewModel?.sessionId {
+                        do {
+                            try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+                        } catch {
+                            log.error("Failed to send session switch request: \(error)")
+                        }
                     }
-                }
 
-                // Scope the HTTP transport's conversationKey to this thread so
-                // SSE events and outgoing messages target the correct backend
-                // conversation instead of sharing a single global one.
-                // Use sessionId as conversationKey for restored threads (stable across restarts),
-                // fall back to thread UUID for new threads without a session yet.
-                let conversationKey = activeViewModel?.sessionId ?? activeThreadId.uuidString
-                daemonClient.switchConversationKey(conversationKey)
+                    // Scope the HTTP transport's conversationKey to this thread so
+                    // SSE events and outgoing messages target the correct backend
+                    // conversation instead of sharing a single global one.
+                    // Use sessionId as conversationKey for restored threads (stable across restarts),
+                    // fall back to thread UUID for new threads without a session yet.
+                    let conversationKey = activeViewModel?.sessionId ?? activeThreadId.uuidString
+                    daemonClient.switchConversationKey(conversationKey)
+                }
             } else {
                 // Only clear the persisted thread ID outside of restoration.
                 // During init, enterDraftMode() sets activeThreadId = nil before

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -33,6 +33,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Switching to a real thread discards any draft
                 draftViewModel = nil
 
+                // Scope the HTTP transport's conversationKey to this thread so
+                // SSE events and outgoing messages target the correct backend
+                // conversation instead of sharing a single global one.
+                daemonClient.switchConversationKey(activeThreadId.uuidString)
+
                 let activeViewModel = getOrCreateViewModel(for: activeThreadId)
                 activeViewModel?.ensureMessageLoopStarted()
                 sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -621,6 +621,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// HTTP transport for communicating with the assistant.
     public var httpTransport: HTTPTransport?
 
+    /// Persisted conversation key set via `switchConversationKey`.
+    /// Used when `connect()` recreates HTTPTransport so the active thread's
+    /// key survives reconnects. `nil` means use the config default.
+    var currentConversationKey: String?
+
     public private(set) var config: DaemonConfig
 
     // MARK: - Init

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -654,6 +654,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
+        currentConversationKey = nil
         cuObservationSequenceBySession.removeAll()
     }
 

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -93,6 +93,7 @@ public protocol DaemonClientProtocol {
     func disconnect()
     func startSSE()
     func stopSSE()
+    func switchConversationKey(_ newKey: String)
     func fetchSurfaceData(surfaceId: String, sessionId: String) async -> SurfaceData?
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
     func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
@@ -103,6 +104,9 @@ extension DaemonClientProtocol {
     public func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws {
         try send(signal)
     }
+
+    /// Default no-op for clients that don't support conversation key switching (e.g. test mocks).
+    public func switchConversationKey(_ newKey: String) {}
 
     /// Default no-op implementation for clients that don't support HTTP surface fetches.
     public func fetchSurfaceData(surfaceId: String, sessionId: String) async -> SurfaceData? { nil }

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -32,10 +32,15 @@ extension DaemonClient {
         let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
         let resolvedToken = bearerToken ?? (try? String(contentsOfFile: resolveHttpTokenPath(environment: tokenEnv), encoding: .utf8)).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
 
+        // Use the persisted conversationKey if one was set via switchConversationKey,
+        // otherwise fall back to the config value. This ensures reconnects after
+        // transport teardown preserve the active thread's conversation key.
+        let effectiveConversationKey = currentConversationKey ?? conversationKey
+
         let transport = HTTPTransport(
             baseURL: baseURL,
             bearerToken: resolvedToken,
-            conversationKey: conversationKey,
+            conversationKey: effectiveConversationKey,
             transportMetadata: config.transportMetadata
         )
 
@@ -93,7 +98,9 @@ extension DaemonClient {
     /// Switch the conversation key on the active HTTP transport.
     /// Updates the key used for SSE subscriptions and message sending,
     /// and reconnects the SSE stream to the new conversation.
+    /// The key is persisted so reconnects (via `connect()`) use the same key.
     public func switchConversationKey(_ newKey: String) {
+        currentConversationKey = newKey
         httpTransport?.switchConversationKey(newKey)
     }
 

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -90,6 +90,13 @@ extension DaemonClient {
         httpTransport?.stopSSE()
     }
 
+    /// Switch the conversation key on the active HTTP transport.
+    /// Updates the key used for SSE subscriptions and message sending,
+    /// and reconnects the SSE stream to the new conversation.
+    public func switchConversationKey(_ newKey: String) {
+        httpTransport?.switchConversationKey(newKey)
+    }
+
     // MARK: - Token Update
 
     /// Push a new bearer token to the active HTTP transport. If SSE is currently

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1339,6 +1339,8 @@ public final class HTTPTransport {
         // Reconnect SSE to the new conversation's event stream.
         // Reset backoff so the reconnect is immediate.
         sseReconnectDelay = 1.0
+        sseReconnectTask?.cancel()
+        sseReconnectTask = nil
         if sseTask != nil {
             startSSEStream()
         }
@@ -3153,7 +3155,13 @@ public final class HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        let body: [String: Any] = ["conversationId": conversationId]
+        var body: [String: Any] = ["conversationId": conversationId]
+        // Include the current conversationKey so the backend maps it to this
+        // conversation. This is important for restored threads whose thread
+        // UUID (used as conversationKey) differs from the original.
+        if !conversationKey.isEmpty {
+            body["conversationKey"] = conversationKey
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1326,9 +1326,10 @@ public final class HTTPTransport {
         setSSEConnected(false)
     }
 
-    /// Update the conversation key and reconnect the SSE stream so subsequent
-    /// messages and events target the new conversation. Called when the user
-    /// switches threads.
+    /// Update the conversation key so subsequent messages target the new
+    /// conversation. Called when the user switches threads.
+    /// Does NOT reconnect SSE — the caller (switchSession) reconnects after
+    /// the backend has registered the key mapping via POST /v1/conversations/switch.
     func switchConversationKey(_ newKey: String) {
         guard newKey != conversationKey else { return }
         log.info("Switching conversationKey from \(self.conversationKey, privacy: .public) to \(newKey, privacy: .public)")
@@ -1336,14 +1337,6 @@ public final class HTTPTransport {
         // Reset session ID mappings — the new conversation will have its own IDs.
         activeLocalSessionId = nil
         remoteSessionId = nil
-        // Reconnect SSE to the new conversation's event stream.
-        // Reset backoff so the reconnect is immediate.
-        sseReconnectDelay = 1.0
-        sseReconnectTask?.cancel()
-        sseReconnectTask = nil
-        if sseTask != nil {
-            startSSEStream()
-        }
     }
 
     private func startSSEStream() {
@@ -3170,8 +3163,16 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse else { return }
 
             if http.statusCode == 200 {
-                // Successful switch — session_info will arrive via SSE
+                // Successful switch — the backend has mapped our conversationKey
+                // to this conversation. Now reconnect SSE so events stream for
+                // the correct conversation.
                 log.info("Session switch to \(conversationId) succeeded")
+                sseReconnectDelay = 1.0
+                sseReconnectTask?.cancel()
+                sseReconnectTask = nil
+                if sseTask != nil {
+                    startSSEStream()
+                }
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -104,7 +104,7 @@ public final class HTTPTransport {
 
     public let baseURL: String
     public private(set) var bearerToken: String?
-    private let conversationKey: String
+    private var conversationKey: String
     private let sourceChannel: String
     let transportMetadata: TransportMetadata
 
@@ -1324,6 +1324,24 @@ public final class HTTPTransport {
         sseTask?.cancel()
         sseTask = nil
         setSSEConnected(false)
+    }
+
+    /// Update the conversation key and reconnect the SSE stream so subsequent
+    /// messages and events target the new conversation. Called when the user
+    /// switches threads.
+    func switchConversationKey(_ newKey: String) {
+        guard newKey != conversationKey else { return }
+        log.info("Switching conversationKey from \(self.conversationKey, privacy: .public) to \(newKey, privacy: .public)")
+        conversationKey = newKey
+        // Reset session ID mappings — the new conversation will have its own IDs.
+        activeLocalSessionId = nil
+        remoteSessionId = nil
+        // Reconnect SSE to the new conversation's event stream.
+        // Reset backoff so the reconnect is immediate.
+        sseReconnectDelay = 1.0
+        if sseTask != nil {
+            startSSEStream()
+        }
     }
 
     private func startSSEStream() {

--- a/clients/shared/Network/MockDaemonClient.swift
+++ b/clients/shared/Network/MockDaemonClient.swift
@@ -35,6 +35,12 @@ public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
     public func startSSE() {}
     public func stopSSE() {}
 
+    /// The most recent conversation key passed to `switchConversationKey(_:)`.
+    public private(set) var currentConversationKey: String?
+    public func switchConversationKey(_ newKey: String) {
+        currentConversationKey = newKey
+    }
+
     /// Inject a server message into all active subscribers.
     public func emit(_ message: ServerMessage) {
         for continuation in continuations {

--- a/clients/shared/Tests/MockDaemonClientTests.swift
+++ b/clients/shared/Tests/MockDaemonClientTests.swift
@@ -158,6 +158,34 @@ final class MockDaemonClientTests: XCTestCase {
         }
     }
 
+    // MARK: - Conversation Key Switching
+
+    func testSwitchConversationKeyRecordsKey() {
+        let client = MockDaemonClient()
+        XCTAssertNil(client.currentConversationKey, "Should be nil before any switch")
+
+        client.switchConversationKey("thread-123")
+        XCTAssertEqual(client.currentConversationKey, "thread-123")
+    }
+
+    func testSwitchConversationKeyUpdatesOnSubsequentCalls() {
+        let client = MockDaemonClient()
+        client.switchConversationKey("thread-A")
+        XCTAssertEqual(client.currentConversationKey, "thread-A")
+
+        client.switchConversationKey("thread-B")
+        XCTAssertEqual(client.currentConversationKey, "thread-B",
+                       "Switching again should update to the latest key")
+    }
+
+    func testSwitchConversationKeyWithUUIDString() {
+        let client = MockDaemonClient()
+        let threadId = UUID()
+        client.switchConversationKey(threadId.uuidString)
+        XCTAssertEqual(client.currentConversationKey, threadId.uuidString,
+                       "Should store the UUID string exactly as provided")
+    }
+
     // MARK: - Multiple Connect/Disconnect Cycles
 
     func testMultipleConnectDisconnectCycles() async throws {


### PR DESCRIPTION
## Summary
- Makes `conversationKey` in `HTTPTransport` mutable and adds `switchConversationKey()` method that updates the key and reconnects the SSE stream
- Adds `switchConversationKey()` to `DaemonClientProtocol` (with default no-op) and forwards through `DaemonClient` to `HTTPTransport`
- Calls `switchConversationKey(activeThreadId.uuidString)` in `ThreadManager.activeThreadId.didSet` so each thread scopes to its own backend conversation
- Updates `MockDaemonClient` to track the current conversation key for test assertions

## Test plan
- [ ] Verify new thread does not show previous thread's history
- [ ] Verify switching between threads sends messages to the correct backend conversation
- [ ] Verify SSE reconnects when switching threads (events arrive for the correct conversation)
- [ ] Run `MockDaemonClientTests` to verify `switchConversationKey` recording works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
