### PR TITLE
fix: pass file attachments through HTTP transport to daemon

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+ExistingRoutes.swift
@@ -17,7 +17,7 @@ extension HTTPTransport {
             guard let self else { return false }
 
             if let msg = message as? UserMessageMessage {
-                Task { await self.sendMessage(content: msg.content, sessionId: msg.sessionId) }
+                Task { await self.sendMessage(content: msg.content, sessionId: msg.sessionId, attachments: msg.attachments) }
                 return true
             } else if let msg = message as? ConfirmationResponseMessage {
                 Task { await self.sendDecision(requestId: msg.requestId, decision: msg.decision, selectedPattern: msg.selectedPattern, selectedScope: msg.selectedScope) }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -416,6 +416,9 @@ public final class HTTPTransport {
         case workspaceFiles
         case workspaceFilesRead
 
+        // Attachments
+        case uploadAttachment
+
         // Misc
         case channelVerificationSessions
         case registerDeviceToken
@@ -814,6 +817,9 @@ public final class HTTPTransport {
             return ("/v1/workspace-files", nil)
         case .workspaceFilesRead:
             return ("/v1/workspace-files/read", nil)
+        // Attachments
+        case .uploadAttachment:
+            return ("/v1/attachments", nil)
         // Misc
         case .channelVerificationSessions:
             return ("/v1/channel-verification-sessions", nil)
@@ -1195,6 +1201,9 @@ public final class HTTPTransport {
             return ("\(prefix)/workspace-files/", nil)
         case .workspaceFilesRead:
             return ("\(prefix)/workspace-files/read/", nil)
+        // Attachments
+        case .uploadAttachment:
+            return ("\(prefix)/attachments/", nil)
         // Misc
         case .channelVerificationSessions:
             return ("\(prefix)/channel-verification-sessions/", nil)
@@ -1492,7 +1501,49 @@ public final class HTTPTransport {
 
     // MARK: - HTTP Endpoints
 
-    func sendMessage(content: String?, sessionId: String, isRetry: Bool = false) async {
+    /// Upload a single attachment and return its server-assigned ID, or nil on failure.
+    private func uploadAttachment(_ attachment: IPCAttachment) async -> String? {
+        guard let url = buildURL(for: .uploadAttachment) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = [
+            "filename": attachment.filename,
+            "mimeType": attachment.mimeType,
+            "data": attachment.data
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                log.error("Attachment upload failed")
+                return nil
+            }
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            return json?["id"] as? String
+        } catch {
+            log.error("Attachment upload error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func sendMessage(content: String?, sessionId: String, attachments: [IPCAttachment]? = nil, isRetry: Bool = false) async {
+        // Upload attachments first and collect their IDs
+        var attachmentIds: [String] = []
+        if let attachments, !attachments.isEmpty {
+            for attachment in attachments {
+                if let id = await uploadAttachment(attachment) {
+                    attachmentIds.append(id)
+                } else {
+                    log.error("Failed to upload attachment: \(attachment.filename)")
+                }
+            }
+        }
+
         guard let url = buildURL(for: .sendMessage) else { return }
 
         var request = URLRequest(url: url)
@@ -1508,6 +1559,9 @@ public final class HTTPTransport {
         if let content, !content.isEmpty {
             body["content"] = content
         }
+        if !attachmentIds.isEmpty {
+            body["attachmentIds"] = attachmentIds
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -1521,7 +1575,7 @@ public final class HTTPTransport {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 switch refreshResult {
                 case .success:
-                    await sendMessage(content: content, sessionId: sessionId, isRetry: true)
+                    await sendMessage(content: content, sessionId: sessionId, attachments: attachments, isRetry: true)
                 case .terminalFailure:
                     // performRefresh() already emitted .authenticationRequired — don't overwrite it
                     break

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1501,9 +1501,15 @@ public final class HTTPTransport {
 
     // MARK: - HTTP Endpoints
 
-    /// Upload a single attachment and return its server-assigned ID, or nil on failure.
-    private func uploadAttachment(_ attachment: IPCAttachment, isRetry: Bool = false) async -> String? {
-        guard let url = buildURL(for: .uploadAttachment) else { return nil }
+    private enum AttachmentUploadResult {
+        case success(id: String)
+        case transientFailure
+        case terminalAuthFailure
+    }
+
+    /// Upload a single attachment and return its server-assigned ID.
+    private func uploadAttachment(_ attachment: IPCAttachment, isRetry: Bool = false) async -> AttachmentUploadResult {
+        guard let url = buildURL(for: .uploadAttachment) else { return .transientFailure }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -1519,51 +1525,58 @@ public final class HTTPTransport {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else { return nil }
+            guard let http = response as? HTTPURLResponse else { return .transientFailure }
 
             if http.statusCode == 200 {
                 let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-                return json?["id"] as? String
+                if let id = json?["id"] as? String {
+                    return .success(id: id)
+                }
+                return .transientFailure
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 switch refreshResult {
                 case .success:
                     return await uploadAttachment(attachment, isRetry: true)
-                case .terminalFailure, .transientFailure:
-                    return nil
+                case .terminalFailure:
+                    // handleAuthenticationFailureAsync already emitted .authenticationRequired
+                    return .terminalAuthFailure
+                case .transientFailure:
+                    return .transientFailure
                 }
             } else {
                 log.error("Attachment upload failed (\(http.statusCode))")
-                return nil
+                return .transientFailure
             }
         } catch {
             log.error("Attachment upload error: \(error.localizedDescription)")
-            return nil
+            return .transientFailure
         }
     }
 
-    func sendMessage(content: String?, sessionId: String, attachments: [IPCAttachment]? = nil, isRetry: Bool = false) async {
-        // Upload attachments first and collect their IDs
-        var attachmentIds: [String] = []
-        if let attachments, !attachments.isEmpty {
-            var uploadFailed = false
+    func sendMessage(content: String?, sessionId: String, attachments: [IPCAttachment]? = nil, uploadedAttachmentIds: [String]? = nil, isRetry: Bool = false) async {
+        // On retry, reuse already-uploaded attachment IDs to avoid duplicates
+        var attachmentIds: [String] = uploadedAttachmentIds ?? []
+
+        if attachmentIds.isEmpty, let attachments, !attachments.isEmpty {
             for attachment in attachments {
-                if let id = await uploadAttachment(attachment) {
+                switch await uploadAttachment(attachment) {
+                case .success(let id):
                     attachmentIds.append(id)
-                } else {
+                case .terminalAuthFailure:
+                    // .authenticationRequired already emitted — don't overwrite with a generic error
+                    return
+                case .transientFailure:
                     log.error("Failed to upload attachment: \(attachment.filename)")
-                    uploadFailed = true
+                    let failedCount = attachments.count - attachmentIds.count
+                    onMessage?(.sessionError(SessionErrorMessage(
+                        sessionId: sessionId,
+                        code: .providerApi,
+                        userMessage: "Failed to upload \(failedCount) attachment\(failedCount == 1 ? "" : "s"). Please try again.",
+                        retryable: true
+                    )))
+                    return
                 }
-            }
-            if uploadFailed {
-                let failedCount = attachments.count - attachmentIds.count
-                onMessage?(.sessionError(SessionErrorMessage(
-                    sessionId: sessionId,
-                    code: .providerApi,
-                    userMessage: "Failed to upload \(failedCount) attachment\(failedCount == 1 ? "" : "s"). Please try again.",
-                    retryable: true
-                )))
-                return
             }
         }
 
@@ -1598,7 +1611,8 @@ public final class HTTPTransport {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 switch refreshResult {
                 case .success:
-                    await sendMessage(content: content, sessionId: sessionId, attachments: attachments, isRetry: true)
+                    // Reuse already-uploaded IDs to avoid duplicate uploads
+                    await sendMessage(content: content, sessionId: sessionId, uploadedAttachmentIds: attachmentIds, isRetry: true)
                 case .terminalFailure:
                     // performRefresh() already emitted .authenticationRequired — don't overwrite it
                     break

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1502,7 +1502,7 @@ public final class HTTPTransport {
     // MARK: - HTTP Endpoints
 
     /// Upload a single attachment and return its server-assigned ID, or nil on failure.
-    private func uploadAttachment(_ attachment: IPCAttachment) async -> String? {
+    private func uploadAttachment(_ attachment: IPCAttachment, isRetry: Bool = false) async -> String? {
         guard let url = buildURL(for: .uploadAttachment) else { return nil }
 
         var request = URLRequest(url: url)
@@ -1519,12 +1519,23 @@ public final class HTTPTransport {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                log.error("Attachment upload failed")
+            guard let http = response as? HTTPURLResponse else { return nil }
+
+            if http.statusCode == 200 {
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                return json?["id"] as? String
+            } else if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                switch refreshResult {
+                case .success:
+                    return await uploadAttachment(attachment, isRetry: true)
+                case .terminalFailure, .transientFailure:
+                    return nil
+                }
+            } else {
+                log.error("Attachment upload failed (\(http.statusCode))")
                 return nil
             }
-            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            return json?["id"] as? String
         } catch {
             log.error("Attachment upload error: \(error.localizedDescription)")
             return nil
@@ -1535,12 +1546,24 @@ public final class HTTPTransport {
         // Upload attachments first and collect their IDs
         var attachmentIds: [String] = []
         if let attachments, !attachments.isEmpty {
+            var uploadFailed = false
             for attachment in attachments {
                 if let id = await uploadAttachment(attachment) {
                     attachmentIds.append(id)
                 } else {
                     log.error("Failed to upload attachment: \(attachment.filename)")
+                    uploadFailed = true
                 }
+            }
+            if uploadFailed {
+                let failedCount = attachments.count - attachmentIds.count
+                onMessage?(.sessionError(SessionErrorMessage(
+                    sessionId: sessionId,
+                    code: .providerApi,
+                    userMessage: "Failed to upload \(failedCount) attachment\(failedCount == 1 ? "" : "s"). Please try again.",
+                    retryable: true
+                )))
+                return
             }
         }
 


### PR DESCRIPTION
## Summary
- The HTTP transport dispatcher in `HTTPDaemonClient+ExistingRoutes.swift` was dropping `msg.attachments` when forwarding `UserMessageMessage` — only `content` and `sessionId` were passed through
- Added `uploadAttachment` endpoint and method to upload each attachment via `POST /v1/attachments` before sending the message
- Updated `sendMessage` to accept optional attachments, upload them to get server-assigned IDs, and include `attachmentIds` in the `POST /v1/messages` body

## Original prompt
i think there's a bug with including attachments. can you look into it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
