### PR TITLE
Remove unused queuedAt field from QueuedMessage

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -1774,7 +1774,6 @@ describe("MessageQueue byte budget", () => {
       })),
       requestId,
       onEvent: () => {},
-      queuedAt: 0,
     };
   }
 

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -236,7 +236,6 @@ export function enqueueMessage(
     turnChannelContext,
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
-    queuedAt: Date.now(),
     displayContent,
   });
   if (!accepted) {

--- a/assistant/src/daemon/session-queue-manager.ts
+++ b/assistant/src/daemon/session-queue-manager.ts
@@ -26,8 +26,6 @@ export interface QueuedMessage {
   turnInterfaceContext?: TurnInterfaceContext;
   /** When false, the turn has no interactive user and should skip clarification prompts. */
   isInteractive?: boolean;
-  /** Timestamp (ms) when the message was enqueued. */
-  queuedAt: number;
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
   displayContent?: string;
 }
@@ -92,7 +90,6 @@ export class MessageQueue {
       );
       return false;
     }
-    item.queuedAt = Date.now();
     this.items.push(item);
     this.currentBytes += itemBytes;
     return true;


### PR DESCRIPTION
Follow-up to PR #14917. The queuedAt field was left behind after the expiry logic removal — it is set but never read. Remove it from the interface, push(), and all call sites.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
