### PR TITLE
Remove dead QUEUE_FULL handling from Swift client

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -420,7 +420,6 @@ struct ChatContentView: View {
         case .providerNetwork: return .wifiOff
         case .rateLimit: return .clockAlert
         case .providerApi: return .cloudOff
-        case .queueFull: return .inbox
         case .sessionAborted: return .circleStop
         case .processingFailed, .regenerateFailed: return .refreshCw
         case .contextTooLarge: return .fileText
@@ -432,7 +431,7 @@ struct ChatContentView: View {
 
     private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
         switch category {
-        case .rateLimit, .queueFull: return VColor.warning
+        case .rateLimit: return VColor.warning
         case .providerNetwork: return .orange
         case .sessionAborted: return VColor.textSecondary
         case .contextTooLarge: return VColor.warning

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -161,8 +161,6 @@ struct ChatSessionErrorToast: View {
             return .creditCard
         case .contextTooLarge:
             return .fileText
-        case .queueFull:
-            return .inbox
         case .sessionAborted:
             return .circleStop
         case .processingFailed, .regenerateFailed:
@@ -178,7 +176,7 @@ struct ChatSessionErrorToast: View {
     /// red for hard failures.
     private func accentColor(for category: SessionErrorCategory) -> Color {
         switch category {
-        case .rateLimit, .queueFull:
+        case .rateLimit:
             return VColor.warning
         case .providerNetwork:
             return Amber._500

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1560,14 +1560,14 @@ final class ChatViewModelTests: XCTestCase {
 
         let errorMsg = SessionErrorMessage(
             sessionId: "sess-1",
-            code: .queueFull,
-            userMessage: "Queue is full",
+            code: .providerApi,
+            userMessage: "Provider error",
             retryable: false
         )
         viewModel.handleServerMessage(.sessionError(errorMsg))
 
         XCTAssertEqual(viewModel.sessionError?.isRetryable, false)
-        XCTAssertEqual(viewModel.sessionError?.category, .queueFull)
+        XCTAssertEqual(viewModel.sessionError?.category, .providerApi)
     }
 
     func testSessionErrorReplacedBySubsequentError() {

--- a/clients/shared/Features/Chat/ChatSessionError.swift
+++ b/clients/shared/Features/Chat/ChatSessionError.swift
@@ -7,7 +7,6 @@ public enum SessionErrorCategory: Equatable, Sendable {
     case providerApi
     case providerBilling
     case contextTooLarge
-    case queueFull
     case sessionAborted
     case processingFailed
     case regenerateFailed
@@ -26,8 +25,6 @@ public enum SessionErrorCategory: Equatable, Sendable {
             self = .providerBilling
         case .contextTooLarge:
             self = .contextTooLarge
-        case .queueFull:
-            self = .queueFull
         case .sessionAborted:
             self = .sessionAborted
         case .sessionProcessingFailed:
@@ -54,8 +51,6 @@ public enum SessionErrorCategory: Equatable, Sendable {
             return "Please add credits to your account or update your API key in Settings."
         case .contextTooLarge:
             return "Start a new thread to reset context, or try a shorter message."
-        case .queueFull:
-            return "Wait for pending messages to finish, then resend."
         case .sessionAborted:
             return "Send a new message to continue the conversation."
         case .processingFailed:

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1548,24 +1548,8 @@ extension ChatViewModel {
                     }
                 }
             } else {
-                // Capture before clearing — surface actions don't set
-                // isSending, so this distinguishes user-message sends
-                // from surface action rejections.
-                let wasSendingUserMessage = isSending
                 // Always clear sending state so regenerate is unblocked.
                 isSending = false
-                // When QUEUE_FULL from a user-message send, the daemon
-                // rejected the message — no message_queued will arrive.
-                // Remove its stale pending ID so subsequent events don't
-                // mis-correlate. Only do this for user-message sends
-                // (wasSendingUserMessage), not surface action rejections
-                // which never append to pendingMessageIds.
-                if msg.code == .queueFull, wasSendingUserMessage, let rejectedId = pendingMessageIds.last {
-                    pendingMessageIds.removeLast()
-                    if let index = messages.firstIndex(where: { $0.id == rejectedId }) {
-                        messages[index].status = .sent
-                    }
-                }
                 if pendingQueuedCount == 0 {
                     // No queued work remains — safe to tear down everything.
                     pendingMessageIds = []

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1427,7 +1427,6 @@ public enum SessionErrorCode: String, CaseIterable, Codable, Sendable {
     case providerApi = "PROVIDER_API"
     case providerBilling = "PROVIDER_BILLING"
     case contextTooLarge = "CONTEXT_TOO_LARGE"
-    case queueFull = "QUEUE_FULL"
     case sessionAborted = "SESSION_ABORTED"
     case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
     case regenerateFailed = "REGENERATE_FAILED"


### PR DESCRIPTION
Follow-up to PR #14905. The daemon no longer sends QUEUE_FULL errors. Remove the dead enum case and special handling logic from the Swift client.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
