### PR TITLE
Add token budget guard and clamp summaryMaxTokens for single-pass compaction

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -2,7 +2,10 @@ import { createUserMessage } from "../agent/message-types.js";
 import type { ContextWindowConfig } from "../config/types.js";
 import type { ContentBlock, Message, Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
-import { estimatePromptTokens } from "./token-estimator.js";
+import {
+  estimatePromptTokens,
+  estimateTextTokens,
+} from "./token-estimator.js";
 import { truncateToolResultsAcrossHistory } from "./tool-result-truncation.js";
 
 const log = getLogger("context-window");
@@ -335,7 +338,10 @@ export class ContextWindowManager {
       };
     }
 
-    const transcript = serializeMessages(compactableMessages);
+    const transcript = this.capTranscriptToTokenBudget(
+      serializeMessages(compactableMessages),
+      existingSummary ?? "No previous summary.",
+    );
     const summaryUpdate = await this.updateSummary(
       existingSummary ?? "No previous summary.",
       transcript,
@@ -467,9 +473,55 @@ export class ContextWindowManager {
   }
 
   private get summaryMaxTokens(): number {
-    return Math.floor(
-      this.config.maxInputTokens * this.config.summaryBudgetRatio,
+    return Math.max(
+      1,
+      Math.floor(
+        this.config.maxInputTokens * this.config.summaryBudgetRatio,
+      ),
     );
+  }
+
+  /**
+   * Trim the serialized transcript so that the summary prompt (system prompt +
+   * existing summary + transcript + scaffolding) fits within the provider's
+   * input token limit, minus the output budget reserved for the summary itself.
+   * This prevents the summarizer LLM call from exceeding its context window
+   * during forced compaction of very large histories.
+   */
+  private capTranscriptToTokenBudget(
+    transcript: string,
+    currentSummary: string,
+  ): string {
+    // Reserve tokens for: system prompt, summary prompt scaffolding, existing
+    // summary, message overhead, and the output (summaryMaxTokens).
+    const overheadTokens =
+      estimateTextTokens(SUMMARY_SYSTEM_PROMPT) +
+      estimateTextTokens(currentSummary) +
+      // Scaffolding text in buildSummaryPrompt ("Update the summary...",
+      // section headers, etc.) — generous fixed estimate.
+      200 +
+      this.summaryMaxTokens;
+
+    const maxTranscriptTokens = Math.max(
+      0,
+      this.config.maxInputTokens - overheadTokens,
+    );
+
+    const transcriptTokens = estimateTextTokens(transcript);
+    if (transcriptTokens <= maxTranscriptTokens) return transcript;
+
+    // Truncate from the beginning (older messages) to preserve recent context.
+    const maxChars = maxTranscriptTokens * 4; // inverse of estimateTextTokens
+    const truncated = transcript.slice(transcript.length - maxChars);
+    log.info(
+      {
+        originalTokens: transcriptTokens,
+        cappedTokens: maxTranscriptTokens,
+        droppedTokens: transcriptTokens - maxTranscriptTokens,
+      },
+      "Capped summary transcript to fit provider input limit",
+    );
+    return `[earlier messages truncated]\n${truncated}`;
   }
 
   private async updateSummary(


### PR DESCRIPTION
Follow-up to PR #14907. Adds an input-token cap before invoking the summarizer to prevent exceeding provider context limits during forced compaction of very large histories. Also clamps summaryMaxTokens to >= 1 to handle edge cases with very small maxInputTokens * summaryBudgetRatio.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
