### PR TITLE
fix: detach ngrok subprocess and fix PID-based shutdown

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1047,6 +1047,19 @@ export async function stopLocalProcesses(
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
 
+  // Kill ngrok directly by PID rather than using stopProcessByPidFile, because
+  // isVellumProcess() checks for /vellum|@vellumai|--vellum-gateway/ which
+  // won't match the ngrok binary — resulting in a no-op that leaves ngrok running.
   const ngrokPidFile = join(vellumDir, "ngrok.pid");
-  await stopProcessByPidFile(ngrokPidFile, "ngrok");
+  if (existsSync(ngrokPidFile)) {
+    try {
+      const pid = parseInt(readFileSync(ngrokPidFile, "utf-8").trim(), 10);
+      if (!isNaN(pid)) {
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {}
+      }
+      unlinkSync(ngrokPidFile);
+    } catch {}
+  }
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -115,6 +115,7 @@ export async function findExistingTunnel(
  */
 export function startNgrokProcess(targetPort: number): ChildProcess {
   const child = spawn("ngrok", ["http", String(targetPort), "--log=stdout"], {
+    detached: true,
     stdio: ["ignore", "pipe", "pipe"],
   });
   return child;
@@ -240,6 +241,15 @@ export async function maybeStartNgrokTunnel(
     const publicUrl = await waitForNgrokUrl();
     saveIngressUrl(publicUrl);
     console.log(`   Tunnel established: ${publicUrl}`);
+
+    // Detach the ngrok process so the CLI (hatch/wake) can exit without
+    // keeping it alive. Remove stdout/stderr listeners and unref all handles.
+    ngrokProcess.stdout?.removeAllListeners("data");
+    ngrokProcess.stderr?.removeAllListeners("data");
+    ngrokProcess.stdout?.destroy();
+    ngrokProcess.stderr?.destroy();
+    ngrokProcess.unref();
+
     return ngrokProcess;
   } catch {
     console.warn(


### PR DESCRIPTION
## Summary
- Detach and unref ngrok child process in maybeStartNgrokTunnel() so the CLI process can exit after hatch/wake
- Replace stopProcessByPidFile() for ngrok with direct PID kill, since isVellumProcess() regex doesn't match ngrok

## Original prompt
Address Codex review feedback from PR #14914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
