### PR TITLE
Fix queue_full rejection edge cases in conversation routes and surface actions

### DIFF
--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -572,16 +572,19 @@ export function handleSurfaceAction(
       requestId,
       surfaceId,
     );
+
+    if (result.rejected) {
+      ctx.surfaceActionRequestIds.delete(requestId);
+      return;
+    }
+
     // Echo the prompt to the client so it appears in the chat UI.
+    // Deferred until after rejection check to avoid ghost messages.
     ctx.sendToClient({
       type: "user_message_echo",
       text: prompt,
       sessionId: ctx.conversationId,
     });
-
-    if (result.rejected) {
-      return;
-    }
 
     if (result.queued) {
       log.info(
@@ -702,15 +705,6 @@ export function handleSurfaceAction(
   ctx.surfaceActionRequestIds.add(requestId);
   const onEvent = (msg: ServerMessage) => ctx.sendToClient(msg);
 
-  // Echo the user's prompt to the client so it appears in the chat UI
-  if (shouldRelayPrompt && prompt) {
-    ctx.sendToClient({
-      type: "user_message_echo",
-      text: prompt,
-      sessionId: ctx.conversationId,
-    });
-  }
-
   ctx.traceEmitter.emit("request_received", "Surface action received", {
     requestId,
     status: "info",
@@ -729,7 +723,18 @@ export function handleSurfaceAction(
     displayContent,
   );
   if (result.rejected) {
+    ctx.surfaceActionRequestIds.delete(requestId);
     return;
+  }
+
+  // Echo the user's prompt to the client so it appears in the chat UI.
+  // Deferred until after rejection check to avoid ghost messages.
+  if (shouldRelayPrompt && prompt) {
+    ctx.sendToClient({
+      type: "user_message_echo",
+      text: prompt,
+      sessionId: ctx.conversationId,
+    });
   }
   if (result.queued) {
     const position = ctx.getQueueDepth();

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -617,30 +617,6 @@ export async function handleSendMessage(
   }
 
   if (session.isProcessing()) {
-    // If a tool confirmation is pending, auto-deny it so the agent
-    // can finish the current turn and process this queued message.
-    if (session.hasAnyPendingConfirmation()) {
-      // Emit authoritative denial state for each pending request.
-      // sendToClient (wired to the SSE hub) delivers these to the client.
-      for (const interaction of pendingInteractions.getByConversation(
-        mapping.conversationId,
-      )) {
-        if (
-          interaction.session === session &&
-          interaction.kind === "confirmation"
-        ) {
-          session.emitConfirmationStateChanged({
-            sessionId: mapping.conversationId,
-            requestId: interaction.requestId,
-            state: "denied" as const,
-            source: "auto_deny" as const,
-          });
-        }
-      }
-      session.denyAllPendingConfirmations();
-      pendingInteractions.removeBySession(session);
-    }
-
     // Queue the message so it's processed when the current turn completes
     const requestId = crypto.randomUUID();
     const enqueueResult = session.enqueueMessage(
@@ -664,6 +640,32 @@ export async function handleSendMessage(
         { status: 429 },
       );
     }
+
+    // Auto-deny pending confirmations only after enqueue succeeds, so we
+    // don't cancel approval-gated workflows when the replacement message
+    // is itself rejected by the queue budget.
+    if (session.hasAnyPendingConfirmation()) {
+      // Emit authoritative denial state for each pending request.
+      // sendToClient (wired to the SSE hub) delivers these to the client.
+      for (const interaction of pendingInteractions.getByConversation(
+        mapping.conversationId,
+      )) {
+        if (
+          interaction.session === session &&
+          interaction.kind === "confirmation"
+        ) {
+          session.emitConfirmationStateChanged({
+            sessionId: mapping.conversationId,
+            requestId: interaction.requestId,
+            state: "denied" as const,
+            source: "auto_deny" as const,
+          });
+        }
+      }
+      session.denyAllPendingConfirmations();
+      pendingInteractions.removeBySession(session);
+    }
+
     return Response.json({ accepted: true, queued: true }, { status: 202 });
   }
 


### PR DESCRIPTION
Follow-up to PR #14924. Fixes three issues with the queue_full rejection path: (1) auto-deny of pending confirmations now happens only after successful enqueue, (2) stale surface request IDs are cleaned up on rejection, (3) user_message_echo is deferred until after rejection check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
