### PR TITLE
Route managed Anthropic LLM requests through Vertex proxy instead of Anthropic proxy

### DIFF
--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -24,6 +24,7 @@ mock.module("../security/secure-keys.js", () => ({
 }));
 
 import {
+  getProvider,
   getProviderRoutingSource,
   initializeProviders,
   listProviders,
@@ -146,6 +147,33 @@ describe("managed proxy integration — credential precedence", () => {
         expect(registered).toContain(p);
         expect(getProviderRoutingSource(p)).toBe("managed-proxy");
       }
+    });
+
+    test("managed anthropic uses vertex proxy path instead of anthropic proxy path", () => {
+      enableManagedProxy();
+      initializeProviders({
+        apiKeys: {},
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+
+      const provider = getProvider("anthropic");
+
+      // Unwrap RetryProvider → LogfireProvider → AnthropicProvider to inspect
+      // the Anthropic SDK client's baseURL. The wrappers use private `inner`
+      // and AnthropicProvider stores the SDK client as private `client`.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const retryInner = (provider as any).inner;
+      // retryInner is the logfire wrapper; it also has an `inner` property
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const logfireInner = (retryInner as any).inner ?? retryInner;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anthropicClient = (logfireInner as any).client;
+
+      expect(anthropicClient).toBeDefined();
+      const baseURL: string = anthropicClient.baseURL;
+      expect(baseURL).toContain("/v1/runtime-proxy/vertex");
+      expect(baseURL).not.toContain("/v1/runtime-proxy/anthropic");
     });
   });
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -227,7 +227,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     routingSources.set("anthropic", "user-key");
   } else {
     // No user Anthropic key — try managed proxy fallback
-    const managedBaseUrl = buildManagedBaseUrl("anthropic");
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "anthropic");


### PR DESCRIPTION
## Summary
- Change managed-mode Anthropic routing from `/v1/runtime-proxy/anthropic` to `/v1/runtime-proxy/vertex`
- Platform's Vertex proxy handles ADC auth and translation to Vertex AI's rawPredict endpoint
- Add test verifying managed Anthropic uses Vertex proxy path

Part of plan: managed-anthropic-vertex-proxy.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
