### PR TITLE
Fix file block serialization test broken by token budget guard

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -260,11 +260,11 @@ describe("ContextWindowManager", () => {
       provider,
       systemPrompt: "system prompt",
       config: makeConfig({
-        maxInputTokens: 280,
+        maxInputTokens: 550,
         targetBudgetRatio: 0.59,
       }),
     });
-    const long = "f".repeat(220);
+    const long = "f".repeat(500);
     const history: Message[] = [
       {
         role: "user",


### PR DESCRIPTION
## Summary
- The `capTranscriptToTokenBudget` method added in #14933 truncates the summary transcript when overhead exceeds `maxInputTokens`. With the test's `maxInputTokens: 280`, overhead (~330 tokens from system prompt + scaffolding + summary budget) exceeded the budget, leaving 0 tokens for transcript content and truncating the file block.
- Increased `maxInputTokens` from 280 to 550 and padding from 220 to 500 chars so compaction still triggers but the serialized file block survives the transcript cap.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22925773684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
