### PR TITLE
fix: add budget ratio validation and optimize pickKeepBoundary search

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -341,6 +341,19 @@ export const AssistantConfigSchema = z
           "contextWindow.targetBudgetRatio must be less than contextWindow.compactThreshold",
       });
     }
+    if (
+      config.contextWindow?.targetBudgetRatio != null &&
+      config.contextWindow?.summaryBudgetRatio != null &&
+      config.contextWindow.targetBudgetRatio <=
+        config.contextWindow.summaryBudgetRatio
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["contextWindow", "targetBudgetRatio"],
+        message:
+          "contextWindow.targetBudgetRatio must be greater than contextWindow.summaryBudgetRatio",
+      });
+    }
     const segmentation = config.memory?.segmentation;
     if (
       segmentation &&

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -433,41 +433,52 @@ export class ContextWindowManager {
     const targetTokens =
       opts?.targetInputTokensOverride ?? this.targetInputTokens;
 
-    // Start from all available turns and reduce until projected tokens fit.
-    let keepTurns = userTurnStarts.length;
-    keepTurns = Math.max(minFloor, keepTurns);
-
-    // When minFloor is 0 and there are no user turns to keep, keepFromIndex
-    // points past the end of the array so all messages become compactable.
-    let keepFromIndex =
-      keepTurns === 0
-        ? messages.length
-        : (userTurnStarts[userTurnStarts.length - keepTurns] ??
-          messages.length);
-
-    while (keepTurns > minFloor) {
+    // Binary search for the maximum keepTurns whose projected tokens fit
+    // within the budget. Token count is monotonically non-decreasing with
+    // keepTurns (more turns = more tokens), so binary search is valid.
+    const projectedTokensForKeep = (turns: number): number => {
+      const fromIndex =
+        turns === 0
+          ? messages.length
+          : (userTurnStarts[userTurnStarts.length - turns] ?? messages.length);
       const rawProjected = [
         createContextSummaryMessage("Projected summary"),
-        ...messages.slice(keepFromIndex),
+        ...messages.slice(fromIndex),
       ];
       const { messages: projectedMessages } =
         truncateToolResultsAcrossHistory(
           rawProjected,
           COMPACTION_TOOL_RESULT_MAX_CHARS,
         );
-      const projectedTokens = estimatePromptTokens(
-        projectedMessages,
-        this.systemPrompt,
-        { providerName: this.provider.name },
-      );
-      if (projectedTokens <= targetTokens) break;
-      keepTurns -= 1;
-      keepFromIndex =
-        keepTurns === 0
-          ? messages.length
-          : (userTurnStarts[userTurnStarts.length - keepTurns] ??
-            keepFromIndex);
+      return estimatePromptTokens(projectedMessages, this.systemPrompt, {
+        providerName: this.provider.name,
+      });
+    };
+
+    let lo = minFloor;
+    let hi = userTurnStarts.length;
+
+    // Fast path: if keeping all turns already fits, skip the search.
+    if (hi > lo && projectedTokensForKeep(hi) > targetTokens) {
+      // Binary search: find the largest keepTurns where projected tokens fit.
+      while (lo < hi) {
+        const mid = lo + Math.ceil((hi - lo) / 2);
+        if (projectedTokensForKeep(mid) <= targetTokens) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+    } else {
+      lo = hi;
     }
+
+    const keepTurns = lo;
+    const keepFromIndex =
+      keepTurns === 0
+        ? messages.length
+        : (userTurnStarts[userTurnStarts.length - keepTurns] ??
+          messages.length);
 
     return { keepFromIndex, keepTurns };
   }


### PR DESCRIPTION
Addresses Codex feedback on #14911:

1. Added schema validation that targetBudgetRatio must be strictly greater than summaryBudgetRatio to prevent non-positive effective compaction budgets
2. Replaced linear search in pickKeepBoundary with binary search to avoid O(turns × tokenization) latency for long conversations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
