### PR TITLE
fix: apply tool result truncation even when all turns fit after projection

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -197,11 +197,22 @@ export class ContextWindowManager {
       targetInputTokensOverride: options?.targetInputTokensOverride,
     });
     if (keepPlan.keepFromIndex <= summaryOffset) {
+      // All turns fit after truncation projection, but the real in-memory
+      // messages may still contain un-truncated tool results. Apply truncation
+      // so the caller gets the token savings even without summarization.
+      const { messages: truncatedMessages, truncatedCount } =
+        truncateToolResultsAcrossHistory(messages, COMPACTION_TOOL_RESULT_MAX_CHARS);
+      const didTruncate = truncatedCount > 0;
+      const estimatedAfterTruncation = didTruncate
+        ? estimatePromptTokens(truncatedMessages, this.systemPrompt, {
+            providerName: this.provider.name,
+          })
+        : previousEstimatedInputTokens;
       return {
-        messages,
-        compacted: false,
+        messages: truncatedMessages,
+        compacted: didTruncate,
         previousEstimatedInputTokens,
-        estimatedInputTokens: previousEstimatedInputTokens,
+        estimatedInputTokens: estimatedAfterTruncation,
         maxInputTokens: this.config.maxInputTokens,
         thresholdTokens,
         compactedMessages: 0,
@@ -211,7 +222,9 @@ export class ContextWindowManager {
         summaryOutputTokens: 0,
         summaryModel: "",
         summaryText: existingSummary ?? "",
-        reason: "unable to compact while keeping recent turns",
+        reason: didTruncate
+          ? "truncated tool results without summarization"
+          : "unable to compact while keeping recent turns",
       };
     }
 


### PR DESCRIPTION
Addresses Codex feedback on #14927:

When pickKeepBoundary projects with truncation and finds all turns fit, maybeCompact could return early without actually applying truncation to the output messages. This ensures truncation is applied in all compaction code paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
