### PR TITLE
Add one-shot and routing support to schedule schema and store

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -29,9 +29,14 @@ mock.module("../util/logger.js", () => ({
 
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
+  cancelSchedule,
   claimDueSchedules,
+  completeOneShot,
   createSchedule,
+  describeCronExpression,
+  failOneShot,
   getSchedule,
+  listSchedules,
   updateSchedule,
 } from "../schedule/schedule-store.js";
 
@@ -567,5 +572,441 @@ describe("claimDueSchedules", () => {
     // Second claim should find nothing since nextRunAt was advanced
     const second = claimDueSchedules(Date.now() - 500);
     expect(second.length).toBe(0);
+  });
+});
+
+// ── One-shot schedules ──────────────────────────────────────────────
+
+describe("createSchedule (one-shot)", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("creates a one-shot schedule with no expression", () => {
+    const fireAt = Date.now() + 60_000;
+    const job = createSchedule({
+      name: "Remind me",
+      message: "take out the trash",
+      nextRunAt: fireAt,
+    });
+
+    expect(job.expression).toBeNull();
+    expect(job.cronExpression).toBeNull();
+    expect(job.nextRunAt).toBe(fireAt);
+    expect(job.enabled).toBe(true);
+    expect(job.status).toBe("active");
+    expect(job.mode).toBe("execute");
+    expect(job.routingIntent).toBe("all_channels");
+    expect(job.routingHints).toEqual({});
+  });
+
+  test("creates a one-shot schedule with notify mode and routing", () => {
+    const fireAt = Date.now() + 60_000;
+    const hints = { preferredChannel: "slack", threadId: "abc123" };
+    const job = createSchedule({
+      name: "Notify me",
+      message: "meeting in 5",
+      nextRunAt: fireAt,
+      mode: "notify",
+      routingIntent: "single_channel",
+      routingHints: hints,
+    });
+
+    expect(job.mode).toBe("notify");
+    expect(job.routingIntent).toBe("single_channel");
+    expect(job.routingHints).toEqual(hints);
+    expect(job.expression).toBeNull();
+    expect(job.status).toBe("active");
+  });
+
+  test("rejects one-shot schedule without nextRunAt", () => {
+    expect(() =>
+      createSchedule({
+        name: "Bad one-shot",
+        message: "no time",
+      }),
+    ).toThrow("One-shot schedules (no expression) require nextRunAt");
+  });
+
+  test("one-shot schedule persists and round-trips correctly", () => {
+    const fireAt = Date.now() + 120_000;
+    const hints = { channel: "telegram" };
+    const job = createSchedule({
+      name: "Persist test",
+      message: "round trip",
+      nextRunAt: fireAt,
+      mode: "notify",
+      routingIntent: "multi_channel",
+      routingHints: hints,
+    });
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.expression).toBeNull();
+    expect(retrieved!.cronExpression).toBeNull();
+    expect(retrieved!.nextRunAt).toBe(fireAt);
+    expect(retrieved!.mode).toBe("notify");
+    expect(retrieved!.routingIntent).toBe("multi_channel");
+    expect(retrieved!.routingHints).toEqual(hints);
+    expect(retrieved!.status).toBe("active");
+  });
+});
+
+// ── One-shot claiming ───────────────────────────────────────────────
+
+describe("claimDueSchedules (one-shot)", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("claims one-shot schedules whose nextRunAt <= now", () => {
+    const job = createSchedule({
+      name: "Due one-shot",
+      message: "fire now",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(1);
+    expect(claimed[0].id).toBe(job.id);
+    expect(claimed[0].expression).toBeNull();
+    expect(claimed[0].status).toBe("firing");
+  });
+
+  test("does not claim one-shot schedules that are not yet due", () => {
+    createSchedule({
+      name: "Future one-shot",
+      message: "not yet",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(0);
+  });
+
+  test("does not double-claim one-shot schedules", () => {
+    createSchedule({
+      name: "Once only",
+      message: "no double",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    const first = claimDueSchedules(Date.now());
+    expect(first.length).toBe(1);
+
+    // Second claim should find nothing since status is now 'firing'
+    const second = claimDueSchedules(Date.now());
+    expect(second.length).toBe(0);
+  });
+
+  test("claims both recurring and one-shot schedules in the same tick", () => {
+    const recurring = createSchedule({
+      name: "Recurring",
+      cronExpression: "* * * * *",
+      message: "recurring",
+      syntax: "cron",
+    });
+    getRawDb().run("UPDATE cron_jobs SET next_run_at = ? WHERE id = ?", [
+      Date.now() - 1000,
+      recurring.id,
+    ]);
+
+    createSchedule({
+      name: "One-shot",
+      message: "one-shot",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(2);
+    const expressions = claimed.map((c) => c.expression);
+    expect(expressions).toContain(null); // one-shot
+    expect(expressions.some((e) => e !== null)).toBe(true); // recurring
+  });
+});
+
+// ── One-shot lifecycle (complete, fail, cancel) ─────────────────────
+
+describe("completeOneShot", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("transitions firing -> fired", () => {
+    const job = createSchedule({
+      name: "Complete me",
+      message: "done",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    // Claim first to get to 'firing' state
+    claimDueSchedules(Date.now());
+
+    completeOneShot(job.id);
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved!.status).toBe("fired");
+    expect(retrieved!.enabled).toBe(false);
+  });
+
+  test("does not transition if not in firing state", () => {
+    const job = createSchedule({
+      name: "Not firing",
+      message: "still active",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    completeOneShot(job.id);
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved!.status).toBe("active"); // unchanged
+    expect(retrieved!.enabled).toBe(true);
+  });
+});
+
+describe("failOneShot", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("transitions firing -> active for retry", () => {
+    const job = createSchedule({
+      name: "Fail me",
+      message: "retry",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    // Claim to get to 'firing'
+    claimDueSchedules(Date.now());
+
+    failOneShot(job.id);
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved!.status).toBe("active");
+    expect(retrieved!.enabled).toBe(true); // still enabled for retry
+  });
+
+  test("can be re-claimed after failing", () => {
+    const job = createSchedule({
+      name: "Retry",
+      message: "try again",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    claimDueSchedules(Date.now());
+    failOneShot(job.id);
+
+    // Should be claimable again
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(1);
+    expect(claimed[0].id).toBe(job.id);
+  });
+});
+
+describe("cancelSchedule", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("cancels an active one-shot schedule", () => {
+    const job = createSchedule({
+      name: "Cancel me",
+      message: "never fire",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const result = cancelSchedule(job.id);
+    expect(result).toBe(true);
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved!.status).toBe("cancelled");
+    expect(retrieved!.enabled).toBe(false);
+  });
+
+  test("returns false for non-active schedule", () => {
+    const job = createSchedule({
+      name: "Already done",
+      message: "completed",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    // Claim and complete it
+    claimDueSchedules(Date.now());
+    completeOneShot(job.id);
+
+    const result = cancelSchedule(job.id);
+    expect(result).toBe(false);
+  });
+
+  test("cancelled schedule is not claimable", () => {
+    const job = createSchedule({
+      name: "Cancelled",
+      message: "should not fire",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    cancelSchedule(job.id);
+
+    const claimed = claimDueSchedules(Date.now());
+    expect(claimed.length).toBe(0);
+  });
+});
+
+// ── Routing and mode round-trip ─────────────────────────────────────
+
+describe("routing and mode fields", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("recurring schedule defaults to execute mode and all_channels", () => {
+    const job = createSchedule({
+      name: "Defaults",
+      cronExpression: "0 9 * * *",
+      message: "check defaults",
+      syntax: "cron",
+    });
+
+    expect(job.mode).toBe("execute");
+    expect(job.routingIntent).toBe("all_channels");
+    expect(job.routingHints).toEqual({});
+    expect(job.status).toBe("active");
+  });
+
+  test("routing hints round-trip through create/read", () => {
+    const hints = { channels: ["slack", "discord"], priority: 1 };
+    const job = createSchedule({
+      name: "Routed",
+      cronExpression: "0 9 * * *",
+      message: "routed msg",
+      syntax: "cron",
+      routingIntent: "multi_channel",
+      routingHints: hints,
+      mode: "notify",
+    });
+
+    const retrieved = getSchedule(job.id);
+    expect(retrieved!.routingIntent).toBe("multi_channel");
+    expect(retrieved!.routingHints).toEqual(hints);
+    expect(retrieved!.mode).toBe("notify");
+  });
+
+  test("routing hints round-trip through DB raw query", () => {
+    const hints = { target: "sms" };
+    const job = createSchedule({
+      name: "Raw round-trip",
+      message: "check raw",
+      nextRunAt: Date.now() + 60_000,
+      routingIntent: "single_channel",
+      routingHints: hints,
+    });
+
+    const raw = getRawDb()
+      .query(
+        "SELECT mode, routing_intent, routing_hints_json, status FROM cron_jobs WHERE id = ?",
+      )
+      .get(job.id) as {
+      mode: string;
+      routing_intent: string;
+      routing_hints_json: string;
+      status: string;
+    } | null;
+    expect(raw).not.toBeNull();
+    expect(raw!.mode).toBe("execute");
+    expect(raw!.routing_intent).toBe("single_channel");
+    expect(JSON.parse(raw!.routing_hints_json)).toEqual(hints);
+    expect(raw!.status).toBe("active");
+  });
+
+  test("updateSchedule updates mode and routing fields", () => {
+    const job = createSchedule({
+      name: "Update routing",
+      cronExpression: "0 9 * * *",
+      message: "update routing",
+      syntax: "cron",
+    });
+
+    const updated = updateSchedule(job.id, {
+      mode: "notify",
+      routingIntent: "single_channel",
+      routingHints: { channel: "telegram" },
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.mode).toBe("notify");
+    expect(updated!.routingIntent).toBe("single_channel");
+    expect(updated!.routingHints).toEqual({ channel: "telegram" });
+  });
+});
+
+// ── listSchedules filters ───────────────────────────────────────────
+
+describe("listSchedules filters", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  test("oneShotOnly filter returns only one-shot schedules", () => {
+    createSchedule({
+      name: "Recurring",
+      cronExpression: "0 9 * * *",
+      message: "recurring",
+      syntax: "cron",
+    });
+    createSchedule({
+      name: "One-shot",
+      message: "one-shot",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const oneShots = listSchedules({ oneShotOnly: true });
+    expect(oneShots.length).toBe(1);
+    expect(oneShots[0].name).toBe("One-shot");
+    expect(oneShots[0].expression).toBeNull();
+  });
+
+  test("recurringOnly filter returns only recurring schedules", () => {
+    createSchedule({
+      name: "Recurring",
+      cronExpression: "0 9 * * *",
+      message: "recurring",
+      syntax: "cron",
+    });
+    createSchedule({
+      name: "One-shot",
+      message: "one-shot",
+      nextRunAt: Date.now() + 60_000,
+    });
+
+    const recurring = listSchedules({ recurringOnly: true });
+    expect(recurring.length).toBe(1);
+    expect(recurring[0].name).toBe("Recurring");
+    expect(recurring[0].expression).not.toBeNull();
+  });
+});
+
+// ── describeCronExpression ──────────────────────────────────────────
+
+describe("describeCronExpression", () => {
+  test("returns 'One-time' for null expression", () => {
+    expect(describeCronExpression(null)).toBe("One-time");
+  });
+
+  test("returns description for valid cron expression", () => {
+    expect(describeCronExpression("0 9 * * *")).toBe("Every day at 9:00 AM");
   });
 });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -48,6 +48,7 @@ import {
   migrateConversationsThreadTypeIndex,
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
+  migrateScheduleOneShotRouting,
   migrateDropLegacyMemberGuardianTables,
   migrateDropUsageCompositeIndexes,
   migrateFkCascadeRebuilds,
@@ -327,6 +328,9 @@ export function initializeDb(): void {
 
   // 49. Drop the unused legacy accounts table after removing account_manage
   migrateDropAccountsTable(database);
+
+  // 50. Extend cron_jobs table with one-shot and routing support
+  migrateScheduleOneShotRouting(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
+++ b/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
@@ -1,0 +1,86 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Extend cron_jobs table with one-shot and routing support.
+ *
+ * - Make `cron_expression` nullable (SQLite requires table rebuild for
+ *   nullability changes). One-shot schedules have NULL cron_expression.
+ * - Add `mode` column: 'notify' | 'execute'
+ * - Add `routing_intent` column: 'single_channel' | 'multi_channel' | 'all_channels'
+ * - Add `routing_hints_json` column: opaque JSON routing hints
+ * - Add `status` column: 'active' | 'firing' | 'fired' | 'cancelled'
+ * - Add composite index for one-shot claiming: (status, next_run_at)
+ */
+export function migrateScheduleOneShotRouting(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  // Check if migration is already done by inspecting whether the status column exists
+  const tableInfo = raw
+    .query("PRAGMA table_info(cron_jobs)")
+    .all() as Array<{ name: string }>;
+  const hasStatusColumn = tableInfo.some((col) => col.name === "status");
+  if (hasStatusColumn) {
+    // Ensure the composite index exists even if the column migration already ran
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_status_next_run_at ON cron_jobs(status, next_run_at)`,
+    );
+    return;
+  }
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+
+      CREATE TABLE cron_jobs_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        cron_expression TEXT,
+        schedule_syntax TEXT NOT NULL DEFAULT 'cron',
+        timezone TEXT,
+        message TEXT NOT NULL,
+        next_run_at INTEGER NOT NULL,
+        last_run_at INTEGER,
+        last_status TEXT,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        created_by TEXT NOT NULL,
+        mode TEXT NOT NULL DEFAULT 'execute',
+        routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+        routing_hints_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      INSERT INTO cron_jobs_new (
+        id, name, enabled, cron_expression, schedule_syntax, timezone,
+        message, next_run_at, last_run_at, last_status, retry_count,
+        created_by, mode, routing_intent, routing_hints_json, status,
+        created_at, updated_at
+      )
+      SELECT
+        id, name, enabled, cron_expression, schedule_syntax, timezone,
+        message, next_run_at, last_run_at, last_status, retry_count,
+        created_by, 'execute', 'all_channels', '{}', 'active',
+        created_at, updated_at
+      FROM cron_jobs;
+
+      DROP TABLE cron_jobs;
+      ALTER TABLE cron_jobs_new RENAME TO cron_jobs;
+
+      CREATE INDEX IF NOT EXISTS idx_cron_jobs_status_next_run_at ON cron_jobs(status, next_run_at);
+
+      COMMIT;
+    `);
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -87,6 +87,7 @@ export { migrateRenameVerificationSessionIdColumn } from "./142-rename-verificat
 export { migrateRenameGuardianVerificationValues } from "./143-rename-guardian-verification-values.js";
 export { migrateRenameVoiceToPhone } from "./144-rename-voice-to-phone.js";
 export { migrateDropAccountsTable } from "./145-drop-accounts-table.js";
+export { migrateScheduleOneShotRouting } from "./146-schedule-oneshot-routing.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -26,7 +26,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
-  cronExpression: text("cron_expression").notNull(), // e.g. '0 9 * * 1-5'
+  cronExpression: text("cron_expression"), // nullable for one-shot schedules; e.g. '0 9 * * 1-5'
   scheduleSyntax: text("schedule_syntax").notNull().default("cron"), // 'cron' | 'rrule'
   timezone: text("timezone"), // e.g. 'America/Los_Angeles'
   message: text("message").notNull(),
@@ -35,6 +35,10 @@ export const cronJobs = sqliteTable("cron_jobs", {
   lastStatus: text("last_status"), // 'ok' | 'error'
   retryCount: integer("retry_count").notNull().default(0),
   createdBy: text("created_by").notNull(), // 'agent' | 'user'
+  mode: text("mode").notNull().default("execute"), // 'notify' | 'execute'
+  routingIntent: text("routing_intent").notNull().default("all_channels"), // 'single_channel' | 'multi_channel' | 'all_channels'
+  routingHintsJson: text("routing_hints_json").notNull().default("{}"),
+  status: text("status").notNull().default("active"), // 'active' | 'firing' | 'fired' | 'cancelled'
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -49,7 +49,7 @@ interface GlobalSearchMemory {
 interface GlobalSearchSchedule {
   id: string;
   name: string;
-  expression: string;
+  expression: string | null;
   message: string;
   enabled: boolean;
   nextRunAt: number | null;

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,5 +1,5 @@
 import { Cron } from "croner";
-import { and, asc, desc, eq, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -14,13 +14,20 @@ import type { ScheduleSyntax } from "./recurrence-types.js";
 
 const logger = getLogger("schedule-store");
 
+export type ScheduleMode = "notify" | "execute";
+export type RoutingIntent =
+  | "single_channel"
+  | "multi_channel"
+  | "all_channels";
+export type ScheduleStatus = "active" | "firing" | "fired" | "cancelled";
+
 export interface ScheduleJob {
   id: string;
   name: string;
   enabled: boolean;
   syntax: ScheduleSyntax;
-  expression: string;
-  cronExpression: string;
+  expression: string | null;
+  cronExpression: string | null;
   timezone: string | null;
   message: string;
   nextRunAt: number;
@@ -28,6 +35,10 @@ export interface ScheduleJob {
   lastStatus: string | null;
   retryCount: number;
   createdBy: string;
+  mode: ScheduleMode;
+  routingIntent: RoutingIntent;
+  routingHints: Record<string, unknown>;
+  status: ScheduleStatus;
   createdAt: number;
   updatedAt: number;
 }
@@ -72,19 +83,34 @@ export function computeNextRunAt(
 
 export function createSchedule(params: {
   name: string;
-  cronExpression: string;
+  cronExpression?: string | null;
   timezone?: string | null;
   message: string;
   enabled?: boolean;
   createdBy?: string;
-  syntax: ScheduleSyntax;
-  expression?: string;
+  syntax?: ScheduleSyntax;
+  expression?: string | null;
+  nextRunAt?: number;
+  mode?: ScheduleMode;
+  routingIntent?: RoutingIntent;
+  routingHints?: Record<string, unknown>;
 }): ScheduleJob {
-  const expression = params.expression ?? params.cronExpression;
+  const expression = params.expression ?? params.cronExpression ?? null;
+  const isOneShot = expression === null;
+  const syntax = params.syntax ?? "cron";
 
-  const spec = { syntax: params.syntax, expression, timezone: params.timezone };
-  if (!isValidScheduleExpression(spec)) {
-    throw new Error(`Invalid ${params.syntax} expression: "${expression}"`);
+  if (isOneShot) {
+    // One-shot schedules must have nextRunAt provided directly
+    if (params.nextRunAt == null) {
+      throw new Error(
+        "One-shot schedules (no expression) require nextRunAt to be provided",
+      );
+    }
+  } else {
+    const spec = { syntax, expression, timezone: params.timezone };
+    if (!isValidScheduleExpression(spec)) {
+      throw new Error(`Invalid ${syntax} expression: "${expression}"`);
+    }
   }
 
   const db = getDb();
@@ -92,14 +118,25 @@ export function createSchedule(params: {
   const now = Date.now();
   const enabled = params.enabled ?? true;
   const timezone = params.timezone ?? null;
-  const nextRunAt = enabled ? computeNextRunAtEngine(spec) : 0;
+  const mode = params.mode ?? "execute";
+  const routingIntent = params.routingIntent ?? "all_channels";
+  const routingHints = params.routingHints ?? {};
+
+  let nextRunAt: number;
+  if (isOneShot) {
+    nextRunAt = params.nextRunAt!;
+  } else {
+    nextRunAt = enabled
+      ? computeNextRunAtEngine({ syntax, expression: expression!, timezone })
+      : 0;
+  }
 
   const row = {
     id,
     name: params.name,
     enabled,
     cronExpression: expression,
-    scheduleSyntax: params.syntax,
+    scheduleSyntax: syntax,
     timezone,
     message: params.message,
     nextRunAt,
@@ -107,6 +144,10 @@ export function createSchedule(params: {
     lastStatus: null as string | null,
     retryCount: 0,
     createdBy: params.createdBy ?? "agent",
+    mode,
+    routingIntent,
+    routingHintsJson: JSON.stringify(routingHints),
+    status: "active" as ScheduleStatus,
     createdAt: now,
     updatedAt: now,
   };
@@ -140,15 +181,27 @@ export function countSchedules(): { total: number; enabled: number } {
 
 export function listSchedules(options?: {
   enabledOnly?: boolean;
+  oneShotOnly?: boolean;
+  recurringOnly?: boolean;
 }): ScheduleJob[] {
   const db = getDb();
-  const conditions = options?.enabledOnly
-    ? eq(scheduleJobs.enabled, true)
-    : undefined;
+  const conditions = [];
+  if (options?.enabledOnly) {
+    conditions.push(eq(scheduleJobs.enabled, true));
+  }
+  if (options?.oneShotOnly) {
+    conditions.push(isNull(scheduleJobs.cronExpression));
+  }
+  if (options?.recurringOnly) {
+    conditions.push(
+      sql`${scheduleJobs.cronExpression} IS NOT NULL`,
+    );
+  }
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
   const rows = db
     .select()
     .from(scheduleJobs)
-    .where(conditions)
+    .where(where)
     .orderBy(asc(scheduleJobs.nextRunAt))
     .all();
   return rows.map(parseJobRow);
@@ -164,6 +217,9 @@ export function updateSchedule(
     enabled?: boolean;
     syntax?: ScheduleSyntax;
     expression?: string;
+    mode?: ScheduleMode;
+    routingIntent?: RoutingIntent;
+    routingHints?: Record<string, unknown>;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -184,11 +240,14 @@ export function updateSchedule(
   const newEnabled =
     updates.enabled !== undefined ? updates.enabled : existing.enabled;
 
-  // Validate if expression or syntax changed
+  const isOneShot = newExpr === null;
+
+  // Validate if expression or syntax changed (only for recurring schedules)
   if (
-    updates.expression !== undefined ||
-    updates.cronExpression !== undefined ||
-    updates.syntax !== undefined
+    !isOneShot &&
+    (updates.expression !== undefined ||
+      updates.cronExpression !== undefined ||
+      updates.syntax !== undefined)
   ) {
     const spec = {
       syntax: newSyntax,
@@ -210,18 +269,24 @@ export function updateSchedule(
   if (updates.timezone !== undefined) set.timezone = updates.timezone;
   if (updates.message !== undefined) set.message = updates.message;
   if (updates.enabled !== undefined) set.enabled = updates.enabled;
+  if (updates.mode !== undefined) set.mode = updates.mode;
+  if (updates.routingIntent !== undefined)
+    set.routingIntent = updates.routingIntent;
+  if (updates.routingHints !== undefined)
+    set.routingHintsJson = JSON.stringify(updates.routingHints);
 
-  // Recompute nextRunAt if schedule timing may have changed
+  // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (
-    updates.cronExpression !== undefined ||
-    updates.expression !== undefined ||
-    updates.syntax !== undefined ||
-    updates.timezone !== undefined ||
-    updates.enabled !== undefined
+    !isOneShot &&
+    (updates.cronExpression !== undefined ||
+      updates.expression !== undefined ||
+      updates.syntax !== undefined ||
+      updates.timezone !== undefined ||
+      updates.enabled !== undefined)
   ) {
     const spec = {
       syntax: newSyntax,
-      expression: newExpr,
+      expression: newExpr!,
       timezone: newTimezone,
     };
     set.nextRunAt = newEnabled ? computeNextRunAtEngine(spec) : 0;
@@ -239,31 +304,41 @@ export function deleteSchedule(id: string): boolean {
 }
 
 /**
- * Claim due recurrence schedules atomically. For each candidate where
- * enabled=true and next_run_at <= now, we advance next_run_at using
- * optimistic locking on the old value to prevent double-claiming by
- * concurrent ticks. Works for both cron and RRULE syntax.
+ * Claim due schedules atomically. Handles both recurring and one-shot schedules.
+ *
+ * For recurring schedules: advance next_run_at using optimistic locking on the
+ * old value to prevent double-claiming by concurrent ticks. Works for both
+ * cron and RRULE syntax.
+ *
+ * For one-shot schedules: transition status from 'active' to 'firing' where
+ * next_run_at <= now and enabled = true and cron_expression IS NULL.
  */
 export function claimDueSchedules(now: number): ScheduleJob[] {
   const db = getDb();
-  const candidates = db
+  const claimed: ScheduleJob[] = [];
+
+  // ── Recurring schedules ──────────────────────────────────────────
+  const recurringCandidates = db
     .select()
     .from(scheduleJobs)
     .where(
-      and(eq(scheduleJobs.enabled, true), lte(scheduleJobs.nextRunAt, now)),
+      and(
+        eq(scheduleJobs.enabled, true),
+        lte(scheduleJobs.nextRunAt, now),
+        sql`${scheduleJobs.cronExpression} IS NOT NULL`,
+      ),
     )
     .orderBy(asc(scheduleJobs.nextRunAt))
     .all();
 
-  const claimed: ScheduleJob[] = [];
-  for (const row of candidates) {
+  for (const row of recurringCandidates) {
     let newNextRunAt: number | null;
     let exhausted = false;
     try {
       const syntax = row.scheduleSyntax as ScheduleSyntax;
       newNextRunAt = computeNextRunAtEngine({
         syntax,
-        expression: row.cronExpression,
+        expression: row.cronExpression!,
         timezone: row.timezone,
       });
     } catch (err) {
@@ -316,7 +391,107 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
       }),
     );
   }
+
+  // ── One-shot schedules ───────────────────────────────────────────
+  const oneShotCandidates = db
+    .select()
+    .from(scheduleJobs)
+    .where(
+      and(
+        isNull(scheduleJobs.cronExpression),
+        eq(scheduleJobs.status, "active"),
+        lte(scheduleJobs.nextRunAt, now),
+        eq(scheduleJobs.enabled, true),
+      ),
+    )
+    .orderBy(asc(scheduleJobs.nextRunAt))
+    .all();
+
+  for (const row of oneShotCandidates) {
+    db.update(scheduleJobs)
+      .set({
+        status: "firing",
+        lastRunAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(scheduleJobs.id, row.id),
+          eq(scheduleJobs.status, "active"),
+        ),
+      )
+      .run();
+
+    if (rawChanges() === 0) continue;
+
+    claimed.push(
+      parseJobRow({
+        ...row,
+        status: "firing",
+        lastRunAt: now,
+        updatedAt: now,
+      }),
+    );
+  }
+
   return claimed;
+}
+
+/**
+ * Complete a one-shot schedule after successful execution.
+ * Transitions status from 'firing' to 'fired' and disables the schedule.
+ */
+export function completeOneShot(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({
+      status: "fired",
+      enabled: false,
+      updatedAt: now,
+    })
+    .where(
+      and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")),
+    )
+    .run();
+}
+
+/**
+ * Revert a one-shot schedule from 'firing' back to 'active' on failure.
+ * Allows the schedule to be retried on the next tick.
+ */
+export function failOneShot(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({
+      status: "active",
+      updatedAt: now,
+    })
+    .where(
+      and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")),
+    )
+    .run();
+}
+
+/**
+ * Cancel a one-shot schedule. Sets status to 'cancelled' and disables it.
+ * Returns true if a row was actually updated (i.e., it was in 'active' status).
+ */
+export function cancelSchedule(id: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({
+      status: "cancelled",
+      enabled: false,
+      updatedAt: now,
+    })
+    .where(
+      and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "active")),
+    )
+    .run();
+  return rawChanges() > 0;
 }
 
 export function createScheduleRun(
@@ -422,14 +597,17 @@ export function formatLocalDate(timestamp: number): string {
 // Convert a cron expression to a human-readable description.
 // Only applicable to cron syntax; RRULE schedules should display the
 // raw expression text instead.
+// Returns "One-time" for null expressions (one-shot schedules).
 //
 // Examples:
-//   "* * * * *"     -> "Every minute"
-//   "0 9 * * 1-5"   -> "Every weekday at 9:00 AM"
-//   "0 9 * * 0,6"   -> "Every weekend at 9:00 AM"
-//   "0 9 1 * *"     -> "On the 1st of every month at 9:00 AM"
-//   "30 14 * * *"   -> "Every day at 2:30 PM"
-export function describeCronExpression(expr: string): string {
+//   null                -> "One-time"
+//   "* * * * *"         -> "Every minute"
+//   "0 9 * * 1-5"       -> "Every weekday at 9:00 AM"
+//   "0 9 * * 0,6"       -> "Every weekend at 9:00 AM"
+//   "0 9 1 * *"         -> "On the 1st of every month at 9:00 AM"
+//   "30 14 * * *"       -> "Every day at 2:30 PM"
+export function describeCronExpression(expr: string | null): string {
+  if (expr === null) return "One-time";
   try {
     const cron = new Cron(expr, { maxRuns: 0 });
     // Access Croner internal state to extract the parsed cron pattern.
@@ -583,9 +761,22 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     lastStatus: row.lastStatus,
     retryCount: row.retryCount,
     createdBy: row.createdBy,
+    mode: (row.mode ?? "execute") as ScheduleMode,
+    routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,
+    routingHints: safeParseJson(row.routingHintsJson),
+    status: (row.status ?? "active") as ScheduleStatus,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+}
+
+function safeParseJson(json: string | null | undefined): Record<string, unknown> {
+  if (!json) return {};
+  try {
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
 }
 
 function parseRunRow(row: typeof scheduleRuns.$inferSelect): ScheduleRun {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -129,7 +129,7 @@ async function runScheduleOnce(
     if (taskMatch) {
       const taskId = taskMatch[1];
       const isRruleSet =
-        job.syntax === "rrule" && hasSetConstructs(job.expression);
+        job.syntax === "rrule" && job.expression != null && hasSetConstructs(job.expression);
       try {
         log.info(
           {
@@ -209,7 +209,7 @@ async function runScheduleOnce(
     });
     const runId = createScheduleRun(job.id, conversation.id);
     const isRruleSetMsg =
-      job.syntax === "rrule" && hasSetConstructs(job.expression);
+      job.syntax === "rrule" && job.expression != null && hasSetConstructs(job.expression);
 
     try {
       log.info(

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -78,9 +78,11 @@ export async function executeScheduleCreate(
     });
 
     const scheduleDescription =
-      job.syntax === "rrule"
-        ? job.expression
-        : describeCronExpression(job.cronExpression);
+      job.expression == null
+        ? "One-time"
+        : job.syntax === "rrule"
+          ? job.expression
+          : describeCronExpression(job.cronExpression);
 
     const nextRunDate = formatLocalDate(job.nextRunAt);
     const integrations = formatIntegrationSummary();

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -10,9 +10,10 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function describeSchedule(job: {
   syntax: string;
-  expression: string;
-  cronExpression: string;
+  expression: string | null;
+  cronExpression: string | null;
 }): string {
+  if (job.expression == null) return "One-time";
   if (job.syntax === "rrule") {
     const label = hasSetConstructs(job.expression) ? "[RRULE set] " : "";
     return `${label}${job.expression}`;
@@ -39,7 +40,7 @@ export async function executeScheduleList(
       `Schedule: ${job.name}`,
       `  ID: ${job.id}`,
       `  Syntax: ${job.syntax}`,
-      `  Expression: ${job.expression}`,
+      `  Expression: ${job.expression ?? "(one-time)"}`,
       `  Schedule: ${describeSchedule(job)}${
         job.timezone ? ` (${job.timezone})` : ""
       }`,

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -93,9 +93,11 @@ export async function executeScheduleUpdate(
     }
 
     const scheduleDescription =
-      job.syntax === "rrule"
-        ? job.expression
-        : describeCronExpression(job.cronExpression);
+      job.expression == null
+        ? "One-time"
+        : job.syntax === "rrule"
+          ? job.expression
+          : describeCronExpression(job.cronExpression);
 
     return {
       content: [


### PR DESCRIPTION
## Summary
- Add migration to extend cron_jobs table with mode, routing_intent, routing_hints_json, and status columns; make cron_expression nullable for one-shot schedules
- Extend schedule-store with one-shot lifecycle (create, claim, complete, fail, cancel) and routing metadata
- Add comprehensive tests for one-shot schedule operations

Part of plan: combine-schedules-reminders.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
