### PR TITLE
Handle one-shot schedules and notify mode in scheduler tick loop

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -596,4 +596,235 @@ describe("scheduler RRULE execution", () => {
     });
     expect(getReminder(reminder.id)?.status).toBe("fired");
   });
+
+  // ── One-shot schedule tests ───────────────────────────────────────
+
+  test("one-shot execute mode fires and marks schedule as fired", async () => {
+    const schedule = createSchedule({
+      name: "One-shot execute",
+      message: "Execute this once",
+      mode: "execute",
+      nextRunAt: Date.now() - 1000,
+      // No expression = one-shot
+    });
+
+    expect(getSchedule(schedule.id)!.status).toBe("active");
+
+    const processedMessages: { conversationId: string; message: string }[] = [];
+    const processMessage = async (conversationId: string, message: string) => {
+      processedMessages.push({ conversationId, message });
+    };
+
+    const scheduler = startScheduler(
+      processMessage,
+      () => {},
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    expect(
+      processedMessages.some((m) => m.message === "Execute this once"),
+    ).toBe(true);
+
+    const after = getSchedule(schedule.id);
+    expect(after).not.toBeNull();
+    expect(after!.status).toBe("fired");
+    expect(after!.enabled).toBe(false);
+
+    // A cron_runs entry should have been created
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs.length).toBeGreaterThanOrEqual(1);
+    expect(runs[0].status).toBe("ok");
+  });
+
+  test("one-shot notify mode emits notification and marks schedule as fired", async () => {
+    const schedule = createSchedule({
+      name: "One-shot notify",
+      message: "Notify about this",
+      mode: "notify",
+      nextRunAt: Date.now() - 1000,
+      routingIntent: "multi_channel",
+      routingHints: { channel: "slack" },
+    });
+
+    expect(getSchedule(schedule.id)!.status).toBe("active");
+
+    const notifyCalls: Array<{
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }> = [];
+    const notifyReminder = (payload: {
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }) => {
+      notifyCalls.push(payload);
+    };
+
+    const scheduler = startScheduler(
+      async () => {},
+      notifyReminder,
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0]).toEqual({
+      id: schedule.id,
+      label: "One-shot notify",
+      message: "Notify about this",
+      routingIntent: "multi_channel",
+      routingHints: { channel: "slack" },
+    });
+
+    const after = getSchedule(schedule.id);
+    expect(after).not.toBeNull();
+    expect(after!.status).toBe("fired");
+    expect(after!.enabled).toBe(false);
+  });
+
+  test("one-shot failure reverts to active for retry", async () => {
+    const schedule = createSchedule({
+      name: "One-shot fail",
+      message: "This will fail",
+      mode: "execute",
+      nextRunAt: Date.now() - 1000,
+    });
+
+    expect(getSchedule(schedule.id)!.status).toBe("active");
+
+    const processMessage = async () => {
+      throw new Error("Simulated failure");
+    };
+
+    const scheduler = startScheduler(
+      processMessage,
+      () => {},
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    const after = getSchedule(schedule.id);
+    expect(after).not.toBeNull();
+    expect(after!.status).toBe("active");
+    expect(after!.enabled).toBe(true);
+  });
+
+  test("recurring + notify mode emits notification and continues recurring", async () => {
+    const rruleExpr = buildEveryMinuteRrule();
+    const schedule = createSchedule({
+      name: "Recurring notify",
+      cronExpression: rruleExpr,
+      message: "Recurring notification",
+      syntax: "rrule",
+      expression: rruleExpr,
+      mode: "notify",
+      routingIntent: "single_channel",
+      routingHints: { preferred: "email" },
+    });
+
+    forceScheduleDue(schedule.id);
+
+    const notifyCalls: Array<{
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }> = [];
+    const notifyReminder = (payload: {
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }) => {
+      notifyCalls.push(payload);
+    };
+
+    const scheduler = startScheduler(
+      async () => {},
+      notifyReminder,
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0]).toEqual({
+      id: schedule.id,
+      label: "Recurring notify",
+      message: "Recurring notification",
+      routingIntent: "single_channel",
+      routingHints: { preferred: "email" },
+    });
+
+    // Schedule should remain enabled and have a future nextRunAt (not fired/disabled)
+    const after = getSchedule(schedule.id);
+    expect(after).not.toBeNull();
+    expect(after!.enabled).toBe(true);
+    expect(after!.nextRunAt).toBeGreaterThan(Date.now() - 5000);
+    // Status should still be "active" (not "fired")
+    expect(after!.status).toBe("active");
+  });
+
+  test("one-shot notify mode passes routing intent and hints to notifier", async () => {
+    const schedule = createSchedule({
+      name: "Routing test",
+      message: "Check routing",
+      mode: "notify",
+      nextRunAt: Date.now() - 1000,
+      routingIntent: "all_channels",
+      routingHints: {
+        requestedByUser: true,
+        channelMentions: ["telegram", "slack"],
+        priority: "high",
+      },
+    });
+
+    const notifyCalls: Array<{
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }> = [];
+    const notifyReminder = (payload: {
+      id: string;
+      label: string;
+      message: string;
+      routingIntent: string;
+      routingHints: Record<string, unknown>;
+    }) => {
+      notifyCalls.push(payload);
+    };
+
+    const scheduler = startScheduler(
+      async () => {},
+      notifyReminder,
+      () => {},
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    scheduler.stop();
+
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0].routingIntent).toBe("all_channels");
+    expect(notifyCalls[0].routingHints).toEqual({
+      requestedByUser: true,
+      channelMentions: ["telegram", "slack"],
+      priority: "high",
+    });
+
+    // Should be marked as fired
+    const after = getSchedule(schedule.id);
+    expect(after!.status).toBe("fired");
+  });
 });

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -17,8 +17,10 @@ import {
 import { hasSetConstructs } from "./recurrence-engine.js";
 import {
   claimDueSchedules,
+  completeOneShot,
   completeScheduleRun,
   createScheduleRun,
+  failOneShot,
 } from "./schedule-store.js";
 
 const log = getLogger("scheduler");
@@ -121,9 +123,43 @@ async function runScheduleOnce(
   const now = Date.now();
   let processed = 0;
 
-  // ── Recurrence schedules (cron + RRULE) ─────────────────────────────
+  // ── Schedules (recurring cron/RRULE + one-shot) ─────────────────────
   const jobs = claimDueSchedules(now);
   for (const job of jobs) {
+    const isOneShot = job.expression === null;
+
+    // ── Notify mode (one-shot or recurring) ─────────────────────────
+    if (job.mode === "notify") {
+      try {
+        log.info(
+          { jobId: job.id, name: job.name, isOneShot },
+          "Firing schedule notification",
+        );
+        notifyReminder({
+          id: job.id,
+          label: job.name,
+          message: job.message,
+          routingIntent: job.routingIntent,
+          routingHints: job.routingHints,
+        });
+        if (isOneShot) {
+          completeOneShot(job.id);
+        }
+      } catch (err) {
+        log.warn(
+          { err, jobId: job.id, name: job.name, isOneShot },
+          "Schedule notification failed",
+        );
+        if (isOneShot) {
+          failOneShot(job.id);
+        }
+      }
+      processed += 1;
+      continue;
+    }
+
+    // ── Execute mode ────────────────────────────────────────────────
+
     // Check if message is a task invocation (run_task:<task_id>)
     const taskMatch = job.message.match(/^run_task:(\S+)$/);
     if (taskMatch) {
@@ -139,6 +175,7 @@ async function runScheduleOnce(
             syntax: job.syntax,
             expression: job.expression,
             isRruleSet,
+            isOneShot,
           },
           "Executing scheduled task",
         );
@@ -159,9 +196,11 @@ async function runScheduleOnce(
             status: "error",
             error: result.error ?? "Task run failed",
           });
+          if (isOneShot) failOneShot(job.id);
         } else {
           completeScheduleRun(runId, { status: "ok" });
           notifySchedule({ id: job.id, name: job.name });
+          if (isOneShot) completeOneShot(job.id);
         }
         processed += 1;
       } catch (err) {
@@ -175,6 +214,7 @@ async function runScheduleOnce(
             syntax: job.syntax,
             expression: job.expression,
             isRruleSet,
+            isOneShot,
           },
           "Scheduled task execution failed",
         );
@@ -192,6 +232,7 @@ async function runScheduleOnce(
         });
         const runId = createScheduleRun(job.id, fallbackConversation.id);
         completeScheduleRun(runId, { status: "error", error: message });
+        if (isOneShot) failOneShot(job.id);
       }
       continue;
     }
@@ -200,7 +241,9 @@ async function runScheduleOnce(
       source: "schedule",
       scheduleJobId: job.id,
       origin: "schedule",
-      systemHint: `Schedule: ${job.name}`,
+      systemHint: isOneShot
+        ? `Reminder: ${job.name}`
+        : `Schedule: ${job.name}`,
     });
     onScheduleThreadCreated?.({
       conversationId: conversation.id,
@@ -219,15 +262,17 @@ async function runScheduleOnce(
           syntax: job.syntax,
           expression: job.expression,
           isRruleSet: isRruleSetMsg,
+          isOneShot,
           conversationId: conversation.id,
         },
-        "Executing schedule",
+        isOneShot ? "Executing one-shot schedule" : "Executing schedule",
       );
       await processMessage(conversation.id, job.message, {
         trustClass: "guardian",
       });
       completeScheduleRun(runId, { status: "ok" });
       notifySchedule({ id: job.id, name: job.name });
+      if (isOneShot) completeOneShot(job.id);
       processed += 1;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -239,10 +284,14 @@ async function runScheduleOnce(
           syntax: job.syntax,
           expression: job.expression,
           isRruleSet: isRruleSetMsg,
+          isOneShot,
         },
-        "Schedule execution failed",
+        isOneShot
+          ? "One-shot schedule execution failed"
+          : "Schedule execution failed",
       );
       completeScheduleRun(runId, { status: "error", error: message });
+      if (isOneShot) failOneShot(job.id);
 
       try {
         invalidateAssistantInferredItemsForConversation(conversation.id);


### PR DESCRIPTION
## Summary
- Update scheduler tick to handle one-shot schedules (null expression) in both execute and notify modes
- Add one-shot lifecycle management (complete/fail) alongside existing recurring schedule processing
- Add notify mode support for recurring schedules (emit notification without marking as fired)
- Keep legacy reminder processing intact for transition period

## Test plan
- [x] One-shot execute mode fires and marks schedule as fired
- [x] One-shot notify mode emits notification and marks schedule as fired
- [x] One-shot failure reverts to active for retry
- [x] Recurring + notify mode emits notification and continues recurring
- [x] Routing intent/hints pass through to notifier callback
- [x] Existing cron/RRULE schedule tests still pass (14/14)
- [x] Type-checks pass

Part of plan: combine-schedules-reminders.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
