### PR TITLE
Add one-shot and routing parameters to schedule tools

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -81,7 +81,7 @@ describe("schedule_create tool", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
+    expect(result.content).toContain("schedule created successfully");
     expect(result.content).toContain("Daily standup");
     expect(result.content).toContain("Every weekday at 9:00 AM");
     expect(result.content).toContain("Enabled: true");
@@ -130,7 +130,7 @@ describe("schedule_create tool", () => {
     expect(result.content).toContain("name is required");
   });
 
-  test("rejects missing expression", async () => {
+  test("rejects missing expression when no fire_at", async () => {
     const result = await executeScheduleCreate(
       {
         name: "Test",
@@ -169,6 +169,157 @@ describe("schedule_create tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Invalid cron expression");
+  });
+});
+
+// ── schedule_create with fire_at (one-shot) ──────────────────────────
+
+describe("schedule_create with fire_at (one-shot)", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("creates a one-shot schedule with fire_at", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const result = await executeScheduleCreate(
+      {
+        name: "One-time reminder",
+        fire_at: futureDate,
+        message: "Don't forget!",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("One-shot schedule created successfully");
+    expect(result.content).toContain("Type: one-shot");
+    expect(result.content).toContain("Mode: execute");
+    expect(result.content).toContain("One-time reminder");
+    expect(result.content).toContain("Status: active");
+  });
+
+  test("rejects fire_at that is not valid ISO 8601", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad date",
+        fire_at: "not-a-date",
+        message: "test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("valid ISO 8601");
+  });
+
+  test("rejects fire_at that is in the past", async () => {
+    const pastDate = new Date(Date.now() - 60 * 1000).toISOString();
+    const result = await executeScheduleCreate(
+      {
+        name: "Past date",
+        fire_at: pastDate,
+        message: "test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("must be in the future");
+  });
+
+  test("fire_at ignores expression param when provided", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const result = await executeScheduleCreate(
+      {
+        name: "Fire at with expression",
+        fire_at: futureDate,
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("One-shot schedule created successfully");
+    expect(result.content).toContain("Type: one-shot");
+  });
+});
+
+// ── schedule_create with mode and routing ──────────────────────────
+
+describe("schedule_create with mode and routing", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("passes mode through to schedule", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Notify schedule",
+        expression: "0 9 * * *",
+        message: "notify test",
+        mode: "notify",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Mode: notify");
+  });
+
+  test("defaults mode to execute", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Default mode",
+        expression: "0 9 * * *",
+        message: "default test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Mode: execute");
+  });
+
+  test("rejects invalid mode", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Bad mode",
+        expression: "0 9 * * *",
+        message: "test",
+        mode: "invalid",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("mode must be one of");
+  });
+
+  test("passes routing_intent and routing_hints through", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const result = await executeScheduleCreate(
+      {
+        name: "Routed schedule",
+        fire_at: futureDate,
+        message: "routed test",
+        routing_intent: "single_channel",
+        routing_hints: { channel: "slack" },
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("One-shot schedule created successfully");
+
+    // Verify in DB
+    const row = getRawDb()
+      .query("SELECT routing_intent, routing_hints_json FROM cron_jobs LIMIT 1")
+      .get() as { routing_intent: string; routing_hints_json: string };
+    expect(row.routing_intent).toBe("single_channel");
+    expect(JSON.parse(row.routing_hints_json)).toEqual({ channel: "slack" });
   });
 });
 
@@ -268,6 +419,116 @@ describe("schedule_list tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Schedule not found");
+  });
+});
+
+// ── schedule_list with one-shot schedules ────────────────────────────
+
+describe("schedule_list with one-shot schedules", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("shows one-shot schedule with fire time in list mode", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    await executeScheduleCreate(
+      {
+        name: "One-shot Event",
+        fire_at: futureDate,
+        message: "fire test",
+      },
+      ctx,
+    );
+
+    const result = await executeScheduleList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("One-shot Event");
+    expect(result.content).toContain("one-shot");
+    expect(result.content).toContain("fire at:");
+    expect(result.content).toContain("active");
+  });
+
+  test("shows one-shot detail view with type and status", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    await executeScheduleCreate(
+      {
+        name: "One-shot Detail",
+        fire_at: futureDate,
+        message: "detail test",
+        mode: "notify",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleList({ job_id: row.id }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Type: one-shot");
+    expect(result.content).toContain("Mode: notify");
+    expect(result.content).toContain("Status: active");
+    expect(result.content).toContain("Fire at:");
+  });
+
+  test("shows mode in list output for recurring schedules", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Recurring with mode",
+        expression: "0 9 * * *",
+        message: "test",
+        mode: "notify",
+      },
+      ctx,
+    );
+
+    const result = await executeScheduleList({}, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("notify");
+  });
+
+  test("shows routing intent in detail when not default", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    await executeScheduleCreate(
+      {
+        name: "Routed One-shot",
+        fire_at: futureDate,
+        message: "routed test",
+        routing_intent: "single_channel",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleList({ job_id: row.id }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Routing: single_channel");
+  });
+
+  test("hides routing intent in detail when it is the default", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Default Routing",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleList({ job_id: row.id }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("Routing:");
   });
 });
 
@@ -422,6 +683,207 @@ describe("schedule_update tool", () => {
   });
 });
 
+// ── schedule_update with mode and routing ────────────────────────────
+
+describe("schedule_update with mode and routing", () => {
+  beforeEach(() => {
+    getRawDb().run("DELETE FROM cron_runs");
+    getRawDb().run("DELETE FROM cron_jobs");
+  });
+
+  test("updates mode", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Mode update",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        mode: "notify",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Mode: notify");
+  });
+
+  test("updates routing_intent", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Routing update",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        routing_intent: "single_channel",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Schedule updated successfully");
+
+    // Verify in DB
+    const dbRow = getRawDb()
+      .query("SELECT routing_intent FROM cron_jobs WHERE id = ?")
+      .get(row.id) as { routing_intent: string };
+    expect(dbRow.routing_intent).toBe("single_channel");
+  });
+
+  test("updates routing_hints", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Hints update",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        routing_hints: { channel: "telegram" },
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+
+    const dbRow = getRawDb()
+      .query("SELECT routing_hints_json FROM cron_jobs WHERE id = ?")
+      .get(row.id) as { routing_hints_json: string };
+    expect(JSON.parse(dbRow.routing_hints_json)).toEqual({
+      channel: "telegram",
+    });
+  });
+
+  test("rejects invalid mode", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Bad mode",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        mode: "invalid",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("mode must be one of");
+  });
+
+  test("rejects invalid routing_intent", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Bad routing",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        routing_intent: "invalid",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("routing_intent must be one of");
+  });
+
+  test("prevents changing one-shot to recurring", async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    await executeScheduleCreate(
+      {
+        name: "One-shot",
+        fire_at: futureDate,
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        expression: "0 9 * * *",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "Cannot change a one-shot schedule to recurring",
+    );
+  });
+
+  test("prevents changing recurring to one-shot", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Recurring",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        fire_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "Cannot change a recurring schedule to one-shot",
+    );
+  });
+});
+
 // ── RRULE support in schedule tools ─────────────────────────────────
 
 describe("schedule_create with RRULE", () => {
@@ -442,7 +904,7 @@ describe("schedule_create with RRULE", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
+    expect(result.content).toContain("schedule created successfully");
     expect(result.content).toContain("Syntax: rrule");
     expect(result.content).toContain("RRULE:FREQ=DAILY");
   });
@@ -655,7 +1117,7 @@ describe("schedule_create with RRULE set (EXDATE)", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
+    expect(result.content).toContain("schedule created successfully");
     expect(result.content).toContain("Syntax: rrule");
   });
 
@@ -677,7 +1139,7 @@ describe("schedule_create with RRULE set (EXDATE)", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
+    expect(result.content).toContain("schedule created successfully");
   });
 
   test("rejects unsupported line types in RRULE set", async () => {
@@ -870,7 +1332,7 @@ describe("schedule_create with RRULE + EXRULE", () => {
     );
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
+    expect(result.content).toContain("schedule created successfully");
     expect(result.content).toContain("Syntax: rrule");
   });
 

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "schedule_create",
-      "description": "Create a recurring scheduled automation that sends a message at a cron or RRULE interval. ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"weekly on Mondays\", \"every hour\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" \u2014 use task_list_add for those requests instead.",
+      "description": "Create a scheduled automation. For recurring: provide expression (cron/RRULE). For one-time: provide fire_at (ISO 8601 timestamp). ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"remind me tomorrow at 3pm\", \"weekly on Mondays\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" — use task_list_add for those requests instead.",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -16,11 +16,15 @@
           "syntax": {
             "type": "string",
             "enum": ["cron", "rrule"],
-            "description": "Schedule syntax type. Auto-detected if omitted."
+            "description": "Schedule syntax type for recurring schedules. Auto-detected if omitted. Ignored when fire_at is provided."
           },
           "expression": {
             "type": "string",
-            "description": "Schedule expression (cron or RRULE)"
+            "description": "Schedule expression (cron or RRULE) for recurring schedules. Not needed when fire_at is provided."
+          },
+          "fire_at": {
+            "type": "string",
+            "description": "ISO 8601 timestamp for a one-time schedule (e.g. \"2025-06-15T09:00:00Z\"). Must be in the future. When provided, expression/syntax are ignored."
           },
           "timezone": {
             "type": "string",
@@ -34,6 +38,20 @@
             "type": "boolean",
             "description": "Whether the job is enabled immediately. Defaults to true."
           },
+          "mode": {
+            "type": "string",
+            "enum": ["notify", "execute"],
+            "description": "Whether to notify the user or execute autonomously when triggered. Defaults to \"execute\"."
+          },
+          "routing_intent": {
+            "type": "string",
+            "enum": ["single_channel", "multi_channel", "all_channels"],
+            "description": "How to route the triggered message across channels. Defaults to \"all_channels\"."
+          },
+          "routing_hints": {
+            "type": "object",
+            "description": "Additional routing metadata (e.g. preferred channel identifiers)"
+          },
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -46,7 +64,7 @@
     },
     {
       "name": "schedule_list",
-      "description": "List recurring scheduled automations (cron jobs or RRULE schedules), or show details and recent runs for a specific one. For the user's task queue, use task_list_show instead.",
+      "description": "List scheduled automations (recurring cron/RRULE schedules and one-time scheduled events), or show details and recent runs for a specific one. For the user's task queue, use task_list_show instead.",
       "category": "schedule",
       "risk": "low",
       "input_schema": {
@@ -72,7 +90,7 @@
     },
     {
       "name": "schedule_update",
-      "description": "Update an existing recurring scheduled automation (expression, syntax, message, name, or enabled state)",
+      "description": "Update an existing scheduled automation (expression, syntax, message, name, enabled state, mode, or routing)",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -107,6 +125,20 @@
             "type": "boolean",
             "description": "Enable or disable the job"
           },
+          "mode": {
+            "type": "string",
+            "enum": ["notify", "execute"],
+            "description": "Whether to notify the user or execute autonomously when triggered"
+          },
+          "routing_intent": {
+            "type": "string",
+            "enum": ["single_channel", "multi_channel", "all_channels"],
+            "description": "How to route the triggered message across channels"
+          },
+          "routing_hints": {
+            "type": "object",
+            "description": "Additional routing metadata (e.g. preferred channel identifiers)"
+          },
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -119,7 +151,7 @@
     },
     {
       "name": "schedule_delete",
-      "description": "Delete a recurring scheduled automation and all its run history",
+      "description": "Delete a scheduled automation and all its run history",
       "category": "schedule",
       "risk": "high",
       "input_schema": {

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -7,7 +7,10 @@ import {
   formatLocalDate,
   isValidCronExpression,
 } from "../../schedule/schedule-store.js";
+import type { ScheduleMode } from "../../schedule/schedule-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const VALID_MODES: ScheduleMode[] = ["notify", "execute"];
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
@@ -17,6 +20,12 @@ export async function executeScheduleCreate(
   const timezone = (input.timezone as string) ?? null;
   const message = input.message as string;
   const enabled = (input.enabled as boolean) ?? true;
+  const fireAt = input.fire_at as string | undefined;
+  const mode = (input.mode as ScheduleMode | undefined) ?? "execute";
+  const routingIntent = input.routing_intent as string | undefined;
+  const routingHints = input.routing_hints as
+    | Record<string, unknown>
+    | undefined;
 
   if (!name || typeof name !== "string") {
     return {
@@ -31,6 +40,75 @@ export async function executeScheduleCreate(
     };
   }
 
+  // Validate mode
+  if (!VALID_MODES.includes(mode)) {
+    return {
+      content: `Error: mode must be one of: ${VALID_MODES.join(", ")}`,
+      isError: true,
+    };
+  }
+
+  // ── One-shot schedule (fire_at) ──────────────────────────────────
+  if (fireAt) {
+    const fireAtMs = Date.parse(fireAt);
+    if (isNaN(fireAtMs)) {
+      return {
+        content:
+          "Error: fire_at must be a valid ISO 8601 timestamp (e.g. 2025-06-15T09:00:00Z)",
+        isError: true,
+      };
+    }
+    if (fireAtMs <= Date.now()) {
+      return {
+        content: "Error: fire_at must be in the future",
+        isError: true,
+      };
+    }
+
+    try {
+      const job = createSchedule({
+        name,
+        cronExpression: null,
+        timezone,
+        message,
+        enabled,
+        syntax: "cron",
+        expression: null,
+        nextRunAt: fireAtMs,
+        mode,
+        routingIntent: routingIntent as
+          | "single_channel"
+          | "multi_channel"
+          | "all_channels"
+          | undefined,
+        routingHints,
+      });
+
+      const fireDate = formatLocalDate(job.nextRunAt);
+      const integrations = formatIntegrationSummary();
+      return {
+        content: [
+          `One-shot schedule created successfully.`,
+          `  ID: ${job.id}`,
+          `  Name: ${job.name}`,
+          `  Type: one-shot`,
+          `  Mode: ${job.mode}`,
+          `  Fire at: ${fireDate}`,
+          `  Enabled: ${job.enabled}`,
+          `  Status: ${job.status}`,
+          ``,
+          `Integrations: ${integrations}`,
+          `\u26a0 If this schedule requires an integration that isn't connected, it will fail at runtime. Warn the user about any missing capabilities before confirming the schedule is ready.`,
+        ].join("\n"),
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `Error creating schedule: ${msg}`, isError: true };
+    }
+  }
+
+  // ── Recurring schedule (expression) ──────────────────────────────
   const resolved = normalizeScheduleSyntax({
     syntax: input.syntax as "cron" | "rrule" | undefined,
     expression: input.expression as string | undefined,
@@ -38,7 +116,8 @@ export async function executeScheduleCreate(
 
   if (!resolved) {
     return {
-      content: "Error: expression is required",
+      content:
+        "Error: expression is required for recurring schedules (or provide fire_at for one-shot)",
       isError: true,
     };
   }
@@ -75,6 +154,13 @@ export async function executeScheduleCreate(
       enabled,
       syntax: resolved.syntax,
       expression: resolved.expression,
+      mode,
+      routingIntent: routingIntent as
+        | "single_channel"
+        | "multi_channel"
+        | "all_channels"
+        | undefined,
+      routingHints,
     });
 
     const scheduleDescription =
@@ -88,10 +174,11 @@ export async function executeScheduleCreate(
     const integrations = formatIntegrationSummary();
     return {
       content: [
-        `Schedule created successfully.`,
+        `Recurring schedule created successfully.`,
         `  ID: ${job.id}`,
         `  Name: ${job.name}`,
         `  Syntax: ${job.syntax}`,
+        `  Mode: ${job.mode}`,
         `  Schedule: ${scheduleDescription}${
           job.timezone ? ` (${job.timezone})` : ""
         }`,

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -21,6 +21,10 @@ function describeSchedule(job: {
   return describeCronExpression(job.cronExpression);
 }
 
+function isOneShot(job: { expression: string | null }): boolean {
+  return job.expression == null;
+}
+
 export async function executeScheduleList(
   input: Record<string, unknown>,
   _context: ToolContext,
@@ -35,23 +39,51 @@ export async function executeScheduleList(
       return { content: `Error: Schedule not found: ${jobId}`, isError: true };
     }
 
+    const oneShot = isOneShot(job);
+
     const runs = getScheduleRuns(jobId, 5);
     const lines = [
       `Schedule: ${job.name}`,
       `  ID: ${job.id}`,
-      `  Syntax: ${job.syntax}`,
-      `  Expression: ${job.expression ?? "(one-time)"}`,
-      `  Schedule: ${describeSchedule(job)}${
-        job.timezone ? ` (${job.timezone})` : ""
-      }`,
+      `  Type: ${oneShot ? "one-shot" : "recurring"}`,
+      `  Mode: ${job.mode}`,
+      `  Status: ${job.status}`,
+    ];
+
+    if (oneShot) {
+      lines.push(`  Fire at: ${formatLocalDate(job.nextRunAt)}`);
+    } else {
+      lines.push(
+        `  Syntax: ${job.syntax}`,
+        `  Expression: ${job.expression ?? "(one-time)"}`,
+        `  Schedule: ${describeSchedule(job)}${
+          job.timezone ? ` (${job.timezone})` : ""
+        }`,
+      );
+    }
+
+    lines.push(
       `  Enabled: ${job.enabled}`,
       `  Message: ${job.message}`,
-      `  Next run: ${formatLocalDate(job.nextRunAt)}`,
+    );
+
+    if (!oneShot) {
+      lines.push(
+        `  Next run: ${formatLocalDate(job.nextRunAt)}`,
+      );
+    }
+
+    lines.push(
       `  Last run: ${job.lastRunAt ? formatLocalDate(job.lastRunAt) : "never"}`,
       `  Last status: ${job.lastStatus ?? "n/a"}`,
       `  Retry count: ${job.retryCount}`,
       `  Created: ${formatLocalDate(job.createdAt)}`,
-    ];
+    );
+
+    // Show routing intent in detail view when not the default
+    if (job.routingIntent !== "all_channels") {
+      lines.push(`  Routing: ${job.routingIntent}`);
+    }
 
     if (runs.length > 0) {
       lines.push("", `Recent runs (${runs.length}):`);
@@ -79,12 +111,21 @@ export async function executeScheduleList(
   const lines = [`Schedules (${jobs.length}):`];
   for (const job of jobs) {
     const status = job.enabled ? "enabled" : "disabled";
-    const next = job.enabled ? formatLocalDate(job.nextRunAt) : "n/a";
-    lines.push(
-      `  - [${status}] ${job.name} (id: ${job.id}) ([${
-        job.syntax
-      }] ${describeSchedule(job)}) — next: ${next}`,
-    );
+    const oneShot = isOneShot(job);
+
+    if (oneShot) {
+      const fireTime = formatLocalDate(job.nextRunAt);
+      lines.push(
+        `  - [${status}] ${job.name} (id: ${job.id}) (one-shot, ${job.mode}) — fire at: ${fireTime} [${job.status}]`,
+      );
+    } else {
+      const next = job.enabled ? formatLocalDate(job.nextRunAt) : "n/a";
+      lines.push(
+        `  - [${status}] ${job.name} (id: ${job.id}) ([${
+          job.syntax
+        }] ${describeSchedule(job)}, ${job.mode}) — next: ${next}`,
+      );
+    }
   }
 
   return { content: lines.join("\n"), isError: false };

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -7,9 +7,21 @@ import {
 import {
   describeCronExpression,
   formatLocalDate,
+  getSchedule,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
+import type {
+  RoutingIntent,
+  ScheduleMode,
+} from "../../schedule/schedule-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const VALID_MODES: ScheduleMode[] = ["notify", "execute"];
+const VALID_ROUTING_INTENTS: RoutingIntent[] = [
+  "single_channel",
+  "multi_channel",
+  "all_channels",
+];
 
 export async function executeScheduleUpdate(
   input: Record<string, unknown>,
@@ -20,11 +32,63 @@ export async function executeScheduleUpdate(
     return { content: "Error: job_id is required", isError: true };
   }
 
+  // Prevent changing a one-shot to recurring or vice versa
+  if (input.expression !== undefined || input.fire_at !== undefined) {
+    const existing = getSchedule(jobId);
+    if (!existing) {
+      return { content: `Error: Schedule not found: ${jobId}`, isError: true };
+    }
+    const isExistingOneShot = existing.expression == null;
+    if (isExistingOneShot && input.expression !== undefined) {
+      return {
+        content:
+          "Error: Cannot change a one-shot schedule to recurring. Delete and recreate instead.",
+        isError: true,
+      };
+    }
+    if (!isExistingOneShot && input.fire_at !== undefined) {
+      return {
+        content:
+          "Error: Cannot change a recurring schedule to one-shot. Delete and recreate instead.",
+        isError: true,
+      };
+    }
+  }
+
   const updates: Record<string, unknown> = {};
   if (input.name !== undefined) updates.name = input.name;
   if (input.timezone !== undefined) updates.timezone = input.timezone;
   if (input.message !== undefined) updates.message = input.message;
   if (input.enabled !== undefined) updates.enabled = input.enabled;
+
+  // Mode validation and pass-through
+  if (input.mode !== undefined) {
+    const mode = input.mode as ScheduleMode;
+    if (!VALID_MODES.includes(mode)) {
+      return {
+        content: `Error: mode must be one of: ${VALID_MODES.join(", ")}`,
+        isError: true,
+      };
+    }
+    updates.mode = mode;
+  }
+
+  // Routing intent validation and pass-through
+  if (input.routing_intent !== undefined) {
+    const routingIntent = input.routing_intent as RoutingIntent;
+    if (!VALID_ROUTING_INTENTS.includes(routingIntent)) {
+      return {
+        content: `Error: routing_intent must be one of: ${VALID_ROUTING_INTENTS.join(", ")}`,
+        isError: true,
+      };
+    }
+    updates.routingIntent = routingIntent;
+  }
+
+  // Routing hints pass-through
+  if (input.routing_hints !== undefined) {
+    updates.routingHints = input.routing_hints;
+  }
 
   // Auto-detect syntax when expression changes without explicit syntax
   if (input.expression !== undefined || input.syntax !== undefined) {
@@ -85,6 +149,9 @@ export async function executeScheduleUpdate(
         enabled?: boolean;
         syntax?: ScheduleSyntax;
         expression?: string;
+        mode?: ScheduleMode;
+        routingIntent?: RoutingIntent;
+        routingHints?: Record<string, unknown>;
       },
     );
 
@@ -104,6 +171,7 @@ export async function executeScheduleUpdate(
         `Schedule updated successfully.`,
         `  Name: ${job.name}`,
         `  Syntax: ${job.syntax}`,
+        `  Mode: ${job.mode}`,
         `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ""}`,
         `  Enabled: ${job.enabled}`,
         `  Next run: ${job.enabled ? formatLocalDate(job.nextRunAt) : "n/a (disabled)"}`,


### PR DESCRIPTION
## Summary
- Extend schedule_create to accept fire_at for one-shot schedules and mode/routing params
- Update schedule_list to display one-shot schedules with fire time and status
- Update schedule_update to support mode and routing field changes
- Update TOOLS.json schema for new parameters

Part of plan: combine-schedules-reminders.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
