### PR TITLE
fix: add missing columns to schedule migration test

### DIFF
--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -28,7 +28,7 @@ describe("schedule_syntax column migration", () => {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         enabled INTEGER NOT NULL DEFAULT 1,
-        cron_expression TEXT NOT NULL,
+        cron_expression TEXT,
         schedule_syntax TEXT NOT NULL DEFAULT 'cron',
         timezone TEXT,
         message TEXT NOT NULL,
@@ -37,6 +37,10 @@ describe("schedule_syntax column migration", () => {
         last_status TEXT,
         retry_count INTEGER NOT NULL DEFAULT 0,
         created_by TEXT NOT NULL,
+        mode TEXT NOT NULL DEFAULT 'execute',
+        routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+        routing_hints_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'active',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -80,7 +84,7 @@ describe("schedule_syntax column migration", () => {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         enabled INTEGER NOT NULL DEFAULT 1,
-        cron_expression TEXT NOT NULL,
+        cron_expression TEXT,
         timezone TEXT,
         message TEXT NOT NULL,
         next_run_at INTEGER NOT NULL,
@@ -88,6 +92,10 @@ describe("schedule_syntax column migration", () => {
         last_status TEXT,
         retry_count INTEGER NOT NULL DEFAULT 0,
         created_by TEXT NOT NULL,
+        mode TEXT NOT NULL DEFAULT 'execute',
+        routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+        routing_hints_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'active',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )
@@ -125,7 +133,7 @@ describe("schedule_syntax column migration", () => {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         enabled INTEGER NOT NULL DEFAULT 1,
-        cron_expression TEXT NOT NULL,
+        cron_expression TEXT,
         timezone TEXT,
         message TEXT NOT NULL,
         next_run_at INTEGER NOT NULL,
@@ -133,6 +141,10 @@ describe("schedule_syntax column migration", () => {
         last_status TEXT,
         retry_count INTEGER NOT NULL DEFAULT 0,
         created_by TEXT NOT NULL,
+        mode TEXT NOT NULL DEFAULT 'execute',
+        routing_intent TEXT NOT NULL DEFAULT 'all_channels',
+        routing_hints_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'active',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       )


### PR DESCRIPTION
## Summary
- Add `mode`, `routing_intent`, `routing_hints_json`, and `status` columns to the hardcoded CREATE TABLE statements in `db-schedule-syntax-migration.test.ts`
- Also make `cron_expression` nullable to match the current schema
- These columns were added in #14942 but the test's manual DDL wasn't updated, causing Drizzle ORM inserts to fail with `SQLiteError: table cron_jobs has no column named mode`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22926685527/job/66538677550

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
