### PR TITLE
Migrate existing reminders into the schedules table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -48,7 +48,6 @@ import {
   migrateConversationsThreadTypeIndex,
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
-  migrateScheduleOneShotRouting,
   migrateDropLegacyMemberGuardianTables,
   migrateDropUsageCompositeIndexes,
   migrateFkCascadeRebuilds,
@@ -66,10 +65,12 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
+  migrateRemindersToSchedules,
   migrateRenameGuardianVerificationValues,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
+  migrateScheduleOneShotRouting,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -331,6 +332,9 @@ export function initializeDb(): void {
 
   // 50. Extend cron_jobs table with one-shot and routing support
   migrateScheduleOneShotRouting(database);
+
+  // 51. Migrate existing reminders into cron_jobs as one-shot schedules
+  migrateRemindersToSchedules(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
+++ b/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Migrate all existing reminders into the cron_jobs (schedules) table as
+ * one-shot schedules.
+ *
+ * Field mapping:
+ *   reminder.label          → cron_jobs.name
+ *   reminder.message        → cron_jobs.message
+ *   reminder.fire_at        → cron_jobs.next_run_at
+ *   reminder.fired_at       → cron_jobs.last_run_at
+ *   reminder.mode           → cron_jobs.mode
+ *   reminder.routing_intent → cron_jobs.routing_intent
+ *   reminder.routing_hints_json → cron_jobs.routing_hints_json
+ *   reminder.created_at     → cron_jobs.created_at
+ *   reminder.updated_at     → cron_jobs.updated_at
+ *
+ * Status mapping:
+ *   pending   → active
+ *   firing    → firing
+ *   fired     → fired
+ *   cancelled → cancelled
+ *
+ * Enabled: pending → 1, all others → 0
+ *
+ * last_status: fired → 'ok', others → NULL
+ *
+ * One-shot schedules have NULL cron_expression. The reminders table is
+ * preserved for the subsequent cleanup PR.
+ */
+export function migrateRemindersToSchedules(database: DrizzleDb): void {
+  withCrashRecovery(
+    database,
+    "migration_reminders_to_schedules_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      // Guard: if the reminders table doesn't exist, nothing to migrate.
+      const hasReminders = raw
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='reminders'",
+        )
+        .get();
+      if (!hasReminders) return;
+
+      // Read all reminders into memory so we can generate a UUID per row.
+      // The cron_jobs table uses TEXT PRIMARY KEY, and we need fresh UUIDs to
+      // avoid collisions with any existing cron_jobs rows.
+      const reminders = raw.query("SELECT * FROM reminders").all() as Array<{
+        id: string;
+        label: string;
+        message: string;
+        fire_at: number;
+        mode: string;
+        status: string;
+        fired_at: number | null;
+        routing_intent: string;
+        routing_hints_json: string;
+        created_at: number;
+        updated_at: number;
+      }>;
+
+      if (reminders.length === 0) return;
+
+      const insert = raw.query(/*sql*/ `
+        INSERT OR IGNORE INTO cron_jobs (
+          id, name, enabled, cron_expression, schedule_syntax, timezone,
+          message, next_run_at, last_run_at, last_status, retry_count,
+          created_by, mode, routing_intent, routing_hints_json, status,
+          created_at, updated_at
+        ) VALUES (
+          ?, ?, ?, NULL, 'cron', NULL,
+          ?, ?, ?, ?, 0,
+          'agent', ?, ?, ?, ?,
+          ?, ?
+        )
+      `);
+
+      for (const r of reminders) {
+        const statusMap: Record<string, string> = {
+          pending: "active",
+          firing: "firing",
+          fired: "fired",
+          cancelled: "cancelled",
+        };
+
+        insert.run(
+          randomUUID(),
+          r.label,
+          r.status === "pending" ? 1 : 0,
+          // message, next_run_at, last_run_at, last_status
+          r.message,
+          r.fire_at,
+          r.fired_at,
+          r.status === "fired" ? "ok" : null,
+          // mode, routing_intent, routing_hints_json, status
+          r.mode,
+          r.routing_intent,
+          r.routing_hints_json,
+          statusMap[r.status] ?? "active",
+          // created_at, updated_at
+          r.created_at,
+          r.updated_at,
+        );
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -88,6 +88,7 @@ export { migrateRenameGuardianVerificationValues } from "./143-rename-guardian-v
 export { migrateRenameVoiceToPhone } from "./144-rename-voice-to-phone.js";
 export { migrateDropAccountsTable } from "./145-drop-accounts-table.js";
 export { migrateScheduleOneShotRouting } from "./146-schedule-oneshot-routing.js";
+export { migrateRemindersToSchedules } from "./147-migrate-reminders-to-schedules.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -177,6 +177,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Drop the unused legacy accounts table and its leftover indexes after account_manage removal",
   },
+  {
+    key: "migration_reminders_to_schedules_v1",
+    version: 26,
+    description:
+      "Copy all existing reminders into cron_jobs as one-shot schedules with correct status and field mapping",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
- Add migration to copy all existing reminders from the reminders table into cron_jobs as one-shot schedules
- Map all fields correctly: label→name, fire_at→next_run_at, status transitions, routing metadata
- Pending reminders become active one-shot schedules ready to fire on next scheduler tick
- Original reminders table preserved for next PR

Part of plan: combine-schedules-reminders.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
