### PR TITLE
security: remove allowHighRisk blanket bypass from ephemeral task rules

### DIFF
--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -95,9 +95,8 @@ describe("ephemeral-permissions", () => {
       expect(fileReadRule.priority).toBe(75);
       expect(fileReadRule.createdAt).toBeGreaterThan(0);
 
-      // allowHighRisk is set because task runs execute asynchronously
-      // without interactive confirmation — pre-approved via preflight
-      expect(fileReadRule.allowHighRisk).toBe(true);
+      // Ephemeral task rules should not auto-allow high-risk tools
+      expect(fileReadRule.allowHighRisk).toBeUndefined();
 
       // Check other rules have correct tool names
       expect(rules[1].tool).toBe("bash");

--- a/assistant/src/tasks/ephemeral-permissions.ts
+++ b/assistant/src/tasks/ephemeral-permissions.ts
@@ -29,10 +29,9 @@ export function clearTaskRunRules(taskRunId: string): void {
  * default rules (50) so pre-approved tools aren't shadowed by default
  * `ask` rules (which would trigger prompting and auto-deny in
  * non-interactive task runs), but below user rules (100) so user deny
- * rules still take precedence. `allowHighRisk` is set because task runs
- * execute asynchronously without interactive confirmation — the client
- * pre-approves tools via the preflight flow before execution begins,
- * so there is no interactive prompt during the run itself.
+ * rules still take precedence. `allowHighRisk` is intentionally omitted:
+ * high-risk tool invocations still flow through the normal risk-classification
+ * path rather than being blanket-approved.
  */
 export function buildTaskRules(
   taskRunId: string,
@@ -45,7 +44,6 @@ export function buildTaskRules(
     pattern: "**",
     scope: "everywhere",
     decision: "allow" as const,
-    allowHighRisk: true,
     priority: 75,
     createdAt: Date.now(),
   }));

--- a/playwright/agent-xcode/.build
+++ b/playwright/agent-xcode/.build
@@ -1,0 +1,1 @@
+/Users/maddieabboud/projects/vellum-assistant/playwright/agent-xcode/.build


### PR DESCRIPTION
## Summary
- Remove `allowHighRisk: true` from `buildTaskRules()` so ephemeral task rules no longer blanket-approve high-risk tool invocations
- High-risk operations now flow through normal risk classification instead of being silently bypassed at the permission layer
- Update the corresponding test assertion to expect `allowHighRisk` to be `undefined`

## Original prompt
finish this security fix: remove `allowHighRisk: true` from ephemeral task rules so that high-risk tool invocations are not auto-allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
