### PR TITLE
fix: recreate pre-existing indexes in migration 146 table rebuild

### DIFF
--- a/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
+++ b/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
@@ -69,6 +69,8 @@ export function migrateScheduleOneShotRouting(database: DrizzleDb): void {
       DROP TABLE cron_jobs;
       ALTER TABLE cron_jobs_new RENAME TO cron_jobs;
 
+      CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at);
+      CREATE INDEX IF NOT EXISTS idx_cron_jobs_syntax_enabled_next_run ON cron_jobs(schedule_syntax, enabled, next_run_at);
       CREATE INDEX IF NOT EXISTS idx_cron_jobs_status_next_run_at ON cron_jobs(status, next_run_at);
 
       COMMIT;


### PR DESCRIPTION
Follow-up to PR #14942. Adds CREATE INDEX IF NOT EXISTS for idx_cron_jobs_enabled_next_run and idx_cron_jobs_syntax_enabled_next_run after the table rebuild in migration 146, preventing index loss during the cron_jobs table swap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
