### PR TITLE
fix: use write scope for cancel routes and sort combined reminders list

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -395,6 +395,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "schedules:DELETE", scopes: ["settings.write"] },
   { endpoint: "schedules/toggle", scopes: ["settings.write"] },
   { endpoint: "schedules/run", scopes: ["settings.write"] },
+  { endpoint: "schedules/cancel", scopes: ["settings.write"] },
 
   // Diagnostics
   { endpoint: "diagnostics/export", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -112,6 +112,13 @@ function handleListReminders(): Response {
     createdAt: s.createdAt,
   }));
 
+  reminders.sort((a, b) => {
+    if (a.fireAt == null && b.fireAt == null) return 0;
+    if (a.fireAt == null) return 1;
+    if (b.fireAt == null) return -1;
+    return new Date(a.fireAt).getTime() - new Date(b.fireAt).getTime();
+  });
+
   return Response.json({
     type: "reminders_list_response",
     reminders,
@@ -300,7 +307,7 @@ export function scheduleRouteDefinitions(deps: {
     {
       endpoint: "schedules/:id/cancel",
       method: "POST",
-      policyKey: "schedules",
+      policyKey: "schedules/cancel",
       handler: ({ params }) => handleCancelSchedule(params.id),
     },
     // Reminder-compat routes: serve reminders from schedule store
@@ -313,7 +320,7 @@ export function scheduleRouteDefinitions(deps: {
     {
       endpoint: "reminders/:id/cancel",
       method: "POST",
-      policyKey: "schedules",
+      policyKey: "schedules/cancel",
       handler: ({ params }) => handleCancelReminder(params.id),
     },
   ];


### PR DESCRIPTION
Follow-up to PR #14946. Changes cancel schedule/reminder POST routes to require write scope instead of read. Sorts the combined reminders list by fireAt for chronological ordering.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
