### PR TITLE
fix: prevent duplicate rows on crash recovery and double-firing in reminder migration

### DIFF
--- a/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
+++ b/assistant/src/memory/migrations/147-migrate-reminders-to-schedules.ts
@@ -79,32 +79,52 @@ export function migrateRemindersToSchedules(database: DrizzleDb): void {
         )
       `);
 
-      for (const r of reminders) {
-        const statusMap: Record<string, string> = {
-          pending: "active",
-          firing: "firing",
-          fired: "fired",
-          cancelled: "cancelled",
-        };
+      // Mark migrated pending reminders as fired so the legacy
+      // claimDueReminders path doesn't fire them a second time.
+      const markFired = raw.query(/*sql*/ `
+        UPDATE reminders SET status = 'fired', fired_at = ?
+        WHERE id = ? AND status = 'pending'
+      `);
 
-        insert.run(
-          randomUUID(),
-          r.label,
-          r.status === "pending" ? 1 : 0,
-          // message, next_run_at, last_run_at, last_status
-          r.message,
-          r.fire_at,
-          r.fired_at,
-          r.status === "fired" ? "ok" : null,
-          // mode, routing_intent, routing_hints_json, status
-          r.mode,
-          r.routing_intent,
-          r.routing_hints_json,
-          statusMap[r.status] ?? "active",
-          // created_at, updated_at
-          r.created_at,
-          r.updated_at,
-        );
+      try {
+        raw.exec("BEGIN");
+
+        for (const r of reminders) {
+          const statusMap: Record<string, string> = {
+            pending: "active",
+            firing: "firing",
+            fired: "fired",
+            cancelled: "cancelled",
+          };
+
+          insert.run(
+            randomUUID(),
+            r.label,
+            r.status === "pending" ? 1 : 0,
+            // message, next_run_at, last_run_at, last_status
+            r.message,
+            r.fire_at,
+            r.fired_at,
+            r.status === "fired" ? "ok" : null,
+            // mode, routing_intent, routing_hints_json, status
+            r.mode,
+            r.routing_intent,
+            r.routing_hints_json,
+            statusMap[r.status] ?? "active",
+            // created_at, updated_at
+            r.created_at,
+            r.updated_at,
+          );
+
+          if (r.status === "pending") {
+            markFired.run(Date.now(), r.id);
+          }
+        }
+
+        raw.exec("COMMIT");
+      } catch (err) {
+        raw.exec("ROLLBACK");
+        throw err;
       }
     },
   );


### PR DESCRIPTION
Follow-up to PR #14948. Wraps migration INSERT loop in a transaction for crash safety. Marks migrated pending reminders as completed in the source table to prevent double-firing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
