### PR TITLE
fix: use strict null check instead of falsy for one-shot schedule detection

### DIFF
--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -96,7 +96,7 @@ export function createSchedule(params: {
   routingHints?: Record<string, unknown>;
 }): ScheduleJob {
   const expression = params.expression ?? params.cronExpression ?? null;
-  const isOneShot = !expression;
+  const isOneShot = expression === null || expression === undefined;
   const syntax = params.syntax ?? "cron";
 
   if (isOneShot) {
@@ -240,7 +240,7 @@ export function updateSchedule(
   const newEnabled =
     updates.enabled !== undefined ? updates.enabled : existing.enabled;
 
-  const isOneShot = !newExpr;
+  const isOneShot = newExpr === null || newExpr === undefined;
 
   // Validate if expression or syntax changed (only for recurring schedules)
   if (

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -120,7 +120,7 @@ async function runScheduleOnce(
   // ── Schedules (recurring cron/RRULE + one-shot) ─────────────────────
   const jobs = claimDueSchedules(now);
   for (const job of jobs) {
-    const isOneShot = !job.expression;
+    const isOneShot = job.expression === null;
 
     // ── Notify mode (one-shot or recurring) ─────────────────────────
     if (job.mode === "notify") {


### PR DESCRIPTION
Follow-up to PR #14947. Changes `!expression` to `expression === null || expression === undefined` (or `=== null` where appropriate) to prevent empty strings from being misclassified as one-shot schedules, which creates stuck schedules due to SQL IS NULL mismatch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
