### PR TITLE
fix: prevent recurring notify schedule deduplication and add failure tracking

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -319,7 +319,7 @@ export async function runDaemon(): Promise<void> {
           },
           routingIntent: schedule.routingIntent,
           routingHints: schedule.routingHints,
-          dedupeKey: `schedule:notify:${schedule.id}`,
+          dedupeKey: `schedule:notify:${schedule.id}:${Date.now()}`,
         });
       },
       (schedule) => {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -146,6 +146,12 @@ async function runScheduleOnce(
         );
         if (isOneShot) {
           failOneShot(job.id);
+        } else {
+          // Track recurring notify-mode failures via a schedule run so the
+          // occurrence isn't silently lost and lastStatus/retryCount update.
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          const runId = createScheduleRun(job.id, `notify-error:${job.id}`);
+          completeScheduleRun(runId, { status: "error", error: errorMsg });
         }
       }
       processed += 1;


### PR DESCRIPTION
Follow-up to PR #14943. Makes notify-mode dedupe keys unique per occurrence to prevent suppression of recurring notifications. Adds error tracking for notify-mode failures so occurrences aren't silently dropped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
