### PR TITLE
Remove unused IPC handler-map exports from session and settings handlers

### DIFF
--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -22,7 +22,6 @@ import {
 import type { IngressConfigRequest } from "../message-protocol.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
-  defineHandlers,
   type HandlerContext,
   log,
 } from "./shared.js";
@@ -252,6 +251,3 @@ export async function handleIngressConfig(
   }
 }
 
-export const ingressHandlers = defineHandlers({
-  ingress_config: handleIngressConfig,
-});

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -11,7 +11,6 @@ import type {
 import { MODEL_TO_PROVIDER } from "../session-slash.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
-  defineHandlers,
   type HandlerContext,
   log,
 } from "./shared.js";
@@ -195,8 +194,3 @@ export function handleImageGenModelSet(
   }
 }
 
-export const modelHandlers = defineHandlers({
-  model_get: (_msg, ctx) => handleModelGet(ctx),
-  model_set: handleModelSet,
-  image_gen_model_set: handleImageGenModelSet,
-});

--- a/assistant/src/daemon/handlers/config-voice.ts
+++ b/assistant/src/daemon/handlers/config-voice.ts
@@ -1,5 +1,5 @@
 import type { VoiceConfigUpdateRequest } from "../message-types/settings.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 /**
  * Send a client_settings_update message to all connected clients.
@@ -214,6 +214,3 @@ export function handleVoiceConfigUpdate(
   );
 }
 
-export const voiceHandlers = defineHandlers({
-  voice_config_update: handleVoiceConfigUpdate,
-});

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -61,7 +61,6 @@ import {
 } from "./session-history.js";
 import { handleUserMessage } from "./session-user-message.js";
 import {
-  defineHandlers,
   type HandlerContext,
   log,
   pendingStandaloneSecrets,
@@ -764,23 +763,3 @@ export function handleReorderThreads(
   );
 }
 
-export const sessionHandlers = defineHandlers({
-  user_message: handleUserMessage,
-  confirmation_response: handleConfirmationResponse,
-  secret_response: handleSecretResponse,
-  session_list: (msg, ctx) =>
-    handleSessionList(ctx, msg.offset ?? 0, msg.limit ?? 50),
-  session_create: handleSessionCreate,
-  sessions_clear: (_msg, ctx) => handleSessionsClear(ctx),
-  session_switch: handleSessionSwitch,
-  session_rename: handleSessionRename,
-  cancel: handleCancel,
-  delete_queued_message: handleDeleteQueuedMessage,
-  history_request: handleHistoryRequest,
-  message_content_request: handleMessageContentRequest,
-  undo: handleUndo,
-  regenerate: handleRegenerate,
-  usage_request: handleUsageRequest,
-  conversation_search: handleConversationSearch,
-  reorder_threads: handleReorderThreads,
-});


### PR DESCRIPTION
## Summary
- Delete sessionHandlers, modelHandlers, voiceHandlers, and ingressHandlers defineHandlers exports
- Remove defineHandlers imports from sessions.ts, config-model.ts, config-voice.ts, config-ingress.ts
- Preserve all individually exported handler functions used by HTTP routes and tests

Part of plan: ipc-handler-dispatch-cleanup.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
