### PR TITLE
Remove unused IPC handler-map exports from channel and identity handlers

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -49,7 +49,7 @@ import type {
   ChannelVerificationSessionRequest,
   ChannelVerificationSessionResponse,
 } from "../message-protocol.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 // -- Transport-agnostic result type (omits the IPC `type` discriminant) --
 
@@ -611,7 +611,3 @@ export async function handleChannelVerificationSession(
     });
   }
 }
-
-export const channelHandlers = defineHandlers({
-  channel_verification_session: handleChannelVerificationSession,
-});

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -22,7 +22,7 @@ import type {
   TelegramConfigRequest,
   TelegramConfigResponse,
 } from "../message-protocol.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 const TELEGRAM_BOT_TOKEN_IN_URL_PATTERN =
   /\/bot\d{8,10}:[A-Za-z0-9_-]{30,120}\//g;
@@ -402,7 +402,3 @@ export async function handleTelegramConfig(
     });
   }
 }
-
-export const telegramHandlers = defineHandlers({
-  telegram_config: handleTelegramConfig,
-});

--- a/assistant/src/daemon/handlers/identity.ts
+++ b/assistant/src/daemon/handlers/identity.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 export interface IdentityFields {
   name: string;
@@ -152,7 +152,3 @@ function handleIdentityGet(ctx: HandlerContext): void {
     });
   }
 }
-
-export const identityHandlers = defineHandlers({
-  identity_get: (_msg, ctx) => handleIdentityGet(ctx),
-});

--- a/assistant/src/daemon/handlers/pairing.ts
+++ b/assistant/src/daemon/handlers/pairing.ts
@@ -10,7 +10,7 @@ import type {
   PairingApprovalResponse,
 } from "../message-protocol.js";
 import type { PairingStore } from "../pairing-store.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 /** Module-level reference set by the daemon server at startup. */
 let pairingStoreRef: PairingStore | null = null;
@@ -106,10 +106,3 @@ function handleApprovedDevicesClear(_ctx: HandlerContext): void {
   clearAllDevices();
   log.info("All approved devices cleared via IPC");
 }
-
-export const pairingHandlers = defineHandlers({
-  pairing_approval_response: handlePairingApprovalResponse,
-  approved_devices_list: (_msg, ctx) => handleApprovedDevicesList(ctx),
-  approved_device_remove: handleApprovedDeviceRemove,
-  approved_devices_clear: (_msg, ctx) => handleApprovedDevicesClear(ctx),
-});


### PR DESCRIPTION
## Summary
- Delete channelHandlers, telegramHandlers, pairingHandlers, and identityHandlers defineHandlers exports
- Remove defineHandlers imports from config-channels.ts, config-telegram.ts, pairing.ts, identity.ts
- Preserve all individually exported handler functions used by HTTP routes and tests

Part of plan: ipc-handler-dispatch-cleanup.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
