### PR TITLE
Remove unused IPC handler-map exports from dictation and skills handlers

### DIFF
--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -13,7 +13,7 @@ import {
   expandSnippets,
 } from "../dictation-text-processing.js";
 import type { DictationRequest } from "../message-protocol.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 // Action verbs for fast heuristic fallback (used when LLM classifier is unavailable)
 const ACTION_VERBS = [
@@ -471,7 +471,3 @@ async function handleCommandMode(
     });
   }
 }
-
-export const dictationHandlers = defineHandlers({
-  dictation_request: handleDictationRequest,
-});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -51,7 +51,6 @@ import type {
 } from "../message-protocol.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
-  defineHandlers,
   ensureSkillEntry,
   type HandlerContext,
   log,
@@ -929,19 +928,3 @@ export async function handleSkillsCreate(
     ...result,
   });
 }
-
-export const skillHandlers = defineHandlers({
-  skills_list: (_msg, ctx) => handleSkillsList(ctx),
-  skill_detail: handleSkillDetail,
-  skills_enable: handleSkillsEnable,
-  skills_disable: handleSkillsDisable,
-  skills_configure: handleSkillsConfigure,
-  skills_install: handleSkillsInstall,
-  skills_uninstall: handleSkillsUninstall,
-  skills_update: handleSkillsUpdate,
-  skills_check_updates: handleSkillsCheckUpdates,
-  skills_search: handleSkillsSearch,
-  skills_inspect: handleSkillsInspect,
-  skills_draft: handleSkillsDraft,
-  skills_create: handleSkillsCreate,
-});


### PR DESCRIPTION
## Summary
- Delete dictationHandlers and skillHandlers defineHandlers exports
- Remove defineHandlers imports from dictation.ts and skills.ts
- Preserve detectDictationModeHeuristic, SkillOperationContext, and all other direct exports

Part of plan: ipc-handler-dispatch-cleanup.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
