### PR TITLE
Update Swift clients to use unified schedule model

### DIFF
--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -1,18 +1,9 @@
-// Schedule, reminder, watcher, and heartbeat types.
+// Schedule, watcher, and heartbeat types.
 
 // === Client → Server ===
 
 export interface SchedulesList {
   type: "schedules_list";
-}
-
-export interface RemindersList {
-  type: "reminders_list";
-}
-
-export interface ReminderCancel {
-  type: "reminder_cancel";
-  id: string;
 }
 
 export interface ScheduleToggle {
@@ -82,20 +73,6 @@ export interface SchedulesListResponse {
   }>;
 }
 
-export interface RemindersListResponse {
-  type: "reminders_list_response";
-  reminders: Array<{
-    id: string;
-    label: string;
-    message: string;
-    fireAt: number;
-    mode: string;
-    status: string;
-    firedAt: number | null;
-    createdAt: number;
-  }>;
-}
-
 export interface HeartbeatAlert {
   type: "heartbeat_alert";
   title: string;
@@ -149,8 +126,6 @@ export type _SchedulesClientMessages =
   | ScheduleToggle
   | ScheduleRemove
   | ScheduleRunNow
-  | RemindersList
-  | ReminderCancel
   | HeartbeatConfig
   | HeartbeatRunsList
   | HeartbeatRunNow
@@ -159,7 +134,6 @@ export type _SchedulesClientMessages =
 
 export type _SchedulesServerMessages =
   | SchedulesListResponse
-  | RemindersListResponse
   | HeartbeatAlert
   | HeartbeatConfigResponse
   | HeartbeatRunsListResponse

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -95,67 +95,6 @@ function handleCancelSchedule(id: string): Response {
   return handleListSchedules();
 }
 
-/**
- * List reminders by querying one-shot schedules from the schedule store.
- * Maps to the legacy RemindersListResponse shape for client compat.
- */
-function handleListReminders(): Response {
-  const oneShotSchedules = listSchedules({ oneShotOnly: true });
-  const reminders = oneShotSchedules.map((s) => ({
-    id: s.id,
-    label: s.name,
-    message: s.message,
-    fireAt: s.nextRunAt,
-    mode: s.mode,
-    status: mapScheduleStatusToReminderStatus(s.status),
-    firedAt: s.lastRunAt,
-    createdAt: s.createdAt,
-  }));
-
-  reminders.sort((a, b) => {
-    if (a.fireAt == null && b.fireAt == null) return 0;
-    if (a.fireAt == null) return 1;
-    if (b.fireAt == null) return -1;
-    return new Date(a.fireAt).getTime() - new Date(b.fireAt).getTime();
-  });
-
-  return Response.json({
-    type: "reminders_list_response",
-    reminders,
-  });
-}
-
-/**
- * Cancel a reminder by cancelling the corresponding one-shot schedule.
- */
-function handleCancelReminder(id: string): Response {
-  const cancelled = cancelSchedule(id);
-  if (cancelled) {
-    log.info({ id }, "Reminder cancelled via schedule store");
-    return handleListReminders();
-  }
-
-  return httpError("NOT_FOUND", "Reminder not found", 404);
-}
-
-/**
- * Map schedule status values to legacy reminder status values for client compat.
- */
-function mapScheduleStatusToReminderStatus(status: string): string {
-  switch (status) {
-    case "active":
-      return "pending";
-    case "firing":
-      return "firing";
-    case "fired":
-      return "fired";
-    case "cancelled":
-      return "cancelled";
-    default:
-      return status;
-  }
-}
-
 async function handleRunScheduleNow(
   id: string,
   sendMessageDeps?: SendMessageDeps,
@@ -310,19 +249,6 @@ export function scheduleRouteDefinitions(deps: {
       method: "POST",
       policyKey: "schedules/cancel",
       handler: ({ params }) => handleCancelSchedule(params.id),
-    },
-    // Reminder-compat routes: serve reminders from schedule store
-    {
-      endpoint: "reminders",
-      method: "GET",
-      policyKey: "schedules",
-      handler: () => handleListReminders(),
-    },
-    {
-      endpoint: "reminders/:id/cancel",
-      method: "POST",
-      policyKey: "schedules/cancel",
-      handler: ({ params }) => handleCancelReminder(params.id),
     },
   ];
 }

--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -27,7 +27,8 @@ struct IOSThread: Identifiable {
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
 
-    /// Whether this thread was created by a schedule or reminder trigger.
+    /// Whether this thread was created by a schedule trigger (including one-shot/reminders).
+    /// Keeps legacy "Reminder: " prefix check for threads created before unification.
     var isScheduleThread: Bool {
         if scheduleJobId != nil { return true }
         return title.hasPrefix("Schedule: ") || title.hasPrefix("Schedule (manual): ") || title.hasPrefix("Reminder: ")

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -4,8 +4,13 @@ import VellumAssistantShared
 
 struct RemindersSection: View {
     @EnvironmentObject var clientProvider: ClientProvider
-    @State private var reminders: [ReminderItem] = []
+    @State private var schedules: [ScheduleItem] = []
     @State private var loading = false
+
+    /// Filter to only show one-shot schedules (reminders).
+    private var oneShotSchedules: [ScheduleItem] {
+        schedules.filter { $0.isOneShot }
+    }
 
     var body: some View {
         Form {
@@ -16,18 +21,18 @@ struct RemindersSection: View {
                         ProgressView()
                         Spacer()
                     }
-                } else if reminders.isEmpty {
+                } else if oneShotSchedules.isEmpty {
                     Text("No active reminders")
                         .foregroundStyle(.secondary)
                         .font(.caption)
                 } else {
-                    ForEach(reminders, id: \.id) { reminder in
-                        reminderRow(reminder)
+                    ForEach(oneShotSchedules, id: \.id) { schedule in
+                        reminderRow(schedule)
                     }
                     .onDelete { indexSet in
-                        let remindersToCancel = indexSet.map { reminders[$0] }
-                        for reminder in remindersToCancel {
-                            cancelReminder(reminder.id)
+                        let items = indexSet.map { oneShotSchedules[$0] }
+                        for item in items {
+                            cancelSchedule(item.id)
                         }
                     }
                 }
@@ -35,29 +40,29 @@ struct RemindersSection: View {
         }
         .navigationTitle("Reminders")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear { loadReminders() }
+        .onAppear { loadSchedules() }
         .onChange(of: clientProvider.isConnected) { _, connected in
-            if connected { loadReminders() }
+            if connected { loadSchedules() }
         }
         .onDisappear {
             if let daemon = clientProvider.client as? DaemonClient {
-                daemon.onRemindersListResponse = nil
+                daemon.onSchedulesListResponse = nil
             }
         }
     }
 
     @ViewBuilder
-    private func reminderRow(_ reminder: ReminderItem) -> some View {
+    private func reminderRow(_ schedule: ScheduleItem) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(reminder.label)
+            Text(schedule.name)
                 .font(.body)
-            Text(reminder.message)
+            Text(schedule.message)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
             HStack(spacing: 8) {
-                statusBadge(reminder.status)
-                if let fireTime = formatTimestamp(reminder.fireAt) {
+                statusBadge(schedule.status)
+                if let fireTime = formatTimestamp(schedule.nextRunAt) {
                     Text(fireTime)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
@@ -70,7 +75,7 @@ struct RemindersSection: View {
     private func statusBadge(_ status: String) -> some View {
         let (color, label): (Color, String) = {
             switch status {
-            case "pending": return (VColor.warning, "Pending")
+            case "active": return (VColor.warning, "Active")
             case "fired": return (VColor.success, "Fired")
             case "cancelled": return (VColor.textMuted, "Cancelled")
             default: return (VColor.textSecondary, status.capitalized)
@@ -86,24 +91,24 @@ struct RemindersSection: View {
             .clipShape(Capsule())
     }
 
-    private func loadReminders() {
+    private func loadSchedules() {
         guard let daemon = clientProvider.client as? DaemonClient else { return }
         loading = true
-        daemon.onRemindersListResponse = { items in
-            reminders = items
+        daemon.onSchedulesListResponse = { items in
+            schedules = items
             loading = false
         }
         do {
-            try daemon.sendListReminders()
+            try daemon.sendListSchedules()
         } catch {
             loading = false
         }
     }
 
-    private func cancelReminder(_ id: String) {
+    private func cancelSchedule(_ id: String) {
         guard let daemon = clientProvider.client as? DaemonClient else { return }
-        try? daemon.sendCancelReminder(id: id)
-        reminders.removeAll { $0.id == id }
+        try? daemon.sendRemoveSchedule(id: id)
+        schedules.removeAll { $0.id == id }
     }
 
     private func formatTimestamp(_ ms: Int) -> String? {

--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -7,6 +7,11 @@ struct SchedulesSection: View {
     @State private var schedules: [ScheduleItem] = []
     @State private var loading = false
 
+    /// Filter to only show recurring schedules (exclude one-shot/reminders).
+    private var recurringSchedules: [ScheduleItem] {
+        schedules.filter { !$0.isOneShot }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -16,16 +21,16 @@ struct SchedulesSection: View {
                         ProgressView()
                         Spacer()
                     }
-                } else if schedules.isEmpty {
+                } else if recurringSchedules.isEmpty {
                     Text("No scheduled tasks")
                         .foregroundStyle(.secondary)
                         .font(.caption)
                 } else {
-                    ForEach(schedules, id: \.id) { schedule in
+                    ForEach(recurringSchedules, id: \.id) { schedule in
                         scheduleRow(schedule)
                     }
                     .onDelete { indexSet in
-                        let schedulesToDelete = indexSet.map { schedules[$0] }
+                        let schedulesToDelete = indexSet.map { recurringSchedules[$0] }
                         for schedule in schedulesToDelete {
                             deleteSchedule(schedule.id)
                         }

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -107,7 +107,7 @@ struct ThreadListView: View {
         activeThreads.filter { !$0.isScheduleThread }
     }
 
-    /// Active threads created by a schedule or reminder.
+    /// Active threads created by a schedule trigger (including one-shot/reminders).
     private var scheduleThreads: [IOSThread] {
         activeThreads.filter { $0.isScheduleThread }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -157,7 +157,7 @@ private let subCategoryMap: [SkillCategory: [SubCategoryDef]] = [
         SubCategoryDef(label: "People", emoji: "\u{1F465}", skillIds: ["contacts", "followups"]),
     ],
     .productivity: [
-        SubCategoryDef(label: "Planning", emoji: "\u{1F4C5}", skillIds: ["google-calendar", "schedule", "reminder"]),
+        SubCategoryDef(label: "Planning", emoji: "\u{1F4C5}", skillIds: ["google-calendar", "schedule"]),
         SubCategoryDef(label: "Work", emoji: "\u{1F4CB}", skillIds: ["document", "tasks", "playbooks"]),
     ],
     .development: [

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -46,7 +46,8 @@ struct ThreadModel: Identifiable, Hashable {
         self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
     }
 
-    /// Whether this thread was created by a schedule or reminder trigger.
+    /// Whether this thread was created by a schedule trigger (including one-shot/reminders).
+    /// Checks for legacy "reminder" source for threads created before unification.
     /// Falls back to title prefix when source is nil (HTTP mode).
     var isScheduleThread: Bool {
         if let source = source {

--- a/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
@@ -5,10 +5,15 @@ struct RemindersView: View {
     let daemonClient: DaemonClient
     @Environment(\.dismiss) var dismiss
 
-    @State private var reminders: [ReminderItem] = []
+    @State private var schedules: [ScheduleItem] = []
     @State private var isLoading = true
     @State private var errorMessage: String? = nil
-    @State private var reminderToCancel: ReminderItem? = nil
+    @State private var scheduleToCancel: ScheduleItem? = nil
+
+    /// Filter to only show one-shot schedules (reminders).
+    private var oneShotSchedules: [ScheduleItem] {
+        schedules.filter { $0.isOneShot }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,11 +44,11 @@ struct RemindersView: View {
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .textSelection(.enabled)
-                    Button("Retry") { loadReminders() }
+                    Button("Retry") { loadSchedules() }
                         .padding(.top, 4)
                 }
                 Spacer()
-            } else if reminders.isEmpty {
+            } else if oneShotSchedules.isEmpty {
                 Spacer()
                 VStack(spacing: 8) {
                     VIconView(.bellDot, size: 32)
@@ -57,10 +62,10 @@ struct RemindersView: View {
                 Spacer()
             } else {
                 List {
-                    ForEach(reminders) { reminder in
+                    ForEach(oneShotSchedules) { schedule in
                         ReminderRow(
-                            reminder: reminder,
-                            onCancel: { reminderToCancel = reminder }
+                            schedule: schedule,
+                            onCancel: { scheduleToCancel = schedule }
                         )
                     }
                 }
@@ -68,57 +73,57 @@ struct RemindersView: View {
         }
         .frame(width: 550, height: 450)
         .onAppear {
-            daemonClient.onRemindersListResponse = { items in
-                reminders = items
+            daemonClient.onSchedulesListResponse = { items in
+                schedules = items
                 isLoading = false
             }
-            loadReminders()
+            loadSchedules()
         }
         .onDisappear {
-            daemonClient.onRemindersListResponse = nil
+            daemonClient.onSchedulesListResponse = nil
         }
         .alert("Cancel Reminder?", isPresented: Binding(
-            get: { reminderToCancel != nil },
-            set: { if !$0 { reminderToCancel = nil } }
+            get: { scheduleToCancel != nil },
+            set: { if !$0 { scheduleToCancel = nil } }
         )) {
-            Button("Keep", role: .cancel) { reminderToCancel = nil }
+            Button("Keep", role: .cancel) { scheduleToCancel = nil }
             Button("Cancel Reminder", role: .destructive) {
-                if let reminder = reminderToCancel {
-                    cancelReminder(id: reminder.id)
-                    reminderToCancel = nil
+                if let schedule = scheduleToCancel {
+                    cancelSchedule(id: schedule.id)
+                    scheduleToCancel = nil
                 }
             }
         } message: {
-            if let reminder = reminderToCancel {
-                Text("Cancel the reminder \"\(reminder.label)\"?")
+            if let schedule = scheduleToCancel {
+                Text("Cancel the reminder \"\(schedule.name)\"?")
             }
         }
     }
 
-    @MainActor private func loadReminders() {
+    @MainActor private func loadSchedules() {
         isLoading = true
         errorMessage = nil
         do {
-            try daemonClient.sendListReminders()
+            try daemonClient.sendListSchedules()
         } catch {
             isLoading = false
             errorMessage = error.localizedDescription
         }
     }
 
-    @MainActor private func cancelReminder(id: String) {
-        try? daemonClient.sendCancelReminder(id: id)
+    @MainActor private func cancelSchedule(id: String) {
+        try? daemonClient.sendRemoveSchedule(id: id)
     }
 }
 
 // MARK: - Reminder Row
 
 private struct ReminderRow: View {
-    let reminder: ReminderItem
+    let schedule: ScheduleItem
     let onCancel: () -> Void
 
     private var scheduledDateText: String {
-        let date = Date(timeIntervalSince1970: Double(reminder.fireAt) / 1000.0)
+        let date = Date(timeIntervalSince1970: Double(schedule.nextRunAt) / 1000.0)
         let formatter = DateFormatter()
         formatter.timeZone = .autoupdatingCurrent
         formatter.dateStyle = .medium
@@ -127,14 +132,14 @@ private struct ReminderRow: View {
     }
 
     private var statusDateText: String {
-        switch reminder.status {
-        case "pending":
-            let date = Date(timeIntervalSince1970: Double(reminder.fireAt) / 1000.0)
+        switch schedule.status {
+        case "active":
+            let date = Date(timeIntervalSince1970: Double(schedule.nextRunAt) / 1000.0)
             let formatter = RelativeDateTimeFormatter()
             formatter.unitsStyle = .abbreviated
             return "Fires: \(formatter.localizedString(for: date, relativeTo: Date()))"
         case "fired":
-            let timestamp = reminder.firedAt ?? reminder.fireAt
+            let timestamp = schedule.lastRunAt ?? schedule.nextRunAt
             let date = Date(timeIntervalSince1970: Double(timestamp) / 1000.0)
             let formatter = DateFormatter()
             formatter.timeZone = .autoupdatingCurrent
@@ -147,8 +152,8 @@ private struct ReminderRow: View {
     }
 
     private var statusColor: Color {
-        switch reminder.status {
-        case "pending": return .blue
+        switch schedule.status {
+        case "active": return .blue
         case "fired": return .green
         case "cancelled": return .secondary
         default: return .secondary
@@ -159,9 +164,9 @@ private struct ReminderRow: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    Text(reminder.label)
+                    Text(schedule.name)
                         .fontWeight(.medium)
-                    Text(reminder.status)
+                    Text(schedule.status)
                         .font(.caption)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -169,13 +174,13 @@ private struct ReminderRow: View {
                         .foregroundStyle(statusColor)
                         .clipShape(Capsule())
                 }
-                Text(reminder.message)
+                Text(schedule.message)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                 HStack(spacing: 6) {
                     Text(statusDateText)
-                    Text("(\(reminder.mode))")
+                    Text("(\(schedule.mode))")
                 }
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
@@ -184,7 +189,7 @@ private struct ReminderRow: View {
 
             Spacer()
 
-            if reminder.status == "pending" {
+            if schedule.status == "active" {
                 Button {
                     onCancel()
                 } label: {

--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -10,6 +10,11 @@ struct ScheduledTasksView: View {
     @State private var errorMessage: String? = nil
     @State private var scheduleToDelete: ScheduleItem? = nil
 
+    /// Filter to only show recurring schedules (exclude one-shot/reminders).
+    private var recurringSchedules: [ScheduleItem] {
+        schedules.filter { !$0.isOneShot }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -42,7 +47,7 @@ struct ScheduledTasksView: View {
                         .padding(.top, 4)
                 }
                 Spacer()
-            } else if schedules.isEmpty {
+            } else if recurringSchedules.isEmpty {
                 Spacer()
                 VStack(spacing: 8) {
                     VIconView(.clock, size: 32)
@@ -56,7 +61,7 @@ struct ScheduledTasksView: View {
                 Spacer()
             } else {
                 List {
-                    ForEach(schedules) { schedule in
+                    ForEach(recurringSchedules) { schedule in
                         ScheduleRow(
                             schedule: schedule,
                             onToggle: { enabled in toggleSchedule(id: schedule.id, enabled: enabled) },

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -12,7 +12,7 @@ struct SettingsAutomationTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            // Reminders section (from old Schedules tab)
+            // Reminders section — one-shot schedules shown as reminders
             if daemonClient != nil {
                 VStack(alignment: .leading, spacing: VSpacing.md) {
                     Text("Reminders")

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -150,9 +150,6 @@ public final class ToolConfirmationNotificationService {
         case "schedule_update": return "Update Schedule"
         case "schedule_delete": return "Delete Schedule"
         case "schedule_list":   return "List Schedules"
-        case "reminder_create":  return "Create Reminder"
-        case "reminder_list":    return "List Reminders"
-        case "reminder_cancel":  return "Cancel Reminder"
         default: return toolName.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }
@@ -189,23 +186,6 @@ public final class ToolConfirmationNotificationService {
             return parts.isEmpty ? "\(verb) schedule" : "\(verb): \(parts.joined(separator: " — "))"
         case "schedule_delete":
             return (input["job_id"]?.value as? String) ?? "schedule"
-        case "reminder_create":
-            let msg = (input["message"]?.value as? String) ?? ""
-            let at = (input["at"]?.value as? String) ?? ""
-            let delay = (input["delay"]?.value as? String) ?? ""
-            var parts: [String] = []
-            if !msg.isEmpty {
-                let truncated = msg.count > 60 ? String(msg.prefix(57)) + "..." : msg
-                parts.append("\"\(truncated)\"")
-            }
-            if !at.isEmpty { parts.append("at \(at)") }
-            else if !delay.isEmpty { parts.append("in \(delay)") }
-            return parts.isEmpty ? "Set reminder" : parts.joined(separator: " ")
-        case "reminder_list":
-            return "List reminders"
-        case "reminder_cancel":
-            let id = (input["reminder_id"]?.value as? String) ?? ""
-            return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         default:
             // Prefer semantically meaningful keys over arbitrary dictionary order
             let preferredKeys = ["name", "query", "message", "description", "title", "url", "path", "command", "id"]

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -99,15 +99,6 @@ public struct ToolConfirmationData: Equatable {
             return "The assistant wants to update a schedule"
         case "schedule_delete":
             return "The assistant wants to delete a schedule"
-        case "reminder_create":
-            let msg = (input["message"]?.value as? String) ?? ""
-            return msg.isEmpty
-                ? "The assistant wants to set a reminder"
-                : "The assistant wants to remind you: \(msg)"
-        case "reminder_list":
-            return "The assistant wants to list reminders"
-        case "reminder_cancel":
-            return "The assistant wants to cancel a reminder"
         default:
             return "The assistant wants to use \(toolName)"
         }
@@ -352,13 +343,6 @@ public struct ToolConfirmationData: Equatable {
             return jobId.isEmpty ? "Delete schedule" : "Delete schedule \(jobId)"
         case "schedule_list":
             return "List schedules"
-        case "reminder_create":
-            return Self.reminderPreview(input: input)
-        case "reminder_list":
-            return "List reminders"
-        case "reminder_cancel":
-            let id = (input["reminder_id"]?.value as? String) ?? ""
-            return id.isEmpty ? "Cancel reminder" : "Cancel reminder \(id)"
         case "credential_store":
             return Self.credentialPreview(input: input)
         default:
@@ -385,23 +369,6 @@ public struct ToolConfirmationData: Equatable {
 
         if parts.isEmpty { return "\(verb) schedule" }
         return "\(verb): \(parts.joined(separator: " — "))"
-    }
-
-    /// Build a preview string for the reminder tool.
-    private static func reminderPreview(input: [String: AnyCodable]) -> String {
-        let message = (input["message"]?.value as? String) ?? ""
-        let delay = (input["delay"]?.value as? String) ?? ""
-        let at = (input["at"]?.value as? String) ?? ""
-
-        var parts: [String] = []
-        if !message.isEmpty {
-            parts.append("\"\(message.count > 60 ? String(message.prefix(57)) + "..." : message)\"")
-        }
-        if !at.isEmpty { parts.append("at \(at)") }
-        else if !delay.isEmpty { parts.append("in \(delay)") }
-
-        if parts.isEmpty { return "Set reminder" }
-        return parts.joined(separator: " ")
     }
 
     /// Build a preview string for the credential_store tool.
@@ -457,7 +424,6 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("memory_"):   return "Memory"
         case "skill_load":                            return "Skill"
         case "evaluate_typescript_code":              return "Code Sandbox"
-        case _ where toolName.hasPrefix("reminder_"):   return "Reminder"
         case "document_create", "document_update":    return "Document"
         default:
             return toolName
@@ -484,7 +450,6 @@ public struct ToolConfirmationData: Equatable {
         case _ where toolName.hasPrefix("memory_"):   return .brain
         case "skill_load":                            return .puzzle
         case "evaluate_typescript_code":              return .fileCode
-        case _ where toolName.hasPrefix("reminder_"):   return .bell
         case "document_create", "document_update":    return .fileText
         default:                                      return .puzzle
         }
@@ -626,17 +591,6 @@ public struct ToolConfirmationData: Equatable {
             return "Allow updating a schedule?"
         case "schedule_delete":
             return "Allow deleting a schedule?"
-        case "reminder_create":
-            let msg = (input["message"]?.value as? String) ?? ""
-            if !msg.isEmpty {
-                let truncated = msg.count > 40 ? String(msg.prefix(37)) + "..." : msg
-                return "Allow setting a reminder: \"\(truncated)\"?"
-            }
-            return "Allow setting a reminder?"
-        case "reminder_list":
-            return "Allow listing reminders?"
-        case "reminder_cancel":
-            return "Allow canceling a reminder?"
         default:
             let tc = toolCategory.lowercased()
             if !r.isEmpty { return "Allow using \(tc) \(r)?" }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -370,9 +370,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `schedules_list_response` message.
     public var onSchedulesListResponse: (([ScheduleItem]) -> Void)?
 
-    /// Called when the daemon sends a `reminders_list_response` message.
-    public var onRemindersListResponse: (([ReminderItem]) -> Void)?
-
     /// Called when the daemon sends a `skills_state_changed` push event.
     public var onSkillStateChanged: ((SkillStateChangedMessage) -> Void)?
 
@@ -1210,18 +1207,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Run a schedule immediately as a one-off execution.
     public func sendRunScheduleNow(id: String) throws {
         try send(ScheduleRunNowMessage(id: id))
-    }
-
-    // MARK: - Reminders Management
-
-    /// Request the list of all reminders from the daemon.
-    public func sendListReminders() throws {
-        try send(RemindersListMessage())
-    }
-
-    /// Cancel a reminder by its ID.
-    public func sendCancelReminder(id: String) throws {
-        try send(ReminderCancelMessage(id: id))
     }
 
     // MARK: - Work Items (Task Queue)

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -96,8 +96,6 @@ extension DaemonClient {
             onToolNamesListResponse?(msg)
         case .schedulesListResponse(let msg):
             onSchedulesListResponse?(msg.schedules)
-        case .remindersListResponse(let msg):
-            onRemindersListResponse?(msg.reminders)
         case .skillStateChanged(let msg):
             onSkillStateChanged?(msg)
         case .skillsOperationResponse(let msg):

--- a/clients/shared/IPC/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/IPC/Generated/GeneratedAPITypes.swift
@@ -3396,56 +3396,6 @@ public struct IPCRegenerateRequest: Codable, Sendable {
     }
 }
 
-public struct IPCReminderCancel: Codable, Sendable {
-    public let type: String
-    public let id: String
-
-    public init(type: String, id: String) {
-        self.type = type
-        self.id = id
-    }
-}
-
-public struct IPCRemindersList: Codable, Sendable {
-    public let type: String
-
-    public init(type: String) {
-        self.type = type
-    }
-}
-
-public struct IPCRemindersListResponse: Codable, Sendable {
-    public let type: String
-    public let reminders: [IPCRemindersListResponseReminder]
-
-    public init(type: String, reminders: [IPCRemindersListResponseReminder]) {
-        self.type = type
-        self.reminders = reminders
-    }
-}
-
-public struct IPCRemindersListResponseReminder: Codable, Sendable {
-    public let id: String
-    public let label: String
-    public let message: String
-    public let fireAt: Int
-    public let mode: String
-    public let status: String
-    public let firedAt: Int?
-    public let createdAt: Int
-
-    public init(id: String, label: String, message: String, fireAt: Int, mode: String, status: String, firedAt: Int?, createdAt: Int) {
-        self.id = id
-        self.label = label
-        self.message = message
-        self.fireAt = fireAt
-        self.mode = mode
-        self.status = status
-        self.firedAt = firedAt
-        self.createdAt = createdAt
-    }
-}
-
 public struct IPCRemoveTrustRule: Codable, Sendable {
     public let type: String
     public let id: String
@@ -3613,8 +3563,12 @@ public struct IPCSchedulesListResponseSchedule: Codable, Sendable {
     public let lastRunAt: Int?
     public let lastStatus: String?
     public let description: String
+    public let mode: String
+    public let status: String
+    public let routingIntent: String
+    public let isOneShot: Bool
 
-    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String, cronExpression: String, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String) {
+    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String, cronExpression: String, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
         self.id = id
         self.name = name
         self.enabled = enabled
@@ -3627,6 +3581,10 @@ public struct IPCSchedulesListResponseSchedule: Codable, Sendable {
         self.lastRunAt = lastRunAt
         self.lastStatus = lastStatus
         self.description = description
+        self.mode = mode
+        self.status = status
+        self.routingIntent = routingIntent
+        self.isOneShot = isOneShot
     }
 }
 

--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -54,16 +54,6 @@ extension HTTPTransport {
                 return true
             }
 
-            // --- Reminders ---
-            if message is RemindersListMessage {
-                Task { await self.sendGenericPost(.reminders, method: "GET", label: "reminders_list") }
-                return true
-            }
-            if let msg = message as? ReminderCancelMessage {
-                Task { await self.sendGenericPost(.reminderCancel(id: msg.id), label: "reminder_cancel") }
-                return true
-            }
-
             // --- Diagnostics ---
             if let msg = message as? DiagnosticsExportRequestMessage {
                 Task { await self.sendDiagnosticsExport(msg) }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -391,10 +391,6 @@ public final class HTTPTransport {
         // Suggestion
         case suggestion
 
-        // Reminders
-        case reminders
-        case reminderCancel(id: String)
-
         // Heartbeat
         case heartbeatConfig
         case heartbeatRuns
@@ -784,12 +780,6 @@ public final class HTTPTransport {
         // Suggestion
         case .suggestion:
             return ("/v1/suggestion", nil)
-        // Reminders
-        case .reminders:
-            return ("/v1/reminders", nil)
-        case .reminderCancel(let id):
-            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
-            return ("/v1/reminders/\(encoded)/cancel", nil)
         // Heartbeat
         case .heartbeatConfig:
             return ("/v1/heartbeat/config", nil)
@@ -1168,12 +1158,6 @@ public final class HTTPTransport {
         // Suggestion
         case .suggestion:
             return ("\(prefix)/suggestion/", nil)
-        // Reminders
-        case .reminders:
-            return ("\(prefix)/reminders/", nil)
-        case .reminderCancel(let id):
-            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
-            return ("\(prefix)/reminders/\(encoded)/cancel/", nil)
         // Heartbeat
         case .heartbeatConfig:
             return ("\(prefix)/heartbeat/config/", nil)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1288,36 +1288,6 @@ extension IPCSchedulesListResponseSchedule: Identifiable {}
 /// Backed by generated `IPCSchedulesListResponse`.
 public typealias SchedulesListResponseMessage = IPCSchedulesListResponse
 
-/// A single reminder item returned from the daemon.
-/// Backed by generated `IPCRemindersListResponseReminder`.
-public typealias ReminderItem = IPCRemindersListResponseReminder
-
-extension IPCRemindersListResponseReminder: Identifiable {}
-
-/// Response containing all reminders.
-/// Backed by generated `IPCRemindersListResponse`.
-public typealias RemindersListResponseMessage = IPCRemindersListResponse
-
-/// Request all reminders from the daemon.
-/// Backed by generated `IPCRemindersList`.
-public typealias RemindersListMessage = IPCRemindersList
-
-extension IPCRemindersList {
-    public init() {
-        self.init(type: "reminders_list")
-    }
-}
-
-/// Cancel a reminder by ID.
-/// Backed by generated `IPCReminderCancel`.
-public typealias ReminderCancelMessage = IPCReminderCancel
-
-extension IPCReminderCancel {
-    public init(id: String) {
-        self.init(type: "reminder_cancel", id: id)
-    }
-}
-
 /// Request all schedules from the daemon.
 /// Backed by generated `IPCSchedulesList`.
 public typealias SchedulesListMessage = IPCSchedulesList
@@ -2173,7 +2143,6 @@ public enum ServerMessage: Decodable, Sendable {
     case toolPermissionSimulateResponse(ToolPermissionSimulateResponseMessage)
     case toolNamesListResponse(ToolNamesListResponseMessage)
     case acceptStarterBundleResponse(IPCAcceptStarterBundleResponse)
-    case remindersListResponse(RemindersListResponseMessage)
     case schedulesListResponse(SchedulesListResponseMessage)
     case appsListResponse(AppsListResponseMessage)
     case appUpdatePreviewResponse(AppUpdatePreviewResponseMessage)
@@ -2458,9 +2427,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "accept_starter_bundle_response":
             let message = try IPCAcceptStarterBundleResponse(from: decoder)
             self = .acceptStarterBundleResponse(message)
-        case "reminders_list_response":
-            let message = try RemindersListResponseMessage(from: decoder)
-            self = .remindersListResponse(message)
         case "schedules_list_response":
             let message = try SchedulesListResponseMessage(from: decoder)
             self = .schedulesListResponse(message)


### PR DESCRIPTION
## Summary
- Remove RemindersList, ReminderCancel, RemindersListResponse IPC types from TypeScript and Swift
- Update macOS RemindersView and iOS RemindersSection to use schedule store with one-shot filter
- Add mode, status, routingIntent, isOneShot fields to schedule list response in Swift types
- Remove transition HTTP shims for /v1/reminders endpoints
- Clean up dead reminder tool name references in ChatMessage and ToolConfirmationNotificationService
- Filter ScheduledTasksView/SchedulesSection to exclude one-shot schedules (shown in reminders view)

Part of plan: combine-schedules-reminders.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
