### PR TITLE
fix: update tool-preview-lifecycle test to use valid channel/interface IDs

### DIFF
--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -135,12 +135,12 @@ function createMockDeps(
       get: () => () => {},
     }) as unknown as EventHandlerDeps["rlog"],
     turnChannelContext: {
-      userMessageChannel: "desktop",
-      assistantMessageChannel: "desktop",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
     } as EventHandlerDeps["turnChannelContext"],
     turnInterfaceContext: {
-      userMessageInterface: "chat",
-      assistantMessageInterface: "chat",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
     } as EventHandlerDeps["turnInterfaceContext"],
     ...overrides,
   } as EventHandlerDeps;


### PR DESCRIPTION
## Summary
- Replace invalid `"desktop"` channel with `"vellum"` and `"chat"` interface with `"macos"` in tool-preview-lifecycle test
- `ChannelId` does not include `"desktop"` and `InterfaceId` does not include `"chat"` per the current type definitions in `channels/types.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22927298430/job/66540717755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
