### PR TITLE
Delete the remaining IPC handler-map infrastructure

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -9,7 +9,7 @@ import {
 } from "../../memory/attachments-store.js";
 import { addMessage } from "../../memory/conversation-crud.js";
 import type { RecordingOptions, RecordingStatus } from "../message-protocol.js";
-import { defineHandlers, type HandlerContext, log } from "./shared.js";
+import { type HandlerContext, log } from "./shared.js";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -1045,19 +1045,3 @@ export function __resetRecordingState(): void {
   finalizedRecordingIds.clear();
   activeRestartToken = null;
 }
-
-// ─── IPC handler wrapper ─────────────────────────────────────────────────────
-
-/** IPC-compatible wrapper: ignores the socket (unused) and delegates to core. */
-async function handleRecordingStatusIpc(
-  msg: RecordingStatus,
-  ctx: HandlerContext,
-): Promise<void> {
-  return handleRecordingStatusCore(msg, ctx);
-}
-
-// ─── Export handler group ────────────────────────────────────────────────────
-
-export const recordingHandlers = defineHandlers({
-  recording_status: handleRecordingStatusIpc,
-});

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -13,7 +13,6 @@ import { getLogger } from "../../util/logger.js";
 import { estimateBase64Bytes } from "../assistant-attachments.js";
 import { ComputerUseSession } from "../computer-use-session.js";
 import type {
-  ClientMessage,
   ServerMessage,
   SessionTransportMetadata,
 } from "../message-protocol.js";
@@ -169,29 +168,6 @@ export interface HandlerContext {
   touchSession(sessionId: string): void;
   /** Optional heartbeat service reference for "Run Now" support. */
   heartbeatService?: HeartbeatService;
-}
-
-// ─── Typed dispatch ──────────────────────────────────────────────────────────
-
-type MessageType = ClientMessage["type"];
-// 'auth' is handled at the transport layer (server.ts) and never reaches dispatch.
-export type DispatchableType = Exclude<MessageType, "auth">;
-type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
-type MessageHandler<T extends MessageType> = (
-  msg: MessageOfType<T>,
-  ctx: HandlerContext,
-) => void | Promise<void>;
-export type DispatchMap = { [T in DispatchableType]: MessageHandler<T> };
-
-/**
- * Type-safe handler group definition. Preserves exact key types so the
- * combined spread in index.ts can be checked for exhaustiveness via
- * `satisfies DispatchMap` instead of an unsafe `as DispatchMap` cast.
- */
-export function defineHandlers<K extends DispatchableType>(
-  handlers: Pick<DispatchMap, K>,
-): Pick<DispatchMap, K> {
-  return handlers;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove recordingHandlers export and handleRecordingStatusIpc wrapper from recording.ts
- Delete MessageType, DispatchableType, MessageOfType, MessageHandler, DispatchMap, and defineHandlers from shared.ts
- Complete removal of the IPC dispatch-map infrastructure

Part of plan: ipc-handler-dispatch-cleanup.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
