### PR TITLE
fix: correct fire_at validation order and update side-effect tool in policy test

### DIFF
--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -737,8 +737,8 @@ describe("ToolExecutor verification control-plane policy gate", () => {
   test("unverified channel actor is blocked from side-effect tools", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
-      "reminder_create",
-      { fire_at: "2026-02-27T12:00:00-05:00", label: "test", message: "hello" },
+      "schedule_create",
+      { name: "test", fire_at: "2026-02-27T12:00:00-05:00", message: "hello" },
       makeContext({ trustClass: "unknown" }),
     );
     expect(result.isError).toBe(true);
@@ -748,8 +748,8 @@ describe("ToolExecutor verification control-plane policy gate", () => {
   test("guardian actor can execute side-effect tools", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
-      "reminder_create",
-      { fire_at: "2026-02-27T12:00:00-05:00", label: "test", message: "hello" },
+      "schedule_create",
+      { name: "test", fire_at: "2026-02-27T12:00:00-05:00", message: "hello" },
       makeContext({ trustClass: "guardian" }),
     );
     expect(result.isError).toBe(false);

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -69,19 +69,19 @@ export async function executeScheduleCreate(
 
   // ── One-shot schedule (fire_at) ──────────────────────────────────
   if (fireAt) {
-    // Require explicit timezone (Z or ±HH:MM offset) to avoid host-timezone ambiguity
-    if (!/(?:Z|[+-]\d{2}:\d{2})\s*$/.test(fireAt)) {
-      return {
-        content:
-          "Error: fire_at must include a timezone offset (e.g. 2025-06-15T09:00:00Z or 2025-06-15T09:00:00+05:30)",
-        isError: true,
-      };
-    }
     const fireAtMs = Date.parse(fireAt);
     if (isNaN(fireAtMs)) {
       return {
         content:
           "Error: fire_at must be a valid ISO 8601 timestamp (e.g. 2025-06-15T09:00:00Z)",
+        isError: true,
+      };
+    }
+    // Require explicit timezone (Z or ±HH:MM offset) to avoid host-timezone ambiguity
+    if (!/(?:Z|[+-]\d{2}:\d{2})\s*$/.test(fireAt)) {
+      return {
+        content:
+          "Error: fire_at must include a timezone offset (e.g. 2025-06-15T09:00:00Z or 2025-06-15T09:00:00+05:30)",
         isError: true,
       };
     }


### PR DESCRIPTION
## Summary
- Reorder `fire_at` validation in `schedule-create.ts` so the ISO 8601 parse check runs before the timezone regex check — ensures "not-a-date" returns the expected "valid ISO 8601" error message
- Replace removed `reminder_create` with `schedule_create` in `verification-control-plane-policy.test.ts` side-effect tool tests — `reminder_create` was deleted in #14954 and is no longer in `SIDE_EFFECT_TOOLS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
