### PR TITLE
M1: Swap menu bar click actions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -176,9 +176,9 @@ extension AppDelegate {
             return
         }
         if event.type == .rightMouseUp || event.modifierFlags.contains(.control) {
-            showStatusMenu()
-        } else {
             toggleQuickInput()
+        } else {
+            showStatusMenu()
         }
     }
 


### PR DESCRIPTION
Swap the click handler in statusBarButtonClicked so left click shows the status menu and right click shows the quick input panel. Closes #14977.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
