### PR TITLE
fix: accept basic ISO8601 UTC offsets (±HHMM) in fire_at validation

### DIFF
--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -77,8 +77,8 @@ export async function executeScheduleCreate(
         isError: true,
       };
     }
-    // Require explicit timezone (Z or ±HH:MM offset) to avoid host-timezone ambiguity
-    if (!/(?:Z|[+-]\d{2}:\d{2})\s*$/.test(fireAt)) {
+    // Require explicit timezone (Z, ±HH:MM, or ±HHMM offset) to avoid host-timezone ambiguity
+    if (!/(?:Z|[+-]\d{2}:?\d{2})\s*$/.test(fireAt)) {
       return {
         content:
           "Error: fire_at must include a timezone offset (e.g. 2025-06-15T09:00:00Z or 2025-06-15T09:00:00+05:30)",


### PR DESCRIPTION
## Summary
- Update fire_at timezone validation regex to also accept ±HHMM (basic ISO 8601 offset without colon)
- Previously only Z and ±HH:MM were accepted

Addresses review feedback on #14958.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
