### PR TITLE
fix: make notify-mode error tracking reachable and reset failure state on success

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -299,8 +299,8 @@ export async function runDaemon(): Promise<void> {
             : undefined,
         );
       },
-      (schedule) => {
-        void emitNotificationSignal({
+      async (schedule) => {
+        await emitNotificationSignal({
           sourceEventName: "schedule.notify",
           sourceChannel: "scheduler",
           sourceSessionId: schedule.id,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -35,7 +35,7 @@ export type ScheduleNotifyModeNotifier = (payload: {
   message: string;
   routingIntent: RoutingIntent;
   routingHints: Record<string, unknown>;
-}) => void;
+}) => Promise<void>;
 
 export type ScheduleNotifier = (schedule: { id: string; name: string }) => void;
 
@@ -129,7 +129,7 @@ async function runScheduleOnce(
           { jobId: job.id, name: job.name, isOneShot },
           "Firing schedule notification",
         );
-        notifyScheduleOneShot({
+        await notifyScheduleOneShot({
           id: job.id,
           label: job.name,
           message: job.message,
@@ -138,6 +138,11 @@ async function runScheduleOnce(
         });
         if (isOneShot) {
           completeOneShot(job.id);
+        } else {
+          // Track recurring notify-mode success so lastStatus resets to ok
+          // and retryCount clears after a transient failure.
+          const runId = createScheduleRun(job.id, `notify-ok:${job.id}`);
+          completeScheduleRun(runId, { status: "ok" });
         }
       } catch (err) {
         log.warn(


### PR DESCRIPTION
## Summary
- Await notification signal instead of fire-and-forget so errors propagate to the scheduler catch block
- Reset lastStatus/retryCount on successful recurring notify executions
- Error tracking catch block was previously unreachable due to void/fire-and-forget pattern

Addresses review feedback on #14960.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
