### PR TITLE
Add EmbeddingInput union type for multimodal embedding inputs

### DIFF
--- a/assistant/src/memory/embedding-types.test.ts
+++ b/assistant/src/memory/embedding-types.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeEmbeddingInput,
+  embeddingInputContentHash,
+  isTextInput,
+  type EmbeddingInput,
+  type MultimodalEmbeddingInput,
+} from "./embedding-types.js";
+
+describe("normalizeEmbeddingInput", () => {
+  test("converts a raw string to a TextEmbeddingInput", () => {
+    const result = normalizeEmbeddingInput("hello");
+    expect(result).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("passes through a TextEmbeddingInput unchanged", () => {
+    const input: MultimodalEmbeddingInput = { type: "text", text: "hello" };
+    const result = normalizeEmbeddingInput(input);
+    expect(result).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("passes through an ImageEmbeddingInput unchanged", () => {
+    const input: MultimodalEmbeddingInput = {
+      type: "image",
+      data: Buffer.from("fake-png"),
+      mimeType: "image/png",
+    };
+    const result = normalizeEmbeddingInput(input);
+    expect(result).toBe(input);
+  });
+
+  test("passes through an AudioEmbeddingInput unchanged", () => {
+    const input: MultimodalEmbeddingInput = {
+      type: "audio",
+      data: Buffer.from("fake-audio"),
+      mimeType: "audio/mp3",
+    };
+    const result = normalizeEmbeddingInput(input);
+    expect(result).toBe(input);
+  });
+
+  test("passes through a VideoEmbeddingInput unchanged", () => {
+    const input: MultimodalEmbeddingInput = {
+      type: "video",
+      data: Buffer.from("fake-video"),
+      mimeType: "video/mp4",
+    };
+    const result = normalizeEmbeddingInput(input);
+    expect(result).toBe(input);
+  });
+});
+
+describe("embeddingInputContentHash", () => {
+  test("produces consistent hash for the same text input", () => {
+    const hash1 = embeddingInputContentHash("hello");
+    const hash2 = embeddingInputContentHash("hello");
+    expect(hash1).toBe(hash2);
+  });
+
+  test("produces same hash for raw string and equivalent TextEmbeddingInput", () => {
+    const hash1 = embeddingInputContentHash("hello");
+    const hash2 = embeddingInputContentHash({ type: "text", text: "hello" });
+    expect(hash1).toBe(hash2);
+  });
+
+  test("produces different hashes for different text inputs", () => {
+    const hash1 = embeddingInputContentHash("hello");
+    const hash2 = embeddingInputContentHash("world");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("produces distinct hashes for text vs binary inputs with same byte content", () => {
+    const content = "hello";
+    const textHash = embeddingInputContentHash(content);
+    const imageHash = embeddingInputContentHash({
+      type: "image",
+      data: Buffer.from(content),
+      mimeType: "image/png",
+    });
+    expect(textHash).not.toBe(imageHash);
+  });
+
+  test("produces different hashes for same data but different mime types", () => {
+    const data = Buffer.from("same-data");
+    const hash1 = embeddingInputContentHash({
+      type: "image",
+      data,
+      mimeType: "image/png",
+    });
+    const hash2 = embeddingInputContentHash({
+      type: "image",
+      data,
+      mimeType: "image/jpeg",
+    });
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("produces different hashes for same data but different modality types", () => {
+    const data = Buffer.from("same-data");
+    const imageHash = embeddingInputContentHash({
+      type: "image",
+      data,
+      mimeType: "application/octet-stream",
+    });
+    const audioHash = embeddingInputContentHash({
+      type: "audio",
+      data,
+      mimeType: "application/octet-stream",
+    });
+    expect(imageHash).not.toBe(audioHash);
+  });
+
+  test("returns a hex string", () => {
+    const hash = embeddingInputContentHash("test");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("isTextInput", () => {
+  test("returns true for a raw string", () => {
+    expect(isTextInput("hello")).toBe(true);
+  });
+
+  test("returns true for a TextEmbeddingInput", () => {
+    expect(isTextInput({ type: "text", text: "hello" })).toBe(true);
+  });
+
+  test("returns false for an ImageEmbeddingInput", () => {
+    const input: EmbeddingInput = {
+      type: "image",
+      data: Buffer.from("fake"),
+      mimeType: "image/png",
+    };
+    expect(isTextInput(input)).toBe(false);
+  });
+
+  test("returns false for an AudioEmbeddingInput", () => {
+    const input: EmbeddingInput = {
+      type: "audio",
+      data: Buffer.from("fake"),
+      mimeType: "audio/mp3",
+    };
+    expect(isTextInput(input)).toBe(false);
+  });
+
+  test("returns false for a VideoEmbeddingInput", () => {
+    const input: EmbeddingInput = {
+      type: "video",
+      data: Buffer.from("fake"),
+      mimeType: "video/mp4",
+    };
+    expect(isTextInput(input)).toBe(false);
+  });
+});

--- a/assistant/src/memory/embedding-types.ts
+++ b/assistant/src/memory/embedding-types.ts
@@ -1,0 +1,65 @@
+import { createHash } from "crypto";
+
+export type EmbeddingTaskType =
+  | "SEMANTIC_SIMILARITY"
+  | "CLASSIFICATION"
+  | "CLUSTERING"
+  | "RETRIEVAL_DOCUMENT"
+  | "RETRIEVAL_QUERY"
+  | "CODE_RETRIEVAL_QUERY"
+  | "QUESTION_ANSWERING"
+  | "FACT_VERIFICATION";
+
+export interface TextEmbeddingInput {
+  type: "text";
+  text: string;
+}
+
+export interface ImageEmbeddingInput {
+  type: "image";
+  data: Buffer;
+  mimeType: string; // "image/png" | "image/jpeg"
+}
+
+export interface AudioEmbeddingInput {
+  type: "audio";
+  data: Buffer;
+  mimeType: string; // "audio/mp3" | "audio/wav"
+}
+
+export interface VideoEmbeddingInput {
+  type: "video";
+  data: Buffer;
+  mimeType: string; // "video/mp4" | "video/mov"
+}
+
+export type MultimodalEmbeddingInput =
+  | TextEmbeddingInput
+  | ImageEmbeddingInput
+  | AudioEmbeddingInput
+  | VideoEmbeddingInput;
+
+/** Accepts raw strings as shorthand for text inputs. */
+export type EmbeddingInput = string | MultimodalEmbeddingInput;
+
+export function normalizeEmbeddingInput(input: EmbeddingInput): MultimodalEmbeddingInput {
+  if (typeof input === "string") return { type: "text", text: input };
+  return input;
+}
+
+export function embeddingInputContentHash(input: EmbeddingInput): string {
+  const normalized = normalizeEmbeddingInput(input);
+  const hash = createHash("sha256");
+  hash.update(normalized.type);
+  if (normalized.type === "text") {
+    hash.update(normalized.text);
+  } else {
+    hash.update(normalized.mimeType);
+    hash.update(normalized.data);
+  }
+  return hash.digest("hex");
+}
+
+export function isTextInput(input: EmbeddingInput): input is string | TextEmbeddingInput {
+  return typeof input === "string" || (typeof input === "object" && input.type === "text");
+}


### PR DESCRIPTION
## Summary
- Add `EmbeddingInput` union type supporting text, image, audio, and video inputs
- Add normalizer, content hash, and type guard helpers
- Add `EmbeddingTaskType` for Gemini task type configuration

Part of plan: multimodal-embedding.md (PR 1 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
