### PR TITLE
Widen EmbeddingBackend interface to accept EmbeddingInput union type

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -6,6 +6,21 @@ import { getLogger } from "../util/logger.js";
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
 import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
+import {
+  type EmbeddingInput,
+  type MultimodalEmbeddingInput,
+  type TextEmbeddingInput,
+  normalizeEmbeddingInput,
+  embeddingInputContentHash,
+  isTextInput,
+} from "./embedding-types.js";
+
+export type {
+  EmbeddingInput,
+  MultimodalEmbeddingInput,
+  TextEmbeddingInput,
+};
+export { normalizeEmbeddingInput, embeddingInputContentHash, isTextInput };
 
 const log = getLogger("memory-embeddings");
 
@@ -34,12 +49,12 @@ class LazyLocalEmbeddingBackend implements EmbeddingBackend {
   }
 
   async embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
     const backend = await this.getDelegate();
     try {
-      return await backend.embed(texts, options);
+      return await backend.embed(inputs, options);
     } catch (err) {
       // The onnxruntime-node failure surfaces here during the first embed() call
       // (via LocalEmbeddingBackend.initialize()). Mark broken so auto mode stops
@@ -103,18 +118,19 @@ function estimateEntryBytes(key: string, vector: number[]): number {
   return key.length * 2 + vector.length * 8;
 }
 
-function vectorCacheKey(provider: string, model: string, text: string): string {
+function vectorCacheKey(provider: string, model: string, input: EmbeddingInput): string {
+  const contentHash = embeddingInputContentHash(input);
   return createHash("sha256")
-    .update(`${provider}\0${model}\0${text}`)
+    .update(`${provider}\0${model}\0${contentHash}`)
     .digest("hex");
 }
 
 function getFromVectorCache(
   provider: string,
   model: string,
-  text: string,
+  input: EmbeddingInput,
 ): number[] | undefined {
-  const key = vectorCacheKey(provider, model, text);
+  const key = vectorCacheKey(provider, model, input);
   const v = vectorCache.get(key);
   if (v !== undefined) {
     // LRU refresh: move to end of insertion order
@@ -127,10 +143,10 @@ function getFromVectorCache(
 function putInVectorCache(
   provider: string,
   model: string,
-  text: string,
+  input: EmbeddingInput,
   vector: number[],
 ): void {
-  const key = vectorCacheKey(provider, model, text);
+  const key = vectorCacheKey(provider, model, input);
   // If replacing an existing entry, subtract its old cost first
   const existing = vectorCache.get(key);
   if (existing !== undefined) {
@@ -188,7 +204,7 @@ export interface EmbeddingBackend {
   readonly provider: EmbeddingProviderName;
   readonly model: string;
   embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]>;
 }
@@ -336,7 +352,7 @@ export function getMemoryBackendStatus(config: AssistantConfig): {
 
 export async function embedWithBackend(
   config: AssistantConfig,
-  texts: string[],
+  inputs: EmbeddingInput[],
   options?: EmbeddingRequestOptions,
 ): Promise<{
   provider: EmbeddingProviderName;
@@ -361,8 +377,8 @@ export async function embedWithBackend(
       : [];
 
   // ── In-memory cache check (primary provider only) ──────────────
-  const cached: (number[] | null)[] = texts.map((t) => {
-    const v = getFromVectorCache(primaryProvider, primaryModel, t);
+  const cached: (number[] | null)[] = inputs.map((input) => {
+    const v = getFromVectorCache(primaryProvider, primaryModel, input);
     if (v && v.length === expectedDim) return v;
     return null;
   });
@@ -378,23 +394,23 @@ export async function embedWithBackend(
     };
   }
 
-  // ── Embed uncached texts ────────────────────────────────────────
+  // ── Embed uncached inputs ───────────────────────────────────────
   const backends: EmbeddingBackend[] = [selection.backend, ...fallbacks];
 
   let lastErr: unknown;
   for (const backend of backends) {
     const isPrimary = backend === selection.backend;
-    // For the primary backend, only embed uncached texts and merge with cached.
-    // For fallback backends, embed ALL texts since the cache was keyed to the primary.
-    const textsToEmbed = isPrimary
-      ? uncachedIndices.map((i) => texts[i])
-      : texts;
+    // For the primary backend, only embed uncached inputs and merge with cached.
+    // For fallback backends, embed ALL inputs since the cache was keyed to the primary.
+    const inputsToEmbed = isPrimary
+      ? uncachedIndices.map((i) => inputs[i])
+      : inputs;
 
     try {
-      const vectors = await backend.embed(textsToEmbed, options);
-      if (vectors.length !== textsToEmbed.length) {
+      const vectors = await backend.embed(inputsToEmbed, options);
+      if (vectors.length !== inputsToEmbed.length) {
         throw new Error(
-          `Embedding backend returned ${vectors.length} vectors for ${textsToEmbed.length} texts`,
+          `Embedding backend returned ${vectors.length} vectors for ${inputsToEmbed.length} inputs`,
         );
       }
       for (const vec of vectors) {
@@ -406,11 +422,11 @@ export async function embedWithBackend(
       }
 
       // Populate cache with freshly embedded vectors
-      for (let i = 0; i < textsToEmbed.length; i++) {
+      for (let i = 0; i < inputsToEmbed.length; i++) {
         putInVectorCache(
           backend.provider,
           backend.model,
-          textsToEmbed[i],
+          inputsToEmbed[i],
           vectors[i],
         );
       }

--- a/assistant/src/memory/embedding-gemini.ts
+++ b/assistant/src/memory/embedding-gemini.ts
@@ -1,7 +1,9 @@
 import type {
   EmbeddingBackend,
+  EmbeddingInput,
   EmbeddingRequestOptions,
 } from "./embedding-backend.js";
+import { normalizeEmbeddingInput } from "./embedding-types.js";
 
 interface GeminiEmbedResponse {
   embedding?: {
@@ -20,21 +22,29 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
   }
 
   async embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
     const vectors: number[][] = [];
-    for (const text of texts) {
-      const values = await this.embedSingle(text, options);
+    for (const input of inputs) {
+      const values = await this.embedSingle(input, options);
       vectors.push(values);
     }
     return vectors;
   }
 
   private async embedSingle(
-    text: string,
+    input: EmbeddingInput,
     options?: EmbeddingRequestOptions,
   ): Promise<number[]> {
+    const normalized = normalizeEmbeddingInput(input);
+    if (normalized.type !== "text") {
+      throw new Error(
+        "Gemini embedding backend only supports text inputs (multimodal support coming soon)",
+      );
+    }
+    const text = normalized.text;
+
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
       this.model,
     )}:embedContent?key=${encodeURIComponent(this.apiKey)}`;

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -6,8 +6,10 @@ import { getEmbeddingModelsDir, getRootDir } from "../util/platform.js";
 import { PromiseGuard } from "../util/promise-guard.js";
 import type {
   EmbeddingBackend,
+  EmbeddingInput,
   EmbeddingRequestOptions,
 } from "./embedding-backend.js";
+import { normalizeEmbeddingInput } from "./embedding-types.js";
 import { EmbeddingRuntimeManager } from "./embedding-runtime-manager.js";
 
 const log = getLogger("memory-embedding-local");
@@ -56,10 +58,20 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
   }
 
   async embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
-    if (texts.length === 0) return [];
+    if (inputs.length === 0) return [];
+
+    const texts = inputs.map((i) => {
+      const n = normalizeEmbeddingInput(i);
+      if (n.type !== "text") {
+        throw new Error(
+          "Local embedding backend only supports text inputs",
+        );
+      }
+      return n.text;
+    });
     if (options?.signal?.aborted)
       throw new DOMException("Aborted", "AbortError");
 

--- a/assistant/src/memory/embedding-ollama.ts
+++ b/assistant/src/memory/embedding-ollama.ts
@@ -1,8 +1,10 @@
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import type {
   EmbeddingBackend,
+  EmbeddingInput,
   EmbeddingRequestOptions,
 } from "./embedding-backend.js";
+import { normalizeEmbeddingInput } from "./embedding-types.js";
 
 interface OllamaEmbeddingsResponse {
   data?: Array<{ embedding: number[] }>;
@@ -24,10 +26,21 @@ export class OllamaEmbeddingBackend implements EmbeddingBackend {
   }
 
   async embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
-    if (texts.length === 0) return [];
+    if (inputs.length === 0) return [];
+
+    const texts = inputs.map((i) => {
+      const n = normalizeEmbeddingInput(i);
+      if (n.type !== "text") {
+        throw new Error(
+          "Ollama embedding backend only supports text inputs",
+        );
+      }
+      return n.text;
+    });
+
     const response = await fetch(`${this.baseUrl}/embeddings`, {
       method: "POST",
       headers: {

--- a/assistant/src/memory/embedding-openai.ts
+++ b/assistant/src/memory/embedding-openai.ts
@@ -2,8 +2,10 @@ import OpenAI from "openai";
 
 import type {
   EmbeddingBackend,
+  EmbeddingInput,
   EmbeddingRequestOptions,
 } from "./embedding-backend.js";
+import { normalizeEmbeddingInput } from "./embedding-types.js";
 
 export class OpenAIEmbeddingBackend implements EmbeddingBackend {
   readonly provider = "openai" as const;
@@ -16,10 +18,21 @@ export class OpenAIEmbeddingBackend implements EmbeddingBackend {
   }
 
   async embed(
-    texts: string[],
+    inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
-    if (texts.length === 0) return [];
+    if (inputs.length === 0) return [];
+
+    const texts = inputs.map((i) => {
+      const n = normalizeEmbeddingInput(i);
+      if (n.type !== "text") {
+        throw new Error(
+          "OpenAI embedding backend only supports text inputs",
+        );
+      }
+      return n.text;
+    });
+
     const response = await this.client.embeddings.create(
       {
         model: this.model,


### PR DESCRIPTION
## Summary
- Change `EmbeddingBackend.embed()` from `string[]` to `EmbeddingInput[]`
- Update all four backends (local, OpenAI, Gemini, Ollama) to accept the new type
- Text-only backends throw descriptive errors on non-text inputs
- Update in-memory vector cache to use modality-aware content hashing

Part of plan: multimodal-embedding.md (PR 4 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
