### PR TITLE
Swap menu bar click actions: left-click for menu, right-click for quick input

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -176,9 +176,9 @@ extension AppDelegate {
             return
         }
         if event.type == .rightMouseUp || event.modifierFlags.contains(.control) {
-            showStatusMenu()
-        } else {
             toggleQuickInput()
+        } else {
+            showStatusMenu()
         }
     }
 


### PR DESCRIPTION
## Summary
Swaps the menu bar icon click behaviors so that left click shows the dropdown menu and right click opens the quick input chat panel. Previously the behavior was reversed.

## Changes
- Swapped `showStatusMenu()` and `toggleQuickInput()` calls in `statusBarButtonClicked(_:)` in `AppDelegate+MenuBar.swift`

## Milestone PRs (merged into feature branch)
- #14978: M1: Swap menu bar click actions

## Project issue
Closes #14976

## Test plan
- [ ] Build the macOS app
- [ ] Left-click the menu bar icon — verify the dropdown menu appears
- [ ] Right-click the menu bar icon — verify the quick input panel appears
- [ ] Control+click the menu bar icon — verify the quick input panel appears

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
