### PR TITLE
fix: use non-placeholder values in secret ingress HTTP parity tests

### DIFF
--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -254,7 +254,7 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
 
   test("handleSendMessage rejects messages containing AWS credentials", async () => {
     const secretContent =
-      "Here is my AWS key AKIAIOSFODNN7EXAMPLE and secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+      "Here is my AWS key AKIAQRSTUVWXYZ123456 and secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
     const session = makeSession({ persistUserMessage, runAgentLoop });
@@ -274,9 +274,9 @@ describe("HTTP POST /v1/messages blocks secret ingress", () => {
     expect(runAgentLoop).toHaveBeenCalledTimes(0);
   });
 
-  test("handleSendMessage rejects messages containing Stripe test keys", async () => {
+  test("handleSendMessage rejects messages containing Stripe live API keys", async () => {
     const secretContent =
-      "My Stripe key is sk_test_4eC39HqLyjWDarjtT1zdp7dc";
+      "My Stripe key is sk_live_4eC39HqLyjWDarjtT1zdp7dc";
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
     const session = makeSession({ persistUserMessage, runAgentLoop });


### PR DESCRIPTION
## Summary
- Two tests in \`http-user-message-parity.test.ts\` were using well-known documentation placeholder values (\`AKIAIOSFODNN7EXAMPLE\`, \`sk_test_*\`) that the secret scanner deliberately allowlists, causing them to return 202 instead of 422
- Replace the AWS access key with a non-placeholder value (\`AKIAQRSTUVWXYZ123456\`) that matches the \`AKIA[0-9A-Z]{16}\` pattern and is not allowlisted
- Replace the Stripe test key (\`sk_test_\`) with a live key (\`sk_live_\`) since the Stripe pattern only detects \`sk_live_\` keys and \`sk_test_\` is in the placeholder prefix list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
