### PR TITLE
fix: add UPDATES.md entry for schedule/reminder unification

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -9,7 +9,16 @@ _
 _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
-_
-_ To add release notes, replace this content with real markdown
-_ describing what changed. The sync will only materialize a bulletin
-_ when non-comment content is present.
+
+<!-- vellum-update-release:schedule-reminder-unification -->
+
+### Reminders are now one-shot schedules
+
+The separate reminder system has been unified into the schedule system. What this means:
+
+- **`reminder_create`, `reminder_list`, and `reminder_cancel` tools no longer exist.** Do not attempt to use them.
+- **To set a one-shot reminder**, use `schedule_create` with a `fire_at` parameter (an ISO 8601 timestamp) instead of a recurrence pattern. This replaces `reminder_create`.
+- **To list or cancel reminders**, use `schedule_list` and `schedule_cancel` — they now cover both recurring schedules and one-shot reminders.
+- Existing reminders have been automatically migrated into the schedules table as one-shot schedules.
+
+<!-- /vellum-update-release:schedule-reminder-unification -->


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** UPDATES.md not updated for user-facing change
**What was expected:** Release note about reminder → one-shot schedule migration
**What was found:** UPDATES.md was empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
