### PR TITLE
fix: update CLI notification examples from reminder.fired to schedule.notify

### DIFF
--- a/assistant/src/cli/__tests__/notifications.test.ts
+++ b/assistant/src/cli/__tests__/notifications.test.ts
@@ -190,7 +190,7 @@ describe("notifications send", () => {
       "--source-channel",
       "scheduler",
       "--source-event-name",
-      "reminder.fired",
+      "schedule.notify",
       "--message",
       "Test",
       "--urgency",
@@ -269,7 +269,7 @@ describe("notifications send", () => {
     expect(parsed.error).toContain("bogus.event");
     // Should list valid event names from the registry
     expect(parsed.error).toContain("user.send_notification");
-    expect(parsed.error).toContain("reminder.fired");
+    expect(parsed.error).toContain("schedule.notify");
   });
 
   test("send rejects invalid urgency", async () => {
@@ -399,7 +399,7 @@ describe("notifications list", () => {
 
     createEvent({
       id: `evt-filter-reminder-${Date.now()}`,
-      sourceEventName: "reminder.fired",
+      sourceEventName: "schedule.notify",
       sourceChannel: "scheduler",
       sourceSessionId: "session-filter-2",
       attentionHints: {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** CLI notification docs use stale reminder.fired event name
**What was expected:** Examples should reference schedule.notify
**What was found:** 4 occurrences of reminder.fired in help text, 3 in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
