### PR TITLE
fix: make expression fields nullable in SchedulesListResponse type

### DIFF
--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -58,8 +58,8 @@ export interface SchedulesListResponse {
     name: string;
     enabled: boolean;
     syntax: string;
-    expression: string;
-    cronExpression: string;
+    expression: string | null;
+    cronExpression: string | null;
     timezone: string | null;
     message: string;
     nextRunAt: number;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** SchedulesListResponse declares expression/cronExpression as non-nullable
**What was expected:** string | null to match runtime values for one-shot schedules
**What was found:** string (non-nullable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
