### PR TITLE
Detect vector dimension or embedding model change and rebuild Qdrant collection

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Mock Qdrant REST client ───────────────────────────────────────────
+
+interface MockCallLog {
+  collectionExists: number;
+  getCollection: number;
+  deleteCollection: number;
+  createCollection: number;
+  createPayloadIndex: number;
+  retrieve: number;
+  upsert: number;
+}
+
+let mockCollectionExists: boolean;
+let mockCollectionSize: number;
+let mockSentinelPayload: Record<string, unknown> | null;
+let callLog: MockCallLog;
+
+function resetMockState() {
+  mockCollectionExists = false;
+  mockCollectionSize = 384;
+  mockSentinelPayload = null;
+  callLog = {
+    collectionExists: 0,
+    getCollection: 0,
+    deleteCollection: 0,
+    createCollection: 0,
+    createPayloadIndex: 0,
+    retrieve: 0,
+    upsert: 0,
+  };
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: class MockQdrantClient {
+    async collectionExists(_name: string) {
+      callLog.collectionExists++;
+      return { exists: mockCollectionExists };
+    }
+
+    async getCollection(_name: string) {
+      callLog.getCollection++;
+      return {
+        config: {
+          params: {
+            vectors: { size: mockCollectionSize },
+          },
+        },
+      };
+    }
+
+    async deleteCollection(_name: string) {
+      callLog.deleteCollection++;
+      mockCollectionExists = false;
+    }
+
+    async createCollection(_name: string, _config: unknown) {
+      callLog.createCollection++;
+      mockCollectionExists = true;
+    }
+
+    async createPayloadIndex(_name: string, _config: unknown) {
+      callLog.createPayloadIndex++;
+    }
+
+    async retrieve(_name: string, opts: { ids: string[] }) {
+      callLog.retrieve++;
+      if (
+        mockSentinelPayload &&
+        opts.ids.includes("00000000-0000-0000-0000-000000000000")
+      ) {
+        return [{ id: "00000000-0000-0000-0000-000000000000", payload: mockSentinelPayload }];
+      }
+      return [];
+    }
+
+    async upsert(_name: string, _opts: unknown) {
+      callLog.upsert++;
+    }
+  },
+}));
+
+import { VellumQdrantClient } from "../memory/qdrant-client.js";
+
+beforeEach(() => {
+  resetMockState();
+});
+
+describe("Qdrant collection migration", () => {
+  test("deletes and recreates collection on dimension mismatch", async () => {
+    mockCollectionExists = true;
+    mockCollectionSize = 384; // Current collection has 384-dim vectors
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768, // New config expects 768-dim vectors
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2-preview",
+    });
+
+    await client.ensureCollection();
+
+    expect(callLog.deleteCollection).toBe(1);
+    expect(callLog.createCollection).toBe(1);
+  });
+
+  test("deletes and recreates collection on model-only mismatch", async () => {
+    mockCollectionExists = true;
+    mockCollectionSize = 768; // Same dimension
+    mockSentinelPayload = {
+      _meta: true,
+      embedding_model: "gemini:gemini-embedding-001", // Old model
+    };
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768, // Same dimension
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2-preview", // New model
+    });
+
+    await client.ensureCollection();
+
+    expect(callLog.deleteCollection).toBe(1);
+    expect(callLog.createCollection).toBe(1);
+    // Sentinel should be written for the new model
+    expect(callLog.upsert).toBe(1);
+  });
+
+  test("leaves collection untouched when dimensions and model match", async () => {
+    mockCollectionExists = true;
+    mockCollectionSize = 768;
+    mockSentinelPayload = {
+      _meta: true,
+      embedding_model: "gemini:gemini-embedding-2-preview",
+    };
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768,
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2-preview",
+    });
+
+    await client.ensureCollection();
+
+    expect(callLog.deleteCollection).toBe(0);
+    expect(callLog.createCollection).toBe(0);
+  });
+
+  test("does not rebuild pre-existing collection without sentinel (graceful upgrade)", async () => {
+    mockCollectionExists = true;
+    mockCollectionSize = 768;
+    mockSentinelPayload = null; // No sentinel — pre-existing collection
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768,
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2-preview",
+    });
+
+    await client.ensureCollection();
+
+    // No sentinel found → no model mismatch → collection kept
+    expect(callLog.deleteCollection).toBe(0);
+    expect(callLog.createCollection).toBe(0);
+  });
+
+  test("writes sentinel point when creating a new collection", async () => {
+    mockCollectionExists = false;
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 768,
+      onDisk: false,
+      quantization: "none",
+      embeddingModel: "gemini:gemini-embedding-2-preview",
+    });
+
+    await client.ensureCollection();
+
+    expect(callLog.createCollection).toBe(1);
+    // Sentinel upsert should be called
+    expect(callLog.upsert).toBe(1);
+  });
+
+  test("does not write sentinel when embeddingModel is not provided", async () => {
+    mockCollectionExists = false;
+
+    const client = new VellumQdrantClient({
+      url: "http://localhost:6333",
+      collection: "memory",
+      vectorSize: 384,
+      onDisk: false,
+      quantization: "none",
+      // No embeddingModel
+    });
+
+    await client.ensureCollection();
+
+    expect(callLog.createCollection).toBe(1);
+    // No sentinel should be written
+    expect(callLog.upsert).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/sessions.ts
+++ b/assistant/src/cli/commands/sessions.ts
@@ -12,6 +12,7 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { listConversations } from "../../memory/conversation-queries.js";
+import { selectEmbeddingBackend } from "../../memory/embedding-backend.js";
 import { initQdrantClient } from "../../memory/qdrant-client.js";
 import { timeAgo } from "../../util/time.js";
 import { initializeDb } from "../db.js";
@@ -223,12 +224,17 @@ Examples:
 
       const config = getConfig();
       const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
+      const embeddingSelection = selectEmbeddingBackend(config);
+      const embeddingModel = embeddingSelection.backend
+        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
+        : undefined;
       const qdrant = initQdrantClient({
         url: qdrantUrl,
         collection: config.memory.qdrant.collection,
         vectorSize: config.memory.qdrant.vectorSize,
         onDisk: config.memory.qdrant.onDisk,
         quantization: config.memory.qdrant.quantization,
+        embeddingModel,
       });
       const deleted = await qdrant.deleteCollection();
       if (deleted) {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -30,6 +30,7 @@ import {
   getMessages,
 } from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db.js";
+import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
 import { QdrantManager } from "../memory/qdrant-manager.js";
@@ -257,12 +258,17 @@ export async function runDaemon(): Promise<void> {
     const qdrantManager = new QdrantManager({ url: qdrantUrl });
     try {
       await qdrantManager.start();
+      const embeddingSelection = selectEmbeddingBackend(config);
+      const embeddingModel = embeddingSelection.backend
+        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
+        : undefined;
       initQdrantClient({
         url: qdrantUrl,
         collection: config.memory.qdrant.collection,
         vectorSize: config.memory.qdrant.vectorSize,
         onDisk: config.memory.qdrant.onDisk,
         quantization: config.memory.qdrant.quantization,
+        embeddingModel,
       });
       log.info("Qdrant vector store initialized");
     } catch (err) {

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -11,6 +11,7 @@ export interface QdrantClientConfig {
   vectorSize: number;
   onDisk: boolean;
   quantization: "scalar" | "none";
+  embeddingModel?: string;
 }
 
 export interface QdrantPointPayload {
@@ -60,7 +61,10 @@ export class VellumQdrantClient {
   private readonly vectorSize: number;
   private readonly onDisk: boolean;
   private readonly quantization: "scalar" | "none";
+  private readonly embeddingModel?: string;
   private collectionReady = false;
+
+  private readonly SENTINEL_ID = "00000000-0000-0000-0000-000000000000";
 
   constructor(config: QdrantClientConfig) {
     this.client = new QdrantRestClient({
@@ -71,6 +75,7 @@ export class VellumQdrantClient {
     this.vectorSize = config.vectorSize;
     this.onDisk = config.onDisk;
     this.quantization = config.quantization;
+    this.embeddingModel = config.embeddingModel;
   }
 
   async ensureCollection(): Promise<void> {
@@ -79,8 +84,47 @@ export class VellumQdrantClient {
     try {
       const exists = await this.client.collectionExists(this.collection);
       if (exists.exists) {
-        this.collectionReady = true;
-        return;
+        try {
+          const info = await this.client.getCollection(this.collection);
+          const currentSize = (
+            info.config?.params?.vectors as { size?: number }
+          )?.size;
+          const dimMismatch =
+            currentSize != null && currentSize !== this.vectorSize;
+
+          // Check model identity via a sentinel point that stores the embedding model
+          let modelMismatch = false;
+          if (this.embeddingModel) {
+            const sentinel = await this.readSentinel();
+            if (sentinel && sentinel !== this.embeddingModel) {
+              modelMismatch = true;
+            }
+          }
+
+          if (dimMismatch || modelMismatch) {
+            log.warn(
+              {
+                collection: this.collection,
+                currentSize,
+                expectedSize: this.vectorSize,
+                modelMismatch,
+              },
+              "Qdrant collection incompatible (dimension or model change) — deleting and recreating. Embeddings will be regenerated on demand.",
+            );
+            await this.client.deleteCollection(this.collection);
+            // Fall through to collection creation below
+          } else {
+            this.collectionReady = true;
+            return;
+          }
+        } catch (err) {
+          log.warn(
+            { err },
+            "Failed to verify collection compatibility, assuming compatible",
+          );
+          this.collectionReady = true;
+          return;
+        }
       }
     } catch {
       // Collection doesn't exist, create it
@@ -159,6 +203,11 @@ export class VellumQdrantClient {
         field_schema: "keyword",
       }),
     ]);
+
+    // Write sentinel point to record the active embedding model
+    if (this.embeddingModel) {
+      await this.writeSentinel(this.embeddingModel);
+    }
 
     this.collectionReady = true;
     log.info(
@@ -287,7 +336,9 @@ export class VellumQdrantClient {
       });
     }
 
-    const mustNotConditions: Array<Record<string, unknown>> = [];
+    const mustNotConditions: Array<Record<string, unknown>> = [
+      { key: "_meta", match: { value: true } },
+    ];
     if (excludeMessageIds && excludeMessageIds.length > 0) {
       mustNotConditions.push({
         key: "message_id",
@@ -297,10 +348,8 @@ export class VellumQdrantClient {
 
     const filter: Record<string, unknown> = {
       must: mustConditions,
+      must_not: mustNotConditions,
     };
-    if (mustNotConditions.length > 0) {
-      filter.must_not = mustNotConditions;
-    }
 
     return this.search(vector, limit, filter);
   }
@@ -387,6 +436,36 @@ export class VellumQdrantClient {
       msg.includes("doesn't exist") ||
       msg.includes("not found")
     );
+  }
+
+  private async readSentinel(): Promise<string | null> {
+    try {
+      const points = await this.client.retrieve(this.collection, {
+        ids: [this.SENTINEL_ID],
+        with_payload: true,
+        with_vector: false,
+      });
+      if (points.length === 0) return null;
+      return (
+        ((points[0].payload as Record<string, unknown>)
+          ?.embedding_model as string) ?? null
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeSentinel(model: string): Promise<void> {
+    await this.client.upsert(this.collection, {
+      wait: true,
+      points: [
+        {
+          id: this.SENTINEL_ID,
+          vector: new Array(this.vectorSize).fill(0), // zero vector, never matched in search
+          payload: { _meta: true, embedding_model: model },
+        },
+      ],
+    });
   }
 
   private async findByTarget(


### PR DESCRIPTION
## Summary
- Add sentinel point to Qdrant collection tracking the active embedding model
- Auto-detect dimension mismatch or model change and rebuild collection
- Exclude sentinel point from search results via `_meta` filter
- Wire `embeddingModel` through `QdrantClientConfig` and `initQdrantClient` call sites

Part of plan: multimodal-embedding.md (PR 15 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
