### PR TITLE
fix: sort imports in embedding-types.test.ts

### DIFF
--- a/assistant/src/memory/embedding-types.test.ts
+++ b/assistant/src/memory/embedding-types.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
+
 import {
-  normalizeEmbeddingInput,
+  type EmbeddingInput,
   embeddingInputContentHash,
   isTextInput,
-  type EmbeddingInput,
   type MultimodalEmbeddingInput,
+  normalizeEmbeddingInput,
 } from "./embedding-types.js";
 
 describe("normalizeEmbeddingInput", () => {


### PR DESCRIPTION
## Summary
- Fix import sort order in `assistant/src/memory/embedding-types.test.ts` to resolve lint CI failure
- Added blank line between external and local import groups; sorted named imports alphabetically

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22927716624/job/66542044103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
