### PR TITLE
fix: make expression fields optional in Swift schedule type for one-shot support

### DIFF
--- a/clients/ios/Views/Settings/SchedulesSection.swift
+++ b/clients/ios/Views/Settings/SchedulesSection.swift
@@ -71,9 +71,11 @@ struct SchedulesSection: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                 HStack(spacing: 4) {
-                    Text(schedule.expression)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+                    if let expression = schedule.expression {
+                        Text(expression)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                     if schedule.enabled, schedule.nextRunAt > 0, let nextRun = formatTimestamp(schedule.nextRunAt) {
                         Text("Next: \(nextRun)")
                             .font(.caption2)

--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -187,10 +187,12 @@ private struct ScheduleRow: View {
                     Text(schedule.description)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(schedule.expression)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                    if let expression = schedule.expression {
+                        Text(expression)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
                     HStack(spacing: 6) {
                         if schedule.enabled {
                             Text("Next: \(nextRunText)")

--- a/clients/shared/IPC/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/IPC/Generated/GeneratedAPITypes.swift
@@ -3555,8 +3555,8 @@ public struct IPCSchedulesListResponseSchedule: Codable, Sendable {
     public let name: String
     public let enabled: Bool
     public let syntax: String
-    public let expression: String
-    public let cronExpression: String
+    public let expression: String?
+    public let cronExpression: String?
     public let timezone: String?
     public let message: String
     public let nextRunAt: Int
@@ -3568,7 +3568,7 @@ public struct IPCSchedulesListResponseSchedule: Codable, Sendable {
     public let routingIntent: String
     public let isOneShot: Bool
 
-    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String, cronExpression: String, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
+    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String?, cronExpression: String?, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
         self.id = id
         self.name = name
         self.enabled = enabled


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** Swift type declares expression/cronExpression as non-optional but server sends null for one-shot schedules
**What was expected:** Optional String? types to handle null values
**What was found:** Non-optional String types that would cause JSONDecoder crash

- Changed `expression` and `cronExpression` from `String` to `String?` in `IPCSchedulesListResponseSchedule` (Swift)
- Changed `expression` and `cronExpression` from `string` to `string | null` in `SchedulesListResponse` (TypeScript IPC type)
- Updated `ScheduledTasksView.swift` and `SchedulesSection.swift` to use optional binding when displaying expression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
