### PR TITLE
fix: use cancel endpoint instead of delete for one-shot schedule cancellation

### DIFF
--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -17,6 +17,11 @@ export interface ScheduleRemove {
   id: string;
 }
 
+export interface ScheduleCancel {
+  type: "schedule_cancel";
+  id: string;
+}
+
 export interface ScheduleRunNow {
   type: "schedule_run_now";
   id: string;
@@ -125,6 +130,7 @@ export type _SchedulesClientMessages =
   | SchedulesList
   | ScheduleToggle
   | ScheduleRemove
+  | ScheduleCancel
   | ScheduleRunNow
   | HeartbeatConfig
   | HeartbeatRunsList

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -107,8 +107,9 @@ struct RemindersSection: View {
 
     private func cancelSchedule(_ id: String) {
         guard let daemon = clientProvider.client as? DaemonClient else { return }
-        try? daemon.sendRemoveSchedule(id: id)
-        schedules.removeAll { $0.id == id }
+        try? daemon.sendCancelSchedule(id: id)
+        // Reload so the cancelled status is reflected in the list.
+        loadSchedules()
     }
 
     private func formatTimestamp(_ ms: Int) -> String? {

--- a/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RemindersView.swift
@@ -112,7 +112,9 @@ struct RemindersView: View {
     }
 
     @MainActor private func cancelSchedule(id: String) {
-        try? daemonClient.sendRemoveSchedule(id: id)
+        try? daemonClient.sendCancelSchedule(id: id)
+        // Reload so the cancelled status is reflected in the list.
+        loadSchedules()
     }
 }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1201,6 +1201,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ScheduleRemoveMessage(id: id))
     }
 
+    /// Cancel a schedule (preserves the record with status 'cancelled').
+    public func sendCancelSchedule(id: String) throws {
+        try send(ScheduleCancelMessage(id: id))
+    }
+
     /// Run a schedule immediately as a one-off execution.
     public func sendRunScheduleNow(id: String) throws {
         try send(ScheduleRunNowMessage(id: id))

--- a/clients/shared/IPC/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/IPC/Generated/GeneratedAPITypes.swift
@@ -3522,6 +3522,16 @@ public struct IPCScheduleRemove: Codable, Sendable {
     }
 }
 
+public struct IPCScheduleCancel: Codable, Sendable {
+    public let type: String
+    public let id: String
+
+    public init(type: String, id: String) {
+        self.type = type
+        self.id = id
+    }
+}
+
 public struct IPCScheduleRunNow: Codable, Sendable {
     public let type: String
     public let id: String

--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -49,6 +49,10 @@ extension HTTPTransport {
                 Task { await self.sendGenericPost(.scheduleDelete(id: msg.id), method: "DELETE", label: "schedule_remove") }
                 return true
             }
+            if let msg = message as? ScheduleCancelMessage {
+                Task { await self.sendGenericPost(.scheduleCancel(id: msg.id), label: "schedule_cancel") }
+                return true
+            }
             if let msg = message as? ScheduleRunNowMessage {
                 Task { await self.sendGenericPost(.scheduleRunNow(id: msg.id), label: "schedule_run_now") }
                 return true

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -366,6 +366,7 @@ public final class HTTPTransport {
         case schedules
         case scheduleToggle(id: String)
         case scheduleDelete(id: String)
+        case scheduleCancel(id: String)
         case scheduleRunNow(id: String)
 
         // Diagnostics
@@ -745,6 +746,9 @@ public final class HTTPTransport {
         case .scheduleDelete(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("/v1/schedules/\(encoded)", nil)
+        case .scheduleCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/schedules/\(encoded)/cancel", nil)
         case .scheduleRunNow(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("/v1/schedules/\(encoded)/run", nil)
@@ -1123,6 +1127,9 @@ public final class HTTPTransport {
         case .scheduleDelete(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("\(prefix)/schedules/\(encoded)/", nil)
+        case .scheduleCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/schedules/\(encoded)/cancel/", nil)
         case .scheduleRunNow(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             return ("\(prefix)/schedules/\(encoded)/run/", nil)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1318,6 +1318,16 @@ extension IPCScheduleRemove {
     }
 }
 
+/// Cancel a schedule (preserves the record with status 'cancelled').
+/// Backed by generated `IPCScheduleCancel`.
+public typealias ScheduleCancelMessage = IPCScheduleCancel
+
+extension IPCScheduleCancel {
+    public init(id: String) {
+        self.init(type: "schedule_cancel", id: id)
+    }
+}
+
 /// Run a schedule immediately as a one-off.
 /// Backed by generated `IPCScheduleRunNow`.
 public typealias ScheduleRunNowMessage = IPCScheduleRunNow


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** Client cancel action uses DELETE (removes record) instead of cancel endpoint (preserves record)
**What was expected:** Cancel sets status to cancelled while preserving the schedule
**What was found:** Cancel permanently deletes the schedule from the database

- Added `ScheduleCancel` IPC message type to daemon message contract
- Added `IPCScheduleCancel` struct to generated Swift types
- Added `ScheduleCancelMessage` typealias and convenience init
- Added `scheduleCancel` endpoint to `HTTPTransport.Endpoint` enum with URL paths for both local and managed transports
- Added HTTP dispatch for `ScheduleCancelMessage` in `HTTPDaemonClient+Settings.swift`
- Added `sendCancelSchedule(id:)` method to `DaemonClient`
- Updated `RemindersView.swift` (macOS) and `RemindersSection.swift` (iOS) to call `sendCancelSchedule` instead of `sendRemoveSchedule`
- Both views now reload the schedule list after cancel so the 'cancelled' status badge is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
