### PR TITLE
fix: widen ScheduleNotifyModeNotifier return type to accept sync notifiers

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -35,7 +35,7 @@ export type ScheduleNotifyModeNotifier = (payload: {
   message: string;
   routingIntent: RoutingIntent;
   routingHints: Record<string, unknown>;
-}) => Promise<void>;
+}) => void | Promise<void>;
 
 export type ScheduleNotifier = (schedule: { id: string; name: string }) => void;
 


### PR DESCRIPTION
## Summary
- Widens `ScheduleNotifyModeNotifier` return type from `Promise<void>` to `void | Promise<void>`
- Fixes type errors in `scheduler-recurrence.test.ts` and `task-scheduler.test.ts` where sync `() => {}` callbacks were passed as notifiers
- `await` on a `void` value is valid JS/TS and the scheduler continues working correctly

## Test plan
- [ ] Type check passes: `bunx tsc --noEmit`
- [ ] Existing scheduler tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
