### PR TITLE
Update embedWithBackend and embedAndUpsert callers for EmbeddingInput

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 
@@ -10,6 +10,11 @@ import {
   embedWithBackend,
   getMemoryBackendStatus,
 } from "./embedding-backend.js";
+import type { EmbeddingInput } from "./embedding-types.js";
+import {
+  embeddingInputContentHash,
+  normalizeEmbeddingInput,
+} from "./embedding-types.js";
 import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
 import { getQdrantClient } from "./qdrant-client.js";
 import { memoryEmbeddings } from "./schema.js";
@@ -138,7 +143,7 @@ export async function embedAndUpsert(
   config: AssistantConfig,
   targetType: "segment" | "item" | "summary",
   targetId: string,
-  text: string,
+  input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,
 ): Promise<void> {
   const status = getMemoryBackendStatus(config);
@@ -148,7 +153,7 @@ export async function embedAndUpsert(
     );
   }
 
-  const contentHash = createHash("sha256").update(text).digest("hex");
+  const contentHash = embeddingInputContentHash(input);
   let provider = status.provider;
   let model = status.model!;
   let vector: number[];
@@ -181,12 +186,20 @@ export async function embedAndUpsert(
       vector = JSON.parse(cachedRow.vectorJson!);
     }
   } else {
-    const embedded = await embedWithBackend(config, [text]);
+    const embedded = await embedWithBackend(config, [input]);
     vector = embedded.vectors[0];
     if (!vector) return;
     provider = embedded.provider;
     model = embedded.model;
   }
+
+  // Extract text for Qdrant payload: use the raw text for text inputs,
+  // or a description string for non-text (image/audio/video) inputs.
+  const normalized = normalizeEmbeddingInput(input);
+  const payloadText =
+    normalized.type === "text"
+      ? normalized.text
+      : `[${normalized.type}:${normalized.mimeType}]`;
 
   // Persist embedding in SQLite for cross-restart cache
   const now = Date.now();
@@ -236,7 +249,7 @@ export async function embedAndUpsert(
   try {
     await withQdrantBreaker(() =>
       qdrant.upsert(targetType, targetId, vector, {
-        text,
+        text: payloadText,
         created_at: (extraPayload?.created_at as number) ?? now,
         ...(extraPayload as Record<string, unknown> | undefined),
       }),


### PR DESCRIPTION
## Summary
- Change `embedAndUpsert` to accept `EmbeddingInput` instead of `string`
- Use `embeddingInputContentHash` for consistent content hashing
- Existing callers pass strings which remain valid `EmbeddingInput`

Part of plan: multimodal-embedding.md (PR 5 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
