### PR TITLE
fix: remove stale reminders index from 104-core-indexes

### DIFF
--- a/assistant/src/memory/migrations/104-core-indexes.ts
+++ b/assistant/src/memory/migrations/104-core-indexes.ts
@@ -199,10 +199,6 @@ export function createCoreIndexes(database: DrizzleDb): void {
   );
 
   database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_reminders_status_fire_at ON reminders(status, fire_at)`,
-  );
-
-  database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`,
   );
   database.run(


### PR DESCRIPTION
## Summary
- The `reminders` table is no longer created in `100-core-tables.ts` (dropped by migration 148). `createCoreIndexes` in `104-core-indexes.ts` still tried to create an index on it, causing a SQLiteError on fresh DBs used in tests.
- Removed the `idx_reminders_status_fire_at` index creation. For existing DBs the index already exists and migration 148 drops it; for fresh DBs the table never exists so no index is needed.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22927716624/job/66542044088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
