### PR TITLE
Store embedding modality in Qdrant point payload via embedAndUpsert

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -247,9 +247,11 @@ export async function embedAndUpsert(
   }
 
   try {
+    const modality = normalized.type;
     await withQdrantBreaker(() =>
       qdrant.upsert(targetType, targetId, vector, {
         text: payloadText,
+        modality,
         created_at: (extraPayload?.created_at as number) ?? now,
         ...(extraPayload as Record<string, unknown> | undefined),
       }),


### PR DESCRIPTION
## Summary
- Add `modality` field to Qdrant upsert payload in `embedAndUpsert`
- Text inputs store `modality: "text"`, non-text inputs store their respective modality

Part of plan: multimodal-embedding.md (PR 7 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
