### PR TITLE
Add media as a valid embedding target type alongside segment/item/summary

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -141,7 +141,7 @@ export function truncate(text: string, max: number): string {
 
 export async function embedAndUpsert(
   config: AssistantConfig,
-  targetType: "segment" | "item" | "summary",
+  targetType: "segment" | "item" | "summary" | "media",
   targetId: string,
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -15,7 +15,7 @@ export interface QdrantClientConfig {
 }
 
 export interface QdrantPointPayload {
-  target_type: "segment" | "item" | "summary";
+  target_type: "segment" | "item" | "summary" | "media";
   target_id: string;
   text: string;
   kind?: string;
@@ -217,7 +217,7 @@ export class VellumQdrantClient {
   }
 
   async upsert(
-    targetType: "segment" | "item" | "summary",
+    targetType: "segment" | "item" | "summary" | "media",
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,
@@ -311,7 +311,7 @@ export class VellumQdrantClient {
   async searchWithFilter(
     vector: number[],
     limit: number,
-    targetTypes: Array<"segment" | "item" | "summary">,
+    targetTypes: Array<"segment" | "item" | "summary" | "media">,
     excludeMessageIds?: string[],
   ): Promise<QdrantSearchResult[]> {
     const mustConditions: Array<Record<string, unknown>> = [
@@ -331,7 +331,7 @@ export class VellumQdrantClient {
               { key: "status", match: { value: "active" } },
             ],
           },
-          { key: "target_type", match: { any: ["segment", "summary"] } },
+          { key: "target_type", match: { any: ["segment", "summary", "media"] } },
         ],
       });
     }


### PR DESCRIPTION
## Summary
- Add `"media"` to target type unions in Qdrant client and embedAndUpsert
- Enables embedding media assets (images, audio, video) into the vector store

Part of plan: multimodal-embedding.md (PR 8 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
