### PR TITLE
Include media target type in semantic search results

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -43,7 +43,7 @@ export async function semanticSearch(
     qdrant.searchWithFilter(
       queryVector,
       fetchLimit,
-      ["item", "summary", "segment"],
+      ["item", "summary", "segment", "media"],
       excludedMessageIds,
     ),
   );
@@ -162,6 +162,23 @@ export async function semanticSearch(
         lexical: 0,
         semantic,
         recency: computeRecencyScore(payload.last_seen_at ?? createdAt),
+        finalScore: 0,
+      });
+    } else if (payload.target_type === "media") {
+      candidates.push({
+        key: `media:${payload.target_id}`,
+        type: "media",
+        id: payload.target_id,
+        source: "semantic",
+        text: payload.text,
+        kind: payload.kind ?? "media",
+        modality: payload.modality,
+        confidence: 0.7,
+        importance: 0.6,
+        createdAt,
+        lexical: 0,
+        semantic,
+        recency: computeRecencyScore(createdAt),
         finalScore: 0,
       });
     } else {

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -1,4 +1,4 @@
-export type CandidateType = "segment" | "item" | "summary";
+export type CandidateType = "segment" | "item" | "summary" | "media";
 export type CandidateSource =
   | "lexical"
   | "semantic"
@@ -14,6 +14,7 @@ export interface Candidate {
   source: CandidateSource;
   text: string;
   kind: string;
+  modality?: "text" | "image" | "audio" | "video";
   confidence: number;
   importance: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
- Add `"media"` to `CandidateType` and `modality` to `Candidate` interface
- Include `"media"` in Qdrant search target types
- Handle media results in semantic search result processing

Part of plan: multimodal-embedding.md (PR 13 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
