### PR TITLE
Embed inline image attachments from user messages into memory

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -2,9 +2,16 @@ import { eq } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../db.js";
+import type { EmbeddingInput } from "../embedding-types.js";
 import { asString, embedAndUpsert } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
-import { memoryItems, memorySegments, memorySummaries } from "../schema.js";
+import { extractMediaBlocks } from "../message-content.js";
+import {
+  memoryItems,
+  memorySegments,
+  memorySummaries,
+  messages,
+} from "../schema.js";
 
 export async function embedSegmentJob(
   job: MemoryJob,
@@ -74,4 +81,39 @@ export async function embedSummaryJob(
       last_seen_at: summary.endAt,
     },
   );
+}
+
+export async function embedAttachmentJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const messageId = asString(job.payload.messageId);
+  const blockIndex = job.payload.blockIndex as number;
+  if (!messageId || typeof blockIndex !== "number") return;
+
+  const db = getDb();
+  const message = db
+    .select()
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  if (!message) return;
+
+  const mediaBlocks = extractMediaBlocks(message.content);
+  const block = mediaBlocks.find((b) => b.index === blockIndex);
+  if (!block) return;
+
+  const input: EmbeddingInput = {
+    type: block.type,
+    data: block.data,
+    mimeType: block.mimeType,
+  };
+
+  // Use messageId + blockIndex as targetId for uniqueness
+  const targetId = `${messageId}:${blockIndex}`;
+  await embedAndUpsert(config, "media", targetId, input, {
+    created_at: message.createdAt,
+    message_id: messageId,
+    conversation_id: message.conversationId,
+  });
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -27,12 +27,14 @@ export type MemoryJobType =
   | "rebuild_index"
   | "reconcile_fts"
   | "delete_qdrant_vectors"
-  | "media_processing";
+  | "media_processing"
+  | "embed_attachment";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
   "embed_item",
   "embed_summary",
+  "embed_attachment",
 ];
 
 export interface MemoryJob<T = Record<string, unknown>> {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -18,6 +18,7 @@ import {
 } from "./job-handlers/conflict.js";
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
+  embedAttachmentJob,
   embedItemJob,
   embedSegmentJob,
   embedSummaryJob,
@@ -333,6 +334,9 @@ async function processJob(
       return;
     case "media_processing":
       await mediaProcessingJob(job);
+      return;
+    case "embed_attachment":
+      await embedAttachmentJob(job, config);
       return;
     default:
       throw new Error(

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -55,6 +55,38 @@ export function extractTextFromStoredMessageContent(raw: string): string {
   }
 }
 
+export function extractMediaBlocks(raw: string): Array<{
+  type: "image";
+  data: Buffer;
+  mimeType: string;
+  index: number;
+}> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const results: Array<{
+      type: "image";
+      data: Buffer;
+      mimeType: string;
+      index: number;
+    }> = [];
+    for (let i = 0; i < parsed.length; i++) {
+      const block = parsed[i] as ContentBlock;
+      if (block.type === "image") {
+        results.push({
+          type: "image" as const,
+          data: Buffer.from(block.source.data, "base64"),
+          mimeType: block.source.media_type,
+          index: i,
+        });
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
 function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value);


### PR DESCRIPTION
## Summary
- Add `embed_attachment` job type and handler
- Add `extractMediaBlocks` to extract image data from message content blocks
- Handler embeds images using multimodal embeddings with message context

Part of plan: multimodal-embedding.md (PR 11 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
