### PR TITLE
fix: sort imports in embedding files to fix lint CI

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -8,11 +8,11 @@ import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
 import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
 import {
   type EmbeddingInput,
-  type MultimodalEmbeddingInput,
-  type TextEmbeddingInput,
-  normalizeEmbeddingInput,
   embeddingInputContentHash,
   isTextInput,
+  type MultimodalEmbeddingInput,
+  normalizeEmbeddingInput,
+  type TextEmbeddingInput,
 } from "./embedding-types.js";
 
 export type {
@@ -20,7 +20,7 @@ export type {
   MultimodalEmbeddingInput,
   TextEmbeddingInput,
 };
-export { normalizeEmbeddingInput, embeddingInputContentHash, isTextInput };
+export { embeddingInputContentHash, isTextInput,normalizeEmbeddingInput };
 
 const log = getLogger("memory-embeddings");
 

--- a/assistant/src/memory/embedding-gemini.test.ts
+++ b/assistant/src/memory/embedding-gemini.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 
 function makeSuccessResponse(values: number[]) {

--- a/assistant/src/memory/embedding-local.ts
+++ b/assistant/src/memory/embedding-local.ts
@@ -9,8 +9,8 @@ import type {
   EmbeddingInput,
   EmbeddingRequestOptions,
 } from "./embedding-backend.js";
-import { normalizeEmbeddingInput } from "./embedding-types.js";
 import { EmbeddingRuntimeManager } from "./embedding-runtime-manager.js";
+import { normalizeEmbeddingInput } from "./embedding-types.js";
 
 const log = getLogger("memory-embedding-local");
 


### PR DESCRIPTION
## Summary
- Sort imports in `embedding-backend.ts`, `embedding-gemini.test.ts`, and `embedding-local.ts` to satisfy the `simple-import-sort` ESLint rule
- Fixes the Lint CI job failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22927905410/job/66542649611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
