### PR TITLE
Add embed_media job handler to embed media assets via multimodal embeddings

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/memory/job-handlers/embedding.test.ts
@@ -1,0 +1,261 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "embed-media-test-"));
+
+mock.module("../../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Track calls to embedAndUpsert
+const embedAndUpsertCalls: Array<{
+  config: unknown;
+  targetType: string;
+  targetId: string;
+  input: unknown;
+  extraPayload: unknown;
+}> = [];
+
+mock.module("../job-utils.js", () => ({
+  asString: (value: unknown) =>
+    typeof value === "string" && value.length > 0 ? value : null,
+  embedAndUpsert: async (
+    config: unknown,
+    targetType: string,
+    targetId: string,
+    input: unknown,
+    extraPayload: unknown,
+  ) => {
+    embedAndUpsertCalls.push({
+      config,
+      targetType,
+      targetId,
+      input,
+      extraPayload,
+    });
+  },
+}));
+
+import { eq } from "drizzle-orm";
+
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getDb, initializeDb, resetDb } from "../db.js";
+import type { MemoryJob } from "../jobs-store.js";
+import { mediaAssets } from "../schema.js";
+import { embedMediaJob } from "./embedding.js";
+
+const TEST_CONFIG: AssistantConfig = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    extraction: {
+      ...DEFAULT_CONFIG.memory.extraction,
+      useLLM: false,
+    },
+  },
+};
+
+describe("embedMediaJob", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    embedAndUpsertCalls.length = 0;
+    resetDb();
+    initializeDb();
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function makeJob(payload: Record<string, unknown>): MemoryJob {
+    return {
+      id: "job-1",
+      type: "embed_media",
+      payload,
+      status: "running",
+      attempts: 0,
+      deferrals: 0,
+      runAfter: 0,
+      lastError: null,
+      startedAt: Date.now(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+  }
+
+  test("skips when assetId is missing", async () => {
+    await embedMediaJob(makeJob({}), TEST_CONFIG);
+    expect(embedAndUpsertCalls).toHaveLength(0);
+  });
+
+  test("skips when asset is not found", async () => {
+    await embedMediaJob(makeJob({ assetId: "nonexistent" }), TEST_CONFIG);
+    expect(embedAndUpsertCalls).toHaveLength(0);
+  });
+
+  test("skips when asset status is not indexed", async () => {
+    const db = getDb();
+    const now = Date.now();
+    // Create a temp file
+    const filePath = join(testDir, "test-registered.png");
+    writeFileSync(filePath, Buffer.from("fake image data"));
+
+    db.insert(mediaAssets)
+      .values({
+        id: "asset-registered",
+        title: "Test Image",
+        filePath,
+        mimeType: "image/png",
+        durationSeconds: null,
+        fileHash: "hash-registered",
+        status: "registered",
+        mediaType: "image",
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    await embedMediaJob(
+      makeJob({ assetId: "asset-registered" }),
+      TEST_CONFIG,
+    );
+    expect(embedAndUpsertCalls).toHaveLength(0);
+  });
+
+  test("embeds indexed image asset with correct input type and target", async () => {
+    const db = getDb();
+    const now = Date.now();
+    const filePath = join(testDir, "test-image.png");
+    const imageData = Buffer.from("fake png data");
+    writeFileSync(filePath, imageData);
+
+    db.insert(mediaAssets)
+      .values({
+        id: "asset-image",
+        title: "My Screenshot",
+        filePath,
+        mimeType: "image/png",
+        durationSeconds: null,
+        fileHash: "hash-image",
+        status: "indexed",
+        mediaType: "image",
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    await embedMediaJob(makeJob({ assetId: "asset-image" }), TEST_CONFIG);
+
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    const call = embedAndUpsertCalls[0];
+    expect(call.targetType).toBe("media");
+    expect(call.targetId).toBe("asset-image");
+    expect(call.input).toEqual({
+      type: "image",
+      data: imageData,
+      mimeType: "image/png",
+    });
+    expect(call.extraPayload).toEqual({
+      created_at: now,
+      kind: "image",
+      subject: "My Screenshot",
+    });
+  });
+
+  test("embeds indexed audio asset with correct modality", async () => {
+    const db = getDb();
+    const now = Date.now();
+    const filePath = join(testDir, "test-audio.mp3");
+    const audioData = Buffer.from("fake mp3 data");
+    writeFileSync(filePath, audioData);
+
+    db.insert(mediaAssets)
+      .values({
+        id: "asset-audio",
+        title: "Podcast Episode",
+        filePath,
+        mimeType: "audio/mp3",
+        durationSeconds: 120,
+        fileHash: "hash-audio",
+        status: "indexed",
+        mediaType: "audio",
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    await embedMediaJob(makeJob({ assetId: "asset-audio" }), TEST_CONFIG);
+
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    const call = embedAndUpsertCalls[0];
+    expect(call.targetType).toBe("media");
+    expect(call.targetId).toBe("asset-audio");
+    expect((call.input as { type: string }).type).toBe("audio");
+    expect((call.input as { mimeType: string }).mimeType).toBe("audio/mp3");
+  });
+
+  test("embeds indexed video asset with correct modality", async () => {
+    const db = getDb();
+    const now = Date.now();
+    const filePath = join(testDir, "test-video.mp4");
+    const videoData = Buffer.from("fake mp4 data");
+    writeFileSync(filePath, videoData);
+
+    db.insert(mediaAssets)
+      .values({
+        id: "asset-video",
+        title: "Tutorial Video",
+        filePath,
+        mimeType: "video/mp4",
+        durationSeconds: 300,
+        fileHash: "hash-video",
+        status: "indexed",
+        mediaType: "video",
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    await embedMediaJob(makeJob({ assetId: "asset-video" }), TEST_CONFIG);
+
+    expect(embedAndUpsertCalls).toHaveLength(1);
+    const call = embedAndUpsertCalls[0];
+    expect(call.targetType).toBe("media");
+    expect(call.targetId).toBe("asset-video");
+    expect((call.input as { type: string }).type).toBe("video");
+    expect((call.input as { mimeType: string }).mimeType).toBe("video/mp4");
+  });
+});

--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -1,10 +1,18 @@
+import { readFile } from "node:fs/promises";
+
 import { eq } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../db.js";
+import type { EmbeddingInput } from "../embedding-types.js";
 import { asString, embedAndUpsert } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
-import { memoryItems, memorySegments, memorySummaries } from "../schema.js";
+import {
+  mediaAssets,
+  memoryItems,
+  memorySegments,
+  memorySummaries,
+} from "../schema.js";
 
 export async function embedSegmentJob(
   job: MemoryJob,
@@ -74,4 +82,36 @@ export async function embedSummaryJob(
       last_seen_at: summary.endAt,
     },
   );
+}
+
+export async function embedMediaJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const assetId = asString(job.payload.assetId);
+  if (!assetId) return;
+
+  const db = getDb();
+  const asset = db
+    .select()
+    .from(mediaAssets)
+    .where(eq(mediaAssets.id, assetId))
+    .get();
+  if (!asset || asset.status !== "indexed") return;
+
+  // Read the media file from disk
+  const fileData = await readFile(asset.filePath);
+
+  // Determine modality from mediaType
+  const input: EmbeddingInput = {
+    type: asset.mediaType as "image" | "audio" | "video",
+    data: fileData,
+    mimeType: asset.mimeType,
+  };
+
+  await embedAndUpsert(config, "media", asset.id, input, {
+    created_at: asset.createdAt,
+    kind: asset.mediaType,
+    subject: asset.title,
+  });
 }

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -27,12 +27,14 @@ export type MemoryJobType =
   | "rebuild_index"
   | "reconcile_fts"
   | "delete_qdrant_vectors"
-  | "media_processing";
+  | "media_processing"
+  | "embed_media";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
   "embed_item",
   "embed_summary",
+  "embed_media",
 ];
 
 export interface MemoryJob<T = Record<string, unknown>> {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -19,6 +19,7 @@ import {
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
   embedItemJob,
+  embedMediaJob,
   embedSegmentJob,
   embedSummaryJob,
 } from "./job-handlers/embedding.js";
@@ -333,6 +334,9 @@ async function processJob(
       return;
     case "media_processing":
       await mediaProcessingJob(job);
+      return;
+    case "embed_media":
+      await embedMediaJob(job, config);
       return;
     default:
       throw new Error(


### PR DESCRIPTION
## Summary
- Add `embed_media` job type to memory job type union
- Add `embedMediaJob` handler that reads media files and embeds them via `embedAndUpsert`
- Register handler in job dispatcher
- Add unit tests verifying correct embedding input type, target type, and skip behavior

Part of plan: multimodal-embedding.md (PR 9 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
