### PR TITLE
security: skip symlinked .md files in skill references/

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -620,7 +620,7 @@ describe("skill_load tool", () => {
     expect(result.content).not.toContain("--- Reference:");
   });
 
-  test("references/ directory skips symlinked markdown files", async () => {
+  test("references/ directory skips symlinked markdown files that escape the skill directory", async () => {
     if (process.platform === "win32") {
       // Symlink creation is not consistently available in Windows test environments.
       return;

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -612,6 +618,33 @@ describe("skill_load tool", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Just body.");
     expect(result.content).not.toContain("--- Reference:");
+  });
+
+  test("references/ directory skips symlinked markdown files", async () => {
+    if (process.platform === "win32") {
+      // Symlink creation is not consistently available in Windows test environments.
+      return;
+    }
+
+    const skillDir = join(TEST_DIR, "skills", "refs-symlink");
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(join(skillDir, "references"), { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      '---\nname: "Refs Symlink"\ndescription: "Skips symlinks"\n---\n\nBody.\n',
+    );
+
+    const outsideSecretPath = join(TEST_DIR, "outside-secret.md");
+    writeFileSync(outsideSecretPath, "TOP_SECRET_DO_NOT_LOAD");
+    symlinkSync(outsideSecretPath, join(skillDir, "references", "secret.md"));
+
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- refs-symlink\n");
+
+    const result = await executeSkillLoad({ skill: "refs-symlink" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Body.");
+    expect(result.content).not.toContain("--- Reference: Secret ---");
+    expect(result.content).not.toContain("TOP_SECRET_DO_NOT_LOAD");
   });
 
   test("references/ directory ignores non-markdown files", async () => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1110,7 +1110,11 @@ function applyFeatureGatedSections(body: string): string {
 function appendReferenceFiles(body: string, directoryPath: string): string {
   try {
     const refsDir = join(directoryPath, "references");
-    if (!existsSync(refsDir) || !statSync(refsDir).isDirectory()) {
+    if (
+      !existsSync(refsDir) ||
+      lstatSync(refsDir).isSymbolicLink() ||
+      !statSync(refsDir).isDirectory()
+    ) {
       return body;
     }
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1100,19 +1100,41 @@ function applyFeatureGatedSections(body: string): string {
 }
 
 /**
+ * Returns true if `filePath` is a symlink whose resolved real path escapes
+ * `rootDir`. Symlinks that stay within `rootDir` are allowed; only those that
+ * point outside are considered unsafe.
+ */
+function isEscapingSymlink(filePath: string, rootDir: string): boolean {
+  try {
+    if (!lstatSync(filePath).isSymbolicLink()) return false;
+    const real = realpathSync(filePath);
+    const normalizedRoot = resolve(rootDir);
+    return (
+      real !== normalizedRoot &&
+      !real.startsWith(normalizedRoot + "/") &&
+      !real.startsWith(normalizedRoot + "\\")
+    );
+  } catch {
+    // If we can't resolve (e.g. dangling symlink), treat as escaping.
+    return true;
+  }
+}
+
+/**
  * Scan for a `references/` subdirectory within a skill directory and append
  * the contents of any `.md` files found there to the skill body. Each
  * reference file is labeled with a `--- Reference: <Name> ---` header.
  * Files are appended in alphabetical order for deterministic output.
- * Non-`.md` files and symlinks are ignored. Errors are logged as warnings and the
- * original body is returned unchanged.
+ * Non-`.md` files are ignored. Symlinks that resolve outside the skill
+ * directory are skipped. Errors are logged as warnings and the original body
+ * is returned unchanged.
  */
 function appendReferenceFiles(body: string, directoryPath: string): string {
   try {
     const refsDir = join(directoryPath, "references");
     if (
       !existsSync(refsDir) ||
-      lstatSync(refsDir).isSymbolicLink() ||
+      isEscapingSymlink(refsDir, directoryPath) ||
       !statSync(refsDir).isDirectory()
     ) {
       return body;
@@ -1121,7 +1143,7 @@ function appendReferenceFiles(body: string, directoryPath: string): string {
     const entries = readdirSync(refsDir);
     const mdFiles = entries
       .filter((f) => f.toLowerCase().endsWith(".md"))
-      .filter((f) => !lstatSync(join(refsDir, f)).isSymbolicLink())
+      .filter((f) => !isEscapingSymlink(join(refsDir, f), directoryPath))
       .sort((a, b) => a.localeCompare(b));
 
     if (mdFiles.length === 0) return body;

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -1103,7 +1104,7 @@ function applyFeatureGatedSections(body: string): string {
  * the contents of any `.md` files found there to the skill body. Each
  * reference file is labeled with a `--- Reference: <Name> ---` header.
  * Files are appended in alphabetical order for deterministic output.
- * Non-`.md` files are ignored. Errors are logged as warnings and the
+ * Non-`.md` files and symlinks are ignored. Errors are logged as warnings and the
  * original body is returned unchanged.
  */
 function appendReferenceFiles(body: string, directoryPath: string): string {
@@ -1116,6 +1117,7 @@ function appendReferenceFiles(body: string, directoryPath: string): string {
     const entries = readdirSync(refsDir);
     const mdFiles = entries
       .filter((f) => f.toLowerCase().endsWith(".md"))
+      .filter((f) => !lstatSync(join(refsDir, f)).isSymbolicLink())
       .sort((a, b) => a.localeCompare(b));
 
     if (mdFiles.length === 0) return body;


### PR DESCRIPTION
## Summary
- Add `lstatSync` symlink check in `appendReferenceFiles` so that `.md` files that are symbolic links inside a skill's `references/` directory are silently skipped, preventing traversal to files outside the skill root
- Add a test verifying that a symlink pointing to an outside secret file is not loaded when executing `skill_load`

## Original prompt
finish this git pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
