### PR TITLE
Enqueue embed_media jobs when media assets finish processing

### DIFF
--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -8,7 +8,7 @@ import { preprocessForAsset } from "../../config/bundled-skills/media-processing
 import { reduceForAsset } from "../../config/bundled-skills/media-processing/tools/query-media-events.js";
 import { getLogger } from "../../util/logger.js";
 import { asString } from "../job-utils.js";
-import type { MemoryJob } from "../jobs-store.js";
+import { type MemoryJob, enqueueMemoryJob } from "../jobs-store.js";
 import { getMediaAssetById, updateMediaAssetStatus } from "../media-store.js";
 
 const log = getLogger("media-processing-job");
@@ -32,6 +32,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
       "Skipping media processing pipeline — only video assets are supported",
     );
     updateMediaAssetStatus(mediaAssetId, "indexed");
+    enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
     return;
   }
 
@@ -107,4 +108,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   if (result.cancelled) {
     throw new Error(`Media processing cancelled for asset ${mediaAssetId}`);
   }
+
+  updateMediaAssetStatus(mediaAssetId, "indexed");
+  enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
 }


### PR DESCRIPTION
## Summary
- Enqueue `embed_media` job after media processing pipeline completes (video)
- Enqueue `embed_media` for image/audio assets when marked as indexed
- Enables automatic multimodal embedding of all ingested media

Part of plan: multimodal-embedding.md (PR 10 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
