### PR TITLE
docs: replace IPC terminology in AGENTS.md files

### DIFF
--- a/assistant/src/notifications/AGENTS.md
+++ b/assistant/src/notifications/AGENTS.md
@@ -1,5 +1,5 @@
 # Notification Pipeline
 
-All notification producers **MUST** go through `emitNotificationSignal()` in `notifications/emit-signal.ts`. Do not bypass the pipeline by broadcasting IPC events directly -- the pipeline handles event persistence, deduplication, decision routing, and delivery audit.
+All notification producers **MUST** go through `emitNotificationSignal()` in `notifications/emit-signal.ts`. Do not bypass the pipeline by broadcasting events directly -- the pipeline handles event persistence, deduplication, decision routing, and delivery audit.
 
-When a notification flow creates a server-side conversation (e.g. guardian question threads, task run threads), the conversation and initial message **MUST** be persisted before the IPC thread-created event is emitted. This ensures the macOS/iOS client can immediately fetch the conversation contents when it receives the event.
+When a notification flow creates a server-side conversation (e.g. guardian question threads, task run threads), the conversation and initial message **MUST** be persisted before the thread-created event is emitted. This ensures the macOS/iOS client can immediately fetch the conversation contents when it receives the event.

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -6,7 +6,7 @@ All inbound HTTP endpoints — APIs, webhooks, OAuth callbacks, or any route tha
 
 Concretely:
 
-- Define new routes in the gateway and have the gateway forward requests to the assistant over the internal IPC/transport.
+- Define new routes in the gateway and have the gateway forward requests to the assistant over the internal HTTP transport.
 - The gateway's public URL is controlled by the **public ingress URL** setting. All externally-facing URLs you generate or advertise (callback URLs, webhook registration URLs, etc.) must be derived from this setting — never hardcode a hostname or port.
 - The daemon should remain unreachable from the public internet. It only receives traffic from the gateway over the internal network.
 


### PR DESCRIPTION
## Summary
- Update gateway AGENTS.md: IPC/transport → HTTP transport
- Update notifications AGENTS.md: remove IPC references from pipeline docs

Part of plan: phase-out-ipc-refs.md (PR 4 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
