### PR TITLE
fix: remove stale vellum.sock and ipc-blobs gitignore rules

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -54,7 +54,6 @@ function cleanGitEnv(workspaceDir: string): Record<string, string> {
 const WORKSPACE_GITIGNORE_RULES = [
   "data/db/",
   "data/qdrant/",
-  "data/ipc-blobs/",
   "logs/",
   "*.log",
   "*.sock",
@@ -67,7 +66,6 @@ const WORKSPACE_GITIGNORE_RULES = [
   "*.db-journal",
   "*.db-wal",
   "*.db-shm",
-  "vellum.sock",
   "vellum.pid",
   "session-token",
 ];


### PR DESCRIPTION
## Summary
- Remove `data/ipc-blobs/` from workspace gitignore rules (IPC blob store no longer exists)
- Remove `vellum.sock` from workspace gitignore rules (socket file no longer created)
- `*.sock` wildcard remains for general coverage

Part of plan: phase-out-ipc-refs.md (PR 2 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
