### PR TITLE
fix: remove dead IPC_ERROR enum value and IpcError class

### DIFF
--- a/assistant/src/errors.ts
+++ b/assistant/src/errors.ts
@@ -18,7 +18,6 @@
  *      ├─ PermissionDeniedError
  *      ├─ ConfigError
  *      ├─ DaemonError
- *      ├─ IpcError
  *      ├─ PlatformError
  *      ├─ IntegrityError
  *      └─ IngressBlockedError
@@ -32,7 +31,6 @@ export {
   ErrorCode,
   IngressBlockedError,
   IntegrityError,
-  IpcError,
   PermissionDeniedError,
   PlatformError,
   ProviderError,

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -14,9 +14,6 @@ export enum ErrorCode {
   // Daemon errors
   DAEMON_ERROR = "DAEMON_ERROR",
 
-  // IPC/socket errors
-  IPC_ERROR = "IPC_ERROR",
-
   // Platform-specific errors (clipboard, unsupported OS features)
   PLATFORM_ERROR = "PLATFORM_ERROR",
 
@@ -167,13 +164,6 @@ export class DaemonError extends AssistantError {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, ErrorCode.DAEMON_ERROR, options);
     this.name = "DaemonError";
-  }
-}
-
-export class IpcError extends AssistantError {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, ErrorCode.IPC_ERROR, options);
-    this.name = "IpcError";
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove unused `IPC_ERROR` enum value from `ErrorCode` enum
- Remove unused `IpcError` class and its re-export
- Dead code left over from IPC transport removal

Part of plan: phase-out-ipc-refs.md (PR 1 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
