### PR TITLE
fix: replace IPC terminology in code comments with HTTP

### DIFF
--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -2,7 +2,7 @@
  * Tests for the tool preview lifecycle feature.
  *
  * Verifies:
- * - handleToolUsePreviewStart emits correct IPC events
+ * - handleToolUsePreviewStart emits correct events
  * - handleToolUsePreviewStart emits activity state with "tool_running" phase
  * - handleInputJsonDelta includes toolUseId in emitted tool_input_delta
  * - handleToolResult includes toolUseId in emitted tool_result
@@ -192,7 +192,7 @@ describe("tool preview lifecycle", () => {
   });
 
   describe("handleToolUsePreviewStart", () => {
-    test("emits tool_use_preview_start IPC message", () => {
+    test("emits tool_use_preview_start message", () => {
       const collector = createEventCollector();
       const deps = createMockDeps({
         onEvent: collector.onEvent,

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -108,7 +108,7 @@ export class CallController {
   private awaitingOpeningAck = false;
   /** Monotonic run id used to suppress stale turn side effects after interruption. */
   private llmRunVersion = 0;
-  /** Optional broadcast function for emitting IPC events to connected clients. */
+  /** Optional broadcast function for emitting events to connected clients. */
   private broadcast?: (msg: ServerMessage) => void;
   /** Assistant identity for scoping guardian bindings. */
   private assistantId: string;

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -155,7 +155,7 @@ let globalBroadcast:
   | ((msg: import("../daemon/message-protocol.js").ServerMessage) => void)
   | undefined;
 
-/** Register a broadcast function so RelayConnection can forward IPC events. */
+/** Register a broadcast function so RelayConnection can forward events to connected clients. */
 export function setRelayBroadcast(
   fn: (msg: import("../daemon/message-protocol.js").ServerMessage) => void,
 ): void {

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -41,7 +41,7 @@ export function getModelInfo(): ModelInfo {
 
 /**
  * Minimal interface for the side-effects needed by setModel / setImageGenModel.
- * Keeps the business logic decoupled from IPC-specific HandlerContext.
+ * Keeps the business logic decoupled from transport-specific HandlerContext.
  */
 export interface ModelSetContext {
   sessions: Map<
@@ -155,7 +155,7 @@ export function setImageGenModel(modelId: string, ctx: ModelSetContext): void {
 }
 
 // ---------------------------------------------------------------------------
-// IPC handlers (delegate to shared logic)
+// HTTP handlers (delegate to shared logic)
 // ---------------------------------------------------------------------------
 
 export function handleModelGet(ctx: HandlerContext): void {

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -402,7 +402,7 @@ export function getMessageContent(
 }
 
 // ---------------------------------------------------------------------------
-// IPC handlers (delegate to shared logic)
+// HTTP handlers (delegate to shared logic)
 // ---------------------------------------------------------------------------
 
 export function handleConversationSearch(

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -94,7 +94,7 @@ export function syncCanonicalStatusFromIpcConfirmationDecision(
   } catch (err) {
     log.debug(
       { err, requestId, targetStatus },
-      "Failed to resolve canonical request from IPC confirmation response",
+      "Failed to resolve canonical request from local confirmation response",
     );
   }
 }
@@ -142,7 +142,7 @@ export function makeIpcEventSender(params: {
       } catch (err) {
         log.debug(
           { err, requestId: event.requestId, conversationId },
-          "Failed to create canonical request from IPC confirmation event",
+          "Failed to create canonical request from local confirmation event",
         );
       }
     } else if (event.type === "secret_request") {
@@ -325,7 +325,7 @@ export function handleSessionList(
  */
 export function clearAllSessions(ctx: HandlerContext): number {
   const cleared = ctx.clearAllSessions();
-  // Also clear DB conversations. When a new IPC connection triggers
+  // Also clear DB conversations. When a new local connection triggers
   // sendInitialSession, it auto-creates a conversation if none exist.
   // Without this DB clear, that auto-created row survives, contradicting
   // the "clear all conversations" intent.
@@ -380,7 +380,7 @@ export async function handleSessionCreate(
     if (title === GENERATING_TITLE) {
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: "ipc" },
+        context: { origin: "local" },
         userMessage: msg.initialMessage,
         onTitleUpdated: (newTitle) => {
           ctx.send({
@@ -598,7 +598,7 @@ export function handleUndo(msg: UndoRequest, ctx: HandlerContext): void {
 
 /**
  * Regenerate the last assistant response for a session. The caller provides
- * a `sendEvent` callback for delivering streaming events (IPC or HTTP/SSE).
+ * a `sendEvent` callback for delivering streaming events via HTTP/SSE.
  * Returns null if the session is not found. Throws on regeneration errors.
  */
 export async function regenerateResponse(
@@ -722,7 +722,7 @@ export function deleteQueuedMessage(
 }
 
 // ---------------------------------------------------------------------------
-// IPC handler (delegates to shared logic)
+// HTTP handler (delegates to shared logic)
 // ---------------------------------------------------------------------------
 
 export function handleDeleteQueuedMessage(

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -40,7 +40,7 @@ export const pendingStandaloneSecrets = new Map<
   }
 >();
 
-// Pending IPC signing responses (bundle signing orchestration), keyed by unique requestId
+// Pending signing responses (bundle signing orchestration), keyed by unique requestId
 interface PendingSigningResolve {
   resolve: (result: {
     signature: string;
@@ -131,7 +131,7 @@ export interface SessionCreateOptions {
   transport?: SessionTransportMetadata;
   assistantId?: string;
   trustContext?: TrustContext;
-  /** Normalized auth context for the session (IPC or HTTP-derived). */
+  /** Normalized auth context for the session. */
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
@@ -602,7 +602,7 @@ const SIGNING_TIMEOUT_MS = 30_000;
 
 /**
  * Create a SigningCallback that sends `sign_bundle_payload` to the Swift client
- * over IPC and waits for the `sign_bundle_payload_response`.
+ * over HTTP and waits for the `sign_bundle_payload_response`.
  */
 export function createSigningCallback(
   ctx: HandlerContext,

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -49,9 +49,9 @@ let broadcasterInstance: NotificationBroadcaster | null = null;
 let registeredBroadcastFn: BroadcastFn | null = null;
 
 /**
- * Register the IPC broadcast function so the vellum adapter can deliver
- * notifications through the daemon's IPC socket. Must be called once
- * during daemon startup (before any signals are emitted).
+ * Register the broadcast function so the vellum adapter can deliver
+ * notifications to connected clients. Must be called once during
+ * daemon startup (before any signals are emitted).
  */
 export function registerBroadcastFn(fn: BroadcastFn): void {
   registeredBroadcastFn = fn;
@@ -69,7 +69,7 @@ function getBroadcaster(): NotificationBroadcaster {
 
     // Wire the thread-created callback so the macOS client is notified
     // immediately when a vellum notification thread is paired — before
-    // slower channel deliveries (e.g. Telegram) delay the IPC push.
+    // slower channel deliveries (e.g. Telegram) delay the push.
     if (registeredBroadcastFn) {
       const broadcastFn = registeredBroadcastFn;
       broadcasterInstance.setOnThreadCreated((info) => {
@@ -104,8 +104,8 @@ function getConnectedChannels(): NotificationChannel[] {
   for (const channel of getDeliverableChannels()) {
     switch (channel) {
       case "vellum":
-        // Vellum is always considered connected (IPC socket is always
-        // available when the daemon is running).
+        // Vellum is always considered connected (the local transport is
+        // always available when the daemon is running).
         channels.push(channel);
         break;
       case "telegram": {
@@ -320,7 +320,7 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 4: Dispatch through the broadcaster
-    // Note: notification_thread_created IPC events are emitted eagerly inside
+    // Note: notification_thread_created events are emitted eagerly inside
     // the broadcaster as soon as vellum conversation pairing succeeds, rather
     // than after all channel deliveries complete. This avoids a race where
     // slow Telegram delivery delays the push past the macOS deep-link retry.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -374,7 +374,7 @@ function makeHubPublisher(
         },
       });
 
-      // Create a canonical guardian request so IPC/HTTP handlers can find it
+      // Create a canonical guardian request so HTTP handlers can find it
       // via applyCanonicalGuardianDecision.
       try {
         const trustContext = session.trustContext;
@@ -528,7 +528,7 @@ export async function handleSendMessage(
   }
 
   // Block inbound messages containing secrets before they reach the model.
-  // This mirrors the legacy IPC handleUserMessage behavior: secrets are
+  // This mirrors the legacy handleUserMessage behavior: secrets are
   // detected and the message is rejected with a safe notice. The client
   // should prompt the user to use the secure credential flow instead.
   if (trimmedContent.length > 0) {
@@ -589,10 +589,7 @@ export async function handleSendMessage(
     sourceInterface === "ios" ||
     sourceInterface === "cli" ||
     sourceInterface === "vellum";
-  // Wire sendToClient to the SSE hub so all subsystems (prompter, surface
-  // resolver, notifiers, trace emitter) can reach the HTTP client.  The
-  // IPC socket removal (PR #14431) left sendToClient as a no-op; this
-  // restores the delivery path using the SSE hub instead.
+  // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   session.updateClient(onEvent, !isInteractiveInterface);
 
   const attachments = hasAttachments
@@ -608,7 +605,7 @@ export async function handleSendMessage(
 
   // Try to consume the message as a canonical guardian approval/rejection reply.
   // On failure, degrade to the existing queue/auto-deny path rather than
-  // surfacing a 500 — mirrors the IPC handler's catch-and-fallback.
+  // surfacing a 500 — mirrors the handler's catch-and-fallback.
   try {
     const inlineReplyResult = await tryConsumeCanonicalGuardianReply({
       conversationId: mapping.conversationId,


### PR DESCRIPTION
## Summary
- Replace all IPC terminology in code comments across handler files, call files, routes, and tests
- Update `origin: "ipc"` string label to `origin: "local"`
- Comment-only changes (plus one string label), no functional impact

Part of plan: phase-out-ipc-refs.md (PR 3 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
