### PR TITLE
docs: replace IPC terminology in client docs

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -608,8 +608,8 @@ When a managed-mode HTTP request receives a 401, the `HTTPDaemonClient` does not
 | `clients/shared/App/Auth/ManagedAssistantBootstrapService.swift` | Discover-or-create orchestrator for managed assistants |
 | `clients/shared/App/Auth/AuthService.swift` | Platform API methods (`getCurrentAssistant`, `hatchAssistant`) |
 | `clients/shared/App/Auth/SessionTokenManager.swift` | Session token storage (Keychain + `~/.vellum/platform-token` file bridge) |
-| `clients/shared/IPC/DaemonConfig.swift` | `RouteMode`, `AuthMode`, `TransportMetadata` types |
-| `clients/shared/IPC/HTTPDaemonClient.swift` | Endpoint builder and auth application for both route modes |
+| `clients/shared/Network/DaemonConfig.swift` | `RouteMode`, `AuthMode`, `TransportMetadata` types |
+| `clients/shared/Network/HTTPDaemonClient.swift` | Endpoint builder and auth application for both route modes |
 | `clients/macos/vellum-assistant/App/AppDelegate.swift` | Transport selection (`configureDaemonTransport`) and startup guardrails |
 | `clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift` | Onboarding sign-in UI and managed bootstrap invocation |
 | `clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift` | `LockfileAssistant.isManaged` computed property and managed entry upsert |
@@ -813,7 +813,7 @@ Cross-platform `ObservableObject` stores in `clients/shared/Features/` encapsula
 | `SkillsStore` | `shared/Features/Skills/SkillsStore.swift` | Skills CRUD: list, search, inspect, install, uninstall, enable/disable, configure, draft, and create. Caches inspect results and uses generation counters to handle stale responses. |
 | `ContactsStore` | `shared/Features/Contacts/ContactsStore.swift` | Contacts CRUD: list, get, update channel policy, delete. Auto-refreshes on `contactsChanged` daemon broadcasts with 500ms debounce. |
 | `DirectoryStore` | `shared/Features/Directory/DirectoryStore.swift` | Directory data: local apps, shared apps, documents. Supports open, delete, share-to-cloud, fork, and bundle operations. Auto-refreshes on `appFilesChanged` broadcasts. |
-| `ChannelTrustStore` | `shared/Features/ChannelTrust/ChannelTrustStore.swift` | Guardian state and channel trust management. Composes `ContactsStore` for guardian contact data, manages pending guardian action prompts via daemon IPC. |
+| `ChannelTrustStore` | `shared/Features/ChannelTrust/ChannelTrustStore.swift` | Guardian state and channel trust management. Composes `ContactsStore` for guardian contact data, manages pending guardian action prompts via daemon HTTP API. |
 
 ### Store Patterns
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -15,7 +15,7 @@ For client architecture details, see [`ARCHITECTURE.md`](ARCHITECTURE.md).
 clients/
 ├── Package.swift              # Multi-platform Swift Package Manager manifest
 ├── shared/                    # VellumAssistantShared - cross-platform code
-│   ├── IPC/                   # Daemon communication (DaemonClient, DaemonConfig, IPCMessages)
+│   ├── Network/                # Daemon communication (DaemonClient, DaemonConfig, MessageTypes)
 │   ├── Features/Chat/         # Shared chat UI (ChatViewModel, MessageBubbleView, InputBarView, etc.)
 │   ├── Features/Skills/       # SkillsStore — cross-platform skills data operations
 │   ├── Features/Contacts/     # ContactsStore — cross-platform contacts data operations
@@ -52,10 +52,10 @@ clients/
 **Purpose**: Platform-agnostic code shared between macOS and iOS apps
 
 **Contains**:
-- **Network layer** (`DaemonClient`, `IPCMessages`, `Generated/GeneratedAPITypes`) - HTTP+SSE communication with the assistant
+- **Network layer** (`DaemonClient`, `MessageTypes`, `Generated/GeneratedAPITypes`) - HTTP+SSE communication with the assistant
   - macOS: HTTP+SSE to the local daemon runtime server
   - iOS: HTTP+SSE through the gateway
-  - Wire types are auto-generated from the TS contract; `IPCMessages.swift` provides
+  - Wire types are auto-generated from the TS contract; `MessageTypes.swift` provides
     typealiases, convenience inits, the `ServerMessage` routing enum, and a few hand-maintained
     types that need Swift-specific logic (e.g. typed enums, polymorphic `AnyCodable` data)
 - **Shared chat features** (`ChatViewModel`, `ChatMessage`, `MessageBubbleView`, `InputBarView`, `AttachmentStripView`, `MarkdownRenderer`, `CurrentStepIndicator`, inline widgets)
@@ -152,7 +152,7 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 
 **~45-50% code reuse** between macOS and iOS achieved through:
 
-1. **Shared IPC layer** - Both platforms communicate with the assistant (different transport)
+1. **Shared network layer** - Both platforms communicate with the assistant (different transport)
 2. **Shared design system** - Tokens and components with conditional compilation
 3. **Shared ViewModels** - ChatViewModel, message models work on both platforms
 
@@ -174,12 +174,12 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 
 ### Adding macOS-Only Code
 1. Place in `clients/macos/vellum-assistant/`
-2. Import `VellumAssistantShared` for access to IPC types
+2. Import `VellumAssistantShared` for access to network types
 3. Can use AppKit, ScreenCaptureKit, etc. freely
 
 ### Adding iOS Code
 1. Place in `clients/ios/App/` (app lifecycle) or `clients/ios/Views/` (UI)
-2. Import `VellumAssistantShared` for IPC, design tokens, ViewModels
+2. Import `VellumAssistantShared` for network types, design tokens, ViewModels
 3. DO NOT import `VellumAssistantLib` (macOS-only)
 4. Use `#if os(iOS)` guards if sharing files with macOS
 
@@ -188,7 +188,7 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 ## Known Limitations
 
 ### iOS Signing Operations
-- iOS clients return explicit error responses when the assistant sends signing requests (macOS-specific IPC)
+- iOS clients return explicit error responses when the assistant sends signing requests (macOS-specific operations)
 - Unsupported operations (`signBundlePayload`, `getSigningIdentity`) are logged and answered with an error message rather than silently dropped
 
 ### iOS Gateway Networking

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -100,12 +100,12 @@ Tests use `Mock*` versions defined in `SessionTests.swift`. Test pattern: `@Main
 
 </details>
 
-### Network Layer (`IPC/`)
+### Network Layer (`Network/`)
 
 All inference (both computer-use sessions and ambient analysis) goes through the assistant's HTTP API:
 - `DaemonClient` — `@MainActor`, HTTP+SSE transport; auto-reconnect, `AsyncStream<ServerMessage>`
-- `IPCMessages.swift` — Codable structs for HTTP request/response types: `cu_session_create`, `cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `ambient_analyze`, `trace_event`, etc.
-- `IPC/Generated/GeneratedAPITypes.swift` — Codable Swift types used for JSON serialization. Use these `IPC*` types directly in Swift code instead of hand-writing structs.
+- `MessageTypes.swift` — Codable structs for HTTP request/response types: `cu_session_create`, `cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `ambient_analyze`, `trace_event`, etc.
+- `Network/Generated/GeneratedAPITypes.swift` — Codable Swift types used for JSON serialization. Use these generated types directly in Swift code instead of hand-writing structs.
 
 ### Ambient Agent (`Ambient/`)
 


### PR DESCRIPTION
## Summary
- Update clients/README.md: IPC/ → Network/, IPCMessages → MessageTypes throughout
- Update clients/ARCHITECTURE.md: IPC file paths → Network paths, IPC → HTTP API
- Update clients/macos/CLAUDE.md: IPC directory and file references → Network

Part of plan: phase-out-ipc-refs.md (PR 5 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
