### PR TITLE
refactor: rename ipc auth types to local in gateway auth layer

### DIFF
--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -37,7 +37,7 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "attachments.write",
     "internal.write",
   ]),
-  ipc_v1: new Set<Scope>(["ipc.all"]),
+  local_v1: new Set<Scope>(["local.all"]),
   ui_page_v1: new Set<Scope>(["settings.read"]),
 };
 

--- a/gateway/src/auth/subject.ts
+++ b/gateway/src/auth/subject.ts
@@ -32,7 +32,7 @@ export type ParseSubResult =
  *   actor:<assistantId>:<actorPrincipalId>
  *   svc:gateway:<assistantId>
  *   svc:daemon:<identifier>
- *   ipc:<assistantId>:<sessionId>
+ *   local:<assistantId>:<sessionId>
  */
 export function parseSub(sub: string): ParseSubResult {
   if (!sub || typeof sub !== "string") {
@@ -68,15 +68,15 @@ export function parseSub(sub: string): ParseSubResult {
     return { ok: true, principalType: "svc_daemon", assistantId: identifier };
   }
 
-  if (parts[0] === "ipc" && parts.length === 3) {
+  if (parts[0] === "local" && parts.length === 3) {
     const [, assistantId, sessionId] = parts;
     if (!assistantId || !sessionId) {
       return {
         ok: false,
-        reason: "ipc sub has empty assistantId or sessionId",
+        reason: "local sub has empty assistantId or sessionId",
       };
     }
-    return { ok: true, principalType: "ipc", assistantId, sessionId };
+    return { ok: true, principalType: "local", assistantId, sessionId };
   }
 
   return { ok: false, reason: `unrecognized sub pattern: ${sub}` };

--- a/gateway/src/auth/token-exchange.ts
+++ b/gateway/src/auth/token-exchange.ts
@@ -77,8 +77,8 @@ export function mintExchangeToken(
       case "svc_gateway":
         exchangeSub = "svc:gateway:self";
         break;
-      case "ipc":
-        exchangeSub = `ipc:self:${parsed.sessionId}`;
+      case "local":
+        exchangeSub = `local:self:${parsed.sessionId}`;
         break;
       default:
         exchangeSub = "svc:gateway:self";

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -13,7 +13,7 @@ export type ScopeProfile =
   | "actor_client_v1"
   | "gateway_ingress_v1"
   | "gateway_service_v1"
-  | "ipc_v1"
+  | "local_v1"
   | "ui_page_v1";
 
 // ---------------------------------------------------------------------------
@@ -35,13 +35,13 @@ export type Scope =
   | "internal.write"
   | "feature_flags.read"
   | "feature_flags.write"
-  | "ipc.all";
+  | "local.all";
 
 // ---------------------------------------------------------------------------
 // Principal types — derived from the sub pattern
 // ---------------------------------------------------------------------------
 
-export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "ipc";
+export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "local";
 
 // ---------------------------------------------------------------------------
 // Token audience — which service the JWT is intended for


### PR DESCRIPTION
## Summary
- Rename `ipc_v1` → `local_v1` scope profile in gateway auth
- Rename `ipc.all` → `local.all` scope in gateway auth
- Rename `"ipc"` → `"local"` principal type in gateway auth
- Update token exchange to handle `local:` subject prefix

Part of plan: phase-out-ipc-refs.md (PR 8 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
