### PR TITLE
Enqueue embed_attachment jobs when indexing messages with image content

### DIFF
--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 import { desc, eq } from "drizzle-orm";
 
+import { getConfig } from "../config/loader.js";
 import type { MemoryConfig } from "../config/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
@@ -10,7 +11,10 @@ import {
   enqueueMemoryJob,
   enqueueResolvePendingConflictsForMessageJob,
 } from "./jobs-store.js";
-import { extractTextFromStoredMessageContent } from "./message-content.js";
+import {
+  extractMediaBlocks,
+  extractTextFromStoredMessageContent,
+} from "./message-content.js";
 import { bumpMemoryVersion } from "./recall-cache.js";
 import { memorySegments } from "./schema.js";
 import { segmentText } from "./segmenter.js";
@@ -73,6 +77,17 @@ export function indexMessageNow(
   const shouldResolveConflicts =
     input.role === "user" && config.conflicts.enabled;
 
+  // Check if the embedding provider supports multimodal (only Gemini does).
+  // If so, scan for image blocks to enqueue embed_attachment jobs.
+  const embeddingProvider = config.embeddings.provider;
+  const fullConfig = getConfig();
+  const supportsMultimodal =
+    embeddingProvider === "gemini" ||
+    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini);
+  const mediaBlocks = supportsMultimodal
+    ? extractMediaBlocks(input.content).filter((b) => b.type === "image")
+    : [];
+
   // Wrap all segment inserts and job enqueues in a single transaction so they
   // either all succeed or all roll back, preventing partial/orphaned state.
   let skippedEmbedJobs = 0;
@@ -119,6 +134,17 @@ export function indexMessageNow(
       } else {
         enqueueMemoryJob("embed_segment", { segmentId }, Date.now(), tx);
       }
+    }
+
+    // Enqueue embed_attachment jobs for image content blocks when the
+    // embedding provider supports multimodal (Gemini only).
+    for (const block of mediaBlocks) {
+      enqueueMemoryJob(
+        "embed_attachment",
+        { messageId: input.messageId, blockIndex: block.index },
+        Date.now(),
+        tx,
+      );
     }
 
     if (shouldExtract && isTrustedActor) {
@@ -168,6 +194,7 @@ export function indexMessageNow(
   const enqueuedJobs =
     segments.length -
     skippedEmbedJobs +
+    mediaBlocks.length +
     (shouldExtract && !extractionGated ? 2 : 1) +
     (shouldResolveConflicts && !extractionGated ? 1 : 0);
   return {


### PR DESCRIPTION
## Summary
- Scan message content for image blocks during memory indexing
- Enqueue `embed_attachment` jobs for each image block when multimodal provider is available
- Guard: only enqueue when Gemini is the active or fallback embedding provider

Part of plan: multimodal-embedding.md (PR 12 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
