### PR TITLE
refactor: rename ipc auth types to local in assistant auth layer

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -389,14 +389,14 @@ describe("resolveLocalIpcTrustContext", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveLocalIpcAuthContext", () => {
-  test("returns AuthContext with ipc principal type", () => {
+  test("returns AuthContext with local principal type", () => {
     const ctx = resolveLocalIpcAuthContext("session-123");
-    expect(ctx.principalType).toBe("ipc");
+    expect(ctx.principalType).toBe("local");
   });
 
-  test("subject follows ipc:self:<sessionId> pattern", () => {
+  test("subject follows local:self:<sessionId> pattern", () => {
     const ctx = resolveLocalIpcAuthContext("session-abc");
-    expect(ctx.subject).toBe("ipc:self:session-abc");
+    expect(ctx.subject).toBe("local:self:session-abc");
   });
 
   test("assistantId is always self", () => {
@@ -404,10 +404,10 @@ describe("resolveLocalIpcAuthContext", () => {
     expect(ctx.assistantId).toBe("self");
   });
 
-  test("uses ipc_v1 scope profile with ipc.all scope", () => {
+  test("uses local_v1 scope profile with local.all scope", () => {
     const ctx = resolveLocalIpcAuthContext("session-123");
-    expect(ctx.scopeProfile).toBe("ipc_v1");
-    expect(ctx.scopes.has("ipc.all")).toBe(true);
+    expect(ctx.scopeProfile).toBe("local_v1");
+    expect(ctx.scopes.has("local.all")).toBe(true);
   });
 
   test("enriches actorPrincipalId from vellum guardian binding when present", () => {

--- a/assistant/src/__tests__/conversation-unread-route.test.ts
+++ b/assistant/src/__tests__/conversation-unread-route.test.ts
@@ -85,7 +85,7 @@ describe("POST /v1/conversations/unread", () => {
   test("registers the unread route with chat.write policy", () => {
     expect(getPolicy("conversations/unread")).toEqual({
       requiredScopes: ["chat.write"],
-      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "ipc"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
     });
   });
 

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -120,7 +120,7 @@ mock.module("../runtime/local-actor-identity.js", () => ({
     guardianPrincipalId: "local-principal",
   }),
   resolveLocalIpcAuthContext: () => ({
-    scope: "ipc_v1",
+    scope: "local_v1",
     actorPrincipalId: "local-principal",
   }),
 }));

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -467,7 +467,7 @@ describe("route policy registration", () => {
     expect(policy?.requiredScopes).toContain("settings.write");
     expect(policy?.allowedPrincipalTypes).toContain("actor");
     expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
-    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+    expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 
   test("migrations/validate policy is still registered", async () => {
@@ -493,7 +493,7 @@ describe("auth policy shape", () => {
     expect(policy!.requiredScopes).toEqual(["settings.write"]);
     // Verify only the expected principal types are allowed
     expect(policy!.allowedPrincipalTypes).toEqual(
-      expect.arrayContaining(["actor", "svc_gateway", "svc_daemon", "ipc"]),
+      expect.arrayContaining(["actor", "svc_gateway", "svc_daemon", "local"]),
     );
     expect(policy!.allowedPrincipalTypes).toHaveLength(4);
   });

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -770,7 +770,7 @@ describe("route policy registration", () => {
     expect(policy?.requiredScopes).toContain("settings.write");
     expect(policy?.allowedPrincipalTypes).toContain("actor");
     expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
-    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+    expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 
   test("import policy matches other migration endpoint policies", async () => {

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -708,7 +708,7 @@ describe("route policy registration", () => {
     expect(policy?.requiredScopes).toContain("settings.write");
     expect(policy?.allowedPrincipalTypes).toContain("actor");
     expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
-    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+    expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 
   test("import-preflight policy matches validate/export policy shape", async () => {

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -676,7 +676,7 @@ describe("route policy registration", () => {
     expect(policy?.requiredScopes).toContain("settings.write");
     expect(policy?.allowedPrincipalTypes).toContain("actor");
     expect(policy?.allowedPrincipalTypes).toContain("svc_gateway");
-    expect(policy?.allowedPrincipalTypes).toContain("ipc");
+    expect(policy?.allowedPrincipalTypes).toContain("local");
   });
 });
 

--- a/assistant/src/runtime/auth/__tests__/context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/context.test.ts
@@ -50,19 +50,19 @@ describe("buildAuthContext", () => {
     }
   });
 
-  test("builds context from valid ipc claims", () => {
+  test("builds context from valid local claims", () => {
     const result = buildAuthContext(
       validClaims({
-        sub: "ipc:self:session-123",
-        scope_profile: "ipc_v1",
+        sub: "local:self:session-123",
+        scope_profile: "local_v1",
       }),
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.context.principalType).toBe("ipc");
+      expect(result.context.principalType).toBe("local");
       expect(result.context.assistantId).toBe("self");
       expect(result.context.sessionId).toBe("session-123");
-      expect(result.context.scopes.has("ipc.all")).toBe(true);
+      expect(result.context.scopes.has("local.all")).toBe(true);
     }
   });
 

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -297,7 +297,7 @@ describe("scope profile contract", () => {
       "attachments.write",
       "internal.write",
     ],
-    ipc_v1: ["ipc.all"],
+    local_v1: ["local.all"],
     ui_page_v1: ["settings.read"],
   };
 
@@ -320,7 +320,7 @@ describe("scope profile contract", () => {
       "actor_client_v1",
       "gateway_ingress_v1",
       "gateway_service_v1",
-      "ipc_v1",
+      "local_v1",
       "ui_page_v1",
     ];
 

--- a/assistant/src/runtime/auth/__tests__/ipc-auth-context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/ipc-auth-context.test.ts
@@ -8,12 +8,12 @@ import { resolveScopeProfile } from "../scopes.js";
 describe("buildIpcAuthContext", () => {
   test("produces correct subject pattern", () => {
     const ctx = buildIpcAuthContext("session-abc");
-    expect(ctx.subject).toBe("ipc:self:session-abc");
+    expect(ctx.subject).toBe("local:self:session-abc");
   });
 
-  test("sets principalType to ipc", () => {
+  test("sets principalType to local", () => {
     const ctx = buildIpcAuthContext("session-abc");
-    expect(ctx.principalType).toBe("ipc");
+    expect(ctx.principalType).toBe("local");
   });
 
   test("uses DAEMON_INTERNAL_ASSISTANT_ID for assistantId", () => {
@@ -27,16 +27,16 @@ describe("buildIpcAuthContext", () => {
     expect(ctx.sessionId).toBe("my-session-123");
   });
 
-  test("uses ipc_v1 scope profile", () => {
+  test("uses local_v1 scope profile", () => {
     const ctx = buildIpcAuthContext("session-abc");
-    expect(ctx.scopeProfile).toBe("ipc_v1");
+    expect(ctx.scopeProfile).toBe("local_v1");
   });
 
-  test("resolves scopes from ipc_v1 profile", () => {
+  test("resolves scopes from local_v1 profile", () => {
     const ctx = buildIpcAuthContext("session-abc");
-    const expectedScopes = resolveScopeProfile("ipc_v1");
+    const expectedScopes = resolveScopeProfile("local_v1");
     expect(ctx.scopes).toBe(expectedScopes);
-    expect(ctx.scopes.has("ipc.all")).toBe(true);
+    expect(ctx.scopes.has("local.all")).toBe(true);
   });
 
   test("uses current policy epoch", () => {

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -129,13 +129,13 @@ describe("enforcePolicy", () => {
     expect(result!.status).toBe(403);
   });
 
-  test("standard actor endpoints allow actor, svc_gateway, and ipc", () => {
+  test("standard actor endpoints allow actor, svc_gateway, and local", () => {
     authDisabled = false;
     const policy = getPolicy("messages:POST");
     expect(policy).toBeDefined();
     expect(policy!.allowedPrincipalTypes).toContain("actor");
     expect(policy!.allowedPrincipalTypes).toContain("svc_gateway");
-    expect(policy!.allowedPrincipalTypes).toContain("ipc");
+    expect(policy!.allowedPrincipalTypes).toContain("local");
   });
 
   test("dev bypass allows all requests through regardless of policy", () => {

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -42,7 +42,7 @@ describe("resolveScopeProfile", () => {
     const scopes = resolveScopeProfile("actor_client_v1");
     expect(scopes.has("ingress.write")).toBe(false);
     expect(scopes.has("internal.write")).toBe(false);
-    expect(scopes.has("ipc.all")).toBe(false);
+    expect(scopes.has("local.all")).toBe(false);
   });
 
   test("gateway_ingress_v1 includes ingress and internal scopes", () => {
@@ -64,9 +64,9 @@ describe("resolveScopeProfile", () => {
     expect(scopes.size).toBe(7);
   });
 
-  test("ipc_v1 includes only ipc.all", () => {
-    const scopes = resolveScopeProfile("ipc_v1");
-    expect(scopes.has("ipc.all")).toBe(true);
+  test("local_v1 includes only local.all", () => {
+    const scopes = resolveScopeProfile("local_v1");
+    expect(scopes.has("local.all")).toBe(true);
     expect(scopes.size).toBe(1);
   });
 });
@@ -82,9 +82,9 @@ describe("hasScope", () => {
     expect(hasScope(ctx, "ingress.write")).toBe(false);
   });
 
-  test("returns true for ipc.all on ipc_v1 profile", () => {
-    const ctx = makeCtx("ipc_v1");
-    expect(hasScope(ctx, "ipc.all")).toBe(true);
+  test("returns true for local.all on local_v1 profile", () => {
+    const ctx = makeCtx("local_v1");
+    expect(hasScope(ctx, "local.all")).toBe(true);
   });
 });
 

--- a/assistant/src/runtime/auth/__tests__/subject.test.ts
+++ b/assistant/src/runtime/auth/__tests__/subject.test.ts
@@ -76,14 +76,14 @@ describe("parseSub", () => {
   });
 
   // -------------------------------------------------------------------------
-  // ipc pattern
+  // local pattern
   // -------------------------------------------------------------------------
 
-  test("parses ipc:<assistantId>:<sessionId>", () => {
-    const result = parseSub("ipc:self:session-xyz");
+  test("parses local:<assistantId>:<sessionId>", () => {
+    const result = parseSub("local:self:session-xyz");
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.principalType).toBe("ipc");
+      expect(result.principalType).toBe("local");
       expect(result.assistantId).toBe("self");
       expect(result.sessionId).toBe("session-xyz");
       expect(result.actorPrincipalId).toBeUndefined();
@@ -158,16 +158,16 @@ describe("parseSub", () => {
     }
   });
 
-  test("fails on ipc with empty sessionId", () => {
-    const result = parseSub("ipc:self:");
+  test("fails on local with empty sessionId", () => {
+    const result = parseSub("local:self:");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toContain("empty");
     }
   });
 
-  test("fails on ipc with empty assistantId", () => {
-    const result = parseSub("ipc::session-abc");
+  test("fails on local with empty assistantId", () => {
+    const result = parseSub("local::session-abc");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toContain("empty");

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -409,7 +409,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "integrations/twitter/auth/start", scopes: ["settings.write"] },
   { endpoint: "integrations/twitter/auth/status", scopes: ["settings.read"] },
 
-  // Workspace files (IPC-migrated)
+  // Workspace files
   { endpoint: "workspace-files", scopes: ["settings.read"] },
   { endpoint: "workspace-files/read", scopes: ["settings.read"] },
 
@@ -421,7 +421,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
   registerPolicy(endpoint, {
     requiredScopes: scopes,
-    allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "ipc"],
+    allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
   });
 }
 

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -37,7 +37,7 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "attachments.write",
     "internal.write",
   ]),
-  ipc_v1: new Set<Scope>(["ipc.all"]),
+  local_v1: new Set<Scope>(["local.all"]),
   ui_page_v1: new Set<Scope>(["settings.read"]),
 };
 

--- a/assistant/src/runtime/auth/subject.ts
+++ b/assistant/src/runtime/auth/subject.ts
@@ -32,7 +32,7 @@ export type ParseSubResult =
  *   actor:<assistantId>:<actorPrincipalId>
  *   svc:gateway:<assistantId>
  *   svc:daemon:<identifier>
- *   ipc:<assistantId>:<sessionId>
+ *   local:<assistantId>:<sessionId>
  */
 export function parseSub(sub: string): ParseSubResult {
   if (!sub || typeof sub !== "string") {
@@ -68,15 +68,15 @@ export function parseSub(sub: string): ParseSubResult {
     return { ok: true, principalType: "svc_daemon", assistantId: identifier };
   }
 
-  if (parts[0] === "ipc" && parts.length === 3) {
+  if (parts[0] === "local" && parts.length === 3) {
     const [, assistantId, sessionId] = parts;
     if (!assistantId || !sessionId) {
       return {
         ok: false,
-        reason: "ipc sub has empty assistantId or sessionId",
+        reason: "local sub has empty assistantId or sessionId",
       };
     }
-    return { ok: true, principalType: "ipc", assistantId, sessionId };
+    return { ok: true, principalType: "local", assistantId, sessionId };
   }
 
   return { ok: false, reason: `unrecognized sub pattern: ${sub}` };

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -13,7 +13,7 @@ export type ScopeProfile =
   | "actor_client_v1"
   | "gateway_ingress_v1"
   | "gateway_service_v1"
-  | "ipc_v1"
+  | "local_v1"
   | "ui_page_v1";
 
 // ---------------------------------------------------------------------------
@@ -35,13 +35,13 @@ export type Scope =
   | "internal.write"
   | "feature_flags.read"
   | "feature_flags.write"
-  | "ipc.all";
+  | "local.all";
 
 // ---------------------------------------------------------------------------
 // Principal types — derived from the sub pattern
 // ---------------------------------------------------------------------------
 
-export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "ipc";
+export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "local";
 
 // ---------------------------------------------------------------------------
 // Token audience — which service the JWT is intended for

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -1,12 +1,12 @@
 /**
- * Deterministic local actor identity for IPC connections.
+ * Deterministic local actor identity for local connections.
  *
- * IPC (Unix domain socket) connections come from the local macOS native app.
- * No actor token is sent over the socket; instead, the daemon assigns a
+ * Local connections come from the native app via local HTTP sessions.
+ * No actor token is sent over the connection; instead, the daemon assigns a
  * deterministic local actor identity server-side by looking up the vellum
  * channel guardian binding.
  *
- * This routes IPC connections through the same `resolveTrustContext`
+ * This routes local connections through the same `resolveTrustContext`
  * pathway used by HTTP channel ingress, producing equivalent
  * guardian-context behavior for the vellum channel.
  */
@@ -34,12 +34,12 @@ const log = getLogger("local-actor-identity");
  */
 export function buildLocalAuthContext(sessionId: string): AuthContext {
   return {
-    subject: `ipc:self:${sessionId}`,
-    principalType: "ipc",
+    subject: `local:self:${sessionId}`,
+    principalType: "local",
     assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sessionId,
-    scopeProfile: "ipc_v1",
-    scopes: resolveScopeProfile("ipc_v1"),
+    scopeProfile: "local_v1",
+    scopes: resolveScopeProfile("local_v1"),
     policyEpoch: CURRENT_POLICY_EPOCH,
   };
 }
@@ -50,11 +50,11 @@ export function buildLocalAuthContext(sessionId: string): AuthContext {
 export const buildIpcAuthContext = buildLocalAuthContext;
 
 /**
- * Resolve the guardian runtime context for a local IPC connection.
+ * Resolve the guardian runtime context for a local connection.
  *
  * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
  * then passes it as the sender identity through `resolveTrustContext` --
- * the same pathway HTTP channel routes use. This ensures IPC and HTTP
+ * the same pathway HTTP channel routes use. This ensures local and HTTP
  * produce equivalent trust classification for the vellum channel.
  *
  * When no vellum guardian binding exists (e.g. fresh install before
@@ -107,10 +107,10 @@ export function resolveLocalIpcTrustContext(
 }
 
 /**
- * Build an AuthContext for a local IPC connection.
+ * Build an AuthContext for a local connection.
  *
  * Produces the same AuthContext shape that HTTP routes receive from JWT
- * verification, using the `ipc_v1` scope profile. The `actorPrincipalId`
+ * verification, using the `local_v1` scope profile. The `actorPrincipalId`
  * is populated from the vellum guardian binding when available, enabling
  * downstream code to resolve guardian context using the same
  * `authContext.actorPrincipalId` path as HTTP sessions.


### PR DESCRIPTION
## Summary
- Rename `ipc_v1` → `local_v1` scope profile
- Rename `ipc.all` → `local.all` scope
- Rename `"ipc"` → `"local"` principal type
- Update subject parser to handle `local:` prefix instead of `ipc:`
- Update all auth tests to match new terminology

Part of plan: phase-out-ipc-refs.md (PR 7 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
