### PR TITLE
fix: update intent-routing test for reminder removal

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -99,7 +99,7 @@ const scheduleCreateDef = scheduleToolsJson.tools.find(
 // 1. System prompt: buildTaskScheduleReminderRoutingSection
 // =====================================================================
 
-describe("Task/Schedule/Reminder routing section in system prompt", () => {
+describe("Task/Schedule routing section in system prompt", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -113,15 +113,14 @@ describe("Task/Schedule/Reminder routing section in system prompt", () => {
   test("system prompt includes the routing section heading", () => {
     const prompt = buildSystemPrompt();
     expect(prompt).toContain(
-      "## Tool Routing: Tasks vs Schedules vs Reminders vs Notifications",
+      "## Tool Routing: Tasks vs Schedules vs Notifications",
     );
   });
 
-  test("routing section lists all four tools in the summary table", () => {
+  test("routing section lists all three tools in the summary table", () => {
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("`task_list_add`");
     expect(prompt).toContain("`schedule_create`");
-    expect(prompt).toContain("`reminder_create`");
     expect(prompt).toContain("`send_notification`");
   });
 
@@ -156,7 +155,7 @@ describe("Task/Schedule/Reminder routing section in system prompt", () => {
   test("routing section is present in the system prompt", () => {
     const prompt = buildSystemPrompt();
     const taskRoutingIdx = prompt.indexOf(
-      "## Tool Routing: Tasks vs Schedules vs Reminders vs Notifications",
+      "## Tool Routing: Tasks vs Schedules vs Notifications",
     );
     expect(taskRoutingIdx).toBeGreaterThanOrEqual(0);
   });


### PR DESCRIPTION
## Summary
Fixes stale test assertions that referenced the removed reminder system.

**Gap:** intent-routing.test.ts asserts old heading "Tasks vs Schedules vs Reminders vs Notifications" and expects reminder_create in prompt
**What was expected:** Updated assertions matching current system prompt without reminders
**What was found:** Test failures on assertions about removed reminder content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
