### PR TITLE
fix: revert TitleOrigin from 'local' back to 'ipc'

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -380,7 +380,7 @@ export async function handleSessionCreate(
     if (title === GENERATING_TITLE) {
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: "local" },
+        context: { origin: "ipc" },
         userMessage: msg.initialMessage,
         onTitleUpdated: (newTitle) => {
           ctx.send({

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -30,7 +30,6 @@ export type TitleOrigin =
   | "voice_inbound"
   | "guardian_request"
   | "schedule"
-  | "reminder"
   | "task"
   | "watcher"
   | "subagent"


### PR DESCRIPTION
## Summary
- Reverts `origin: "local"` back to `origin: "ipc"` in sessions.ts to fix TS2322 type error
- Removes dead `"reminder"` variant from `TitleOrigin` union (no longer used after reminder removal)

**Gap:** sessions.ts uses `origin: "local"` but `TitleOrigin` only includes `"ipc"`
**What was expected:** Valid TitleOrigin value
**What was found:** TS2322 type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
