### PR TITLE
fix: align intent-routing tests with reminder removal; fix lexical-only memory degradation

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -113,15 +113,14 @@ describe("Task/Schedule/Reminder routing section in system prompt", () => {
   test("system prompt includes the routing section heading", () => {
     const prompt = buildSystemPrompt();
     expect(prompt).toContain(
-      "## Tool Routing: Tasks vs Schedules vs Reminders vs Notifications",
+      "## Tool Routing: Tasks vs Schedules vs Notifications",
     );
   });
 
-  test("routing section lists all four tools in the summary table", () => {
+  test("routing section lists all three tools in the summary table", () => {
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("`task_list_add`");
     expect(prompt).toContain("`schedule_create`");
-    expect(prompt).toContain("`reminder_create`");
     expect(prompt).toContain("`send_notification`");
   });
 
@@ -156,7 +155,7 @@ describe("Task/Schedule/Reminder routing section in system prompt", () => {
   test("routing section is present in the system prompt", () => {
     const prompt = buildSystemPrompt();
     const taskRoutingIdx = prompt.indexOf(
-      "## Tool Routing: Tasks vs Schedules vs Reminders vs Notifications",
+      "## Tool Routing: Tasks vs Schedules vs Notifications",
     );
     expect(taskRoutingIdx).toBeGreaterThanOrEqual(0);
   });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -828,7 +828,17 @@ export async function buildMemoryRecall(
   // degradation state. This ensures results computed with boosted limits
   // are marked degraded and excluded from the recall cache — preventing
   // stale boosted results from being served after the breaker closes.
-  if (collected.semanticSearchFailed || collected.semanticUnavailable) {
+  //
+  // Exception: when semanticUnavailable is solely because no embedding
+  // provider is configured (queryVector == null) and embeddings are not
+  // required, lexical-only results are the expected steady state — do not
+  // mark as degraded.
+  const semanticActuallyFailed =
+    collected.semanticSearchFailed ||
+    (collected.semanticUnavailable &&
+      (embeddingResult.queryVector != null ||
+        config.memory.embeddings.required));
+  if (semanticActuallyFailed) {
     embeddingResult.degraded = true;
     embeddingResult.reason =
       embeddingResult.reason ??


### PR DESCRIPTION
## Summary
- Update intent-routing tests to match the updated system prompt heading and tool table after reminder removal in #14954/#14983 (heading no longer includes "Reminders", table no longer has \`reminder_create\`)
- Fix \`buildMemoryRecall\` to not mark results as degraded when \`semanticUnavailable\` is solely due to no embedding backend being configured (and embeddings are not required); lexical-only is the expected steady state in that case

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22928056600/job/66543132578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
