### PR TITLE
fix: resolve lint errors in embedding test and media-processing imports

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/memory/job-handlers/embedding.test.ts
@@ -60,8 +60,6 @@ mock.module("../job-utils.js", () => ({
   },
 }));
 
-import { eq } from "drizzle-orm";
-
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb, initializeDb, resetDb } from "../db.js";

--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -8,7 +8,7 @@ import { preprocessForAsset } from "../../config/bundled-skills/media-processing
 import { reduceForAsset } from "../../config/bundled-skills/media-processing/tools/query-media-events.js";
 import { getLogger } from "../../util/logger.js";
 import { asString } from "../job-utils.js";
-import { type MemoryJob, enqueueMemoryJob } from "../jobs-store.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { getMediaAssetById, updateMediaAssetStatus } from "../media-store.js";
 
 const log = getLogger("media-processing-job");


### PR DESCRIPTION
## Summary
- Remove unused `eq` import from `embedding.test.ts` (leftover from prior refactor)
- Fix import specifier ordering in `media-processing.ts`: `{ enqueueMemoryJob, type MemoryJob }` (alphabetical, per simple-import-sort)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22928156800/job/66543455976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
