### PR TITLE
feat(trust-store): migrate legacy root trust.json to protected subdir on load

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -57,6 +57,7 @@ import {
 } from "../permissions/trust-store.js";
 
 const trustPath = join(testDir, "protected", "trust.json");
+const legacyTrustPath = join(testDir, "trust.json");
 const DEFAULT_TEMPLATES = getDefaultRuleTemplates();
 const NUM_DEFAULTS = DEFAULT_TEMPLATES.length;
 const DEFAULT_PRIORITY_BY_ID = new Map(
@@ -69,6 +70,11 @@ describe("Trust Store", () => {
     clearCache();
     try {
       rmSync(trustPath);
+    } catch {
+      /* may not exist */
+    }
+    try {
+      rmSync(legacyTrustPath);
     } catch {
       /* may not exist */
     }
@@ -1221,6 +1227,79 @@ describe("Trust Store", () => {
   // ── loadFromDisk resilience (misc) ──────────────────────────────
 
   describe("loadFromDisk resilience (misc)", () => {
+    test("migrates legacy root trust file to protected path", () => {
+      mkdirSync(dirname(legacyTrustPath), { recursive: true });
+      writeFileSync(
+        legacyTrustPath,
+        JSON.stringify({
+          version: 3,
+          rules: [
+            {
+              id: "legacy-deny",
+              tool: "host_bash",
+              pattern: "rm -rf *",
+              scope: "everywhere",
+              decision: "deny",
+              priority: 200,
+              createdAt: 123,
+            },
+          ],
+        }),
+      );
+
+      clearCache();
+      const rules = getAllRules();
+
+      expect(rules.find((r) => r.id === "legacy-deny")).toBeDefined();
+      expect(readFileSync(trustPath, "utf-8")).toContain("legacy-deny");
+      expect(() => readFileSync(legacyTrustPath, "utf-8")).toThrow();
+    });
+
+    test("prefers protected trust file when both protected and legacy files exist", () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(
+        trustPath,
+        JSON.stringify({
+          version: 3,
+          rules: [
+            {
+              id: "protected-rule",
+              tool: "bash",
+              pattern: "protected *",
+              scope: "/tmp",
+              decision: "allow",
+              priority: 100,
+              createdAt: 1,
+            },
+          ],
+        }),
+      );
+      writeFileSync(
+        legacyTrustPath,
+        JSON.stringify({
+          version: 3,
+          rules: [
+            {
+              id: "legacy-rule",
+              tool: "bash",
+              pattern: "legacy *",
+              scope: "/tmp",
+              decision: "deny",
+              priority: 200,
+              createdAt: 2,
+            },
+          ],
+        }),
+      );
+
+      clearCache();
+      const rules = getAllRules();
+
+      expect(rules.find((r) => r.id === "protected-rule")).toBeDefined();
+      expect(rules.find((r) => r.id === "legacy-rule")).toBeUndefined();
+      expect(readFileSync(legacyTrustPath, "utf-8")).toContain("legacy-rule");
+    });
+
     test("malformed file (valid JSON but null) is handled gracefully", () => {
       mkdirSync(dirname(trustPath), { recursive: true });
       writeFileSync(trustPath, "null");

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -217,10 +217,32 @@ function backfillDefaults(rules: TrustRule[]): boolean {
   return changed;
 }
 
+function getLegacyTrustPath(): string {
+  return join(getRootDir(), "trust.json");
+}
+
 function loadFromDisk(): TrustRule[] {
   const path = getTrustPath();
   let rules: TrustRule[] = [];
   let needsSave = false;
+
+  // Migrate legacy trust file from root dir to protected subdir.
+  // Only migrate when the protected path does not yet exist.
+  if (!existsSync(path)) {
+    const legacyPath = getLegacyTrustPath();
+    if (existsSync(legacyPath)) {
+      try {
+        mkdirSync(dirname(path), { recursive: true });
+        renameSync(legacyPath, path);
+        log.info(
+          { from: legacyPath, to: path },
+          "Migrated legacy trust file to protected path",
+        );
+      } catch (err) {
+        log.warn({ err }, "Failed to migrate legacy trust file");
+      }
+    }
+  }
 
   if (existsSync(path)) {
     try {

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -234,12 +234,27 @@ function loadFromDisk(): TrustRule[] {
       try {
         mkdirSync(dirname(path), { recursive: true });
         renameSync(legacyPath, path);
+        chmodSync(path, 0o600);
         log.info(
           { from: legacyPath, to: path },
           "Migrated legacy trust file to protected path",
         );
       } catch (err) {
-        log.warn({ err }, "Failed to migrate legacy trust file");
+        log.warn(
+          { err },
+          "Failed to migrate legacy trust file; reading from legacy path",
+        );
+        // Fall back: copy content so the normal read path picks it up.
+        try {
+          const content = readFileSync(legacyPath, "utf-8");
+          mkdirSync(dirname(path), { recursive: true });
+          writeFileSync(path, content, { mode: 0o600 });
+        } catch (copyErr) {
+          log.warn(
+            { copyErr },
+            "Failed to copy legacy trust file to protected path",
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add migration logic in `loadFromDisk` that moves `{rootDir}/trust.json` → `{rootDir}/protected/trust.json` when the protected path doesn't yet exist
- When both files exist, the protected path wins and the legacy file is left untouched
- Add two new tests covering these migration scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
