### PR TITLE
refactor: rename resolveLocalIpc* to resolveLocal* and remove deprecated alias

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -63,8 +63,8 @@ import {
 } from "../runtime/auth/token-service.js";
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import {
-  resolveLocalIpcAuthContext,
-  resolveLocalIpcTrustContext,
+  resolveLocalAuthContext,
+  resolveLocalTrustContext,
 } from "../runtime/local-actor-identity.js";
 
 // ---------------------------------------------------------------------------
@@ -357,20 +357,20 @@ describe("bootstrap endpoint idempotency", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Local IPC identity resolution
+// Local identity resolution
 // ---------------------------------------------------------------------------
 
-describe("resolveLocalIpcTrustContext", () => {
+describe("resolveLocalTrustContext", () => {
   test("returns guardian context when vellum binding exists", () => {
     ensureVellumGuardianBinding("self");
 
-    const ctx = resolveLocalIpcTrustContext();
+    const ctx = resolveLocalTrustContext();
     expect(ctx.trustClass).toBe("guardian");
     expect(ctx.sourceChannel).toBe("vellum");
   });
 
   test("returns guardian context with principal when no vellum binding exists (pre-bootstrap self-heal)", () => {
-    const ctx = resolveLocalIpcTrustContext();
+    const ctx = resolveLocalTrustContext();
     expect(ctx.trustClass).toBe("guardian");
     expect(ctx.sourceChannel).toBe("vellum");
     expect(ctx.guardianPrincipalId).toBeDefined();
@@ -378,33 +378,33 @@ describe("resolveLocalIpcTrustContext", () => {
 
   test("respects custom sourceChannel parameter", () => {
     ensureVellumGuardianBinding("self");
-    const ctx = resolveLocalIpcTrustContext("vellum");
+    const ctx = resolveLocalTrustContext("vellum");
     expect(ctx.sourceChannel).toBe("vellum");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Local IPC AuthContext resolution
+// Local AuthContext resolution
 // ---------------------------------------------------------------------------
 
-describe("resolveLocalIpcAuthContext", () => {
+describe("resolveLocalAuthContext", () => {
   test("returns AuthContext with local principal type", () => {
-    const ctx = resolveLocalIpcAuthContext("session-123");
+    const ctx = resolveLocalAuthContext("session-123");
     expect(ctx.principalType).toBe("local");
   });
 
   test("subject follows local:self:<sessionId> pattern", () => {
-    const ctx = resolveLocalIpcAuthContext("session-abc");
+    const ctx = resolveLocalAuthContext("session-abc");
     expect(ctx.subject).toBe("local:self:session-abc");
   });
 
   test("assistantId is always self", () => {
-    const ctx = resolveLocalIpcAuthContext("session-123");
+    const ctx = resolveLocalAuthContext("session-123");
     expect(ctx.assistantId).toBe("self");
   });
 
   test("uses local_v1 scope profile with local.all scope", () => {
-    const ctx = resolveLocalIpcAuthContext("session-123");
+    const ctx = resolveLocalAuthContext("session-123");
     expect(ctx.scopeProfile).toBe("local_v1");
     expect(ctx.scopes.has("local.all")).toBe(true);
   });
@@ -414,7 +414,7 @@ describe("resolveLocalIpcAuthContext", () => {
     const guardianResult = findGuardianForChannel("vellum");
     expect(guardianResult).toBeTruthy();
 
-    const ctx = resolveLocalIpcAuthContext("session-123");
+    const ctx = resolveLocalAuthContext("session-123");
     expect(ctx.actorPrincipalId).toBe(
       guardianResult!.contact.principalId ?? undefined,
     );
@@ -425,14 +425,14 @@ describe("resolveLocalIpcAuthContext", () => {
     resetDb();
     initializeDb();
 
-    const ctx = resolveLocalIpcAuthContext("session-123");
+    const ctx = resolveLocalAuthContext("session-123");
     // Self-heal creates a vellum guardian binding automatically
     expect(ctx.actorPrincipalId).toBeDefined();
     expect(ctx.actorPrincipalId).toMatch(/^vellum-principal-/);
   });
 
   test("sessionId matches the provided argument", () => {
-    const ctx = resolveLocalIpcAuthContext("my-session");
+    const ctx = resolveLocalAuthContext("my-session");
     expect(ctx.sessionId).toBe("my-session");
   });
 });

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -86,7 +86,7 @@ mock.module("../memory/conversation-crud.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalIpcTrustContext: () => ({
+  resolveLocalTrustContext: () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
   }),

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -114,12 +114,12 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalIpcTrustContext: () => ({
+  resolveLocalTrustContext: () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
     guardianPrincipalId: "local-principal",
   }),
-  resolveLocalIpcAuthContext: () => ({
+  resolveLocalAuthContext: () => ({
     scope: "local_v1",
     actorPrincipalId: "local-principal",
   }),

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -104,7 +104,7 @@ mock.module("../memory/conversation-crud.js", () => ({
 }));
 
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalIpcTrustContext: () => ({
+  resolveLocalTrustContext: () => ({
     trustClass: "guardian",
     sourceChannel: "vellum",
   }),

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -64,7 +64,7 @@ mock.module("../runtime/guardian-vellum-migration.js", () => ({
 // Mock local-actor-identity to return a stable guardian context that uses
 // the same principal as the canonical requests created in tests.
 mock.module("../runtime/local-actor-identity.js", () => ({
-  resolveLocalIpcTrustContext: () => ({
+  resolveLocalTrustContext: () => ({
     sourceChannel: "vellum",
     trustClass: "guardian",
     guardianPrincipalId: "test-principal-id",

--- a/assistant/src/runtime/auth/__tests__/local-auth-context.test.ts
+++ b/assistant/src/runtime/auth/__tests__/local-auth-context.test.ts
@@ -1,56 +1,56 @@
 import { describe, expect, test } from "bun:test";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
-import { buildIpcAuthContext } from "../../local-actor-identity.js";
+import { buildLocalAuthContext } from "../../local-actor-identity.js";
 import { CURRENT_POLICY_EPOCH } from "../policy.js";
 import { resolveScopeProfile } from "../scopes.js";
 
-describe("buildIpcAuthContext", () => {
+describe("buildLocalAuthContext", () => {
   test("produces correct subject pattern", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.subject).toBe("local:self:session-abc");
   });
 
   test("sets principalType to local", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.principalType).toBe("local");
   });
 
   test("uses DAEMON_INTERNAL_ASSISTANT_ID for assistantId", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.assistantId).toBe(DAEMON_INTERNAL_ASSISTANT_ID);
     expect(ctx.assistantId).toBe("self");
   });
 
   test("includes sessionId from argument", () => {
-    const ctx = buildIpcAuthContext("my-session-123");
+    const ctx = buildLocalAuthContext("my-session-123");
     expect(ctx.sessionId).toBe("my-session-123");
   });
 
   test("uses local_v1 scope profile", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.scopeProfile).toBe("local_v1");
   });
 
   test("resolves scopes from local_v1 profile", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     const expectedScopes = resolveScopeProfile("local_v1");
     expect(ctx.scopes).toBe(expectedScopes);
     expect(ctx.scopes.has("local.all")).toBe(true);
   });
 
   test("uses current policy epoch", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.policyEpoch).toBe(CURRENT_POLICY_EPOCH);
   });
 
   test("does not set actorPrincipalId", () => {
-    const ctx = buildIpcAuthContext("session-abc");
+    const ctx = buildLocalAuthContext("session-abc");
     expect(ctx.actorPrincipalId).toBeUndefined();
   });
 
   test("matches AuthContext shape from HTTP JWT-derived contexts", () => {
-    const ctx = buildIpcAuthContext("session-xyz");
+    const ctx = buildLocalAuthContext("session-xyz");
 
     // Verify all required AuthContext fields are present
     expect(typeof ctx.subject).toBe("string");
@@ -63,8 +63,8 @@ describe("buildIpcAuthContext", () => {
   });
 
   test("different session IDs produce different subjects", () => {
-    const ctx1 = buildIpcAuthContext("session-1");
-    const ctx2 = buildIpcAuthContext("session-2");
+    const ctx1 = buildLocalAuthContext("session-1");
+    const ctx2 = buildLocalAuthContext("session-2");
     expect(ctx1.subject).not.toBe(ctx2.subject);
     expect(ctx1.sessionId).not.toBe(ctx2.sessionId);
   });

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -45,11 +45,6 @@ export function buildLocalAuthContext(sessionId: string): AuthContext {
 }
 
 /**
- * @deprecated Use `buildLocalAuthContext` instead.
- */
-export const buildIpcAuthContext = buildLocalAuthContext;
-
-/**
  * Resolve the guardian runtime context for a local connection.
  *
  * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
@@ -61,7 +56,7 @@ export const buildIpcAuthContext = buildLocalAuthContext;
  * bootstrap), falls back to a minimal guardian context so the local
  * user is not incorrectly denied.
  */
-export function resolveLocalIpcTrustContext(
+export function resolveLocalTrustContext(
   sourceChannel: ChannelId = "vellum",
 ): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
@@ -81,7 +76,7 @@ export function resolveLocalIpcTrustContext(
 
   // No guardian contact with a principalId — bootstrap via ensureVellumGuardianBinding
   // to self-heal (creates the binding + contact if missing).
-  log.debug("No vellum guardian contact found; bootstrapping binding for IPC");
+  log.debug("No vellum guardian contact found; bootstrapping binding for local session");
   try {
     const principalId = ensureVellumGuardianBinding(assistantId);
     const trustCtx = resolveTrustContext({
@@ -115,7 +110,7 @@ export function resolveLocalIpcTrustContext(
  * downstream code to resolve guardian context using the same
  * `authContext.actorPrincipalId` path as HTTP sessions.
  */
-export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
+export function resolveLocalAuthContext(sessionId: string): AuthContext {
   const authContext = buildLocalAuthContext(sessionId);
 
   // Enrich with the guardian principal ID from contacts-first path
@@ -128,10 +123,10 @@ export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
   }
 
   // Self-heal: no guardian contact with principalId — bootstrap via
-  // ensureVellumGuardianBinding (mirrors resolveLocalIpcTrustContext).
+  // ensureVellumGuardianBinding (mirrors resolveLocalTrustContext).
   try {
     log.debug(
-      "No vellum guardian contact found; bootstrapping binding for IPC auth",
+      "No vellum guardian contact found; bootstrapping binding for local auth",
     );
     const principalId = ensureVellumGuardianBinding(authContext.assistantId);
     return { ...authContext, actorPrincipalId: principalId };


### PR DESCRIPTION
## Summary
- Rename `resolveLocalIpcTrustContext` → `resolveLocalTrustContext`
- Rename `resolveLocalIpcAuthContext` → `resolveLocalAuthContext`
- Remove deprecated `buildIpcAuthContext` alias
- Rename test file `ipc-auth-context.test.ts` → `local-auth-context.test.ts`
- Update all callers and mocks across test files

Part of plan: phase-out-ipc-refs.md (PR 9 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
