### PR TITLE
feat: replace implicit `skillFlagKey` with frontmatter-driven feature flag gating

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -32,7 +32,8 @@ let currentConfig: Record<string, unknown> = {
   sandbox: { enabled: false, backend: "native" },
 };
 
-const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
+const DECLARED_FLAG_ID = "hatch-new-assistant";
+const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
 const DECLARED_SKILL_ID = "hatch-new-assistant";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -137,12 +138,16 @@ function createSkillOnDisk(
   id: string,
   name: string,
   description: string,
+  featureFlag?: string,
 ): void {
   const skillsDir = join(TEST_DIR, "skills");
   mkdirSync(join(skillsDir, id), { recursive: true });
+  const ffBlock = featureFlag
+    ? `\nmetadata:\n  vellum:\n    feature-flag: "${featureFlag}"`
+    : "";
   writeFileSync(
     join(skillsDir, id, "SKILL.md"),
-    `---\nname: "${name}"\ndescription: "${description}"\n---\n\nInstructions for ${id}.\n`,
+    `---\nname: "${name}"\ndescription: "${description}"${ffBlock}\n---\n\nInstructions for ${id}.\n`,
   );
   const indexPath = join(skillsDir, "SKILLS.md");
   const existing = existsSync(indexPath)
@@ -161,8 +166,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
       "Toggle hatch new assistant behavior",
+      DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter");
+    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -184,8 +190,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
       "Toggle hatch new assistant behavior",
+      DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter");
+    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -193,7 +200,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    // Both skills are declared in the registry with defaultEnabled: false
+    // Both skills declare feature flags with registry defaultEnabled: false
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
     expect(result).not.toContain('id="twitter"');
   });
@@ -203,8 +210,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
       "Toggle hatch new assistant behavior",
+      DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter");
+    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -225,6 +233,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
       "Toggle hatch new assistant behavior",
+      DECLARED_FLAG_ID,
     );
 
     currentConfig = {
@@ -238,7 +247,12 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
   });
 
   test("persisted overrides for undeclared flags are respected", () => {
-    createSkillOnDisk("browser", "Browser", "Web browsing automation");
+    createSkillOnDisk(
+      "browser",
+      "Browser",
+      "Web browsing automation",
+      "browser",
+    );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -247,13 +261,18 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    // Even though 'browser' is not in the defaults registry, the user
+    // browser declares featureFlag: "browser" and the user
     // explicitly disabled it — that override must be honored.
     expect(result).not.toContain('id="browser"');
   });
 
   test("declared flags with no persisted override use registry default", () => {
-    createSkillOnDisk("browser", "Browser", "Web browsing automation");
+    createSkillOnDisk(
+      "browser",
+      "Browser",
+      "Web browsing automation",
+      "browser",
+    );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -263,6 +282,19 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     // browser is declared in the registry with defaultEnabled: true
     expect(result).toContain('id="browser"');
+  });
+
+  test("skill without featureFlag is never flag-gated", () => {
+    createSkillOnDisk("my-skill", "My Skill", "A skill without feature flag");
+
+    currentConfig = {
+      sandbox: { enabled: false, backend: "native" },
+    };
+
+    const result = buildSystemPrompt();
+
+    // Skills without featureFlag declared are never gated — always pass through
+    expect(result).toContain('id="my-skill"');
   });
 });
 
@@ -328,7 +360,10 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     } as any;
 
     expect(
-      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+      isAssistantFeatureFlagEnabled(
+        skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
+        config,
+      ),
     ).toBe(false);
   });
 
@@ -336,7 +371,10 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     const config = {} as any;
 
     expect(
-      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+      isAssistantFeatureFlagEnabled(
+        skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
+        config,
+      ),
     ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -225,7 +225,10 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../config/skill-state.js", () => ({
-  skillFlagKey: (skillId: string) => `feature_flags.${skillId}.enabled`,
+  skillFlagKey: (skill: { featureFlag?: string }) =>
+    skill.featureFlag
+      ? `feature_flags.${skill.featureFlag}.enabled`
+      : undefined,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -5,7 +5,8 @@ import type { AssistantConfig } from "../config/schema.js";
 import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
 
-const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
+const DECLARED_FLAG_ID = "hatch-new-assistant";
+const DECLARED_FLAG_KEY = `feature_flags.${DECLARED_FLAG_ID}.enabled`;
 const DECLARED_SKILL_ID = "hatch-new-assistant";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,6 +38,7 @@ function makeConfig(overrides: Partial<AssistantConfig> = {}): AssistantConfig {
 function makeSkill(
   id: string,
   source: "bundled" | "managed" = "bundled",
+  featureFlag?: string,
 ): SkillSummary {
   return {
     id,
@@ -49,6 +51,7 @@ function makeSkill(
     userInvocable: true,
     disableModelInvocation: false,
     source,
+    featureFlag,
   };
 }
 
@@ -60,7 +63,10 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
   test("returns false when no flag overrides (registry default is false)", () => {
     const config = makeConfig();
     expect(
-      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+      isAssistantFeatureFlagEnabled(
+        skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
+        config,
+      ),
     ).toBe(false);
   });
 
@@ -69,7 +75,10 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
     });
     expect(
-      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+      isAssistantFeatureFlagEnabled(
+        skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
+        config,
+      ),
     ).toBe(true);
   });
 
@@ -78,7 +87,10 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
     });
     expect(
-      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+      isAssistantFeatureFlagEnabled(
+        skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
+        config,
+      ),
     ).toBe(false);
   });
 });
@@ -137,7 +149,10 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
 describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
-    const catalog = [makeSkill(DECLARED_SKILL_ID), makeSkill("twitter")];
+    const catalog = [
+      makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
+      makeSkill("twitter", "bundled", "twitter"),
+    ];
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
@@ -153,7 +168,10 @@ describe("resolveSkillStates with feature flags", () => {
   });
 
   test("flag ON skill appears normally", () => {
-    const catalog = [makeSkill(DECLARED_SKILL_ID), makeSkill("twitter")];
+    const catalog = [
+      makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
+      makeSkill("twitter", "bundled", "twitter"),
+    ];
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: true,
@@ -169,7 +187,7 @@ describe("resolveSkillStates with feature flags", () => {
   });
 
   test("declared flag key defaults to registry value (false)", () => {
-    const catalog = [makeSkill(DECLARED_SKILL_ID)];
+    const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
@@ -177,8 +195,19 @@ describe("resolveSkillStates with feature flags", () => {
     expect(resolved.length).toBe(0);
   });
 
+  test("skill without featureFlag is never flag-gated", () => {
+    const catalog = [makeSkill("no-flag-skill")];
+    const config = makeConfig();
+
+    const resolved = resolveSkillStates(catalog, config);
+    const ids = resolved.map((r) => r.summary.id);
+
+    // Skills without featureFlag are never gated — always pass through
+    expect(ids).toContain("no-flag-skill");
+  });
+
   test("feature flag OFF takes precedence over user-enabled config entry", () => {
-    const catalog = [makeSkill(DECLARED_SKILL_ID)];
+    const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig({
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
       skills: {
@@ -205,9 +234,9 @@ describe("resolveSkillStates with feature flags", () => {
 
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     const catalog = [
-      makeSkill(DECLARED_SKILL_ID),
-      makeSkill("twitter"),
-      makeSkill("deploy"),
+      makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
+      makeSkill("twitter", "bundled", "twitter"),
+      makeSkill("deploy", "bundled", "deploy"),
     ];
     const config = makeConfig({
       assistantFeatureFlagValues: {

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -58,7 +58,10 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../config/skill-state.js", () => ({
-  skillFlagKey: (skillId: string) => `feature_flags.${skillId}.enabled`,
+  skillFlagKey: (skill: { featureFlag?: string }) =>
+    skill.featureFlag
+      ? `feature_flags.${skill.featureFlag}.enabled`
+      : undefined,
 }));
 
 mock.module("../skills/active-skill-tools.js", () => {
@@ -221,7 +224,7 @@ const { projectSkillTools, resetSkillToolProjection } =
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSkill(id: string): SkillSummary {
+function makeSkill(id: string, featureFlag?: string): SkillSummary {
   return {
     id,
     name: id,
@@ -232,6 +235,7 @@ function makeSkill(id: string): SkillSummary {
     userInvocable: true,
     disableModelInvocation: false,
     source: "managed",
+    featureFlag,
   };
 }
 
@@ -293,7 +297,7 @@ describe("projectSkillTools feature flag enforcement", () => {
   });
 
   test("no skill tools projected for flag OFF skill even with old markers", () => {
-    mockCatalog = [makeSkill(DECLARED_SKILL_ID)];
+    mockCatalog = [makeSkill(DECLARED_SKILL_ID, DECLARED_SKILL_ID)];
     mockManifests = {
       [DECLARED_SKILL_ID]: makeManifest(["browser_navigate", "browser_click"]),
     };
@@ -317,7 +321,7 @@ describe("projectSkillTools feature flag enforcement", () => {
   });
 
   test("skill tools projected normally when flag is ON", () => {
-    mockCatalog = [makeSkill(DECLARED_SKILL_ID)];
+    mockCatalog = [makeSkill(DECLARED_SKILL_ID, DECLARED_SKILL_ID)];
     mockManifests = {
       [DECLARED_SKILL_ID]: makeManifest(["browser_navigate", "browser_click"]),
     };
@@ -339,14 +343,14 @@ describe("projectSkillTools feature flag enforcement", () => {
     expect(result.allowedToolNames.has("browser_click")).toBe(true);
   });
 
-  test("skill tools projected normally when flag key is absent (defaults to enabled)", () => {
+  test("skill tools projected normally when no featureFlag declared (never gated)", () => {
     mockCatalog = [makeSkill(DECLARED_SKILL_ID)];
     mockManifests = { [DECLARED_SKILL_ID]: makeManifest(["browser_navigate"]) };
 
     const history = buildHistoryWithMarker(DECLARED_SKILL_ID);
     const prevActive = new Map<string, string>();
 
-    // No overrides — should default to enabled
+    // No overrides — skill has no featureFlag so it's never gated
     currentConfig = {};
 
     const result = projectSkillTools(history, {
@@ -358,7 +362,10 @@ describe("projectSkillTools feature flag enforcement", () => {
   });
 
   test("mixed flag-on and flag-off skills — only flag-on tools projected", () => {
-    mockCatalog = [makeSkill(DECLARED_SKILL_ID), makeSkill("twitter")];
+    mockCatalog = [
+      makeSkill(DECLARED_SKILL_ID, DECLARED_SKILL_ID),
+      makeSkill("twitter"),
+    ];
     mockManifests = {
       [DECLARED_SKILL_ID]: makeManifest(["browser_navigate"]),
       twitter: makeManifest(["twitter_post"]),

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -68,7 +68,10 @@ mock.module("../config/skills.js", () => ({
 // Mock skill-state.js to break the transitive import chain — the benchmark
 // only needs skillFlagKey and doesn't exercise resolveSkillStates.
 mock.module("../config/skill-state.js", () => ({
-  skillFlagKey: (id: string) => `feature_flags.${id}.enabled`,
+  skillFlagKey: (skill: { featureFlag?: string }) =>
+    skill.featureFlag
+      ? `feature_flags.${skill.featureFlag}.enabled`
+      : undefined,
   resolveSkillStates: () => [],
 }));
 

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -14,13 +14,15 @@ export interface ResolvedSkill {
 }
 
 /**
- * Derive the feature flag key for a given skill ID.
- *
- * Exported so other modules (system-prompt, session-skill-tools, skill loader)
- * can perform the same mapping.
+ * Derive the feature flag key for a skill from its frontmatter `featureFlag` field.
+ * Returns undefined if the skill has no feature flag declared.
  */
-export function skillFlagKey(skillId: string): string {
-  return `feature_flags.${skillId}.enabled`;
+export function skillFlagKey(
+  skill: Pick<SkillSummary, "featureFlag">,
+): string | undefined {
+  return skill.featureFlag
+    ? `feature_flags.${skill.featureFlag}.enabled`
+    : undefined;
 }
 
 export function resolveSkillStates(
@@ -34,8 +36,9 @@ export function resolveSkillStates(
   };
 
   for (const skill of catalog) {
-    // Assistant feature flag gate: if the flag is explicitly OFF, skip this skill entirely
-    if (!isAssistantFeatureFlagEnabled(skillFlagKey(skill.id), config)) {
+    // Assistant feature flag gate: if the skill declares a flag and it's disabled, skip it
+    const flagKey = skillFlagKey(skill);
+    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
       continue;
     }
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,13 +1,14 @@
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   getConfig,
   invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { resolveSkillStates } from "../../config/skill-state.js";
+import { resolveSkillStates, skillFlagKey } from "../../config/skill-state.js";
 import {
   ensureSkillIcon,
   loadSkillBySelector,
@@ -346,6 +347,20 @@ export async function installSkill(
   try {
     // Bundled skills are already available — no install needed
     const catalog = loadSkillCatalog();
+
+    // Feature flag gate: reject install if the skill's flag is disabled
+    const config = getConfig();
+    const flaggedSkill = catalog.find((s) => s.id === spec.slug);
+    if (flaggedSkill) {
+      const flagKey = skillFlagKey(flaggedSkill);
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
+        return {
+          success: false,
+          error: `Skill "${spec.slug}" is currently unavailable (disabled by feature flag)`,
+        };
+      }
+    }
+
     const bundled = catalog.find(
       (s) => s.id === spec.slug && s.source === "bundled",
     );

--- a/assistant/src/daemon/session-skill-tools.ts
+++ b/assistant/src/daemon/session-skill-tools.ts
@@ -240,12 +240,21 @@ export function projectSkillTools(
   const contextIds = contextEntries.map((e) => e.id);
   const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
 
+  // Load the catalog (cached for session lifetime) and index by ID
+  const catalog = getCachedCatalog(options?.cache);
+  const catalogById = new Map<string, SkillSummary>();
+  for (const skill of catalog) {
+    catalogById.set(skill.id, skill);
+  }
+
   // Assistant feature flag gate: drop skills whose flag is explicitly OFF,
   // even if they have markers in conversation history from before the flag was turned off.
   const config = getConfig();
   const activeIds = new Set<string>();
   for (const id of allCandidateIds) {
-    if (isAssistantFeatureFlagEnabled(skillFlagKey(id), config)) {
+    const skill = catalogById.get(id);
+    const flagKey = skill ? skillFlagKey(skill) : undefined;
+    if (!flagKey || isAssistantFeatureFlagEnabled(flagKey, config)) {
       activeIds.add(id);
     }
   }
@@ -268,13 +277,6 @@ export function projectSkillTools(
   if (activeIds.size === 0) {
     prevActive.clear();
     return { toolDefinitions: [], allowedToolNames: new Set() };
-  }
-
-  // Load the catalog (cached for session lifetime) and index by ID
-  const catalog = getCachedCatalog(options?.cache);
-  const catalogById = new Map<string, SkillSummary>();
-  for (const skill of catalog) {
-    catalogById.set(skill.id, skill);
   }
 
   const allToolDefinitions: ToolDefinition[] = [];

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -879,22 +879,24 @@ function appendSkillsCatalog(basePrompt: string): string {
   const config = getConfig();
 
   // Filter out skills whose assistant feature flag is explicitly OFF
-  const flagFiltered = skills.filter((s) =>
-    isAssistantFeatureFlagEnabled(skillFlagKey(s.id), config),
-  );
+  const flagFiltered = skills.filter((s) => {
+    const flagKey = skillFlagKey(s);
+    return !flagKey || isAssistantFeatureFlagEnabled(flagKey, config);
+  });
 
   const sections: string[] = [basePrompt];
 
   const catalog = formatSkillsCatalog(flagFiltered);
   if (catalog) sections.push(catalog);
 
-  sections.push(buildDynamicSkillWorkflowSection(config));
+  sections.push(buildDynamicSkillWorkflowSection(config, flagFiltered));
 
   return sections.join("\n\n");
 }
 
 function buildDynamicSkillWorkflowSection(
-  config: import("../config/schema.js").AssistantConfig,
+  _config: import("../config/schema.js").AssistantConfig,
+  activeSkills: SkillSummary[],
 ): string {
   const lines = [
     "## Dynamic Skill Authoring Workflow",
@@ -910,7 +912,9 @@ function buildDynamicSkillWorkflowSection(
     "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
   ];
 
-  if (isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config)) {
+  const activeSkillIds = new Set(activeSkills.map((s) => s.id));
+
+  if (activeSkillIds.has("browser")) {
     lines.push(
       "",
       "### Browser Skill Prerequisite",
@@ -918,7 +922,7 @@ function buildDynamicSkillWorkflowSection(
     );
   }
 
-  if (isAssistantFeatureFlagEnabled("feature_flags.twitter.enabled", config)) {
+  if (activeSkillIds.has("twitter")) {
     lines.push(
       "",
       "### X (Twitter) Skill",
@@ -926,9 +930,7 @@ function buildDynamicSkillWorkflowSection(
     );
   }
 
-  if (
-    isAssistantFeatureFlagEnabled("feature_flags.messaging.enabled", config)
-  ) {
+  if (activeSkillIds.has("messaging")) {
     lines.push(
       "",
       "### Messaging Skill",

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -69,7 +69,8 @@ export class SkillLoadTool implements Tool {
 
     // Assistant feature flag gate: reject loading if the skill's flag is OFF
     const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(skillFlagKey(skill.id), config)) {
+    const flagKey = skillFlagKey(skill);
+    if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) {
       return {
         content: `Error: skill "${skill.id}" is currently unavailable (disabled by feature flag)`,
         isError: true,
@@ -122,7 +123,11 @@ export class SkillLoadTool implements Tool {
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
         if (!child) continue;
-        if (!isAssistantFeatureFlagEnabled(skillFlagKey(childId), config))
+        const childFlagKey = skillFlagKey(child);
+        if (
+          childFlagKey &&
+          !isAssistantFeatureFlagEnabled(childFlagKey, config)
+        )
           continue;
 
         childLines.push(
@@ -162,7 +167,11 @@ export class SkillLoadTool implements Tool {
       for (const childId of skill.includes) {
         const child = catalogIndex.get(childId);
         if (!child) continue;
-        if (!isAssistantFeatureFlagEnabled(skillFlagKey(childId), config))
+        const childFlagKey2 = skillFlagKey(child);
+        if (
+          childFlagKey2 &&
+          !isAssistantFeatureFlagEnabled(childFlagKey2, config)
+        )
           continue;
         let childHash: string | undefined;
         try {


### PR DESCRIPTION
## Summary
- Repurpose `skillFlagKey()` to take a skill object and return `string | undefined` based on the frontmatter `featureFlag` field
- Update all 5 enforcement points (resolveSkillStates, skill load tool, session-skill-tools, system prompt, install handler) to use the new signature
- Replace hardcoded browser/twitter/messaging flag checks in system-prompt.ts with catalog-driven lookups
- Skills without `featureFlag` declared are never flag-gated

Part of plan: skill-frontmatter-feature-flag.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
