### PR TITLE
chore: update feature flag guardrails test for frontmatter-driven gating

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -56,8 +56,6 @@ function loadRegistry(): Registry {
  * exercising legacy paths.
  */
 const LEGACY_KEY_ALLOWLIST = new Set([
-  // Legacy wrapper (deprecated, kept for migration)
-  "assistant/src/config/skill-state.ts",
   // Type definitions documenting the legacy format
   "assistant/src/config/types.ts",
   // macOS client: fallback reads from legacy config section


### PR DESCRIPTION
## Summary
- Remove `assistant/src/config/skill-state.ts` from the legacy key allowlist since it no longer contains `skills.<id>.enabled` patterns
- Guardrails tests continue to pass with the new frontmatter-driven gating

Part of plan: skill-frontmatter-feature-flag.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
