### PR TITLE
fix: resolve symlinks in rootDir for isEscapingSymlink on macOS

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1108,7 +1108,7 @@ function isEscapingSymlink(filePath: string, rootDir: string): boolean {
   try {
     if (!lstatSync(filePath).isSymbolicLink()) return false;
     const real = realpathSync(filePath);
-    const normalizedRoot = resolve(rootDir);
+    const normalizedRoot = getCanonicalPath(rootDir);
     return (
       real !== normalizedRoot &&
       !real.startsWith(normalizedRoot + "/") &&


### PR DESCRIPTION
## Summary
- Replace `resolve(rootDir)` with `getCanonicalPath(rootDir)` in `isEscapingSymlink` so intermediate symlinks in the root path (e.g. macOS `/tmp` → `/private/tmp`) are fully resolved before comparison
- Previously, `realpathSync(filePath)` produced a canonical path while `resolve(rootDir)` did not, causing valid symlinks within the skill directory to be incorrectly classified as escaping on macOS
- `getCanonicalPath` already exists at `skills.ts:495` and uses `realpathSync` when the path exists, making both sides of the comparison consistent

## Original prompt
address this feedback The isEscapingSymlink function compares realpathSync(filePath) (which resolves ALL symlinks in the path) against resolve(rootDir) (which only resolves . and .., NOT symlinks). On systems where intermediate path components are symlinks (e.g., macOS where /tmp → /private/tmp), these produce inconsistent paths: real would be /private/tmp/.../file.md while normalizedRoot would be /tmp/.../skillDir/. This causes symlinks that legitimately stay within the skill directory to be incorrectly classified as "escaping," silently dropping valid reference files. The fix should use realpathSync(rootDir) (or the existing getCanonicalPath at assistant/src/config/skills.ts:495) instead of resolve(rootDir) on line 1111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
