### PR TITLE
fix: add scopeIds filtering for media candidates in semantic search

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -165,6 +165,10 @@ export async function semanticSearch(
         finalScore: 0,
       });
     } else if (payload.target_type === "media") {
+      // Media points don't currently store scope_id in their Qdrant payload,
+      // so we can't verify scope membership. Skip them when a scope filter is
+      // active to prevent cross-scope media leakage.
+      if (scopeIds) continue;
       candidates.push({
         key: `media:${payload.target_id}`,
         type: "media",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** Media candidates bypass scopeIds filtering in semantic search
**What was expected:** Media candidates should respect scopeIds filtering like all other candidate types
**What was found:** The media branch in semantic search didn't check scopeIds, allowing cross-scope media leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
