### PR TITLE
fix: prevent media target IDs from polluting segment batch-fetch

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -59,7 +59,8 @@ export async function semanticSearch(
       itemTargetIds.push(r.payload.target_id);
     else if (r.payload.target_type === "summary")
       summaryTargetIds.push(r.payload.target_id);
-    else segmentTargetIds.push(r.payload.target_id);
+    else if (r.payload.target_type === "segment")
+      segmentTargetIds.push(r.payload.target_id);
   }
 
   const itemsMap = new Map<string, typeof memoryItems.$inferSelect>();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** Media target IDs pollute segment batch-fetch in semantic search
**What was expected:** Media candidates should not trigger unnecessary segment DB queries
**What was found:** The else branch in the batch-fetch loop caught both segments and media, sending media IDs to the segments table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
