### PR TITLE
fix: revert vectorSize default to 384 for local backend compatibility

### DIFF
--- a/assistant/src/config/schemas/memory-storage.ts
+++ b/assistant/src/config/schemas/memory-storage.ts
@@ -64,7 +64,7 @@ export const QdrantConfigSchema = z.object({
     .number({ error: "memory.qdrant.vectorSize must be a number" })
     .int("memory.qdrant.vectorSize must be an integer")
     .positive("memory.qdrant.vectorSize must be a positive integer")
-    .default(768),
+    .default(384),
   onDisk: z
     .boolean({ error: "memory.qdrant.onDisk must be a boolean" })
     .default(true),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** Default vectorSize 768 incompatible with non-Gemini backends
**What was expected:** Default config should work with auto mode (local backend first, 384-dim)
**What was found:** vectorSize default was changed to 768, breaking all non-Gemini users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
