### PR TITLE
fix: skip text-only fallback backends for multimodal embed inputs

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -410,6 +410,11 @@ export async function embedWithBackend(
       ? uncachedIndices.map((i) => inputs[i])
       : inputs;
 
+    // Skip text-only backends for multimodal inputs
+    if (backend.provider !== "gemini" && inputs.some((i) => !isTextInput(i))) {
+      continue;
+    }
+
     try {
       const vectors = await backend.embed(inputsToEmbed, options);
       if (vectors.length !== inputsToEmbed.length) {
@@ -456,6 +461,12 @@ export async function embedWithBackend(
         );
       }
     }
+  }
+  const hasMultimodal = inputs.some((i) => !isTextInput(i));
+  if (hasMultimodal) {
+    throw new Error(
+      "No available embedding backend supports multimodal inputs. Gemini API key is required for image/audio/video embeddings.",
+    );
   }
   throw lastErr;
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** Non-text fallback backends cause misleading fatal errors for multimodal embed jobs
**What was expected:** Fallback should skip text-only backends for multimodal inputs with a clear error
**What was found:** Text-only backends threw "only supports text inputs" errors classified as fatal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
