### PR TITLE
fix: re-enqueue embed_media jobs during index rebuild

### DIFF
--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -7,6 +7,7 @@ import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
 import {
+  mediaAssets,
   memoryEmbeddings,
   memoryItems,
   memorySegments,
@@ -47,6 +48,15 @@ export function rebuildIndexJob(): void {
     .all();
   for (const segment of segments) {
     enqueueMemoryJob("embed_segment", { segmentId: segment.id });
+  }
+
+  const assets = db
+    .select({ id: mediaAssets.id })
+    .from(mediaAssets)
+    .where(eq(mediaAssets.status, "indexed"))
+    .all();
+  for (const asset of assets) {
+    enqueueMemoryJob("embed_media", { assetId: asset.id });
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** rebuildIndexJob doesn't re-enqueue media/attachment jobs
**What was expected:** Index rebuild should regenerate all embedding types including media
**What was found:** Only segment, item, and summary embeddings were re-enqueued; media embeddings were lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
