### PR TITLE
fix: remove unused isTextInput function

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -9,7 +9,6 @@ import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
 import {
   type EmbeddingInput,
   embeddingInputContentHash,
-  isTextInput,
   type MultimodalEmbeddingInput,
   normalizeEmbeddingInput,
   type TextEmbeddingInput,
@@ -20,7 +19,7 @@ export type {
   MultimodalEmbeddingInput,
   TextEmbeddingInput,
 };
-export { embeddingInputContentHash, isTextInput,normalizeEmbeddingInput };
+export { embeddingInputContentHash, normalizeEmbeddingInput };
 
 const log = getLogger("memory-embeddings");
 

--- a/assistant/src/memory/embedding-types.test.ts
+++ b/assistant/src/memory/embedding-types.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  type EmbeddingInput,
   embeddingInputContentHash,
-  isTextInput,
   type MultimodalEmbeddingInput,
   normalizeEmbeddingInput,
 } from "./embedding-types.js";
@@ -114,42 +112,5 @@ describe("embeddingInputContentHash", () => {
   test("returns a hex string", () => {
     const hash = embeddingInputContentHash("test");
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
-  });
-});
-
-describe("isTextInput", () => {
-  test("returns true for a raw string", () => {
-    expect(isTextInput("hello")).toBe(true);
-  });
-
-  test("returns true for a TextEmbeddingInput", () => {
-    expect(isTextInput({ type: "text", text: "hello" })).toBe(true);
-  });
-
-  test("returns false for an ImageEmbeddingInput", () => {
-    const input: EmbeddingInput = {
-      type: "image",
-      data: Buffer.from("fake"),
-      mimeType: "image/png",
-    };
-    expect(isTextInput(input)).toBe(false);
-  });
-
-  test("returns false for an AudioEmbeddingInput", () => {
-    const input: EmbeddingInput = {
-      type: "audio",
-      data: Buffer.from("fake"),
-      mimeType: "audio/mp3",
-    };
-    expect(isTextInput(input)).toBe(false);
-  });
-
-  test("returns false for a VideoEmbeddingInput", () => {
-    const input: EmbeddingInput = {
-      type: "video",
-      data: Buffer.from("fake"),
-      mimeType: "video/mp4",
-    };
-    expect(isTextInput(input)).toBe(false);
   });
 });

--- a/assistant/src/memory/embedding-types.ts
+++ b/assistant/src/memory/embedding-types.ts
@@ -59,7 +59,3 @@ export function embeddingInputContentHash(input: EmbeddingInput): string {
   }
   return hash.digest("hex");
 }
-
-export function isTextInput(input: EmbeddingInput): input is string | TextEmbeddingInput {
-  return typeof input === "string" || (typeof input === "object" && input.type === "text");
-}


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** isTextInput is dead code
**What was expected:** No dead code per project conventions
**What was found:** isTextInput defined and exported but never called anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
