### PR TITLE
fix: align tests with amazon CLI move and gitignore rule changes

### DIFF
--- a/assistant/src/__tests__/amazon-cdp-integration.test.ts
+++ b/assistant/src/__tests__/amazon-cdp-integration.test.ts
@@ -1,7 +1,7 @@
 /**
- * Verify that the Amazon CLI does NOT define its own CDP launch/window logic.
+ * Verify that the Amazon skill scripts do NOT define their own CDP launch/window logic.
  *
- * The Amazon CLI now uses browser extension relay instead of CDP for session
+ * The Amazon skill now uses browser extension relay instead of CDP for session
  * management, so we only verify that old inline CDP patterns are absent.
  */
 
@@ -9,21 +9,23 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-const AMAZON_CLI_DIR = join(
+const AMAZON_SCRIPTS_DIR = join(
   import.meta.dirname ?? __dirname,
   "..",
-  "cli",
-  "commands",
+  "..",
+  "..",
+  "skills",
   "amazon",
+  "scripts",
 );
 
-// Read all .ts files in the amazon/ directory and concatenate their source
-const amazonSource = readdirSync(AMAZON_CLI_DIR)
+// Read all .ts files in the amazon/scripts/ directory and concatenate their source
+const amazonSource = readdirSync(AMAZON_SCRIPTS_DIR)
   .filter((f) => f.endsWith(".ts"))
-  .map((f) => readFileSync(join(AMAZON_CLI_DIR, f), "utf-8"))
+  .map((f) => readFileSync(join(AMAZON_SCRIPTS_DIR, f), "utf-8"))
   .join("\n");
 
-describe("Amazon CLI CDP integration", () => {
+describe("Amazon skill CDP integration", () => {
   test("does not define its own CDP_BASE constant", () => {
     // The old inline constant was: const CDP_BASE = "http://localhost:9222";
     expect(amazonSource).not.toMatch(/const\s+CDP_BASE\s*=/);

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -63,11 +63,9 @@ describe("WorkspaceGitService", () => {
       const content = readFileSync(gitignorePath, "utf-8");
       expect(content).toContain("data/db/");
       expect(content).toContain("data/qdrant/");
-      expect(content).toContain("data/ipc-blobs/");
       expect(content).toContain("*.log");
       expect(content).toContain("*.sock");
       expect(content).toContain("*.pid");
-      expect(content).toContain("vellum.sock");
       expect(content).toContain("session-token");
     });
 
@@ -641,9 +639,8 @@ describe("WorkspaceGitService", () => {
       expect(contentAfter).toContain("node_modules/"); // original rule preserved
       expect(contentAfter).toContain("data/db/");
       expect(contentAfter).toContain("data/qdrant/");
-      expect(contentAfter).toContain("data/ipc-blobs/");
       expect(contentAfter).toContain("*.log");
-      expect(contentAfter).toContain("vellum.sock");
+      expect(contentAfter).toContain("*.sock");
       expect(contentAfter).toContain("session-token");
     });
 
@@ -677,12 +674,11 @@ describe("WorkspaceGitService", () => {
       // New selective rules should be present
       expect(contentAfter).toContain("data/db/");
       expect(contentAfter).toContain("data/qdrant/");
-      expect(contentAfter).toContain("data/ipc-blobs/");
 
       // Other existing rules should be preserved
       expect(contentAfter).toContain("logs/");
       expect(contentAfter).toContain("*.log");
-      expect(contentAfter).toContain("vellum.sock");
+      expect(contentAfter).toContain("*.sock");
     });
 
     test("existing repo gets local identity set on init", async () => {
@@ -725,7 +721,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\ndata/ipc-blobs/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.sock\nvellum.pid\nsession-token\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.pid\nsession-token\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });
@@ -778,14 +774,13 @@ describe("WorkspaceGitService", () => {
         join(testDir, "data", "qdrant", "index.bin"),
         "qdrant content",
       );
-      mkdirSync(join(testDir, "data", "ipc-blobs"), { recursive: true });
-      writeFileSync(join(testDir, "data", "ipc-blobs", "blob1"), "ipc content");
-
       // Create files in tracked data subdirectories
       mkdirSync(join(testDir, "data", "memory"), { recursive: true });
       writeFileSync(join(testDir, "data", "memory", "index.json"), "{}");
       mkdirSync(join(testDir, "data", "apps"), { recursive: true });
       writeFileSync(join(testDir, "data", "apps", "state.json"), "{}");
+      mkdirSync(join(testDir, "data", "ipc-blobs"), { recursive: true });
+      writeFileSync(join(testDir, "data", "ipc-blobs", "blob1"), "ipc content");
 
       // Commit all changes, then verify what was included
       await service.commitChanges("test commit");
@@ -799,11 +794,11 @@ describe("WorkspaceGitService", () => {
       // Ignored subdirectories should NOT be in the commit
       expect(committedFiles).not.toContain("data/db/");
       expect(committedFiles).not.toContain("data/qdrant/");
-      expect(committedFiles).not.toContain("data/ipc-blobs/");
 
-      // Tracked subdirectories SHOULD be in the commit
+      // Non-ignored data subdirectories SHOULD be in the commit
       expect(committedFiles).toContain("data/memory/index.json");
       expect(committedFiles).toContain("data/apps/state.json");
+      expect(committedFiles).toContain("data/ipc-blobs/blob1");
     });
 
     test("respects .gitignore for log files", async () => {

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -24,7 +24,6 @@ Commands:
   email [options]                          Email operations (provider-agnostic)
   contacts [options]                       Manage and query the contact graph
   channel-verification-sessions [options]  Manage channel verification sessions
-  amazon [options]                         Shop on Amazon and Amazon Fresh. Requires an active session (use "refresh" to authenticate).
   autonomy [options]                       View and configure autonomy tiers
   completions <shell>                      Generate shell completion script (e.g. assistant completions bash >> ~/.bashrc)
   notifications [options]                  Send and inspect notifications through the unified notification router


### PR DESCRIPTION
## Summary
- Update `amazon-cdp-integration.test.ts` to read from `skills/amazon/scripts/` instead of the removed `src/cli/commands/amazon/` directory
- Remove the `amazon` command from `CLI_HELP_REFERENCE` in `reference.ts` to match `buildCliProgram()` output after the CLI namespace removal
- Fix `workspace-git-service.test.ts` expectations to match actual `WORKSPACE_GITIGNORE_RULES` (remove `data/ipc-blobs/` and `vellum.sock` assertions that don't match the rules)

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22928371182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
