### PR TITLE
fix: inline isTextInput check in embedding-backend.ts

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -410,7 +410,7 @@ export async function embedWithBackend(
       : inputs;
 
     // Skip text-only backends for multimodal inputs
-    if (backend.provider !== "gemini" && inputs.some((i) => !isTextInput(i))) {
+    if (backend.provider !== "gemini" && inputs.some((i) => typeof i !== "string" && i.type !== "text")) {
       continue;
     }
 
@@ -461,7 +461,7 @@ export async function embedWithBackend(
       }
     }
   }
-  const hasMultimodal = inputs.some((i) => !isTextInput(i));
+  const hasMultimodal = inputs.some((i) => typeof i !== "string" && i.type !== "text");
   if (hasMultimodal) {
     throw new Error(
       "No available embedding backend supports multimodal inputs. Gemini API key is required for image/audio/video embeddings.",


### PR DESCRIPTION
## Summary
- `isTextInput` was removed in #15041 but two call sites in `embedding-backend.ts` were missed, causing type check CI failure
- Inline the equivalent check (`typeof i !== "string" && i.type !== "text"`) at both call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
