### PR TITLE
fix: use JSON metadata format in feature flag tests

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -143,7 +143,7 @@ function createSkillOnDisk(
   const skillsDir = join(TEST_DIR, "skills");
   mkdirSync(join(skillsDir, id), { recursive: true });
   const ffBlock = featureFlag
-    ? `\nmetadata:\n  vellum:\n    feature-flag: "${featureFlag}"`
+    ? `\nmetadata: {"vellum":{"feature-flag":"${featureFlag}"}}`
     : "";
   writeFileSync(
     join(skillsDir, id, "SKILL.md"),

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -92,7 +92,7 @@ function writeSkill(
   mkdirSync(skillDir, { recursive: true });
   writeFileSync(
     join(skillDir, "SKILL.md"),
-    `---\nname: "${name}"\ndescription: "${description}"\n---\n\n${body}\n`,
+    `---\nname: "${name}"\ndescription: "${description}"\nmetadata: {"vellum":{"feature-flag":"${skillId}"}}\n---\n\n${body}\n`,
   );
 }
 


### PR DESCRIPTION
## Summary
- `assistant-feature-flags-integration.test.ts`: fix `createSkillOnDisk` helper to write SKILL.md metadata in JSON format (`{"vellum":{"feature-flag":"..."}}`) instead of YAML — the skill parser only handles JSON, so the YAML format silently dropped the `featureFlag` field and broke flag gating tests
- `skill-load-feature-flag.test.ts`: add `feature-flag` to SKILL.md in `writeSkill` helper so the `skill_load` tool correctly gates skills via the frontmatter-driven flag check introduced in #15032

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22928397988/job/66544239533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
