### PR TITLE
fix: update migration-routes JSDoc to reference local instead of ipc principal type

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -115,7 +115,7 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
  *        with Content-Disposition header for download.
  *   500: Standard error envelope for unexpected failures.
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, ipc.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
  */
 export async function handleMigrationExport(req: Request): Promise<Response> {
   let description: string | undefined;
@@ -254,7 +254,7 @@ async function extractFileData(
  *   400: Standard error envelope for missing/empty body
  *   500: Standard error envelope for unexpected failures
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, ipc.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
  */
 export async function handleMigrationImportPreflight(
   req: Request,
@@ -339,7 +339,7 @@ export async function handleMigrationImportPreflight(
  *   400: Standard error envelope for missing/empty body
  *   500: Standard error envelope for unexpected failures
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, ipc.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
  */
 export async function handleMigrationImport(req: Request): Promise<Response> {
   const extracted = await extractFileData(req);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc-refs.md.

**Gap:** migration-routes.ts JSDoc comments reference `ipc` principal type
**What was expected:** Comments should reference `local` since the principal type was renamed
**What was found:** Three JSDoc comments still said `Allowed for actor, svc_gateway, ipc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
