### PR TITLE
fix: remove dead getIpcBlobDir from test platform mock

### DIFF
--- a/assistant/src/__tests__/managed-twitter-guardrails.test.ts
+++ b/assistant/src/__tests__/managed-twitter-guardrails.test.ts
@@ -77,7 +77,6 @@ mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
   getWorkspaceDir: () => testDir,
-  getIpcBlobDir: () => join(testDir, "ipc-blobs"),
   isMacOS: () => process.platform === "darwin",
   isLinux: () => process.platform === "linux",
   isWindows: () => process.platform === "win32",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc-refs.md.

**Gap:** managed-twitter-guardrails.test.ts mocks deleted getIpcBlobDir function
**What was expected:** Dead IPC mock code should be removed
**What was found:** Platform mock still included `getIpcBlobDir` which no longer exists in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
