### PR TITLE
fix: rename TitleOrigin variant from ipc to local

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -380,7 +380,7 @@ export async function handleSessionCreate(
     if (title === GENERATING_TITLE) {
       queueGenerateConversationTitle({
         conversationId: conversation.id,
-        context: { origin: "ipc" },
+        context: { origin: "local" },
         userMessage: msg.initialMessage,
         onTitleUpdated: (newTitle) => {
           ctx.send({

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -35,7 +35,7 @@ export type TitleOrigin =
   | "subagent"
   | "sequence"
   | "heartbeat"
-  | "ipc"
+  | "local"
   | "task_submit"
   | "misc";
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc-refs.md.

**Gap:** TitleOrigin type still uses `"ipc"` instead of `"local"`
**What was expected:** IPC terminology should be phased out from TitleOrigin type
**What was found:** `TitleOrigin` had `"ipc"` variant and sessions.ts used `origin: "ipc"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
