### PR TITLE
fix: update workspace-git-service tests after ipc-blobs and vellum.sock gitignore removal

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -629,7 +629,6 @@ describe("WorkspaceGitService", () => {
       // Verify .gitignore does NOT have our rules yet
       const contentBefore = readFileSync(join(testDir, ".gitignore"), "utf-8");
       expect(contentBefore).not.toContain("data/db/");
-      expect(contentBefore).not.toContain("vellum.sock");
 
       // Initialize the service — should append rules
       const service = new WorkspaceGitService(testDir);
@@ -652,7 +651,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const oldGitignore =
-        "# Runtime state - excluded from git tracking\ndata/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.sock\nvellum.pid\nsession-token\n";
+        "# Runtime state - excluded from git tracking\ndata/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.pid\nsession-token\n";
       writeFileSync(join(testDir, ".gitignore"), oldGitignore);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });
@@ -779,8 +778,6 @@ describe("WorkspaceGitService", () => {
       writeFileSync(join(testDir, "data", "memory", "index.json"), "{}");
       mkdirSync(join(testDir, "data", "apps"), { recursive: true });
       writeFileSync(join(testDir, "data", "apps", "state.json"), "{}");
-      mkdirSync(join(testDir, "data", "ipc-blobs"), { recursive: true });
-      writeFileSync(join(testDir, "data", "ipc-blobs", "blob1"), "ipc content");
 
       // Commit all changes, then verify what was included
       await service.commitChanges("test commit");
@@ -798,7 +795,6 @@ describe("WorkspaceGitService", () => {
       // Non-ignored data subdirectories SHOULD be in the commit
       expect(committedFiles).toContain("data/memory/index.json");
       expect(committedFiles).toContain("data/apps/state.json");
-      expect(committedFiles).toContain("data/ipc-blobs/blob1");
     });
 
     test("respects .gitignore for log files", async () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc-refs.md.

**Gap:** workspace-git-service tests not updated after gitignore rule removal
**What was expected:** Tests should not assert the presence of removed gitignore entries
**What was found:** Tests still expected `data/ipc-blobs/` and `vellum.sock` in gitignore output

- Removed `vellum.sock` negative assertion from the "existing repo gets .gitignore rules appended" test
- Removed `vellum.sock` from the old gitignore migration test fixture
- Removed `data/ipc-blobs/` test fixture creation and corresponding commit assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
