### PR TITLE
fix: remove stale assistant amazon references from scripts and SKILL.md

### DIFF
--- a/skills/amazon/SKILL.md
+++ b/skills/amazon/SKILL.md
@@ -17,7 +17,7 @@ You can shop on Amazon (and Amazon Fresh for groceries) for the user using the b
 
 The Amazon scripts are bundled with this skill. Run them via `bun run {baseDir}/scripts/amazon.ts <subcommand> [options]`.
 
-Do NOT use `assistant amazon` directly — use the bundled scripts.
+All Amazon interaction goes through the bundled scripts below, not browser automation.
 
 ## Typical Flow — Regular Amazon Shopping
 
@@ -83,7 +83,7 @@ Session capture (`bun run {baseDir}/scripts/amazon.ts refresh`) and session chec
 - **Show prices.** Always show prices when presenting products or the cart summary.
 - **Use `--json` flag** on all commands for reliable parsing.
 - **Always use `host_bash`** for these commands, never `bash`.
-- **Do NOT use the browser skill.** All Amazon interaction goes through the bundled scripts, not browser automation. Do NOT use `assistant amazon` directly — use the bundled scripts.
+- **Do NOT use the browser skill.** All Amazon interaction goes through the bundled scripts, not browser automation.
 - **Rate limiting.** Amazon may rate-limit rapid sequential requests. Wait 8-10 seconds between cart operations. If you get a 403 error, wait 15-20 seconds and retry.
 - **Always-allow tip.** At the start of an ordering flow, suggest the user enable "always allow" for the Amazon script commands: "Tip: You can type 'a' to always allow Amazon commands for this session so you won't be prompted each time."
 - **Fresh slot required.** Amazon Fresh orders require a delivery slot to be selected before checkout. If the user skips this step, remind them to run `bun run {baseDir}/scripts/amazon.ts fresh delivery-slots --json` and select a slot.

--- a/skills/amazon/scripts/cart.ts
+++ b/skills/amazon/scripts/cart.ts
@@ -321,7 +321,7 @@ export async function addToCart(opts: {
                       __error: true,
                       __message: 'Add-to-cart failed: ASIN ' + ${JSON.stringify(
                         opts.asin,
-                      )} + ' was not found in the Fresh cart after adding. The item may be unavailable or the session cookies may be stale. Try running assistant amazon refresh.'
+                      )} + ' was not found in the Fresh cart after adding. The item may be unavailable or the session cookies may be stale. Try running the refresh command.'
                     });
                   }
                   items = allFreshItems.map(function(item) {


### PR DESCRIPTION
## Summary
Fixes two gaps from the Amazon CLI → skills/scripts migration review:

- Update error message in cart.ts that still referenced `assistant amazon refresh` to use a generic reference
- Reword SKILL.md lines that referenced the now-deleted `assistant amazon` CLI command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
