### PR TITLE
fix: resolve isTextInput compilation error and improve multimodal fallback logic

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -401,6 +401,7 @@ export async function embedWithBackend(
   const backends: EmbeddingBackend[] = [selection.backend, ...fallbacks];
 
   let lastErr: unknown;
+  let anyBackendAttempted = false;
   for (const backend of backends) {
     const isPrimary = backend === selection.backend;
     // For the primary backend, only embed uncached inputs and merge with cached.
@@ -410,11 +411,15 @@ export async function embedWithBackend(
       : inputs;
 
     // Skip text-only backends for multimodal inputs
-    if (backend.provider !== "gemini" && inputs.some((i) => typeof i !== "string" && i.type !== "text")) {
+    const hasNonText = inputsToEmbed.some(
+      (i) => typeof i !== "string" && normalizeEmbeddingInput(i).type !== "text",
+    );
+    if (backend.provider !== "gemini" && hasNonText) {
       continue;
     }
 
     try {
+      anyBackendAttempted = true;
       const vectors = await backend.embed(inputsToEmbed, options);
       if (vectors.length !== inputsToEmbed.length) {
         throw new Error(
@@ -461,11 +466,15 @@ export async function embedWithBackend(
       }
     }
   }
-  const hasMultimodal = inputs.some((i) => typeof i !== "string" && i.type !== "text");
-  if (hasMultimodal) {
-    throw new Error(
-      "No available embedding backend supports multimodal inputs. Gemini API key is required for image/audio/video embeddings.",
+  if (!anyBackendAttempted) {
+    const hasMultimodal = inputs.some(
+      (i) => typeof i !== "string" && normalizeEmbeddingInput(i).type !== "text",
     );
+    if (hasMultimodal) {
+      throw new Error(
+        "No available embedding backend supports multimodal inputs. Gemini API key is required for image/audio/video embeddings.",
+      );
+    }
   }
   throw lastErr;
 }


### PR DESCRIPTION
## Summary
Fixes three related issues in embedding-backend.ts identified during plan review:

1. **Compilation fix**: `isTextInput` was removed in #15041 but still referenced by #15039. Replaced with inline equivalent using `normalizeEmbeddingInput`.
2. **Error masking fix**: When Gemini is the only backend and fails with a retryable error (429/5xx), the generic "no multimodal backend" error was thrown instead, preventing proper retry classification. Now only throws generic error when all backends were skipped (not when they failed).
3. **Skip check accuracy**: Multimodal skip check now evaluates `inputsToEmbed` (actual inputs for the current backend) instead of `inputs` (all original inputs), preventing incorrect skipping when cached inputs contain multimodal content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
