### PR TITLE
fix: re-enqueue embed_attachment jobs during index rebuild

### DIFF
--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -1,9 +1,11 @@
 import { eq } from "drizzle-orm";
 
+import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
 import { getDb, rawExec } from "../db.js";
 import { asString, BackendUnavailableError } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import { extractMediaBlocks } from "../message-content.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
 import {
@@ -12,6 +14,7 @@ import {
   memoryItems,
   memorySegments,
   memorySummaries,
+  messages,
 } from "../schema.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -57,6 +60,31 @@ export function rebuildIndexJob(): void {
     .all();
   for (const asset of assets) {
     enqueueMemoryJob("embed_media", { assetId: asset.id });
+  }
+
+  // Re-enqueue embed_attachment jobs for messages with image content.
+  // Only when the embedding provider supports multimodal (Gemini).
+  const fullConfig = getConfig();
+  const embeddingProvider = fullConfig.memory.embeddings.provider;
+  const supportsMultimodal =
+    embeddingProvider === "gemini" ||
+    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini);
+
+  if (supportsMultimodal) {
+    const allMessages = db
+      .select({ id: messages.id, content: messages.content })
+      .from(messages)
+      .all();
+    for (const msg of allMessages) {
+      const blocks = extractMediaBlocks(msg.content);
+      const imageBlocks = blocks.filter((b) => b.type === "image");
+      for (const block of imageBlocks) {
+        enqueueMemoryJob("embed_attachment", {
+          messageId: msg.id,
+          blockIndex: block.index,
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** rebuildIndexJob does not re-enqueue embed_attachment jobs
**What was expected:** Index rebuild should regenerate all embedding types including message image attachments
**What was found:** Only segment, item, summary, and media embeddings were re-enqueued; message attachments were lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
