### PR TITLE
fix: correct schedule_cancel to schedule_delete in UPDATES.md

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -18,7 +18,7 @@ The separate reminder system has been unified into the schedule system. What thi
 
 - **`reminder_create`, `reminder_list`, and `reminder_cancel` tools no longer exist.** Do not attempt to use them.
 - **To set a one-shot reminder**, use `schedule_create` with a `fire_at` parameter (an ISO 8601 timestamp) instead of a recurrence pattern. This replaces `reminder_create`.
-- **To list or cancel reminders**, use `schedule_list` and `schedule_cancel` — they now cover both recurring schedules and one-shot reminders.
+- **To list or cancel reminders**, use `schedule_list` and `schedule_delete` — they now cover both recurring schedules and one-shot reminders.
 - Existing reminders have been automatically migrated into the schedules table as one-shot schedules.
 
 <!-- /vellum-update-release:schedule-reminder-unification -->


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** UPDATES.md references non-existent schedule_cancel tool
**What was expected:** Reference to actual tool name schedule_delete
**What was found:** Line 21 says schedule_cancel but tool is schedule_delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
