### PR TITLE
fix: update schedule.notify event description to cover recurring schedules

### DIFF
--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -37,7 +37,7 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     id: "user.send_notification",
     description: "User-initiated notification via assistant tool",
   },
-  { id: "schedule.notify", description: "Scheduled one-shot notification triggered" },
+  { id: "schedule.notify", description: "Scheduled notification triggered (one-shot or recurring)" },
   { id: "schedule.complete", description: "Scheduled task finished running" },
   {
     id: "guardian.question",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for combine-schedules-reminders.md.

**Gap:** schedule.notify event description inaccurately says "one-shot" only
**What was expected:** Description should cover both one-shot and recurring notify-mode schedules
**What was found:** Description says "Scheduled one-shot notification triggered" but event fires for all notify-mode schedules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
