### PR TITLE
fix: remove dead featureFlag field from VellumMetadata interface

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -98,8 +98,6 @@ export interface VellumMetadata {
   install?: InstallerSpec[];
   /** Declares a standalone CLI entry point for this skill. */
   cli?: SkillCliSpec;
-  /** Feature flag ID that gates this skill. When set, the skill is hidden/blocked if the flag is disabled. */
-  featureFlag?: string;
 }
 
 export interface SkillRequirements {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-frontmatter-feature-flag.md.

**Gap:** VellumMetadata.featureFlag is unreachable dead code
**What was expected:** VellumMetadata should not have a featureFlag field (it's never populated at runtime)
**What was found:** camelCase featureFlag on VellumMetadata never populated from kebab-case Zod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
