### PR TITLE
fix: replace IPC terminology in LLM-facing and user-facing strings

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -341,7 +341,7 @@ function buildInChatConfigurationSection(): string {
     "**How to collect credentials and secrets:**",
     '- Use `credential_store` with `action: "prompt"` to present a secure input field. The value never appears in the conversation.',
     '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser. Some services (e.g. Twitter/X) define their own auth flow via dedicated skill instructions — check the service\'s skill documentation for provider-specific setup steps.',
-    "- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate IPC or config tool to persist the value.",
+    "- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate config tool to persist the value.",
     "",
     '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',
     "",

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -53,7 +53,7 @@ export function executeDocumentCreate(
       surface_id: surfaceId,
       title,
       opened: false,
-      error: "No IPC client connected to open document editor",
+      error: "No client connected to open document editor",
     }),
     isError: false,
   };
@@ -92,7 +92,7 @@ export function executeDocumentUpdate(
   return {
     content: JSON.stringify({
       success: false,
-      error: "No IPC client connected to update document",
+      error: "No client connected to update document",
     }),
     isError: true,
   };

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -23,7 +23,7 @@ export async function executeSubagentSpawn(
     | undefined;
   if (!sendToClient) {
     return {
-      content: "No IPC client connected — cannot spawn subagent.",
+      content: "No client connected — cannot spawn subagent.",
       isError: true,
     };
   }

--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -133,7 +133,7 @@ export class VoiceConfigUpdateTool implements Tool {
   name = "voice_config_update";
   description =
     "Update a voice configuration setting (TTS voice ID, PTT activation key, wake word enabled/keyword/timeout). " +
-    "Changes take effect immediately via IPC broadcast to the desktop client.";
+    "Changes take effect immediately.";
   category = "system";
   defaultRiskLevel = RiskLevel.Low;
 


### PR DESCRIPTION
## Summary
- Remove 'IPC' from system prompt tool reference
- Remove 'IPC broadcast' from voice-config tool description
- Replace 'No IPC client connected' with 'No client connected' in error messages

Part of plan: phase-out-ipc-refs.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
