### PR TITLE
fix: rename truncateForIpc to truncateForClient and update ToolContext JSDoc

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -164,22 +164,22 @@ export function emitLlmCallStartedIfNeeded(
   );
 }
 
-// ── IPC Size Caps ────────────────────────────────────────────────────
+// ── Client Payload Size Caps ─────────────────────────────────────────
 // The client truncates tool results anyway (2 000 chars in ChatViewModel),
 // but the full string can be megabytes (file_read, bash output). Capping
-// here avoids sending oversized payloads over IPC which get decoded on
-// the client's main thread.
+// here avoids sending oversized payloads which get decoded on the
+// client's main thread.
 
 const TOOL_RESULT_MAX_CHARS = 2_000;
 const TOOL_RESULT_TRUNCATION_SUFFIX = "...[truncated]";
 
 // tool_input_delta streams accumulated JSON as tools run. For non-app
 // tools the client discards it (extractCodePreview only handles app tools),
-// so we cap it aggressively to avoid excessive IPC traffic.
+// so we cap it aggressively to avoid excessive client traffic.
 const TOOL_INPUT_DELTA_MAX_CHARS = 50_000;
 const APP_TOOL_NAMES = new Set(["app_create", "app_update"]);
 
-function truncateForIpc(
+function truncateForClient(
   value: string,
   maxChars: number,
   suffix: string,
@@ -407,7 +407,7 @@ export function handleInputJsonDelta(
   // app_create/app_update code previews; all other tools discard it.
   const content = APP_TOOL_NAMES.has(event.toolName)
     ? event.accumulatedJson
-    : truncateForIpc(
+    : truncateForClient(
         event.accumulatedJson,
         TOOL_INPUT_DELTA_MAX_CHARS,
         TOOL_RESULT_TRUNCATION_SUFFIX,
@@ -432,7 +432,7 @@ export function handleToolResult(
   deps.onEvent({
     type: "tool_result",
     toolName: "",
-    result: truncateForIpc(
+    result: truncateForClient(
       event.content,
       TOOL_RESULT_MAX_CHARS,
       TOOL_RESULT_TRUNCATION_SUFFIX,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -136,9 +136,9 @@ export interface ToolContext {
     allowedTools?: string[];
     allowedDomains?: string[];
   }) => Promise<SecretPromptResult>;
-  /** Optional callback to send a message to the connected IPC client (e.g. open_url). */
+  /** Optional callback to send a message to the connected client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
-  /** True when an interactive IPC client is connected (not just a no-op callback). */
+  /** True when an interactive client is connected (not just a no-op callback). */
   isInteractive?: boolean;
   /** Memory scope ID from the session's memory policy, so memory tools can target the correct scope. */
   memoryScopeId?: string;


### PR DESCRIPTION
## Summary
- Rename `truncateForIpc` → `truncateForClient` and update section comment from "IPC Size Caps" to "Client Payload Size Caps"
- Remove 'IPC client' from ToolContext JSDoc comments

Part of plan: phase-out-ipc-refs.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
