### PR TITLE
fix: gate embed_media jobs behind supportsMultimodal check in media processing

### DIFF
--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -6,12 +6,22 @@ import {
 import { mapSegmentsForAsset } from "../../config/bundled-skills/media-processing/tools/analyze-keyframes.js";
 import { preprocessForAsset } from "../../config/bundled-skills/media-processing/tools/extract-keyframes.js";
 import { reduceForAsset } from "../../config/bundled-skills/media-processing/tools/query-media-events.js";
+import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
 import { asString } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { getMediaAssetById, updateMediaAssetStatus } from "../media-store.js";
 
 const log = getLogger("media-processing-job");
+
+function supportsMultimodalEmbedding(): boolean {
+  const fullConfig = getConfig();
+  const embeddingProvider = fullConfig.memory.embeddings.provider;
+  return (
+    embeddingProvider === "gemini" ||
+    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini)
+  );
+}
 
 export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   const mediaAssetId = asString(job.payload.mediaAssetId);
@@ -32,7 +42,9 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
       "Skipping media processing pipeline — only video assets are supported",
     );
     updateMediaAssetStatus(mediaAssetId, "indexed");
-    enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
+    if (supportsMultimodalEmbedding()) {
+      enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
+    }
     return;
   }
 
@@ -110,5 +122,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   }
 
   updateMediaAssetStatus(mediaAssetId, "indexed");
-  enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
+  if (supportsMultimodalEmbedding()) {
+    enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
+  }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** media-processing.ts enqueues embed_media unconditionally
**What was expected:** embed_media jobs should be gated behind multimodal backend capability
**What was found:** Both non-video and post-pipeline paths enqueued embed_media without checking for Gemini support

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
