### PR TITLE
fix: gate embed_media jobs behind supportsMultimodal check in rebuildIndexJob

### DIFF
--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -53,17 +53,9 @@ export function rebuildIndexJob(): void {
     enqueueMemoryJob("embed_segment", { segmentId: segment.id });
   }
 
-  const assets = db
-    .select({ id: mediaAssets.id })
-    .from(mediaAssets)
-    .where(eq(mediaAssets.status, "indexed"))
-    .all();
-  for (const asset of assets) {
-    enqueueMemoryJob("embed_media", { assetId: asset.id });
-  }
-
-  // Re-enqueue embed_attachment jobs for messages with image content.
-  // Only when the embedding provider supports multimodal (Gemini).
+  // Re-enqueue multimodal embedding jobs only when the embedding provider
+  // supports multimodal inputs (Gemini). Without this gate, embed_media and
+  // embed_attachment jobs would all fail for non-Gemini users.
   const fullConfig = getConfig();
   const embeddingProvider = fullConfig.memory.embeddings.provider;
   const supportsMultimodal =
@@ -71,6 +63,15 @@ export function rebuildIndexJob(): void {
     (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini);
 
   if (supportsMultimodal) {
+    const assets = db
+      .select({ id: mediaAssets.id })
+      .from(mediaAssets)
+      .where(eq(mediaAssets.status, "indexed"))
+      .all();
+    for (const asset of assets) {
+      enqueueMemoryJob("embed_media", { assetId: asset.id });
+    }
+
     const allMessages = db
       .select({ id: messages.id, content: messages.content })
       .from(messages)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for multimodal-embedding.md.

**Gap:** embed_media jobs enqueued unconditionally in rebuildIndexJob
**What was expected:** Both media job types should be gated behind multimodal backend capability check
**What was found:** embed_media was ungated, causing job failures for non-Gemini users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
