### PR TITLE
fix: update subagent test to use renamed client error message

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -160,7 +160,7 @@ describe("Subagent tool execute validation", () => {
       makeContext("sess-1"),
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("No IPC client");
+    expect(result.content).toContain("No client connected");
   });
 
   test("spawn returns error when missing label", async () => {


### PR DESCRIPTION
## Summary
- Updates the `spawn returns error when no sendToClient` test assertion to match the renamed error string
- The source message was changed from `"No IPC client"` to `"No client connected — cannot spawn subagent."` as part of the IPC terminology rename, but this test was not updated

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22929289087/job/66547062636

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
