### PR TITLE
fix: sweep remaining IPC terminology from assistant code comments

### DIFF
--- a/assistant/src/bundler/bundle-signer.ts
+++ b/assistant/src/bundler/bundle-signer.ts
@@ -2,7 +2,7 @@
  * Bundle signing for .vellum archives.
  *
  * Computes content hashes, constructs a canonical signing payload,
- * and requests an Ed25519 signature from the Swift client via IPC.
+ * and requests an Ed25519 signature from the Swift client.
  */
 
 import { createHash } from "node:crypto";
@@ -22,8 +22,8 @@ export interface SignatureJson {
 }
 
 /**
- * Callback type for requesting a signature from the Swift client via IPC.
- * The caller provides this so the signer doesn't need to know about IPC details.
+ * Callback type for requesting a signature from the Swift client.
+ * The caller provides this so the signer doesn't need to know about transport details.
  */
 export type SigningCallback = (payload: string) => Promise<{
   signature: string; // base64-encoded
@@ -109,7 +109,7 @@ export async function signBundle(
   });
   const canonicalPayload = JSON.stringify(signingPayload);
 
-  // 4. Request signature from Swift via IPC
+  // 4. Request signature from Swift client
   const { signature, keyId } = await requestSignature(canonicalPayload);
 
   // 5. Build SignatureJson

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -2,7 +2,7 @@
  * Reusable Twilio REST API helpers.
  *
  * Provides low-level building blocks (auth header, base URL, credential
- * resolution) shared across the voice provider and IPC
+ * resolution) shared across the voice provider and the
  * config handler. Uses fetch() directly — no twilio npm package.
  */
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -471,7 +471,7 @@ export async function startVoiceTurn(
 
   // Fire-and-forget the agent loop
   const cleanup = () => {
-    // Reset channel capabilities so a subsequent IPC/desktop session on the
+    // Reset channel capabilities so a subsequent desktop session on the
     // same conversation is not incorrectly treated as a voice client.
     session.setChannelCapabilities(null);
     session.setTrustContext(null);

--- a/assistant/src/cli/http-client.ts
+++ b/assistant/src/cli/http-client.ts
@@ -1,9 +1,8 @@
 /**
  * HTTP client helpers for the built-in CLI.
  *
- * Provides authenticated HTTP communication with the daemon's HTTP server,
- * replacing the previous Unix socket IPC transport. Patterns are adapted
- * from `cli/src/lib/http-client.ts` (external CLI).
+ * Provides authenticated HTTP communication with the daemon's HTTP server.
+ * Patterns are adapted from `cli/src/lib/http-client.ts` (external CLI).
  */
 
 import { readFileSync } from "node:fs";

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -51,7 +51,7 @@ import type {
 } from "../message-protocol.js";
 import { type HandlerContext, log } from "./shared.js";
 
-// -- Transport-agnostic result type (omits the IPC `type` discriminant) --
+// -- Transport-agnostic result type (omits the `type` discriminant) --
 
 export type ChannelVerificationSessionResult = Omit<
   ChannelVerificationSessionResponse,
@@ -224,7 +224,7 @@ export function revokeVerificationForChannel(
 }
 
 // ---------------------------------------------------------------------------
-// Trusted-contact verification (shared by IPC + HTTP transports)
+// Trusted-contact verification (shared across transports)
 // ---------------------------------------------------------------------------
 
 /** Session TTL in seconds (matches challenge TTL of 10 minutes). */
@@ -252,7 +252,7 @@ function toVerificationChannel(channelType: string): ChannelId | null {
  * channel, derives the verification channel and destination, checks rate
  * limits, and creates the appropriate outbound session.
  *
- * Returns a `ChannelVerificationSessionResult` so both the IPC handler
+ * Returns a `ChannelVerificationSessionResult` so both the message handler
  * and the HTTP handler can wrap it in their respective response envelopes.
  */
 export async function verifyTrustedContact(

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -53,7 +53,7 @@ export function summarizeTelegramError(err: unknown): string {
   return redactTelegramBotTokens(parts.join(" "));
 }
 
-// -- Transport-agnostic result type (omits the IPC `type` discriminant) --
+// -- Transport-agnostic result type (omits the `type` discriminant) --
 
 export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 
@@ -359,7 +359,7 @@ export async function setupTelegram(
   };
 }
 
-// -- IPC handler (thin wrapper over extracted functions) --
+// -- Message handler (thin wrapper over extracted functions) --
 
 export async function handleTelegramConfig(
   msg: TelegramConfigRequest,

--- a/assistant/src/daemon/handlers/config-voice.ts
+++ b/assistant/src/daemon/handlers/config-voice.ts
@@ -194,7 +194,7 @@ export function normalizeActivationKey(
 }
 
 /**
- * Process a voice configuration update request from a session or IPC client.
+ * Process a voice configuration update request from a session or client.
  * Validates the activation key and broadcasts the change to all connected clients.
  */
 export function handleVoiceConfigUpdate(

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -497,7 +497,7 @@ export async function finalizeAndPublishRecording(params: {
   }
 
   // Restrict accepted file paths to the app's recordings directory to
-  // prevent attachment of arbitrary files via crafted IPC messages.
+  // prevent attachment of arbitrary files via crafted messages.
   let resolvedPath: string;
   try {
     resolvedPath = realpathSync(filePath);

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -62,7 +62,7 @@ import {
 /**
  * Minimal context needed by the standalone skill business-logic functions.
  * HandlerContext satisfies this interface, but HTTP routes can also provide
- * a compatible object without coupling to IPC internals.
+ * a compatible object without coupling to handler internals.
  */
 export interface SkillOperationContext {
   debounceTimers: HandlerContext["debounceTimers"];
@@ -204,7 +204,7 @@ function heuristicDraft(body: string): {
 const LLM_DRAFT_TIMEOUT_MS = 15_000;
 
 // ─── Standalone business-logic functions ─────────────────────────────────────
-// These are consumed by both the IPC handlers below and the HTTP route layer.
+// These are consumed by both the handlers below and the HTTP route layer.
 
 /** Helper: suppress config reload, save, debounce, and update fingerprint. */
 function saveConfigWithSuppression(
@@ -764,7 +764,7 @@ export async function createSkill(
   }
 }
 
-// ─── IPC handlers (thin wrappers) ───────────────────────────────────────────
+// ─── HTTP handlers (thin wrappers) ──────────────────────────────────────────
 
 export function handleSkillsList(ctx: HandlerContext): void {
   const skills = listSkills(ctx);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -395,7 +395,7 @@ export async function runDaemon(): Promise<void> {
     const hostname = getRuntimeHttpHost();
 
     // Mint a JWT bearer token for the pairing flow. This replaces the
-    // old static http-token that was removed — the pairing IPC handler
+    // old static http-token that was removed — the pairing handler
     // and HTTP auto-approve logic both guard on a non-empty bearer token.
     const pairingBearerToken = mintPairingBearerToken();
 

--- a/assistant/src/daemon/message-types/browser.ts
+++ b/assistant/src/daemon/message-types/browser.ts
@@ -1,5 +1,5 @@
 // Browser interaction types.
-// CDP request/response IPC was removed — Playwright's connectOverCDP is broken
+// CDP request/response messaging was removed — Playwright's connectOverCDP is broken
 // under Bun's runtime. Browser is now launched directly via Playwright.
 
 // --- Domain-level union aliases (consumed by the barrel file) ---

--- a/assistant/src/daemon/message-types/guardian-actions.ts
+++ b/assistant/src/daemon/message-types/guardian-actions.ts
@@ -1,4 +1,4 @@
-// Guardian action decision IPC types.
+// Guardian action decision message types.
 // Enables desktop clients to fetch pending guardian prompts and submit
 // button decisions deterministically (without text parsing).
 

--- a/assistant/src/daemon/message-types/settings.ts
+++ b/assistant/src/daemon/message-types/settings.ts
@@ -2,7 +2,7 @@
 
 // === Client → Server ===
 
-/** Request from a session or IPC client to change the voice activation key. */
+/** Request from a session or client to change the voice activation key. */
 export interface VoiceConfigUpdateRequest {
   type: "voice_config_update";
   /** The desired activation key (enum value or natural-language name). */

--- a/assistant/src/daemon/message-types/shared.ts
+++ b/assistant/src/daemon/message-types/shared.ts
@@ -1,4 +1,4 @@
-// Shared types used across multiple IPC domains.
+// Shared types used across multiple message domains.
 
 export type ThreadType = "standard" | "private";
 

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -199,7 +199,7 @@ export async function resolveAssistantAttachments(
   }
 
   // Persist resolved attachments and link to the last assistant message.
-  // Large video attachments are omitted from the IPC payload and lazy-loaded
+  // Large video attachments are omitted from the event payload and lazy-loaded
   // by the client via the HTTP endpoint (same pattern as history_response).
   const MAX_INLINE_B64_SIZE = 512 * 1024;
 

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -5,7 +5,7 @@ import type {
 } from "./message-protocol.js";
 
 /**
- * Classified session error ready for IPC emission.
+ * Classified session error ready for client emission.
  */
 export interface ClassifiedSessionError {
   code: SessionErrorCode;
@@ -93,11 +93,11 @@ export function isUserCancellation(error: unknown, ctx: ErrorContext): boolean {
   return false;
 }
 
-/** Maximum length for debugDetails to prevent unbounded IPC payloads. */
+/** Maximum length for debugDetails to prevent unbounded event payloads. */
 const MAX_DEBUG_DETAIL_LENGTH = 4000;
 
 /**
- * Truncate debug details to a reasonable size for IPC transport.
+ * Truncate debug details to a reasonable size for transport.
  */
 function truncateDebugDetails(details: string): string {
   if (details.length <= MAX_DEBUG_DETAIL_LENGTH) return details;
@@ -305,7 +305,7 @@ function classifyByMessage(
 }
 
 /**
- * Build a `session_error` IPC message from a classified error.
+ * Build a `session_error` server message from a classified error.
  */
 export function buildSessionErrorMessage(
   sessionId: string,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -511,7 +511,7 @@ export async function drainQueue(
 
 /**
  * Convenience function that persists a user message and runs the agent loop
- * in a single call. Used by the IPC path where blocking is expected.
+ * in a single call. Used by the message-handler path where blocking is expected.
  */
 export async function processMessage(
   session: ProcessSessionContext,

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -90,7 +90,7 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   allowedToolNames?: Set<string>;
   /** Session memory policy — used to propagate scopeId and strictSideEffects into ToolContext. */
   memoryPolicy: { scopeId: string; strictSideEffects: boolean };
-  /** True when the session has no connected IPC client (HTTP-only path). */
+  /** True when the session has no connected client (HTTP-only path). */
   hasNoClient?: boolean;
   /** When true, the session is executing a task run and must not become interactive. */
   headlessLock?: boolean;

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -521,7 +521,7 @@ export class Session {
     // guardian trust-class and conversation context are available.
 
     // Emit authoritative confirmation state and activity transition centrally
-    // so ALL callers (IPC handlers, /v1/confirm, channel bridges) get
+    // so ALL callers (HTTP handlers, /v1/confirm, channel bridges) get
     // consistent events without duplicating emission logic.
     const resolvedState =
       decision === "deny" || decision === "always_deny"

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -1,6 +1,6 @@
 /**
  * Vellum channel adapter — delivers notifications to connected desktop
- * and mobile clients via the daemon's IPC broadcast mechanism.
+ * and mobile clients via the daemon's event broadcast mechanism.
  *
  * The adapter broadcasts a `notification_intent` message that the Vellum
  * client can use to display a native notification (e.g. NSUserNotification

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -79,8 +79,8 @@ export class NotificationBroadcaster {
   ): Promise<NotificationDeliveryResult[]> {
     const destinations = resolveDestinations(decision.selectedChannels);
 
-    // Ensure vellum is processed first so the notification_thread_created IPC
-    // push fires immediately, before slower channel sends (e.g. Telegram 30s
+    // Ensure vellum is processed first so the notification_thread_created
+    // event fires immediately, before slower channel sends (e.g. Telegram 30s
     // timeout) can delay it past the macOS deep-link retry window.
     const orderedChannels = [...decision.selectedChannels].sort((a, b) => {
       if (a === "vellum") return -1;
@@ -242,10 +242,10 @@ export class NotificationBroadcaster {
           }
         }
 
-        // Emit notification_thread_created IPC event only when a NEW
+        // Emit notification_thread_created event only when a NEW
         // conversation was actually created. Reusing an existing thread
-        // should not fire the IPC event — the client already knows about
-        // the conversation.
+        // should not fire the event — the client already knows about the
+        // conversation.
         if (
           pairing.createdNewConversation &&
           pairing.strategy === "start_new_conversation"

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -293,7 +293,7 @@ function buildFallbackDecision(
     signal.attentionHints.urgency === "high" &&
     signal.attentionHints.requiresAction;
 
-  // Always include the vellum channel in the fallback — it's a local IPC
+  // Always include the vellum channel in the fallback — it's a local
   // broadcast with no cost, so desktop notifications should never be lost
   // when the LLM is unavailable. External channels (e.g. Telegram) are
   // only included for high-urgency actionable signals.
@@ -320,7 +320,7 @@ function buildFallbackDecision(
     selectedChannels,
     reasoningSummary: isHighUrgencyAction
       ? "Fallback: high urgency + requires action — all channels"
-      : "Fallback: vellum-only (local IPC, always delivered)",
+      : "Fallback: vellum-only (local, always delivered)",
     renderedCopy: copy,
     dedupeKey: `fallback:${signal.sourceEventName}:${signal.sourceSessionId}:${signal.createdAt}`,
     confidence: 0.3,

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -3,7 +3,7 @@
  *
  * Reads guardian delivery info from the contacts table.
  *
- * - Vellum: no external endpoint needed — delivery goes through the IPC
+ * - Vellum: no external endpoint needed — delivery goes through the event
  *   broadcast mechanism to connected desktop/mobile clients. The
  *   guardianPrincipalId is included in metadata so downstream adapters
  *   can scope guardian-sensitive notifications to bound guardian devices.
@@ -40,7 +40,7 @@ export function resolveDestinations(
     // guard, so we narrow with a switch over known deliverable values.
     switch (channel as NotificationChannel) {
       case "vellum": {
-        // Vellum delivery is local IPC — no external endpoint required.
+        // Vellum delivery is local — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
         // guardian-sensitive notifications for scoped delivery.
         const guardianResult = findGuardianForChannel("vellum");

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -47,7 +47,7 @@ export interface OAuthConnectOptions {
   isInteractive: boolean;
   /** Open a URL in the user's browser (interactive path). */
   openUrl?: (url: string) => void;
-  /** Send a message to the client (e.g. open_url IPC). */
+  /** Send a message to the client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
   /** Tools allowed to use the resulting credential. */
   allowedTools?: string[];

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -1,9 +1,8 @@
 /**
  * In-process pub/sub hub for assistant events.
  *
- * Provides subscribe / publish primitives used by both the IPC daemon send
- * paths (PR 3) and the SSE route (PR 5). No runtime route or daemon
- * integration is wired here.
+ * Provides subscribe / publish primitives used by the daemon send paths
+ * and the SSE route. No runtime route or daemon integration is wired here.
  */
 
 import type { AssistantEvent } from "./assistant-event.js";

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -13,8 +13,8 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /**
- * A single assistant event wrapping an IPC ServerMessage payload.
- * The `message` field is intentionally unchanged from the IPC form so that
+ * A single assistant event wrapping a ServerMessage payload.
+ * The `message` field preserves the original form so that
  * delta semantics (text deltas, tool input deltas, etc.) are preserved.
  */
 export interface AssistantEvent {
@@ -26,7 +26,7 @@ export interface AssistantEvent {
   sessionId?: string;
   /** ISO-8601 timestamp of when the event was emitted. */
   emittedAt: string;
-  /** Unchanged IPC outbound message payload. */
+  /** Outbound server message payload. */
   message: ServerMessage;
 }
 
@@ -36,7 +36,7 @@ export interface AssistantEvent {
  * Construct an `AssistantEvent` envelope around a `ServerMessage`.
  *
  * @param assistantId  The logical assistant identifier (e.g. from the daemon or HTTP route).
- * @param message      The unchanged IPC outbound message payload.
+ * @param message      The outbound server message payload.
  * @param sessionId    Optional conversation/session id — pass when known.
  */
 export function buildAssistantEvent(

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -13,7 +13,7 @@
  * reply text for the guardian's confirmation message.
  *
  * This module is channel-agnostic: both inbound-message-handler (Telegram
- * channels) and session-process (mac/IPC channel) use it.
+ * channels) and session-process (desktop channel) use it.
  */
 
 import { startCall } from "../calls/call-domain.js";

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -3,7 +3,7 @@
  * request is resolved with tool metadata.
  *
  * Used by both the channel inbound path (inbound-message-handler.ts) and
- * the desktop/IPC path (session-process.ts) to ensure grants are minted
+ * the desktop path (session-process.ts) to ensure grants are minted
  * consistently regardless of which channel the guardian answers on.
  */
 

--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -3,7 +3,7 @@
  *
  * Encapsulates the core business logic — validation, conversation scoping,
  * canonical decision application, and result mapping — so both the HTTP
- * handler and the IPC handler can delegate here without duplicating code.
+ * handler and the message handler can delegate here without duplicating code.
  */
 
 import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";
@@ -61,7 +61,7 @@ export type ProcessGuardianDecisionResult =
  *
  * Validates the action, checks conversation scope if applicable, applies the
  * canonical decision, and maps the result to a caller-agnostic shape that
- * both HTTP and IPC handlers can interpret.
+ * both HTTP and message handlers can interpret.
  */
 export async function processGuardianDecision(
   params: ProcessGuardianDecisionParams,
@@ -97,7 +97,7 @@ export async function processGuardianDecision(
     action: action as ApprovalAction,
     actorContext: {
       actorPrincipalId: actorContext.actorPrincipalId,
-      actorExternalUserId: undefined, // Desktop/IPC path — no channel-native ID
+      actorExternalUserId: undefined, // Desktop path — no channel-native ID
       channel,
       guardianPrincipalId: actorContext.guardianPrincipalId,
     },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -243,12 +243,12 @@ export class RuntimeHttpServer {
     return this.server?.port ?? this.port;
   }
 
-  /** Expose the pairing store so the daemon server can wire IPC handlers. */
+  /** Expose the pairing store so the daemon server can wire HTTP handlers. */
   getPairingStore(): PairingStore {
     return this.pairingStore;
   }
 
-  /** Set a callback for broadcasting IPC messages (wired by daemon server). */
+  /** Set a callback for broadcasting server messages (wired by daemon server). */
   setPairingBroadcast(fn: (msg: ServerMessage) => void): void {
     this.pairingBroadcast = fn;
   }

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -1,8 +1,8 @@
 /**
  * Shared business logic for invite management.
  *
- * Extracted from the IPC handlers in daemon/handlers/config-inbox.ts so that
- * both the HTTP routes and the IPC handlers call the same logic.
+ * Extracted from the handlers in daemon/handlers/config-inbox.ts so that
+ * both the HTTP routes and the message handlers call the same logic.
  *
  * Member/contact operations have been migrated to the /v1/contacts and
  * /v1/contacts/channels endpoints.
@@ -38,7 +38,7 @@ import {
 } from "./invite-redemption-service.js";
 
 // ---------------------------------------------------------------------------
-// Response shapes — used by both HTTP routes and IPC handlers
+// Response shapes — used by both HTTP routes and message handlers
 // ---------------------------------------------------------------------------
 
 export interface InviteResponseData {

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -2,7 +2,7 @@
  * HTTP route definitions for app CRUD, bundling, sharing, versioning,
  * gallery, and signing operations.
  *
- * Business logic is extracted from the IPC handlers in
+ * Business logic is extracted from the handlers in
  * `daemon/handlers/apps.ts`, `daemon/handlers/publish.ts`,
  * `daemon/handlers/signing.ts`, and `daemon/handlers/open-bundle-handler.ts`
  * so that the same operations are available over HTTP.
@@ -887,8 +887,7 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
       handler: async ({ params }) => {
         try {
           // Package without signing callback (HTTP clients handle signing
-          // separately or skip it). The IPC flow used a socket-based
-          // signing callback; HTTP callers can use the sign-bundle
+          // separately or skip it). HTTP callers can use the sign-bundle
           // endpoint independently if needed.
           const result = await packageApp(params.id);
           const bundleData = readFileSync(result.bundlePath);

--- a/assistant/src/runtime/routes/computer-use-routes.ts
+++ b/assistant/src/runtime/routes/computer-use-routes.ts
@@ -2,9 +2,7 @@
  * HTTP route handlers for computer use session lifecycle.
  *
  * These endpoints expose CU session management, ride-shotgun, and watch
- * observation functionality over HTTP. The existing IPC handlers remain
- * as the primary transport; these routes provide the HTTP-first API
- * surface for the phase-out-ipc migration.
+ * observation functionality over HTTP.
  *
  * All CU write operations require the `chat.write` scope.
  */
@@ -306,8 +304,7 @@ async function handleObservation(
  * POST /v1/computer-use/tasks — submit a task.
  *
  * This is a simplified HTTP version of task_submit that creates a CU session.
- * The full task_submit flow (with routing, recording intents, etc.) remains
- * IPC-only for now; this endpoint provides direct CU session creation.
+ * This endpoint provides direct CU session creation.
  *
  * Body: { task, screenWidth, screenHeight, interactionType? }
  */

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -1,9 +1,7 @@
 /**
  * HTTP route handlers for diagnostics export and dictation processing.
  *
- * Migrated from IPC handlers:
- *   - handlers/diagnostics.ts (diagnostics_export_request)
- *   - handlers/dictation.ts (dictation_request)
+ * Handles diagnostics export and dictation processing requests.
  */
 
 import { randomBytes } from "node:crypto";
@@ -53,7 +51,7 @@ import type { RouteDefinition } from "../http-router.js";
 const log = getLogger("diagnostics-routes");
 
 // ---------------------------------------------------------------------------
-// Diagnostics export — redaction helpers (shared with IPC handler)
+// Diagnostics export — redaction helpers
 // ---------------------------------------------------------------------------
 
 const MAX_CONTENT_LENGTH = 500;
@@ -653,7 +651,7 @@ async function handleDictation(body: DictationBody): Promise<Response> {
       log.warn(
         "Dictation: no provider available, using heuristic + raw transcription",
       );
-      // Build an IPC-compatible msg for the heuristic
+      // Build a compatible msg for the heuristic
       const mode = detectDictationModeHeuristic({
         type: "dictation_request",
         transcription: body.transcription,

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for document persistence operations.
  *
  * Exposes document CRUD over HTTP, sharing business logic with the
- * IPC handlers in `daemon/handlers/documents.ts`.
+ * handlers in `daemon/handlers/documents.ts`.
  */
 import { rawAll, rawGet, rawRun } from "../../memory/db.js";
 import { getLogger } from "../../util/logger.js";
@@ -24,7 +24,7 @@ interface DocumentRow {
 type DocumentListRow = Omit<DocumentRow, "content">;
 
 // ---------------------------------------------------------------------------
-// Shared business logic (used by both IPC handlers and HTTP routes)
+// Shared business logic (used by both message handlers and HTTP routes)
 // ---------------------------------------------------------------------------
 
 export function saveDocument(params: {

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -2,7 +2,7 @@
  * Route handlers for Slack channel listing and direct sharing.
  *
  * These endpoints let the UI post app links directly to Slack channels
- * without going through the legacy IPC-based Slack share flow.
+ * without going through the legacy Slack share flow.
  */
 
 import { getApp } from "../../../../memory/app-store.js";

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -299,7 +299,7 @@ export async function handlePairingRequest(
     // tokens and creating DB records for unapproved devices).
     pendingDeviceIds.set(pairingRequestId, { deviceId, createdAt: Date.now() });
 
-    // Send IPC to macOS to show approval prompt
+    // Broadcast to macOS to show approval prompt
     if (ctx.pairingBroadcast) {
       ctx.pairingBroadcast({
         type: "pairing_approval_request",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -1,7 +1,7 @@
 /**
  * HTTP route handlers for schedule management.
  *
- * Migrated from IPC handler: handlers/config-scheduling.ts
+ * HTTP route handlers for schedule management.
  */
 
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";

--- a/assistant/src/runtime/routes/session-query-routes.ts
+++ b/assistant/src/runtime/routes/session-query-routes.ts
@@ -2,8 +2,7 @@
  * HTTP route definitions for model configuration, conversation search,
  * message content, and queued message deletion.
  *
- * These routes expose IPC-only functionality over the HTTP API, enabling
- * clients to migrate from the Unix socket transport to HTTP+SSE.
+ * These routes expose session query functionality over the HTTP API.
  *
  * GET    /v1/model                   — current model info
  * PUT    /v1/model                   — set model

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -2,12 +2,8 @@
  * HTTP route handlers for settings, identity/avatar, voice config,
  * OAuth connect, Twitter auth, and workspace files.
  *
- * Migrated from IPC handlers:
- *   - handlers/config-voice.ts (voice_config_update)
- *   - handlers/avatar.ts (generate_avatar)
- *   - handlers/oauth-connect.ts (oauth_connect_start)
- *   - handlers/twitter-auth.ts (twitter_auth_start, twitter_auth_status)
- *   - handlers/workspace-files.ts (workspace_files_list, workspace_file_read)
+ * Handles settings, identity/avatar, voice config,
+ * OAuth connect, Twitter auth, and workspace files.
  *   - handlers/config-tools.ts (tool_names_list, tool_permission_simulate, env_vars_request)
  */
 
@@ -69,9 +65,8 @@ function handleVoiceConfigUpdate(activationKey: string): Response {
   if (!result.ok) {
     return httpError("BAD_REQUEST", result.reason, 400);
   }
-  // The broadcast to IPC clients happens via the IPC handler. The HTTP
-  // route validates and returns the canonical value; the caller (client)
-  // applies the setting locally.
+  // The HTTP route validates and returns the canonical value; the caller
+  // (client) applies the setting locally.
   return Response.json({ ok: true, activationKey: result.value });
 }
 
@@ -479,7 +474,7 @@ function handleTwitterAuthStatus(): Response {
 }
 
 // ---------------------------------------------------------------------------
-// Workspace files (IPC-style list/read)
+// Workspace files (list/read)
 // ---------------------------------------------------------------------------
 
 const WORKSPACE_FILES = ["IDENTITY.md", "SOUL.md", "USER.md", "skills/"];
@@ -827,7 +822,7 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: () => handleTwitterAuthStatus(),
     },
 
-    // Workspace files (IPC-style list/read -- distinct from workspace-routes.ts tree/file)
+    // Workspace files (list/read -- distinct from workspace-routes.ts tree/file)
     {
       endpoint: "workspace-files",
       method: "GET",

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -1,7 +1,7 @@
 /**
  * Route handlers for skill management operations.
  *
- * These HTTP routes expose the same business logic as the IPC skill handlers,
+ * These HTTP routes expose the same business logic as the skill handlers,
  * using the standalone functions extracted in `../../daemon/handlers/skills.ts`.
  */
 

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for subagent operations.
  *
  * Exposes subagent detail, abort, and message operations over HTTP,
- * sharing business logic with the IPC handlers in
+ * sharing business logic with the handlers in
  * `daemon/handlers/subagents.ts`.
  */
 import { getMessages } from "../../memory/conversation-crud.js";
@@ -14,7 +14,7 @@ import type { RouteDefinition } from "../http-router.js";
 const log = getLogger("subagents-routes");
 
 // ---------------------------------------------------------------------------
-// Shared business logic (used by both IPC handlers and HTTP routes)
+// Shared business logic (used by both message handlers and HTTP routes)
 // ---------------------------------------------------------------------------
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -167,7 +167,7 @@ export function subagentRouteDefinitions(): RouteDefinition[] {
         const manager = getSubagentManager();
         const aborted = manager.abort(
           params.id,
-          () => {}, // No IPC send callback needed for HTTP
+          () => {}, // No send callback needed for HTTP
           sessionId,
         );
 

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for work item (task queue) operations.
  *
  * Exposes all work item CRUD and lifecycle operations over HTTP,
- * sharing business logic with the IPC handlers in
+ * sharing business logic with the handlers in
  * `daemon/handlers/work-items.ts`.
  */
 import type { ServerMessage } from "../../daemon/message-protocol.js";
@@ -195,7 +195,7 @@ function extractToolHighlights(
 }
 
 // ---------------------------------------------------------------------------
-// Shared business logic functions (exported for IPC handler reuse)
+// Shared business logic functions (exported for handler reuse)
 // ---------------------------------------------------------------------------
 
 export interface WorkItemOutputResult {

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -4,7 +4,7 @@
  * These pure functions encapsulate the business logic for starting, resending,
  * and cancelling outbound verification flows (Telegram, voice, Slack).
  * They return transport-agnostic result objects and are consumed by both the
- * IPC handler (config-channels.ts) and the HTTP route layer (channel-verification-routes.ts).
+ * message handler (config-channels.ts) and the HTTP route layer (channel-verification-routes.ts).
  */
 
 import { createHash, randomBytes } from "node:crypto";
@@ -99,7 +99,7 @@ export interface CancelOutboundParams {
 
 /**
  * Transport-agnostic result object returned by outbound actions.
- * Maps 1:1 with the fields in ChannelVerificationSessionResponse minus the IPC
+ * Maps 1:1 with the fields in ChannelVerificationSessionResponse minus the
  * `type` discriminant.
  */
 export interface OutboundActionResult {

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -59,7 +59,7 @@ export interface OAuth2TokenResult {
 }
 
 export interface OAuth2FlowCallbacks {
-  /** Open a URL in the user's browser (e.g. via IPC `open_url`). */
+  /** Open a URL in the user's browser (e.g. via `open_url` message). */
   openUrl: (url: string) => void;
 }
 

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -188,7 +188,7 @@ export class SubagentManager {
       memoryPolicy,
     );
 
-    // Mark session as having no direct IPC client — it routes through parent.
+    // Mark session as having no direct client — it routes through parent.
     // This ensures interactive prompts (host attachment reads) fail fast.
     session.updateClient(wrappedSendToClient, true);
 

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -26,7 +26,7 @@ const AUTO_APPROVE_TOOLS = new Set([
   "Bash(find *)",
 ]);
 
-// Tools that always require user approval via confirmation IPC
+// Tools that always require user approval via confirmation prompt
 const APPROVAL_REQUIRED_TOOLS = new Set([
   "Bash",
   "Edit",

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -12,7 +12,7 @@ export function executeDocumentCreate(
   const initialContent = (input.initial_content as string | undefined) || "";
   const surfaceId = `doc-${randomUUID()}`;
 
-  // Send document_editor_show IPC message to open the built-in RTE
+  // Send document_editor_show message to open the built-in RTE
   if (context.sendToClient) {
     context.sendToClient({
       type: "document_editor_show",
@@ -47,7 +47,7 @@ export function executeDocumentCreate(
     };
   }
 
-  // Fallback if no IPC client is connected
+  // Fallback if no client is connected
   return {
     content: JSON.stringify({
       surface_id: surfaceId,
@@ -67,7 +67,7 @@ export function executeDocumentUpdate(
   const content = input.content as string;
   const mode = (input.mode as string | undefined) || "append";
 
-  // Send document_editor_update IPC message to update the built-in RTE
+  // Send document_editor_update message to update the built-in RTE
   if (context.sendToClient) {
     context.sendToClient({
       type: "document_editor_update",
@@ -88,7 +88,7 @@ export function executeDocumentUpdate(
     };
   }
 
-  // Fallback if no IPC client is connected
+  // Fallback if no client is connected
   return {
     content: JSON.stringify({
       success: false,

--- a/assistant/src/tools/system/open-system-settings.ts
+++ b/assistant/src/tools/system/open-system-settings.ts
@@ -66,7 +66,7 @@ export class OpenSystemSettingsTool implements Tool {
 
     const meta = PANES[pane as PaneName];
 
-    // Send open_url IPC to the client — the x-apple.systempreferences: scheme
+    // Send open_url to the client — the x-apple.systempreferences: scheme
     // opens System Settings directly without a browser confirmation dialog.
     if (context.sendToClient) {
       context.sendToClient({

--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -194,7 +194,7 @@ export class VoiceConfigUpdateTool implements Tool {
     const meta = VOICE_SETTINGS[setting as VoiceSettingName];
     const friendlyName = FRIENDLY_NAMES[setting as VoiceSettingName];
 
-    // Send client_settings_update IPC to write to UserDefaults
+    // Send client_settings_update message to write to UserDefaults
     if (context.sendToClient) {
       context.sendToClient({
         type: "client_settings_update",


### PR DESCRIPTION
## Summary
- Broad sweep of remaining IPC references in ~60 assistant/src TypeScript files
- Replace IPC handler/event/client/broadcast terminology with HTTP/SSE/client equivalents
- Remove historical migration comments that reference the deleted IPC transport
- Comment-only changes, no functional impact

Part of plan: phase-out-ipc-refs.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
