### PR TITLE
fix: rename Ipc function names in sessions handler

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -78,7 +78,7 @@ function parseBindingSourceChannel(
   return null;
 }
 
-export function syncCanonicalStatusFromIpcConfirmationDecision(
+export function syncCanonicalStatusFromConfirmationDecision(
   requestId: string,
   decision: ConfirmationResponse["decision"],
 ): void {
@@ -99,7 +99,7 @@ export function syncCanonicalStatusFromIpcConfirmationDecision(
   }
 }
 
-export function makeIpcEventSender(params: {
+export function makeEventSender(params: {
   ctx: HandlerContext;
   session: Session;
   conversationId: string;
@@ -175,7 +175,7 @@ export function handleConfirmationResponse(
         undefined,
         { source: "button" },
       );
-      syncCanonicalStatusFromIpcConfirmationDecision(
+      syncCanonicalStatusFromConfirmationDecision(
         msg.requestId,
         msg.decision,
       );
@@ -193,7 +193,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
-      syncCanonicalStatusFromIpcConfirmationDecision(
+      syncCanonicalStatusFromConfirmationDecision(
         msg.requestId,
         msg.decision,
       );
@@ -395,7 +395,7 @@ export async function handleSessionCreate(
     const requestId = uuid();
     const transportChannel =
       parseChannelId(msg.transport?.channelId) ?? "vellum";
-    const sendEvent = makeIpcEventSender({
+    const sendEvent = makeEventSender({
       ctx,
       session,
       conversationId: conversation.id,
@@ -649,7 +649,7 @@ export async function handleRegenerate(
   const regenerateChannel =
     parseChannelId(session.getTurnChannelContext()?.assistantMessageChannel) ??
     "vellum";
-  const sendEvent = makeIpcEventSender({
+  const sendEvent = makeEventSender({
     ctx,
     session,
     conversationId: msg.sessionId,


### PR DESCRIPTION
## Summary
- Rename `syncCanonicalStatusFromIpcConfirmationDecision` → `syncCanonicalStatusFromConfirmationDecision`
- Rename `makeIpcEventSender` → `makeEventSender`
- Update all callers and importers

Part of plan: phase-out-ipc-refs.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
