### PR TITLE
fix: replace IPC terminology in skill docs and githooks

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -26,7 +26,7 @@ Automatically checks for plain text keys and secrets before allowing a commit.
 1. **Secret scanning** — Detects plain text keys, tokens, passwords, and other sensitive information
 2. **Prettier formatting** — Runs `prettier --check` on staged files in `assistant/`, `cli/`, and `gateway/`
 3. **ESLint** — Runs `eslint` on staged source files in `assistant/`, `cli/`, and `gateway/`
-4. **IPC contract verification** — When IPC contract files are staged, verifies generated Swift models, inventory snapshot, and decoder sync are up to date
+4. **Message contract verification** — When message contract files are staged, verifies generated Swift models, inventory snapshot, and decoder sync are up to date
 5. **Tool registration guard** — Blocks new tool registrations in `assistant/src/tools/` (requires Team Jarvis approval, see `assistant/src/tools/AGENTS.md`)
 
 **Behavior:**
@@ -37,7 +37,7 @@ Automatically checks for plain text keys and secrets before allowing a commit.
 - Avoids known false positives for architecture/db identifier strings like `assistant_auth_tokens` and migration checkpoint keys
 - Ignores checksum/hash fixture fields (for example `nonceSha256`) while still scanning adjacent lines
 - Runs prettier and eslint on staged files in assistant, cli, and gateway directories
-- When IPC contract files are staged, verifies the generated Swift models and inventory snapshot are up to date
+- When message contract files are staged, verifies the generated Swift models and inventory snapshot are up to date
 - Catches unstaged generated output files (e.g., regenerated but not `git add`-ed)
 
 **Verification:**

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -697,7 +697,7 @@ echo "✅ No plain text keys detected in $CHECKED_FILES files"
 
 DIRS_TO_CHECK=("assistant" "cli" "gateway")
 
-# Detect bun location (reused by IPC check below)
+# Detect bun location (reused by message contract check below)
 BUN="${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
 
 for DIR in "${DIRS_TO_CHECK[@]}"; do

--- a/skills/screen-recording/SKILL.md
+++ b/skills/screen-recording/SKILL.md
@@ -84,7 +84,7 @@ Dynamic name prefixes (from IDENTITY.md) are stripped during classification, so 
 
 Recording intent resolution follows a precedence chain:
 
-### 1. `commandIntent` (structured IPC) — highest priority
+### 1. `commandIntent` (structured command) — highest priority
 
 The macOS client can send structured intents with `domain: 'screen_recording'` and `action: 'start' | 'stop' | 'restart' | 'pause' | 'resume'`. These bypass text parsing entirely. The assistant checks for `commandIntent` before any text analysis.
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -112,7 +112,7 @@ When the user reports a problem, follow the appropriate decision tree:
 
 ### "Changed a setting but it didn't work"
 
-1. **IPC broadcast** — The setting should take effect immediately. If it didn't, suggest restarting the assistant.
+1. **Event broadcast** — The setting should take effect immediately. If it didn't, suggest restarting the assistant.
 2. **Verify** — Open the Voice settings tab with `navigate_settings_tab` to confirm the setting was persisted.
 
 ## Deep Debugging


### PR DESCRIPTION
## Summary
- Update skills/voice-setup/SKILL.md: "IPC broadcast" → "Event broadcast"
- Update skills/screen-recording/SKILL.md: "structured IPC" → "structured command"
- Update .githooks/README.md: "IPC contract verification/files" → "message contract verification/files"
- Update .githooks/pre-commit: "reused by IPC check below" → "reused by message contract check below"

Part of plan: phase-out-ipc-refs.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
