### PR TITLE
docs: replace IPC terminology in architecture documentation

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -124,7 +124,7 @@ assistant/
 ├── drizzle/                  # Database migrations
 ├── drizzle.config.ts         # Drizzle ORM config (SQLite)
 ├── docs/                     # Internal documentation
-├── scripts/                  # Test runners and IPC codegen
+├── scripts/                  # Test runners and message codegen
 ├── Dockerfile                # Production container image
 └── package.json
 ```
@@ -194,7 +194,7 @@ Internal forwarding routes (`/v1/internal/twilio/*`) are unaffected — these ac
 
 The `/channels/inbound` endpoint requires a JWT with the `svc_gateway` principal type and `ingress.write` scope to prove the request originated from the gateway. This ensures channel messages can only arrive via the gateway (which performs webhook-level verification) and not via direct HTTP calls that bypass signature checks.
 
-- **JWT-based enforcement:** The route policy in `route-policy.ts` restricts `/channels/inbound` to the `svc_gateway` principal type with `ingress.write` scope. Actor and IPC principals are rejected with 403.
+- **JWT-based enforcement:** The route policy in `route-policy.ts` restricts `/channels/inbound` to the `svc_gateway` principal type with `ingress.write` scope. Actor and local principals are rejected with 403.
 - **Dev bypass:** When `DISABLE_HTTP_AUTH` + `VELLUM_UNSAFE_AUTH_BYPASS=1` are set, JWT verification is skipped and a synthetic dev context is used.
 
 ## Twilio Setup Primitive
@@ -259,7 +259,7 @@ The channel guardian service generates verification challenge instructions with 
 ### Operator Notes
 
 - **Verification input format:** Channel verification accepts a bare code reply only (6-digit numeric for identity-bound sessions; 64-char hex for unbound inbound/bootstrap compatibility).
-- **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the assistant returns `already_bound`. This prevents accidental guardian replacement.
+- **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the HTTP request. Without it, the assistant returns `already_bound`. This prevents accidental guardian replacement.
 - **Takeover prevention:** Verification is rejected when an active binding exists for a different external user. Same-user re-verification is allowed.
 
 ### Vellum Guardian Identity (Actor Tokens)
@@ -350,7 +350,7 @@ Guardian verification can also be initiated through normal desktop chat. When th
 | `/v1/channel-verification-sessions/revoke` | POST   | Cancel all active sessions and revoke the guardian binding. Body: `{ channel? }`                                                                                                                                                                  |
 | `/v1/channel-verification-sessions/status` | GET    | Check guardian binding status. Query: `?channel=<channel>`                                                                                                                                                                                        |
 
-These endpoints share the same business logic as the IPC-based verification flow via `verification-outbound-actions.ts`. Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly.
+These endpoints share the same business logic as the HTTP-based verification flow via `verification-outbound-actions.ts`. Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly.
 
 **Security constraint:** Guardian verification control-plane endpoints are restricted to guardian and desktop (trusted) actors only. Non-guardian and unverified-channel actors cannot invoke these endpoints conversationally via tools. Attempts are denied with a message explaining that guardian verification actions are restricted to guardian users.
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -89,7 +89,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant UI as Settings UI (Swift)
-    participant IPC as IPC Socket
+    participant HTTP as HTTP Transport
     participant Handler as Daemon Handlers
     participant Registry as IntegrationRegistry
     participant OAuth as OAuth2 PKCE Flow
@@ -101,15 +101,15 @@ sequenceDiagram
     participant API as Gmail REST API
 
     Note over UI,API: Connection Flow
-    UI->>IPC: integration_connect {integrationId: "gmail"}
-    IPC->>Handler: dispatch
+    UI->>HTTP: integration_connect {integrationId: "gmail"}
+    HTTP->>Handler: dispatch
     Handler->>Registry: getIntegration("gmail")
     Registry-->>Handler: IntegrationDefinition
     Handler->>OAuth: startOAuth2Flow(config)
     OAuth->>OAuth: generate code_verifier + code_challenge (S256)
     OAuth->>OAuth: start Bun.serve on random port
-    OAuth->>IPC: open_url (Google consent URL)
-    IPC->>Browser: open URL
+    OAuth->>HTTP: open_url (Google consent URL)
+    HTTP->>Browser: open URL
     Browser->>Google: user authorizes
     Google->>OAuth: callback with auth code
     OAuth->>Google: exchange code + code_verifier for tokens
@@ -117,8 +117,8 @@ sequenceDiagram
     OAuth->>Vault: setSecureKey (access + refresh)
     OAuth->>Vault: upsertCredentialMetadata (allowedTools, expiresAt)
     OAuth-->>Handler: success + account email
-    Handler->>IPC: integration_connect_result {success, accountInfo}
-    IPC->>UI: show connected state
+    Handler->>HTTP: integration_connect_result {success, accountInfo}
+    HTTP->>UI: show connected state
 
     Note over UI,API: Tool Execution Flow
     Tool->>TokenMgr: withValidToken("gmail", callback)
@@ -148,7 +148,7 @@ Twitter's OAuth2 flow delegates to the shared **connect orchestrator** (`oauth/c
 ```mermaid
 sequenceDiagram
     participant UI as Settings UI (Swift)
-    participant IPC as IPC Socket
+    participant HTTP as HTTP Transport
     participant Handler as oauth-connect handler
     participant Orchestrator as ConnectOrchestrator
     participant ScopePolicy as Scope Policy
@@ -159,8 +159,8 @@ sequenceDiagram
     participant API as X API (v2)
 
     Note over UI,API: Connection Flow (via generic orchestrator)
-    UI->>IPC: oauth_connect_start {service: "twitter"}
-    IPC->>Handler: dispatch
+    UI->>HTTP: oauth_connect_start {service: "twitter"}
+    HTTP->>Handler: dispatch
     Handler->>Handler: resolve client_id / client_secret from keychain
     Handler->>Orchestrator: orchestrateOAuthConnect(options)
     Orchestrator->>Orchestrator: resolveService("twitter") → "integration:twitter"
@@ -169,8 +169,8 @@ sequenceDiagram
     ScopePolicy-->>Orchestrator: {ok: true, scopes}
     Orchestrator->>OAuth: startOAuth2Flow(config)
     OAuth->>OAuth: generate code_verifier + code_challenge (S256)
-    OAuth->>IPC: open_url (twitter.com/i/oauth2/authorize)
-    IPC->>Browser: open URL
+    OAuth->>HTTP: open_url (twitter.com/i/oauth2/authorize)
+    HTTP->>Browser: open URL
     Browser->>Twitter: user authorizes
     Twitter->>OAuth: callback with auth code
     OAuth->>Twitter: exchange code + code_verifier at api.x.com/2/oauth2/token
@@ -180,8 +180,8 @@ sequenceDiagram
     API-->>Orchestrator: username
     Orchestrator->>Vault: storeOAuth2Tokens (access + refresh + metadata)
     Orchestrator-->>Handler: {success, grantedScopes, accountInfo: "@username"}
-    Handler->>IPC: oauth_connect_result {success, accountInfo}
-    IPC->>UI: show connected state
+    Handler->>HTTP: oauth_connect_result {success, accountInfo}
+    HTTP->>UI: show connected state
 ```
 
 #### Two-Mode Operation Architecture
@@ -348,7 +348,7 @@ Returns `{ ok: true, scopes }` or `{ ok: false, error, allowedScopes }`.
 
 Result is a discriminated union: `{ success, deferred, grantedScopes, accountInfo }` or `{ success: false, error }`.
 
-### Generic Daemon IPC
+### Generic Daemon HTTP API
 
 `assistant/src/daemon/handlers/oauth-connect.ts` handles `oauth_connect_start` messages. The handler:
 

--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -61,7 +61,7 @@ graph LR
 | `assistant/src/security/secure-keys.ts`            | Unified API surface. Sync variants use encrypted store only. Async variants (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`) try broker first. **Reads** fall back to the encrypted store when the broker is unavailable or key is not found. **Writes** return `false` on broker failure (no encrypted-store fallback). **Deletes** return `"deleted"`, `"not-found"`, or `"error"` to let callers distinguish idempotent no-ops from real failures. |
 | `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via native async UDS connection (`node:net`), falls back to encrypted store. All public credential read functions are async.                                                                                                                                                                                                                                                                                                  |
 
-## IPC Contract
+## Message Contract
 
 ### Transport
 

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -7,7 +7,7 @@ Assistant memory and context-injection architecture details.
 ```mermaid
 graph TB
     subgraph "Write Path"
-        MSG_IN["Incoming Message<br/>(IPC or HTTP)"]
+        MSG_IN["Incoming Message<br/>(HTTP)"]
         STORE["ConversationStore.addMessage()<br/>Drizzle ORM → SQLite"]
         INDEX["Memory Indexer"]
         SEGMENT["Split into segments<br/>→ memory_segments"]
@@ -242,7 +242,7 @@ Two trust gates enforce trust-class-based access control over the memory pipelin
 
 - **Read gate** (`session-memory.ts`): When the current session's actor is untrusted, the memory recall pipeline returns a no-op context — no recall injection, no dynamic profile, no conflict resolution. This ensures untrusted actors cannot surface or exploit previously extracted memory.
 
-Trust policy is **cross-channel and trust-class-based**: decisions use `trustContext.trustClass`, not the channel string. Desktop/IPC sessions default to `trustClass: 'guardian'`. External channels (Telegram, SMS, WhatsApp, phone) provide explicit trust context via the resolver. Messages without provenance metadata are treated as trusted (guardian); all new messages carry provenance.
+Trust policy is **cross-channel and trust-class-based**: decisions use `trustContext.trustClass`, not the channel string. Desktop sessions default to `trustClass: 'guardian'`. External channels (Telegram, SMS, WhatsApp, phone) provide explicit trust context via the resolver. Messages without provenance metadata are treated as trusted (guardian); all new messages carry provenance.
 
 ---
 

--- a/assistant/docs/architecture/scheduling.md
+++ b/assistant/docs/architecture/scheduling.md
@@ -104,7 +104,7 @@ One reminder creates one notification signal. The routing intent on that single 
 
 Channel availability is resolved when the signal is emitted (not when the reminder is created):
 
-- **Vellum** — always connected (local IPC)
+- **Vellum** — always connected (local HTTP)
 - **Telegram** — connected when an active guardian binding exists
 - **SMS** — connected when an active guardian binding exists
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -179,7 +179,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 | `assistant/src/permissions/checker.ts`        | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation                                                                                                 |
 | `assistant/src/permissions/shell-identity.ts` | `analyzeShellCommand()`, `deriveShellActionKeys()`, `buildShellCommandCandidates()`, `buildShellAllowlistOptions()` — parser-based shell command identity and action key derivation |
 | `assistant/src/permissions/trust-store.ts`    | Rule persistence, `findHighestPriorityRule()`, execution-target matching, starter bundle                                                                                            |
-| `assistant/src/permissions/prompter.ts`       | IPC prompt flow: `confirmation_request` → `confirmation_response`                                                                                                                   |
+| `assistant/src/permissions/prompter.ts`       | HTTP prompt flow: `confirmation_request` → `confirmation_response`                                                                                                                   |
 | `assistant/src/permissions/defaults.ts`       | Default rule templates (system ask rules for host tools, CU, etc.)                                                                                                                  |
 | `assistant/src/skills/version-hash.ts`        | `computeSkillVersionHash()` — deterministic SHA-256 of skill source files                                                                                                           |
 | `assistant/src/skills/path-classifier.ts`     | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection                                                                                                                  |
@@ -220,30 +220,30 @@ sequenceDiagram
     participant Model as LLM
     participant Vault as credential_store tool
     participant Prompter as SecretPrompter
-    participant IPC as IPC Socket
+    participant HTTP as HTTP Transport
     participant UI as SecretPromptManager (Swift)
     participant Keychain as macOS Keychain
 
     Model->>Vault: action: "prompt", service, field, label
     Vault->>Prompter: requestSecret(service, field, label, ...)
-    Prompter->>IPC: secret_request {requestId, service, field, label, allowOneTimeSend}
-    IPC->>UI: Show SecretPromptView (floating panel)
+    Prompter->>HTTP: secret_request {requestId, service, field, label, allowOneTimeSend}
+    HTTP->>UI: Show SecretPromptView (floating panel)
     UI->>UI: User enters value in SecureField
     alt Store (default)
-        UI->>IPC: secret_response {requestId, value, delivery: "store"}
-        IPC->>Prompter: resolve(value, "store")
+        UI->>HTTP: secret_response {requestId, value, delivery: "store"}
+        HTTP->>Prompter: resolve(value, "store")
         Prompter->>Vault: {value, delivery: "store"}
         Vault->>Keychain: setSecureKey("credential:svc:field", value)
         Vault->>Model: "Credential stored securely" (no value in output)
     else One-Time Send (if enabled)
-        UI->>IPC: secret_response {requestId, value, delivery: "transient_send"}
-        IPC->>Prompter: resolve(value, "transient_send")
+        UI->>HTTP: secret_response {requestId, value, delivery: "transient_send"}
+        HTTP->>Prompter: resolve(value, "transient_send")
         Prompter->>Vault: {value, delivery: "transient_send"}
         Note over Vault: Hands value to CredentialBroker<br/>for single-use consumption
         Vault->>Model: "One-time credential provided" (no value in output)
     else Cancel
-        UI->>IPC: secret_response {requestId, value: null}
-        IPC->>Prompter: resolve(null)
+        UI->>HTTP: secret_response {requestId, value: null}
+        HTTP->>Prompter: resolve(null)
         Prompter->>Vault: null
         Vault->>Model: "User cancelled"
     end
@@ -303,7 +303,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 | `assistant/src/tools/credentials/metadata-store.ts`  | JSON file metadata CRUD for credential records                        |
 | `assistant/src/tools/credentials/broker.ts`          | Brokered credential access with policy enforcement and transient send |
 | `assistant/src/tools/credentials/policy-validate.ts` | Policy input validation (allowedTools, allowedDomains)                |
-| `assistant/src/permissions/secret-prompter.ts`       | IPC secret_request/secret_response flow                               |
+| `assistant/src/permissions/secret-prompter.ts`       | HTTP secret_request/secret_response flow                               |
 | `assistant/src/security/secret-scanner.ts`           | Regex + entropy-based secret detection                                |
 | `assistant/src/security/secret-ingress.ts`           | Inbound message secret blocking                                       |
 | `clients/macos/.../SecretPromptManager.swift`        | Floating panel UI for secure credential entry                         |

--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -31,7 +31,7 @@ Design doc defining how unknown users gain access to a Vellum assistant via chan
 
    This ensures unknown inbound access attempts always trigger guardian notification, even when the requester's source channel has no guardian binding.
 
-4. **Guardian approves the request.** The guardian responds to the notification (via Telegram inline button, macOS app, or IPC). On approval, the assistant creates a verification session via `createOutboundSession()` and generates a 6-digit verification code.
+4. **Guardian approves the request.** The guardian responds to the notification (via Telegram inline button, macOS app, or local app). On approval, the assistant creates a verification session via `createOutboundSession()` and generates a 6-digit verification code.
 5. **Guardian receives the verification code.** The assistant delivers the code to the guardian's verified channel (Telegram chat, SMS, etc.).
 6. **Guardian gives the code to the requester out-of-band** (in person, text message, phone call, etc.). This out-of-band transfer is the trust anchor: it proves the requester has a real-world relationship with the guardian.
 7. **Requester enters the code** back to the assistant on the same channel. The inbound message handler intercepts bare 6-digit codes when a pending verification session exists for that channel.
@@ -162,7 +162,7 @@ sequenceDiagram
     Note over G: Guardian sees access request<br/>with requester identity
 
     alt Guardian approves
-        G->>A: Approve (inline button / IPC / plain text)
+        G->>A: Approve (inline button / HTTP / plain text)
         A->>A: resolveApprovalRequest(id, 'approved')
         A->>A: createOutboundSession(bound to requester identity)
         A-->>G: "Approved. Verification code: 847293.<br/>Give this to the requester."
@@ -182,7 +182,7 @@ sequenceDiagram
         A->>A: Process message normally
 
     else Guardian denies
-        G->>A: Deny (inline button / IPC / plain text)
+        G->>A: Deny (inline button / HTTP / plain text)
         A->>A: resolveApprovalRequest(id, 'denied')
         A-->>U: (No notification — user only knows<br/>they were denied if they message again)
 


### PR DESCRIPTION
## Summary
- Update assistant/README.md, security.md, integrations.md, memory.md, scheduling.md, keychain-broker.md, trusted-contact-access.md
- Replace IPC Socket Mermaid participants with HTTP Transport
- Update section headings, table descriptions, and prose

Part of plan: phase-out-ipc-refs.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
