### PR TITLE
fix: replace IPC terminology in test file descriptions and comments

### DIFF
--- a/assistant/src/__tests__/assistant-attachment-directive.test.ts
+++ b/assistant/src/__tests__/assistant-attachment-directive.test.ts
@@ -423,7 +423,7 @@ describe("resolveHostDirective", () => {
     writeFileSync(join(TEST_DIR, "doc.txt"), "content");
 
     const failApprove = async () => {
-      throw new Error("IPC disconnected");
+      throw new Error("connection lost");
     };
     const result = await resolveHostDirective(makeHostDirective(), failApprove);
 

--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -244,7 +244,7 @@ describe("assistant ID boundary", () => {
     // Excluded:
     //   - Test files (they may legitimately assert against the value)
     //   - Migration files (SQL literals like DEFAULT 'self' are fine)
-    //   - IPC contract files (comments documenting default values are fine)
+    //   - Message contract files (comments documenting default values are fine)
     //   - CSP headers ('self' in Content-Security-Policy has nothing to do with assistant IDs)
     const pattern = `(assistantId|assistant_id).*['"]self['"]`;
 
@@ -307,21 +307,21 @@ describe("assistant ID boundary", () => {
   // -------------------------------------------------------------------------
   // Rule (e): No assistantId on daemon control-plane request/param types
   //
-  // Daemon IPC contracts and guardian outbound param interfaces must not
+  // Daemon message contracts and guardian outbound param interfaces must not
   // accept an assistantId field -- the daemon always uses
   // DAEMON_INTERNAL_ASSISTANT_ID internally. Accepting assistantId on these
   // surfaces invites callers to pass external IDs into daemon scoping.
   // -------------------------------------------------------------------------
 
-  test("IPC contract types do not contain assistantId for guardian requests", () => {
-    const ipcContractPath = join(
+  test("message contract types do not contain assistantId for guardian requests", () => {
+    const contractPath = join(
       import.meta.dir,
       "..",
       "daemon",
       "message-types",
       "integrations.ts",
     );
-    const content = readFileSync(ipcContractPath, "utf-8");
+    const content = readFileSync(contractPath, "utf-8");
 
     // Extract the interface blocks for the request types and verify
     // none of them declare an assistantId property.
@@ -334,7 +334,7 @@ describe("assistant ID boundary", () => {
       const typeIndex = content.indexOf(typeName);
       expect(
         typeIndex,
-        `Expected to find ${typeName} in IPC contract`,
+        `Expected to find ${typeName} in message contract`,
       ).toBeGreaterThan(-1);
 
       // Extract from the type declaration to the next '}' line

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1292,7 +1292,7 @@ describe("assistant-scoped approval request lookups", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 10. IPC handler — channel-aware guardian status response
+// 10. HTTP handler — channel-aware guardian status response
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
@@ -1326,7 +1326,7 @@ function createMockCtx(): {
   return { ctx, lastResponse: () => captured };
 }
 
-describe("IPC handler channel-aware guardian status", () => {
+describe("HTTP handler channel-aware guardian status", () => {
   beforeEach(() => {
     resetTables();
   });
@@ -1952,10 +1952,10 @@ describe("pending challenge lookup", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 16. IPC handler — voice guardian verification
+// 16. HTTP handler — voice guardian verification
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("IPC handler voice guardian verification", () => {
+describe("HTTP handler voice guardian verification", () => {
   beforeEach(() => {
     resetTables();
   });
@@ -2538,7 +2538,7 @@ describe("outbound verification sessions", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 18. Outbound Voice Verification (IPC Handlers)
+// 18. Outbound Voice Verification (HTTP Handlers)
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("outbound voice verification", () => {

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -316,13 +316,13 @@ describe("Invariant 3: secrets never logged in plaintext", () => {
         );
       });
     } else if (tc.component === "ipc_decode") {
-      // PR 24 — IPC decode log hygiene: the TS daemon's IPC parser must
+      // PR 24 — message decode log hygiene: the TS daemon's message parser must
       // not log raw message content that could contain secrets.
       // Logging metadata (line length, error type) is acceptable; logging
       // the raw line, trimmed content, or error.message is not.
       test(`${tc.label}`, () => {
         const thisDir = dirname(fileURLToPath(import.meta.url));
-        const ipcSrc = readFileSync(
+        const protocolSrc = readFileSync(
           resolve(thisDir, "../daemon/message-protocol.ts"),
           "utf-8",
         );
@@ -333,11 +333,11 @@ describe("Invariant 3: secrets never logged in plaintext", () => {
         // helper calls like formatErr(err)) don't terminate the match
         // early — avoiding false negatives — while still scoping each
         // pattern to a single line (no cross-statement matching).
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*trimmed[^.]/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*line[^L]/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*data\b/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*buffer\b/);
-        expect(ipcSrc).not.toMatch(/\blog\.\w+\([^\n]*err\.message\b/);
+        expect(protocolSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*trimmed[^.]/);
+        expect(protocolSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*line[^L]/);
+        expect(protocolSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*data\b/);
+        expect(protocolSrc).not.toMatch(/\blog\.\w+\([^\n]*[{,]\s*buffer\b/);
+        expect(protocolSrc).not.toMatch(/\blog\.\w+\([^\n]*err\.message\b/);
       });
     } else {
       // PR 25 — secret prompter log hygiene: verify the prompter source

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests that daemon IPC outbound messages are mirrored into the
+ * Tests that daemon outbound messages are mirrored into the
  * assistant-events hub as AssistantEvent objects.
  *
  * Tests:
@@ -84,7 +84,7 @@ describe("daemon send → one mirrored assistant event", () => {
     const hub = new AssistantEventHub();
     const received: AssistantEvent[] = [];
 
-    hub.subscribe({ assistantId: "ast_ipc" }, (e) => {
+    hub.subscribe({ assistantId: "ast_test" }, (e) => {
       received.push(e);
     });
 
@@ -93,11 +93,11 @@ describe("daemon send → one mirrored assistant event", () => {
       sessionId: "sess_a",
       text: "hello",
     };
-    const event = buildAssistantEvent("ast_ipc", msg, "sess_a");
+    const event = buildAssistantEvent("ast_test", msg, "sess_a");
     await hub.publish(event);
 
     expect(received).toHaveLength(1);
-    expect(received[0].assistantId).toBe("ast_ipc");
+    expect(received[0].assistantId).toBe("ast_test");
     expect(received[0].sessionId).toBe("sess_a");
     expect(received[0].message.type).toBe("assistant_text_delta");
   });
@@ -106,12 +106,12 @@ describe("daemon send → one mirrored assistant event", () => {
     const hub = new AssistantEventHub();
     const received: AssistantEvent[] = [];
 
-    hub.subscribe({ assistantId: "ast_ipc" }, (e) => {
+    hub.subscribe({ assistantId: "ast_test" }, (e) => {
       received.push(e);
     });
 
     const msg: ServerMessage = { type: "pong" }; // no sessionId field
-    const event = buildAssistantEvent("ast_ipc", msg, "sess_explicit");
+    const event = buildAssistantEvent("ast_test", msg, "sess_explicit");
 
     await hub.publish(event);
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -272,7 +272,7 @@ describe("guardian-dispatch", () => {
           channel: "vellum",
           destination: "vellum",
           status: "failed",
-          errorMessage: "IPC unavailable",
+          errorMessage: "delivery unavailable",
           conversationId: "conv-vellum-3",
         },
       ],

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for IPC confirmation response handling (handleConfirmationResponse).
+ * Tests for confirmation response handling (handleConfirmationResponse).
  *
  * The legacy handleUserMessage tests that previously lived here were removed
  * when session-user-message.ts was deleted. The approval-reply behavior they
@@ -240,7 +240,7 @@ describe("handleConfirmationResponse canonical status sync", () => {
     ).__approvalConsumptionUseMockCanonicalStore = false;
   });
 
-  test("syncs canonical status to approved for IPC allow decisions", () => {
+  test("syncs canonical status to approved for allow decisions", () => {
     const session = {
       hasPendingConfirmation: (requestId: string) =>
         requestId === "req-confirm-allow",
@@ -278,7 +278,7 @@ describe("handleConfirmationResponse canonical status sync", () => {
     expect(resolveMock).toHaveBeenCalledWith("req-confirm-allow");
   });
 
-  test("syncs canonical status to denied for IPC deny decisions in CU sessions", () => {
+  test("syncs canonical status to denied for deny decisions in CU sessions", () => {
     const cuSession = {
       hasPendingConfirmation: (requestId: string) =>
         requestId === "req-confirm-deny",

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for HTTP POST /v1/messages behavior after the legacy handleUserMessage
- * IPC entry point was retired.
+ * legacy entry point was retired.
  *
  * Secret ingress blocking has been ported to the HTTP path. Recording intent
  * interception has been deliberately retired — the HTTP path has dedicated
@@ -329,7 +329,7 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     // The HTTP path deliberately does not intercept recording commands.
     // Dedicated /v1/recording/* endpoints handle recording lifecycle.
     // Text-based recording intent interception was retired with the
-    // legacy IPC handleUserMessage entry point.
+    // legacy handleUserMessage entry point.
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);
     const session = makeSession({ persistUserMessage, runAgentLoop });

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -336,7 +336,7 @@ describe("notification broadcaster", () => {
     expect(vellumAdapter.sent).toHaveLength(0);
   });
 
-  // ── Thread-created IPC emission ─────────────────────────────────────
+  // ── Thread-created event emission ───────────────────────────────────
 
   test("fires onThreadCreated when a new vellum conversation is created (start_new)", async () => {
     const vellumAdapter = new MockAdapter("vellum");
@@ -373,9 +373,9 @@ describe("notification broadcaster", () => {
   test("does NOT fire class-level onThreadCreated when reusing an existing thread", async () => {
     const vellumAdapter = new MockAdapter("vellum");
     const broadcaster = new NotificationBroadcaster([vellumAdapter]);
-    const ipcCalls: ThreadCreatedInfo[] = [];
+    const eventCalls: ThreadCreatedInfo[] = [];
     const dispatchCalls: ThreadCreatedInfo[] = [];
-    broadcaster.setOnThreadCreated((info) => ipcCalls.push(info));
+    broadcaster.setOnThreadCreated((info) => eventCalls.push(info));
 
     // Simulate a successful reuse by injecting a pairing result with
     // createdNewConversation=false. This bypasses the real conversation
@@ -403,10 +403,10 @@ describe("notification broadcaster", () => {
       onThreadCreated: (info) => dispatchCalls.push(info),
     });
 
-    // The class-level IPC callback should NOT fire because
+    // The class-level event callback should NOT fire because
     // createdNewConversation is false — the client already knows about
     // the reused conversation.
-    expect(ipcCalls).toHaveLength(0);
+    expect(eventCalls).toHaveLength(0);
 
     // The per-dispatch callback SHOULD fire for both new and reused
     // pairings (used by callers like dispatchGuardianQuestion for
@@ -489,8 +489,8 @@ describe("notification broadcaster", () => {
   test("reused thread via binding-key continuation does NOT emit class-level onThreadCreated", async () => {
     const vellumAdapter = new MockAdapter("vellum");
     const broadcaster = new NotificationBroadcaster([vellumAdapter]);
-    const ipcCalls: ThreadCreatedInfo[] = [];
-    broadcaster.setOnThreadCreated((info) => ipcCalls.push(info));
+    const eventCalls: ThreadCreatedInfo[] = [];
+    broadcaster.setOnThreadCreated((info) => eventCalls.push(info));
 
     // Simulate binding-key continuation: pairing reuses an existing bound
     // conversation (createdNewConversation=false, strategy=continue_existing_conversation)
@@ -507,21 +507,21 @@ describe("notification broadcaster", () => {
 
     await broadcaster.broadcastDecision(signal, decision);
 
-    // The class-level IPC callback should NOT fire because
+    // The class-level event callback should NOT fire because
     // createdNewConversation is false — the thread already exists
     // in the external channel and the client already knows about it.
-    expect(ipcCalls).toHaveLength(0);
+    expect(eventCalls).toHaveLength(0);
   });
 
   test("fresh conversation for continue_existing_conversation does NOT emit class-level onThreadCreated", async () => {
     const vellumAdapter = new MockAdapter("vellum");
     const broadcaster = new NotificationBroadcaster([vellumAdapter]);
-    const ipcCalls: ThreadCreatedInfo[] = [];
-    broadcaster.setOnThreadCreated((info) => ipcCalls.push(info));
+    const eventCalls: ThreadCreatedInfo[] = [];
+    broadcaster.setOnThreadCreated((info) => eventCalls.push(info));
 
     // First delivery to a new destination: creates a fresh conversation but
     // the strategy is continue_existing_conversation (not start_new_conversation),
-    // so the IPC event should NOT fire — these are background threads not
+    // so the event should NOT fire — these are background threads not
     // meant to appear in the sidebar.
     nextPairingResult = {
       conversationId: "conv-new-telegram-dest",
@@ -537,8 +537,8 @@ describe("notification broadcaster", () => {
     await broadcaster.broadcastDecision(signal, decision);
 
     // Even though createdNewConversation is true, the strategy is
-    // continue_existing_conversation, so the IPC gate rejects it.
-    expect(ipcCalls).toHaveLength(0);
+    // continue_existing_conversation, so the event gate rejects it.
+    expect(eventCalls).toHaveLength(0);
   });
 
   test("per-dispatch onThreadCreated fires for reused binding-key conversation", async () => {

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -224,7 +224,7 @@ describe("notification deep-link metadata", () => {
 
     test("returns success: false when broadcast throws", async () => {
       const adapter = new VellumAdapter(() => {
-        throw new Error("IPC connection lost");
+        throw new Error("connection lost");
       });
 
       const result = await adapter.send(
@@ -236,10 +236,10 @@ describe("notification deep-link metadata", () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("IPC connection lost");
+      expect(result.error).toContain("connection lost");
     });
 
-    test("sourceEventName is included in the IPC payload", async () => {
+    test("sourceEventName is included in the event payload", async () => {
       const messages: ServerMessage[] = [];
       const adapter = new VellumAdapter((msg) => messages.push(msg));
 

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for the ASK_GUARDIAN canonical notification path.
  *
  * Validates that guardian dispatch relies on the generic notification
- * pipeline (including thread-created callbacks) without a custom IPC path.
+ * pipeline (including thread-created callbacks) without a custom dispatch path.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -197,7 +197,7 @@ describe("ASK_GUARDIAN canonical notification path", () => {
     expect(payload.requestCode).toBeDefined();
   });
 
-  test("uses notification_thread_created callback instead of a guardian-specific IPC path", async () => {
+  test("uses notification_thread_created callback instead of a guardian-specific dispatch path", async () => {
     const convId = "conv-guardian-notif-2";
     ensureConversation(convId);
     mockThreadCreated = {

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -203,7 +203,7 @@ describe("handleRecordingStart", () => {
     mockFileSize = 1024;
   });
 
-  test("sends recording_start IPC and returns a UUID", () => {
+  test("sends recording_start event and returns a UUID", () => {
     const { ctx, sent } = createCtx();
     const conversationId = "conv-1";
 

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -1,7 +1,7 @@
 /**
- * IPC parity tests for the SSE assistant-events endpoint.
+ * HTTP parity tests for the SSE assistant-events endpoint.
  *
- * Asserts that every streaming/delta IPC ServerMessage type is preserved
+ * Asserts that every streaming/delta ServerMessage type is preserved
  * exactly — field-for-field — when delivered through the SSE route.
  *
  * Message types covered:
@@ -124,7 +124,7 @@ async function publishAndReadFrame(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("SSE IPC parity — streaming/delta message types", () => {
+describe("SSE HTTP parity — streaming/delta message types", () => {
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM conversation_keys");

--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -103,10 +103,10 @@ describe("secret prompt log hygiene", () => {
     }
   });
 
-  test("sent IPC message contains value=undefined (value flows through IPC, not logs)", async () => {
+  test("sent message contains value=undefined (value flows through event, not logs)", async () => {
     const promise = prompter.prompt("svc", "tok", "Token");
     const msg = sentMessages[0] as SecretRequest & { value?: unknown };
-    // The IPC message should NOT contain a value field
+    // The message should NOT contain a value field
     expect(msg.value).toBeUndefined();
     prompter.resolveSecret(msg.requestId, undefined);
     await promise;

--- a/assistant/src/__tests__/tool-notification-listener.test.ts
+++ b/assistant/src/__tests__/tool-notification-listener.test.ts
@@ -6,7 +6,7 @@ import type { AssistantDomainEvents } from "../events/domain-events.js";
 import { registerToolNotificationListener } from "../events/tool-notification-listener.js";
 
 describe("registerToolNotificationListener", () => {
-  test("forwards tool.secret.detected events to IPC secret_detected messages", async () => {
+  test("forwards tool.secret.detected events to secret_detected messages", async () => {
     const bus = new EventBus<AssistantDomainEvents>();
     const messages: ServerMessage[] = [];
     registerToolNotificationListener(bus, (msg) => messages.push(msg));


### PR DESCRIPTION
## Summary
- Replace IPC terminology in ~14 test files
- Update describe blocks, test names, variable names, and comments
- No functional changes

Part of plan: phase-out-ipc-refs.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
