### PR TITLE
fix: replace IPC terminology in Swift comments and variable names

### DIFF
--- a/clients/ios/App/AmbientAgentManager.swift
+++ b/clients/ios/App/AmbientAgentManager.swift
@@ -100,7 +100,7 @@ final class AmbientAgentManager: ObservableObject {
         summaryTask?.cancel()
         summaryTask = nil
 
-        // iOS sends the ride_shotgun_start IPC message to the Mac daemon,
+        // iOS sends the ride_shotgun_start message to the Mac daemon,
         // which owns screen capture. The daemon will send back progress and
         // result messages over the same SSE connection.
         let session = RideShotgunSession(durationSeconds: durationSeconds)

--- a/clients/ios/App/RideShotgunSession.swift
+++ b/clients/ios/App/RideShotgunSession.swift
@@ -105,7 +105,7 @@ final class RideShotgunSession: ObservableObject, Identifiable {
     func cancel() {
         // Send ride_shotgun_stop so the daemon terminates the capture session
         // immediately rather than running to timeout.  Use the watchId if we
-        // have one; if we cancelled before watch_started arrived, skip the IPC
+        // have one; if we cancelled before watch_started arrived, skip the send
         // (the daemon will time out on its own shortly after never receiving
         // any client activity).
         if let watchId = expectedWatchId, let daemonClient {

--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -444,7 +444,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         // Should set error text when daemon is not connected
         XCTAssertNotNil(viewModel.errorText)
-        // No IPC messages should have been sent
+        // No messages should have been sent
         let confirmations = mockClient.sentMessages.compactMap { $0 as? ConfirmationResponseMessage }
         XCTAssertTrue(confirmations.isEmpty)
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -255,7 +255,7 @@ extension AppDelegate {
         assistantCli.stopMonitoring()
 
         // 2. Clear assistant-scoped runtime state while the daemon is still
-        // running so forceStop can deliver a recording_status IPC message.
+        // running so forceStop can deliver a recording_status message.
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -374,7 +374,7 @@ extension AppDelegate {
     }
 
     /// Schedules a fallback local notification for any notification_thread_created
-    /// event. If the corresponding notification_intent IPC arrives within the
+    /// event. If the corresponding notification_intent event arrives within the
     /// delay window, the fallback is cancelled (preventing duplicates). Guardian
     /// questions use a specific body; all other event types use a generic body.
     func scheduleNotificationFallback(
@@ -411,7 +411,7 @@ extension AppDelegate {
         }
     }
 
-    /// Send a `conversation_seen_signal` IPC message to the daemon.
+    /// Send a `conversation_seen_signal` message to the daemon.
     func sendConversationSeenSignal(
         conversationId: String,
         signalType: String,

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -284,7 +284,7 @@ extension AppDelegate {
     /// Creates the thread in the sidebar and applies urgency surfacing policy.
     /// Guardian questions are time-sensitive, so they are foregrounded when the
     /// app is active. All notification types get a fallback native alert when
-    /// backgrounded to guarantee delivery if the notification_intent IPC is late.
+    /// backgrounded to guarantee delivery if the notification_intent event is late.
     func handleNotificationThreadCreated(_ msg: IPCNotificationThreadCreated) {
         // Guardian scoping: skip thread creation for notifications targeted at
         // a different guardian identity. When the local principal is nil (not yet

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -136,7 +136,7 @@ extension AppDelegate {
         }
         voiceInput?.start()
 
-        // Restart key monitors when the activation key is changed remotely via IPC
+        // Restart key monitors when the activation key is changed remotely via HTTP
         NotificationCenter.default.addObserver(
             forName: .activationKeyChanged,
             object: nil,

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -142,7 +142,7 @@ extension AppDelegate {
 
                 let decision = await self.toolConfirmationNotificationService.showConfirmation(msg)
                 // If the inline chat path already forwarded the response, skip
-                // the duplicate IPC send and state update.
+                // the duplicate send and state update.
                 guard decision != ToolConfirmationNotificationService.inlineHandledSentinel else {
                     return
                 }
@@ -151,7 +151,7 @@ extension AppDelegate {
                         requestId: msg.requestId,
                         decision: decision
                     )
-                    // Only sync the inline message state if the IPC send succeeded.
+                    // Only sync the inline message state if the send succeeded.
                     self.mainWindow?.threadManager.updateConfirmationStateAcrossThreads(
                         requestId: msg.requestId,
                         decision: decision

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -187,7 +187,7 @@ final class AvatarAppearanceManager {
     }
 
     /// Reloads the custom avatar from disk. Called when the daemon notifies
-    /// that the avatar image has been regenerated (via `avatar_updated` IPC).
+    /// that the avatar image has been regenerated (via `avatar_updated` event).
     /// Invalidates all cached images so SwiftUI views pick up the new avatar.
     func reloadAvatar() {
         cachedChatAvatar = nil

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftUI
 import VellumAssistantShared
 
-/// ViewModel for the contacts list, providing daemon IPC integration
+/// ViewModel for the contacts list, providing daemon HTTP integration
 /// for loading and filtering contacts. Delegates data operations to
 /// the shared ContactsStore.
 @MainActor

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -690,7 +690,7 @@ struct MainWindowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .openDynamicWorkspace)) { notification in
             if let msg = notification.userInfo?["surfaceMessage"] as? UiSurfaceShowMessage {
-                // Full message from daemon live IPC (AppDelegate path)
+                // Full message from daemon live event (AppDelegate path)
                 windowState.activeDynamicSurface = msg
                 windowState.activeDynamicParsedSurface = Surface.from(msg)
                 // Determine the app ID from the surface if available
@@ -705,7 +705,7 @@ struct MainWindowView: View {
                 }
             } else if let ref = notification.userInfo?["surfaceRef"] as? SurfaceRef {
                 // Lightweight ref from inline surface click — the daemon will
-                // send a fresh ui_surface_show via live IPC with the full payload.
+                // send a fresh ui_surface_show via SSE with the full payload.
                 // Use the real appId for the app_open_request when available,
                 // because surfaceId is a daemon-generated identifier
                 // (e.g. "app-open-<uuid>") that doesn't match any real app.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -32,9 +32,9 @@ enum SettingsTab: String {
         return tabs
     }
 
-    /// Maps legacy tab names (from IPC or saved state) to current tabs.
+    /// Maps legacy tab names (from HTTP or saved state) to current tabs.
     /// The `isDevMode` parameter gates dev-only tabs so external callers
-    /// (e.g. daemon IPC) cannot navigate to them when dev mode is off.
+    /// (e.g. daemon HTTP) cannot navigate to them when dev mode is off.
     static func fromLegacyRawValue(_ value: String, isDevMode: Bool = false, contactsEnabled: Bool = false, sentryTestingEnabled: Bool = false) -> SettingsTab? {
         let tab: SettingsTab?
         // Try current values first

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1239,7 +1239,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Mark all visible (non-archived, non-private) threads as seen locally.
-    /// IPC signals are NOT sent immediately — call `commitPendingSeenSignals()`
+    /// Seen signals are NOT sent immediately — call `commitPendingSeenSignals()`
     /// after the undo window expires, or `cancelPendingSeenSignals()` if the
     /// user clicks Undo. Returns the IDs of threads that were actually marked.
     @discardableResult
@@ -1279,7 +1279,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return markedIds
     }
 
-    /// Send the deferred IPC seen signals that were collected by
+    /// Send the deferred seen signals that were collected by
     /// `markAllThreadsSeen()`. Called when the undo window expires
     /// (toast dismissed or auto-dismiss timer fires).
     internal func commitPendingSeenSignals() {
@@ -1293,14 +1293,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
-    /// Cancel any pending IPC seen signals (user clicked Undo).
+    /// Cancel any pending seen signals (user clicked Undo).
     internal func cancelPendingSeenSignals() {
         pendingSeenSessionIds = []
         pendingSeenSignalTask?.cancel()
         pendingSeenSignalTask = nil
     }
 
-    /// Schedule deferred IPC seen signals to fire after a delay.
+    /// Schedule deferred seen signals to fire after a delay.
     /// If the user clicks Undo before the delay, call
     /// `cancelPendingSeenSignals()` to prevent them from sending.
     /// The optional `onCommit` closure is called after the signals are sent,
@@ -1316,7 +1316,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Restore the unseen flag for the given thread IDs and cancel any
-    /// pending IPC seen signals (used by undo). Restores prior
+    /// pending seen signals (used by undo). Restores prior
     /// `lastSeenAssistantMessageAt` and `pendingAttentionOverrides`
     /// values captured by `markAllThreadsSeen()` instead of blindly
     /// clearing them.
@@ -1357,7 +1357,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     // MARK: - Private
 
-    /// Send a `conversation_seen_signal` IPC message to the daemon.
+    /// Send a `conversation_seen_signal` message to the daemon.
     private func emitConversationSeenSignal(conversationId: String) {
         let signal = IPCConversationSeenSignal(
             conversationId: conversationId,
@@ -1839,7 +1839,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// For the active thread, the seen signal is only emitted on meaningful
     /// transitions — when a new assistant message first appears (new messageId)
     /// or when streaming completes (isStreaming goes from true to false). This
-    /// avoids O(n) IPC calls per streaming response (one per text delta) while
+    /// avoids O(n) HTTP calls per streaming response (one per text delta) while
     /// still advancing the server-side seen cursor.
     private func handleAssistantMessageArrival(threadId: UUID, previousSnapshot: AssistantActivitySnapshot?, currentSnapshot: AssistantActivitySnapshot) {
         // Skip during thread restoration or history re-hydration —
@@ -1862,7 +1862,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         if threadId == activeThreadId {
             threads[index].hasUnseenLatestAssistantMessage = false
-            // Only emit the IPC seen signal on meaningful transitions:
+            // Only emit the seen signal on meaningful transitions:
             // 1. A new assistant message appeared (different messageId)
             // 2. Streaming just completed (isStreaming went true -> false)
             let streamingJustCompleted = previousSnapshot?.isStreaming == true && !currentSnapshot.isStreaming

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -17,7 +17,7 @@ private let kPendingKeyDeletionTombstones = "pendingKeyDeletionTombstones"
 public final class SettingsStore: ObservableObject {
     // MARK: - Navigation
 
-    /// Set externally (e.g. via IPC) to deep-link into a specific settings tab.
+    /// Set externally (e.g. via HTTP) to deep-link into a specific settings tab.
     /// SettingsPanel observes this and clears it after applying.
     @Published var pendingSettingsTab: SettingsTab?
 
@@ -262,12 +262,12 @@ public final class SettingsStore: ObservableObject {
     @Published var ingressEnabled: Bool = false
     @Published var ingressPublicBaseUrl: String = ""
     /// Read-only gateway target derived from daemon config.
-    /// Initial value reads env var > lockfile runtimeUrl > default 7830; updated by IPC.
+    /// Initial value reads env var > lockfile runtimeUrl > default 7830; updated by HTTP.
     @Published var localGatewayTarget: String = LockfilePaths.resolveGatewayUrl(
         connectedAssistantId: UserDefaults.standard.string(forKey: "connectedAssistantId")
     )
 
-    /// Set to `true` once the first ingress config IPC response arrives, so the
+    /// Set to `true` once the first ingress config response arrives, so the
     /// view layer can defer diagnostics until the real config values are available.
     @Published var ingressConfigLoaded: Bool = false
 
@@ -304,7 +304,7 @@ public final class SettingsStore: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let configPath: String?
 
-    /// Guards against stale IPC `get` responses overwriting an optimistic
+    /// Guards against stale `get` responses overwriting an optimistic
     /// toggle. Set when `setIngressEnabled` fires; cleared once a matching
     /// response arrives.
     private var pendingIngressEnabled: Bool?
@@ -489,7 +489,7 @@ public final class SettingsStore: ObservableObject {
             .receive(on: RunLoop.main)
             .assign(to: &$isAnyTrustRulesSheetOpen)
 
-        // Wire up Vercel API config IPC response
+        // Wire up Vercel API config response
         daemonClient?.onVercelApiConfigResponse = { [weak self] response in
             guard let self else { return }
             if response.success {
@@ -497,7 +497,7 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Wire up model info IPC response
+        // Wire up model info response
         daemonClient?.onModelInfo = { [weak self] response in
             guard let self else { return }
             self.lastDaemonModel = response.model
@@ -507,7 +507,7 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Wire up Twitter integration config IPC response
+        // Wire up Twitter integration config response
         daemonClient?.onTwitterIntegrationConfigResponse = { [weak self] response in
             guard let self else { return }
             if response.success {
@@ -520,7 +520,7 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Wire up ingress config IPC response
+        // Wire up ingress config response
         daemonClient?.onIngressConfigResponse = { [weak self] response in
             guard let self else { return }
             // For remote assistants, prefer the lockfile's runtimeUrl because the
@@ -561,7 +561,7 @@ public final class SettingsStore: ObservableObject {
             self.ingressConfigLoaded = true
         }
 
-        // Wire up platform config IPC response
+        // Wire up platform config response
         daemonClient?.onPlatformConfigResponse = { [weak self] response in
             guard let self else { return }
             if response.success {
@@ -580,7 +580,7 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Wire up Twitter auth result IPC response
+        // Wire up Twitter auth result response
         daemonClient?.onTwitterAuthResult = { [weak self] response in
             guard let self else { return }
             self.twitterAuthInProgress = false
@@ -596,7 +596,7 @@ public final class SettingsStore: ObservableObject {
             self.refreshTwitterStatus()
         }
 
-        // Wire up Telegram config IPC response
+        // Wire up Telegram config response
         daemonClient?.onTelegramConfigResponse = { [weak self] response in
             guard let self else { return }
             self.telegramSaveInProgress = false
@@ -611,9 +611,9 @@ public final class SettingsStore: ObservableObject {
             }
         }
 
-        // Twilio config is now handled via HTTP — no IPC callback wiring needed.
+        // Twilio config is now handled via HTTP — no callback wiring needed.
 
-        // Wire up channel verification IPC response
+        // Wire up channel verification response
         daemonClient?.onChannelVerificationSessionResponse = { [weak self] response in
             guard let self else { return }
             guard let channel = self.resolveVerificationResponseChannel(response.channel) else { return }
@@ -2417,7 +2417,7 @@ public final class SettingsStore: ObservableObject {
         do {
             try daemonClient?.send(IngressConfigRequestMessage(action: "set", publicBaseUrl: trimmed, enabled: shouldEnable))
         } catch {
-            // IPC send failed — roll back the optimistic update
+            // Send failed — roll back the optimistic update
             ingressPublicBaseUrl = previous
             pendingIngressUrl = nil
             ingressReachable = previousReachable
@@ -2502,7 +2502,7 @@ public final class SettingsStore: ObservableObject {
         do {
             try daemonClient.sendApprovedDeviceRemove(hashedDeviceId: hashedDeviceId)
         } catch {
-            // IPC failed — restore optimistically removed devices
+            // Send failed — restore optimistically removed devices
             approvedDevices.append(contentsOf: removed)
         }
     }
@@ -2513,7 +2513,7 @@ public final class SettingsStore: ObservableObject {
             try daemonClient.sendApprovedDevicesClear()
             approvedDevices = []
         } catch {
-            // IPC failed — don't clear local state
+            // Send failed — don't clear local state
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -319,7 +319,7 @@ final class ToolPermissionTesterModel: ObservableObject {
 
     // MARK: - Actions
 
-    /// Build input from fields, send a simulate request via IPC, and update result state.
+    /// Build input from fields, send a simulate request via HTTP, and update result state.
     func simulate() {
         lastError = nil
         lastResult = nil
@@ -329,7 +329,7 @@ final class ToolPermissionTesterModel: ObservableObject {
 
         // Capture form values now so the snapshot reflects the state at
         // request time, not at response time (the user may edit the form
-        // while the IPC round-trip is in flight).
+        // while the HTTP round-trip is in flight).
         pendingSnapshotToolName = toolName
         pendingSnapshotInputJSON = buildInputJSONString()
 
@@ -356,21 +356,21 @@ final class ToolPermissionTesterModel: ObservableObject {
         }
     }
 
-    /// Local-only: mark the simulation result as "allowed" without touching IPC.
+    /// Local-only: mark the simulation result as "allowed" without touching the daemon.
     func allowOnce() {
         guard var result = lastResult else { return }
         result.localOverrideLabel = "Allowed (simulation)"
         lastResult = result
     }
 
-    /// Local-only: mark the simulation result as "denied" without touching IPC.
+    /// Local-only: mark the simulation result as "denied" without touching the daemon.
     func denyOnce() {
         guard var result = lastResult else { return }
         result.localOverrideLabel = "Denied (simulation)"
         lastResult = result
     }
 
-    /// Persist a trust rule via IPC, then re-simulate to show updated decision.
+    /// Persist a trust rule via HTTP, then re-simulate to show updated decision.
     ///
     /// Uses the snapshot captured at simulation time so the persisted rule
     /// matches the context that produced the prompt, not whatever the user

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -111,7 +111,7 @@ struct TrustRulesView: View {
                 rules.removeAll { $0.id == id }
             }
         } catch {
-            // IPC failed — keep the rule visible
+            // Send failed — keep the rule visible
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -24,7 +24,7 @@ final class SecretPromptManager {
     /// Called when the user responds to a secret prompt.
     /// Parameters: (requestId, value?, delivery?) — value is nil if user cancelled.
     /// `delivery` is "store" (default) or "transient_send" for one-time use.
-    /// Returns `true` if the IPC send succeeded.
+    /// Returns `true` if the send succeeded.
     var onResponse: ((String, String?, String?) -> Bool)?
 
     func showPrompt(_ message: SecretRequestMessage) {

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -39,7 +39,7 @@ final class SurfaceViewModel: ObservableObject {
     }
 }
 
-/// Manages the lifecycle of surface windows (NSPanel) shown in response to daemon IPC messages.
+/// Manages the lifecycle of surface windows (NSPanel) shown in response to daemon messages.
 ///
 /// Each surface is displayed in a floating, non-activating panel positioned at the bottom-right
 /// of the screen, using a floating, non-activating NSPanel.

--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -5,7 +5,7 @@ import os
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "DictationContext")
 
 /// Context captured at Fn-hold activation time, describing the user's current app state.
-/// This is the Swift-side struct — it will be mapped to IPC types in M3.
+/// This is the Swift-side struct — it will be mapped to message types in M3.
 struct DictationContext {
     let bundleIdentifier: String
     let appName: String

--- a/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/OpenAIVoiceService.swift
@@ -82,7 +82,7 @@ final class OpenAIVoiceService: ObservableObject, VoiceServiceProtocol {
     /// Mirrored from: assistant/src/config/elevenlabs-schema.ts (DEFAULT_ELEVENLABS_VOICE_ID)
     private static let defaultVoiceId = "21m00Tcm4TlvDq8ikWAM"
 
-    /// ElevenLabs voice ID — reads from UserDefaults (set via daemon IPC), falls back to Rachel.
+    /// ElevenLabs voice ID — reads from UserDefaults (set via daemon HTTP), falls back to Rachel.
     private static var elevenLabsVoiceId: String {
         UserDefaults.standard.string(forKey: "ttsVoiceId").flatMap { $0.isEmpty ? nil : $0 }
             ?? Self.defaultVoiceId

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -488,7 +488,7 @@ final class VoiceModeManager: ObservableObject {
         case denied
         case ambiguous
 
-        /// The decision string sent to the daemon via IPC.
+        /// The decision string sent to the daemon via HTTP.
         var decisionString: String {
             switch self {
             case .allow: return "allow"

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -31,7 +31,7 @@ enum RecordingState: Equatable, Sendable {
 /// Centralized recording orchestration ensuring at most one active recording.
 ///
 /// Manages the recording lifecycle (start/stop), enforces the single-active
-/// guard, and sends `RecordingStatus` IPC messages back to the daemon.
+/// guard, and sends `RecordingStatus` messages back to the daemon.
 @MainActor
 final class RecordingManager: ObservableObject {
 
@@ -307,7 +307,7 @@ final class RecordingManager: ObservableObject {
         log.info("Force-stopped recording (synchronous cancel)")
     }
 
-    // MARK: - IPC
+    // MARK: - Daemon Communication
 
     private func sendStatus(
         sessionId: String,

--- a/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
+++ b/clients/macos/vellum-assistant/Recording/ScreenRecorder.swift
@@ -413,7 +413,7 @@ final class ScreenRecorder: NSObject {
     private var telemetryDisplayID: UInt32?
 
     /// Callback invoked when the SCStream stops with an error mid-recording.
-    /// RecordingManager sets this to react to stream failures (update state, send IPC, clean up).
+    /// RecordingManager sets this to react to stream failures (update state, notify daemon, clean up).
     var onStreamError: ((RecorderError) -> Void)?
 
     /// When true, incoming sample buffers are silently dropped instead of being

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -72,7 +72,7 @@ public final class ToolConfirmationNotificationService {
 
     /// Called when the inline chat path already sent the confirmation response
     /// to the daemon. Resumes the continuation with a sentinel so that
-    /// `setupToolConfirmationNotifications` skips the duplicate IPC send.
+    /// `setupToolConfirmationNotifications` skips the duplicate send.
     public func handleInlineResponse(requestId: String) {
         guard let continuation = pendingRequests.removeValue(forKey: requestId) else {
             log.warning("No pending request for inline response: requestId=\(requestId, privacy: .public)")

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2031,7 +2031,7 @@ final class ChatViewModelTests: XCTestCase {
     func testRetryButtonAppearsForNonConnectionSendFailure() {
         viewModel.sessionId = "sess-1"
         daemonClient.isConnected = true
-        // Make the IPC send throw to simulate a non-connection send failure
+        // Make the send throw to simulate a non-connection send failure
         // (e.g. socket write error while technically connected).
         daemonClient.sendOverride = { _ in throw NSError(domain: "test", code: 1) }
 

--- a/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
+++ b/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
@@ -154,14 +154,14 @@ final class RideShotgunSessionTests: XCTestCase {
         XCTAssertNil(agent.currentSession)
     }
 
-    // MARK: - IPC Message Delivery Path
+    // MARK: - Message Delivery Path
 
     @MainActor
     func testRideShotgunErrorMessageTransitionsSessionToFailed() async throws {
         // Exercises the actual subscription loop in RideShotgunSession.start():
         // a rideShotgunError message delivered through the DaemonClient stream
         // should transition the session from .starting to .failed with the error
-        // message from the IPC payload.
+        // message from the event payload.
         let mockClient = MockDaemonClient()
         let continuation = mockClient.setupTestStream()
 
@@ -169,7 +169,7 @@ final class RideShotgunSessionTests: XCTestCase {
         session.start(daemonClient: mockClient)
         XCTAssertEqual(session.state, .starting)
 
-        // Deliver the error through the IPC subscription
+        // Deliver the error through the event subscription
         let errorMessage = RideShotgunErrorMessage(
             type: "ride_shotgun_error",
             watchId: "w-1",

--- a/clients/macos/vellum-assistantTests/SessionTests.swift
+++ b/clients/macos/vellum-assistantTests/SessionTests.swift
@@ -594,7 +594,7 @@ final class SessionTests: XCTestCase {
         }
     }
 
-    // MARK: - IPC Message Sending
+    // MARK: - Message Sending
 
     @MainActor
     func testSessionCreate_sentOnStart() async {

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -93,7 +93,7 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
 
 // MARK: - Helpers
 
-/// Build an IPCSessionListResponse via JSON round-trip.
+/// Build a SessionListResponseMessage via JSON round-trip.
 private func makeSessionListResponse(sessions: [(id: String, title: String, createdAt: Int, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
     let sessionDicts = sessions.map { session -> [String: Any] in
         var dict: [String: Any] = ["id": session.id, "title": session.title, "createdAt": session.createdAt, "updatedAt": session.updatedAt]
@@ -136,7 +136,7 @@ private func makeSessionListResponse(sessions: [(id: String, title: String, upda
     makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, nil, nil) })
 }
 
-/// Build an IPCHistoryResponse via JSON round-trip.
+/// Build a HistoryResponseMessage via JSON round-trip.
 private func makeHistoryResponse(sessionId: String, messages: [(role: String, text: String)], hasMore: Bool = false) -> HistoryResponseMessage {
     let msgDicts = messages.map { msg -> [String: Any] in
         ["role": msg.role, "text": msg.text, "timestamp": 1000.0]
@@ -146,7 +146,7 @@ private func makeHistoryResponse(sessionId: String, messages: [(role: String, te
     return try! JSONDecoder().decode(HistoryResponseMessage.self, from: data)
 }
 
-/// Build an IPCSessionTitleUpdated via JSON round-trip.
+/// Build a SessionTitleUpdatedMessage via JSON round-trip.
 private func makeSessionTitleUpdated(sessionId: String, title: String) -> SessionTitleUpdatedMessage {
     let dict: [String: Any] = ["type": "session_title_updated", "sessionId": sessionId, "title": title]
     let data = try! JSONSerialization.data(withJSONObject: dict)

--- a/clients/shared/App/Auth/SessionTokenManager.swift
+++ b/clients/shared/App/Auth/SessionTokenManager.swift
@@ -10,7 +10,7 @@ public extension Notification.Name {
 /// so existing macOS users' stored sessions are preserved after upgrade.
 ///
 /// Also writes the token to `~/.vellum/platform-token` so the daemon can
-/// read it for authenticated platform API calls without IPC round-trips.
+/// read it for authenticated platform API calls without round-trips.
 public enum SessionTokenManager {
     private static let provider = "session-token"
 

--- a/clients/shared/DesignSystem/Tokens/SFSymbolMapping.swift
+++ b/clients/shared/DesignSystem/Tokens/SFSymbolMapping.swift
@@ -1,5 +1,5 @@
 /// Maps SF Symbol names to `VIcon` cases.
-/// Used by dynamic icon consumers (weather widget, IPC surfaces, trace views)
+/// Used by dynamic icon consumers (weather widget, HTTP surfaces, trace views)
 /// where the icon name arrives as a string at runtime.
 public enum SFSymbolMapping {
 
@@ -316,7 +316,7 @@ public enum SFSymbolMapping {
         "square.and.arrow.down": .arrowDownToLine,
         "qrcode": .qrCode,
 
-        // IPC / Composition
+        // HTTP / Composition
         "app.fill": .layoutGrid,
         "shippingbox.fill": .package,
     ]

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1356,7 +1356,7 @@ public struct ChatAttachment: Identifiable {
     /// (e.g. recordings) where the file lives on the same Mac as the client.
     public let filePath: String?
 
-    /// Whether this attachment's binary data was omitted to keep the IPC payload small.
+    /// Whether this attachment's binary data was omitted to keep the payload small.
     /// The client should fetch it lazily via the HTTP endpoint when the user interacts.
     public var isLazyLoad: Bool { data.isEmpty && sizeBytes != nil }
 

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -73,9 +73,9 @@ public final class ChatMessageManager: ObservableObject {
 
     // MARK: - Model / provider
 
-    /// The currently active model ID, updated via `model_info` IPC messages.
+    /// The currently active model ID, updated via `model_info` messages.
     @Published public var selectedModel: String = "claude-opus-4-6"
-    /// Set of provider keys with configured API keys, updated via `model_info` IPC messages.
+    /// Set of provider keys with configured API keys, updated via `model_info` messages.
     @Published public var configuredProviders: Set<String> = ["anthropic"]
 
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -316,7 +316,7 @@ extension ChatViewModel {
         return nil
     }
 
-    /// Map IPC attachment DTOs to ChatAttachment values, generating thumbnails for images.
+    /// Map attachment DTOs to ChatAttachment values, generating thumbnails for images.
     func mapIPCAttachments(_ ipcAttachments: [IPCUserMessageAttachment]) -> [ChatAttachment] {
         ipcAttachments.compactMap { ipc in
             let id = ipc.id ?? UUID().uuidString
@@ -978,7 +978,7 @@ extension ChatViewModel {
         case .error(let err):
             log.error("Server error: \(err.message, privacy: .private)")
             // Only process errors relevant to this chat session. Generic daemon
-            // errors (e.g., IPC validation failures from unrelated message types
+            // errors (e.g., validation failures from unrelated message types
             // like work_item_delete) should not pollute the chat UI.
             guard isSending || isThinking || isCancelling || currentAssistantMessageId != nil || isWorkspaceRefinementInFlight else {
                 return
@@ -1045,7 +1045,7 @@ extension ChatViewModel {
                     } else if let blockedUserMessage {
                         secretBlockedMessageText = blockedUserMessage.text
                     }
-                    // Reconstruct IPC attachments from the blocked user message's ChatAttachments
+                    // Reconstruct attachments from the blocked user message's ChatAttachments
                     if let blockedUserMessage, !blockedUserMessage.attachments.isEmpty {
                         secretBlockedAttachments = blockedUserMessage.attachments.map {
                             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -235,12 +235,12 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.dismissedDocumentSurfaceIds }
         set { messageManager.dismissedDocumentSurfaceIds = newValue }
     }
-    /// The currently active model ID, updated via `model_info` IPC messages.
+    /// The currently active model ID, updated via `model_info` messages.
     public var selectedModel: String {
         get { messageManager.selectedModel }
         set { messageManager.selectedModel = newValue }
     }
-    /// Set of provider keys with configured API keys, updated via `model_info` IPC messages.
+    /// Set of provider keys with configured API keys, updated via `model_info` messages.
     public var configuredProviders: Set<String> {
         get { messageManager.configuredProviders }
         set { messageManager.configuredProviders = newValue }
@@ -377,7 +377,7 @@ public final class ChatViewModel: ObservableObject {
     /// Used to ensure this ChatViewModel only claims its own session.
     var bootstrapCorrelationId: String?
     /// Thread type sent with `session_create` (e.g. "private").
-    /// Set by `createSessionIfNeeded(threadType:)` and included in the IPC
+    /// Set by `createSessionIfNeeded(threadType:)` and included in the
     /// message so the daemon can persist the correct thread kind.
     public var threadType: String?
     /// Skill IDs to pre-activate in the session. Included in the
@@ -1330,7 +1330,7 @@ public final class ChatViewModel: ObservableObject {
             // task reference, which would cause duplicate subscriptions.
             if self?.messageLoopGeneration == generation {
                 self?.messageLoopTask = nil
-                // Reset spinner state — if IPC drops mid-turn the client
+                // Reset spinner state — if the connection drops mid-turn the client
                 // never receives message_complete, leaving the UI stuck.
                 self?.isThinking = false
                 self?.isSending = false
@@ -1389,7 +1389,7 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - Model
 
-    /// Switch the active model via the daemon's `model_set` IPC command.
+    /// Switch the active model via the daemon's `model_set` command.
     public func setModel(_ modelId: String) {
         // Ensure the message loop is running so we receive the model_info response.
         // VMs restored with an existing sessionId may not have started it yet.
@@ -1988,7 +1988,7 @@ public final class ChatViewModel: ObservableObject {
             return
         }
         // Send the response to the daemon first, then update UI state only on success.
-        // This prevents the UI from showing a finalized decision when the IPC
+        // This prevents the UI from showing a finalized decision when the
         // message was never delivered (e.g. daemon disconnected).
         do {
             try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil))
@@ -1997,7 +1997,7 @@ public final class ChatViewModel: ObservableObject {
             errorText = "Failed to send confirmation response."
             return
         }
-        // IPC send succeeded — update the message state
+        // Send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_thread"
             messages[index].confirmation?.state = isApproval ? .approved : .denied
@@ -2012,7 +2012,7 @@ public final class ChatViewModel: ObservableObject {
     /// Respond to a tool confirmation with "always_allow", sending the selected pattern and scope
     /// so the backend atomically persists the trust rule alongside the confirmation response.
     /// If the daemon is disconnected, shows an error without attempting a fallback (since
-    /// respondToConfirmation would also fail). On IPC send errors, attempts a one-time allow
+    /// respondToConfirmation would also fail). On send errors, attempts a one-time allow
     /// fallback and only claims success if the fallback actually went through.
     public func respondToAlwaysAllow(requestId: String, selectedPattern: String, selectedScope: String, decision: String = "always_allow") {
         guard daemonClient.isConnected else {
@@ -2023,7 +2023,7 @@ public final class ChatViewModel: ObservableObject {
         do {
             try daemonClient.send(ConfirmationResponseMessage(requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope))
         } catch {
-            log.warning("Always-allow IPC failed: \(error.localizedDescription)")
+            log.warning("Always-allow send failed: \(error.localizedDescription)")
             // Try one-time allow as fallback (daemon may still be connected)
             respondToConfirmation(requestId: requestId, decision: "allow")
             // respondToConfirmation sets errorText on failure; override with more context if it succeeded
@@ -2033,7 +2033,7 @@ public final class ChatViewModel: ObservableObject {
             }
             return
         }
-        // IPC send succeeded — update the message state
+        // Send succeeded — update the message state
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             messages[index].confirmation?.state = .approved
             messages[index].confirmation?.approvedDecision = decision
@@ -2059,7 +2059,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     /// Send an add_trust_rule message to persist a trust rule.
-    /// Returns `true` if the IPC send succeeded, `false` otherwise.
+    /// Returns `true` if the send succeeded, `false` otherwise.
     public func addTrustRule(toolName: String, pattern: String, scope: String, decision: String) -> Bool {
         guard daemonClient.isConnected else {
             log.warning("Cannot send add_trust_rule: daemon not connected")

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -71,7 +71,7 @@ struct InlineAppCreatedCard: View {
         .onAppear {
             previewImage = preview.previewImage
             // Fallback request: fires for history-loaded surfaces that didn't go
-            // through the eager uiSurfaceShow IPC handler (app restart, reconnect,
+            // through the eager uiSurfaceShow handler (app restart, reconnect,
             // thread switch). For live surfaces the eager request in
             // ChatViewModel+MessageHandling may have already fired; the duplicate
             // is harmless since the daemon treats preview requests idempotently.

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -28,7 +28,7 @@ struct OfflineQueuedMessage: Codable, Identifiable {
         }
     }
 
-    /// Reconstruct the IPC attachment list for dispatch.
+    /// Reconstruct the attachment list for dispatch.
     var ipcAttachments: [IPCAttachment]? {
         guard !attachments.isEmpty else { return nil }
         return attachments.map {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -134,7 +134,7 @@ public enum FormFieldType: String, Sendable, Equatable {
 }
 
 /// A form field default value that can be a string, number, or boolean,
-/// matching the `string | number | boolean` union in ipc-protocol.ts.
+/// matching the `string | number | boolean` union in message-protocol.ts.
 public enum FormFieldDefault: Sendable, Equatable {
     case string(String)
     case number(Double)
@@ -154,7 +154,7 @@ public enum FormFieldDefault: Sendable, Equatable {
         }
     }
 
-    /// Parse from an untyped Any value coming from IPC JSON.
+    /// Parse from an untyped Any value coming from JSON.
     public static func from(_ value: Any?) -> FormFieldDefault? {
         guard let value = value else { return nil }
         // Check Bool before numeric types because Bool conforms to numeric protocols in Swift.
@@ -468,10 +468,10 @@ public struct Surface: Identifiable, Sendable {
     }
 }
 
-// MARK: - Parsing from IPC Messages
+// MARK: - Parsing from Messages
 
 public extension Surface {
-    /// Parse a `Surface` from a `UiSurfaceShowMessage` received over IPC.
+    /// Parse a `Surface` from a `UiSurfaceShowMessage` received from the daemon.
     /// The message carries an `AnyCodable` data payload whose shape depends on `surfaceType`.
     static func from(_ message: UiSurfaceShowMessage) -> Surface? {
         guard let surfaceType = SurfaceType(rawValue: message.surfaceType) else {
@@ -609,7 +609,7 @@ public extension Surface {
 
     /// Merge a partial update dict into existing `SurfaceData`, keeping fields that are not
     /// present in the update unchanged. This supports the `Partial<SurfaceData>` contract
-    /// from ipc-protocol.ts.
+    /// from message-protocol.ts.
     private static func mergeSurfaceData(existing: SurfaceData, update: [String: Any?]) -> SurfaceData? {
         switch existing {
         case .card(let card):

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -3,8 +3,8 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DaemonClient")
 
-/// Shared signpost log for IPC instrumentation (Points of Interest lane in Instruments).
-private let ipcLog = OSLog(
+/// Shared signpost log for network instrumentation (Points of Interest lane in Instruments).
+private let networkLog = OSLog(
     subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
     category: .pointsOfInterest
 )
@@ -718,31 +718,31 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Send a message to the daemon via HTTP transport.
     /// Throws `SendError.notConnected` when the transport is unavailable.
     public func send<T: Encodable>(_ message: T) throws {
-        let sendID = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+        let sendID = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
 
         if let override = sendOverride {
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            os_signpost(.end, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
             try override(message)
             return
         }
 
         guard let httpTransport else {
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            os_signpost(.end, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
             log.warning("Cannot send: not connected")
             throw SendError.notConnected
         }
 
         guard httpTransport.isConnected else {
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            os_signpost(.end, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
             throw SendError.notConnected
         }
 
         do {
             try httpTransport.send(message)
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            os_signpost(.end, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
         } catch {
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            os_signpost(.end, log: networkLog, name: "daemonHTTPSend", signpostID: sendID)
             throw error
         }
     }
@@ -765,7 +765,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Surface Actions
 
     /// Convenience method for sending a surface action response to the daemon.
-    /// Keeps the IPC message construction co-located with the client.
+    /// Keeps the message construction co-located with the client.
     public func sendSurfaceAction(sessionId: String?, surfaceId: String, actionId: String, data: [String: AnyCodable]?) throws {
         let message = UiSurfaceActionMessage(
             sessionId: sessionId,
@@ -1532,7 +1532,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         return await httpTransport.fetchRemoteIdentity()
     }
 
-    /// Request identity info via IPC.
+    /// Request identity info via HTTP.
     public func sendIdentityGet() throws {
         try send(IdentityGetRequestMessage())
     }
@@ -2169,9 +2169,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         #if os(macOS)
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
-            let sid = OSSignpostID(log: ipcLog)
-            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+            let sid = OSSignpostID(log: networkLog)
+            os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
             return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
         }
 
@@ -2179,9 +2179,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             throw FeatureFlagError.invalidURL
         }
 
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -2195,9 +2195,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
         return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
         #endif
     }
@@ -2212,9 +2212,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         #if os(macOS)
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
-            let sid = OSSignpostID(log: ipcLog)
-            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+            let sid = OSSignpostID(log: networkLog)
+            os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
             return try await httpTransport.getFeatureFlags(featureFlagToken: token)
         }
 
@@ -2223,9 +2223,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             throw FeatureFlagError.invalidURL
         }
 
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -2239,9 +2239,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
         return try await httpTransport.getFeatureFlags(featureFlagToken: token)
         #endif
     }
@@ -2266,9 +2266,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // (the runtime), it does NOT serve feature-flag routes — so we must
         // fall through to the local gateway path below.
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
-            let sid = OSSignpostID(log: ipcLog)
-            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+            let sid = OSSignpostID(log: networkLog)
+            os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
             try await httpTransport.setFeatureFlag(key: key, enabled: enabled, featureFlagToken: token)
             return
         }
@@ -2283,9 +2283,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         let body: [String: Any] = ["enabled": enabled]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
 
         let (_, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -2297,9 +2297,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
-        let sid = OSSignpostID(log: ipcLog)
-        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
-        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+        let sid = OSSignpostID(log: networkLog)
+        os_signpost(.begin, log: networkLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: networkLog, name: "daemonHTTPRequest", signpostID: sid) }
         try await httpTransport.setFeatureFlag(key: key, enabled: enabled, featureFlagToken: token)
         #endif
     }

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -67,7 +67,7 @@ extension DaemonClient {
 
         do {
             try await transport.connect()
-            isAuthenticated = true  // HTTP transport uses bearer token, no IPC auth needed
+            isAuthenticated = true  // HTTP transport uses bearer token, no additional auth needed
             isConnecting = false
             log.info("connect: transport connected successfully to \(baseURL, privacy: .public), SSE should be running")
         } catch {

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1,4 +1,4 @@
-// Originally auto-generated from IPC contract types. Now maintained manually.
+// Originally auto-generated from message contract types. Now maintained manually.
 //
 // This file contains Swift Codable DTOs derived from the message-types contract.
 // The discriminated union enums (ClientMessage/ServerMessage) remain
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// MARK: - Generated IPC types
+// MARK: - Generated message types
 
 public struct IPCAcceptStarterBundle: Codable, Sendable {
     public let type: String
@@ -5622,7 +5622,7 @@ public struct IPCVercelApiConfigResponse: Codable, Sendable {
     }
 }
 
-/// Request from a session or IPC client to change the voice activation key.
+/// Request from a session or client to change the voice activation key.
 public struct IPCVoiceConfigUpdateRequest: Codable, Sendable {
     public let type: String
     /// The desired activation key (enum value or natural-language name).

--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -201,7 +201,7 @@ extension HTTPTransport {
                 }
             }
 
-            // REST returns { success, result, error? } — wrap into IPC envelope
+            // REST returns { success, result, error? } — wrap into HTTP envelope
             let rest = try decoder.decode(RESTAppDataResponse.self, from: data)
             let ipcResponse = IPCAppDataResponse(
                 type: "app_data_response",

--- a/clients/shared/Network/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Documents.swift
@@ -101,7 +101,7 @@ extension HTTPTransport {
                 }
             }
 
-            // REST returns { documents: [...] } without `type` — wrap into IPC envelope
+            // REST returns { documents: [...] } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentListResponse.self, from: data)
             let ipcDocs = rest.documents.map { doc in
                 IPCDocumentListResponseDocument(
@@ -144,7 +144,7 @@ extension HTTPTransport {
                 }
             }
 
-            // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into IPC envelope
+            // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentLoadResponse.self, from: data)
             let ipcResponse = IPCDocumentLoadResponse(
                 type: "document_load_response",
@@ -212,7 +212,7 @@ extension HTTPTransport {
                 }
             }
 
-            // REST returns { success, surfaceId, error? } without `type` — wrap into IPC envelope
+            // REST returns { success, surfaceId, error? } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentSaveResponse.self, from: data)
             let ipcResponse = IPCDocumentSaveResponse(
                 type: "document_save_response",

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -5,7 +5,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 // MARK: - Existing HTTP Route Dispatchers
 
-/// Registers domain dispatchers for the ~29 already-migrated IPC message types
+/// Registers domain dispatchers for the ~29 already-migrated message types
 /// that are transported over HTTP (user_message, confirmation_response, etc.).
 /// This keeps the main `send()` method thin and extensible — new domain
 /// dispatchers can be added in separate extension files without modifying the

--- a/clients/shared/Network/HTTPDaemonClient+Sessions.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Sessions.swift
@@ -5,7 +5,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 // MARK: - Session Domain Dispatcher
 
-/// Registers a domain dispatcher that translates session-related IPC message
+/// Registers a domain dispatcher that translates session-related message
 /// types into HTTP API calls. Handles:
 ///   session_switch, session_rename, sessions_clear, cancel, undo,
 ///   regenerate, model_get, model_set, image_gen_model_set,

--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -162,7 +162,7 @@ extension HTTPTransport {
                 return true
             }
             // ingress_config and platform_config do not have HTTP routes yet;
-            // they continue to use IPC-only handlers and are not dispatched here.
+            // they continue to use HTTP handlers and are not dispatched here.
             if let msg = message as? VercelApiConfigRequestMessage {
                 Task { await self.sendEncodablePost(.integrationsVercelConfig, body: msg, label: "vercel_api_config") }
                 return true
@@ -200,7 +200,7 @@ extension HTTPTransport {
                 return true
             }
 
-            // --- Workspace Files (legacy IPC) ---
+            // --- Workspace Files (legacy HTTP) ---
             if message is WorkspaceFilesListRequestMessage {
                 Task { await self.sendGenericPost(.workspaceFiles, method: "GET", label: "workspace_files_list") }
                 return true
@@ -256,7 +256,7 @@ extension HTTPTransport {
                 return
             }
 
-            // Wrap the HTTP response with the IPC envelope fields the router expects.
+            // Wrap the HTTP response with the envelope fields the router expects.
             guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 log.error("twitter_auth_status: unexpected response shape")
                 return

--- a/clients/shared/Network/HTTPDaemonClient+Skills.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Skills.swift
@@ -5,7 +5,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 
 // MARK: - Skills Domain Dispatcher
 
-/// Registers a domain dispatcher that translates skill-related IPC message
+/// Registers a domain dispatcher that translates skill-related message
 /// types into HTTP API calls. Handles:
 ///   skills_list, skills_enable, skills_disable, skills_configure,
 ///   skills_install, skills_uninstall, skills_update, skills_check_updates,

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -97,7 +97,7 @@ public struct WorkspaceFileResponse: Codable, Sendable {
 /// Responsibilities:
 /// - Periodic health check via `GET /healthz` to drive connection status
 /// - SSE stream connection to `GET /v1/events?conversationKey=...` (on demand)
-/// - Translating IPC message types to HTTP API calls
+/// - Translating message types to HTTP API calls
 /// - Auto-reconnect with exponential backoff
 @MainActor
 public final class HTTPTransport {
@@ -409,7 +409,7 @@ public final class HTTPTransport {
         // Link Open
         case linkOpen
 
-        // Workspace Files (legacy IPC)
+        // Workspace Files (legacy HTTP)
         case workspaceFiles
         case workspaceFilesRead
 
@@ -806,7 +806,7 @@ public final class HTTPTransport {
         // Link Open
         case .linkOpen:
             return ("/v1/link/open", nil)
-        // Workspace Files (legacy IPC)
+        // Workspace Files (legacy HTTP)
         case .workspaceFiles:
             return ("/v1/workspace-files", nil)
         case .workspaceFilesRead:
@@ -1187,7 +1187,7 @@ public final class HTTPTransport {
         // Link Open
         case .linkOpen:
             return ("\(prefix)/link/open/", nil)
-        // Workspace Files (legacy IPC)
+        // Workspace Files (legacy HTTP)
         case .workspaceFiles:
             return ("\(prefix)/workspace-files/", nil)
         case .workspaceFilesRead:
@@ -1475,7 +1475,7 @@ public final class HTTPTransport {
 
     // MARK: - Send (HTTP API Calls)
 
-    /// Translate an IPC message to the appropriate HTTP API call.
+    /// Translate a message to the appropriate HTTP API call.
     /// Domain dispatchers are tried in registration order; the first match wins.
     /// If no dispatcher handles the message, it falls through to a default log.
     func send<T: Encodable>(_ message: T) throws {
@@ -2668,7 +2668,7 @@ public final class HTTPTransport {
             // The runtime's /v1/messages endpoint returns messages with `content`
             // (string) and `timestamp` (ISO 8601 string), but IPCHistoryResponseMessage
             // expects `text` and `timestamp` as a Double (ms since epoch). Transform
-            // the response to match the expected IPC format.
+            // the response to match the expected message format.
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let messages = json["messages"] as? [[String: Any]] {
@@ -3869,7 +3869,7 @@ public final class HTTPTransport {
             guard let http = response as? HTTPURLResponse else { return }
 
             if http.statusCode == 200 {
-                // The HTTP route returns { data: ... }. The IPC handler emits
+                // The HTTP route returns { data: ... }. The handler emits
                 // skills_operation_response with operation: "search".
                 // Try to decode the `data` field as ClawhubSearchData.
                 var searchData: ClawhubSearchData?
@@ -4041,7 +4041,7 @@ public final class HTTPTransport {
     }
 
     /// Inject a `"type"` field into a JSON response before decoding.
-    /// HTTP endpoints return raw payloads without the IPC `type` discriminator.
+    /// HTTP endpoints return raw payloads without the `type` discriminator.
     /// This helper patches the JSON so existing Codable types (which expect
     /// `type`) can decode unchanged.
     private func injectType(_ typeValue: String, into data: Data) -> Data {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -10,7 +10,7 @@ import Foundation
 // ┌─────────────────────────────────┬──────────────────────────────────────────┐
 // │ Type                            │ Reason                                   │
 // ├─────────────────────────────────┼──────────────────────────────────────────┤
-// │ AnyCodable                      │ Infrastructure — not an IPC message type │
+// │ AnyCodable                      │ Infrastructure — not a message type      │
 // │ UiSurfaceShowMessage            │ Uses AnyCodable for `data` field and     │
 // │                                 │ custom SurfaceActionData array; the      │
 // │                                 │ contract type is skipped (SKIP_TYPES)    │
@@ -958,7 +958,7 @@ public struct UiSurfaceCompleteMessage: Decodable, Sendable {
     public let submittedData: [String: AnyCodable]?
 }
 
-/// Document editor messages — backed by generated types from IPC contract.
+/// Document editor messages — backed by generated types from the message contract.
 public typealias DocumentEditorShowMessage = IPCDocumentEditorShow
 public typealias DocumentEditorUpdateMessage = IPCDocumentEditorUpdate
 public typealias DocumentSaveRequestMessage = IPCDocumentSaveRequest
@@ -1130,7 +1130,7 @@ extension IPCWorkspaceFilesListResponseFile: Identifiable {
 /// Response containing a workspace file's content.
 public typealias WorkspaceFileReadResponseMessage = IPCWorkspaceFileReadResponse
 
-/// Request to fetch assistant identity info via IPC.
+/// Request to fetch assistant identity info via HTTP.
 public typealias IdentityGetRequestMessage = IPCIdentityGetRequest
 
 extension IPCIdentityGetRequest {
@@ -1664,7 +1664,7 @@ public typealias UnpublishPageResponseMessage = IPCUnpublishPageResponse
 // MARK: - Push Notification Device Token (Manual)
 
 /// Sent to register an APNS device token so the daemon can route push notifications.
-/// Kept hand-maintained — not yet part of the generated IPC contract.
+/// Kept hand-maintained — not yet part of the generated message contract.
 public struct RegisterDeviceTokenMessage: Encodable, Sendable {
     public let type: String = "register_device_token"
     public let token: String
@@ -1854,7 +1854,7 @@ extension IPCTelegramConfigRequest {
 /// Backed by generated `IPCTelegramConfigResponse`.
 public typealias TelegramConfigResponseMessage = IPCTelegramConfigResponse
 
-// MARK: - Twilio Number Models (standalone, no IPC dependency)
+// MARK: - Twilio Number Models (standalone, no generated-type dependency)
 
 /// Capabilities of a Twilio phone number.
 public struct TwilioNumberCapabilities: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Rename `ipcLog` → `networkLog` and `daemonIPCSend` → `daemonHTTPSend` in DaemonClient.swift
- Update `ipc-protocol.ts` references to `message-protocol.ts` in SurfaceTypes.swift
- Replace IPC in comments across ~48 Swift files

Part of plan: phase-out-ipc-refs.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
