### PR TITLE
fix: ensure cron_jobs indexes exist outside migration rebuild branch

### DIFF
--- a/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
+++ b/assistant/src/memory/migrations/146-schedule-oneshot-routing.ts
@@ -20,7 +20,13 @@ export function migrateScheduleOneShotRouting(database: DrizzleDb): void {
     .all() as Array<{ name: string }>;
   const hasStatusColumn = tableInfo.some((col) => col.name === "status");
   if (hasStatusColumn) {
-    // Ensure the composite index exists even if the column migration already ran
+    // Ensure all indexes exist even if the column migration already ran
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled_next_run ON cron_jobs(enabled, next_run_at)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_syntax_enabled_next_run ON cron_jobs(schedule_syntax, enabled, next_run_at)`,
+    );
     raw.exec(
       /*sql*/ `CREATE INDEX IF NOT EXISTS idx_cron_jobs_status_next_run_at ON cron_jobs(status, next_run_at)`,
     );


### PR DESCRIPTION
Migration 146 only recreated pre-existing cron_jobs indexes inside the table rebuild branch. Databases that already ran the migration keep missing idx_cron_jobs_enabled_next_run and idx_cron_jobs_syntax_enabled_next_run. This ensures the indexes are always created.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
