### PR TITLE
fix: propagate notification signal errors in scheduler notify mode

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -323,6 +323,7 @@ export async function runDaemon(): Promise<void> {
           routingIntent: schedule.routingIntent,
           routingHints: schedule.routingHints,
           dedupeKey: `schedule:notify:${schedule.id}:${Date.now()}`,
+          throwOnError: true,
         });
       },
       (schedule) => {


### PR DESCRIPTION
emitNotificationSignal swallows errors internally (fire-and-forget pattern), making the scheduler's catch block for recurring notify-mode schedules dead code. Adding throwOnError: true ensures pipeline failures propagate so the scheduler can properly record them as errors and update lastStatus/retryCount.

Addresses feedback from #14982.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
