### PR TITLE
fix: surface degraded flag when optional embeddings fail

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -538,7 +538,7 @@ async function generateQueryEmbedding(
         };
       }
       logMemoryEmbeddingWarning(err, "query");
-      degraded = config.memory.embeddings.required;
+      degraded = true;
       reason = `memory.embedding_failure: ${
         err instanceof Error ? err.message : String(err)
       }`;


### PR DESCRIPTION
The degraded flag was suppressed when optional embedding failures occurred, masking backend issues. When `embedWithRetry` throws and embeddings are optional, `degraded` was set to `config.memory.embeddings.required` (false), hiding the failure. Now it is always set to `true` on embedding failure, ensuring lexical-only fallback results are not cached as healthy and callers know recall quality may be reduced.

Addresses feedback from #15027.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
