### PR TITLE
fix: only skip out-of-scope media hits instead of dropping all media

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -9,6 +9,7 @@ import {
 } from "../qdrant-circuit-breaker.js";
 import type { QdrantSearchResult } from "../qdrant-client.js";
 import { getQdrantClient } from "../qdrant-client.js";
+import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import {
   memoryItems,
   memoryItemSources,
@@ -166,10 +167,15 @@ export async function semanticSearch(
         finalScore: 0,
       });
     } else if (payload.target_type === "media") {
-      // Media points don't currently store scope_id in their Qdrant payload,
-      // so we can't verify scope membership. Skip them when a scope filter is
-      // active to prevent cross-scope media leakage.
-      if (scopeIds) continue;
+      // Media points don't store scope_id directly in their Qdrant payload.
+      // Derive scope from the conversation_id when available; treat media
+      // without a conversation association as belonging to the "default" scope.
+      if (scopeIds) {
+        const mediaScopeId = payload.conversation_id
+          ? getConversationMemoryScopeId(payload.conversation_id)
+          : "default";
+        if (!scopeIds.includes(mediaScopeId)) continue;
+      }
       candidates.push({
         key: `media:${payload.target_id}`,
         type: "media",


### PR DESCRIPTION
The scopeIds filter was unconditionally dropping all media hits when scopeIds was present. This fixes it to only skip media hits that don't match the requested scopes, by deriving scope from the conversation_id on the Qdrant payload (or treating unscoped media as 'default').
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
