### PR TITLE
fix: check actual backend multimodal capability for embed_attachment gate

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -548,6 +548,21 @@ function selectFallbackBackends(
   return backends;
 }
 
+/**
+ * Returns true when the currently resolved embedding backend supports
+ * multimodal inputs (images, audio, video). Today only Gemini does.
+ *
+ * This replaces the earlier heuristic that checked `auto + gemini key`,
+ * which was wrong because `auto` mode may resolve to a text-only backend
+ * (local, OpenAI) even when a Gemini key exists.
+ */
+export function selectedBackendSupportsMultimodal(
+  config: AssistantConfig,
+): boolean {
+  const { backend } = selectEmbeddingBackend(config);
+  return backend?.provider === "gemini";
+}
+
 function isOllamaConfigured(config: AssistantConfig): boolean {
   return (
     config.provider === "ollama" ||

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -7,6 +7,7 @@ import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import { getDb } from "./db.js";
+import { selectedBackendSupportsMultimodal } from "./embedding-backend.js";
 import {
   enqueueMemoryJob,
   enqueueResolvePendingConflictsForMessageJob,
@@ -77,13 +78,9 @@ export function indexMessageNow(
   const shouldResolveConflicts =
     input.role === "user" && config.conflicts.enabled;
 
-  // Check if the embedding provider supports multimodal (only Gemini does).
-  // If so, scan for image blocks to enqueue embed_attachment jobs.
-  const embeddingProvider = config.embeddings.provider;
-  const fullConfig = getConfig();
-  const supportsMultimodal =
-    embeddingProvider === "gemini" ||
-    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini);
+  // Check if the resolved embedding backend supports multimodal input.
+  // Only enqueue embed_attachment jobs when it does (currently Gemini only).
+  const supportsMultimodal = selectedBackendSupportsMultimodal(getConfig());
   const mediaBlocks = supportsMultimodal
     ? extractMediaBlocks(input.content).filter((b) => b.type === "image")
     : [];

--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
 import { getDb, rawExec } from "../db.js";
+import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
 import { asString, BackendUnavailableError } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractMediaBlocks } from "../message-content.js";
@@ -53,16 +54,10 @@ export function rebuildIndexJob(): void {
     enqueueMemoryJob("embed_segment", { segmentId: segment.id });
   }
 
-  // Re-enqueue multimodal embedding jobs only when the embedding provider
-  // supports multimodal inputs (Gemini). Without this gate, embed_media and
-  // embed_attachment jobs would all fail for non-Gemini users.
-  const fullConfig = getConfig();
-  const embeddingProvider = fullConfig.memory.embeddings.provider;
-  const supportsMultimodal =
-    embeddingProvider === "gemini" ||
-    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini);
-
-  if (supportsMultimodal) {
+  // Re-enqueue multimodal embedding jobs only when the resolved embedding
+  // backend supports multimodal inputs. Without this gate, embed_media and
+  // embed_attachment jobs would all fail for text-only backends.
+  if (selectedBackendSupportsMultimodal(getConfig())) {
     const assets = db
       .select({ id: mediaAssets.id })
       .from(mediaAssets)

--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -8,20 +8,12 @@ import { preprocessForAsset } from "../../config/bundled-skills/media-processing
 import { reduceForAsset } from "../../config/bundled-skills/media-processing/tools/query-media-events.js";
 import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
+import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
 import { asString } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { getMediaAssetById, updateMediaAssetStatus } from "../media-store.js";
 
 const log = getLogger("media-processing-job");
-
-function supportsMultimodalEmbedding(): boolean {
-  const fullConfig = getConfig();
-  const embeddingProvider = fullConfig.memory.embeddings.provider;
-  return (
-    embeddingProvider === "gemini" ||
-    (embeddingProvider === "auto" && !!fullConfig.apiKeys.gemini)
-  );
-}
 
 export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   const mediaAssetId = asString(job.payload.mediaAssetId);
@@ -42,7 +34,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
       "Skipping media processing pipeline — only video assets are supported",
     );
     updateMediaAssetStatus(mediaAssetId, "indexed");
-    if (supportsMultimodalEmbedding()) {
+    if (selectedBackendSupportsMultimodal(getConfig())) {
       enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
     }
     return;
@@ -122,7 +114,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   }
 
   updateMediaAssetStatus(mediaAssetId, "indexed");
-  if (supportsMultimodalEmbedding()) {
+  if (selectedBackendSupportsMultimodal(getConfig())) {
     enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
   }
 }


### PR DESCRIPTION
The embed_attachment gate checked auto+Gemini key but didn't verify the actual backend supports multimodal. Adds selectedBackendSupportsMultimodal() helper that uses selectEmbeddingBackend() to check the resolved backend. Also removed redundant getConfig() call pattern and local supportsMultimodalEmbedding() function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
