### PR TITLE
fix: replace remaining IPC in Swift test names and mapIPCAttachments function

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1608,7 +1608,7 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.sessionError?.debugDetails,
                         "Error: 500 Internal Server Error\n  at handler.ts:42",
-                        "debugDetails should be passed through from IPC message")
+                        "debugDetails should be passed through from server message")
     }
 
     func testDebugDetailsNilWhenNotProvided() {
@@ -1623,7 +1623,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.sessionError(errorMsg))
 
         XCTAssertNil(viewModel.sessionError?.debugDetails,
-                      "debugDetails should be nil when not provided in IPC message")
+                      "debugDetails should be nil when not provided in server message")
     }
 
     // MARK: - Regression: Cancel semantics and error channel split
@@ -2425,7 +2425,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(callbackSessionId, "callback-session", "Should fire onSessionCreated callback")
     }
 
-    func testCreateSessionIfNeededSendsThreadTypeInIPC() {
+    func testCreateSessionIfNeededSendsThreadTypeInMessage() {
         var capturedMessages: [Any] = []
         daemonClient.sendOverride = { msg in
             capturedMessages.append(msg)

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -820,7 +820,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Outbound Verification: startOutboundVerification
 
-    func testStartOutboundVerificationSendsCorrectIPCMessage() {
+    func testStartOutboundVerificationSendsCorrectMessage() {
         store.startOutboundVerification(channel: "sms", destination: "+15551234567")
 
         let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
@@ -907,7 +907,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Outbound Verification: resend sends correct message
 
-    func testResendOutboundSendsCorrectIPCMessage() {
+    func testResendOutboundSendsCorrectMessage() {
         let verificationMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
         let resendCountBefore = verificationMessagesBefore.filter { $0.action == "resend_session" }.count
 

--- a/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
@@ -32,7 +32,7 @@ final class ThreadManagerRenameTests: XCTestCase {
 
     // MARK: - Rename with sessionId
 
-    func testRenameWithSessionIdSendsIPC() {
+    func testRenameWithSessionIdSendsMessage() {
         guard let thread = threadManager.threads.first else {
             XCTFail("Expected at least one thread")
             return

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -318,7 +318,7 @@ public final class ChatAttachmentManager: ObservableObject {
         }.value
     }
 
-    // MARK: - Static helpers (shared with ChatViewModel+Attachments and mapIPCAttachments)
+    // MARK: - Static helpers (shared with ChatViewModel+Attachments and mapMessageAttachments)
 
     /// Resize image data to fit within `maxDimension` and return PNG data.
     nonisolated public static func generateThumbnail(from data: Data, maxDimension: CGFloat) -> Data? {
@@ -331,7 +331,7 @@ public final class ChatAttachmentManager: ObservableObject {
         // NSImage.lockFocus()/draw()/unlockFocus() must run on the main thread.
         // This helper is called from two contexts:
         //   1. Task.detached (background) — must hop to main via DispatchQueue.main.sync.
-        //   2. @MainActor callers (e.g. ChatViewModel.mapIPCAttachments) — already on the
+        //   2. @MainActor callers (e.g. ChatViewModel.mapMessageAttachments) — already on the
         //      main thread, so DispatchQueue.main.sync would deadlock. Execute inline.
         let drawBlock = {
             let resized = NSImage(size: newSize)

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -317,8 +317,8 @@ extension ChatViewModel {
     }
 
     /// Map attachment DTOs to ChatAttachment values, generating thumbnails for images.
-    func mapIPCAttachments(_ ipcAttachments: [IPCUserMessageAttachment]) -> [ChatAttachment] {
-        ipcAttachments.compactMap { ipc in
+    func mapMessageAttachments(_ attachments: [IPCUserMessageAttachment]) -> [ChatAttachment] {
+        attachments.compactMap { ipc in
             let id = ipc.id ?? UUID().uuidString
             let base64 = ipc.data
             let dataLength = base64.count
@@ -367,7 +367,7 @@ extension ChatViewModel {
     /// Ingest attachments from a completion/handoff event into the current or new assistant message.
     func ingestAssistantAttachments(_ ipcAttachments: [IPCUserMessageAttachment]?) {
         guard let ipcAttachments, !ipcAttachments.isEmpty else { return }
-        let chatAttachments = mapIPCAttachments(ipcAttachments)
+        let chatAttachments = mapMessageAttachments(ipcAttachments)
         guard !chatAttachments.isEmpty else { return }
 
         if let existingId = currentAssistantMessageId,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2207,7 +2207,7 @@ public final class ChatViewModel: ObservableObject {
                     return toolCall
                 }
             }
-            let attachments: [ChatAttachment] = mapIPCAttachments(item.attachments ?? [])
+            let attachments: [ChatAttachment] = mapMessageAttachments(item.attachments ?? [])
 
             // Map surfaces from history to inlineSurfaces
             var inlineSurfaces: [InlineSurfaceData] = []

--- a/clients/shared/Tests/HTTPTransportAppsListResponseTests.swift
+++ b/clients/shared/Tests/HTTPTransportAppsListResponseTests.swift
@@ -46,7 +46,7 @@ final class HTTPTransportAppsListResponseTests: XCTestCase {
         super.tearDown()
     }
 
-    func testAppsListResponseWrapsRawHTTPPayloadIntoIPCMessage() async throws {
+    func testAppsListResponseWrapsRawHTTPPayloadIntoMessage() async throws {
         let responseExpectation = expectation(description: "apps list response")
 
         MockAppsURLProtocol.requestHandler = { request in
@@ -86,7 +86,7 @@ final class HTTPTransportAppsListResponseTests: XCTestCase {
         await fulfillment(of: [responseExpectation], timeout: 1.0)
     }
 
-    func testSharedAppsListResponseWrapsRawHTTPPayloadIntoIPCMessage() async throws {
+    func testSharedAppsListResponseWrapsRawHTTPPayloadIntoMessage() async throws {
         let responseExpectation = expectation(description: "shared apps list response")
 
         MockAppsURLProtocol.requestHandler = { request in


### PR DESCRIPTION
## Summary
- Rename ~8 Swift test functions from IPC to message terminology
- Rename `mapIPCAttachments` → `mapMessageAttachments` in production code
- Update callers and comments

Part of plan: phase-out-ipc-refs.md (review fix round 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
