### PR TITLE
fix: sort imports in memory/search/semantic.ts

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -1,6 +1,7 @@
 import { inArray } from "drizzle-orm";
 
 import { getLogger } from "../../util/logger.js";
+import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import { getDb } from "../db.js";
 import {
   _getQdrantBreakerState,
@@ -9,7 +10,6 @@ import {
 } from "../qdrant-circuit-breaker.js";
 import type { QdrantSearchResult } from "../qdrant-client.js";
 import { getQdrantClient } from "../qdrant-client.js";
-import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import {
   memoryItems,
   memoryItemSources,


### PR DESCRIPTION
## Summary
- Fixes unsorted imports in `assistant/src/memory/search/semantic.ts` that caused the lint CI job to fail
- Moved `../conversation-crud.js` import before `../db.js` to match alphabetical sort order required by `simple-import-sort`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22930565943/job/66550926991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
