### PR TITLE
Add host_bash proxy request/response message types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -20,6 +20,7 @@ export * from "./message-types/contacts.js";
 export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
+export * from "./message-types/host-bash.js";
 export * from "./message-types/inbox.js";
 export * from "./message-types/integrations.js";
 export * from "./message-types/memory.js";
@@ -66,6 +67,10 @@ import type {
   _GuardianActionsClientMessages,
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
+import type {
+  _HostBashClientMessages,
+  _HostBashServerMessages,
+} from "./message-types/host-bash.js";
 import type {
   _InboxClientMessages,
   _InboxServerMessages,
@@ -150,6 +155,7 @@ export type ClientMessage =
   | _SubagentsClientMessages
   | _DocumentsClientMessages
   | _GuardianActionsClientMessages
+  | _HostBashClientMessages
   | _WorkspaceClientMessages
   | _SchedulesClientMessages
   | _DiagnosticsClientMessages
@@ -175,6 +181,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _HostBashServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages
   | _SchedulesServerMessages

--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -1,0 +1,31 @@
+// Host bash proxy types.
+// Enables proxying shell commands to the desktop client (host machine)
+// when running as a managed assistant.
+
+// === Server → Client ===
+
+export interface HostBashRequest {
+  type: "host_bash_request";
+  requestId: string;
+  sessionId: string;
+  command: string;
+  working_dir?: string;
+  timeout_seconds?: number;
+}
+
+// === Client → Server ===
+
+export interface HostBashResponse {
+  type: "host_bash_response";
+  requestId: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostBashClientMessages = HostBashResponse;
+
+export type _HostBashServerMessages = HostBashRequest;


### PR DESCRIPTION
## Summary
- Add `HostBashRequest` (Server→Client) and `HostBashResponse` (Client→Server) message types for proxying host_bash commands to the desktop client
- Wire types into `ClientMessage` and `ServerMessage` protocol unions in `message-protocol.ts`

Part of plan: host-bash-proxy.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
