### PR TITLE
fix: rename ipc-prefixed local variables in Swift client code

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -162,7 +162,7 @@ extension AppDelegate {
 
             // 2. Send task_submit — daemon classifies and creates the session
             let screenBounds = CGDisplayBounds(CGMainDisplayID())
-            let ipcAttachments: [IPCAttachment]? = submission.attachments.isEmpty ? nil : submission.attachments.map {
+            let messageAttachments: [IPCAttachment]? = submission.attachments.isEmpty ? nil : submission.attachments.map {
                 IPCAttachment(
                     filename: $0.fileName,
                     mimeType: $0.mimeType,
@@ -175,7 +175,7 @@ extension AppDelegate {
                     task: effectiveTask,
                     screenWidth: Int(screenBounds.width),
                     screenHeight: Int(screenBounds.height),
-                    attachments: ipcAttachments,
+                    attachments: messageAttachments,
                     source: submission.source
                 ))
             } catch {

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -125,7 +125,7 @@ final class ComputerUseSession: ObservableObject {
 
         // 2. Send session create message (skip if daemon already created via task_submit)
         if !skipSessionCreate {
-            let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
+            let messageAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
                 IPCAttachment(
                     filename: $0.fileName,
                     mimeType: $0.mimeType,
@@ -143,7 +143,7 @@ final class ComputerUseSession: ObservableObject {
                     task: task,
                     screenWidth: Int(screenSize.width),
                     screenHeight: Int(screenSize.height),
-                    attachments: ipcAttachments,
+                    attachments: messageAttachments,
                     interactionType: interactionTypeString
                 ))
             } catch {

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -82,7 +82,7 @@ final class TextSession: ObservableObject {
                         log.info("Got daemon session ID: \(info.sessionId)")
 
                         // Now send the user message
-                        let ipcAttachments: [IPCAttachment]? = self.attachments.isEmpty ? nil : self.attachments.map {
+                        let messageAttachments: [IPCAttachment]? = self.attachments.isEmpty ? nil : self.attachments.map {
                             IPCAttachment(
                                 filename: $0.fileName,
                                 mimeType: $0.mimeType,
@@ -93,7 +93,7 @@ final class TextSession: ObservableObject {
                         try? self.daemonClient.send(UserMessageMessage(
                             sessionId: info.sessionId,
                             content: self.task,
-                            attachments: ipcAttachments
+                            attachments: messageAttachments
                         ))
 
                         // Track the initial user message

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1078,7 +1078,7 @@ public final class ChatViewModel: ObservableObject {
         secretBlockedCurrentPage = nil
         flushCoalescedPublish()
 
-        let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
+        let messageAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
         }
 
@@ -1092,10 +1092,10 @@ public final class ChatViewModel: ObservableObject {
         if sessionId == nil {
             // First message: need to bootstrap session
             pendingUserMessageDisplayText = rawText
-            bootstrapSession(userMessage: text, attachments: ipcAttachments)
+            bootstrapSession(userMessage: text, attachments: messageAttachments)
         } else {
             // Subsequent messages: send directly (daemon queues if busy)
-            sendUserMessage(text, displayText: rawText, attachments: ipcAttachments, queuedMessageId: queuedMessageId)
+            sendUserMessage(text, displayText: rawText, attachments: messageAttachments, queuedMessageId: queuedMessageId)
         }
     }
 
@@ -1307,7 +1307,7 @@ public final class ChatViewModel: ObservableObject {
         // via the normal error retry path, rather than duplicating on the next flush.
         for queued in mine {
             queue.remove(id: queued.id)
-            sendUserMessage(queued.text, displayText: queued.displayText, attachments: queued.ipcAttachments)
+            sendUserMessage(queued.text, displayText: queued.displayText, attachments: queued.messageAttachments)
         }
     }
 

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -29,7 +29,7 @@ struct OfflineQueuedMessage: Codable, Identifiable {
     }
 
     /// Reconstruct the attachment list for dispatch.
-    var ipcAttachments: [IPCAttachment]? {
+    var messageAttachments: [IPCAttachment]? {
         guard !attachments.isEmpty else { return nil }
         return attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)

--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -203,7 +203,7 @@ extension HTTPTransport {
 
             // REST returns { success, result, error? } — wrap into HTTP envelope
             let rest = try decoder.decode(RESTAppDataResponse.self, from: data)
-            let ipcResponse = IPCAppDataResponse(
+            let response = IPCAppDataResponse(
                 type: "app_data_response",
                 surfaceId: msg.surfaceId,
                 callId: msg.callId,
@@ -211,7 +211,7 @@ extension HTTPTransport {
                 result: rest.result,
                 error: rest.error
             )
-            onMessage?(.appDataResponse(ipcResponse))
+            onMessage?(.appDataResponse(response))
         } catch {
             log.error("App data request error: \(error.localizedDescription)")
         }

--- a/clients/shared/Network/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Documents.swift
@@ -103,7 +103,7 @@ extension HTTPTransport {
 
             // REST returns { documents: [...] } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentListResponse.self, from: data)
-            let ipcDocs = rest.documents.map { doc in
+            let docs = rest.documents.map { doc in
                 IPCDocumentListResponseDocument(
                     surfaceId: doc.surfaceId,
                     conversationId: doc.conversationId,
@@ -113,11 +113,11 @@ extension HTTPTransport {
                     updatedAt: doc.updatedAt
                 )
             }
-            let ipcResponse = IPCDocumentListResponse(
+            let response = IPCDocumentListResponse(
                 type: "document_list_response",
-                documents: ipcDocs
+                documents: docs
             )
-            onMessage?(.documentListResponse(ipcResponse))
+            onMessage?(.documentListResponse(response))
         } catch {
             log.error("Fetch document list error: \(error.localizedDescription)")
         }
@@ -146,7 +146,7 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentLoadResponse.self, from: data)
-            let ipcResponse = IPCDocumentLoadResponse(
+            let response = IPCDocumentLoadResponse(
                 type: "document_load_response",
                 surfaceId: rest.surfaceId,
                 conversationId: rest.conversationId,
@@ -158,7 +158,7 @@ extension HTTPTransport {
                 success: rest.success,
                 error: rest.error
             )
-            onMessage?(.documentLoadResponse(ipcResponse))
+            onMessage?(.documentLoadResponse(response))
         } catch {
             log.error("Fetch document load error: \(error.localizedDescription)")
         }
@@ -214,13 +214,13 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, error? } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentSaveResponse.self, from: data)
-            let ipcResponse = IPCDocumentSaveResponse(
+            let response = IPCDocumentSaveResponse(
                 type: "document_save_response",
                 surfaceId: rest.surfaceId,
                 success: rest.success,
                 error: rest.error
             )
-            onMessage?(.documentSaveResponse(ipcResponse))
+            onMessage?(.documentSaveResponse(response))
         } catch {
             log.error("Document save error: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for phase-out-ipc-refs.md.

- Renames `ipcAttachments` local vars/properties across 5 Swift files to `messageAttachments`
- Renames `ipcResponse` and `ipcDocs` local vars in HTTPDaemonClient files to `response` and `docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
