### PR TITLE
fix: rename response local vars in Swift HTTP client to avoid redeclaration

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -203,7 +203,7 @@ extension HTTPTransport {
 
             // REST returns { success, result, error? } — wrap into HTTP envelope
             let rest = try decoder.decode(RESTAppDataResponse.self, from: data)
-            let response = IPCAppDataResponse(
+            let appDataResponse = IPCAppDataResponse(
                 type: "app_data_response",
                 surfaceId: msg.surfaceId,
                 callId: msg.callId,
@@ -211,7 +211,7 @@ extension HTTPTransport {
                 result: rest.result,
                 error: rest.error
             )
-            onMessage?(.appDataResponse(response))
+            onMessage?(.appDataResponse(appDataResponse))
         } catch {
             log.error("App data request error: \(error.localizedDescription)")
         }

--- a/clients/shared/Network/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Documents.swift
@@ -113,11 +113,11 @@ extension HTTPTransport {
                     updatedAt: doc.updatedAt
                 )
             }
-            let response = IPCDocumentListResponse(
+            let documentListResponse = IPCDocumentListResponse(
                 type: "document_list_response",
                 documents: docs
             )
-            onMessage?(.documentListResponse(response))
+            onMessage?(.documentListResponse(documentListResponse))
         } catch {
             log.error("Fetch document list error: \(error.localizedDescription)")
         }
@@ -146,7 +146,7 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentLoadResponse.self, from: data)
-            let response = IPCDocumentLoadResponse(
+            let documentLoadResponse = IPCDocumentLoadResponse(
                 type: "document_load_response",
                 surfaceId: rest.surfaceId,
                 conversationId: rest.conversationId,
@@ -158,7 +158,7 @@ extension HTTPTransport {
                 success: rest.success,
                 error: rest.error
             )
-            onMessage?(.documentLoadResponse(response))
+            onMessage?(.documentLoadResponse(documentLoadResponse))
         } catch {
             log.error("Fetch document load error: \(error.localizedDescription)")
         }
@@ -214,13 +214,13 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, error? } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentSaveResponse.self, from: data)
-            let response = IPCDocumentSaveResponse(
+            let documentSaveResponse = IPCDocumentSaveResponse(
                 type: "document_save_response",
                 surfaceId: rest.surfaceId,
                 success: rest.success,
                 error: rest.error
             )
-            onMessage?(.documentSaveResponse(response))
+            onMessage?(.documentSaveResponse(documentSaveResponse))
         } catch {
             log.error("Document save error: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
- Rename second `response` binding in `HTTPDaemonClient+Apps.swift` to `appDataResponse` to fix Swift compilation error
- Rename second `response` binding in `HTTPDaemonClient+Documents.swift` to `documentListResponse`, `documentLoadResponse`, and `documentSaveResponse` for the same reason
- These collided with the `response` from `URLSession.shared.data(for:)` in the same `do` block

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22931123748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
