### PR TITLE
fix: add missing svc_daemon to migration-routes JSDoc auth comments

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -115,7 +115,7 @@ export async function handleMigrationValidate(req: Request): Promise<Response> {
  *        with Content-Disposition header for download.
  *   500: Standard error envelope for unexpected failures.
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
 export async function handleMigrationExport(req: Request): Promise<Response> {
   let description: string | undefined;
@@ -254,7 +254,7 @@ async function extractFileData(
  *   400: Standard error envelope for missing/empty body
  *   500: Standard error envelope for unexpected failures
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
 export async function handleMigrationImportPreflight(
   req: Request,
@@ -339,7 +339,7 @@ export async function handleMigrationImportPreflight(
  *   400: Standard error envelope for missing/empty body
  *   500: Standard error envelope for unexpected failures
  *
- * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, local.
+ * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
 export async function handleMigrationImport(req: Request): Promise<Response> {
   const extracted = await extractFileData(req);


### PR DESCRIPTION
Devin flagged that JSDoc auth comments on migration route handlers omit svc_daemon from the allowed principal types, which is inconsistent with the actual route policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
