### PR TITLE
fix: correct contradictory IPC→HTTP comment in Swift settings handler

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -162,7 +162,7 @@ extension HTTPTransport {
                 return true
             }
             // ingress_config and platform_config do not have HTTP routes yet;
-            // they continue to use HTTP handlers and are not dispatched here.
+            // they continue to use SSE message handlers and are not dispatched here.
             if let msg = message as? VercelApiConfigRequestMessage {
                 Task { await self.sendEncodablePost(.integrationsVercelConfig, body: msg, label: "vercel_api_config") }
                 return true


### PR DESCRIPTION
Devin flagged that the mechanical IPC→HTTP rename created a self-contradictory comment. Changes 'HTTP handlers' to 'SSE message handlers' since these settings use the SSE message path, not dedicated HTTP routes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
