### PR TITLE
Handle host_bash_request in desktop client with local Process execution

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -343,6 +343,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `secret_request` message for secure credential input.
     public var onSecretRequest: ((SecretRequestMessage) -> Void)?
 
+    /// Called when the daemon sends a `host_bash_request` message for proxy command execution.
+    public var onHostBashRequest: ((HostBashRequest) -> Void)?
+
     /// Called when the daemon sends a `task_routed` message (e.g. escalation from text_qa to CU).
     public var onTaskRouted: ((TaskRoutedMessage) -> Void)?
 

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -78,6 +78,9 @@ extension DaemonClient {
             onAssistantActivityState?(msg)
         case .secretRequest(let msg):
             onSecretRequest?(msg)
+        case .hostBashRequest(let msg):
+            onHostBashRequest?(msg)
+            handleHostBashRequest(msg)
         case .taskRouted(let msg):
             onTaskRouted?(msg)
         case .dictationResponse(let msg):
@@ -348,4 +351,27 @@ extension DaemonClient {
         }
     }
     #endif
+
+    // MARK: - Host Bash Proxy
+
+    /// Handle a host_bash_request by executing the command locally via
+    /// `Foundation.Process` and posting the result back to the daemon.
+    func handleHostBashRequest(_ msg: HostBashRequest) {
+        #if os(macOS)
+        httpTransport?.executeHostBashRequest(msg)
+        #else
+        log.warning("Received host_bash_request on iOS — local execution not supported")
+        // Post an error result back so the daemon doesn't hang waiting
+        Task {
+            let result = HostBashResultPayload(
+                requestId: msg.requestId,
+                stdout: "",
+                stderr: "Host bash execution is not supported on iOS",
+                exitCode: nil,
+                timedOut: false
+            )
+            await httpTransport?.postHostBashResult(result)
+        }
+        #endif
+    }
 }

--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -1,0 +1,140 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HostBash")
+
+// MARK: - Host Bash Proxy Execution
+
+extension HTTPTransport {
+
+    /// Post the result of a host bash execution back to the daemon.
+    func postHostBashResult(_ result: HostBashResultPayload, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .hostBashResult) else {
+            log.error("Failed to build URL for host_bash_result")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(result)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    switch refreshResult {
+                    case .success:
+                        await postHostBashResult(result, isRetry: true)
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
+                        log.error("Host bash result failed: authentication error after 401 refresh")
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("Host bash result failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("Host bash result error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Execute a host bash request locally and post the result back to the daemon.
+    /// Spawns `/bin/bash -c -- <command>` via `Foundation.Process`, enforces a
+    /// timeout, and collects stdout/stderr.
+    func executeHostBashRequest(_ request: HostBashRequest) {
+        Task.detached {
+            let maxTimeout: Double = 600
+            let defaultTimeout: Double = 120
+            let timeout = min(request.timeoutSeconds ?? defaultTimeout, maxTimeout)
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/bash")
+            process.arguments = ["-c", "--", request.command]
+
+            if let workingDir = request.workingDir, !workingDir.isEmpty {
+                process.currentDirectoryURL = URL(fileURLWithPath: workingDir)
+            } else {
+                process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
+            }
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            // Use a sendable box for the timeout flag shared between the timer
+            // and the termination handler.
+            final class TimedOutBox: @unchecked Sendable {
+                private let lock = NSLock()
+                private var _value = false
+                var value: Bool {
+                    get { lock.withLock { _value } }
+                    set { lock.withLock { _value = newValue } }
+                }
+            }
+            let timedOutBox = TimedOutBox()
+
+            // Set up timeout timer
+            let timerSource = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
+            timerSource.schedule(deadline: .now() + timeout)
+            timerSource.setEventHandler {
+                timedOutBox.value = true
+                if process.isRunning {
+                    process.terminate()
+                    // Give the process a moment to terminate gracefully, then SIGKILL
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                        if process.isRunning {
+                            kill(process.processIdentifier, SIGKILL)
+                        }
+                    }
+                }
+            }
+            timerSource.resume()
+
+            do {
+                try process.run()
+            } catch {
+                timerSource.cancel()
+                log.error("Failed to launch host bash process: \(error.localizedDescription)")
+                let result = HostBashResultPayload(
+                    requestId: request.requestId,
+                    stdout: "",
+                    stderr: "Failed to launch process: \(error.localizedDescription)",
+                    exitCode: nil,
+                    timedOut: false
+                )
+                await self.postHostBashResult(result)
+                return
+            }
+
+            // Read pipe data before waiting for exit to avoid deadlock when
+            // the pipe buffer fills (Process blocks on write until we read).
+            let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+            process.waitUntilExit()
+            timerSource.cancel()
+
+            let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+            let exitCode = Int(process.terminationStatus)
+            let timedOut = timedOutBox.value
+
+            let result = HostBashResultPayload(
+                requestId: request.requestId,
+                stdout: stdout,
+                stderr: stderr,
+                exitCode: timedOut ? nil : exitCode,
+                timedOut: timedOut
+            )
+
+            log.debug("Host bash completed — requestId=\(request.requestId, privacy: .public) exitCode=\(exitCode) timedOut=\(timedOut)")
+            await self.postHostBashResult(result)
+        }
+    }
+}

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -416,6 +416,9 @@ public final class HTTPTransport {
         // Attachments
         case uploadAttachment
 
+        // Host Bash Proxy
+        case hostBashResult
+
         // Misc
         case channelVerificationSessions
         case registerDeviceToken
@@ -814,6 +817,9 @@ public final class HTTPTransport {
         // Attachments
         case .uploadAttachment:
             return ("/v1/attachments", nil)
+        // Host Bash Proxy
+        case .hostBashResult:
+            return ("/v1/host-bash-result", nil)
         // Misc
         case .channelVerificationSessions:
             return ("/v1/channel-verification-sessions", nil)
@@ -1195,6 +1201,9 @@ public final class HTTPTransport {
         // Attachments
         case .uploadAttachment:
             return ("\(prefix)/attachments/", nil)
+        // Host Bash Proxy
+        case .hostBashResult:
+            return ("\(prefix)/host-bash-result/", nil)
         // Misc
         case .channelVerificationSessions:
             return ("\(prefix)/channel-verification-sessions/", nil)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1507,6 +1507,54 @@ extension IPCConfirmationRequestDiff: Equatable {
 /// Backed by generated `IPCConfirmationStateChanged`.
 public typealias ConfirmationStateChangedMessage = IPCConfirmationStateChanged
 
+// MARK: - Host Bash Proxy
+
+/// Request from the daemon to execute a bash command on the host machine.
+/// The desktop client receives this via SSE, runs the command locally via
+/// `Foundation.Process`, and POSTs the result back to `/v1/host-bash-result`.
+public struct HostBashRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let sessionId: String
+    public let command: String
+    public let workingDir: String?
+    public let timeoutSeconds: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case requestId = "request_id"
+        case sessionId = "session_id"
+        case command
+        case workingDir = "working_dir"
+        case timeoutSeconds = "timeout_seconds"
+    }
+}
+
+/// Payload posted back to the daemon with the result of a host bash execution.
+public struct HostBashResultPayload: Codable, Sendable {
+    public let requestId: String
+    public let stdout: String
+    public let stderr: String
+    public let exitCode: Int?
+    public let timedOut: Bool
+
+    public init(requestId: String, stdout: String, stderr: String, exitCode: Int?, timedOut: Bool) {
+        self.requestId = requestId
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.timedOut = timedOut
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case requestId = "request_id"
+        case stdout
+        case stderr
+        case exitCode = "exit_code"
+        case timedOut = "timed_out"
+    }
+}
+
 /// Server-side assistant activity lifecycle event.
 /// Backed by generated `IPCAssistantActivityState`.
 public typealias AssistantActivityStateMessage = IPCAssistantActivityState
@@ -2239,6 +2287,7 @@ public enum ServerMessage: Decodable, Sendable {
     case contactsResponse(ContactsResponseMessage)
     case tokenRotated(TokenRotatedMessage)
     case identityChanged(IPCIdentityChanged)
+    case hostBashRequest(HostBashRequest)
     case pong
     case unknown(String)
 
@@ -2683,6 +2732,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "identity_changed":
             let message = try IPCIdentityChanged(from: decoder)
             self = .identityChanged(message)
+        case "host_bash_request":
+            let message = try HostBashRequest(from: decoder)
+            self = .hostBashRequest(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add `HostBashRequest` and `HostBashResultPayload` message types in Swift with snake_case CodingKeys matching the daemon's JSON contract
- Wire `host_bash_request` SSE event handling in `ServerMessage` enum and `DaemonMessageRouter`
- Implement local command execution via `Foundation.Process` (`/bin/bash -c --`) with timeout enforcement (DispatchSource timer + SIGKILL) in new `HTTPDaemonClient+HostBash.swift`
- Add `postHostBashResult` HTTP POST method for returning execution results to `/v1/host-bash-result`, with 401 retry support and platform proxy path mapping
- iOS gracefully returns an error result instead of attempting execution

Part of plan: host-bash-proxy.md (PR 4 of 4)

## Test plan
- [ ] Verify `host_bash_request` SSE events are decoded correctly by the desktop client
- [ ] Verify commands execute locally via `Foundation.Process` and results are posted back
- [ ] Verify timeout enforcement terminates long-running processes with SIGKILL
- [ ] Verify working directory defaults to user's home when not specified
- [ ] Verify managed assistant proxy path (`/v1/assistants/{id}/host-bash-result/`) routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
