### PR TITLE
fix: call ensurePayloadIndexes in 409 concurrent-creation path

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -114,7 +114,7 @@ export class VellumQdrantClient {
             await this.client.deleteCollection(this.collection);
             // Fall through to collection creation below
           } else {
-            await this.ensurePayloadIndexes();
+            await this.ensurePayloadIndexesSafe();
             this.collectionReady = true;
             return;
           }
@@ -123,7 +123,7 @@ export class VellumQdrantClient {
             { err },
             "Failed to verify collection compatibility, assuming compatible",
           );
-          await this.ensurePayloadIndexes();
+          await this.ensurePayloadIndexesSafe();
           this.collectionReady = true;
           return;
         }
@@ -168,13 +168,14 @@ export class VellumQdrantClient {
         "status" in err &&
         (err as { status: number }).status === 409
       ) {
+        await this.ensurePayloadIndexesSafe();
         this.collectionReady = true;
         return;
       }
       throw err;
     }
 
-    await this.ensurePayloadIndexes();
+    await this.ensurePayloadIndexesSafe();
 
     // Write sentinel point to record the active embedding model
     if (this.embeddingModel) {
@@ -408,6 +409,23 @@ export class VellumQdrantClient {
       msg.includes("doesn't exist") ||
       msg.includes("not found")
     );
+  }
+
+  /**
+   * Wraps ensurePayloadIndexes so that a 404 (collection deleted between
+   * our existence check and index creation) resets collectionReady instead
+   * of propagating — the next operation will self-heal via ensureCollection.
+   */
+  private async ensurePayloadIndexesSafe(): Promise<void> {
+    try {
+      await this.ensurePayloadIndexes();
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        return;
+      }
+      throw err;
+    }
   }
 
   private async ensurePayloadIndexes(): Promise<void> {


### PR DESCRIPTION
Devin flagged that the 409 concurrent-creation handler skips ensurePayloadIndexes(), inconsistent with the PR's intent. Also wraps ensurePayloadIndexes in try-catch for the race where collection is deleted between checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
