### PR TITLE
fix: add scope metadata to media embedding payloads

### DIFF
--- a/assistant/src/memory/job-handlers/embedding.ts
+++ b/assistant/src/memory/job-handlers/embedding.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { eq } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../config/types.js";
+import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import { getDb } from "../db.js";
 import type { EmbeddingInput } from "../embedding-types.js";
 import { asString, embedAndUpsert } from "../job-utils.js";
@@ -146,9 +147,11 @@ export async function embedAttachmentJob(
 
   // Use messageId + blockIndex as targetId for uniqueness
   const targetId = `${messageId}:${blockIndex}`;
+  const memoryScopeId = getConversationMemoryScopeId(message.conversationId);
   await embedAndUpsert(config, "media", targetId, input, {
     created_at: message.createdAt,
     message_id: messageId,
     conversation_id: message.conversationId,
+    memory_scope_id: memoryScopeId,
   });
 }

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -167,13 +167,13 @@ export async function semanticSearch(
         finalScore: 0,
       });
     } else if (payload.target_type === "media") {
-      // Media points don't store scope_id directly in their Qdrant payload.
-      // Derive scope from the conversation_id when available; treat media
-      // without a conversation association as belonging to the "default" scope.
+      // Use stored memory_scope_id when available; fall back to deriving
+      // scope from conversation_id for legacy media points.
       if (scopeIds) {
-        const mediaScopeId = payload.conversation_id
-          ? getConversationMemoryScopeId(payload.conversation_id)
-          : "default";
+        const mediaScopeId = payload.memory_scope_id
+          ?? (payload.conversation_id
+            ? getConversationMemoryScopeId(payload.conversation_id)
+            : "default");
         if (!scopeIds.includes(mediaScopeId)) continue;
       }
       candidates.push({


### PR DESCRIPTION
Codex flagged that media embedding upserts in embedAttachmentJob lack scope metadata, causing potential scope leaks in scoped retrieval. Adds memory_scope_id to media embedding payloads consistent with how other embedding types handle scope. Also updates semantic search to prefer stored memory_scope_id over deriving it from conversation_id at query time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
