### PR TITLE
fix: avoid unnecessary memory allocation during embed_attachment rebuild

### DIFF
--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, like } from "drizzle-orm";
 
 import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
@@ -6,7 +6,7 @@ import { getDb, rawExec } from "../db.js";
 import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
 import { asString, BackendUnavailableError } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
-import { extractMediaBlocks } from "../message-content.js";
+import { extractMediaBlockMeta } from "../message-content.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
 import {
@@ -67,14 +67,14 @@ export function rebuildIndexJob(): void {
       enqueueMemoryJob("embed_media", { assetId: asset.id });
     }
 
-    const allMessages = db
+    const imageMessages = db
       .select({ id: messages.id, content: messages.content })
       .from(messages)
+      .where(like(messages.content, '%"type":"image"%'))
       .all();
-    for (const msg of allMessages) {
-      const blocks = extractMediaBlocks(msg.content);
-      const imageBlocks = blocks.filter((b) => b.type === "image");
-      for (const block of imageBlocks) {
+    for (const msg of imageMessages) {
+      const blocks = extractMediaBlockMeta(msg.content);
+      for (const block of blocks) {
         enqueueMemoryJob("embed_attachment", {
           messageId: msg.id,
           blockIndex: block.index,

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -87,6 +87,29 @@ export function extractMediaBlocks(raw: string): Array<{
   }
 }
 
+/**
+ * Lightweight variant of extractMediaBlocks that returns only type and index
+ * metadata without decoding base64 image data into Buffers.
+ */
+export function extractMediaBlockMeta(
+  raw: string,
+): Array<{ type: "image"; index: number }> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const results: Array<{ type: "image"; index: number }> = [];
+    for (let i = 0; i < parsed.length; i++) {
+      const block = parsed[i] as { type?: string };
+      if (block.type === "image") {
+        results.push({ type: "image" as const, index: i });
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
 function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value);


### PR DESCRIPTION
Codex and Devin both flagged that the rebuild path eagerly decodes base64 image data and does a full table scan on messages. Now filters messages with a LIKE pre-filter and uses a lightweight metadata-only extraction to avoid memory pressure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
