### PR TITLE
fix: add ensureActorScopedHistory to remaining session test mocks

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -85,6 +85,7 @@ function registerPendingConfirmation(
 ): void {
   const mockSession = {
     handleConfirmationResponse: mock(() => {}),
+    ensureActorScopedHistory: async () => {},
   } as unknown as Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -269,6 +269,7 @@ describe("Telegram callback seen signals", () => {
     const handleConfirmationResponse = mock(() => {});
     const mockSession = {
       handleConfirmationResponse,
+      ensureActorScopedHistory: async () => {},
     } as unknown as import("../daemon/session.js").Session;
     pendingInteractions.register("req-cb-test", {
       session: mockSession,

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -123,6 +123,7 @@ function registerPendingInteraction(
   const handleConfirmationResponse = mock(() => {});
   const mockSession = {
     handleConfirmationResponse,
+    ensureActorScopedHistory: async () => {},
   } as unknown as Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -129,6 +129,7 @@ function registerPendingToolApprovalInteraction(
   const handleConfirmationResponse = mock(() => {});
   const mockSession = {
     handleConfirmationResponse,
+    ensureActorScopedHistory: async () => {},
   } as unknown as import("../daemon/session.js").Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -82,6 +82,7 @@ function makeStreamingSession(events: ServerMessage[]): Session {
       }
     },
     handleConfirmationResponse: () => {},
+    ensureActorScopedHistory: async () => {},
     abort: () => {},
   } as unknown as Session;
 }
@@ -215,6 +216,7 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
+      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },
@@ -266,6 +268,7 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
+      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },
@@ -664,6 +667,7 @@ describe("voice-session-bridge", () => {
       ) => {
         handleConfirmationCalls.push({ requestId, decision, decisionContext });
       },
+      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -737,6 +741,7 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
+      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -804,6 +809,7 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
+      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -869,6 +875,7 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
+      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -942,6 +949,7 @@ describe("voice-session-bridge", () => {
       ) => {
         handleSecretCalls.push({ requestId, value, delivery });
       },
+      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -1001,6 +1009,7 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
+      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },


### PR DESCRIPTION
Devin flagged that several other test files with session mocks also need ensureActorScopedHistory to prevent runtime failures if code paths call this method. Adds the mock to all remaining test files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
