### PR TITLE
fix: add ensureActorScopedHistory to remaining session test mocks

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -151,6 +151,7 @@ function registerPendingInteraction(
   const handleConfirmationResponse = mock(() => {});
   const mockSession = {
     handleConfirmationResponse,
+    ensureActorScopedHistory: async () => {},
   } as unknown as Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -85,6 +85,7 @@ function registerPendingConfirmation(
 ): void {
   const mockSession = {
     handleConfirmationResponse: mock(() => {}),
+    ensureActorScopedHistory: async () => {},
   } as unknown as Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -123,6 +123,7 @@ function registerPendingInteraction(
   const handleConfirmationResponse = mock(() => {});
   const mockSession = {
     handleConfirmationResponse,
+    ensureActorScopedHistory: async () => {},
   } as unknown as Session;
 
   pendingInteractions.register(requestId, {

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -72,6 +72,7 @@ function makeStreamingSession(events: ServerMessage[]): Session {
     setTurnChannelContext: () => {},
     setVoiceCallControlPrompt: () => {},
     updateClient: () => {},
+    ensureActorScopedHistory: async () => {},
     runAgentLoop: async (
       _content: string,
       _messageId: string,
@@ -211,6 +212,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         await new Promise((r) => setTimeout(r, 200));
       },
@@ -262,6 +264,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         await new Promise((r) => setTimeout(r, 200));
       },
@@ -639,6 +642,7 @@ describe("voice-session-bridge", () => {
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
       },
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         // Simulate the prompter emitting a confirmation_request via the
         // updateClient callback (this is how the real prompter works).
@@ -723,6 +727,7 @@ describe("voice-session-bridge", () => {
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
       },
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         clientHandler({
           type: "confirmation_request",
@@ -790,6 +795,7 @@ describe("voice-session-bridge", () => {
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
       },
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         clientHandler({
           type: "confirmation_request",
@@ -853,6 +859,7 @@ describe("voice-session-bridge", () => {
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
       },
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         clientHandler({
           type: "confirmation_request",
@@ -925,6 +932,7 @@ describe("voice-session-bridge", () => {
       updateClient: (handler: (msg: ServerMessage) => void) => {
         clientHandler = handler;
       },
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         clientHandler({
           type: "secret_request",
@@ -997,6 +1005,7 @@ describe("voice-session-bridge", () => {
       setTurnChannelContext: () => {},
       setVoiceCallControlPrompt: () => {},
       updateClient: () => {},
+      ensureActorScopedHistory: async () => {},
       runAgentLoop: async () => {
         await new Promise((r) => setTimeout(r, 200));
       },


### PR DESCRIPTION
Devin flagged that several test files with `as unknown as Session` mocks were missing the `ensureActorScopedHistory` method added in #15079. Adds the mock to voice-session-bridge, channel-approvals, guardian-grant-minting, and channel-approval-routes test files to prevent runtime failures if code paths call this method.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
