### PR TITLE
fix: resolve lint errors - import sort and unused variable

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -34,7 +34,6 @@ import * as externalConversationStore from "../../memory/external-conversation-s
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { truncate } from "../../util/truncate.js";
-import type { HostBashResponse } from "../message-types/host-bash.js";
 import type {
   CancelRequest,
   ConfirmationResponse,
@@ -50,6 +49,7 @@ import type {
   UsageRequest,
 } from "../message-protocol.js";
 import { normalizeThreadType } from "../message-protocol.js";
+import type { HostBashResponse } from "../message-types/host-bash.js";
 import type { Session } from "../session.js";
 import {
   buildSessionErrorMessage,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -95,7 +95,6 @@ import { appManagementRouteDefinitions } from "./routes/app-management-routes.js
 import { handleServePage } from "./routes/app-routes.js";
 import { appRouteDefinitions } from "./routes/app-routes.js";
 import { approvalRouteDefinitions } from "./routes/approval-routes.js";
-import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
 import { callRouteDefinitions } from "./routes/call-routes.js";
@@ -125,6 +124,7 @@ import { globalSearchRouteDefinitions } from "./routes/global-search-routes.js";
 import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.js";
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
+import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -4,14 +4,11 @@
  * Resolves pending host bash proxy requests by requestId when the desktop
  * client returns execution results via HTTP.
  */
-import { getLogger } from "../../util/logger.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import * as pendingInteractions from "../pending-interactions.js";
-
-const log = getLogger("host-bash-routes");
 
 /**
  * POST /v1/host-bash-result — resolve a pending host bash request by requestId.


### PR DESCRIPTION
## Summary
- Fix import sort order in `sessions.ts` and `http-server.ts` (`simple-import-sort/imports` rule)
- Remove unused `log` variable and `getLogger` import from `host-bash-routes.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22931320173/job/66553310340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
