### PR TITLE
Connect host_bash tool to HostBashProxy for client-side execution

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -69,7 +69,7 @@ mock.module("../tools/terminal/sandbox.js", () => ({
 }));
 
 import { hostShellTool } from "../tools/host-terminal/host-shell.js";
-import type { ToolContext } from "../tools/types.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 
 const testDirs: string[] = [];
 
@@ -685,5 +685,151 @@ describe("host_bash — spawn error handling", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("<command_completed />");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HostBashProxy delegation
+// ---------------------------------------------------------------------------
+
+describe("host_bash — proxy delegation", () => {
+  function makeMockProxy(result: ToolExecutionResult) {
+    const calls: Array<{
+      input: { command: string; working_dir?: string; timeout_seconds?: number };
+      sessionId: string;
+    }> = [];
+
+    return {
+      proxy: {
+        isAvailable: () => true,
+        request: async (
+          input: { command: string; working_dir?: string; timeout_seconds?: number },
+          sessionId: string,
+          _signal?: AbortSignal,
+        ) => {
+          calls.push({ input, sessionId });
+          return result;
+        },
+        updateSender: () => {},
+        dispose: () => {},
+        resolve: () => {},
+        hasPendingRequest: () => false,
+      },
+      calls,
+    };
+  }
+
+  test("delegates to proxy when hostBashProxy is available", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxied output",
+      isError: false,
+    };
+    const { proxy, calls } = makeMockProxy(proxyResult);
+
+    const ctx: ToolContext = {
+      ...makeContext(),
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    };
+
+    spawnCalls.length = 0;
+    const result = await hostShellTool.execute(
+      { command: "echo hello", working_dir: "/tmp", timeout_seconds: 30 },
+      ctx,
+    );
+
+    expect(result).toBe(proxyResult);
+    expect(calls.length).toBe(1);
+    expect(calls[0].input.command).toBe("echo hello");
+    expect(calls[0].input.working_dir).toBe("/tmp");
+    expect(calls[0].input.timeout_seconds).toBe(30);
+    expect(calls[0].sessionId).toBe("test-session");
+    // Should NOT have spawned a local process
+    expect(spawnCalls.length).toBe(0);
+  });
+
+  test("still validates input before proxying (null bytes in command)", async () => {
+    const proxyResult: ToolExecutionResult = { content: "proxied", isError: false };
+    const { proxy, calls } = makeMockProxy(proxyResult);
+
+    const ctx: ToolContext = {
+      ...makeContext(),
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    };
+
+    const result = await hostShellTool.execute(
+      { command: "echo \0evil" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("null bytes");
+    // Proxy should NOT have been called
+    expect(calls.length).toBe(0);
+  });
+
+  test("still validates input before proxying (relative working_dir)", async () => {
+    const proxyResult: ToolExecutionResult = { content: "proxied", isError: false };
+    const { proxy, calls } = makeMockProxy(proxyResult);
+
+    const ctx: ToolContext = {
+      ...makeContext(),
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    };
+
+    const result = await hostShellTool.execute(
+      { command: "echo test", working_dir: "relative/path" },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("working_dir must be absolute");
+    expect(calls.length).toBe(0);
+  });
+
+  test("falls back to local execution when proxy is not available", async () => {
+    const unavailableProxy = {
+      isAvailable: () => false,
+      request: async () => {
+        throw new Error("should not be called");
+      },
+      updateSender: () => {},
+      dispose: () => {},
+      resolve: () => {},
+      hasPendingRequest: () => false,
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), "host-shell-proxy-fallback-"));
+    testDirs.push(dir);
+
+    const ctx: ToolContext = {
+      ...makeContext(),
+      hostBashProxy: unavailableProxy as unknown as ToolContext["hostBashProxy"],
+    };
+
+    spawnCalls.length = 0;
+    const result = await hostShellTool.execute(
+      { command: "echo local-fallback", working_dir: dir },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe("local-fallback");
+    // Should have spawned locally
+    expect(spawnCalls.length).toBe(1);
+  });
+
+  test("falls back to local execution when no proxy is set", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "host-shell-no-proxy-"));
+    testDirs.push(dir);
+
+    spawnCalls.length = 0;
+    const result = await hostShellTool.execute(
+      { command: "echo no-proxy", working_dir: dir },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content.trim()).toBe("no-proxy");
+    expect(spawnCalls.length).toBe(1);
   });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -100,6 +100,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   trustContext?: TrustContext;
   /** Voice/call session ID, if the session originates from a call. Propagated into ToolContext for scoped grant consumption. */
   callSessionId?: string;
+  /** Optional proxy for delegating host_bash execution to a connected client. */
+  hostBashProxy?: import("./host-bash-proxy.js").HostBashProxy;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -178,6 +180,7 @@ export function createToolExecutor(
       memoryScopeId: ctx.memoryPolicy.scopeId,
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       toolUseId,
+      hostBashProxy: ctx.hostBashProxy,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -46,7 +46,7 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
-import type { HostBashProxy } from "./host-bash-proxy.js";
+import { HostBashProxy } from "./host-bash-proxy.js";
 import type {
   ServerMessage,
   SurfaceData,
@@ -270,6 +270,7 @@ export class Session {
       }
     });
     this.secretPrompter = new SecretPrompter(sendToClient);
+    this.hostBashProxy = new HostBashProxy(sendToClient);
 
     // Register watch/call notifiers (reads ctx properties lazily)
     registerSessionNotifiers(conversationId, this);
@@ -373,6 +374,7 @@ export class Session {
     this.prompter.updateSender(sendToClient);
     this.secretPrompter.updateSender(sendToClient);
     this.traceEmitter.updateSender(sendToClient);
+    this.hostBashProxy?.updateSender(sendToClient);
   }
 
   /** Returns the current sendToClient reference for identity comparison. */
@@ -415,6 +417,7 @@ export class Session {
 
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
+    this.hostBashProxy?.dispose();
     disposeSession(this);
   }
 

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -101,6 +101,20 @@ class HostShellTool implements Tool {
         isError: true,
       };
     }
+    // Proxy to connected client for execution on the user's machine
+    // when a capable client is available (managed/cloud-hosted mode).
+    if (context.hostBashProxy?.isAvailable()) {
+      return context.hostBashProxy.request(
+        {
+          command,
+          working_dir: rawWorkingDir as string | undefined,
+          timeout_seconds: input.timeout_seconds as number | undefined,
+        },
+        context.sessionId,
+        context.signal,
+      );
+    }
+
     const workingDir =
       typeof rawWorkingDir === "string" ? rawWorkingDir : homedir();
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -169,6 +169,8 @@ export interface ToolContext {
   channelPermissionChannelId?: string;
   /** The tool_use block ID from the LLM response, used to correlate confirmation prompts with specific tool invocations. */
   toolUseId?: string;
+  /** Optional proxy for delegating host_bash execution to a connected client (managed/cloud-hosted mode). */
+  hostBashProxy?: import("../daemon/host-bash-proxy.js").HostBashProxy;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Add `hostBashProxy` to `ToolContext` interface for proxy-capable sessions
- Modify `host_bash` tool to delegate to proxy when available, falling back to local execution
- Wire `HostBashProxy` instantiation in Session constructor and through session-tool-setup
- Ensure sender updates on reconnection alongside PermissionPrompter

Part of plan: host-bash-proxy.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
