### PR TITLE
feat: add /btw to macOS slash command popup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -18,6 +18,7 @@ struct SlashCommand: Identifiable {
         SlashCommand(name: "model", description: "Switch the active model", icon: "cpu"),
         SlashCommand(name: "models", description: "List all available models", icon: "list.bullet"),
         SlashCommand(name: "status", description: "Show session status and context usage", icon: "info.circle"),
+        SlashCommand(name: "btw", description: "Ask a side question while the assistant is working", icon: "bubble.left.and.text.bubble.right"),
     ]
 }
 
@@ -85,8 +86,13 @@ extension ComposerView {
     func selectSlashCommand(_ command: SlashCommand) {
         withAnimation(VAnimation.fast) { showSlashMenu = false }
         slashSelectedIndex = 0
-        inputText = "/\(command.name)"
-        onSend()
+        if command.name == "btw" {
+            inputText = "/\(command.name) "
+            // Don't auto-send — user needs to type the question
+        } else {
+            inputText = "/\(command.name)"
+            onSend()
+        }
     }
 
     func handleSlashNavigation(_ action: SlashNavigation) {


### PR DESCRIPTION
## Summary
- Add `/btw` entry to macOS slash command list with description and icon
- Special-case selection to fill input with `/btw ` (trailing space) without auto-sending

Part of plan: btw-side-chain.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
