### PR TITLE
feat: keep CLI input enabled during busy state, queue messages

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1265,7 +1265,6 @@ function ChatApp({
 
   const showSpinner = useCallback((text: string) => {
     setSpinnerText(text);
-    setInputFocused(false);
   }, []);
 
   const hideSpinner = useCallback(() => {
@@ -1723,6 +1722,43 @@ function ChatApp({
           const errorMsg = `Doctor assistant unreachable: ${err instanceof Error ? err.message : err}`;
           h.showError(errorMsg);
           chatLogRef.current.push({ role: "error", content: errorMsg });
+        }
+        return;
+      }
+
+      if (busyRef.current) {
+        if (trimmed.startsWith("/btw ")) {
+          // Handled below by /btw command handler (added in a later PR)
+        } else {
+          const isConnected = await ensureConnected();
+          if (!isConnected) return;
+          try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(
+              () => controller.abort(),
+              SEND_TIMEOUT_MS,
+            );
+            const sendResult = await sendMessage(
+              runtimeUrl,
+              assistantId,
+              trimmed,
+              controller.signal,
+              bearerToken,
+            );
+            clearTimeout(timeoutId);
+            if (sendResult.accepted) {
+              h.addStatus(
+                "Message queued — will be processed after current response",
+                "gray",
+              );
+            } else {
+              h.showError("Message was not accepted by the assistant");
+            }
+          } catch (err) {
+            h.showError(
+              `Failed to queue message: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Remove `setInputFocused(false)` from `showSpinner` so users can type while assistant is working
- Add busy-state guard in `handleInput` that queues regular messages via POST /v1/messages
- `/btw` prefix falls through for future handler (PR 4)

Part of plan: btw-side-chain.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
