### PR TITLE
fix: remove duplicate ensureActorScopedHistory keys in voice-session-bridge tests

### DIFF
--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -83,7 +83,6 @@ function makeStreamingSession(events: ServerMessage[]): Session {
       }
     },
     handleConfirmationResponse: () => {},
-    ensureActorScopedHistory: async () => {},
     abort: () => {},
   } as unknown as Session;
 }
@@ -218,7 +217,6 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
-      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },
@@ -271,7 +269,6 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
-      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },
@@ -671,7 +668,6 @@ describe("voice-session-bridge", () => {
       ) => {
         handleConfirmationCalls.push({ requestId, decision, decisionContext });
       },
-      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -746,7 +742,6 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
-      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -815,7 +810,6 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
-      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -882,7 +876,6 @@ describe("voice-session-bridge", () => {
       handleConfirmationResponse: (requestId: string, decision: string) => {
         handleConfirmationCalls.push({ requestId, decision });
       },
-      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -957,7 +950,6 @@ describe("voice-session-bridge", () => {
       ) => {
         handleSecretCalls.push({ requestId, value, delivery });
       },
-      ensureActorScopedHistory: async () => {},
       abort: () => {},
     } as unknown as Session;
 
@@ -1018,7 +1010,6 @@ describe("voice-session-bridge", () => {
         await new Promise((r) => setTimeout(r, 200));
       },
       handleConfirmationResponse: () => {},
-      ensureActorScopedHistory: async () => {},
       abort: () => {
         abortCalled = true;
       },


### PR DESCRIPTION
## Summary

- Removes 9 duplicate `ensureActorScopedHistory` property definitions across multiple object literals in `voice-session-bridge.test.ts`
- Each test session mock had the property defined twice (once before `runAgentLoop`, once after `handleConfirmationResponse`), causing TS1117 errors in the Type Check CI job

## Original prompt

Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22931492616/job/66553831512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
