### PR TITLE
feat: parse skill metadata as YAML instead of JSON

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -36,6 +36,7 @@
         "tree-sitter-bash": "0.25.1",
         "uuid": "^11.1.0",
         "web-tree-sitter": "0.26.5",
+        "yaml": "^2.7.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -53,6 +53,7 @@
     "tree-sitter-bash": "0.25.1",
     "uuid": "^11.1.0",
     "web-tree-sitter": "0.26.5",
+    "yaml": "^2.7.1",
     "zod": "^4.3.6"
   },
   "engines": {

--- a/assistant/src/__tests__/frontmatter.test.ts
+++ b/assistant/src/__tests__/frontmatter.test.ts
@@ -74,15 +74,6 @@ describe("parseFrontmatterFields", () => {
     expect(result).not.toBeNull();
     expect(result!.fields.name).toBe("Test");
     expect(result!.fields.description).toBe("Desc");
-    expect(Object.keys(result!.fields)).toHaveLength(2);
-  });
-
-  test("skips lines without a colon separator", () => {
-    const input = '---\nname: "Test"\nno-colon-here\n---\nBody';
-    const result = parseFrontmatterFields(input);
-    expect(result).not.toBeNull();
-    expect(Object.keys(result!.fields)).toHaveLength(1);
-    expect(result!.fields.name).toBe("Test");
   });
 
   // -- Escape sequence handling (double-quoted) --
@@ -110,8 +101,6 @@ describe("parseFrontmatterFields", () => {
   });
 
   test("handles \\\\n correctly (escaped backslash followed by n, not newline)", () => {
-    // \\n in the source → the regex sees \\n → should produce \ followed by n (literal)
-    // The single-pass regex handles: \\ → \ and the trailing n is not part of an escape
     const result = parseFrontmatterFields('---\npath: "back\\\\name"\n---\n');
     expect(result!.fields.path).toBe("back\\name");
   });
@@ -164,17 +153,6 @@ describe("parseFrontmatterFields", () => {
 
   // -- Edge cases with quoting --
 
-  test("value that starts with quote but does not end with matching quote is treated as unquoted", () => {
-    // "hello world (no closing quote) — should be treated as the raw value
-    const result = parseFrontmatterFields('---\nname: "hello world\n---\n');
-    expect(result!.fields.name).toBe('"hello world');
-  });
-
-  test("mismatched quotes (double-start, single-end) treated as unquoted", () => {
-    const result = parseFrontmatterFields("---\nname: \"hello'\n---\n");
-    expect(result!.fields.name).toBe("\"hello'");
-  });
-
   test("empty double-quoted value", () => {
     const result = parseFrontmatterFields('---\nname: ""\n---\n');
     expect(result!.fields.name).toBe("");
@@ -190,26 +168,26 @@ describe("parseFrontmatterFields", () => {
     expect(result!.fields.name).toBe("  spaced  ");
   });
 
-  test("value with only whitespace (no quotes) is trimmed", () => {
-    const result = parseFrontmatterFields("---\nname:    \n---\n");
-    expect(result!.fields.name).toBe("");
+  // -- YAML array values --
+
+  test("YAML inline array is parsed as a native array", () => {
+    const result = parseFrontmatterFields("---\nincludes: [a, b]\n---\n");
+    expect(result!.fields.includes).toEqual(["a", "b"]);
   });
 
-  // -- JSON array values --
-
-  test("JSON array value is preserved as raw string", () => {
+  test("JSON-style array value is parsed as a native array", () => {
     const result = parseFrontmatterFields('---\nincludes: ["a","b"]\n---\n');
-    expect(result!.fields.includes).toBe('["a","b"]');
+    expect(result!.fields.includes).toEqual(["a", "b"]);
   });
 
   // -- Boolean-like values --
 
-  test("boolean-like values are preserved as strings", () => {
+  test("boolean values are parsed as native booleans", () => {
     const result = parseFrontmatterFields(
       "---\nuser-invocable: false\ndisable-model-invocation: true\n---\n",
     );
-    expect(result!.fields["user-invocable"]).toBe("false");
-    expect(result!.fields["disable-model-invocation"]).toBe("true");
+    expect(result!.fields["user-invocable"]).toBe(false);
+    expect(result!.fields["disable-model-invocation"]).toBe(true);
   });
 
   // -- CRLF handling --
@@ -226,9 +204,74 @@ describe("parseFrontmatterFields", () => {
   // -- Multiple escape sequences in one value --
 
   test("handles multiple escape sequences in a single double-quoted value", () => {
-    // File content between quotes: a\nb\rc\\
-    // After unescape: a<newline>b<cr>c<backslash>
     const result = parseFrontmatterFields('---\ndesc: "a\\nb\\rc\\\\"\n---\n');
     expect(result!.fields.desc).toBe("a\nb\rc\\");
+  });
+
+  // -- YAML nested metadata parsing --
+
+  test("parses YAML nested metadata as proper object", () => {
+    const input = [
+      "---",
+      'name: "Test"',
+      'description: "A test skill"',
+      "metadata:",
+      '  emoji: "\uD83D\uDD0C"',
+      "  vellum:",
+      '    display-name: "Test Skill"',
+      "    user-invocable: false",
+      "---",
+      "Body",
+    ].join("\n");
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(result!.fields.name).toBe("Test");
+    expect(result!.fields.metadata).toEqual({
+      emoji: "\uD83D\uDD0C",
+      vellum: {
+        "display-name": "Test Skill",
+        "user-invocable": false,
+      },
+    });
+  });
+
+  test("parses YAML metadata with arrays and nested objects", () => {
+    const input = [
+      "---",
+      'name: "Test"',
+      'description: "A test skill"',
+      "metadata:",
+      "  vellum:",
+      "    os:",
+      "      - darwin",
+      "      - linux",
+      "    requires:",
+      "      bins:",
+      "        - node",
+      "        - npm",
+      "---",
+      "Body",
+    ].join("\n");
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    const meta = result!.fields.metadata as Record<string, unknown>;
+    const vellum = meta.vellum as Record<string, unknown>;
+    expect(vellum.os).toEqual(["darwin", "linux"]);
+    expect(vellum.requires).toEqual({ bins: ["node", "npm"] });
+  });
+
+  test("returns null for invalid YAML frontmatter", () => {
+    // Tabs are invalid in YAML indentation — should return null
+    const input = "---\nname: valid\nbad:\n\t- indentation\n---\nBody";
+    const result = parseFrontmatterFields(input);
+    expect(result).toBeNull();
+  });
+
+  test("handles empty frontmatter block", () => {
+    const input = "---\n\n---\nBody";
+    const result = parseFrontmatterFields(input);
+    expect(result).not.toBeNull();
+    expect(result!.fields).toEqual({});
+    expect(result!.body).toBe("Body");
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration test: end-to-end frontmatter parsing → feature flag resolution.
  *
- * Creates a SKILL.md with a `"feature-flag"` field in its metadata JSON,
+ * Creates a SKILL.md with a `feature-flag` field in its YAML metadata,
  * parses it via the real frontmatter parser, and verifies that `skillFlagKey()`
  * returns the correct key and `resolveSkillStates()` correctly gates the skill.
  */
@@ -17,11 +17,13 @@ import { parseFrontmatterFields } from "../skills/frontmatter.js";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-/** A SKILL.md with `"feature-flag": "contacts"` declared in its vellum metadata. */
+/** A SKILL.md with `feature-flag: contacts` declared in its vellum metadata. */
 const SKILL_MD_WITH_FLAG = `---
 name: "Contacts"
 description: "View and manage contacts"
-metadata: {"vellum": {"feature-flag": "contacts"}}
+metadata:
+  vellum:
+    feature-flag: contacts
 ---
 
 Instructions for the contacts skill.
@@ -31,7 +33,8 @@ Instructions for the contacts skill.
 const SKILL_MD_WITHOUT_FLAG = `---
 name: "Plain Skill"
 description: "A skill with no feature flag"
-metadata: {"vellum": {}}
+metadata:
+  vellum: {}
 ---
 
 Instructions for the plain skill.
@@ -75,25 +78,23 @@ function buildSkillSummary(
   const parsed = parseFrontmatterFields(skillMd);
   if (!parsed) return null;
 
-  const metadataRaw = parsed.fields.metadata?.trim();
   let featureFlag: string | undefined;
-  if (metadataRaw) {
-    try {
-      const json = JSON.parse(metadataRaw);
-      featureFlag =
-        typeof json?.vellum?.["feature-flag"] === "string"
-          ? json.vellum["feature-flag"]
-          : undefined;
-    } catch {
-      // ignore parse errors
-    }
+  const metadataObj = parsed.fields.metadata;
+  if (metadataObj != null && typeof metadataObj === "object") {
+    const vellum = (metadataObj as Record<string, unknown>).vellum as
+      | Record<string, unknown>
+      | undefined;
+    featureFlag =
+      typeof vellum?.["feature-flag"] === "string"
+        ? vellum["feature-flag"]
+        : undefined;
   }
 
   return {
     id,
-    name: parsed.fields.name ?? id,
-    displayName: parsed.fields.name ?? id,
-    description: parsed.fields.description ?? "",
+    name: (parsed.fields.name as string) ?? id,
+    displayName: (parsed.fields.name as string) ?? id,
+    description: (parsed.fields.description as string) ?? "",
     directoryPath: `/fake/skills/${id}`,
     skillFilePath: `/fake/skills/${id}/SKILL.md`,
     bundled: source === "bundled",
@@ -109,15 +110,15 @@ function buildSkillSummary(
 // ---------------------------------------------------------------------------
 
 describe("frontmatter feature-flag integration", () => {
-  test("parses feature-flag from frontmatter metadata JSON", () => {
+  test("parses feature-flag from frontmatter YAML metadata", () => {
     const parsed = parseFrontmatterFields(SKILL_MD_WITH_FLAG);
     expect(parsed).not.toBeNull();
 
-    const metadataRaw = parsed!.fields.metadata?.trim();
-    expect(metadataRaw).toBeTruthy();
+    const metadataObj = parsed!.fields.metadata as Record<string, unknown>;
+    expect(metadataObj).toBeTruthy();
 
-    const json = JSON.parse(metadataRaw!);
-    expect(json.vellum["feature-flag"]).toBe("contacts");
+    const vellum = metadataObj.vellum as Record<string, unknown>;
+    expect(vellum["feature-flag"]).toBe("contacts");
   });
 
   test("skillFlagKey returns correct key for parsed skill", () => {
@@ -179,8 +180,9 @@ describe("frontmatter feature-flag integration", () => {
     // Step 1: Parse SKILL.md with feature-flag in metadata
     const parsed = parseFrontmatterFields(SKILL_MD_WITH_FLAG);
     expect(parsed).not.toBeNull();
-    const json = JSON.parse(parsed!.fields.metadata!);
-    const flagId = json.vellum["feature-flag"];
+    const metadataObj = parsed!.fields.metadata as Record<string, unknown>;
+    const vellum = metadataObj.vellum as Record<string, unknown>;
+    const flagId = vellum["feature-flag"];
     expect(flagId).toBe("contacts");
 
     // Step 2: Build SkillSummary (as the catalog loader would)

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -348,8 +348,11 @@ function parseFrontmatter(
 
   const { fields, body } = result;
 
-  const name = fields.name?.trim();
-  const description = fields.description?.trim();
+  const name = typeof fields.name === "string" ? fields.name.trim() : undefined;
+  const description =
+    typeof fields.description === "string"
+      ? fields.description.trim()
+      : undefined;
   if (!name || !description) {
     log.warn(
       { skillFilePath },
@@ -358,25 +361,31 @@ function parseFrontmatter(
     return null;
   }
 
-  // Parse metadata as single-line JSON string, validate with Zod schema
+  // metadata is already a parsed object from YAML — validate with Zod schema
   let metadata: VellumMetadata | undefined;
   let parsedMeta: z.infer<typeof SkillMetadataSchema> | undefined;
   let vellum: z.infer<typeof VellumMetadataSchema> | undefined;
 
-  const metadataRaw = fields.metadata?.trim();
-  if (metadataRaw) {
-    try {
-      const json = JSON.parse(metadataRaw);
-      const result = SkillMetadataSchema.safeParse(json);
-      if (result.success) {
-        parsedMeta = result.data;
+  const metadataRaw = fields.metadata;
+  if (metadataRaw != null) {
+    if (typeof metadataRaw === "string") {
+      // metadata is a string — this means someone wrote inline JSON or a
+      // bare string value. YAML metadata must be a nested object.
+      log.warn(
+        { skillFilePath },
+        "Metadata must be a YAML object, not a string; ignoring metadata field",
+      );
+    } else if (typeof metadataRaw === "object") {
+      const zodResult = SkillMetadataSchema.safeParse(metadataRaw);
+      if (zodResult.success) {
+        parsedMeta = zodResult.data;
         vellum = parsedMeta.vellum;
         if (parsedMeta.vellum) {
           metadata = parsedMeta.vellum as VellumMetadata;
         }
         // Inject top-level emoji into metadata when metadata.vellum doesn't
         // carry its own emoji. The Agent Skills spec places emoji at the
-        // top level of the metadata JSON, so bundled skills that follow
+        // top level of the metadata object, so bundled skills that follow
         // this convention would otherwise lose their emoji value.
         if (parsedMeta.emoji) {
           if (metadata && !metadata.emoji) {
@@ -386,27 +395,30 @@ function parseFrontmatter(
           }
         }
       } else {
-        // Zod validation failed — fall back to raw JSON so we don't lose
-        // all metadata because of a single bad field value.  We coerce
+        // Zod validation failed — fall back to raw parsed object so we don't
+        // lose all metadata because of a single bad field value.  We coerce
         // critical array fields so downstream code that iterates them
         // (e.g. `.join()`, `for...of`, `.some()`) won't crash.
         log.warn(
-          { err: result.error, skillFilePath },
-          "Metadata failed schema validation; falling back to raw JSON",
+          { err: zodResult.error, skillFilePath },
+          "Metadata failed schema validation; falling back to raw object",
         );
-        parsedMeta = json;
-        vellum = json?.vellum;
-        if (json?.vellum && typeof json.vellum === "object") {
-          const raw = json.vellum as Record<string, unknown>;
+        const raw = metadataRaw as Record<string, unknown>;
+        parsedMeta = raw as z.infer<typeof SkillMetadataSchema>;
+        vellum = raw?.vellum as z.infer<typeof VellumMetadataSchema>;
+        if (raw?.vellum && typeof raw.vellum === "object") {
+          const vellumRaw = raw.vellum as Record<string, unknown>;
 
           // Coerce `os` to string[] — a bare string is wrapped in an array.
-          if (raw.os !== undefined) {
-            raw.os = Array.isArray(raw.os) ? raw.os : [raw.os];
+          if (vellumRaw.os !== undefined) {
+            vellumRaw.os = Array.isArray(vellumRaw.os)
+              ? vellumRaw.os
+              : [vellumRaw.os];
           }
 
           // Coerce `requires` sub-fields to arrays.
-          if (raw.requires && typeof raw.requires === "object") {
-            const req = raw.requires as Record<string, unknown>;
+          if (vellumRaw.requires && typeof vellumRaw.requires === "object") {
+            const req = vellumRaw.requires as Record<string, unknown>;
             for (const key of ["bins", "anyBins", "env", "config"] as const) {
               if (req[key] !== undefined && !Array.isArray(req[key])) {
                 req[key] = typeof req[key] === "string" ? [req[key]] : [];
@@ -414,14 +426,9 @@ function parseFrontmatter(
             }
           }
 
-          metadata = raw as unknown as VellumMetadata;
+          metadata = vellumRaw as unknown as VellumMetadata;
         }
       }
-    } catch (err) {
-      log.warn(
-        { err, skillFilePath },
-        "Failed to parse metadata JSON in frontmatter",
-      );
     }
   }
 

--- a/assistant/src/skills/frontmatter.ts
+++ b/assistant/src/skills/frontmatter.ts
@@ -1,17 +1,23 @@
 /**
  * Shared frontmatter parsing for SKILL.md files.
  *
- * Frontmatter is a YAML-like block delimited by `---` at the top of a file.
+ * Frontmatter is a YAML block delimited by `---` at the top of a file.
  * This module provides a single implementation used by the skill catalog loader
  * and the CC command registry.
  */
+
+import { parse as parseYaml } from "yaml";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("frontmatter");
 
 /** Matches a `---` delimited frontmatter block at the start of a file. */
 export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 export interface FrontmatterParseResult {
   /** Key-value pairs extracted from the frontmatter block. */
-  fields: Record<string, string>;
+  fields: Record<string, unknown>;
   /** The remaining file content after the frontmatter block. */
   body: string;
 }
@@ -20,8 +26,8 @@ export interface FrontmatterParseResult {
  * Parse frontmatter fields from file content.
  *
  * Extracts key-value pairs from the `---` delimited block at the top of the
- * file. Handles single- and double-quoted values, and unescapes common escape
- * sequences (`\n`, `\r`, `\\`, `\"`) in double-quoted values.
+ * file using a proper YAML parser. Handles nested objects, arrays, quoted
+ * strings, escape sequences, and all YAML features natively.
  *
  * Returns `null` if no frontmatter block is found.
  */
@@ -32,80 +38,16 @@ export function parseFrontmatterFields(
   if (!match) return null;
 
   const frontmatter = match[1];
-  const fields: Record<string, string> = {};
+  const body = content.slice(match[0].length);
 
-  const lines = frontmatter.split(/\r?\n/);
-  let currentKey: string | undefined;
-  let continuationLines: string[] = [];
-
-  function flushContinuation() {
-    if (currentKey !== undefined) {
-      if (continuationLines.length > 0) {
-        const joined = continuationLines.map((l) => l.trim()).join(" ");
-        // Try parsing as-is first to avoid corrupting commas inside quoted strings.
-        // Only apply trailing-comma cleanup if the raw text isn't valid JSON.
-        try {
-          JSON.parse(joined);
-          fields[currentKey] = joined;
-        } catch {
-          fields[currentKey] = joined.replace(/,\s*([}\]])/g, "$1");
-        }
-      } else {
-        fields[currentKey] = "";
-      }
+  try {
+    const parsed = parseYaml(frontmatter);
+    if (parsed == null || typeof parsed !== "object") {
+      return { fields: {}, body };
     }
-    currentKey = undefined;
-    continuationLines = [];
+    return { fields: parsed as Record<string, unknown>, body };
+  } catch (err) {
+    log.warn({ err }, "Failed to parse YAML frontmatter");
+    return null;
   }
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-
-    // Continuation line: indented and no top-level key: pattern
-    // (i.e. starts with whitespace and either has no colon or the colon
-    // is inside braces/quotes — heuristic: line starts with space/tab)
-    if (currentKey !== undefined && /^\s/.test(line)) {
-      continuationLines.push(trimmed);
-      continue;
-    }
-
-    // Flush any pending multiline value
-    flushContinuation();
-
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex === -1) continue;
-
-    const key = trimmed.slice(0, separatorIndex).trim();
-    let value = trimmed.slice(separatorIndex + 1).trim();
-
-    if (!value) {
-      // Value may continue on subsequent indented lines
-      currentKey = key;
-      continuationLines = [];
-      continue;
-    }
-
-    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
-    const isSingleQuoted = value.startsWith("'") && value.endsWith("'");
-    if (isDoubleQuoted || isSingleQuoted) {
-      value = value.slice(1, -1);
-      if (isDoubleQuoted) {
-        // Unescape sequences produced by buildSkillMarkdown's esc().
-        // Only for double-quoted values — single-quoted YAML treats backslashes literally.
-        // Single-pass to avoid misinterpreting \\n (escaped backslash + n) as a newline.
-        value = value.replace(/\\(["\\nr])/g, (_, ch) => {
-          if (ch === "n") return "\n";
-          if (ch === "r") return "\r";
-          return ch; // handles \\ → \ and \" → "
-        });
-      }
-    }
-    fields[key] = value;
-  }
-
-  // Flush any trailing multiline value
-  flushContinuation();
-
-  return { fields, body: content.slice(match[0].length) };
 }


### PR DESCRIPTION
## Summary
- Replace custom line-by-line frontmatter parser with proper YAML parser (yaml package)
- Update metadata parsing in skills.ts to consume parsed YAML objects directly instead of JSON.parse
- Update frontmatter tests for YAML-native types (booleans, arrays, nested objects)

Part of plan: yaml-skill-metadata.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
