### PR TITLE
feat: add POST /v1/btw SSE-streaming side-chain endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -97,6 +97,7 @@ import { appRouteDefinitions } from "./routes/app-routes.js";
 import { approvalRouteDefinitions } from "./routes/approval-routes.js";
 import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
+import { btwRouteDefinitions } from "./routes/btw-routes.js";
 import { callRouteDefinitions } from "./routes/call-routes.js";
 import {
   startCanonicalGuardianExpirySweep,
@@ -922,6 +923,10 @@ export class RuntimeHttpServer {
           }
         },
       },
+
+      ...btwRouteDefinitions({
+        sendMessageDeps: this.sendMessageDeps,
+      }),
 
       ...conversationRouteDefinitions({
         interfacesDir: this.interfacesDir,

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -1,0 +1,145 @@
+/**
+ * HTTP route handler for the POST /v1/btw SSE-streaming side-chain endpoint.
+ *
+ * Runs an ephemeral LLM call that reuses the session's provider, system prompt,
+ * tool definitions, and message history for prompt-cache efficiency. The response
+ * is streamed as SSE events (`btw_text_delta`, `btw_complete`, `btw_error`).
+ *
+ * No messages are persisted. `session.processing` is never set or checked.
+ */
+
+import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
+import {
+  createTimeout,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { buildToolDefinitions } from "../../daemon/session-tool-setup.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import type { SendMessageDeps } from "../http-types.js";
+import type { AuthContext } from "../auth/types.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("btw-routes");
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function handleBtw(
+  req: Request,
+  deps: { sendMessageDeps?: SendMessageDeps },
+  _authContext: AuthContext,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    conversationKey?: string;
+    content?: string;
+  };
+
+  const { conversationKey, content } = body;
+
+  if (!conversationKey) {
+    return httpError("BAD_REQUEST", "conversationKey is required", 400);
+  }
+  if (!content || typeof content !== "string") {
+    return httpError("BAD_REQUEST", "content must be a non-empty string", 400);
+  }
+
+  if (!deps.sendMessageDeps) {
+    return httpError(
+      "SERVICE_UNAVAILABLE",
+      "Message processing is not available",
+      503,
+    );
+  }
+
+  const mapping = getOrCreateConversation(conversationKey);
+  const session = await deps.sendMessageDeps.getOrCreateSession(
+    mapping.conversationId,
+  );
+
+  const messages = [...session.getMessages(), userMessage(content.trim())];
+  const tools = buildToolDefinitions();
+  const { signal: timeoutSignal, cleanup: cleanupTimeout } =
+    createTimeout(30_000);
+
+  // Combine the timeout signal with the request's abort signal so that
+  // disconnection or timeout both cancel the provider call.
+  const combinedController = new AbortController();
+  const onTimeoutAbort = () => combinedController.abort();
+  const onRequestAbort = () => combinedController.abort();
+  timeoutSignal.addEventListener("abort", onTimeoutAbort, { once: true });
+  req.signal.addEventListener("abort", onRequestAbort, { once: true });
+  const combinedSignal = combinedController.signal;
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      (async () => {
+        try {
+          await session.provider.sendMessage(messages, tools, session.systemPrompt, {
+            config: {
+              max_tokens: 1024,
+              tool_choice: { type: "none" },
+            },
+            onEvent: (event) => {
+              if (event.type === "text_delta") {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
+                  ),
+                );
+              }
+            },
+            signal: combinedSignal,
+          });
+
+          controller.enqueue(
+            encoder.encode(`event: btw_complete\ndata: {}\n\n`),
+          );
+          controller.close();
+        } catch (err: unknown) {
+          const message =
+            err instanceof Error ? err.message : "Unknown error";
+          log.error({ err }, "btw side-chain streaming error");
+          controller.enqueue(
+            encoder.encode(
+              `event: btw_error\ndata: ${JSON.stringify({ error: message })}\n\n`,
+            ),
+          );
+          controller.close();
+        } finally {
+          cleanupTimeout();
+          timeoutSignal.removeEventListener("abort", onTimeoutAbort);
+          req.signal.removeEventListener("abort", onRequestAbort);
+        }
+      })();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function btwRouteDefinitions(deps: {
+  sendMessageDeps?: SendMessageDeps;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "btw",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleBtw(req, deps, authContext),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add new `POST /v1/btw` endpoint that returns an SSE stream for ephemeral side-chain conversations
- Uses same provider, model, system prompt, and tool definitions as the main agent loop for prompt cache reuse
- Never persists messages, never touches session.processing, never publishes to event hub

Part of plan: btw-side-chain.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
