### PR TITLE
feat: emit YAML metadata in buildSkillMarkdown instead of inline JSON

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -20,6 +20,8 @@ import {
   test,
 } from "bun:test";
 
+import { parse as parseYaml } from "yaml";
+
 let TEST_DIR = "";
 
 mock.module("../util/platform.js", () => ({
@@ -104,11 +106,9 @@ describe("buildSkillMarkdown", () => {
       emoji: "🧪",
     });
     expect(result).toContain("metadata:");
-    const metadataLine = result
-      .split("\n")
-      .find((l) => l.startsWith("metadata:"));
-    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
-    expect(json.vellum.emoji).toBe("🧪");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    const parsed = parseYaml(fmMatch![1]);
+    expect(parsed.metadata.vellum.emoji).toBe("🧪");
   });
 
   test("includes user-invocable=false in metadata.vellum", () => {
@@ -118,11 +118,9 @@ describe("buildSkillMarkdown", () => {
       bodyMarkdown: "Body.",
       userInvocable: false,
     });
-    const metadataLine = result
-      .split("\n")
-      .find((l) => l.startsWith("metadata:"));
-    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
-    expect(json.vellum["user-invocable"]).toBe(false);
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    const parsed = parseYaml(fmMatch![1]);
+    expect(parsed.metadata.vellum["user-invocable"]).toBe(false);
   });
 
   test("includes disable-model-invocation in metadata.vellum", () => {
@@ -132,11 +130,9 @@ describe("buildSkillMarkdown", () => {
       bodyMarkdown: "Body.",
       disableModelInvocation: true,
     });
-    const metadataLine = result
-      .split("\n")
-      .find((l) => l.startsWith("metadata:"));
-    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
-    expect(json.vellum["disable-model-invocation"]).toBe(true);
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    const parsed = parseYaml(fmMatch![1]);
+    expect(parsed.metadata.vellum["disable-model-invocation"]).toBe(true);
   });
 
   test("escapes double quotes in name and description", () => {
@@ -201,18 +197,16 @@ describe("buildSkillMarkdown", () => {
     expect(skill!.name).toBe("path\\name");
   });
 
-  test("includes field emits JSON array in metadata.vellum", () => {
+  test("includes field emits YAML list in metadata.vellum", () => {
     const result = buildSkillMarkdown({
       name: "Parent",
       description: "Has children",
       bodyMarkdown: "Body.",
       includes: ["child-a", "child-b"],
     });
-    const metadataLine = result
-      .split("\n")
-      .find((l) => l.startsWith("metadata:"));
-    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
-    expect(json.vellum.includes).toEqual(["child-a", "child-b"]);
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    const parsed = parseYaml(fmMatch![1]);
+    expect(parsed.metadata.vellum.includes).toEqual(["child-a", "child-b"]);
   });
 
   test("omits metadata when no vellum fields provided", () => {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -9,6 +9,8 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { stringify as stringifyYaml } from "yaml";
+
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 
@@ -67,7 +69,10 @@ export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
   lines.push(`description: "${esc(input.description)}"`);
 
   // Build metadata object matching the format parseFrontmatter expects:
-  // metadata: {"vellum":{"emoji":"...","user-invocable":false,...}}
+  // metadata:
+  //   vellum:
+  //     emoji: "..."
+  //     user-invocable: false
   const vellum: Record<string, unknown> = {};
   if (input.emoji) {
     vellum.emoji = input.emoji;
@@ -84,7 +89,11 @@ export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
 
   if (Object.keys(vellum).length > 0) {
     const metadata = { vellum };
-    lines.push(`metadata: ${JSON.stringify(metadata)}`);
+    const yamlBlock = stringifyYaml(metadata, { indent: 2 });
+    lines.push("metadata:");
+    for (const yamlLine of yamlBlock.trimEnd().split("\n")) {
+      lines.push(`  ${yamlLine}`);
+    }
   }
 
   lines.push("---");


### PR DESCRIPTION
## Summary
- Update buildSkillMarkdown() to emit YAML-formatted metadata instead of inline JSON
- Update managed-store tests to parse YAML metadata instead of JSON
- Round-trip tests verify write → load → values match

Part of plan: yaml-skill-metadata.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
