### PR TITLE
feat: add streaming /btw HTTP method to macOS client

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -419,6 +419,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case hostBashResult
 
+        // BTW side-chain
+        case btw
+
         // Misc
         case channelVerificationSessions
         case registerDeviceToken
@@ -820,6 +823,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case .hostBashResult:
             return ("/v1/host-bash-result", nil)
+        // BTW side-chain
+        case .btw:
+            return ("/v1/btw", nil)
         // Misc
         case .channelVerificationSessions:
             return ("/v1/channel-verification-sessions", nil)
@@ -1204,6 +1210,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case .hostBashResult:
             return ("\(prefix)/host-bash-result/", nil)
+        // BTW side-chain
+        case .btw:
+            return ("\(prefix)/btw/", nil)
         // Misc
         case .channelVerificationSessions:
             return ("\(prefix)/channel-verification-sessions/", nil)
@@ -1642,6 +1651,69 @@ public final class HTTPTransport {
                 userMessage: error.localizedDescription,
                 retryable: true
             )))
+        }
+    }
+
+    /// Send a /btw side-chain question and stream the response text.
+    /// Returns an AsyncThrowingStream that yields text deltas from SSE btw_text_delta events.
+    func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
+        return AsyncThrowingStream { continuation in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+
+                guard let url = self.buildURL(for: .btw) else {
+                    continuation.finish(throwing: URLError(.badURL))
+                    return
+                }
+
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                request.timeoutInterval = 120
+                self.applyAuth(&request)
+
+                let body: [String: Any] = [
+                    "conversationKey": conversationKey,
+                    "content": content,
+                ]
+
+                do {
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+                    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                        throw URLError(.badServerResponse, userInfo: [
+                            NSLocalizedDescriptionKey: "HTTP \(statusCode)"
+                        ])
+                    }
+
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+
+                        if line.hasPrefix("data: ") {
+                            let jsonString = String(line.dropFirst(6))
+                            if let data = jsonString.data(using: .utf8),
+                               let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                                if let text = parsed["text"] as? String {
+                                    continuation.yield(text)
+                                }
+                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                    break
+                                }
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `sendBtwMessage()` to `HTTPTransport` that streams SSE text deltas from the `/v1/btw` endpoint
- Add `btw` case to the `Endpoint` enum with path mappings in both `buildRuntimeFlatPath` and `buildPlatformProxyPath`
- Parses `btw_text_delta` events and yields text via `AsyncThrowingStream<String, Error>`
- Handles HTTP errors (non-200 status codes) and stream completion (`btw_complete`)
- Follows existing patterns: `buildURL`, `applyAuth`, `URLSession.shared.bytes`, `[weak self]` capture

Part of plan: btw-side-chain.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
