### PR TITLE
chore: convert bundled skill metadata from inline JSON to YAML

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -2,7 +2,12 @@
 name: app-builder
 description: Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS. Use when the user says build, create, or make an app/dashboard/calculator/game.
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🏗️","vellum":{"display-name":"App Builder","includes":["frontend-design"]}}
+metadata:
+  emoji: "🏗️"
+  vellum:
+    display-name: "App Builder"
+    includes:
+      - "frontend-design"
 ---
 
 You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -2,7 +2,12 @@
 name: browser
 description: Navigate and interact with web pages using a headless browser
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🌐","vellum":{"display-name":"Browser","user-invocable":true,"feature-flag":"browser"}}
+metadata:
+  emoji: "🌐"
+  vellum:
+    display-name: "Browser"
+    user-invocable: true
+    feature-flag: "browser"
 ---
 
 Use this skill to browse the web. After loading this skill, the following browser tools become available:

--- a/assistant/src/config/bundled-skills/chatgpt-import/SKILL.md
+++ b/assistant/src/config/bundled-skills/chatgpt-import/SKILL.md
@@ -2,7 +2,11 @@
 name: chatgpt-import
 description: Import conversation history from ChatGPT into Vellum
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📥","vellum":{"display-name":"ChatGPT Import","user-invocable":true}}
+metadata:
+  emoji: "📥"
+  vellum:
+    display-name: "ChatGPT Import"
+    user-invocable: true
 ---
 
 Import ChatGPT conversation history into Vellum so users can keep their conversation context and memory when switching from ChatGPT.

--- a/assistant/src/config/bundled-skills/claude-code/SKILL.md
+++ b/assistant/src/config/bundled-skills/claude-code/SKILL.md
@@ -2,7 +2,11 @@
 name: claude-code
 description: Delegate coding tasks to Claude Code, an AI-powered coding agent
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"💻","vellum":{"display-name":"Claude Code","user-invocable":true}}
+metadata:
+  emoji: "💻"
+  vellum:
+    display-name: "Claude Code"
+    user-invocable: true
 ---
 
 You are delegating a coding task to Claude Code, an autonomous AI coding agent. Use this skill when the user needs hands-on software engineering work done.

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -2,7 +2,12 @@
 name: computer-use
 description: Computer-use action tools for controlling the macOS desktop via accessibility and screen capture.
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🖥️","vellum":{"display-name":"Computer Use","user-invocable":false,"disable-model-invocation":true}}
+metadata:
+  emoji: "🖥️"
+  vellum:
+    display-name: "Computer Use"
+    user-invocable: false
+    disable-model-invocation: true
 ---
 
 This skill provides the 12 computer*use*\* action tools for controlling

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -2,7 +2,12 @@
 name: contacts
 description: Manage contacts, communication channels, access control, and invite links
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"👥","vellum":{"display-name":"Contacts","user-invocable":true,"feature-flag":"contacts"}}
+metadata:
+  emoji: "👥"
+  vellum:
+    display-name: "Contacts"
+    user-invocable: true
+    feature-flag: "contacts"
 ---
 
 Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, phone), and creating/managing invite links that grant access.

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -2,7 +2,10 @@
 name: document
 description: Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides). Use when the user says write, draft, compose, or create a blog/article/essay.
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📄","vellum":{"display-name":"Document"}}
+metadata:
+  emoji: "📄"
+  vellum:
+    display-name: "Document"
 ---
 
 Create and edit long-form documents using the built-in rich text editor. Documents open in workspace mode with chat docked to the side.

--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -2,7 +2,14 @@
 name: doordash
 description: Order food, groceries, and convenience items from DoorDash using the built-in CLI integration
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🍕","vellum":{"display-name":"DoorDash","user-invocable":true,"cli":{"command":"doordash","entry":"doordash-entry.ts"}}}
+metadata:
+  emoji: "🍕"
+  vellum:
+    display-name: "DoorDash"
+    user-invocable: true
+    cli:
+      command: "doordash"
+      entry: "doordash-entry.ts"
 ---
 
 You can order food from DoorDash for the user using the `doordash` CLI.

--- a/assistant/src/config/bundled-skills/followups/SKILL.md
+++ b/assistant/src/config/bundled-skills/followups/SKILL.md
@@ -2,7 +2,10 @@
 name: followups
 description: Track sent messages awaiting responses across communication channels
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📨","vellum":{"display-name":"Followups"}}
+metadata:
+  emoji: "📨"
+  vellum:
+    display-name: "Followups"
 ---
 
 Track messages sent on external channels (email, Slack, WhatsApp, etc.) that are awaiting a response.

--- a/assistant/src/config/bundled-skills/google-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-calendar/SKILL.md
@@ -2,7 +2,11 @@
 name: google-calendar
 description: View, create, and manage Google Calendar events and check availability
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📅","vellum":{"display-name":"Google Calendar","user-invocable":true}}
+metadata:
+  emoji: "📅"
+  vellum:
+    display-name: "Google Calendar"
+    user-invocable: true
 ---
 
 You are a Google Calendar assistant with full access to the user's calendar. Use the Calendar tools to help them view, create, and manage events.

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -2,7 +2,11 @@
 name: image-studio
 description: Generate and edit images using AI
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🎨","vellum":{"display-name":"Image Studio","user-invocable":true}}
+metadata:
+  emoji: "🎨"
+  vellum:
+    display-name: "Image Studio"
+    user-invocable: true
 ---
 
 You are an image generation assistant. When the user asks you to create or edit images, use the `media_generate_image` tool.

--- a/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
+++ b/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
@@ -2,7 +2,10 @@
 name: knowledge-graph
 description: Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🕸️","vellum":{"display-name":"Knowledge Graph"}}
+metadata:
+  emoji: "🕸️"
+  vellum:
+    display-name: "Knowledge Graph"
 ---
 
 # Knowledge Graph

--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -2,7 +2,10 @@
 name: media-processing
 description: "Ingest and process media files (video, audio, image) through a 3-phase pipeline: preprocess, map (Gemini), and reduce (Claude)"
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🎬","vellum":{"display-name":"Media Processing"}}
+metadata:
+  emoji: "🎬"
+  vellum:
+    display-name: "Media Processing"
 ---
 
 Ingest and track processing of media files (video, audio, images) through a configurable 3-phase pipeline.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -2,7 +2,12 @@
 name: messaging
 description: Read, search, send, and manage messages across Slack, Gmail, Telegram, and other platforms
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"💬","vellum":{"display-name":"Messaging","user-invocable":true,"feature-flag":"messaging"}}
+metadata:
+  emoji: "💬"
+  vellum:
+    display-name: "Messaging"
+    user-invocable: true
+    feature-flag: "messaging"
 ---
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.

--- a/assistant/src/config/bundled-skills/notifications/SKILL.md
+++ b/assistant/src/config/bundled-skills/notifications/SKILL.md
@@ -2,7 +2,11 @@
 name: notifications
 description: Send notifications through the unified notification router
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🔔","vellum":{"display-name":"Notifications","user-invocable":true}}
+metadata:
+  emoji: "🔔"
+  vellum:
+    display-name: "Notifications"
+    user-invocable: true
 ---
 
 Use `send_notification` for user-facing alerts and notifications. This tool routes through the unified notification pipeline, which handles channel selection, delivery, deduplication, and audit logging.

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -2,7 +2,15 @@
 name: phone-calls
 description: Set up Twilio for AI-powered voice calls — both outgoing calls on behalf of the user and incoming calls where the assistant answers as a receptionist
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📞","vellum":{"display-name":"Phone Calls","user-invocable":true,"includes":["twilio-setup", "public-ingress","elevenlabs-voice"]}}
+metadata:
+  emoji: "📞"
+  vellum:
+    display-name: "Phone Calls"
+    user-invocable: true
+    includes:
+      - "twilio-setup"
+      - "public-ingress"
+      - "elevenlabs-voice"
 ---
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.

--- a/assistant/src/config/bundled-skills/playbooks/SKILL.md
+++ b/assistant/src/config/bundled-skills/playbooks/SKILL.md
@@ -2,7 +2,10 @@
 name: playbooks
 description: Trigger-action automation rules for handling incoming messages
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📖","vellum":{"display-name":"Playbooks"}}
+metadata:
+  emoji: "📖"
+  vellum:
+    display-name: "Playbooks"
 ---
 
 Playbooks are trigger-action automation rules that tell the assistant how to handle incoming messages matching a pattern.

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -2,7 +2,10 @@
 name: schedule
 description: Recurring and one-shot scheduling — cron, RRULE, or single fire-at time
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"📅","vellum":{"display-name":"Schedule"}}
+metadata:
+  emoji: "📅"
+  vellum:
+    display-name: "Schedule"
 ---
 
 Manage scheduled automations. Schedules can be **recurring** (cron or RRULE expression) or **one-shot** (a single `fire_at` timestamp). Both recurring and one-shot schedules support two modes: **execute** (run a message through the assistant) and **notify** (send a notification to the user).

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -2,7 +2,11 @@
 name: slack
 description: Scan channels, summarize threads, and manage Slack with privacy guardrails
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"💬","vellum":{"display-name":"Slack","user-invocable":true}}
+metadata:
+  emoji: "💬"
+  vellum:
+    display-name: "Slack"
+    user-invocable: true
 ---
 
 You are a Slack assistant that helps users stay on top of their Slack workspace. Use the slack tools for channel scanning, thread summarization, and Slack-specific operations.

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -2,7 +2,10 @@
 name: subagent
 description: Spawn and manage autonomous background agents for parallel work
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🤖","vellum":{"display-name":"Subagent"}}
+metadata:
+  emoji: "🤖"
+  vellum:
+    display-name: "Subagent"
 ---
 
 Subagent orchestration -- spawn background agents to work on tasks in parallel.

--- a/assistant/src/config/bundled-skills/tasks/SKILL.md
+++ b/assistant/src/config/bundled-skills/tasks/SKILL.md
@@ -2,7 +2,10 @@
 name: tasks
 description: Two-layer task system with reusable templates and a prioritized work queue
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"✅","vellum":{"display-name":"Tasks"}}
+metadata:
+  emoji: "✅"
+  vellum:
+    display-name: "Tasks"
 ---
 
 Two-layer task system: **task templates** (reusable definitions with input placeholders) and **work items** (instances in the Task Queue with priority tiers and status tracking).

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -2,7 +2,10 @@
 name: transcribe
 description: Transcribe audio and video files using Whisper (cloud API or local)
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"🎙️","vellum":{"display-name":"Transcribe"}}
+metadata:
+  emoji: "🎙️"
+  vellum:
+    display-name: "Transcribe"
 ---
 
 Transcribe audio and video files using OpenAI's Whisper model — either via the cloud API or locally via whisper.cpp.

--- a/assistant/src/config/bundled-skills/watcher/SKILL.md
+++ b/assistant/src/config/bundled-skills/watcher/SKILL.md
@@ -2,7 +2,10 @@
 name: watcher
 description: Polling watcher system for monitoring external sources
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"emoji":"👀","vellum":{"display-name":"Watcher"}}
+metadata:
+  emoji: "👀"
+  vellum:
+    display-name: "Watcher"
 ---
 
 Create and manage watchers that poll external services for events and process them with an action prompt.


### PR DESCRIPTION
## Summary
- Convert all 23 bundled SKILL.md files from inline JSON metadata to proper YAML format
- Nested objects, arrays, and booleans now use standard YAML syntax
- Aligns bundled skills with the Agent Skills specification

Part of plan: yaml-skill-metadata.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
