### PR TITLE
test: add unit tests for POST /v1/btw endpoint

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for the POST /v1/btw SSE-streaming side-chain endpoint.
+ *
+ * Validates request validation (400s), service unavailability (503),
+ * successful SSE streaming, provider argument passing, no persistence,
+ * and no session.processing mutation.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be defined before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const mockGetOrCreateConversation = mock((_key: string) => ({
+  conversationId: "conv-test-123",
+  created: false,
+}));
+
+mock.module("../memory/conversation-key-store.js", () => ({
+  getOrCreateConversation: mockGetOrCreateConversation,
+}));
+
+const mockAddMessage = mock(() => {});
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: mockAddMessage,
+}));
+
+const MOCK_TOOLS = [
+  { name: "test_tool", description: "A test tool", input_schema: { type: "object", properties: {} } },
+];
+
+mock.module("../daemon/session-tool-setup.js", () => ({
+  buildToolDefinitions: () => MOCK_TOOLS,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import type { ProviderResponse, SendMessageOptions } from "../providers/types.js";
+import type { AuthContext, Scope } from "../runtime/auth/types.js";
+import type { SendMessageDeps } from "../runtime/http-types.js";
+import { btwRouteDefinitions } from "../runtime/routes/btw-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_AUTH_CONTEXT: AuthContext = {
+  subject: "test-user",
+  principalType: "local",
+  assistantId: "self",
+  scopeProfile: "local_v1",
+  scopes: new Set<Scope>(["local.all"]),
+  policyEpoch: 0,
+};
+
+function makeMockProvider(
+  onSendMessage?: (
+    messages: unknown[],
+    tools: unknown[],
+    systemPrompt: string | undefined,
+    options: SendMessageOptions | undefined,
+  ) => Promise<ProviderResponse>,
+) {
+  const defaultSendMessage = async (
+    _messages: unknown[],
+    _tools: unknown[],
+    _systemPrompt: string | undefined,
+    options: SendMessageOptions | undefined,
+  ): Promise<ProviderResponse> => {
+    options?.onEvent?.({ type: "text_delta", text: "hello" });
+    return {
+      content: [{ type: "text", text: "hello" }],
+      model: "test-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "end_turn",
+    };
+  };
+
+  return {
+    name: "test-provider",
+    sendMessage: mock(onSendMessage ?? defaultSendMessage),
+  };
+}
+
+function makeMockSession(providerOverride?: ReturnType<typeof makeMockProvider>) {
+  const provider = providerOverride ?? makeMockProvider();
+  return {
+    provider,
+    systemPrompt: "You are a helpful assistant.",
+    processing: false,
+    getMessages: () => [
+      { role: "user" as const, content: [{ type: "text" as const, text: "prior message" }] },
+      { role: "assistant" as const, content: [{ type: "text" as const, text: "prior response" }] },
+    ],
+  };
+}
+
+function makeSendMessageDeps(session?: ReturnType<typeof makeMockSession>): SendMessageDeps {
+  const s = session ?? makeMockSession();
+  return {
+    getOrCreateSession: mock(async (_conversationId: string) => s) as unknown as SendMessageDeps["getOrCreateSession"],
+    assistantEventHub: {} as never,
+    resolveAttachments: () => [],
+  };
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/v1/btw", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callHandler(
+  body: Record<string, unknown>,
+  deps: { sendMessageDeps?: SendMessageDeps },
+): Promise<Response> {
+  const routes = btwRouteDefinitions(deps);
+  const route = routes.find((r) => r.endpoint === "btw" && r.method === "POST");
+  if (!route) throw new Error("btw route not found");
+  const req = makeRequest(body);
+  const url = new URL(req.url);
+  return route.handler({
+    req,
+    url,
+    server: null as never,
+    authContext: FAKE_AUTH_CONTEXT,
+    params: {},
+  });
+}
+
+async function readStream(response: Response): Promise<string> {
+  return await response.text();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/btw", () => {
+  // -- Validation (400s) --
+
+  test("returns 400 for missing conversationKey", async () => {
+    const res = await callHandler(
+      { content: "hello" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("conversationKey");
+  });
+
+  test("returns 400 for missing content", async () => {
+    const res = await callHandler(
+      { conversationKey: "key" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("content");
+  });
+
+  test("returns 400 for empty content", async () => {
+    const res = await callHandler(
+      { conversationKey: "key", content: "" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("content");
+  });
+
+  // -- Service unavailability (503) --
+
+  test("returns 503 when sendMessageDeps is unavailable", async () => {
+    const res = await callHandler(
+      { conversationKey: "key", content: "hello" },
+      { sendMessageDeps: undefined },
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  // -- Successful SSE streaming --
+
+  test("streams btw_text_delta SSE events", async () => {
+    const res = await callHandler(
+      { conversationKey: "key", content: "hello" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const text = await readStream(res);
+    expect(text).toContain(`event: btw_text_delta\ndata: {"text":"hello"}`);
+  });
+
+  test("response ends with btw_complete", async () => {
+    const res = await callHandler(
+      { conversationKey: "key", content: "hello" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    const text = await readStream(res);
+    expect(text).toContain("event: btw_complete\ndata: {}");
+  });
+
+  // -- Provider receives correct args --
+
+  test("provider receives session messages + btw user message, system prompt, tools, and tool_choice none", async () => {
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    const deps = makeSendMessageDeps(session);
+
+    const res = await callHandler(
+      { conversationKey: "key", content: "  my question  " },
+      { sendMessageDeps: deps },
+    );
+    // Consume the stream to ensure the provider call completes
+    await readStream(res);
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [messages, tools, systemPrompt, options] = provider.sendMessage.mock.calls[0];
+
+    // Messages should be session messages + the new user message (trimmed)
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "prior message" }],
+    });
+    expect(messages[1]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "prior response" }],
+    });
+    expect(messages[2]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "my question" }],
+    });
+
+    // Tools
+    expect(tools).toEqual(MOCK_TOOLS);
+
+    // System prompt from session
+    expect(systemPrompt).toBe("You are a helpful assistant.");
+
+    // Options: tool_choice must be "none"
+    expect(options.config.tool_choice).toEqual({ type: "none" });
+  });
+
+  // -- No persistence --
+
+  test("does not persist any messages (addMessage never called)", async () => {
+    mockAddMessage.mockClear();
+
+    const res = await callHandler(
+      { conversationKey: "key", content: "hello" },
+      { sendMessageDeps: makeSendMessageDeps() },
+    );
+    await readStream(res);
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
+
+  // -- session.processing not touched --
+
+  test("session.processing remains unchanged", async () => {
+    const session = makeMockSession();
+    const deps = makeSendMessageDeps(session);
+
+    // Verify initial state
+    expect(session.processing).toBe(false);
+
+    const res = await callHandler(
+      { conversationKey: "key", content: "hello" },
+      { sendMessageDeps: deps },
+    );
+    await readStream(res);
+
+    // processing should still be false — the handler never sets it
+    expect(session.processing).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for the /btw SSE-streaming endpoint
- Tests cover: validation (400s), unavailability (503), successful SSE streaming, provider args, no persistence, no session.processing mutation
- All tests fully mocked, no external service dependencies

Part of plan: btw-side-chain.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
