### PR TITLE
fix: correct JSON CodingKeys mismatch in Swift host bash types

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1522,8 +1522,8 @@ public struct HostBashRequest: Decodable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case type
-        case requestId = "request_id"
-        case sessionId = "session_id"
+        case requestId
+        case sessionId
         case command
         case workingDir = "working_dir"
         case timeoutSeconds = "timeout_seconds"
@@ -1547,11 +1547,11 @@ public struct HostBashResultPayload: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case requestId = "request_id"
+        case requestId
         case stdout
         case stderr
-        case exitCode = "exit_code"
-        case timedOut = "timed_out"
+        case exitCode
+        case timedOut
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** JSON CodingKeys mismatch between Swift client and TypeScript daemon
**What was expected:** Swift CodingKeys should match TypeScript camelCase property names
**What was found:** Swift used snake_case CodingKeys for requestId/sessionId/exitCode/timedOut, but the daemon sends camelCase

🤖 Generated with [Claude Code](https://claude.com/claude-code)