### PR TITLE
test: add integration test for YAML metadata round-trip

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -782,3 +782,82 @@ describe("validateManagedSkillId edge cases", () => {
     expect(validateManagedSkillId("a1.b2-c3_d4")).toBeNull();
   });
 });
+
+describe("YAML metadata round-trip", () => {
+  test("all vellum fields round-trip through write and load", () => {
+    // Create a managed skill with every vellum metadata field populated
+    createManagedSkill({
+      id: "yaml-roundtrip-all",
+      name: "Full Metadata Skill",
+      description: "Tests all vellum fields round-trip correctly",
+      bodyMarkdown: "Full metadata body.",
+      emoji: "🔬",
+      userInvocable: false,
+      disableModelInvocation: true,
+      includes: ["child-a", "child-b"],
+    });
+
+    // Load it back via loadSkillCatalog
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const skill = catalog.find((s) => s.id === "yaml-roundtrip-all");
+    expect(skill).toBeDefined();
+
+    // Verify all fields are correctly preserved
+    expect(skill!.name).toBe("Full Metadata Skill");
+    expect(skill!.description).toBe(
+      "Tests all vellum fields round-trip correctly",
+    );
+    expect(skill!.emoji).toBe("🔬");
+    expect(skill!.userInvocable).toBe(false);
+    expect(skill!.disableModelInvocation).toBe(true);
+    expect(skill!.includes).toEqual(["child-a", "child-b"]);
+  });
+
+  test("hand-authored YAML nested metadata parses correctly", () => {
+    // Manually write a SKILL.md with YAML-style nested metadata matching
+    // the format used in skills/ directory (bundled skills format)
+    const skillDir = join(TEST_DIR, "skills", "yaml-nested-test");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: yaml-nested-skill",
+        "description: Hand-authored YAML nested metadata test",
+        'compatibility: "Designed for Vellum personal assistants"',
+        "metadata:",
+        '  emoji: "🧪"',
+        "  vellum:",
+        '    display-name: "YAML Nested Skill"',
+        "    user-invocable: false",
+        "    disable-model-invocation: true",
+        "    os:",
+        `      - "${process.platform}"`,
+        "    includes:",
+        '      - "child-a"',
+        '      - "child-b"',
+        "---",
+        "",
+        "Hand-authored body content.",
+        "",
+      ].join("\n"),
+    );
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const skill = catalog.find((s) => s.id === "yaml-nested-test");
+    expect(skill).toBeDefined();
+
+    // Verify all nested vellum fields are correctly parsed
+    expect(skill!.name).toBe("yaml-nested-skill");
+    expect(skill!.description).toBe("Hand-authored YAML nested metadata test");
+    expect(skill!.displayName).toBe("YAML Nested Skill");
+    expect(skill!.userInvocable).toBe(false);
+    expect(skill!.disableModelInvocation).toBe(true);
+    expect(skill!.emoji).toBe("🧪");
+    expect(skill!.includes).toEqual(["child-a", "child-b"]);
+
+    // Verify os is parsed into metadata
+    expect(skill!.metadata).toBeDefined();
+    expect(skill!.metadata!.os).toEqual([process.platform]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add round-trip test for YAML metadata through full write → load pipeline
- Add test for hand-authored YAML nested metadata (previously silently broken)

Part of plan: yaml-skill-metadata.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
