### PR TITLE
fix: remove dead handleHostBashResponse handler

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -49,7 +49,6 @@ import type {
   UsageRequest,
 } from "../message-protocol.js";
 import { normalizeThreadType } from "../message-protocol.js";
-import type { HostBashResponse } from "../message-types/host-bash.js";
 import type { Session } from "../session.js";
 import {
   buildSessionErrorMessage,
@@ -176,10 +175,7 @@ export function handleConfirmationResponse(
         undefined,
         { source: "button" },
       );
-      syncCanonicalStatusFromConfirmationDecision(
-        msg.requestId,
-        msg.decision,
-      );
+      syncCanonicalStatusFromConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
@@ -194,10 +190,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
-      syncCanonicalStatusFromConfirmationDecision(
-        msg.requestId,
-        msg.decision,
-      );
+      syncCanonicalStatusFromConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
@@ -241,29 +234,6 @@ export function handleSecretResponse(
   log.warn(
     { requestId: msg.requestId },
     "No session found with pending secret prompt for requestId",
-  );
-}
-
-export function handleHostBashResponse(
-  msg: HostBashResponse,
-  ctx: HandlerContext,
-): void {
-  for (const [sessionId, session] of ctx.sessions) {
-    if (session.hasPendingHostBash(msg.requestId)) {
-      ctx.touchSession(sessionId);
-      session.resolveHostBash(msg.requestId, {
-        stdout: msg.stdout,
-        stderr: msg.stderr,
-        exitCode: msg.exitCode,
-        timedOut: msg.timedOut,
-      });
-      pendingInteractions.resolve(msg.requestId);
-      return;
-    }
-  }
-  log.warn(
-    { requestId: msg.requestId },
-    "No session found with pending host bash request for requestId",
   );
 }
 
@@ -780,4 +750,3 @@ export function handleReorderThreads(
     })),
   );
 }
-


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** Dead handleHostBashResponse handler
**What was expected:** No unused code per dead code removal policy
**What was found:** handleHostBashResponse exported but never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
