### PR TITLE
fix: register host_bash_request in makeHubPublisher pending interactions

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -361,9 +361,9 @@ export function handleListMessages(
  * Build an `onEvent` callback that publishes every outbound event to the
  * assistant event hub, maintaining ordered delivery through a serial chain.
  *
- * Also registers pending interactions when confirmation_request or
- * secret_request events flow through, so standalone approval endpoints
- * can look up the session by requestId.
+ * Also registers pending interactions when confirmation_request,
+ * secret_request, or host_bash_request events flow through, so
+ * standalone approval/result endpoints can look up the session by requestId.
  */
 function makeHubPublisher(
   deps: SendMessageDeps,
@@ -433,6 +433,12 @@ function makeHubPublisher(
         session,
         conversationId,
         kind: "secret",
+      });
+    } else if (msg.type === "host_bash_request") {
+      pendingInteractions.register(msg.requestId, {
+        session,
+        conversationId,
+        kind: "host_bash",
       });
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** host_bash_request not registered in makeHubPublisher
**What was expected:** The primary HTTP message path should track host_bash pending interactions
**What was found:** Only confirmation_request and secret_request were tracked, causing /v1/host-bash-result to return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
