### PR TITLE
fix: guard executeHostBashRequest with #if os(macOS) for iOS build

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -43,6 +43,7 @@ extension HTTPTransport {
         }
     }
 
+    #if os(macOS)
     /// Execute a host bash request locally and post the result back to the daemon.
     /// Spawns `/bin/bash -c -- <command>` via `Foundation.Process`, enforces a
     /// timeout, and collects stdout/stderr.
@@ -137,4 +138,5 @@ extension HTTPTransport {
             await self.postHostBashResult(result)
         }
     }
+    #endif
 }


### PR DESCRIPTION
## Summary
- `executeHostBashRequest` uses `Foundation.Process` which is macOS-only, but the file lives in `clients/shared/` and is compiled for iOS too
- Wraps the method with `#if os(macOS)` so iOS doesn't see it — matches the existing `#if os(macOS)` guard in `DaemonMessageRouter.swift` that already prevents calling it on iOS
- Fixes the \"cannot find 'Process' in scope\" iOS build error

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22931769034/job/66554672362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
