### PR TITLE
feat: add btw state management and send interception to ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -533,6 +533,13 @@ public final class ChatViewModel: ObservableObject {
     /// send `hasMore` in the history response.
     @Published public var hasMoreHistory: Bool = false
 
+    // MARK: - BTW Side-Chain State
+
+    /// The accumulated response text from a /btw side-chain query, or nil when inactive.
+    @Published public var btwResponse: String?
+    /// True while a /btw request is in flight.
+    @Published public var btwLoading: Bool = false
+
     /// Whether there are more messages above the current display window.
     /// True when either:
     ///   1. There are locally loaded messages outside the current display suffix, OR
@@ -967,6 +974,15 @@ public final class ChatViewModel: ObservableObject {
         let hasSkillInvocation = pendingSkillInvocation != nil
         guard !text.isEmpty || hasAttachments || hasSkillInvocation else { return }
 
+        // Intercept /btw side-chain messages before the normal send path.
+        if text.hasPrefix("/btw ") {
+            let question = String(text.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            inputText = ""
+            flushCoalescedPublish()
+            sendBtwMessage(question: question)
+            return
+        }
+
         // Confirmation state is now server-authoritative: the daemon emits
         // `confirmation_state_changed` events for all resolution paths.
         // No client-side pessimistic denial is needed.
@@ -1097,6 +1113,37 @@ public final class ChatViewModel: ObservableObject {
             // Subsequent messages: send directly (daemon queues if busy)
             sendUserMessage(text, displayText: rawText, attachments: messageAttachments, queuedMessageId: queuedMessageId)
         }
+    }
+
+    // MARK: - BTW Side-Chain
+
+    /// Send a /btw side-chain question and stream the response into `btwResponse`.
+    public func sendBtwMessage(question: String) {
+        guard !question.isEmpty else { return }
+        btwLoading = true
+        btwResponse = ""
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let stream = self.daemonClient.sendBtwMessage(
+                    content: question,
+                    conversationKey: self.sessionId ?? ""
+                )
+                for try await delta in stream {
+                    self.btwResponse = (self.btwResponse ?? "") + delta
+                }
+            } catch {
+                self.btwResponse = "Failed to get response: \(error.localizedDescription)"
+            }
+            self.btwLoading = false
+        }
+    }
+
+    /// Clear btw side-chain state.
+    public func dismissBtw() {
+        btwResponse = nil
+        btwLoading = false
     }
 
     private func bootstrapSession(userMessage: String?, attachments: [IPCAttachment]?) {

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -97,6 +97,7 @@ public protocol DaemonClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
     func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
+    func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error>
 }
 
 extension DaemonClientProtocol {
@@ -109,6 +110,11 @@ extension DaemonClientProtocol {
     public func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? { nil }
     public func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? { nil }
     public func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? { nil }
+
+    /// Default no-op implementation for clients that don't support btw side-chain.
+    public func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
 }
 
 // MARK: - Usage Response Models
@@ -861,6 +867,77 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
         return await executeLocalRequest(path: "v1/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10)
+    }
+
+    // MARK: - BTW Side-Chain
+
+    /// Send a /btw side-chain question and stream the response text.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
+        if let httpTransport {
+            return httpTransport.sendBtwMessage(content: content, conversationKey: conversationKey)
+        }
+
+        // Local daemon path — stream SSE from the daemon's /v1/btw endpoint.
+        return AsyncThrowingStream { continuation in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+
+                guard var request = self.buildLocalRequest(
+                    target: .daemon,
+                    path: "v1/btw",
+                    method: "POST",
+                    timeout: 120
+                ) else {
+                    continuation.finish(throwing: URLError(.badURL))
+                    return
+                }
+
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+                let body: [String: String] = [
+                    "conversationKey": conversationKey,
+                    "content": content,
+                ]
+
+                do {
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+                    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                        throw URLError(.badServerResponse, userInfo: [
+                            NSLocalizedDescriptionKey: "HTTP \(statusCode)"
+                        ])
+                    }
+
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+
+                        if line.hasPrefix("data: ") {
+                            let jsonString = String(line.dropFirst(6))
+                            if let data = jsonString.data(using: .utf8),
+                               let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                                if let text = parsed["text"] as? String {
+                                    continuation.yield(text)
+                                }
+                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                    break
+                                }
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
     }
 
     // MARK: - Workspace API


### PR DESCRIPTION
## Summary
- Add `sendBtwMessage` to `DaemonClientProtocol` with default no-op, and implement on `DaemonClient` (delegates to HTTPTransport for remote, local SSE for local daemon)
- Add `btwResponse` and `btwLoading` published properties to `ChatViewModel`
- Add `sendBtwMessage(question:)` that streams deltas from the daemon client
- Add `dismissBtw()` to clear btw state
- Intercept `/btw` messages in `sendMessage()` before normal send path

Part of plan: btw-side-chain.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
