### PR TITLE
fix: validate pending interaction kind in host-bash-result endpoint

### DIFF
--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -35,14 +35,27 @@ export async function handleHostBashResult(
     return httpError("BAD_REQUEST", "requestId is required", 400);
   }
 
-  const interaction = pendingInteractions.resolve(requestId);
-  if (!interaction) {
+  // Peek first (non-destructive) so we can validate the interaction kind
+  // without accidentally consuming a confirmation or secret interaction.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
     return httpError(
       "NOT_FOUND",
       "No pending interaction found for this requestId",
       404,
     );
   }
+
+  if (peeked.kind !== "host_bash") {
+    return httpError(
+      "CONFLICT",
+      `Pending interaction is of kind "${peeked.kind}", expected "host_bash"`,
+      409,
+    );
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
 
   interaction.session.resolveHostBash(requestId, {
     stdout: stdout ?? "",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** Missing kind validation in host-bash-routes.ts
**What was expected:** Endpoint should validate interaction.kind === "host_bash"
**What was found:** Any pending interaction could be consumed regardless of kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
