### PR TITLE
fix: add route policy, handle stream close errors, and set modelIntent for /v1/btw

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -126,6 +126,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Conversation / messaging
   { endpoint: "messages:GET", scopes: ["chat.read"] },
   { endpoint: "messages:POST", scopes: ["chat.write"] },
+  { endpoint: "btw", scopes: ["chat.write"] },
   { endpoint: "conversations", scopes: ["chat.read"] },
   { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
   { endpoint: "conversations/switch", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -8,17 +8,17 @@
  * No messages are persisted. `session.processing` is never set or checked.
  */
 
+import { buildToolDefinitions } from "../../daemon/session-tool-setup.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import {
   createTimeout,
   userMessage,
 } from "../../providers/provider-send-message.js";
-import { buildToolDefinitions } from "../../daemon/session-tool-setup.js";
+import { getLogger } from "../../util/logger.js";
+import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import type { SendMessageDeps } from "../http-types.js";
-import type { AuthContext } from "../auth/types.js";
-import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("btw-routes");
 
@@ -78,37 +78,46 @@ async function handleBtw(
     start(controller) {
       (async () => {
         try {
-          await session.provider.sendMessage(messages, tools, session.systemPrompt, {
-            config: {
-              max_tokens: 1024,
-              tool_choice: { type: "none" },
+          await session.provider.sendMessage(
+            messages,
+            tools,
+            session.systemPrompt,
+            {
+              config: {
+                max_tokens: 1024,
+                tool_choice: { type: "none" },
+                modelIntent: "latency-optimized",
+              },
+              onEvent: (event) => {
+                if (event.type === "text_delta") {
+                  controller.enqueue(
+                    encoder.encode(
+                      `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
+                    ),
+                  );
+                }
+              },
+              signal: combinedSignal,
             },
-            onEvent: (event) => {
-              if (event.type === "text_delta") {
-                controller.enqueue(
-                  encoder.encode(
-                    `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
-                  ),
-                );
-              }
-            },
-            signal: combinedSignal,
-          });
+          );
 
           controller.enqueue(
             encoder.encode(`event: btw_complete\ndata: {}\n\n`),
           );
           controller.close();
         } catch (err: unknown) {
-          const message =
-            err instanceof Error ? err.message : "Unknown error";
+          const message = err instanceof Error ? err.message : "Unknown error";
           log.error({ err }, "btw side-chain streaming error");
-          controller.enqueue(
-            encoder.encode(
-              `event: btw_error\ndata: ${JSON.stringify({ error: message })}\n\n`,
-            ),
-          );
-          controller.close();
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `event: btw_error\ndata: ${JSON.stringify({ error: message })}\n\n`,
+              ),
+            );
+            controller.close();
+          } catch {
+            /* stream already closed */
+          }
         } finally {
           cleanupTimeout();
           timeoutSignal.removeEventListener("abort", onTimeoutAbort);
@@ -138,6 +147,7 @@ export function btwRouteDefinitions(deps: {
     {
       endpoint: "btw",
       method: "POST",
+      policyKey: "btw",
       handler: async ({ req, authContext }) =>
         handleBtw(req, deps, authContext),
     },


### PR DESCRIPTION
Add scope-gated route policy for /v1/btw to prevent privilege escalation, wrap catch-block stream operations in try/catch for client disconnect safety, and add modelIntent: latency-optimized for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
