### PR TITLE
fix: read stdout and stderr concurrently to prevent pipe deadlock

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -112,12 +112,28 @@ extension HTTPTransport {
                 return
             }
 
-            // Read pipe data before waiting for exit to avoid deadlock when
-            // the pipe buffer fills (Process blocks on write until we read).
-            let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            // Read stdout and stderr concurrently to avoid deadlock.
+            // If we read sequentially and the process fills one pipe's buffer
+            // (~64 KB), the process blocks on that write, the other pipe never
+            // reaches EOF, and this thread hangs forever.
+            var stdoutData = Data()
+            var stderrData = Data()
+            let pipeGroup = DispatchGroup()
+
+            pipeGroup.enter()
+            DispatchQueue.global().async {
+                stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                pipeGroup.leave()
+            }
+
+            pipeGroup.enter()
+            DispatchQueue.global().async {
+                stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                pipeGroup.leave()
+            }
 
             process.waitUntilExit()
+            pipeGroup.wait()
             timerSource.cancel()
 
             let stdout = String(data: stdoutData, encoding: .utf8) ?? ""


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** Sequential pipe reads can deadlock for stderr-heavy commands
**What was expected:** Concurrent reads of stdout and stderr
**What was found:** Sequential reads that can deadlock when stderr buffer fills

In `executeHostBashRequest`, stdout and stderr pipes were read sequentially. If a process writes >64KB to stderr before writing to stdout, the stderr pipe buffer fills, the process blocks, stdout never reaches EOF, and the client hangs forever. This fix reads both pipes concurrently using a `DispatchGroup` with two async dispatch queue blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
