### PR TITLE
fix: make HostBashProxy only available when client is connected and normalize timeout

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -70,10 +70,7 @@ describe("HostBashProxy", () => {
     test("formats error output correctly", async () => {
       setup();
 
-      const resultPromise = proxy.request(
-        { command: "false" },
-        "session-1",
-      );
+      const resultPromise = proxy.request({ command: "false" }, "session-1");
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const requestId = sent.requestId as string;
@@ -187,9 +184,23 @@ describe("HostBashProxy", () => {
   });
 
   describe("isAvailable", () => {
-    test("returns true", () => {
+    test("returns false by default (no client connected)", () => {
       setup();
+      expect(proxy.isAvailable()).toBe(false);
+    });
+
+    test("returns true after updateSender with clientConnected=true", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
       expect(proxy.isAvailable()).toBe(true);
+    });
+
+    test("returns false after updateSender with clientConnected=false", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
+      expect(proxy.isAvailable()).toBe(true);
+      proxy.updateSender(sendToClient, false);
+      expect(proxy.isAvailable()).toBe(false);
     });
   });
 
@@ -219,7 +230,7 @@ describe("HostBashProxy", () => {
       setup();
 
       const newMessages: unknown[] = [];
-      proxy.updateSender((msg) => newMessages.push(msg));
+      proxy.updateSender((msg) => newMessages.push(msg), true);
 
       const resultPromise = proxy.request(
         { command: "echo updated" },

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -19,13 +19,18 @@ interface PendingRequest {
 export class HostBashProxy {
   private pending = new Map<string, PendingRequest>();
   private sendToClient: (msg: ServerMessage) => void;
+  private clientConnected = false;
 
   constructor(sendToClient: (msg: ServerMessage) => void) {
     this.sendToClient = sendToClient;
   }
 
-  updateSender(sendToClient: (msg: ServerMessage) => void): void {
+  updateSender(
+    sendToClient: (msg: ServerMessage) => void,
+    clientConnected: boolean,
+  ): void {
     this.sendToClient = sendToClient;
+    this.clientConnected = clientConnected;
   }
 
   request(
@@ -69,9 +74,7 @@ export class HostBashProxy {
           if (this.pending.has(requestId)) {
             clearTimeout(timer);
             this.pending.delete(requestId);
-            resolve(
-              formatShellOutput("", "Aborted", null, false, 0),
-            );
+            resolve(formatShellOutput("", "Aborted", null, false, 0));
           }
         };
         signal.addEventListener("abort", onAbort, { once: true });
@@ -119,7 +122,7 @@ export class HostBashProxy {
   }
 
   isAvailable(): boolean {
-    return true;
+    return this.clientConnected;
   }
 
   dispose(): void {

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -374,7 +374,7 @@ export class Session {
     this.prompter.updateSender(sendToClient);
     this.secretPrompter.updateSender(sendToClient);
     this.traceEmitter.updateSender(sendToClient);
-    this.hostBashProxy?.updateSender(sendToClient);
+    this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
   }
 
   /** Returns the current sendToClient reference for identity comparison. */
@@ -583,10 +583,6 @@ export class Session {
 
   hasPendingHostBash(requestId: string): boolean {
     return this.hostBashProxy?.hasPendingRequest(requestId) ?? false;
-  }
-
-  setHostBashProxy(proxy: HostBashProxy | undefined): void {
-    this.hostBashProxy = proxy;
   }
 
   // ── Server-authoritative state signals ─────────────────────────────

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -104,11 +104,21 @@ class HostShellTool implements Tool {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (context.hostBashProxy?.isAvailable()) {
+      const { shellDefaultTimeoutSec, shellMaxTimeoutSec } =
+        getConfig().timeouts;
+      const rawSec =
+        typeof input.timeout_seconds === "number"
+          ? input.timeout_seconds
+          : shellDefaultTimeoutSec;
+      const normalizedTimeout = Math.max(
+        1,
+        Math.min(rawSec, shellMaxTimeoutSec),
+      );
       return context.hostBashProxy.request(
         {
           command,
           working_dir: rawWorkingDir as string | undefined,
-          timeout_seconds: input.timeout_seconds as number | undefined,
+          timeout_seconds: normalizedTimeout,
         },
         context.sessionId,
         context.signal,


### PR DESCRIPTION
Fix HostBashProxy.isAvailable() to only return true when a client sender is registered, preventing local/CLI sessions from hanging. Also normalize timeout_seconds in the proxy path to match local execution bounds. Remove dead setHostBashProxy method.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
