### PR TITLE
fix: handle busy-state message queuing and /btw drop in CLI

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -373,13 +373,7 @@ async function handleConfirmationPrompt(
   const index = await chatApp.showSelection("Tool Approval", options);
 
   if (index === 0) {
-    await submitDecision(
-      baseUrl,
-      assistantId,
-      requestId,
-      "allow",
-      bearerToken,
-    );
+    await submitDecision(baseUrl, assistantId, requestId, "allow", bearerToken);
     chatApp.addStatus("\u2714 Allowed", "green");
     return;
   }
@@ -408,13 +402,7 @@ async function handleConfirmationPrompt(
     return;
   }
 
-  await submitDecision(
-    baseUrl,
-    assistantId,
-    requestId,
-    "deny",
-    bearerToken,
-  );
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -451,13 +439,7 @@ async function handlePatternSelection(
     return;
   }
 
-  await submitDecision(
-    baseUrl,
-    assistantId,
-    requestId,
-    "deny",
-    bearerToken,
-  );
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -505,13 +487,7 @@ async function handleScopeSelection(
     return;
   }
 
-  await submitDecision(
-    baseUrl,
-    assistantId,
-    requestId,
-    "deny",
-    bearerToken,
-  );
+  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken);
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -1270,6 +1246,7 @@ function ChatApp({
 
   const showSpinner = useCallback((text: string) => {
     setSpinnerText(text);
+    setInputFocused(false);
   }, []);
 
   const hideSpinner = useCallback(() => {
@@ -1792,8 +1769,21 @@ function ChatApp({
 
       if (busyRef.current) {
         // /btw is already handled above this block
+        if (!trimmed.startsWith("/")) {
+          const userMsg: RuntimeMessage = {
+            id: "local-user-" + Date.now(),
+            role: "user",
+            content: trimmed,
+            timestamp: new Date().toISOString(),
+          };
+          h.addMessage(userMsg);
+        }
         const isConnected = await ensureConnected();
-        if (!isConnected) return;
+        if (!isConnected) {
+          h.showError("Cannot send — not connected to the assistant.");
+          setInputFocused(true);
+          return;
+        }
         try {
           const controller = new AbortController();
           const timeoutId = setTimeout(
@@ -1809,6 +1799,7 @@ function ChatApp({
           );
           clearTimeout(timeoutId);
           if (sendResult.accepted) {
+            chatLogRef.current.push({ role: "user", content: trimmed });
             h.addStatus(
               "Message queued — will be processed after current response",
               "gray",
@@ -1821,6 +1812,7 @@ function ChatApp({
             `Failed to queue message: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
+        setInputFocused(true);
         return;
       }
 
@@ -1876,6 +1868,7 @@ function ChatApp({
         }
 
         h.showSpinner("Working...");
+        setInputFocused(true);
 
         while (true) {
           await new Promise((resolve) =>


### PR DESCRIPTION
Fix multiple CLI busy-state issues flagged in PR #15104 review:

1. **Display queued messages in feed**: User messages sent while busy are now added to the feed (via addMessage) and chat log (chatLogRef), matching the normal send path. Previously they were sent to the server but invisible to the user.

2. **Restore input focus control for spinner callers**: Re-added setInputFocused(false) to showSpinner so that /pair, /retire, and connection flows properly disable input. Input is explicitly re-enabled only in the busy-state working path and after message queuing.

3. **Show error on failed connection during busy state**: Instead of silently dropping messages when ensureConnected() returns false during busy state, now shows an error message.

4. **/btw during busy state**: Already resolved by PR #15109 which moved /btw handling above the busy block.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
