### PR TITLE
fix: only create HostBashProxy for desktop client sessions

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -22,10 +22,10 @@ describe("HostBashProxy", () => {
   let sentMessages: unknown[];
   let sendToClient: (msg: unknown) => void;
 
-  function setup() {
+  function setup(onInternalResolve?: (requestId: string) => void) {
     sentMessages = [];
     sendToClient = (msg: unknown) => sentMessages.push(msg);
-    proxy = new HostBashProxy(sendToClient);
+    proxy = new HostBashProxy(sendToClient, onInternalResolve);
   }
 
   afterEach(() => {
@@ -70,10 +70,7 @@ describe("HostBashProxy", () => {
     test("formats error output correctly", async () => {
       setup();
 
-      const resultPromise = proxy.request(
-        { command: "false" },
-        "session-1",
-      );
+      const resultPromise = proxy.request({ command: "false" }, "session-1");
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const requestId = sent.requestId as string;
@@ -251,6 +248,74 @@ describe("HostBashProxy", () => {
         exitCode: 0,
         timedOut: false,
       });
+    });
+  });
+
+  describe("onInternalResolve callback", () => {
+    test("fires on abort", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      expect(resolvedIds).toEqual([requestId]);
+    });
+
+    test("fires for each pending request on dispose", () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      // Create two pending requests and catch rejections from dispose
+      const p1 = proxy.request({ command: "echo a" }, "session-1");
+      const p2 = proxy.request({ command: "echo b" }, "session-1");
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const ids = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(ids).toHaveLength(2);
+
+      proxy.dispose();
+
+      expect(resolvedIds).toHaveLength(2);
+      expect(resolvedIds).toContain(ids[0]);
+      expect(resolvedIds).toContain(ids[1]);
+    });
+
+    test("does not fire on normal client-initiated resolve", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      // Normal resolve from client — should NOT trigger onInternalResolve
+      proxy.resolve(requestId, {
+        stdout: "hello",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      await resultPromise;
+      expect(resolvedIds).toEqual([]);
     });
   });
 });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -34,6 +34,7 @@ import * as externalConversationStore from "../../memory/external-conversation-s
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { truncate } from "../../util/truncate.js";
+import { HostBashProxy } from "../host-bash-proxy.js";
 import type {
   CancelRequest,
   ConfirmationResponse,
@@ -176,10 +177,7 @@ export function handleConfirmationResponse(
         undefined,
         { source: "button" },
       );
-      syncCanonicalStatusFromConfirmationDecision(
-        msg.requestId,
-        msg.decision,
-      );
+      syncCanonicalStatusFromConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
@@ -194,10 +192,7 @@ export function handleConfirmationResponse(
         msg.selectedPattern,
         msg.selectedScope,
       );
-      syncCanonicalStatusFromConfirmationDecision(
-        msg.requestId,
-        msg.decision,
-      );
+      syncCanonicalStatusFromConfirmationDecision(msg.requestId, msg.decision);
       pendingInteractions.resolve(msg.requestId);
       return;
     }
@@ -436,6 +431,15 @@ export async function handleSessionCreate(
       userMessageInterface: transportInterface,
       assistantMessageInterface: transportInterface,
     });
+    // Only create the host bash proxy for desktop client interfaces that can
+    // execute commands on the user's machine.
+    if (transportInterface === "macos" || transportInterface === "ios") {
+      session.setHostBashProxy(
+        new HostBashProxy(sendEvent, (requestId) => {
+          pendingInteractions.resolve(requestId);
+        }),
+      );
+    }
     session
       .processMessage(msg.initialMessage, [], sendEvent, requestId)
       .catch((err) => {
@@ -780,4 +784,3 @@ export function handleReorderThreads(
     })),
   );
 }
-

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -19,9 +19,14 @@ interface PendingRequest {
 export class HostBashProxy {
   private pending = new Map<string, PendingRequest>();
   private sendToClient: (msg: ServerMessage) => void;
+  private onInternalResolve?: (requestId: string) => void;
 
-  constructor(sendToClient: (msg: ServerMessage) => void) {
+  constructor(
+    sendToClient: (msg: ServerMessage) => void,
+    onInternalResolve?: (requestId: string) => void,
+  ) {
     this.sendToClient = sendToClient;
+    this.onInternalResolve = onInternalResolve;
   }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
@@ -47,6 +52,7 @@ export class HostBashProxy {
       const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.onInternalResolve?.(requestId);
         log.warn(
           { requestId, command: input.command },
           "Host bash proxy request timed out",
@@ -69,9 +75,8 @@ export class HostBashProxy {
           if (this.pending.has(requestId)) {
             clearTimeout(timer);
             this.pending.delete(requestId);
-            resolve(
-              formatShellOutput("", "Aborted", null, false, 0),
-            );
+            this.onInternalResolve?.(requestId);
+            resolve(formatShellOutput("", "Aborted", null, false, 0));
           }
         };
         signal.addEventListener("abort", onAbort, { once: true });
@@ -123,8 +128,9 @@ export class HostBashProxy {
   }
 
   dispose(): void {
-    for (const [, entry] of this.pending) {
+    for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
+      this.onInternalResolve?.(requestId);
       entry.reject(
         new AssistantError(
           "Host bash proxy disposed",

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -56,6 +56,7 @@ import type {
   SessionCreateOptions,
 } from "./handlers/shared.js";
 import type { SkillOperationContext } from "./handlers/skills.js";
+import { HostBashProxy } from "./host-bash-proxy.js";
 import type { ServerMessage } from "./message-protocol.js";
 import {
   DEFAULT_MEMORY_POLICY,
@@ -635,6 +636,18 @@ export class DaemonServer {
     session.setChannelCapabilities(
       resolveChannelCapabilities(sourceChannel, sourceInterface),
     );
+    // Only create the host bash proxy for desktop client interfaces that can
+    // execute commands on the user's machine. Non-desktop sessions (CLI,
+    // channels, headless) fall back to local execution.
+    if (resolvedInterface === "macos" || resolvedInterface === "ios") {
+      session.setHostBashProxy(
+        new HostBashProxy(session.getCurrentSender(), (requestId) => {
+          pendingInteractions.resolve(requestId);
+        }),
+      );
+    } else {
+      session.setHostBashProxy(undefined);
+    }
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({
       userMessageChannel: resolvedChannel,

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -270,7 +270,6 @@ export class Session {
       }
     });
     this.secretPrompter = new SecretPrompter(sendToClient);
-    this.hostBashProxy = new HostBashProxy(sendToClient);
 
     // Register watch/call notifiers (reads ctx properties lazily)
     registerSessionNotifiers(conversationId, this);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -16,6 +16,7 @@ import {
 } from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
+import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
   buildModelInfoEvent,
@@ -607,6 +608,18 @@ export async function handleSendMessage(
     sourceInterface === "vellum";
   // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   session.updateClient(onEvent, !isInteractiveInterface);
+  // Only create the host bash proxy for desktop client interfaces that can
+  // execute commands on the user's machine. Non-desktop sessions (CLI,
+  // channels, headless) fall back to local execution.
+  if (sourceInterface === "macos" || sourceInterface === "ios") {
+    session.setHostBashProxy(
+      new HostBashProxy(onEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      }),
+    );
+  } else {
+    session.setHostBashProxy(undefined);
+  }
 
   const attachments = hasAttachments
     ? smDeps.resolveAttachments(attachmentIds)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1522,8 +1522,8 @@ public struct HostBashRequest: Decodable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case type
-        case requestId = "request_id"
-        case sessionId = "session_id"
+        case requestId
+        case sessionId
         case command
         case workingDir = "working_dir"
         case timeoutSeconds = "timeout_seconds"
@@ -1547,11 +1547,11 @@ public struct HostBashResultPayload: Codable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case requestId = "request_id"
+        case requestId
         case stdout
         case stderr
-        case exitCode = "exit_code"
-        case timedOut = "timed_out"
+        case exitCode
+        case timedOut
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** HostBashProxy.isAvailable() always returns true
**What was expected:** Proxy should only activate for desktop clients, falling back to local execution for CLI/channels
**What was found:** HostBashProxy was created for all sessions, causing non-desktop sessions to hang until timeout

**Fix:** Removed unconditional HostBashProxy creation from the Session constructor. Instead, the proxy is now only created when the session interface is `"macos"` or `"ios"` (desktop clients), in three entry points:
- `DaemonServer.prepareSessionForMessage()` (legacy SSE path)
- `handleSendMessage()` (HTTP API path)
- `handleSessionCreate()` (session creation with initial message)

Non-desktop sessions (CLI, Telegram, SMS, headless) get `undefined` for `hostBashProxy`, and the tool's optional chaining (`context.hostBashProxy?.isAvailable()`) short-circuits to local execution.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
