### PR TITLE
fix: add setHostBashProxy to session mocks in conversation-routes tests

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -169,6 +169,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       assistantId: "self",
       trustContext: undefined,
       hasPendingConfirmation: () => false,
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -242,6 +243,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       assistantId: "self",
       trustContext: undefined,
       hasPendingConfirmation: () => false,
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -311,6 +313,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: (requestId: string) =>
         requestId === "tool-approval-live",
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -384,6 +387,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       assistantId: "self",
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "tool-req-code-1",
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -453,6 +457,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       assistantId: "self",
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-reject-1",
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -516,6 +521,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       assistantId: "self",
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-1",
+      setHostBashProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -201,6 +201,7 @@ function makeSession() {
     assistantId: "self",
     trustContext: undefined,
     hasPendingConfirmation: () => false,
+    setHostBashProxy: () => {},
     usageStats: {
       inputTokens: 1000,
       outputTokens: 500,


### PR DESCRIPTION
## Summary
- Recent PRs (#15125, #15127) added `session.setHostBashProxy()` to `handleSendMessage` in `conversation-routes.ts`, but the session mocks in the affected tests were not updated
- Added `setHostBashProxy: () => {}` to all 6 session mocks in `conversation-routes-guardian-reply.test.ts` and the 1 mock in `conversation-routes-slash-commands.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22932128446/job/66555759036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
