### PR TITLE
fix: re-enable input focus after showSpinner in confirmation/secret polling paths

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1894,6 +1894,7 @@ function ChatApp({
                 bearerToken,
               );
               h.showSpinner("Working...");
+              setInputFocused(true);
               continue;
             }
 
@@ -1920,6 +1921,7 @@ function ChatApp({
                 },
               );
               h.showSpinner("Working...");
+              setInputFocused(true);
               continue;
             }
           } catch {


### PR DESCRIPTION
Addresses review feedback on #15126. Adds setInputFocused(true) after showSpinner calls in the confirmation and secret prompt polling paths, matching the existing pattern and preventing input from staying unfocused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
