### PR TITLE
fix: resolve VShadow.sm build error in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -363,7 +363,7 @@ struct ChatView: View {
             .padding(VSpacing.md)
             .background(VColor.surface)
             .cornerRadius(VRadius.md)
-            .vShadow(.sm)
+            .vShadow(VShadow.sm)
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, 80)
             .transition(.opacity.combined(with: .move(edge: .bottom)))


### PR DESCRIPTION
## Summary
- Fixed build error `type 'VShadow.Definition' has no member 'sm'` in `ChatView.swift:366`
- The shorthand `.vShadow(.sm)` requires `sm` to be a static member on `VShadow.Definition`, but it's defined on `VShadow`; changed to `VShadow.sm` to match all other usages

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22932170329/job/66555875634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
