### PR TITLE
refactor: update iOS app and tests to use renamed DTO types

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -143,7 +143,7 @@ class IOSThreadStore: ObservableObject {
     }
 
     private func applySessionMetadata(
-        _ session: IPCSessionListResponseSession,
+        _ session: SessionListResponseSession,
         to thread: inout IOSThread
     ) {
         thread.isPinned = session.isPinned ?? false
@@ -649,7 +649,7 @@ class IOSThreadStore: ObservableObject {
         }
     }
 
-    private func handleSubagentDetailResponse(_ response: IPCSubagentDetailResponse) {
+    private func handleSubagentDetailResponse(_ response: SubagentDetailResponse) {
         for (_, vm) in viewModels {
             if vm.activeSubagents.contains(where: { $0.id == response.subagentId }) {
                 vm.subagentDetailStore.populateFromDetailResponse(response)
@@ -658,7 +658,7 @@ class IOSThreadStore: ObservableObject {
         }
     }
 
-    private func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+    private func handleMessageContentResponse(_ response: MessageContentResponse) {
         for (_, vm) in viewModels {
             if vm.messages.contains(where: { $0.daemonMessageId == response.messageId }) {
                 vm.handleMessageContentResponse(response)
@@ -710,7 +710,7 @@ class IOSThreadStore: ObservableObject {
         threads[idx].lastSeenAssistantMessageAt = threads[idx].latestAssistantMessageAt
         saveConnectedCache()
 
-        let signal = IPCConversationSeenSignal(
+        let signal = ConversationSeenSignal(
             conversationId: sessionId,
             sourceChannel: "vellum",
             signalType: Self.attentionSignalType,
@@ -954,7 +954,7 @@ class IOSThreadStore: ObservableObject {
         threads[idx].lastSeenAssistantMessageAt = nil
         saveConnectedCache()
 
-        let signal = IPCConversationUnreadSignal(
+        let signal = ConversationUnreadSignal(
             conversationId: sessionId,
             sourceChannel: "vellum",
             signalType: Self.attentionSignalType,
@@ -1035,12 +1035,12 @@ class IOSThreadStore: ObservableObject {
     }
 
     private func sendReorderThreads() {
-        let updates = threads.compactMap { thread -> IPCReorderThreadsRequestUpdate? in
+        let updates = threads.compactMap { thread -> ReorderThreadsRequestUpdate? in
             guard let sessionId = thread.sessionId, !thread.isArchived, !thread.isPrivate else {
                 return nil
             }
 
-            return IPCReorderThreadsRequestUpdate(
+            return ReorderThreadsRequestUpdate(
                 sessionId: sessionId,
                 displayOrder: thread.displayOrder.map(Double.init),
                 isPinned: thread.isPinned
@@ -1049,7 +1049,7 @@ class IOSThreadStore: ObservableObject {
         guard !updates.isEmpty else { return }
 
         do {
-            try daemonClient.send(IPCReorderThreadsRequest(
+            try daemonClient.send(ReorderThreadsRequest(
                 type: "reorder_threads",
                 updates: updates
             ))

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -426,9 +426,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testOpeningUnreadConnectedThreadMarksItSeenAndEmitsSignal() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationSeenSignal] = []
+        var sentSignals: [ConversationSeenSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationSeenSignal {
+            if let signal = message as? ConversationSeenSignal {
                 sentSignals.append(signal)
             }
         }
@@ -479,9 +479,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testOpeningAlreadySeenConnectedThreadDoesNotEmitSignal() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationSeenSignal] = []
+        var sentSignals: [ConversationSeenSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationSeenSignal {
+            if let signal = message as? ConversationSeenSignal {
                 sentSignals.append(signal)
             }
         }
@@ -513,9 +513,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testMarkingSeenConnectedThreadUnreadUpdatesLocalStateAndEmitsSignal() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationUnreadSignal] = []
+        var sentSignals: [ConversationUnreadSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationUnreadSignal {
+            if let signal = message as? ConversationUnreadSignal {
                 sentSignals.append(signal)
             }
         }
@@ -567,9 +567,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testMarkingAlreadyUnreadConnectedThreadUnreadDoesNothing() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationUnreadSignal] = []
+        var sentSignals: [ConversationUnreadSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationUnreadSignal {
+            if let signal = message as? ConversationUnreadSignal {
                 sentSignals.append(signal)
             }
         }
@@ -640,9 +640,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testMarkingThreadWithoutAssistantReplyUnreadDoesNothing() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationUnreadSignal] = []
+        var sentSignals: [ConversationUnreadSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationUnreadSignal {
+            if let signal = message as? ConversationUnreadSignal {
                 sentSignals.append(signal)
             }
         }
@@ -672,9 +672,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testMarkingThreadWithLoadedAssistantReplyUnreadUsesLocalMessageTimestamp() {
         let daemonClient = DaemonClient()
-        var sentSignals: [IPCConversationUnreadSignal] = []
+        var sentSignals: [ConversationUnreadSignal] = []
         daemonClient.sendOverride = { message in
-            if let signal = message as? IPCConversationUnreadSignal {
+            if let signal = message as? ConversationUnreadSignal {
                 sentSignals.append(signal)
             }
         }
@@ -815,9 +815,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testPinningConnectedThreadUpdatesLocalStateAndEmitsReorder() {
         let daemonClient = DaemonClient()
-        var reorderRequests: [IPCReorderThreadsRequest] = []
+        var reorderRequests: [ReorderThreadsRequest] = []
         daemonClient.sendOverride = { message in
-            if let request = message as? IPCReorderThreadsRequest {
+            if let request = message as? ReorderThreadsRequest {
                 reorderRequests.append(request)
             }
         }
@@ -906,9 +906,9 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
     func testUnpinningConnectedThreadRecompactsPinnedOrderAndEmitsReorder() {
         let daemonClient = DaemonClient()
-        var reorderRequests: [IPCReorderThreadsRequest] = []
+        var reorderRequests: [ReorderThreadsRequest] = []
         daemonClient.sendOverride = { message in
-            if let request = message as? IPCReorderThreadsRequest {
+            if let request = message as? ReorderThreadsRequest {
                 reorderRequests.append(request)
             }
         }

--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 
 struct IntegrationsSection: View {
     @EnvironmentObject var clientProvider: ClientProvider
-    @State private var integrations: [IPCIntegrationListResponseIntegration] = []
+    @State private var integrations: [IntegrationListResponseIntegration] = []
     @State private var connectingIntegrationId: String?
 
     var body: some View {

--- a/clients/ios/Views/Tasks/IOSTaskOutputDetailView.swift
+++ b/clients/ios/Views/Tasks/IOSTaskOutputDetailView.swift
@@ -69,7 +69,7 @@ struct IOSTaskOutputDetailView: View {
 
     // MARK: - Metadata
 
-    private func metadataSection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+    private func metadataSection(_ output: WorkItemOutputResponseOutput) -> some View {
         HStack(spacing: VSpacing.sm) {
             // Status badge
             HStack(spacing: 4) {
@@ -100,7 +100,7 @@ struct IOSTaskOutputDetailView: View {
 
     // MARK: - Summary
 
-    private func summarySection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+    private func summarySection(_ output: WorkItemOutputResponseOutput) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text("Summary")
                 .font(VFont.captionMedium)

--- a/clients/ios/Views/Tasks/IOSTaskPermissionPreflightView.swift
+++ b/clients/ios/Views/Tasks/IOSTaskPermissionPreflightView.swift
@@ -91,7 +91,7 @@ struct IOSTaskPermissionPreflightView: View {
 
     // MARK: - Permissions List
 
-    private func permissionsList(_ permissions: [IPCWorkItemPreflightResponsePermission]) -> some View {
+    private func permissionsList(_ permissions: [WorkItemPreflightResponsePermission]) -> some View {
         List {
             Section {
                 Text("Task: \(itemTitle)")
@@ -119,7 +119,7 @@ struct IOSTaskPermissionPreflightView: View {
         }
     }
 
-    private func permissionRow(_ permission: IPCWorkItemPreflightResponsePermission) -> some View {
+    private func permissionRow(_ permission: WorkItemPreflightResponsePermission) -> some View {
         let isApproved = approvedTools.contains(permission.tool)
         return HStack(spacing: VSpacing.sm) {
             Button {

--- a/clients/ios/Views/Tasks/TasksView.swift
+++ b/clients/ios/Views/Tasks/TasksView.swift
@@ -139,7 +139,7 @@ struct TasksView: View {
 
 /// A single task row in the iOS task list.
 private struct TaskRow: View {
-    let item: IPCWorkItemsListResponseItem
+    let item: WorkItemsListResponseItem
     let hasOutput: Bool
     let runningIds: Set<String>
     let timeoutIds: Set<String>

--- a/clients/ios/Views/Tasks/TasksViewModel.swift
+++ b/clients/ios/Views/Tasks/TasksViewModel.swift
@@ -6,7 +6,7 @@ import VellumAssistantShared
 /// Centralizes task queue state and daemon callbacks for the iOS Tasks tab.
 @MainActor
 class TasksViewModel: ObservableObject {
-    @Published var items: [IPCWorkItemsListResponseItem] = []
+    @Published var items: [WorkItemsListResponseItem] = []
     @Published var isLoading = true
     @Published var errorMessage: String?
 
@@ -22,18 +22,18 @@ class TasksViewModel: ObservableObject {
     @Published var cancelInFlightIds: Set<String> = []
 
     /// The currently selected item for output detail viewing.
-    @Published var selectedOutputItem: IPCWorkItemsListResponseItem?
+    @Published var selectedOutputItem: WorkItemsListResponseItem?
     /// Loading/loaded/error state for the output detail sheet.
     @Published var outputState: IOSTaskOutputState = .loading
 
     /// The item currently undergoing permission preflight.
-    @Published var preflightItem: IPCWorkItemsListResponseItem?
+    @Published var preflightItem: WorkItemsListResponseItem?
     /// Loading/loaded/error state for the preflight sheet.
     @Published var preflightState: IOSPreflightState = .loading
 
     /// Tracks the item awaiting a preflight response from the daemon.
     /// Unlike `preflightItem`, this does NOT trigger the sheet.
-    private var pendingPreflightItem: IPCWorkItemsListResponseItem?
+    private var pendingPreflightItem: WorkItemsListResponseItem?
 
     private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
 
@@ -197,7 +197,7 @@ class TasksViewModel: ObservableObject {
     }
 
     /// Whether a task's status indicates it may have output to display.
-    func taskHasOutput(_ item: IPCWorkItemsListResponseItem) -> Bool {
+    func taskHasOutput(_ item: WorkItemsListResponseItem) -> Bool {
         let status = WorkItemStatus(rawStatus: item.status)
         switch status {
         case .awaitingReview, .done, .failed: return true
@@ -209,7 +209,7 @@ class TasksViewModel: ObservableObject {
 
     /// Initiates the run flow via a preflight check. The permission sheet only
     /// appears if the daemon reports non-empty permissions.
-    func initiateRun(item: IPCWorkItemsListResponseItem) {
+    func initiateRun(item: WorkItemsListResponseItem) {
         logger.info("initiateRun: id=\(item.id, privacy: .public)")
         guard !runInFlightIds.contains(item.id) else {
             logger.warning("initiateRun: skipping — already in flight for id=\(item.id, privacy: .public)")
@@ -289,7 +289,7 @@ class TasksViewModel: ObservableObject {
 
     // MARK: - Output
 
-    func fetchOutput(for item: IPCWorkItemsListResponseItem) {
+    func fetchOutput(for item: WorkItemsListResponseItem) {
         logger.info("fetchOutput: id=\(item.id, privacy: .public)")
         selectedOutputItem = item
         outputState = .loading
@@ -353,14 +353,14 @@ class TasksViewModel: ObservableObject {
 /// Loading/loaded/error state for fetching task output on iOS.
 enum IOSTaskOutputState {
     case loading
-    case loaded(IPCWorkItemOutputResponseOutput)
+    case loaded(WorkItemOutputResponseOutput)
     case error(String)
 }
 
 /// Loading/loaded/error state for the permission preflight check on iOS.
 enum IOSPreflightState {
     case loading
-    case loaded([IPCWorkItemPreflightResponsePermission])
+    case loaded([WorkItemPreflightResponsePermission])
     case error(String)
 }
 


### PR DESCRIPTION
## Summary
- Updated all IPC-prefixed type references across 7 iOS app and test files
- Replaced type annotations, initializer calls, and test fixtures

Part of plan: swift-ipc-dto-type-rename.md (PR 7 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
