### PR TITLE
refactor: update macOS tests to use renamed DTO types

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -427,7 +427,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
                 "subtitle": "v3"
             ] as [String: Any])
         ]
-        let historySurface = IPCHistoryResponseSurface(
+        let historySurface = HistoryResponseSurface(
             surfaceId: "hist-surface-1",
             surfaceType: "dynamic_page",
             title: "History App",
@@ -435,8 +435,8 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             actions: nil,
             display: nil
         )
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
                 id: nil,
                 role: "assistant",
                 text: "Here is your restored app",
@@ -472,7 +472,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             ] as [String: Any]),
             "appId": AnyCodable("app-light-1")
         ]
-        let historySurface = IPCHistoryResponseSurface(
+        let historySurface = HistoryResponseSurface(
             surfaceId: "hist-light-surface",
             surfaceType: "dynamic_page",
             title: "Light Mode App",
@@ -480,8 +480,8 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             actions: nil,
             display: nil
         )
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
                 id: nil,
                 role: "assistant",
                 text: "Here are your slides",

--- a/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
@@ -203,8 +203,8 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
     // MARK: - History hydration preserves URLs as plain text
 
     func testPopulateFromHistoryWithMediaURLsHasNoEmbeds() {
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
                 id: nil,
                 role: "assistant",
                 text: "Check out https://www.youtube.com/watch?v=abc and https://vimeo.com/123",

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1699,7 +1699,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages.count, 1) // assistant only
 
         // Complete with attachments
-        let attachment = IPCUserMessageAttachment(
+        let attachment = UserMessageAttachment(
             id: "att-1", filename: "photo.png", mimeType: "image/png",
             data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
@@ -1719,7 +1719,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.isThinking = true
 
         // Complete with attachments but no prior text deltas (attachment-only turn)
-        let attachment = IPCUserMessageAttachment(
+        let attachment = UserMessageAttachment(
             id: "att-1", filename: "report.pdf", mimeType: "application/pdf",
             data: "JVBER", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
@@ -1742,7 +1742,7 @@ final class ChatViewModelTests: XCTestCase {
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Generated file")))
 
         // Handoff with attachments
-        let attachment = IPCUserMessageAttachment(
+        let attachment = UserMessageAttachment(
             id: "att-2", filename: "output.csv", mimeType: "text/csv",
             data: "Y29sQQ==", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
@@ -1782,13 +1782,13 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - History Attachment Hydration
 
     func testPopulateFromHistoryHydratesAssistantAttachments() {
-        let attachment = IPCUserMessageAttachment(
+        let attachment = UserMessageAttachment(
             id: "hist-att-1", filename: "chart.png", mimeType: "image/png",
             data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(id: nil, role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
-            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(id: nil, role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
+            HistoryResponseMessage(id: nil, role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
         viewModel.populateFromHistory(historyItems, hasMore: false)
@@ -1801,12 +1801,12 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testPopulateFromHistoryIncludesAttachmentOnlyMessages() {
-        let attachment = IPCUserMessageAttachment(
+        let attachment = UserMessageAttachment(
             id: "hist-att-2", filename: "report.pdf", mimeType: "application/pdf",
             data: "JVBER", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
         viewModel.populateFromHistory(historyItems, hasMore: false)
@@ -1819,8 +1819,8 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testPopulateFromHistorySkipsEmptyMessagesWithNoAttachments() {
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
         viewModel.populateFromHistory(historyItems, hasMore: false)
@@ -1879,9 +1879,9 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testPopulateFromHistoryUsesTextSegments() {
-        let toolCall = IPCHistoryResponseToolCall(name: "memory_save", input: ["key": AnyCodable("task")], result: "saved", isError: nil, imageData: nil)
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(
+        let toolCall = HistoryResponseToolCall(name: "memory_save", input: ["key": AnyCodable("task")], result: "saved", isError: nil, imageData: nil)
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
                 id: nil,
                 role: "assistant",
                 text: "What are you working on?Saved that to memory.",
@@ -1905,9 +1905,9 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testPopulateFromHistoryFallsBackToLegacy() {
-        let toolCall = IPCHistoryResponseToolCall(name: "bash", input: ["command": AnyCodable("ls")], result: "file.txt", isError: nil, imageData: nil)
-        let historyItems: [IPCHistoryResponseMessage] = [
-            IPCHistoryResponseMessage(
+        let toolCall = HistoryResponseToolCall(name: "bash", input: ["command": AnyCodable("ls")], result: "file.txt", isError: nil, imageData: nil)
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
                 id: nil,
                 role: "assistant",
                 text: "Here are the files.",

--- a/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/SecretPromptManagerTests.swift
@@ -35,8 +35,8 @@ final class SecretPromptManagerTests: XCTestCase {
         allowedTools: [String]? = nil,
         allowedDomains: [String]? = nil,
         allowOneTimeSend: Bool? = nil
-    ) -> IPCSecretRequest {
-        IPCSecretRequest(
+    ) -> SecretRequest {
+        SecretRequest(
             type: "secret_request",
             requestId: requestId,
             service: "github",

--- a/clients/macos/vellum-assistantTests/SharedAppsLoaderTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedAppsLoaderTests.swift
@@ -64,10 +64,10 @@ final class SharedAppsLoaderTests: XCTestCase {
         }
 
         await Task.yield()
-        client.emit(.sharedAppsListResponse(IPCSharedAppsListResponse(
+        client.emit(.sharedAppsListResponse(SharedAppsListResponse(
             type: "shared_apps_list_response",
             apps: [
-                IPCSharedAppsListResponseApp(
+                SharedAppsListResponseApp(
                     uuid: "shared-1",
                     name: "Shared Things",
                     description: "Shared app",
@@ -102,10 +102,10 @@ final class SharedAppsLoaderTests: XCTestCase {
         }
 
         await Task.yield()
-        client.emit(.appsListResponse(IPCAppsListResponse(
+        client.emit(.appsListResponse(AppsListResponse(
             type: "apps_list_response",
             apps: [
-                IPCAppsListResponseApp(
+                AppsListResponseApp(
                     id: "local-1",
                     name: "Local Things",
                     description: nil,
@@ -115,10 +115,10 @@ final class SharedAppsLoaderTests: XCTestCase {
                 )
             ]
         )))
-        client.emit(.sharedAppsListResponse(IPCSharedAppsListResponse(
+        client.emit(.sharedAppsListResponse(SharedAppsListResponse(
             type: "shared_apps_list_response",
             apps: [
-                IPCSharedAppsListResponseApp(
+                SharedAppsListResponseApp(
                     uuid: "shared-2",
                     name: "Shared Followup",
                     description: nil,

--- a/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
@@ -45,7 +45,7 @@ final class ThreadManagerRenameTests: XCTestCase {
 
         XCTAssertEqual(threadManager.threads[0].title, "Renamed Thread")
 
-        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        let renameMessages = capturedMessages.compactMap { $0 as? SessionRenameRequest }
         XCTAssertEqual(renameMessages.count, 1)
         XCTAssertEqual(renameMessages.first?.sessionId, "session-abc")
         XCTAssertEqual(renameMessages.first?.title, "Renamed Thread")
@@ -64,7 +64,7 @@ final class ThreadManagerRenameTests: XCTestCase {
         threadManager.renameThread(id: thread.id, title: "")
 
         XCTAssertEqual(threadManager.threads[0].title, originalTitle)
-        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        let renameMessages = capturedMessages.compactMap { $0 as? SessionRenameRequest }
         XCTAssertTrue(renameMessages.isEmpty)
     }
 
@@ -79,7 +79,7 @@ final class ThreadManagerRenameTests: XCTestCase {
         threadManager.renameThread(id: thread.id, title: "   \n  ")
 
         XCTAssertEqual(threadManager.threads[0].title, originalTitle)
-        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        let renameMessages = capturedMessages.compactMap { $0 as? SessionRenameRequest }
         XCTAssertTrue(renameMessages.isEmpty)
     }
 

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -138,7 +138,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertFalse(seenSignals.isEmpty, "Seen signal should be emitted on new message arrival and stream completion")
         XCTAssertEqual(seenSignals.last?.conversationId, "session-realtime")
     }
@@ -251,7 +251,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         threadManager.selectThread(id: firstId)
         XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertFalse(seenSignals.isEmpty, "selectThread should emit a seen signal to the daemon")
         XCTAssertEqual(seenSignals.last?.conversationId, "session-first")
     }
@@ -275,7 +275,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
                        "markConversationSeen should clear the unseen flag")
         XCTAssertEqual(threadManager.unseenVisibleConversationCount, 0)
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertFalse(seenSignals.isEmpty, "markConversationSeen should emit a seen signal to the daemon")
         XCTAssertEqual(seenSignals.last?.conversationId, "session-mark-seen")
     }
@@ -299,7 +299,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
                       "markConversationUnread should set the unseen flag")
 
-        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertEqual(unreadSignals.count, 1, "markConversationUnread should emit a single unread signal")
         XCTAssertEqual(unreadSignals.last?.conversationId, "session-mark-unread")
     }
@@ -319,7 +319,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         threadManager.markConversationUnread(threadId: threadId)
 
-        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertTrue(unreadSignals.isEmpty, "Already-unread threads should not emit duplicate unread signals")
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage)
     }
@@ -351,7 +351,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
                       "Live assistant replies should allow unread even before hydration backfills timestamps")
 
-        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertEqual(unreadSignals.count, 1)
         XCTAssertEqual(unreadSignals.last?.conversationId, "session-live-unread")
     }
@@ -401,7 +401,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         // Fail only unread signals so markConversationUnread triggers rollback,
         // while allowing seen signals from commitPendingSeenSignals to succeed.
         daemonClient.sendOverride = { [weak self] message in
-            if message is IPCConversationUnreadSignal {
+            if message is ConversationUnreadSignal {
                 throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
                     NSLocalizedDescriptionKey: "offline"
                 ])
@@ -418,7 +418,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         // so committing should emit a seen signal for the session.
         threadManager.commitPendingSeenSignals()
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.map(\.conversationId), ["session-requeue"])
     }
 
@@ -437,7 +437,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         threadManager.markConversationUnread(threadId: threadId)
 
-        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertTrue(unreadSignals.isEmpty, "Threads without assistant replies should not emit unread signals")
         XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
     }
@@ -549,10 +549,10 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         threadManager.commitPendingSeenSignals()
         waitForPropagation()
 
-        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        let unreadSignals = sentMessages.compactMap { $0 as? ConversationUnreadSignal }
         XCTAssertEqual(unreadSignals.map(\.conversationId), ["session-first"])
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.map(\.conversationId), ["session-second"])
 
         XCTAssertTrue(threadManager.threads.contains(where: {
@@ -579,7 +579,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "chunk1", sessionId: "session-streaming")))
         waitForPropagation()
 
-        let signalsAfterFirstDelta = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let signalsAfterFirstDelta = sentMessages.compactMap { $0 as? ConversationSeenSignal }
             .filter { $0.conversationId == "session-streaming" }
         let countAfterFirst = signalsAfterFirstDelta.count
 
@@ -589,7 +589,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: " chunk4", sessionId: "session-streaming")))
         waitForPropagation()
 
-        let signalsAfterMoreDeltas = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let signalsAfterMoreDeltas = sentMessages.compactMap { $0 as? ConversationSeenSignal }
             .filter { $0.conversationId == "session-streaming" }
         XCTAssertEqual(signalsAfterMoreDeltas.count, countAfterFirst,
                        "Mid-stream text deltas should not emit additional seen signals (was O(n), should be O(1))")
@@ -598,7 +598,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         vm.handleServerMessage(.messageComplete(MessageCompleteMessage(sessionId: "session-streaming")))
         waitForPropagation()
 
-        let signalsAfterComplete = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let signalsAfterComplete = sentMessages.compactMap { $0 as? ConversationSeenSignal }
             .filter { $0.conversationId == "session-streaming" }
         XCTAssertEqual(signalsAfterComplete.count, countAfterFirst + 1,
                        "Stream completion should emit exactly one additional seen signal")
@@ -623,7 +623,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
 
-        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        let seenSignals = sentMessages.compactMap { $0 as? ConversationSeenSignal }
         XCTAssertEqual(seenSignals.last?.conversationId, "session-active")
     }
 

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -75,7 +75,7 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
     }
 
     func mergeAssistantAttention(
-        from session: IPCSessionListResponseSession,
+        from session: SessionListResponseSession,
         intoThreadAt index: Int
     ) {
         threads[index].hasUnseenLatestAssistantMessage =

--- a/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceInputManagerTests.swift
@@ -128,7 +128,7 @@ final class VoiceInputManagerTests: XCTestCase {
         manager.handleFinalTranscription("take a note")
 
         XCTAssertEqual(mockDaemon.sentMessages.count, 1)
-        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        let sent = mockDaemon.sentMessages.first as? DictationRequest
         XCTAssertNotNil(sent)
         XCTAssertEqual(sent?.transcription, "take a note")
         XCTAssertEqual(sent?.context.appName, "Notes")
@@ -154,7 +154,7 @@ final class VoiceInputManagerTests: XCTestCase {
 
         manager.handleFinalTranscription("replace this")
 
-        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        let sent = mockDaemon.sentMessages.first as? DictationRequest
         XCTAssertEqual(sent?.context.selectedText, "selected snippet")
     }
 
@@ -178,7 +178,7 @@ final class VoiceInputManagerTests: XCTestCase {
 
         manager.handleFinalTranscription("search for this")
 
-        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        let sent = mockDaemon.sentMessages.first as? DictationRequest
         XCTAssertEqual(sent?.context.bundleIdentifier, "com.apple.Safari")
     }
 
@@ -190,7 +190,7 @@ final class VoiceInputManagerTests: XCTestCase {
 
         manager.handleFinalTranscription("type something")
 
-        let sent = mockDaemon.sentMessages.first as? IPCDictationRequest
+        let sent = mockDaemon.sentMessages.first as? DictationRequest
         XCTAssertEqual(sent?.context.cursorInTextField, false)
     }
 


### PR DESCRIPTION
## Summary
- Updated all IPC-prefixed type references across 9 macOS test files
- Replaced test fixture constructors, type annotations, and comments

Part of plan: swift-ipc-dto-type-rename.md (PR 6 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
