### PR TITLE
refactor: update DaemonClient and HTTPDaemonClient to use renamed DTO types

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -88,7 +88,7 @@ public protocol DaemonClientProtocol {
     var isConnected: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
-    func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws
+    func sendConversationUnread(_ signal: ConversationUnreadSignal) async throws
     func connect() async throws
     func disconnect()
     func startSSE()
@@ -101,7 +101,7 @@ public protocol DaemonClientProtocol {
 }
 
 extension DaemonClientProtocol {
-    public func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws {
+    public func sendConversationUnread(_ signal: ConversationUnreadSignal) async throws {
         try send(signal)
     }
 
@@ -362,7 +362,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onNotificationIntent: ((NotificationIntentMessage) -> Void)?
 
     /// Called when a notification delivery creates a new vellum conversation thread.
-    public var onNotificationThreadCreated: ((IPCNotificationThreadCreated) -> Void)?
+    public var onNotificationThreadCreated: ((NotificationThreadCreated) -> Void)?
 
     /// Called when the daemon sends a `trust_rules_list_response` message.
     public var onTrustRulesListResponse: (([TrustRuleItem]) -> Void)?
@@ -410,13 +410,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onForkSharedAppResponse: ((ForkSharedAppResponseMessage) -> Void)?
 
     /// Called when the daemon sends an `app_history_response` message.
-    public var onAppHistoryResponse: ((IPCAppHistoryResponse) -> Void)?
+    public var onAppHistoryResponse: ((AppHistoryResponse) -> Void)?
 
     /// Called when the daemon sends an `app_diff_response` message.
-    public var onAppDiffResponse: ((IPCAppDiffResponse) -> Void)?
+    public var onAppDiffResponse: ((AppDiffResponse) -> Void)?
 
     /// Called when the daemon sends an `app_restore_response` message.
-    public var onAppRestoreResponse: ((IPCAppRestoreResponse) -> Void)?
+    public var onAppRestoreResponse: ((AppRestoreResponse) -> Void)?
 
     /// Called when the daemon sends a `bundle_app_response` message.
     public var onBundleAppResponse: ((BundleAppResponseMessage) -> Void)?
@@ -434,7 +434,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
 
     /// Called when the daemon sends a `message_content_response` with full (untruncated) content.
-    public var onMessageContentResponse: ((IPCMessageContentResponse) -> Void)?
+    public var onMessageContentResponse: ((MessageContentResponse) -> Void)?
 
     /// Called when the daemon sends a `share_app_cloud_response` message.
     public var onShareAppCloudResponse: ((ShareAppCloudResponseMessage) -> Void)?
@@ -458,19 +458,19 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onTelegramConfigResponse: ((TelegramConfigResponseMessage) -> Void)?
 
     /// Called when the daemon sends a `heartbeat_config_response` message.
-    public var onHeartbeatConfigResponse: ((IPCHeartbeatConfigResponse) -> Void)?
+    public var onHeartbeatConfigResponse: ((HeartbeatConfigResponse) -> Void)?
 
     /// Called when the daemon sends a `heartbeat_runs_list_response` message.
-    public var onHeartbeatRunsListResponse: ((IPCHeartbeatRunsListResponse) -> Void)?
+    public var onHeartbeatRunsListResponse: ((HeartbeatRunsListResponse) -> Void)?
 
     /// Called when the daemon sends a `heartbeat_run_now_response` message.
-    public var onHeartbeatRunNowResponse: ((IPCHeartbeatRunNowResponse) -> Void)?
+    public var onHeartbeatRunNowResponse: ((HeartbeatRunNowResponse) -> Void)?
 
     /// Called when the daemon sends a `heartbeat_checklist_response` message.
-    public var onHeartbeatChecklistResponse: ((IPCHeartbeatChecklistResponse) -> Void)?
+    public var onHeartbeatChecklistResponse: ((HeartbeatChecklistResponse) -> Void)?
 
     /// Called when the daemon sends a `heartbeat_checklist_write_response` message.
-    public var onHeartbeatChecklistWriteResponse: ((IPCHeartbeatChecklistWriteResponse) -> Void)?
+    public var onHeartbeatChecklistWriteResponse: ((HeartbeatChecklistWriteResponse) -> Void)?
 
     /// Called when the daemon sends a `twitter_integration_config_response` message.
     public var onTwitterIntegrationConfigResponse: ((TwitterIntegrationConfigResponseMessage) -> Void)?
@@ -494,7 +494,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onOpenUrl: ((OpenUrlMessage) -> Void)?
 
     /// Called when the daemon sends a `navigate_settings` message.
-    public var onNavigateSettings: ((IPCNavigateSettings) -> Void)?
+    public var onNavigateSettings: ((NavigateSettings) -> Void)?
 
     /// Called when the daemon sends a `ui_layout_config` message.
     public var onLayoutConfig: ((UiLayoutConfigMessage) -> Void)?
@@ -506,43 +506,43 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onEnvVarsResponse: ((EnvVarsResponseMessage) -> Void)?
 
     /// Called when the daemon sends a `work_items_list_response` message.
-    public var onWorkItemsListResponse: ((IPCWorkItemsListResponse) -> Void)?
+    public var onWorkItemsListResponse: ((WorkItemsListResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_status_changed` broadcast.
-    public var onWorkItemStatusChanged: ((IPCWorkItemStatusChanged) -> Void)?
+    public var onWorkItemStatusChanged: ((WorkItemStatusChanged) -> Void)?
 
     /// Called when the daemon sends a `tasks_changed` broadcast.
-    public var onTasksChanged: ((IPCTasksChanged) -> Void)?
+    public var onTasksChanged: ((TasksChanged) -> Void)?
 
     /// Called when the daemon sends a `work_item_delete_response` message.
-    public var onWorkItemDeleteResponse: ((IPCWorkItemDeleteResponse) -> Void)?
+    public var onWorkItemDeleteResponse: ((WorkItemDeleteResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_run_task_response` message.
-    public var onWorkItemRunTaskResponse: ((IPCWorkItemRunTaskResponse) -> Void)?
+    public var onWorkItemRunTaskResponse: ((WorkItemRunTaskResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_output_response` message.
-    public var onWorkItemOutputResponse: ((IPCWorkItemOutputResponse) -> Void)?
+    public var onWorkItemOutputResponse: ((WorkItemOutputResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_update_response` message.
-    public var onWorkItemUpdateResponse: ((IPCWorkItemUpdateResponse) -> Void)?
+    public var onWorkItemUpdateResponse: ((WorkItemUpdateResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_preflight_response` message.
-    public var onWorkItemPreflightResponse: ((IPCWorkItemPreflightResponse) -> Void)?
+    public var onWorkItemPreflightResponse: ((WorkItemPreflightResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_approve_permissions_response` message.
-    public var onWorkItemApprovePermissionsResponse: ((IPCWorkItemApprovePermissionsResponse) -> Void)?
+    public var onWorkItemApprovePermissionsResponse: ((WorkItemApprovePermissionsResponse) -> Void)?
 
     /// Called when the daemon sends a `work_item_cancel_response` message.
-    public var onWorkItemCancelResponse: ((IPCWorkItemCancelResponse) -> Void)?
+    public var onWorkItemCancelResponse: ((WorkItemCancelResponse) -> Void)?
 
     /// Called when the daemon sends a generic `error` message (e.g. when a handler fails).
     public var onError: ((ErrorMessage) -> Void)?
 
     /// Called when a task run creates a conversation so the client can show it as a visible chat thread.
-    public var onTaskRunThreadCreated: ((IPCTaskRunThreadCreated) -> Void)?
+    public var onTaskRunThreadCreated: ((TaskRunThreadCreated) -> Void)?
 
     /// Called when a schedule creates a conversation so the client can show it as a visible chat thread.
-    public var onScheduleThreadCreated: ((IPCScheduleThreadCreated) -> Void)?
+    public var onScheduleThreadCreated: ((ScheduleThreadCreated) -> Void)?
 
     /// Called when the daemon requests pairing approval from macOS.
     public var onPairingApprovalRequest: ((PairingApprovalRequestMessage) -> Void)?
@@ -554,43 +554,43 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onApprovedDeviceRemoveResponse: ((ApprovedDeviceRemoveResponseMessage) -> Void)?
 
     /// Called when a subagent is spawned.
-    public var onSubagentSpawned: ((IPCSubagentSpawned) -> Void)?
+    public var onSubagentSpawned: ((SubagentSpawned) -> Void)?
 
     /// Called when a subagent's status changes (running, completed, failed, aborted).
-    public var onSubagentStatusChanged: ((IPCSubagentStatusChanged) -> Void)?
+    public var onSubagentStatusChanged: ((SubagentStatusChanged) -> Void)?
 
     /// Called when the daemon sends a `subagent_detail_response` with lazy-loaded events.
-    public var onSubagentDetailResponse: ((IPCSubagentDetailResponse) -> Void)?
+    public var onSubagentDetailResponse: ((SubagentDetailResponse) -> Void)?
 
     /// Called when the daemon sends a `recording_pause` message.
-    public var onRecordingPause: ((IPCRecordingPause) -> Void)?
+    public var onRecordingPause: ((RecordingPause) -> Void)?
 
     /// Called when the daemon sends a `recording_resume` message.
-    public var onRecordingResume: ((IPCRecordingResume) -> Void)?
+    public var onRecordingResume: ((RecordingResume) -> Void)?
 
     /// Called when the daemon sends a `recording_start` message.
-    public var onRecordingStart: ((IPCRecordingStart) -> Void)?
+    public var onRecordingStart: ((RecordingStart) -> Void)?
 
     /// Called when the daemon sends a `recording_stop` message.
-    public var onRecordingStop: ((IPCRecordingStop) -> Void)?
+    public var onRecordingStop: ((RecordingStop) -> Void)?
 
     /// Called when the daemon sends a `client_settings_update` message.
-    public var onClientSettingsUpdate: ((IPCClientSettingsUpdate) -> Void)?
+    public var onClientSettingsUpdate: ((ClientSettingsUpdate) -> Void)?
 
     /// Called when the daemon broadcasts an `identity_changed` event (IDENTITY.md changed on disk).
-    public var onIdentityChanged: ((IPCIdentityChanged) -> Void)?
+    public var onIdentityChanged: ((IdentityChanged) -> Void)?
 
     /// Called when the daemon sends an `avatar_updated` message after regenerating the avatar.
-    public var onAvatarUpdated: ((IPCAvatarUpdated) -> Void)?
+    public var onAvatarUpdated: ((AvatarUpdated) -> Void)?
 
     /// Called when the daemon sends a `generate_avatar_response` message.
-    public var onGenerateAvatarResponse: ((IPCGenerateAvatarResponse) -> Void)?
+    public var onGenerateAvatarResponse: ((GenerateAvatarResponse) -> Void)?
 
     /// Called when the daemon sends a `contacts_response` message.
     public var onContactsResponse: ((ContactsResponseMessage) -> Void)?
 
     /// Called when the daemon broadcasts a `contacts_changed` event (contact table mutated).
-    public var onContactsChanged: ((IPCContactsChanged) -> Void)?
+    public var onContactsChanged: ((ContactsChanged) -> Void)?
 
     // MARK: - Broadcast Subscribers
 
@@ -756,7 +756,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
-    public func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws {
+    public func sendConversationUnread(_ signal: ConversationUnreadSignal) async throws {
         if let override = sendOverride {
             try override(signal)
             return
@@ -1295,47 +1295,47 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Request the list of work items from the daemon, optionally filtered by status.
     public func sendWorkItemsList(status: String? = nil) throws {
-        try send(IPCWorkItemsListRequest(type: "work_items_list", status: status))
+        try send(WorkItemsListRequest(type: "work_items_list", status: status))
     }
 
     /// Mark a work item as complete (reviewed).
     public func sendWorkItemComplete(id: String) throws {
-        try send(IPCWorkItemCompleteRequest(type: "work_item_complete", id: id))
+        try send(WorkItemCompleteRequest(type: "work_item_complete", id: id))
     }
 
     /// Delete a work item.
     public func sendWorkItemDelete(id: String) throws {
-        try send(IPCWorkItemDeleteRequest(type: "work_item_delete", id: id))
+        try send(WorkItemDeleteRequest(type: "work_item_delete", id: id))
     }
 
     /// Run the task associated with a work item via daemon-side execution.
     public func sendWorkItemRunTask(id: String) throws {
-        try send(IPCWorkItemRunTaskRequest(type: "work_item_run_task", id: id))
+        try send(WorkItemRunTaskRequest(type: "work_item_run_task", id: id))
     }
 
     /// Request the latest output for a work item.
     public func sendWorkItemOutput(id: String) throws {
-        try send(IPCWorkItemOutputRequest(type: "work_item_output", id: id))
+        try send(WorkItemOutputRequest(type: "work_item_output", id: id))
     }
 
     /// Update fields on an existing work item.
     public func sendWorkItemUpdate(id: String, title: String? = nil, notes: String? = nil, status: String? = nil, priorityTier: Double? = nil, sortIndex: Int? = nil) throws {
-        try send(IPCWorkItemUpdateRequest(type: "work_item_update", id: id, title: title, notes: notes, status: status, priorityTier: priorityTier, sortIndex: sortIndex))
+        try send(WorkItemUpdateRequest(type: "work_item_update", id: id, title: title, notes: notes, status: status, priorityTier: priorityTier, sortIndex: sortIndex))
     }
 
     /// Request a permission preflight check for a work item's required tools.
     public func sendWorkItemPreflight(id: String) throws {
-        try send(IPCWorkItemPreflightRequest(type: "work_item_preflight", id: id))
+        try send(WorkItemPreflightRequest(type: "work_item_preflight", id: id))
     }
 
     /// Approve specific permissions for a work item before running.
     public func sendWorkItemApprovePermissions(id: String, approvedTools: [String]) throws {
-        try send(IPCWorkItemApprovePermissionsRequest(type: "work_item_approve_permissions", id: id, approvedTools: approvedTools))
+        try send(WorkItemApprovePermissionsRequest(type: "work_item_approve_permissions", id: id, approvedTools: approvedTools))
     }
 
     /// Cancel a running work item.
     public func sendWorkItemCancel(id: String) throws {
-        try send(IPCWorkItemCancelRequest(type: "work_item_cancel", id: id))
+        try send(WorkItemCancelRequest(type: "work_item_cancel", id: id))
     }
 
     // MARK: - Subagent Management
@@ -1443,7 +1443,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Request full (untruncated) content for a specific message.
     /// Used to rehydrate messages that were loaded with truncated text/tool results.
     public func sendMessageContentRequest(sessionId: String, messageId: String) throws {
-        try send(IPCMessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: messageId))
+        try send(MessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: messageId))
     }
 
     // MARK: - Apps
@@ -1470,17 +1470,17 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Request version history for an app.
     public func sendAppHistory(appId: String, limit: Int? = nil) throws {
-        try send(IPCAppHistoryRequest(type: "app_history_request", appId: appId, limit: limit.map { Double($0) }))
+        try send(AppHistoryRequest(type: "app_history_request", appId: appId, limit: limit.map { Double($0) }))
     }
 
     /// Request a diff between two versions of an app.
     public func sendAppDiff(appId: String, fromCommit: String, toCommit: String? = nil) throws {
-        try send(IPCAppDiffRequest(type: "app_diff_request", appId: appId, fromCommit: fromCommit, toCommit: toCommit))
+        try send(AppDiffRequest(type: "app_diff_request", appId: appId, fromCommit: fromCommit, toCommit: toCommit))
     }
 
     /// Restore an app to a previous version.
     public func sendAppRestore(appId: String, commitHash: String) throws {
-        try send(IPCAppRestoreRequest(type: "app_restore_request", appId: appId, commitHash: commitHash))
+        try send(AppRestoreRequest(type: "app_restore_request", appId: appId, commitHash: commitHash))
     }
 
     /// Request bundling an app for sharing.
@@ -1552,7 +1552,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Get, set, or clear Telegram bot token configuration.
-    public func sendTelegramConfig(action: String, botToken: String? = nil, commands: [IPCTelegramConfigRequestCommand]? = nil) throws {
+    public func sendTelegramConfig(action: String, botToken: String? = nil, commands: [TelegramConfigRequestCommand]? = nil) throws {
         try send(TelegramConfigRequestMessage(action: action, botToken: botToken, commands: commands))
     }
 
@@ -1849,32 +1849,32 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Get the current heartbeat configuration.
     public func sendHeartbeatConfigGet() throws {
-        try send(IPCHeartbeatConfig(type: "heartbeat_config", action: "get"))
+        try send(HeartbeatConfig(type: "heartbeat_config", action: "get"))
     }
 
     /// Set heartbeat configuration fields.
     public func sendHeartbeatConfigSet(enabled: Bool? = nil, intervalMs: Double? = nil, activeHoursStart: Double? = nil, activeHoursEnd: Double? = nil) throws {
-        try send(IPCHeartbeatConfig(type: "heartbeat_config", action: "set", enabled: enabled, intervalMs: intervalMs, activeHoursStart: activeHoursStart, activeHoursEnd: activeHoursEnd))
+        try send(HeartbeatConfig(type: "heartbeat_config", action: "set", enabled: enabled, intervalMs: intervalMs, activeHoursStart: activeHoursStart, activeHoursEnd: activeHoursEnd))
     }
 
     /// Request the list of recent heartbeat runs.
     public func sendHeartbeatRunsList(limit: Int? = nil) throws {
-        try send(IPCHeartbeatRunsList(type: "heartbeat_runs_list", limit: limit.map { Double($0) }))
+        try send(HeartbeatRunsList(type: "heartbeat_runs_list", limit: limit.map { Double($0) }))
     }
 
     /// Trigger an immediate heartbeat run.
     public func sendHeartbeatRunNow() throws {
-        try send(IPCHeartbeatRunNow(type: "heartbeat_run_now"))
+        try send(HeartbeatRunNow(type: "heartbeat_run_now"))
     }
 
     /// Read the heartbeat checklist (HEARTBEAT.md).
     public func sendHeartbeatChecklistRead() throws {
-        try send(IPCHeartbeatChecklistRead(type: "heartbeat_checklist_read"))
+        try send(HeartbeatChecklistRead(type: "heartbeat_checklist_read"))
     }
 
     /// Write the heartbeat checklist (HEARTBEAT.md).
     public func sendHeartbeatChecklistWrite(content: String) throws {
-        try send(IPCHeartbeatChecklistWrite(type: "heartbeat_checklist_write", content: content))
+        try send(HeartbeatChecklistWrite(type: "heartbeat_checklist_write", content: content))
     }
 
     // MARK: - Pairing

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -328,7 +328,7 @@ extension DaemonClient {
     }
 
     /// Handle a get_signing_identity request from the daemon.
-    func handleGetSigningIdentity(_ msg: IPCGetSigningIdentityRequest) {
+    func handleGetSigningIdentity(_ msg: GetSigningIdentityRequest) {
         do {
             let keyId = try SigningIdentityManager.shared.getKeyId()
             let publicKey = try SigningIdentityManager.shared.getPublicKey()

--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -35,13 +35,13 @@ extension HTTPTransport {
             } else if let msg = message as? OpenBundleMessage {
                 Task { await self.handleOpenBundle(filePath: msg.filePath) }
                 return true
-            } else if let msg = message as? IPCAppHistoryRequest {
+            } else if let msg = message as? AppHistoryRequest {
                 Task { await self.fetchAppHistory(appId: msg.appId, limit: msg.limit) }
                 return true
-            } else if let msg = message as? IPCAppDiffRequest {
+            } else if let msg = message as? AppDiffRequest {
                 Task { await self.fetchAppDiff(appId: msg.appId, fromCommit: msg.fromCommit, toCommit: msg.toCommit) }
                 return true
-            } else if let msg = message as? IPCAppRestoreRequest {
+            } else if let msg = message as? AppRestoreRequest {
                 Task { await self.handleAppRestore(appId: msg.appId, commitHash: msg.commitHash) }
                 return true
             } else if message is SharedAppsListRequestMessage {
@@ -124,7 +124,7 @@ extension HTTPTransport {
 
             let decoded = try decoder.decode(HTTPAppsListResponse.self, from: data)
             let apps = decoded.apps.map { app in
-                IPCAppsListResponseApp(
+                AppsListResponseApp(
                     id: app.id,
                     name: app.name,
                     description: app.description,
@@ -135,7 +135,7 @@ extension HTTPTransport {
                     contentId: app.contentId
                 )
             }
-            onMessage?(.appsListResponse(IPCAppsListResponse(
+            onMessage?(.appsListResponse(AppsListResponse(
                 type: "apps_list_response",
                 apps: apps
             )))
@@ -203,7 +203,7 @@ extension HTTPTransport {
 
             // REST returns { success, result, error? } — wrap into HTTP envelope
             let rest = try decoder.decode(RESTAppDataResponse.self, from: data)
-            let appDataResponse = IPCAppDataResponse(
+            let appDataResponse = AppDataResponse(
                 type: "app_data_response",
                 surfaceId: msg.surfaceId,
                 callId: msg.callId,
@@ -289,7 +289,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppDeleteResponse.self, from: data)
+            let decoded = try decoder.decode(AppDeleteResponse.self, from: data)
             onMessage?(.appDeleteResponse(decoded))
         } catch {
             log.error("App delete error: \(error.localizedDescription)")
@@ -317,7 +317,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppPreviewResponse.self, from: data)
+            let decoded = try decoder.decode(AppPreviewResponse.self, from: data)
             onMessage?(.appPreviewResponse(decoded))
         } catch {
             log.error("Fetch app preview error: \(error.localizedDescription)")
@@ -350,7 +350,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppUpdatePreviewResponse.self, from: data)
+            let decoded = try decoder.decode(AppUpdatePreviewResponse.self, from: data)
             onMessage?(.appUpdatePreviewResponse(decoded))
         } catch {
             log.error("App update preview error: \(error.localizedDescription)")
@@ -380,7 +380,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCBundleAppResponse.self, from: data)
+            let decoded = try decoder.decode(BundleAppResponse.self, from: data)
             onMessage?(.bundleAppResponse(decoded))
         } catch {
             log.error("Bundle app error: \(error.localizedDescription)")
@@ -413,7 +413,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCOpenBundleResponse.self, from: data)
+            let decoded = try decoder.decode(OpenBundleResponse.self, from: data)
             onMessage?(.openBundleResponse(decoded))
         } catch {
             log.error("Open bundle error: \(error.localizedDescription)")
@@ -449,7 +449,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppHistoryResponse.self, from: data)
+            let decoded = try decoder.decode(AppHistoryResponse.self, from: data)
             onMessage?(.appHistoryResponse(decoded))
         } catch {
             log.error("Fetch app history error: \(error.localizedDescription)")
@@ -486,7 +486,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppDiffResponse.self, from: data)
+            let decoded = try decoder.decode(AppDiffResponse.self, from: data)
             onMessage?(.appDiffResponse(decoded))
         } catch {
             log.error("Fetch app diff error: \(error.localizedDescription)")
@@ -519,7 +519,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppRestoreResponse.self, from: data)
+            let decoded = try decoder.decode(AppRestoreResponse.self, from: data)
             onMessage?(.appRestoreResponse(decoded))
         } catch {
             log.error("App restore error: \(error.localizedDescription)")
@@ -543,7 +543,7 @@ extension HTTPTransport {
                 }
                 if http.statusCode == 404 {
                     // Older assistants may not expose the shared-apps route yet.
-                    onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(
+                    onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
                         type: "shared_apps_list_response",
                         apps: []
                     )))
@@ -557,7 +557,7 @@ extension HTTPTransport {
 
             let decoded = try decoder.decode(HTTPSharedAppsListResponse.self, from: data)
             let apps = decoded.apps.map { app in
-                IPCSharedAppsListResponseApp(
+                SharedAppsListResponseApp(
                     uuid: app.uuid,
                     name: app.name,
                     description: app.description,
@@ -573,7 +573,7 @@ extension HTTPTransport {
                     updateAvailable: app.updateAvailable
                 )
             }
-            onMessage?(.sharedAppsListResponse(IPCSharedAppsListResponse(
+            onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
                 type: "shared_apps_list_response",
                 apps: apps
             )))
@@ -604,7 +604,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCSharedAppDeleteResponse.self, from: data)
+            let decoded = try decoder.decode(SharedAppDeleteResponse.self, from: data)
             onMessage?(.sharedAppDeleteResponse(decoded))
         } catch {
             log.error("Shared app delete error: \(error.localizedDescription)")
@@ -667,7 +667,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCShareAppCloudResponse.self, from: data)
+            let decoded = try decoder.decode(ShareAppCloudResponse.self, from: data)
             onMessage?(.shareAppCloudResponse(decoded))
         } catch {
             log.error("Share app cloud error: \(error.localizedDescription)")

--- a/clients/shared/Network/HTTPDaemonClient+ComputerUse.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ComputerUse.swift
@@ -56,7 +56,7 @@ extension HTTPTransport {
             }
 
             // --- Recording Status (client → server lifecycle update) ---
-            if let msg = message as? IPCRecordingStatus {
+            if let msg = message as? RecordingStatus {
                 Task { await self.sendRecordingStatus(msg) }
                 return true
             }
@@ -253,7 +253,7 @@ extension HTTPTransport {
 
     // MARK: - Recording Endpoints
 
-    private func sendRecordingStatus(_ msg: IPCRecordingStatus) async {
+    private func sendRecordingStatus(_ msg: RecordingStatus) async {
         guard let url = buildURL(for: .recordingStatus) else { return }
 
         var request = URLRequest(url: url)

--- a/clients/shared/Network/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Documents.swift
@@ -104,7 +104,7 @@ extension HTTPTransport {
             // REST returns { documents: [...] } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentListResponse.self, from: data)
             let docs = rest.documents.map { doc in
-                IPCDocumentListResponseDocument(
+                DocumentListResponseDocument(
                     surfaceId: doc.surfaceId,
                     conversationId: doc.conversationId,
                     title: doc.title,
@@ -113,7 +113,7 @@ extension HTTPTransport {
                     updatedAt: doc.updatedAt
                 )
             }
-            let documentListResponse = IPCDocumentListResponse(
+            let documentListResponse = DocumentListResponse(
                 type: "document_list_response",
                 documents: docs
             )
@@ -146,7 +146,7 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentLoadResponse.self, from: data)
-            let documentLoadResponse = IPCDocumentLoadResponse(
+            let documentLoadResponse = DocumentLoadResponse(
                 type: "document_load_response",
                 surfaceId: rest.surfaceId,
                 conversationId: rest.conversationId,
@@ -214,7 +214,7 @@ extension HTTPTransport {
 
             // REST returns { success, surfaceId, error? } without `type` — wrap into HTTP envelope
             let rest = try decoder.decode(RESTDocumentSaveResponse.self, from: data)
-            let documentSaveResponse = IPCDocumentSaveResponse(
+            let documentSaveResponse = DocumentSaveResponse(
                 type: "document_save_response",
                 surfaceId: rest.surfaceId,
                 success: rest.success,

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -43,10 +43,10 @@ extension HTTPTransport {
             } else if let msg = message as? HistoryRequestMessage {
                 Task { await self.fetchHistory(sessionId: msg.sessionId) }
                 return true
-            } else if let msg = message as? IPCConversationSeenSignal {
+            } else if let msg = message as? ConversationSeenSignal {
                 Task { await self.sendConversationSeen(msg) }
                 return true
-            } else if let msg = message as? IPCConversationUnreadSignal {
+            } else if let msg = message as? ConversationUnreadSignal {
                 Task {
                     do {
                         try await self.sendConversationUnread(msg)

--- a/clients/shared/Network/HTTPDaemonClient+Sessions.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Sessions.swift
@@ -16,19 +16,19 @@ extension HTTPTransport {
         registerDomainDispatcher { [weak self] message in
             guard let self else { return false }
 
-            if let msg = message as? IPCSessionSwitchRequest {
+            if let msg = message as? SessionSwitchRequest {
                 Task { await self.switchSession(conversationId: msg.sessionId) }
                 return true
-            } else if let msg = message as? IPCSessionRenameRequest {
+            } else if let msg = message as? SessionRenameRequest {
                 Task { await self.renameSession(sessionId: msg.sessionId, name: msg.title) }
                 return true
-            } else if message is IPCSessionsClearRequest {
+            } else if message is SessionsClearRequest {
                 Task { await self.clearAllSessions() }
                 return true
             } else if let msg = message as? CancelMessage {
                 Task { await self.cancelGeneration(sessionId: msg.sessionId ?? "") }
                 return true
-            } else if let msg = message as? IPCUndoRequest {
+            } else if let msg = message as? UndoRequest {
                 Task { await self.undoLastMessage(sessionId: msg.sessionId) }
                 return true
             } else if let msg = message as? RegenerateMessage {
@@ -43,7 +43,7 @@ extension HTTPTransport {
             } else if let msg = message as? ImageGenModelSetRequestMessage {
                 Task { await self.setImageGenModel(modelId: msg.model) }
                 return true
-            } else if let msg = message as? IPCConversationSearchRequest {
+            } else if let msg = message as? ConversationSearchRequest {
                 Task {
                     await self.searchConversations(
                         query: msg.query,
@@ -52,7 +52,7 @@ extension HTTPTransport {
                     )
                 }
                 return true
-            } else if let msg = message as? IPCMessageContentRequest {
+            } else if let msg = message as? MessageContentRequest {
                 Task { await self.fetchMessageContent(sessionId: msg.sessionId, messageId: msg.messageId) }
                 return true
             } else if let msg = message as? DeleteQueuedMessageMessage {

--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -25,7 +25,7 @@ extension HTTPTransport {
             }
 
             // --- Voice Config ---
-            if let msg = message as? IPCVoiceConfigUpdateRequest {
+            if let msg = message as? VoiceConfigUpdateRequest {
                 Task { await self.sendEncodablePost(.settingsVoice, body: msg, method: "PUT", label: "voice_config_update") }
                 return true
             }
@@ -69,7 +69,7 @@ extension HTTPTransport {
             }
 
             // --- Dictation ---
-            if let msg = message as? IPCDictationRequest {
+            if let msg = message as? DictationRequest {
                 Task { await self.sendEncodablePost(.dictation, body: msg, label: "dictation_request") }
                 return true
             }
@@ -91,7 +91,7 @@ extension HTTPTransport {
             }
 
             // --- OAuth ---
-            if let msg = message as? IPCOAuthConnectStartRequest {
+            if let msg = message as? OAuthConnectStartRequest {
                 Task { await self.sendEncodablePost(.integrationsOAuthStart, body: msg, label: "oauth_connect_start") }
                 return true
             }
@@ -107,13 +107,13 @@ extension HTTPTransport {
             }
 
             // --- Suggestion ---
-            if let msg = message as? IPCSuggestionRequest {
+            if let msg = message as? SuggestionRequest {
                 Task { await self.sendEncodablePost(.suggestion, body: msg, label: "suggestion_request") }
                 return true
             }
 
             // --- Heartbeat ---
-            if let msg = message as? IPCHeartbeatConfig {
+            if let msg = message as? HeartbeatConfig {
                 if msg.action == "get" {
                     Task { await self.sendGenericPost(.heartbeatConfig, method: "GET", label: "heartbeat_config_get") }
                 } else {
@@ -121,19 +121,19 @@ extension HTTPTransport {
                 }
                 return true
             }
-            if let msg = message as? IPCHeartbeatRunsList {
+            if let msg = message as? HeartbeatRunsList {
                 Task { await self.sendEncodablePost(.heartbeatRuns, body: msg, method: "GET", label: "heartbeat_runs_list") }
                 return true
             }
-            if message is IPCHeartbeatRunNow {
+            if message is HeartbeatRunNow {
                 Task { await self.sendGenericPost(.heartbeatRunNow, label: "heartbeat_run_now") }
                 return true
             }
-            if message is IPCHeartbeatChecklistRead {
+            if message is HeartbeatChecklistRead {
                 Task { await self.sendGenericPost(.heartbeatChecklist, method: "GET", label: "heartbeat_checklist_read") }
                 return true
             }
-            if let msg = message as? IPCHeartbeatChecklistWrite {
+            if let msg = message as? HeartbeatChecklistWrite {
                 Task { await self.sendEncodablePost(.heartbeatChecklistWrite, body: msg, method: "PUT", label: "heartbeat_checklist_write") }
                 return true
             }

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -17,7 +17,7 @@ extension HTTPTransport {
             } else if let msg = message as? SubagentAbortMessage {
                 Task { await self.handleSubagentAbort(subagentId: msg.subagentId) }
                 return true
-            } else if let msg = message as? IPCSubagentMessageRequest {
+            } else if let msg = message as? SubagentMessageRequest {
                 Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content) }
                 return true
             }
@@ -55,7 +55,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCSubagentDetailResponse.self, from: data)
+            let decoded = try decoder.decode(SubagentDetailResponse.self, from: data)
             onMessage?(.subagentDetailResponse(decoded))
         } catch {
             log.error("Fetch subagent detail error: \(error.localizedDescription)")

--- a/clients/shared/Network/HTTPDaemonClient+WorkItems.swift
+++ b/clients/shared/Network/HTTPDaemonClient+WorkItems.swift
@@ -11,22 +11,22 @@ extension HTTPTransport {
         registerDomainDispatcher { [weak self] message in
             guard let self else { return false }
 
-            if let msg = message as? IPCWorkItemsListRequest {
+            if let msg = message as? WorkItemsListRequest {
                 Task { await self.fetchWorkItemsList(status: msg.status) }
                 return true
-            } else if let msg = message as? IPCWorkItemCompleteRequest {
+            } else if let msg = message as? WorkItemCompleteRequest {
                 Task { await self.handleWorkItemComplete(id: msg.id) }
                 return true
-            } else if let msg = message as? IPCWorkItemDeleteRequest {
+            } else if let msg = message as? WorkItemDeleteRequest {
                 Task { await self.handleWorkItemDelete(id: msg.id) }
                 return true
-            } else if let msg = message as? IPCWorkItemRunTaskRequest {
+            } else if let msg = message as? WorkItemRunTaskRequest {
                 Task { await self.handleWorkItemRunTask(id: msg.id) }
                 return true
-            } else if let msg = message as? IPCWorkItemOutputRequest {
+            } else if let msg = message as? WorkItemOutputRequest {
                 Task { await self.fetchWorkItemOutput(id: msg.id) }
                 return true
-            } else if let msg = message as? IPCWorkItemUpdateRequest {
+            } else if let msg = message as? WorkItemUpdateRequest {
                 Task {
                     await self.handleWorkItemUpdate(
                         id: msg.id,
@@ -38,13 +38,13 @@ extension HTTPTransport {
                     )
                 }
                 return true
-            } else if let msg = message as? IPCWorkItemPreflightRequest {
+            } else if let msg = message as? WorkItemPreflightRequest {
                 Task { await self.handleWorkItemPreflight(id: msg.id) }
                 return true
-            } else if let msg = message as? IPCWorkItemApprovePermissionsRequest {
+            } else if let msg = message as? WorkItemApprovePermissionsRequest {
                 Task { await self.handleWorkItemApprovePermissions(id: msg.id, approvedTools: msg.approvedTools) }
                 return true
-            } else if let msg = message as? IPCWorkItemCancelRequest {
+            } else if let msg = message as? WorkItemCancelRequest {
                 Task { await self.handleWorkItemCancel(id: msg.id) }
                 return true
             }
@@ -84,7 +84,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemsListResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemsListResponse.self, from: data)
             onMessage?(.workItemsListResponse(decoded))
         } catch {
             log.error("Fetch work items list error: \(error.localizedDescription)")
@@ -143,7 +143,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemDeleteResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemDeleteResponse.self, from: data)
             onMessage?(.workItemDeleteResponse(decoded))
         } catch {
             log.error("Work item delete error: \(error.localizedDescription)")
@@ -172,7 +172,7 @@ extension HTTPTransport {
                     log.error("Work item run task failed (\(http.statusCode)): \(errorBody)")
                     // Decode error to emit a response with error info
                     let errorMsg = (try? JSONDecoder().decode(HTTPErrorEnvelopeLocal.self, from: data))?.error.message ?? "HTTP \(http.statusCode)"
-                    onMessage?(.workItemRunTaskResponse(IPCWorkItemRunTaskResponse(
+                    onMessage?(.workItemRunTaskResponse(WorkItemRunTaskResponse(
                         type: "work_item_run_task_response",
                         id: id,
                         lastRunId: "",
@@ -184,11 +184,11 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemRunTaskResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemRunTaskResponse.self, from: data)
             onMessage?(.workItemRunTaskResponse(decoded))
         } catch {
             log.error("Work item run task error: \(error.localizedDescription)")
-            onMessage?(.workItemRunTaskResponse(IPCWorkItemRunTaskResponse(
+            onMessage?(.workItemRunTaskResponse(WorkItemRunTaskResponse(
                 type: "work_item_run_task_response",
                 id: id,
                 lastRunId: "",
@@ -219,7 +219,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemOutputResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemOutputResponse.self, from: data)
             onMessage?(.workItemOutputResponse(decoded))
         } catch {
             log.error("Fetch work item output error: \(error.localizedDescription)")
@@ -275,7 +275,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemUpdateResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemUpdateResponse.self, from: data)
             onMessage?(.workItemUpdateResponse(decoded))
         } catch {
             log.error("Work item update error: \(error.localizedDescription)")
@@ -305,7 +305,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemPreflightResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemPreflightResponse.self, from: data)
             onMessage?(.workItemPreflightResponse(decoded))
         } catch {
             log.error("Work item preflight error: \(error.localizedDescription)")
@@ -338,7 +338,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemApprovePermissionsResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemApprovePermissionsResponse.self, from: data)
             onMessage?(.workItemApprovePermissionsResponse(decoded))
         } catch {
             log.error("Work item approve permissions error: \(error.localizedDescription)")
@@ -368,7 +368,7 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCWorkItemCancelResponse.self, from: data)
+            let decoded = try decoder.decode(WorkItemCancelResponse.self, from: data)
             onMessage?(.workItemCancelResponse(decoded))
         } catch {
             log.error("Work item cancel error: \(error.localizedDescription)")

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -30,10 +30,10 @@ struct ConversationsListResponse: Decodable {
         let threadType: String?
         let source: String?
         let scheduleJobId: String?
-        let channelBinding: IPCChannelBinding?
+        let channelBinding: ChannelBinding?
         let conversationOriginChannel: String?
         let conversationOriginInterface: String?
-        let assistantAttention: IPCAssistantAttention?
+        let assistantAttention: AssistantAttention?
         let displayOrder: Double?
         let isPinned: Bool?
     }
@@ -1517,7 +1517,7 @@ public final class HTTPTransport {
     }
 
     /// Upload a single attachment and return its server-assigned ID.
-    private func uploadAttachment(_ attachment: IPCAttachment, isRetry: Bool = false) async -> AttachmentUploadResult {
+    private func uploadAttachment(_ attachment: UserMessageAttachment, isRetry: Bool = false) async -> AttachmentUploadResult {
         guard let url = buildURL(for: .uploadAttachment) else { return .transientFailure }
 
         var request = URLRequest(url: url)
@@ -1563,7 +1563,7 @@ public final class HTTPTransport {
         }
     }
 
-    func sendMessage(content: String?, sessionId: String, attachments: [IPCAttachment]? = nil, uploadedAttachmentIds: [String]? = nil, isRetry: Bool = false) async {
+    func sendMessage(content: String?, sessionId: String, attachments: [UserMessageAttachment]? = nil, uploadedAttachmentIds: [String]? = nil, isRetry: Bool = false) async {
         // On retry, reuse already-uploaded attachment IDs to avoid duplicates
         var attachmentIds: [String] = uploadedAttachmentIds ?? []
 
@@ -1929,7 +1929,7 @@ public final class HTTPTransport {
         return jsonCompatible
     }
 
-    func sendConversationSeen(_ signal: IPCConversationSeenSignal, isRetry: Bool = false) async {
+    func sendConversationSeen(_ signal: ConversationSeenSignal, isRetry: Bool = false) async {
         guard let url = buildURL(for: .conversationsSeen) else { return }
 
         var request = URLRequest(url: url)
@@ -1973,7 +1973,7 @@ public final class HTTPTransport {
         }
     }
 
-    func sendConversationUnread(_ signal: IPCConversationUnreadSignal, isRetry: Bool = false) async throws {
+    func sendConversationUnread(_ signal: ConversationUnreadSignal, isRetry: Bool = false) async throws {
         guard let url = buildURL(for: .conversationsUnread) else {
             throw HTTPTransportError.invalidURL
         }
@@ -2597,7 +2597,7 @@ public final class HTTPTransport {
             }
 
             do {
-                let decoded = try decoder.decode(IPCTrustRulesListResponse.self, from: data)
+                let decoded = try decoder.decode(TrustRulesListResponse.self, from: data)
                 onMessage?(.trustRulesListResponse(decoded))
             } catch {
                 log.error("HTTPTransport: failed to decode trust rules response: \(error)")
@@ -2711,7 +2711,7 @@ public final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, scheduleJobId: $0.scheduleJobId, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention, displayOrder: $0.displayOrder, isPinned: $0.isPinned)
+                    SessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, scheduleJobId: $0.scheduleJobId, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention, displayOrder: $0.displayOrder, isPinned: $0.isPinned)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {
@@ -2747,7 +2747,7 @@ public final class HTTPTransport {
             }
 
             // The runtime's /v1/messages endpoint returns messages with `content`
-            // (string) and `timestamp` (ISO 8601 string), but IPCHistoryResponseMessage
+            // (string) and `timestamp` (ISO 8601 string), but HistoryResponseMessage
             // expects `text` and `timestamp` as a Double (ms since epoch). Transform
             // the response to match the expected message format.
             do {
@@ -3506,7 +3506,7 @@ public final class HTTPTransport {
 
             if http.statusCode == 200 {
                 let patched = injectType("conversation_search_response", into: data)
-                let decoded = try decoder.decode(IPCConversationSearchResponse.self, from: patched)
+                let decoded = try decoder.decode(ConversationSearchResponse.self, from: patched)
                 onMessage?(.conversationSearchResponse(decoded))
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
@@ -3534,7 +3534,7 @@ public final class HTTPTransport {
 
             if http.statusCode == 200 {
                 let patched = injectType("message_content_response", into: data)
-                let decoded = try decoder.decode(IPCMessageContentResponse.self, from: patched)
+                let decoded = try decoder.decode(MessageContentResponse.self, from: patched)
                 onMessage?(.messageContentResponse(decoded))
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)


### PR DESCRIPTION
## Summary
- Updated all IPC-prefixed type references across 11 DaemonClient/HTTPDaemonClient files
- Replaced type annotations, generic params, initializer calls, closure types, and property declarations

Part of plan: swift-ipc-dto-type-rename.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
