### PR TITLE
fix: buffer SSE lines, handle btw_error events, and update HELP_DISPLAY_HEIGHT in CLI /btw

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -99,7 +99,7 @@ const MIN_FEED_ROWS = 3;
 // Feed item height estimation
 const TOOL_CALL_CHROME_LINES = 2; // header (┌) + footer (└)
 const MESSAGE_SPACING = 1;
-const HELP_DISPLAY_HEIGHT = 6;
+const HELP_DISPLAY_HEIGHT = 8;
 
 interface ListMessagesResponse {
   messages: RuntimeMessage[];
@@ -1513,18 +1513,26 @@ function ChatApp({
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
           let fullText = "";
+          let sseError = "";
           const reader = res.body?.getReader();
           const decoder = new TextDecoder();
           if (reader) {
+            let buffer = "";
             while (true) {
               const { done, value } = await reader.read();
               if (done) break;
-              const chunk = decoder.decode(value, { stream: true });
-              for (const line of chunk.split("\n")) {
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split("\n");
+              buffer = lines.pop() ?? "";
+              for (const line of lines) {
                 if (line.startsWith("data: ")) {
                   try {
                     const data = JSON.parse(line.slice(6));
-                    if (data.text) fullText += data.text;
+                    if (data.error) {
+                      sseError = data.error;
+                    } else if (data.text) {
+                      fullText += data.text;
+                    }
                   } catch {
                     /* skip malformed */
                   }
@@ -1532,7 +1540,11 @@ function ChatApp({
               }
             }
           }
-          h.addStatus(fullText || "No response");
+          if (sseError) {
+            h.showError(`/btw: ${sseError}`);
+          } else {
+            h.addStatus(fullText || "No response");
+          }
         } catch (err) {
           h.showError(
             `/btw failed: ${err instanceof Error ? err.message : err}`,

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1655,10 +1655,11 @@ public final class HTTPTransport {
     }
 
     /// Send a /btw side-chain question and stream the response text.
-    /// Returns an AsyncThrowingStream that yields text deltas from SSE btw_text_delta events.
-    func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
+    /// Returns an AsyncThrowingStream that yields text deltas from SSE `btw_text_delta` events.
+    /// Throws on `btw_error` events and handles 401 authentication retry.
+    func sendBtwMessage(content: String, conversationKey: String, isRetry: Bool = false) -> AsyncThrowingStream<String, Error> {
         return AsyncThrowingStream { continuation in
-            Task { @MainActor [weak self] in
+            let task = Task { @MainActor [weak self] in
                 guard let self else {
                     continuation.finish()
                     return
@@ -1686,20 +1687,64 @@ public final class HTTPTransport {
 
                     let (bytes, response) = try await URLSession.shared.bytes(for: request)
 
-                    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                    guard let http = response as? HTTPURLResponse else {
+                        throw URLError(.badServerResponse)
+                    }
+
+                    if http.statusCode == 401 && !isRetry {
+                        // Collect response body for auth refresh
+                        var bodyChunks: [UInt8] = []
+                        for try await byte in bytes {
+                            bodyChunks.append(byte)
+                        }
+                        let responseData = Data(bodyChunks)
+                        let refreshResult = await self.handleAuthenticationFailureAsync(responseData: responseData)
+                        switch refreshResult {
+                        case .success:
+                            // Retry with refreshed auth — pipe the retry stream into this continuation
+                            let retryStream = self.sendBtwMessage(content: content, conversationKey: conversationKey, isRetry: true)
+                            do {
+                                for try await text in retryStream {
+                                    if Task.isCancelled { break }
+                                    continuation.yield(text)
+                                }
+                                continuation.finish()
+                            } catch {
+                                continuation.finish(throwing: error)
+                            }
+                            return
+                        case .terminalFailure:
+                            continuation.finish()
+                            return
+                        case .transientFailure:
+                            throw URLError(.userAuthenticationRequired, userInfo: [
+                                NSLocalizedDescriptionKey: "Authentication failed — please try again."
+                            ])
+                        }
+                    }
+
+                    guard http.statusCode == 200 else {
                         throw URLError(.badServerResponse, userInfo: [
-                            NSLocalizedDescriptionKey: "HTTP \(statusCode)"
+                            NSLocalizedDescriptionKey: "HTTP \(http.statusCode)"
                         ])
                     }
 
+                    var currentEventType: String?
                     for try await line in bytes.lines {
                         if Task.isCancelled { break }
 
-                        if line.hasPrefix("data: ") {
+                        if line.hasPrefix("event: ") {
+                            currentEventType = String(line.dropFirst(7))
+                        } else if line.hasPrefix("data: ") {
                             let jsonString = String(line.dropFirst(6))
                             if let data = jsonString.data(using: .utf8),
                                let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                                if currentEventType == "btw_error" {
+                                    let errorMessage = parsed["message"] as? String ?? parsed["error"] as? String ?? "Unknown btw error"
+                                    throw URLError(.badServerResponse, userInfo: [
+                                        NSLocalizedDescriptionKey: errorMessage
+                                    ])
+                                }
                                 if let text = parsed["text"] as? String {
                                     continuation.yield(text)
                                 }
@@ -1707,6 +1752,9 @@ public final class HTTPTransport {
                                     break
                                 }
                             }
+                            currentEventType = nil
+                        } else if line.isEmpty {
+                            currentEventType = nil
                         }
                     }
                     continuation.finish()
@@ -1714,6 +1762,7 @@ public final class HTTPTransport {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 


### PR DESCRIPTION
Addresses review feedback on #15109. Adds SSE line buffering to handle chunk-split frames, surfaces btw_error events to users instead of showing 'No response', and updates HELP_DISPLAY_HEIGHT to match the actual rendered line count.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
