### PR TITLE
feat: open threads in separate windows

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -100,6 +100,7 @@ extension AppDelegate {
         Task {
             await authManager.logout()
 
+            mainWindow?.threadWindowManager?.closeAll()
             mainWindow?.close()
             mainWindow = nil
             conversationBadgeCancellable?.cancel()
@@ -258,6 +259,7 @@ extension AppDelegate {
         //    awake and can be switched back to without a cold start.
         daemonClient.disconnect()
         // Close and recreate the main window to reset thread/session state
+        mainWindow?.threadWindowManager?.closeAll()
         mainWindow?.close()
         mainWindow = nil
 
@@ -438,6 +440,7 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
+        mainWindow?.threadWindowManager?.closeAll()
         mainWindow?.close()
         mainWindow = nil
         conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -216,6 +216,7 @@ public final class MainWindow {
     private let services: AppServices
     private var window: NSWindow?
     let threadManager: ThreadManager
+    private(set) var threadWindowManager: ThreadWindowManager!
     let appListManager = AppListManager()
     let traceStore = TraceStore()
     let usageDashboardStore: UsageDashboardStore
@@ -267,6 +268,11 @@ public final class MainWindow {
         )
         self.usageDashboardStore = UsageDashboardStore(client: services.daemonClient)
         self.taskQueueViewModel = TaskQueueViewModel(daemonClient: services.daemonClient)
+        self.threadWindowManager = ThreadWindowManager(
+            threadManager: threadManager,
+            daemonClient: services.daemonClient,
+            settingsStore: services.settingsStore
+        )
         self.threadManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient
         services.daemonClient.onTraceEvent = { [weak self] msg in
@@ -375,7 +381,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, taskQueueViewModel: taskQueueViewModel, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, threadWindowManager: threadWindowManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, taskQueueViewModel: taskQueueViewModel, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -239,7 +239,8 @@ extension MainWindowView {
                             threadManager: threadManager,
                             windowState: windowState,
                             sidebar: sidebar,
-                            selectThread: { selectThread(thread) }
+                            selectThread: { selectThread(thread) },
+                            onOpenInNewWindow: { threadWindowManager.openInNewWindow(threadId: $0) }
                         )
                             .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 
 struct MainWindowView: View {
     @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var threadWindowManager: ThreadWindowManager
     @ObservedObject var appListManager: AppListManager
     var zoomManager: ZoomManager
     var conversationZoomManager: ConversationZoomManager
@@ -57,8 +58,9 @@ struct MainWindowView: View {
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, taskQueueViewModel: TaskQueueViewModel, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, threadWindowManager: ThreadWindowManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, taskQueueViewModel: TaskQueueViewModel, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
+        self.threadWindowManager = threadWindowManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
         self.conversationZoomManager = conversationZoomManager
@@ -493,7 +495,12 @@ struct MainWindowView: View {
                                 threadManager.archiveThread(id: id)
                                 dismissThreadDrawer()
                             },
-                            onRename: { startRenameActiveThread(); dismissThreadDrawer() }
+                            onRename: { startRenameActiveThread(); dismissThreadDrawer() },
+                            onOpenInNewWindow: {
+                                guard let id = threadManager.activeThreadId else { return }
+                                threadWindowManager.openInNewWindow(threadId: id)
+                                dismissThreadDrawer()
+                            }
                         )
                         .offset(x: threadTitleFrame.minX, y: threadTitleFrame.maxY)
                         .zIndex(10)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1194,7 +1194,9 @@ private struct AppLoadingView: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), usageDashboardStore: UsageDashboardStore(client: dc), taskQueueViewModel: TaskQueueViewModel(daemonClient: dc), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager(), voiceModeManager: VoiceModeManager())
+        let tm = ThreadManager(daemonClient: dc)
+        let ss = SettingsStore(daemonClient: dc)
+        MainWindowView(threadManager: tm, threadWindowManager: ThreadWindowManager(threadManager: tm, daemonClient: dc, settingsStore: ss), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), usageDashboardStore: UsageDashboardStore(client: dc), taskQueueViewModel: TaskQueueViewModel(daemonClient: dc), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: ss, authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager(), voiceModeManager: VoiceModeManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -12,6 +12,8 @@ struct SidebarThreadItem: View {
     var selectThread: () -> Void
     /// Optional additional callback after selection (e.g. dismiss a popover).
     var onSelect: (() -> Void)? = nil
+    /// Opens the thread in a separate window.
+    var onOpenInNewWindow: ((UUID) -> Void)? = nil
 
     private var isSelected: Bool {
         switch windowState.selection {
@@ -160,6 +162,13 @@ struct SidebarThreadItem: View {
         }
         .padding(.horizontal, VSpacing.sm)
         .contextMenu {
+            if let onOpenInNewWindow {
+                Button {
+                    onOpenInNewWindow(thread.id)
+                } label: {
+                    Label { Text("Open in new window") } icon: { VIconView(.externalLink, size: 14) }
+                }
+            }
             Button {
                 withAnimation(VAnimation.standard) {
                     if thread.isPinned {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1581,9 +1581,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     // MARK: - Detached Window Support
 
     /// Get or create a ViewModel for use in a detached window.
-    /// Unlike the private `getOrCreateViewModel`, this is accessible to ThreadWindowManager.
+    /// Unlike the private `getOrCreateViewModel`, this also ensures the message
+    /// loop is started and history is loaded — the same initialization that
+    /// `activeThreadId.didSet` performs for the main window.
     func getOrCreateViewModel(forDetached threadId: UUID) -> ChatViewModel? {
-        return getOrCreateViewModel(for: threadId)
+        let vm = getOrCreateViewModel(for: threadId)
+        vm?.ensureMessageLoopStarted()
+        sessionRestorer.loadHistoryIfNeeded(threadId: threadId)
+        return vm
     }
 
     /// Pin a ViewModel so it won't be evicted by LRU cache management.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -78,6 +78,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// exceeded, the least-recently-accessed VM (that isn't the active thread) is
     /// evicted. This prevents unbounded memory growth from accumulated conversations.
     private let maxCachedViewModels = 10
+    /// Thread IDs whose ViewModels are pinned (open in detached windows).
+    /// Pinned VMs are excluded from LRU eviction.
+    private(set) var pinnedViewModelIds: Set<UUID> = []
     /// Tracks access order for LRU eviction. Most-recently-accessed ID is at the end.
     private var vmAccessOrder: [UUID] = []
     private let daemonClient: DaemonClient
@@ -1575,6 +1578,26 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return viewModel
     }
 
+    // MARK: - Detached Window Support
+
+    /// Get or create a ViewModel for use in a detached window.
+    /// Unlike the private `getOrCreateViewModel`, this is accessible to ThreadWindowManager.
+    func getOrCreateViewModel(forDetached threadId: UUID) -> ChatViewModel? {
+        return getOrCreateViewModel(for: threadId)
+    }
+
+    /// Pin a ViewModel so it won't be evicted by LRU cache management.
+    /// Used when a thread is opened in a detached window.
+    func pinViewModel(threadId: UUID) {
+        pinnedViewModelIds.insert(threadId)
+    }
+
+    /// Unpin a ViewModel, allowing LRU eviction again.
+    /// Called when a detached window is closed.
+    func unpinViewModel(threadId: UUID) {
+        pinnedViewModelIds.remove(threadId)
+    }
+
     // MARK: - VM LRU Cache Management
 
     /// Move `threadId` to the end of `vmAccessOrder` (most-recently-used position).
@@ -1587,10 +1610,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// keeping at most `maxCachedViewModels` entries in the dictionary.
     private func evictStaleCachedViewModels() {
         while chatViewModels.count > maxCachedViewModels {
-            // Find the oldest non-active, non-busy VM so we never cancel an in-flight response
-            // just because the user switched threads.
+            // Find the oldest non-active, non-pinned, non-busy VM so we never cancel
+            // an in-flight response or evict a VM backing a detached window.
             guard let victim = vmAccessOrder.first(where: {
-                guard $0 != activeThreadId, let vm = chatViewModels[$0] else { return false }
+                guard $0 != activeThreadId, !pinnedViewModelIds.contains($0),
+                      let vm = chatViewModels[$0] else { return false }
                 return !vm.isSending && !vm.isThinking && vm.pendingQueuedCount == 0
             }) else {
                 break

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
@@ -48,9 +48,14 @@ struct ThreadActionsDrawer: View {
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
+    var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            if let onOpenInNewWindow {
+                SidebarPrimaryRow(icon: VIcon.externalLink.rawValue, label: "Open in new window", action: onOpenInNewWindow)
+            }
+
             if presentation.canCopy {
                 SidebarPrimaryRow(icon: VIcon.copy.rawValue, label: "Copy full thread", action: onCopy)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -35,7 +35,7 @@ final class ThreadWindow: NSObject, NSWindowDelegate {
         let hostingController = NSHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let windowWidth: CGFloat = 700
+        let windowWidth: CGFloat = 900
         let windowHeight: CGFloat = 700
         // Offset slightly from center so it doesn't overlap the main window exactly
         let windowRect = NSRect(
@@ -60,6 +60,8 @@ final class ThreadWindow: NSObject, NSWindowDelegate {
         nsWindow.backgroundColor = NSColor(VColor.backgroundSubtle)
         nsWindow.isReleasedWhenClosed = false
         nsWindow.contentMinSize = NSSize(width: 500, height: 400)
+        nsWindow.setFrame(windowRect, display: false)
+        nsWindow.setFrameAutosaveName("ThreadWindow-\(threadId.uuidString)")
         nsWindow.delegate = self
         nsWindow.observeAppActivation()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -1,0 +1,252 @@
+import AppKit
+import Combine
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadWindow")
+
+/// A lightweight window that displays a single thread's chat.
+/// Used when a user pops a thread out into its own window.
+@MainActor
+final class ThreadWindow: NSObject, NSWindowDelegate {
+    let threadId: UUID
+    private var window: NSWindow?
+    private let onClose: () -> Void
+
+    init(
+        threadId: UUID,
+        title: String,
+        viewModel: ChatViewModel,
+        daemonClient: DaemonClient,
+        settingsStore: SettingsStore,
+        onClose: @escaping () -> Void
+    ) {
+        self.threadId = threadId
+        self.onClose = onClose
+        super.init()
+
+        let rootView = ThreadWindowContentView(
+            viewModel: viewModel,
+            daemonClient: daemonClient,
+            settingsStore: settingsStore,
+            title: title
+        )
+        let hostingController = NSHostingController(rootView: rootView)
+
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let windowWidth: CGFloat = 700
+        let windowHeight: CGFloat = 700
+        // Offset slightly from center so it doesn't overlap the main window exactly
+        let windowRect = NSRect(
+            x: screenFrame.midX - windowWidth / 2 + 40,
+            y: screenFrame.midY - windowHeight / 2 - 20,
+            width: windowWidth,
+            height: windowHeight
+        )
+
+        let nsWindow = TitleBarZoomableWindow(
+            contentRect: windowRect,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        nsWindow.contentViewController = hostingController
+        nsWindow.title = title
+        nsWindow.titleVisibility = .hidden
+        nsWindow.titlebarAppearsTransparent = true
+        nsWindow.isMovableByWindowBackground = false
+        nsWindow.backgroundColor = NSColor(VColor.backgroundSubtle)
+        nsWindow.isReleasedWhenClosed = false
+        nsWindow.contentMinSize = NSSize(width: 500, height: 400)
+        nsWindow.delegate = self
+        nsWindow.observeAppActivation()
+
+        self.window = nsWindow
+    }
+
+    func show() {
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func focus() {
+        if let window, window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func updateTitle(_ title: String) {
+        window?.title = title
+    }
+
+    func close() {
+        window?.close()
+    }
+
+    // MARK: - NSWindowDelegate
+
+    nonisolated func windowWillClose(_ notification: Notification) {
+        MainActor.assumeIsolated {
+            onClose()
+        }
+    }
+}
+
+// MARK: - SwiftUI Content View
+
+/// The root SwiftUI view for a detached thread window.
+/// Contains a title bar area and the chat view.
+struct ThreadWindowContentView: View {
+    @ObservedObject var viewModel: ChatViewModel
+    let daemonClient: DaemonClient
+    @ObservedObject var settingsStore: SettingsStore
+    let title: String
+
+    @AppStorage("themePreference") private var themePreference: String = "system"
+    @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Title bar
+            HStack {
+                Spacer()
+                Text(title)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                Spacer()
+            }
+            .frame(height: 36)
+            .padding(.horizontal, 78) // Account for traffic lights
+            .background(VColor.backgroundSubtle)
+
+            // Chat content
+            DetachedChatViewWrapper(
+                viewModel: viewModel,
+                daemonClient: daemonClient,
+                settingsStore: settingsStore
+            )
+            .padding(16)
+        }
+        .ignoresSafeArea(edges: .top)
+        .background(VColor.background.ignoresSafeArea())
+        .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
+        .onReceive(DistributedNotificationCenter.default().publisher(for: Notification.Name("AppleInterfaceThemeChangedNotification"))) { _ in
+            systemIsDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        }
+    }
+}
+
+/// Simplified chat wrapper for detached thread windows.
+/// Mirrors ActiveChatViewWrapper but without voice mode, ambient agent, etc.
+struct DetachedChatViewWrapper: View {
+    @ObservedObject var viewModel: ChatViewModel
+    let daemonClient: DaemonClient
+    @ObservedObject var settingsStore: SettingsStore
+    @State private var anchorMessageId: UUID?
+
+    var body: some View {
+        ChatView(
+            messages: viewModel.messages,
+            inputText: Binding(
+                get: { viewModel.inputText },
+                set: { viewModel.inputText = $0 }
+            ),
+            hasAPIKey: true,
+            isThinking: viewModel.isThinking,
+            isSending: viewModel.isSending,
+            errorText: viewModel.errorText,
+            pendingQueuedCount: viewModel.pendingQueuedCount,
+            suggestion: viewModel.suggestion,
+            pendingAttachments: viewModel.pendingAttachments,
+            isLoadingAttachment: viewModel.isLoadingAttachment,
+            isRecording: viewModel.isRecording,
+            onOpenSettings: {},
+            onSend: { viewModel.sendMessage() },
+            onStop: viewModel.stopGenerating,
+            onDismissError: viewModel.dismissError,
+            isRetryableError: viewModel.isRetryableError,
+            onRetryError: { viewModel.retryLastMessage() },
+            isConnectionError: viewModel.isConnectionError,
+            hasRetryPayload: viewModel.hasRetryPayload,
+            isSecretBlockError: viewModel.isSecretBlockError,
+            onSendAnyway: { viewModel.sendAnyway() },
+            onAcceptSuggestion: viewModel.acceptSuggestion,
+            onAttach: { openFilePicker(viewModel: viewModel) },
+            onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
+            onDropFiles: { urls in urls.forEach { viewModel.addAttachment(url: $0) } },
+            onDropImageData: { data, name in
+                let filename: String
+                if let name {
+                    let base = ((name as NSString).lastPathComponent as NSString).deletingPathExtension
+                    filename = base.isEmpty ? "Dropped Image.png" : "\(base).png"
+                } else {
+                    filename = "Dropped Image.png"
+                }
+                viewModel.addAttachment(imageData: data, filename: filename)
+            },
+            onPaste: { viewModel.addAttachmentFromPasteboard() },
+            onMicrophoneToggle: {},
+            onModelPickerSelect: { _, modelId in settingsStore.setModel(modelId) },
+            selectedModel: settingsStore.selectedModel,
+            configuredProviders: settingsStore.configuredProviders,
+            assistantActivityPhase: viewModel.assistantActivityPhase,
+            assistantActivityAnchor: viewModel.assistantActivityAnchor,
+            assistantActivityReason: viewModel.assistantActivityReason,
+            assistantStatusText: viewModel.assistantStatusText,
+            onConfirmationAllow: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
+            onConfirmationDeny: { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
+            onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision) },
+            onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
+            onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
+            onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
+            sessionError: viewModel.sessionError,
+            onRetry: { viewModel.retryAfterSessionError() },
+            onDismissSessionError: { viewModel.dismissSessionError() },
+            onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+            watchSession: nil,
+            onStopWatch: {},
+            onReportMessage: { daemonMessageId in
+                guard let sessionId = viewModel.sessionId else { return }
+                do {
+                    try daemonClient.sendDiagnosticsExportRequest(
+                        conversationId: sessionId,
+                        anchorMessageId: daemonMessageId
+                    )
+                } catch {}
+            },
+            mediaEmbedSettings: MediaEmbedResolverSettings(
+                enabled: settingsStore.mediaEmbedsEnabled,
+                enabledSince: settingsStore.mediaEmbedsEnabledSince,
+                allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
+            ),
+            activeSubagents: viewModel.activeSubagents,
+            onAbortSubagent: { subagentId in
+                try? daemonClient.sendSubagentAbort(subagentId: subagentId)
+            },
+            onRehydrateMessage: { messageId in
+                viewModel.rehydrateMessage(id: messageId)
+            },
+            onSurfaceRefetch: { surfaceId, sessionId in
+                viewModel.refetchStrippedSurface(surfaceId: surfaceId, sessionId: sessionId)
+            },
+            subagentDetailStore: viewModel.subagentDetailStore,
+            resolveHttpPort: daemonClient.httpPortResolver,
+            isHistoryLoaded: viewModel.isHistoryLoaded,
+            dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
+            onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
+            connectionDiagnosticHint: viewModel.connectionDiagnosticHint,
+            anchorMessageId: $anchorMessageId,
+            displayedMessageCount: viewModel.displayedMessageCount,
+            hasMoreMessages: viewModel.hasMoreMessages,
+            isLoadingMoreMessages: viewModel.isLoadingMoreMessages,
+            loadPreviousMessagePage: { await viewModel.loadPreviousMessagePage() }
+        )
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Combine
+import VellumAssistantShared
+import SwiftUI
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ThreadWindowManager")
+
+/// Manages detached thread windows — threads opened in their own separate window.
+@MainActor
+final class ThreadWindowManager: ObservableObject {
+    private let threadManager: ThreadManager
+    private let daemonClient: DaemonClient
+    private let settingsStore: SettingsStore
+
+    /// Map of thread ID → detached window.
+    private var windows: [UUID: ThreadWindow] = [:]
+
+    /// Thread IDs that are currently open in a detached window.
+    /// Published so the sidebar can show visual indicators.
+    @Published private(set) var detachedThreadIds: Set<UUID> = []
+
+    init(threadManager: ThreadManager, daemonClient: DaemonClient, settingsStore: SettingsStore) {
+        self.threadManager = threadManager
+        self.daemonClient = daemonClient
+        self.settingsStore = settingsStore
+    }
+
+    /// Open a thread in a new window. If already open, focus the existing window.
+    func openInNewWindow(threadId: UUID) {
+        if let existing = windows[threadId] {
+            existing.focus()
+            return
+        }
+
+        guard let viewModel = threadManager.getOrCreateViewModel(forDetached: threadId) else {
+            log.warning("Cannot open thread \(threadId) in new window — thread not found")
+            return
+        }
+
+        // Pin the VM so LRU eviction doesn't kill it while the window is open
+        threadManager.pinViewModel(threadId: threadId)
+
+        let thread = threadManager.threads.first(where: { $0.id == threadId })
+        let title = thread?.title ?? "Conversation"
+
+        let window = ThreadWindow(
+            threadId: threadId,
+            title: title,
+            viewModel: viewModel,
+            daemonClient: daemonClient,
+            settingsStore: settingsStore,
+            onClose: { [weak self] in
+                self?.handleWindowClosed(threadId: threadId)
+            }
+        )
+        window.show()
+
+        windows[threadId] = window
+        detachedThreadIds.insert(threadId)
+        log.info("Opened thread \(threadId) in new window")
+    }
+
+    /// Update the title of a detached window when the thread is renamed.
+    func updateTitle(threadId: UUID, title: String) {
+        windows[threadId]?.updateTitle(title)
+    }
+
+    /// Close a detached window programmatically (e.g. when thread is archived).
+    func closeWindow(threadId: UUID) {
+        windows[threadId]?.close()
+        // handleWindowClosed will be called by the onClose callback
+    }
+
+    /// Whether a thread is currently open in a detached window.
+    func isDetached(_ threadId: UUID) -> Bool {
+        detachedThreadIds.contains(threadId)
+    }
+
+    /// Close all detached windows.
+    func closeAll() {
+        for (_, window) in windows {
+            window.close()
+        }
+        // handleWindowClosed handles cleanup for each
+    }
+
+    private func handleWindowClosed(threadId: UUID) {
+        windows.removeValue(forKey: threadId)
+        detachedThreadIds.remove(threadId)
+        threadManager.unpinViewModel(threadId: threadId)
+        log.info("Closed detached window for thread \(threadId)")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
@@ -76,15 +76,10 @@ final class ThreadWindowManager: ObservableObject {
         windows[threadId] = window
         detachedThreadIds.insert(threadId)
 
-        // Switch the main window away from this thread to avoid two windows
-        // with the same shared ChatViewModel both showing an active composer.
+        // Switch the main window to a fresh new-thread composer so the user
+        // can start a new conversation while the popped-out thread continues.
         if threadManager.activeThreadId == threadId {
-            let next = threadManager.visibleThreads.first(where: { $0.id != threadId })
-            if let next {
-                threadManager.selectThread(id: next.id)
-            } else {
-                threadManager.enterDraftMode()
-            }
+            threadManager.enterDraftMode()
         }
 
         log.info("Opened thread \(threadId) in new window")
@@ -118,6 +113,7 @@ final class ThreadWindowManager: ObservableObject {
         windows.removeValue(forKey: threadId)
         detachedThreadIds.remove(threadId)
         threadManager.unpinViewModel(threadId: threadId)
+
         log.info("Closed detached window for thread \(threadId)")
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
@@ -20,10 +20,27 @@ final class ThreadWindowManager: ObservableObject {
     /// Published so the sidebar can show visual indicators.
     @Published private(set) var detachedThreadIds: Set<UUID> = []
 
+    private var threadsCancellable: AnyCancellable?
+
     init(threadManager: ThreadManager, daemonClient: DaemonClient, settingsStore: SettingsStore) {
         self.threadManager = threadManager
         self.daemonClient = daemonClient
         self.settingsStore = settingsStore
+        observeThreadArchival()
+    }
+
+    /// Close detached windows when their thread is archived or deleted.
+    private func observeThreadArchival() {
+        threadsCancellable = threadManager.$threads
+            .sink { [weak self] threads in
+                guard let self else { return }
+                let activeIds = Set(threads.filter { !$0.isArchived }.map(\.id))
+                for detachedId in self.detachedThreadIds {
+                    if !activeIds.contains(detachedId) {
+                        self.closeWindow(threadId: detachedId)
+                    }
+                }
+            }
     }
 
     /// Open a thread in a new window. If already open, focus the existing window.
@@ -58,6 +75,18 @@ final class ThreadWindowManager: ObservableObject {
 
         windows[threadId] = window
         detachedThreadIds.insert(threadId)
+
+        // Switch the main window away from this thread to avoid two windows
+        // with the same shared ChatViewModel both showing an active composer.
+        if threadManager.activeThreadId == threadId {
+            let next = threadManager.visibleThreads.first(where: { $0.id != threadId })
+            if let next {
+                threadManager.selectThread(id: next.id)
+            } else {
+                threadManager.enterDraftMode()
+            }
+        }
+
         log.info("Opened thread \(threadId) in new window")
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -21,8 +21,11 @@ extension ChatViewModel {
     func belongsToSession(_ messageSessionId: String?) -> Bool {
         guard let messageSessionId else { return true }
         guard let sessionId else {
-            // No session established yet — accept all messages
-            return true
+            // No session established yet — reject messages from known sessions.
+            // The VM will claim its own session via correlationId matching in
+            // the sessionInfo handler; stray messages from other sessions must
+            // not leak into a draft/bootstrapping VM.
+            return false
         }
         return messageSessionId == sessionId
     }

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -32,6 +32,8 @@ extension HTTPTransport {
                 let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
                 self.activeLocalSessionId = sessionId
                 self.remoteSessionId = nil  // Reset — will be learned from the first SSE event
+                // Register for multi-session remapping (popout windows).
+                self.pendingLocalSessionIds.append(sessionId)
                 let info = ServerMessage.sessionInfo(
                     SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
                 )

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -181,6 +181,16 @@ public final class HTTPTransport {
     /// All occurrences are remapped to `activeLocalSessionId` in incoming events.
     var remoteSessionId: String?
 
+    /// Map of daemon remote session IDs → client local session IDs.
+    /// Supports multiple concurrent sessions (e.g. popout windows) where SSE
+    /// events from different conversations need remapping to the correct local ID.
+    var sessionIdMap: [String: String] = [:]
+
+    /// Local session IDs that haven't yet learned their remote counterpart.
+    /// When a new session is created, its local ID is added here. The first SSE
+    /// event with an unknown remote ID is paired with the oldest pending entry.
+    var pendingLocalSessionIds: [String] = []
+
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
@@ -1426,39 +1436,57 @@ public final class HTTPTransport {
         // local session ID so that ChatViewModel.belongsToSession() passes.
         // The daemon assigns its own UUID via getOrCreateConversation(), which
         // differs from the correlationId the client uses as sessionId.
+        // Supports multiple concurrent sessions (popout windows) via sessionIdMap.
         var jsonString = data
-        if let localId = activeLocalSessionId {
-            if remoteSessionId == nil {
-                // Learn the daemon's session ID from the first event envelope.
-                if let eventData = data.data(using: .utf8),
-                   let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
-                   let eventSessionId = envelope.sessionId,
-                   eventSessionId != localId {
-                    remoteSessionId = eventSessionId
-                    log.info("Learned remote sessionId \(eventSessionId, privacy: .public) → local \(localId, privacy: .public)")
-                }
+
+        // Try to learn a new remote → local mapping from the event envelope.
+        if !pendingLocalSessionIds.isEmpty,
+           let eventData = data.data(using: .utf8),
+           let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
+           let eventSessionId = envelope.sessionId,
+           sessionIdMap[eventSessionId] == nil,
+           !sessionIdMap.values.contains(eventSessionId) {
+            // This is an unknown remote ID — pair it with the oldest pending local ID.
+            let localId = pendingLocalSessionIds.removeFirst()
+            sessionIdMap[eventSessionId] = localId
+            // Keep legacy fields in sync for code that still reads them.
+            if activeLocalSessionId == localId {
+                remoteSessionId = eventSessionId
             }
-            if let remoteId = remoteSessionId {
-                // Replace only the sessionId JSON value — not arbitrary occurrences
-                // of the UUID elsewhere in the payload. Handle both compact
-                // ("sessionId":"…") and pretty-printed ("sessionId": "…") JSON.
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\":\"\(remoteId)\"",
-                    with: "\"sessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\": \"\(remoteId)\"",
-                    with: "\"sessionId\": \"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\":\"\(remoteId)\"",
-                    with: "\"parentSessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\": \"\(remoteId)\"",
-                    with: "\"parentSessionId\": \"\(localId)\""
-                )
+            log.info("Learned remote sessionId \(eventSessionId, privacy: .public) → local \(localId, privacy: .public)")
+        }
+
+        // Legacy single-session learning (for sessions created before this change).
+        if let localId = activeLocalSessionId, remoteSessionId == nil,
+           sessionIdMap.values.first(where: { $0 == localId }) == nil {
+            if let eventData = data.data(using: .utf8),
+               let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
+               let eventSessionId = envelope.sessionId,
+               eventSessionId != localId {
+                remoteSessionId = eventSessionId
+                sessionIdMap[eventSessionId] = localId
+                log.info("Learned remote sessionId (legacy) \(eventSessionId, privacy: .public) → local \(localId, privacy: .public)")
             }
+        }
+
+        // Apply all known remote → local remappings.
+        for (remoteId, localId) in sessionIdMap {
+            jsonString = jsonString.replacingOccurrences(
+                of: "\"sessionId\":\"\(remoteId)\"",
+                with: "\"sessionId\":\"\(localId)\""
+            )
+            jsonString = jsonString.replacingOccurrences(
+                of: "\"sessionId\": \"\(remoteId)\"",
+                with: "\"sessionId\": \"\(localId)\""
+            )
+            jsonString = jsonString.replacingOccurrences(
+                of: "\"parentSessionId\":\"\(remoteId)\"",
+                with: "\"parentSessionId\":\"\(localId)\""
+            )
+            jsonString = jsonString.replacingOccurrences(
+                of: "\"parentSessionId\": \"\(remoteId)\"",
+                with: "\"parentSessionId\": \"\(localId)\""
+            )
         }
 
         guard let jsonData = jsonString.data(using: .utf8) else { return }


### PR DESCRIPTION
## Summary
- Adds ability to pop any thread into its own standalone macOS window for side-by-side multitasking
- Accessible via thread title dropdown ("Open in new window") and sidebar right-click context menu
- `ThreadWindow` hosts a lightweight chat-only NSWindow per thread; `ThreadWindowManager` tracks open windows and prevents duplicates
- Pinned ViewModels are excluded from LRU eviction so detached threads stay alive

## Test plan
- [ ] Click thread title dropdown → "Open in new window" → verify thread opens in a new window
- [ ] Right-click a thread in the sidebar → "Open in new window" → same behavior
- [ ] Try opening the same thread twice → should focus existing window instead of creating a duplicate
- [ ] Send messages in the detached window → verify they appear and stream correctly
- [ ] Close the detached window → verify no crash, thread still accessible in main window
- [ ] Open 10+ threads in detached windows → verify no LRU eviction of active detached VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
