### PR TITLE
fix: remove dead hasPendingHostBash from Session

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -580,10 +580,6 @@ export class Session {
     this.hostBashProxy?.resolve(requestId, response);
   }
 
-  hasPendingHostBash(requestId: string): boolean {
-    return this.hostBashProxy?.hasPendingRequest(requestId) ?? false;
-  }
-
   setHostBashProxy(proxy: HostBashProxy | undefined): void {
     this.hostBashProxy = proxy;
   }


### PR DESCRIPTION
## Summary
Removes unused `hasPendingHostBash()` method from Session class per dead code removal policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
