### PR TITLE
refactor: update macOS app to use renamed DTO types

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -125,8 +125,8 @@ extension AppDelegate {
 
     func unpackAndLoadBundle(
         filePath: String,
-        manifest: IPCOpenBundleResponseManifest,
-        signatureResult: IPCOpenBundleResponseSignatureResult,
+        manifest: OpenBundleResponseManifest,
+        signatureResult: OpenBundleResponseSignatureResult,
         bundleSizeBytes: Int,
         onSuccess: (() -> Void)? = nil,
         onError: ((String) -> Void)? = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -314,7 +314,7 @@ extension AppDelegate {
         errorCode: String?
     ) {
         guard let deliveryId else { return }
-        let result = IPCNotificationIntentResult(
+        let result = NotificationIntentResult(
             type: "notification_intent_result",
             deliveryId: deliveryId,
             success: success,
@@ -418,7 +418,7 @@ extension AppDelegate {
         source: String,
         evidenceText: String? = nil
     ) {
-        let signal = IPCConversationSeenSignal(
+        let signal = ConversationSeenSignal(
             conversationId: conversationId,
             sourceChannel: "vellum",
             signalType: signalType,

--- a/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Recording.swift
@@ -11,7 +11,7 @@ extension AppDelegate {
     ///
     /// Checks screen recording permission, optionally shows the source picker,
     /// and starts recording via the RecordingManager.
-    func handleRecordingStart(_ msg: IPCRecordingStart) {
+    func handleRecordingStart(_ msg: RecordingStart) {
         // Check screen recording permission
         let permissionStatus = PermissionManager.screenRecordingStatus()
         guard permissionStatus == .granted else {
@@ -19,7 +19,7 @@ extension AppDelegate {
             PermissionManager.requestScreenRecordingAccess()
 
             // Notify daemon that recording failed due to permission
-            let statusMsg = IPCRecordingStatus(
+            let statusMsg = RecordingStatus(
                 type: "recording_status",
                 sessionId: msg.recordingId,
                 status: "failed",
@@ -52,7 +52,7 @@ extension AppDelegate {
     }
 
     /// Handle a `recording_pause` message from the daemon.
-    func handleRecordingPause(_ msg: IPCRecordingPause) {
+    func handleRecordingPause(_ msg: RecordingPause) {
         let paused = recordingManager.pause(sessionId: msg.recordingId)
         if paused {
             recordingHUDWindow?.setPaused(true)
@@ -60,7 +60,7 @@ extension AppDelegate {
     }
 
     /// Handle a `recording_resume` message from the daemon.
-    func handleRecordingResume(_ msg: IPCRecordingResume) {
+    func handleRecordingResume(_ msg: RecordingResume) {
         let resumed = recordingManager.resume(sessionId: msg.recordingId)
         if resumed {
             recordingHUDWindow?.setPaused(false)
@@ -94,7 +94,7 @@ extension AppDelegate {
                 if operationToken != nil {
                     // Restart flow: picker dismissed without selection —
                     // send restart_cancelled so the daemon knows to abort.
-                    let statusMsg = IPCRecordingStatus(
+                    let statusMsg = RecordingStatus(
                         type: "recording_status",
                         sessionId: recordingId,
                         status: "restart_cancelled",
@@ -105,7 +105,7 @@ extension AppDelegate {
                     log.info("Restart cancelled — source picker dismissed for session \(recordingId, privacy: .public)")
                 } else {
                     // Normal start flow: picker cancelled
-                    let statusMsg = IPCRecordingStatus(
+                    let statusMsg = RecordingStatus(
                         type: "recording_status",
                         sessionId: recordingId,
                         status: "failed",
@@ -120,7 +120,7 @@ extension AppDelegate {
     /// Start recording and show the recording HUD only after recording is confirmed.
     private func startRecording(
         recordingId: String,
-        options: IPCRecordingOptions?,
+        options: RecordingOptions?,
         attachToConversationId: String?,
         promptForSource: Bool = false,
         operationToken: String? = nil
@@ -153,7 +153,7 @@ extension AppDelegate {
                 }
             }
             // Rebuild options with the resolved mic permission
-            let effectiveOptions = IPCRecordingOptions(
+            let effectiveOptions = RecordingOptions(
                 captureScope: options?.captureScope,
                 displayId: options?.displayId,
                 windowId: options?.windowId,

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -162,8 +162,8 @@ extension AppDelegate {
 
             // 2. Send task_submit — daemon classifies and creates the session
             let screenBounds = CGDisplayBounds(CGMainDisplayID())
-            let messageAttachments: [IPCAttachment]? = submission.attachments.isEmpty ? nil : submission.attachments.map {
-                IPCAttachment(
+            let messageAttachments: [UserMessageAttachment]? = submission.attachments.isEmpty ? nil : submission.attachments.map {
+                UserMessageAttachment(
                     filename: $0.fileName,
                     mimeType: $0.mimeType,
                     data: $0.data.base64EncodedString(),
@@ -285,7 +285,7 @@ extension AppDelegate {
     /// Guardian questions are time-sensitive, so they are foregrounded when the
     /// app is active. All notification types get a fallback native alert when
     /// backgrounded to guarantee delivery if the notification_intent event is late.
-    func handleNotificationThreadCreated(_ msg: IPCNotificationThreadCreated) {
+    func handleNotificationThreadCreated(_ msg: NotificationThreadCreated) {
         // Guardian scoping: skip thread creation for notifications targeted at
         // a different guardian identity. When the local principal is nil (not yet
         // bootstrapped), pass through all notifications so urgent prompts aren't

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -38,7 +38,7 @@ final class VoiceInputManager {
     var daemonClient: (any DaemonClientProtocol)?
 
     /// Called when the daemon returns a dictation response (cleaned-up text + action plan).
-    var onDictationResponse: ((IPCDictationResponse) -> Void)?
+    var onDictationResponse: ((DictationResponse) -> Void)?
 
     /// Called when the daemon classifies dictation as an action (e.g. "Slack Alex about the standup").
     /// The callback receives the original transcription text for routing to a full agent session.
@@ -753,7 +753,7 @@ final class VoiceInputManager {
                 onTranscription?(text)
                 return
             }
-            let request = IPCDictationRequest(
+            let request = DictationRequest(
                 transcription: text,
                 context: .create(
                     bundleIdentifier: context.bundleIdentifier,

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -125,8 +125,8 @@ final class ComputerUseSession: ObservableObject {
 
         // 2. Send session create message (skip if daemon already created via task_submit)
         if !skipSessionCreate {
-            let messageAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
-                IPCAttachment(
+            let messageAttachments: [UserMessageAttachment]? = attachments.isEmpty ? nil : attachments.map {
+                UserMessageAttachment(
                     filename: $0.fileName,
                     mimeType: $0.mimeType,
                     data: $0.data.base64EncodedString(),

--- a/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/TextSession.swift
@@ -82,8 +82,8 @@ final class TextSession: ObservableObject {
                         log.info("Got daemon session ID: \(info.sessionId)")
 
                         // Now send the user message
-                        let messageAttachments: [IPCAttachment]? = self.attachments.isEmpty ? nil : self.attachments.map {
-                            IPCAttachment(
+                        let messageAttachments: [UserMessageAttachment]? = self.attachments.isEmpty ? nil : self.attachments.map {
+                            UserMessageAttachment(
                                 filename: $0.fileName,
                                 mimeType: $0.mimeType,
                                 data: $0.data.base64EncodedString(),

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -8,12 +8,12 @@ struct AppVersionHistoryPanel: View {
     let appName: String
     let onClose: () -> Void
 
-    @State private var versions: [IPCAppHistoryResponseVersion] = []
+    @State private var versions: [AppHistoryResponseVersion] = []
     @State private var isLoading = true
-    @State private var selectedVersion: IPCAppHistoryResponseVersion?
+    @State private var selectedVersion: AppHistoryResponseVersion?
     @State private var diffText: String?
     @State private var isDiffLoading = false
-    @State private var restoreConfirmVersion: IPCAppHistoryResponseVersion?
+    @State private var restoreConfirmVersion: AppHistoryResponseVersion?
     @State private var isRestoring = false
     @State private var restoreError: String?
     @State private var pendingDiffCommitHash: String?
@@ -123,7 +123,7 @@ struct AppVersionHistoryPanel: View {
         }
     }
 
-    private func versionRow(_ version: IPCAppHistoryResponseVersion, isFirst: Bool) -> some View {
+    private func versionRow(_ version: AppHistoryResponseVersion, isFirst: Bool) -> some View {
         let isSelected = selectedVersion?.commitHash == version.commitHash
         return Button(action: {
             if selectedVersion?.commitHash == version.commitHash {
@@ -181,7 +181,7 @@ struct AppVersionHistoryPanel: View {
     // MARK: - Diff Detail
 
     @ViewBuilder
-    private func diffDetailView(for version: IPCAppHistoryResponseVersion) -> some View {
+    private func diffDetailView(for version: AppHistoryResponseVersion) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             // Diff header
             HStack {
@@ -282,7 +282,7 @@ struct AppVersionHistoryPanel: View {
         }
     }
 
-    private func selectVersion(_ version: IPCAppHistoryResponseVersion) {
+    private func selectVersion(_ version: AppHistoryResponseVersion) {
         selectedVersion = version
         isDiffLoading = true
         diffText = nil
@@ -314,7 +314,7 @@ struct AppVersionHistoryPanel: View {
         }
     }
 
-    private func restoreVersion(_ version: IPCAppHistoryResponseVersion) {
+    private func restoreVersion(_ version: AppHistoryResponseVersion) {
         isRestoring = true
         restoreError = nil
         restoreConfirmVersion = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskOutputView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskOutputView.swift
@@ -73,7 +73,7 @@ struct TaskOutputView: View {
 
     // MARK: - Loaded Content
 
-    private func loadedContent(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+    private func loadedContent(_ output: WorkItemOutputResponseOutput) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 metadataSection(output)
@@ -88,7 +88,7 @@ struct TaskOutputView: View {
 
     // MARK: - Metadata
 
-    private func metadataSection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+    private func metadataSection(_ output: WorkItemOutputResponseOutput) -> some View {
         HStack(spacing: VSpacing.sm) {
             HStack(spacing: 4) {
                 Circle()
@@ -121,7 +121,7 @@ struct TaskOutputView: View {
 
     // MARK: - Summary
 
-    private func summarySection(_ output: IPCWorkItemOutputResponseOutput) -> some View {
+    private func summarySection(_ output: WorkItemOutputResponseOutput) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text("Summary")
                 .font(VFont.captionMedium)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskPreflightView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskPreflightView.swift
@@ -97,7 +97,7 @@ struct TaskPreflightView: View {
 
     // MARK: - Permissions List
 
-    private func permissionsListView(_ permissions: [IPCWorkItemPreflightResponsePermission]) -> some View {
+    private func permissionsListView(_ permissions: [WorkItemPreflightResponsePermission]) -> some View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -134,7 +134,7 @@ struct TaskPreflightView: View {
         }
     }
 
-    private func permissionRow(_ permission: IPCWorkItemPreflightResponsePermission) -> some View {
+    private func permissionRow(_ permission: WorkItemPreflightResponsePermission) -> some View {
         let isApproved = approvedTools.contains(permission.tool)
         return HStack(spacing: VSpacing.sm) {
             Button {
@@ -197,7 +197,7 @@ struct TaskPreflightView: View {
 
     // MARK: - Approve Footer
 
-    private func approveFooter(permissions: [IPCWorkItemPreflightResponsePermission]) -> some View {
+    private func approveFooter(permissions: [WorkItemPreflightResponsePermission]) -> some View {
         HStack {
             Spacer()
             Button {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueuePanel.swift
@@ -158,7 +158,7 @@ struct TaskQueuePanel: View {
 
 /// A single task row in the macOS task queue panel.
 private struct TaskQueueRow: View {
-    let item: IPCWorkItemsListResponseItem
+    let item: WorkItemsListResponseItem
     let hasOutput: Bool
     let runningIds: Set<String>
     let timeoutIds: Set<String>

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueueViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/TaskQueueViewModel.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 /// Centralizes task queue state and daemon callbacks for the macOS Task Queue panel.
 @MainActor
 class TaskQueueViewModel: ObservableObject {
-    @Published var items: [IPCWorkItemsListResponseItem] = []
+    @Published var items: [WorkItemsListResponseItem] = []
     @Published var isLoading = true
     @Published var errorMessage: String?
 
@@ -17,12 +17,12 @@ class TaskQueueViewModel: ObservableObject {
     @Published var cancelInFlightIds: Set<String> = []
 
     /// The currently selected item for output detail viewing.
-    @Published var selectedOutputItem: IPCWorkItemsListResponseItem?
+    @Published var selectedOutputItem: WorkItemsListResponseItem?
     /// Loading/loaded/error state for the output detail sheet.
     @Published var outputState: TaskOutputState = .loading
 
     /// The item currently undergoing permission preflight.
-    @Published var preflightItem: IPCWorkItemsListResponseItem?
+    @Published var preflightItem: WorkItemsListResponseItem?
     /// Loading/loaded/error state for the preflight sheet.
     @Published var preflightState: TaskPreflightState = .loading
 
@@ -34,7 +34,7 @@ class TaskQueueViewModel: ObservableObject {
     private var refreshTask: Task<Void, Never>?
 
     /// Tracks the item awaiting a preflight response from the daemon.
-    private var pendingPreflightItem: IPCWorkItemsListResponseItem?
+    private var pendingPreflightItem: WorkItemsListResponseItem?
 
     private var runTimeoutTasks: [String: Task<Void, Never>] = [:]
 
@@ -50,7 +50,7 @@ class TaskQueueViewModel: ObservableObject {
 
     // MARK: - Filtered Items
 
-    var filteredItems: [IPCWorkItemsListResponseItem] {
+    var filteredItems: [WorkItemsListResponseItem] {
         switch statusFilter {
         case .all:
             return items
@@ -196,7 +196,7 @@ class TaskQueueViewModel: ObservableObject {
     }
 
     /// Whether a task's status indicates it may have output to display.
-    func taskHasOutput(_ item: IPCWorkItemsListResponseItem) -> Bool {
+    func taskHasOutput(_ item: WorkItemsListResponseItem) -> Bool {
         let status = WorkItemStatus(rawStatus: item.status)
         switch status {
         case .awaitingReview, .done, .failed: return true
@@ -208,7 +208,7 @@ class TaskQueueViewModel: ObservableObject {
 
     /// Initiates the run flow via a preflight check. The permission sheet only
     /// appears if the daemon reports non-empty permissions.
-    func initiateRun(item: IPCWorkItemsListResponseItem) {
+    func initiateRun(item: WorkItemsListResponseItem) {
         logger.info("initiateRun: id=\(item.id, privacy: .public)")
         guard !runInFlightIds.contains(item.id) else {
             logger.warning("initiateRun: skipping — already in flight for id=\(item.id, privacy: .public)")
@@ -287,7 +287,7 @@ class TaskQueueViewModel: ObservableObject {
 
     // MARK: - Output
 
-    func fetchOutput(for item: IPCWorkItemsListResponseItem) {
+    func fetchOutput(for item: WorkItemsListResponseItem) {
         logger.info("fetchOutput: id=\(item.id, privacy: .public)")
         selectedOutputItem = item
         outputState = .loading
@@ -351,14 +351,14 @@ class TaskQueueViewModel: ObservableObject {
 /// Loading/loaded/error state for fetching task output.
 enum TaskOutputState {
     case loading
-    case loaded(IPCWorkItemOutputResponseOutput)
+    case loaded(WorkItemOutputResponseOutput)
     case error(String)
 }
 
 /// Loading/loaded/error state for the permission preflight check.
 enum TaskPreflightState {
     case loading
-    case loaded([IPCWorkItemPreflightResponsePermission])
+    case loaded([WorkItemPreflightResponsePermission])
     case error(String)
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -47,7 +47,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // causing ownership checks (e.g. subagent abort) to fail.
                 if let sessionId = activeViewModel?.sessionId {
                     do {
-                        try daemonClient.send(IPCSessionSwitchRequest(sessionId: sessionId))
+                        try daemonClient.send(SessionSwitchRequest(sessionId: sessionId))
                     } catch {
                         log.error("Failed to send session switch request: \(error)")
                     }
@@ -963,7 +963,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// unpinned threads without explicit ordering, sends nil so they sort by recency.
     private func sendReorderThreads() {
         let visible = visibleThreads
-        var updates: [IPCReorderThreadsRequestUpdate] = []
+        var updates: [ReorderThreadsRequestUpdate] = []
         for thread in visible {
             guard let sessionId = thread.sessionId else { continue }
             let order: Double?
@@ -974,7 +974,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             } else {
                 order = thread.displayOrder.map { Double($0) }
             }
-            updates.append(IPCReorderThreadsRequestUpdate(
+            updates.append(ReorderThreadsRequestUpdate(
                 sessionId: sessionId,
                 displayOrder: order,
                 isPinned: thread.isPinned
@@ -982,7 +982,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         guard !updates.isEmpty else { return }
         do {
-            try daemonClient.send(IPCReorderThreadsRequest(
+            try daemonClient.send(ReorderThreadsRequest(
                 type: "reorder_threads",
                 updates: updates
             ))
@@ -1053,7 +1053,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
         threads[index].title = trimmed
         if let sessionId = threads[index].sessionId {
-            try? daemonClient.send(IPCSessionRenameRequest(
+            try? daemonClient.send(SessionRenameRequest(
                 type: "session_rename",
                 sessionId: sessionId,
                 title: trimmed
@@ -1359,7 +1359,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
     /// Send a `conversation_seen_signal` message to the daemon.
     private func emitConversationSeenSignal(conversationId: String) {
-        let signal = IPCConversationSeenSignal(
+        let signal = ConversationSeenSignal(
             conversationId: conversationId,
             sourceChannel: "vellum",
             signalType: "macos_conversation_opened",
@@ -1375,7 +1375,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     private func emitConversationUnreadSignal(conversationId: String) async throws {
-        let signal = IPCConversationUnreadSignal(
+        let signal = ConversationUnreadSignal(
             conversationId: conversationId,
             sourceChannel: "vellum",
             signalType: "macos_conversation_opened",
@@ -1470,7 +1470,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         sendReorderThreads()
         // Flush any rename that was queued before the session ID was assigned.
         if let pendingTitle = pendingRenames.removeValue(forKey: threadId) {
-            try? daemonClient.send(IPCSessionRenameRequest(
+            try? daemonClient.send(SessionRenameRequest(
                 type: "session_rename",
                 sessionId: sessionId,
                 title: pendingTitle
@@ -1479,7 +1479,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func mergeAssistantAttention(
-        from session: IPCSessionListResponseSession,
+        from session: SessionListResponseSession,
         intoThreadAt index: Int
     ) {
         threads[index].hasUnseenLatestAssistantMessage =

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -32,7 +32,7 @@ protocol ThreadRestorerDelegate: AnyObject {
     /// owner to preserve optimistic local seen/unread state until the daemon
     /// catches up or returns a newer reply.
     func mergeAssistantAttention(
-        from session: IPCSessionListResponseSession,
+        from session: SessionListResponseSession,
         intoThreadAt index: Int
     )
 }
@@ -306,7 +306,7 @@ final class ThreadSessionRestorer {
         delegate.threads[index].title = response.title
     }
 
-    func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+    func handleMessageContentResponse(_ response: MessageContentResponse) {
         guard let delegate else { return }
         // Route the full content back to the ChatViewModel that owns this message.
         // We check all threads with existing VMs for a matching daemonMessageId.
@@ -319,7 +319,7 @@ final class ThreadSessionRestorer {
         }
     }
 
-    func handleSubagentDetailResponse(_ response: IPCSubagentDetailResponse) {
+    func handleSubagentDetailResponse(_ response: SubagentDetailResponse) {
         guard let delegate else { return }
         // Only check threads that already have a VM — subagent events are only
         // relevant to active conversations, so we must not trigger lazy VM

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatRunsView.swift
@@ -5,9 +5,9 @@ struct HeartbeatRunsView: View {
     let daemonClient: DaemonClient
     @Environment(\.dismiss) var dismiss
 
-    @State private var runs: [IPCHeartbeatRunsListResponseRun] = []
+    @State private var runs: [HeartbeatRunsListResponseRun] = []
     @State private var expandedRunId: String?
-    @State private var previousRunsListCallback: ((IPCHeartbeatRunsListResponse) -> Void)?
+    @State private var previousRunsListCallback: ((HeartbeatRunsListResponse) -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -85,7 +85,7 @@ public final class SettingsStore: ObservableObject {
 
     @Published var twitterMode: String = "local_byo"
     @Published var twitterManagedAvailable: Bool = false
-    @Published var twitterManagedPrerequisites: IPCManagedPrerequisites?
+    @Published var twitterManagedPrerequisites: ManagedPrerequisites?
     @Published var twitterLocalClientConfigured: Bool = false
     @Published var twitterConnected: Bool = false
     @Published var twitterAccountInfo: String?

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -8,7 +8,7 @@ struct SimulationResult: Equatable {
     let riskLevel: String
     let reason: String
     let matchedRuleId: String?
-    let promptPayload: IPCToolPermissionSimulateResponsePromptPayload?
+    let promptPayload: ToolPermissionSimulateResponsePromptPayload?
     /// Transient display state set by local-only actions (allowOnce / denyOnce).
     var localOverrideLabel: String?
 

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -6,9 +6,9 @@ import VellumAssistantShared
 @MainActor
 @Observable
 final class BundleConfirmationViewModel {
-    let manifest: IPCOpenBundleResponseManifest
-    let scanResult: IPCOpenBundleResponseScanResult
-    let signatureResult: IPCOpenBundleResponseSignatureResult
+    let manifest: OpenBundleResponseManifest
+    let scanResult: OpenBundleResponseScanResult
+    let signatureResult: OpenBundleResponseSignatureResult
     let bundleSizeBytes: Int
     let filePath: String
 

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -39,8 +39,8 @@ enum BundleSandbox {
     /// Returns the UUID and the directory URL where the contents were extracted.
     static func unpack(
         filePath: String,
-        manifest: IPCOpenBundleResponseManifest,
-        signatureResult: IPCOpenBundleResponseSignatureResult,
+        manifest: OpenBundleResponseManifest,
+        signatureResult: OpenBundleResponseSignatureResult,
         bundleSizeBytes: Int
     ) throws -> (uuid: String, directory: URL) {
         let uuid = UUID().uuidString.lowercased()

--- a/clients/macos/vellum-assistant/Recording/RecordingManager.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingManager.swift
@@ -73,7 +73,7 @@ final class RecordingManager: ObservableObject {
     ///   - attachToConversationId: Optional conversation ID to attach the recording to.
     /// - Returns: `true` if the recording started successfully, `false` otherwise.
     @discardableResult
-    func start(sessionId: String, options: IPCRecordingOptions? = nil, attachToConversationId: String? = nil, promptForSource: Bool = false, operationToken: String? = nil) async -> Bool {
+    func start(sessionId: String, options: RecordingOptions? = nil, attachToConversationId: String? = nil, promptForSource: Bool = false, operationToken: String? = nil) async -> Bool {
         guard !state.isActive else {
             log.warning("Cannot start recording — already active (state=\(String(describing: self.state)), owner=\(self.ownerSessionId ?? "nil"))")
             sendStatus(sessionId: sessionId, status: "failed", error: "Another recording is already active")
@@ -321,7 +321,7 @@ final class RecordingManager: ObservableObject {
             return
         }
 
-        let message = IPCRecordingStatus(
+        let message = RecordingStatus(
             type: "recording_status",
             sessionId: sessionId,
             status: status,

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -7,7 +7,7 @@ import VellumAssistantShared
 /// Displays per-row thumbnails and a larger preview pane above the source list.
 struct RecordingSourcePickerView: View {
     @ObservedObject var viewModel: RecordingSourcePickerViewModel
-    var onStart: (IPCRecordingOptions) -> Void
+    var onStart: (RecordingOptions) -> Void
     var onCancel: () -> Void
 
     @State private var hoveredDisplayId: UInt32?

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerViewModel.swift
@@ -147,8 +147,8 @@ final class RecordingSourcePickerViewModel: ObservableObject {
     }
 
     /// Computed recording options for the current selection.
-    var selectedRecordingOptions: IPCRecordingOptions {
-        IPCRecordingOptions(
+    var selectedRecordingOptions: RecordingOptions {
+        RecordingOptions(
             captureScope: captureScope.rawValue.lowercased(),
             displayId: captureScope == .display ? selectedDisplayId.map { String($0) } : nil,
             windowId: captureScope == .window ? selectedWindowId.map { Double($0) } : nil,

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -23,7 +23,7 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
     /// - Parameters:
     ///   - onStart: Called with the selected recording options when the user clicks Start.
     ///   - onCancel: Called when the user dismisses the picker.
-    func show(onStart: @escaping (IPCRecordingOptions) -> Void, onCancel: @escaping () -> Void) {
+    func show(onStart: @escaping (RecordingOptions) -> Void, onCancel: @escaping () -> Void) {
         // Dismiss any existing picker window
         dismiss()
 


### PR DESCRIPTION
## Summary
- Updated all IPC-prefixed type references across 23 macOS app files
- Replaced type annotations, initializer calls, switch cases, and comments

Part of plan: swift-ipc-dto-type-rename.md (PR 5 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
