### PR TITLE
refactor: update shared Features to use renamed DTO types

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -555,12 +555,12 @@ struct ChatGallerySection: View {
                             input: ["command": AnyCodable("npm install express")],
                             riskLevel: "medium",
                             allowlistOptions: [
-                                IPCConfirmationRequestAllowlistOption(
+                                ConfirmationRequestAllowlistOption(
                                     label: "exact", description: "This exact command", pattern: "npm install express"
                                 ),
                             ],
                             scopeOptions: [
-                                IPCConfirmationRequestScopeOption(
+                                ConfirmationRequestScopeOption(
                                     label: "This project", scope: "project"
                                 ),
                             ],

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -34,9 +34,9 @@ public struct ToolConfirmationData: Equatable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let riskLevel: String
-    public let diff: IPCConfirmationRequestDiff?
-    public let allowlistOptions: [IPCConfirmationRequestAllowlistOption]
-    public let scopeOptions: [IPCConfirmationRequestScopeOption]
+    public let diff: ConfirmationRequestDiff?
+    public let allowlistOptions: [ConfirmationRequestAllowlistOption]
+    public let scopeOptions: [ConfirmationRequestScopeOption]
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
@@ -598,7 +598,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: IPCConfirmationRequestDiff? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption] = [], scopeOptions: [IPCConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -620,17 +620,17 @@ public struct ToolConfirmationData: Equatable {
         input: [String: AnyCodable],
         riskLevel: String,
         executionTarget: String?,
-        promptPayload: IPCToolPermissionSimulateResponsePromptPayload
+        promptPayload: ToolPermissionSimulateResponsePromptPayload
     ) -> ToolConfirmationData {
         let allowlistOptions = promptPayload.allowlistOptions.map { opt in
-            IPCConfirmationRequestAllowlistOption(
+            ConfirmationRequestAllowlistOption(
                 label: opt.label,
                 description: opt.description,
                 pattern: opt.pattern
             )
         }
         let scopeOptions = promptPayload.scopeOptions.map { opt in
-            IPCConfirmationRequestScopeOption(label: opt.label, scope: opt.scope)
+            ConfirmationRequestScopeOption(label: opt.label, scope: opt.scope)
         }
         return ToolConfirmationData(
             requestId: "simulation",

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -317,7 +317,7 @@ extension ChatViewModel {
     }
 
     /// Map attachment DTOs to ChatAttachment values, generating thumbnails for images.
-    func mapMessageAttachments(_ attachments: [IPCUserMessageAttachment]) -> [ChatAttachment] {
+    func mapMessageAttachments(_ attachments: [UserMessageAttachment]) -> [ChatAttachment] {
         attachments.compactMap { attachment in
             let id = attachment.id ?? UUID().uuidString
             let base64 = attachment.data
@@ -365,7 +365,7 @@ extension ChatViewModel {
     }
 
     /// Ingest attachments from a completion/handoff event into the current or new assistant message.
-    func ingestAssistantAttachments(_ attachments: [IPCUserMessageAttachment]?) {
+    func ingestAssistantAttachments(_ attachments: [UserMessageAttachment]?) {
         guard let attachments, !attachments.isEmpty else { return }
         let chatAttachments = mapMessageAttachments(attachments)
         guard !chatAttachments.isEmpty else { return }
@@ -1048,7 +1048,7 @@ extension ChatViewModel {
                     // Reconstruct attachments from the blocked user message's ChatAttachments
                     if let blockedUserMessage, !blockedUserMessage.attachments.isEmpty {
                         secretBlockedAttachments = blockedUserMessage.attachments.map {
-                            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
                         }
                     }
                     secretBlockedActiveSurfaceId = activeSurfaceId

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -355,11 +355,11 @@ public final class ChatViewModel: ObservableObject {
     public var onVoiceTextDelta: ((String) -> Void)?
     /// When true, messages are prefixed with a concise-response instruction for voice conversations.
     public var isVoiceModeActive: Bool = false
-    var pendingUserAttachments: [IPCAttachment]?
+    var pendingUserAttachments: [UserMessageAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
     private(set) var lastFailedMessageText: String?
     private(set) var lastFailedMessageDisplayText: String?
-    private(set) var lastFailedMessageAttachments: [IPCAttachment]?
+    private(set) var lastFailedMessageAttachments: [UserMessageAttachment]?
     /// Set only when a send operation (bootstrapSession or sendUserMessage) fails.
     /// Used by `isRetryableError` to ensure the retry button only appears for
     /// actual send failures, not for unrelated errors (attachment validation,
@@ -370,7 +370,7 @@ public final class ChatViewModel: ObservableObject {
     var secretBlockedMessageText: String?
     /// Stashed context from the blocked send, so sendAnyway() can reconstruct
     /// the original UserMessageMessage with attachments and surface metadata.
-    var secretBlockedAttachments: [IPCAttachment]?
+    var secretBlockedAttachments: [UserMessageAttachment]?
     var secretBlockedActiveSurfaceId: String?
     var secretBlockedCurrentPage: String?
     /// Nonce sent with `session_create` and echoed back in `session_info`.
@@ -622,7 +622,7 @@ public final class ChatViewModel: ObservableObject {
               let sessionId = sessionId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
         do {
-            try daemonClient.send(IPCMessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: daemonMessageId))
+            try daemonClient.send(MessageContentRequest(type: "message_content_request", sessionId: sessionId, messageId: daemonMessageId))
         } catch {
             log.error("Failed to send message_content_request: \(error)")
         }
@@ -643,7 +643,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// Handle a `message_content_response` from the daemon, updating the matching
     /// message with full (untruncated) text and tool call results.
-    public func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
+    public func handleMessageContentResponse(_ response: MessageContentResponse) {
         guard let idx = messages.firstIndex(where: { $0.daemonMessageId == response.messageId }) else { return }
 
         // Only update text when the message has a single segment (non-interleaved).
@@ -1018,7 +1018,7 @@ public final class ChatViewModel: ObservableObject {
                 pendingUserMessage = text
                 pendingUserMessageDisplayText = rawText
                 pendingUserAttachments = attachments.isEmpty ? nil : attachments.map {
-                    IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+                    UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
                 }
                 isThinking = true
                 var userMsg = ChatMessage(role: .user, text: rawText, status: .sent, skillInvocation: pendingSkillInvocation, attachments: attachments)
@@ -1094,8 +1094,8 @@ public final class ChatViewModel: ObservableObject {
         secretBlockedCurrentPage = nil
         flushCoalescedPublish()
 
-        let messageAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
-            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
+        let messageAttachments: [UserMessageAttachment]? = attachments.isEmpty ? nil : attachments.map {
+            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)
         }
 
         // Track the user text for this turn so assistantTextDelta can tag the
@@ -1146,7 +1146,7 @@ public final class ChatViewModel: ObservableObject {
         btwLoading = false
     }
 
-    private func bootstrapSession(userMessage: String?, attachments: [IPCAttachment]?) {
+    private func bootstrapSession(userMessage: String?, attachments: [UserMessageAttachment]?) {
         // Only set sending/thinking indicators when there's an actual user
         // message; message-less session creates (e.g. private thread
         // pre-allocation) are silent and shouldn't affect UI state.
@@ -1211,7 +1211,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    private func sendUserMessage(_ text: String, displayText: String? = nil, attachments: [IPCAttachment]? = nil, queuedMessageId: UUID? = nil) {
+    private func sendUserMessage(_ text: String, displayText: String? = nil, attachments: [UserMessageAttachment]? = nil, queuedMessageId: UUID? = nil) {
         guard let sessionId else { return }
 
         // Check connectivity before entering sending state so the UI
@@ -2184,7 +2184,7 @@ public final class ChatViewModel: ObservableObject {
     ///     (older page fetched on demand). When `false`, the standard initial-load
     ///     or reconnect-catch-up logic applies.
     public func populateFromHistory(
-        _ historyMessages: [IPCHistoryResponseMessage],
+        _ historyMessages: [HistoryResponseMessage],
         hasMore: Bool,
         oldestTimestamp: Double? = nil,
         isPaginationLoad: Bool = false

--- a/clients/shared/Features/Chat/OfflineMessageQueue.swift
+++ b/clients/shared/Features/Chat/OfflineMessageQueue.swift
@@ -17,7 +17,7 @@ struct OfflineQueuedMessage: Codable, Identifiable {
     let attachments: [OfflineQueuedAttachment]
     let enqueuedAt: Date
 
-    init(sessionId: String?, text: String, displayText: String? = nil, attachments: [IPCAttachment]?) {
+    init(sessionId: String?, text: String, displayText: String? = nil, attachments: [UserMessageAttachment]?) {
         self.id = UUID()
         self.sessionId = sessionId
         self.text = text
@@ -29,10 +29,10 @@ struct OfflineQueuedMessage: Codable, Identifiable {
     }
 
     /// Reconstruct the attachment list for dispatch.
-    var messageAttachments: [IPCAttachment]? {
+    var messageAttachments: [UserMessageAttachment]? {
         guard !attachments.isEmpty else { return nil }
         return attachments.map {
-            IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)
+            UserMessageAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: $0.extractedText)
         }
     }
 }
@@ -40,7 +40,7 @@ struct OfflineQueuedMessage: Codable, Identifiable {
 struct OfflineQueuedAttachment: Codable {
     let filename: String
     let mimeType: String
-    /// Base64-encoded attachment data, matching the `IPCAttachment.data` string format.
+    /// Base64-encoded attachment data, matching the `UserMessageAttachment.data` string format.
     let data: String
     let extractedText: String?
 }
@@ -76,7 +76,7 @@ final class OfflineMessageQueue {
     // MARK: - Enqueue
 
     /// Append a message to the end of the offline queue and persist it.
-    func enqueue(sessionId: String?, text: String, displayText: String? = nil, attachments: [IPCAttachment]?) {
+    func enqueue(sessionId: String?, text: String, displayText: String? = nil, attachments: [UserMessageAttachment]?) {
         let message = OfflineQueuedMessage(sessionId: sessionId, text: text, displayText: displayText, attachments: attachments)
         queue.append(message)
         save()

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -230,7 +230,7 @@ public final class SubagentDetailStore {
     }
 
     /// Record a status change with optional usage stats.
-    public func recordStatusChanged(subagentId: String, usage: IPCUsageStats?) {
+    public func recordStatusChanged(subagentId: String, usage: UsageStats?) {
         if let usage {
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: usage.inputTokens,
@@ -321,7 +321,7 @@ public final class SubagentDetailStore {
     /// Populate events from a lazy-loaded `subagent_detail_response`.
     /// This is a one-time bulk load that goes through the normal staging path
     /// so that the coalescing flush batches all events into a single update.
-    public func populateFromDetailResponse(_ response: IPCSubagentDetailResponse) {
+    public func populateFromDetailResponse(_ response: SubagentDetailResponse) {
         let subagentId = response.subagentId
         if let objective = response.objective {
             stagedObjectives[subagentId] = objective
@@ -338,7 +338,7 @@ public final class SubagentDetailStore {
             case "text":
                 handleEvent(
                     subagentId: subagentId,
-                    event: .assistantTextDelta(IPCAssistantTextDelta(type: "assistant_text_delta", text: event.content, sessionId: nil))
+                    event: .assistantTextDelta(AssistantTextDelta(type: "assistant_text_delta", text: event.content, sessionId: nil))
                 )
             case "tool_use":
                 let input: [String: AnyCodable]
@@ -350,12 +350,12 @@ public final class SubagentDetailStore {
                 }
                 handleEvent(
                     subagentId: subagentId,
-                    event: .toolUseStart(IPCToolUseStart(type: "tool_use_start", toolName: event.toolName ?? "unknown", input: input, sessionId: nil))
+                    event: .toolUseStart(ToolUseStart(type: "tool_use_start", toolName: event.toolName ?? "unknown", input: input, sessionId: nil))
                 )
             case "tool_result":
                 handleEvent(
                     subagentId: subagentId,
-                    event: .toolResult(IPCToolResult(type: "tool_result", toolName: event.toolName ?? "unknown", result: event.content, isError: event.isError, diff: nil, status: nil, sessionId: nil, imageData: nil))
+                    event: .toolResult(ToolResult(type: "tool_result", toolName: event.toolName ?? "unknown", result: event.content, isError: event.isError, diff: nil, status: nil, sessionId: nil, imageData: nil))
                 )
             default:
                 break

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -998,10 +998,10 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("npm install express")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm install express"),
+                    ConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm install express"),
                 ],
                 scopeOptions: [
-                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    ConfirmationRequestScopeOption(label: "This project", scope: "project"),
                 ],
                 executionTarget: "host"
             ),
@@ -1046,12 +1046,12 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("ls -la ~/Library/Application\\ Support/")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "ls -la ~/Library/Application\\ Support/"),
-                    IPCConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"ls -la ~/Library/Application\\\" command", pattern: "ls -la ~/Library/Application*"),
-                    IPCConfirmationRequestAllowlistOption(label: "tool", description: "Any ls command", pattern: "ls *"),
+                    ConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "ls -la ~/Library/Application\\ Support/"),
+                    ConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"ls -la ~/Library/Application\\\" command", pattern: "ls -la ~/Library/Application*"),
+                    ConfirmationRequestAllowlistOption(label: "tool", description: "Any ls command", pattern: "ls *"),
                 ],
                 scopeOptions: [
-                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    ConfirmationRequestScopeOption(label: "This project", scope: "project"),
                 ],
                 executionTarget: "host"
             ),
@@ -1125,11 +1125,11 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("npm test")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm test"),
+                    ConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm test"),
                 ],
                 scopeOptions: [
-                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
-                    IPCConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
+                    ConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    ConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
                 ],
                 executionTarget: "host"
             ),
@@ -1146,13 +1146,13 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("git push origin main")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "git push origin main"),
-                    IPCConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"git push\" command", pattern: "git push *"),
-                    IPCConfirmationRequestAllowlistOption(label: "tool", description: "Any git command", pattern: "git *"),
+                    ConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "git push origin main"),
+                    ConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"git push\" command", pattern: "git push *"),
+                    ConfirmationRequestAllowlistOption(label: "tool", description: "Any git command", pattern: "git *"),
                 ],
                 scopeOptions: [
-                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
-                    IPCConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
+                    ConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    ConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
                 ],
                 executionTarget: "host"
             ),

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -514,7 +514,7 @@ public extension Surface {
 
     /// Create a Surface from a history response surface.
     /// Used when populating messages from history.
-    static func from(_ historySurface: IPCHistoryResponseSurface, sessionId: String?) -> Surface? {
+    static func from(_ historySurface: HistoryResponseSurface, sessionId: String?) -> Surface? {
         guard let surfaceType = SurfaceType(rawValue: historySurface.surfaceType) else {
             return nil
         }

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -95,7 +95,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
 
         try transport.send(
-            IPCConversationUnreadSignal(
+            ConversationUnreadSignal(
                 conversationId: "conv-123",
                 sourceChannel: "vellum",
                 signalType: "macos_conversation_opened",
@@ -155,7 +155,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
 
         do {
             try await transport.sendConversationUnread(
-                IPCConversationUnreadSignal(
+                ConversationUnreadSignal(
                     conversationId: "conv-123",
                     sourceChannel: "vellum",
                     signalType: "macos_conversation_opened",
@@ -202,7 +202,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
 
         try transport.send(
-            IPCConversationUnreadSignal(
+            ConversationUnreadSignal(
                 conversationId: "conv-456",
                 sourceChannel: "vellum",
                 signalType: "macos_conversation_opened",
@@ -255,7 +255,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
 
         try transport.send(
-            IPCConversationUnreadSignal(
+            ConversationUnreadSignal(
                 conversationId: "conv-789",
                 sourceChannel: "vellum",
                 signalType: "macos_conversation_opened",
@@ -306,7 +306,7 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
 
         try transport.send(
-            IPCConversationSeenSignal(
+            ConversationSeenSignal(
                 conversationId: "conv-321",
                 sourceChannel: "vellum",
                 signalType: "macos_conversation_seen",

--- a/clients/shared/Tests/ToolConfirmationDataTests.swift
+++ b/clients/shared/Tests/ToolConfirmationDataTests.swift
@@ -24,7 +24,7 @@ final class ToolConfirmationDataTests: XCTestCase {
     }
 
     func testUnifiedDiffPreviewShowsReplacedLines() {
-        let diff = IPCConfirmationRequestDiff(
+        let diff = ConfirmationRequestDiff(
             filePath: "/tmp/test.txt",
             oldContent: "line1\nline2\nline3",
             newContent: "line1\nline2-updated\nline3",
@@ -51,7 +51,7 @@ final class ToolConfirmationDataTests: XCTestCase {
         newLines[2] = "CHANGED_A"
         newLines[17] = "CHANGED_B"
 
-        let diff = IPCConfirmationRequestDiff(
+        let diff = ConfirmationRequestDiff(
             filePath: "/tmp/multi.txt",
             oldContent: oldLines.joined(separator: "\n"),
             newContent: newLines.joined(separator: "\n"),
@@ -79,7 +79,7 @@ final class ToolConfirmationDataTests: XCTestCase {
         var newLines = oldLines
         newLines[500] = "line501-updated"
 
-        let diff = IPCConfirmationRequestDiff(
+        let diff = ConfirmationRequestDiff(
             filePath: "/tmp/large.txt",
             oldContent: oldLines.joined(separator: "\n"),
             newContent: newLines.joined(separator: "\n"),


### PR DESCRIPTION
## Summary
- Updated all IPC-prefixed type references across 10 shared Features/Tests files
- Replaced type annotations, initializer calls, pattern matches, and comments

Part of plan: swift-ipc-dto-type-rename.md (PR 4 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
