### PR TITLE
fix: remove dead HostBashResponse type from message protocol

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -67,10 +67,7 @@ import type {
   _GuardianActionsClientMessages,
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
-import type {
-  _HostBashClientMessages,
-  _HostBashServerMessages,
-} from "./message-types/host-bash.js";
+import type { _HostBashServerMessages } from "./message-types/host-bash.js";
 import type {
   _InboxClientMessages,
   _InboxServerMessages,
@@ -155,7 +152,6 @@ export type ClientMessage =
   | _SubagentsClientMessages
   | _DocumentsClientMessages
   | _GuardianActionsClientMessages
-  | _HostBashClientMessages
   | _WorkspaceClientMessages
   | _SchedulesClientMessages
   | _DiagnosticsClientMessages

--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -13,19 +13,6 @@ export interface HostBashRequest {
   timeout_seconds?: number;
 }
 
-// === Client → Server ===
-
-export interface HostBashResponse {
-  type: "host_bash_response";
-  requestId: string;
-  stdout: string;
-  stderr: string;
-  exitCode: number | null;
-  timedOut: boolean;
-}
-
 // --- Domain-level union aliases (consumed by the barrel file) ---
-
-export type _HostBashClientMessages = HostBashResponse;
 
 export type _HostBashServerMessages = HostBashRequest;


### PR DESCRIPTION
## Summary
- Removes unused `HostBashResponse` interface and `_HostBashClientMessages` from the message protocol
- The client posts bash results via HTTP POST to `/v1/host-bash-result`, not through the SSE message protocol, making these types dead code

## Test plan
- [x] `bunx tsc --noEmit` passes cleanly
- [x] Pre-commit hooks (lint, format, secrets check) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
