### PR TITLE
fix: ensure HostBashProxy clientConnected is set in all code paths

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -410,11 +410,11 @@ export async function handleSessionCreate(
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine.
     if (transportInterface === "macos" || transportInterface === "ios") {
-      session.setHostBashProxy(
-        new HostBashProxy(sendEvent, (requestId) => {
-          pendingInteractions.resolve(requestId);
-        }),
-      );
+      const proxy = new HostBashProxy(sendEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
+      proxy.updateSender(sendEvent, true);
+      session.setHostBashProxy(proxy);
     }
     session
       .processMessage(msg.initialMessage, [], sendEvent, requestId)

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -618,11 +618,11 @@ export async function handleSendMessage(
   // execute commands on the user's machine. Non-desktop sessions (CLI,
   // channels, headless) fall back to local execution.
   if (sourceInterface === "macos" || sourceInterface === "ios") {
-    session.setHostBashProxy(
-      new HostBashProxy(onEvent, (requestId) => {
-        pendingInteractions.resolve(requestId);
-      }),
-    );
+    const proxy = new HostBashProxy(onEvent, (requestId) => {
+      pendingInteractions.resolve(requestId);
+    });
+    proxy.updateSender(onEvent, true);
+    session.setHostBashProxy(proxy);
   } else {
     session.setHostBashProxy(undefined);
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-bash-proxy.md.

**Gap:** HostBashProxy clientConnected never set to true in conversation-routes and handlers/sessions
**What was expected:** Proxy should be available for desktop sessions
**What was found:** updateClient() was called before the proxy was created, so clientConnected stayed false and isAvailable() always returned false, causing the tool to fall through to local execution instead of proxying to the host.

**Fix:** After creating the HostBashProxy in both `conversation-routes.ts` and `handlers/sessions.ts`, explicitly call `proxy.updateSender(sender, true)` to mark it as connected before setting it on the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
