### PR TITLE
fix: HTTPTransport btw_complete detection uses SSE event type instead of JSON data field

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1748,7 +1748,7 @@ public final class HTTPTransport {
                                 if let text = parsed["text"] as? String {
                                     continuation.yield(text)
                                 }
-                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                if currentEventType == "btw_complete" {
                                     break
                                 }
                             }


### PR DESCRIPTION
## Summary
- Fix btw_complete detection to use SSE event type (`currentEventType`) instead of JSON data field (`parsed["type"]`). The daemon sends `event: btw_complete\ndata: {}\n\n` — the completion signal is in the SSE event header, not in the JSON payload which has no `type` key.

Note: Gaps B (onTermination handler), C (btw_error handling), and D (401 retry) were already correctly implemented in the existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
