### PR TITLE
fix: DaemonClient btw_complete detection and error handling

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -916,20 +916,32 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                         ])
                     }
 
+                    var currentEventType: String?
                     for try await line in bytes.lines {
                         if Task.isCancelled { break }
 
-                        if line.hasPrefix("data: ") {
+                        if line.hasPrefix("event: ") {
+                            currentEventType = String(line.dropFirst(7))
+                        } else if line.hasPrefix("data: ") {
                             let jsonString = String(line.dropFirst(6))
                             if let data = jsonString.data(using: .utf8),
                                let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                                if currentEventType == "btw_error" {
+                                    let errorMessage = parsed["message"] as? String ?? parsed["error"] as? String ?? "Unknown btw error"
+                                    throw URLError(.badServerResponse, userInfo: [
+                                        NSLocalizedDescriptionKey: errorMessage
+                                    ])
+                                }
                                 if let text = parsed["text"] as? String {
                                     continuation.yield(text)
                                 }
-                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                if currentEventType == "btw_complete" {
                                     break
                                 }
                             }
+                            currentEventType = nil
+                        } else if line.isEmpty {
+                            currentEventType = nil
                         }
                     }
                     continuation.finish()

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1748,7 +1748,7 @@ public final class HTTPTransport {
                                 if let text = parsed["text"] as? String {
                                     continuation.yield(text)
                                 }
-                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                if currentEventType == "btw_complete" {
                                     break
                                 }
                             }


### PR DESCRIPTION
## Summary
Fixes review gaps in DaemonClient.sendBtwMessage:
- Fix btw_complete detection to parse SSE event type instead of checking JSON data field
- Handle btw_error events by extracting error message and throwing
- Also fix same btw_complete detection bug in HTTPDaemonClient

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
