### PR TITLE
fix: ChatViewModel btw Task cancellation and pending state cleanup

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -539,6 +539,8 @@ public final class ChatViewModel: ObservableObject {
     @Published public var btwResponse: String?
     /// True while a /btw request is in flight.
     @Published public var btwLoading: Bool = false
+    /// The in-flight btw streaming task, stored for cancellation.
+    private var btwTask: Task<Void, Never>?
 
     /// Whether there are more messages above the current display window.
     /// True when either:
@@ -978,6 +980,8 @@ public final class ChatViewModel: ObservableObject {
         if text.hasPrefix("/btw ") {
             let question = String(text.dropFirst(5)).trimmingCharacters(in: .whitespaces)
             inputText = ""
+            pendingAttachments = []
+            pendingSkillInvocation = nil
             flushCoalescedPublish()
             sendBtwMessage(question: question)
             return
@@ -1120,10 +1124,14 @@ public final class ChatViewModel: ObservableObject {
     /// Send a /btw side-chain question and stream the response into `btwResponse`.
     public func sendBtwMessage(question: String) {
         guard !question.isEmpty else { return }
+
+        // Cancel any in-flight btw task to prevent interleaved deltas.
+        btwTask?.cancel()
+
         btwLoading = true
         btwResponse = ""
 
-        Task { @MainActor [weak self] in
+        btwTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let stream = self.daemonClient.sendBtwMessage(
@@ -1131,9 +1139,11 @@ public final class ChatViewModel: ObservableObject {
                     conversationKey: self.sessionId ?? ""
                 )
                 for try await delta in stream {
+                    guard !Task.isCancelled else { return }
                     self.btwResponse = (self.btwResponse ?? "") + delta
                 }
             } catch {
+                guard !Task.isCancelled else { return }
                 self.btwResponse = "Failed to get response: \(error.localizedDescription)"
             }
             self.btwLoading = false
@@ -1142,6 +1152,8 @@ public final class ChatViewModel: ObservableObject {
 
     /// Clear btw side-chain state.
     public func dismissBtw() {
+        btwTask?.cancel()
+        btwTask = nil
         btwResponse = nil
         btwLoading = false
     }


### PR DESCRIPTION
## Summary
Fixes review gaps in ChatViewModel:
- Store btw Task for proper cancellation on dismiss or new btw request
- Clear pendingAttachments and pendingSkillInvocation in /btw intercept path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
