### PR TITLE
fix: only log collection created when ensurePayloadIndexesSafe succeeds

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -186,11 +186,11 @@ export class VellumQdrantClient {
       }
 
       this.collectionReady = true;
+      log.info(
+        { collection: this.collection },
+        "Qdrant collection created with payload indexes",
+      );
     }
-    log.info(
-      { collection: this.collection },
-      "Qdrant collection created with payload indexes",
-    );
   }
 
   async upsert(


### PR DESCRIPTION
Addresses review feedback from PR #15132. Moves the 'Qdrant collection created with payload indexes' log inside the success conditional so it doesn't misleadingly fire when the collection was deleted between creation and index setup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
