### PR TITLE
fix: check SSE event type instead of JSON type for btw_complete detection

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1748,7 +1748,7 @@ public final class HTTPTransport {
                                 if let text = parsed["text"] as? String {
                                     continuation.yield(text)
                                 }
-                                if let type = parsed["type"] as? String, type == "btw_complete" {
+                                if currentEventType == "btw_complete" {
                                     break
                                 }
                             }


### PR DESCRIPTION
Addresses review feedback from PR #15136. The btw_complete event detection checked parsed["type"] in the JSON body, but the server sends btw_complete as an SSE event type with empty JSON {}. Now checks currentEventType == "btw_complete" instead, matching how btw_error is already handled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
