### PR TITLE
fix: dispose old host bash proxy, register in pendingInteractions, fix ordering

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -152,6 +152,12 @@ export function makeEventSender(params: {
         conversationId,
         kind: "secret",
       });
+    } else if (event.type === "host_bash_request") {
+      pendingInteractions.register(event.requestId, {
+        session,
+        conversationId,
+        kind: "host_bash",
+      });
     }
 
     ctx.send(event);
@@ -396,7 +402,6 @@ export async function handleSessionCreate(
       conversationId: conversation.id,
       sourceChannel: transportChannel,
     });
-    session.updateClient(sendEvent, false);
     session.setTurnChannelContext({
       userMessageChannel: transportChannel,
       assistantMessageChannel: transportChannel,
@@ -408,14 +413,15 @@ export async function handleSessionCreate(
       assistantMessageInterface: transportInterface,
     });
     // Only create the host bash proxy for desktop client interfaces that can
-    // execute commands on the user's machine.
+    // execute commands on the user's machine. Set before updateClient so
+    // updateClient's call to hostBashProxy.updateSender targets the new proxy.
     if (transportInterface === "macos" || transportInterface === "ios") {
       const proxy = new HostBashProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });
-      proxy.updateSender(sendEvent, true);
       session.setHostBashProxy(proxy);
     }
+    session.updateClient(sendEvent, false);
     session
       .processMessage(msg.initialMessage, [], sendEvent, requestId)
       .catch((err) => {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -639,12 +639,16 @@ export class DaemonServer {
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Non-desktop sessions (CLI,
     // channels, headless) fall back to local execution.
+    // Reuse the existing proxy if the session is actively processing a
+    // host bash request to avoid orphaning in-flight requests.
     if (resolvedInterface === "macos" || resolvedInterface === "ios") {
-      session.setHostBashProxy(
-        new HostBashProxy(session.getCurrentSender(), (requestId) => {
-          pendingInteractions.resolve(requestId);
-        }),
-      );
+      if (!session.isProcessing() || !session.hostBashProxy) {
+        session.setHostBashProxy(
+          new HostBashProxy(session.getCurrentSender(), (requestId) => {
+            pendingInteractions.resolve(requestId);
+          }),
+        );
+      }
     } else {
       session.setHostBashProxy(undefined);
     }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -581,6 +581,9 @@ export class Session {
   }
 
   setHostBashProxy(proxy: HostBashProxy | undefined): void {
+    if (this.hostBashProxy && this.hostBashProxy !== proxy) {
+      this.hostBashProxy.dispose();
+    }
     this.hostBashProxy = proxy;
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -612,20 +612,26 @@ export async function handleSendMessage(
     sourceInterface === "ios" ||
     sourceInterface === "cli" ||
     sourceInterface === "vellum";
-  // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
-  session.updateClient(onEvent, !isInteractiveInterface);
   // Only create the host bash proxy for desktop client interfaces that can
   // execute commands on the user's machine. Non-desktop sessions (CLI,
   // channels, headless) fall back to local execution.
+  // Set the proxy BEFORE updateClient so updateClient's call to
+  // hostBashProxy.updateSender targets the correct (new) proxy.
   if (sourceInterface === "macos" || sourceInterface === "ios") {
-    const proxy = new HostBashProxy(onEvent, (requestId) => {
-      pendingInteractions.resolve(requestId);
-    });
-    proxy.updateSender(onEvent, true);
-    session.setHostBashProxy(proxy);
+    // Reuse the existing proxy if the session is actively processing a
+    // host bash request to avoid orphaning in-flight requests.
+    if (!session.isProcessing() || !session.hostBashProxy) {
+      const proxy = new HostBashProxy(onEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
+      session.setHostBashProxy(proxy);
+    }
   } else {
     session.setHostBashProxy(undefined);
   }
+  // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
+  // Called after setHostBashProxy so updateSender targets the current proxy.
+  session.updateClient(onEvent, !isInteractiveInterface);
 
   const attachments = hasAttachments
     ? smDeps.resolveAttachments(attachmentIds)


### PR DESCRIPTION
Addresses review feedback from PR #15127. Fixes:

1. **Dispose old proxy in setHostBashProxy**: Added dispose() call on the old proxy before replacement, preventing timer/resource leaks from orphaned in-flight requests.

2. **Register host_bash_request in sessions.ts makeEventSender**: Added missing host_bash_request handler to pendingInteractions registration, matching the analogous code in server.ts and conversation-routes.ts.

3. **Fix updateClient/setHostBashProxy ordering**: Moved setHostBashProxy before updateClient in all call sites so updateClient's internal call to hostBashProxy.updateSender targets the correct (new) proxy, ensuring clientConnected=true and isAvailable() returns true.

4. **Reuse existing proxy when session is processing**: In server.ts and conversation-routes.ts, skip proxy replacement when the session is actively processing to avoid orphaning in-flight host bash requests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
