### PR TITLE
fix: btw overlay animation, dismiss cancellation, and design token padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -290,6 +290,7 @@ struct ChatView: View {
             .overlay(alignment: .bottom) {
                 btwOverlay
             }
+            .animation(VAnimation.fast, value: btwResponse != nil)
 
             // Drop target overlay
             if isDropTargeted {
@@ -365,9 +366,8 @@ struct ChatView: View {
             .cornerRadius(VRadius.md)
             .vShadow(VShadow.sm)
             .padding(.horizontal, VSpacing.lg)
-            .padding(.bottom, 80)
+            .padding(.bottom, VSpacing.xxxl + VSpacing.xxl)
             .transition(.opacity.combined(with: .move(edge: .bottom)))
-            .animation(VAnimation.fast, value: btwResponse != nil)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1142,6 +1142,8 @@ public final class ChatViewModel: ObservableObject {
                     guard !Task.isCancelled else { return }
                     self.btwResponse = (self.btwResponse ?? "") + delta
                 }
+            } catch is CancellationError {
+                // Stream was cancelled via dismiss — no error to show.
             } catch {
                 guard !Task.isCancelled else { return }
                 self.btwResponse = "Failed to get response: \(error.localizedDescription)"
@@ -1150,7 +1152,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
-    /// Clear btw side-chain state.
+    /// Clear btw side-chain state and cancel any in-flight stream.
     public func dismissBtw() {
         btwTask?.cancel()
         btwTask = nil


### PR DESCRIPTION
Addresses review feedback from PR #15129.

- Move `.animation(VAnimation.fast, value:)` to the parent overlay call site so SwiftUI has animation context for exit transitions (previously inside the conditional block where it was removed instantly)
- Cancel in-flight btw stream on dismiss so the overlay doesn't reappear from subsequent deltas
- Replace magic number `80` with `VSpacing.xxxl + VSpacing.xxl` (48 + 32 = 80)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
