### PR TITLE
fix: add onTermination cancellation to DaemonClient.sendBtwMessage

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -880,7 +880,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         // Local daemon path — stream SSE from the daemon's /v1/btw endpoint.
         return AsyncThrowingStream { continuation in
-            Task { @MainActor [weak self] in
+            let task = Task { @MainActor [weak self] in
                 guard let self else {
                     continuation.finish()
                     return
@@ -949,6 +949,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
         }
     }
 


### PR DESCRIPTION
## Summary
Add continuation.onTermination handler to cancel the inner Task when the stream consumer stops iterating, matching the pattern in HTTPDaemonClient. Prevents orphaned network tasks on btw dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
