### PR TITLE
fix: resolve HistoryResponseMessage ambiguity in Swift build

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -628,7 +628,7 @@ class IOSThreadStore: ObservableObject {
         }
     }
 
-    private func handleHistoryResponse(_ response: HistoryResponseMessage) {
+    private func handleHistoryResponse(_ response: HistoryResponse) {
         guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
         guard let vm = viewModels[threadId] else { return }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -273,7 +273,7 @@ final class ThreadSessionRestorer {
         delegate.restoreLastActiveThread()
     }
 
-    func handleHistoryResponse(_ response: HistoryResponseMessage) {
+    func handleHistoryResponse(_ response: HistoryResponse) {
         guard let threadId = pendingHistoryBySessionId.removeValue(forKey: response.sessionId) else { return }
         guard let viewModel = delegate?.chatViewModel(for: threadId) else { return }
 

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -136,14 +136,14 @@ private func makeSessionListResponse(sessions: [(id: String, title: String, upda
     makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, nil, nil) })
 }
 
-/// Build a HistoryResponseMessage via JSON round-trip.
-private func makeHistoryResponse(sessionId: String, messages: [(role: String, text: String)], hasMore: Bool = false) -> HistoryResponseMessage {
+/// Build a HistoryResponse via JSON round-trip.
+private func makeHistoryResponse(sessionId: String, messages: [(role: String, text: String)], hasMore: Bool = false) -> HistoryResponse {
     let msgDicts = messages.map { msg -> [String: Any] in
         ["role": msg.role, "text": msg.text, "timestamp": 1000.0]
     }
     let dict: [String: Any] = ["type": "history_response", "sessionId": sessionId, "messages": msgDicts, "hasMore": hasMore]
     let data = try! JSONSerialization.data(withJSONObject: dict)
-    return try! JSONDecoder().decode(HistoryResponseMessage.self, from: data)
+    return try! JSONDecoder().decode(HistoryResponse.self, from: data)
 }
 
 /// Build a SessionTitleUpdatedMessage via JSON round-trip.

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -431,7 +431,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public var onSessionTitleUpdated: ((SessionTitleUpdatedMessage) -> Void)?
 
     /// Called when the daemon sends a `history_response` message.
-    public var onHistoryResponse: ((HistoryResponseMessage) -> Void)?
+    public var onHistoryResponse: ((HistoryResponse) -> Void)?
 
     /// Called when the daemon sends a `message_content_response` with full (untruncated) content.
     public var onMessageContentResponse: ((MessageContentResponse) -> Void)?

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1258,11 +1258,6 @@ public typealias SkillsInspectResponseMessage = SkillsInspectResponse
 /// Backed by generated `SessionListResponse`.
 public typealias SessionListResponseMessage = SessionListResponse
 
-/// Response containing message history for a session.
-/// Backed by generated `HistoryResponse`.
-public typealias HistoryResponseMessage = HistoryResponse
-
-
 /// A single scheduled task item returned from the daemon.
 /// Backed by generated `SchedulesListResponseSchedule`.
 public typealias ScheduleItem = SchedulesListResponseSchedule
@@ -2139,7 +2134,7 @@ public enum ServerMessage: Decodable, Sendable {
     case sessionInfo(SessionInfoMessage)
     case sessionTitleUpdated(SessionTitleUpdatedMessage)
     case sessionListResponse(SessionListResponseMessage)
-    case historyResponse(HistoryResponseMessage)
+    case historyResponse(HistoryResponse)
     case memoryStatus(MemoryStatusMessage)
     case taskRouted(TaskRoutedMessage)
     case dictationResponse(DictationResponseMessage)
@@ -2323,7 +2318,7 @@ public enum ServerMessage: Decodable, Sendable {
             let message = try SessionListResponseMessage(from: decoder)
             self = .sessionListResponse(message)
         case "history_response":
-            let message = try HistoryResponseMessage(from: decoder)
+            let message = try HistoryResponse(from: decoder)
             self = .historyResponse(message)
         case "memory_status":
             let message = try MemoryStatusMessage(from: decoder)


### PR DESCRIPTION
## Summary
- Remove the `HistoryResponseMessage = HistoryResponse` typealias from `MessageTypes.swift` that conflicts with the generated `HistoryResponseMessage` struct in `GeneratedAPITypes.swift`
- Update all call sites that used `HistoryResponseMessage` to mean the container type to use `HistoryResponse` directly (DaemonClient, ThreadSessionRestorer, IOSThreadStore, tests)

## Original prompt
Fix this CI issue https://github.com/vellum-ai/vellum-assistant/actions/runs/22932690994/job/66557469022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
