### PR TITLE
fix: remove client-side 600s timeout cap in host bash execution

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -49,9 +49,8 @@ extension HTTPTransport {
     /// timeout, and collects stdout/stderr.
     func executeHostBashRequest(_ request: HostBashRequest) {
         Task.detached {
-            let maxTimeout: Double = 600
             let defaultTimeout: Double = 120
-            let timeout = min(request.timeoutSeconds ?? defaultTimeout, maxTimeout)
+            let timeout = request.timeoutSeconds ?? defaultTimeout
 
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/bash")


### PR DESCRIPTION
## Summary
Removes the hardcoded 600s maxTimeout cap in the Swift host bash executor. The daemon already validates and caps timeout_seconds before sending the request, so the client should trust the daemon-provided value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
