### PR TITLE
fix: add btwTask deinit cancellation and isCancelled guard in ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1148,6 +1148,7 @@ public final class ChatViewModel: ObservableObject {
                 guard !Task.isCancelled else { return }
                 self.btwResponse = "Failed to get response: \(error.localizedDescription)"
             }
+            guard !Task.isCancelled else { return }
             self.btwLoading = false
         }
     }
@@ -2552,6 +2553,7 @@ public final class ChatViewModel: ObservableObject {
         // so they will exit naturally when self is deallocated.
         reconnectLatchTimeoutTask?.cancel()
         reconnectDebounceTask?.cancel()
+        btwTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
Address review feedback from PR #15153: (1) cancel btwTask in deinit to match pattern of all other stored Task properties, (2) add Task.isCancelled guard before setting btwLoading=false to prevent cancelled task from clobbering successor's loading state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
