### PR TITLE
fix: align proxy timeout to fire before executor outer timeout

### DIFF
--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -52,9 +52,9 @@ export class HostBashProxy {
 
     return new Promise<ToolExecutionResult>((resolve, reject) => {
       const shellMaxTimeoutSec = getConfig().timeouts.shellMaxTimeoutSec;
-      // Generous timeout: let the client-side timeout fire first
-      const proxyTimeoutSec = shellMaxTimeoutSec + 30;
       const timeoutSec = input.timeout_seconds ?? shellMaxTimeoutSec;
+      // Proxy timeout: slightly after client-side timeout, but before executor's outer timeout
+      const proxyTimeoutSec = timeoutSec + 3;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
         this.onInternalResolve?.(requestId);


### PR DESCRIPTION
## Summary
Fixes timeout race where the executor's outer timeout (shellTimeoutSec + 5s) fires before the proxy's internal timeout (shellMaxTimeoutSec + 30s), orphaning pending state in the proxy and pendingInteractions tracker.

Changes proxy timeout from `shellMaxTimeoutSec + 30` to `timeoutSec + 3`, ensuring the ordering: client timeout → proxy timeout → executor timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
