### PR TITLE
fix: prevent silent input drop during CLI connecting state

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1481,6 +1481,15 @@ function ChatApp({
         return;
       }
 
+      // If a connection attempt is already in progress, don't silently drop input
+      if (connectingRef.current) {
+        h.addStatus(
+          "Still connecting — please wait a moment and try again.",
+          "yellow",
+        );
+        return;
+      }
+
       if (trimmed.startsWith("/btw ")) {
         const question = trimmed.slice(5).trim();
         if (!question) return;


### PR DESCRIPTION
Address review feedback from PR #15154: prevent user input from being silently dropped when the CLI is in the connecting state. When ensureConnected() is in progress and the user submits input, show feedback instead of silently discarding.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
