### PR TITLE
fix: update pendingInteractions docstrings to include host_bash

### DIFF
--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,11 +1,12 @@
 /**
  * In-memory tracker that maps requestId to session info for pending
- * confirmation and secret interactions.
+ * confirmation, secret, and host_bash interactions.
  *
- * When the agent loop emits a confirmation_request or secret_request,
- * the onEvent callback registers the interaction here. Standalone HTTP
- * endpoints (/v1/confirm, /v1/secret, /v1/trust-rules) look up the
- * session from this tracker to resolve the interaction.
+ * When the agent loop emits a confirmation_request, secret_request, or
+ * host_bash_request, the onEvent callback registers the interaction here.
+ * Standalone HTTP endpoints (/v1/confirm, /v1/secret, /v1/trust-rules,
+ * /v1/host-bash-result) look up the session from this tracker to resolve
+ * the interaction.
  */
 
 import type { Session } from "../daemon/session.js";
@@ -78,8 +79,9 @@ export function getByConversation(
 }
 
 /**
- * Remove all pending interactions for a given session.
- * Used when auto-denying all pending confirmations (e.g. new user message).
+ * Remove all pending interactions (confirmation, secret, and host_bash)
+ * for a given session. Used when auto-denying all pending interactions
+ * (e.g. new user message).
  */
 export function removeBySession(session: Session): void {
   for (const [requestId, interaction] of pending) {


### PR DESCRIPTION
## Summary
Updates module-level and removeBySession docstrings in pending-interactions.ts to mention host_bash interactions and the /v1/host-bash-result endpoint, matching the actual kind union type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
