### PR TITLE
fix: resolve GalleryCategory name collision breaking macOS build

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -1,7 +1,7 @@
 #if DEBUG
 import SwiftUI
 
-enum GalleryCategory: String, CaseIterable, Identifiable {
+enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
     case appIcons = "App Icons"
     case buttons = "Buttons"
     case chat = "Chat"
@@ -34,12 +34,12 @@ enum GalleryCategory: String, CaseIterable, Identifiable {
 }
 
 struct ComponentGalleryView: View {
-    @State private var selectedCategory: GalleryCategory? = .buttons
+    @State private var selectedCategory: ComponentGalleryCategory? = .buttons
 
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedCategory) {
-                ForEach(GalleryCategory.allCases) { category in
+                ForEach(ComponentGalleryCategory.allCases) { category in
                     Label { Text(category.rawValue) } icon: { VIconView(category.vIcon, size: 14) }
                         .tag(category)
                 }


### PR DESCRIPTION
## Summary
- Renamed the local `GalleryCategory` enum in `ComponentGalleryView.swift` to `ComponentGalleryCategory` to resolve a name collision with the generated `GalleryCategory` struct in `GeneratedAPITypes.swift`
- Both types were in the same Swift module (`VellumAssistantShared`), causing ambiguity errors that broke the macOS build

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22932813360/job/66557839389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
