### PR TITLE
chore: remove twitter feature flag from all registries and system prompt

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -168,20 +168,25 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "Toggle hatch new assistant behavior",
       DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
+    createSkillOnDisk(
+      "browser",
+      "Browser",
+      "Web browsing automation",
+      "browser",
+    );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
-        "feature_flags.twitter.enabled": true,
+        "feature_flags.browser.enabled": true,
       },
     };
 
     const result = buildSystemPrompt();
 
-    // twitter is explicitly enabled, declared flagged skill is explicitly off
-    expect(result).toContain('id="twitter"');
+    // browser is explicitly enabled, declared flagged skill is explicitly off
+    expect(result).toContain('id="browser"');
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
   });
 
@@ -192,7 +197,12 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "Toggle hatch new assistant behavior",
       DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
+    createSkillOnDisk(
+      "contacts",
+      "Contacts",
+      "View and manage contacts",
+      "contacts",
+    );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
@@ -202,7 +212,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     // Both skills declare feature flags with registry defaultEnabled: false
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="twitter"');
+    expect(result).not.toContain('id="contacts"');
   });
 
   test("flagged-off skills hidden when all flags are OFF", () => {
@@ -212,20 +222,25 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
       "Toggle hatch new assistant behavior",
       DECLARED_FLAG_ID,
     );
-    createSkillOnDisk("twitter", "Twitter", "Post to X/Twitter", "twitter");
+    createSkillOnDisk(
+      "contacts",
+      "Contacts",
+      "View and manage contacts",
+      "contacts",
+    );
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
-        "feature_flags.twitter.enabled": false,
+        "feature_flags.contacts.enabled": false,
       },
     };
 
     const result = buildSystemPrompt();
 
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).not.toContain('id="twitter"');
+    expect(result).not.toContain('id="contacts"');
   });
 
   test("assistantFeatureFlagValues overrides control visibility", () => {

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -173,12 +173,12 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("twitter", "bundled", "twitter"),
+      makeSkill("browser", "bundled", "browser"),
     ];
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
-        "feature_flags.twitter.enabled": true,
+        "feature_flags.browser.enabled": true,
       },
     });
 
@@ -186,18 +186,18 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).not.toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("twitter");
+    expect(ids).toContain("browser");
   });
 
   test("flag ON skill appears normally", () => {
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("twitter", "bundled", "twitter"),
+      makeSkill("browser", "bundled", "browser"),
     ];
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: true,
-        "feature_flags.twitter.enabled": true,
+        "feature_flags.browser.enabled": true,
       },
     });
 
@@ -205,7 +205,7 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("twitter");
+    expect(ids).toContain("browser");
   });
 
   test("declared flag key defaults to registry value (false)", () => {
@@ -257,13 +257,13 @@ describe("resolveSkillStates with feature flags", () => {
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("twitter", "bundled", "twitter"),
+      makeSkill("browser", "bundled", "browser"),
       makeSkill("deploy", "bundled", "deploy"),
     ];
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
-        "feature_flags.twitter.enabled": true,
+        "feature_flags.browser.enabled": true,
         "feature_flags.deploy.enabled": false,
       },
     });
@@ -271,8 +271,8 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // hatch-new-assistant and deploy explicitly false; twitter explicitly true
-    expect(ids).toEqual(["twitter"]);
+    // hatch-new-assistant and deploy explicitly false; browser explicitly true
+    expect(ids).toEqual(["browser"]);
   });
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -364,11 +364,11 @@ describe("projectSkillTools feature flag enforcement", () => {
   test("mixed flag-on and flag-off skills — only flag-on tools projected", () => {
     mockCatalog = [
       makeSkill(DECLARED_SKILL_ID, DECLARED_SKILL_ID),
-      makeSkill("twitter"),
+      makeSkill("plain-skill"),
     ];
     mockManifests = {
       [DECLARED_SKILL_ID]: makeManifest(["browser_navigate"]),
-      twitter: makeManifest(["twitter_post"]),
+      "plain-skill": makeManifest(["plain_action"]),
     };
 
     const history: Message[] = [
@@ -400,7 +400,7 @@ describe("projectSkillTools feature flag enforcement", () => {
             type: "tool_use",
             id: "tu-2",
             name: "skill_load",
-            input: { skill: "twitter" },
+            input: { skill: "plain-skill" },
           },
         ],
       },
@@ -411,14 +411,14 @@ describe("projectSkillTools feature flag enforcement", () => {
             type: "tool_result",
             tool_use_id: "tu-2",
             content:
-              '<loaded_skill id="twitter" version="v1:default-hash-twitter" />',
+              '<loaded_skill id="plain-skill" version="v1:default-hash-plain-skill" />',
           },
         ],
       },
     ];
     const prevActive = new Map<string, string>();
 
-    // Declared skill is OFF, twitter is undeclared with no persisted override so remains ON.
+    // Declared skill is OFF, plain-skill is undeclared with no persisted override so remains ON.
     currentConfig = {
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
     };
@@ -428,7 +428,7 @@ describe("projectSkillTools feature flag enforcement", () => {
     });
 
     const toolNames = result.toolDefinitions.map((t) => t.name);
-    expect(toolNames).toContain("twitter_post");
+    expect(toolNames).toContain("plain_action");
     expect(toolNames).not.toContain("browser_navigate");
   });
 });

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "twitter",
-      "scope": "assistant",
-      "key": "feature_flags.twitter.enabled",
-      "label": "Twitter",
-      "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": false
-    },
-    {
       "id": "messaging",
       "scope": "assistant",
       "key": "feature_flags.messaging.enabled",

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -922,14 +922,6 @@ function buildDynamicSkillWorkflowSection(
     );
   }
 
-  if (activeSkillIds.has("twitter")) {
-    lines.push(
-      "",
-      "### X (Twitter) Skill",
-      'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the X skill provides CLI commands (`vellum x post`, `vellum x reply`) that are faster and more reliable.',
-    );
-  }
-
   if (activeSkillIds.has("messaging")) {
     lines.push(
       "",

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -32,14 +32,6 @@ const TEST_REGISTRY = {
       defaultEnabled: true,
     },
     {
-      id: "twitter",
-      scope: "assistant",
-      key: "feature_flags.twitter.enabled",
-      label: "Twitter",
-      description: "Twitter skill",
-      defaultEnabled: true,
-    },
-    {
       id: "guardian-verify-setup",
       scope: "assistant",
       key: "feature_flags.guardian-verify-setup.enabled",
@@ -161,11 +153,11 @@ describe("GET /v1/feature-flags handler", () => {
     }
 
     // Verify specific labels
-    const twitterFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.twitter.enabled",
+    const browserFlag2 = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
     );
-    expect(twitterFlag).toBeDefined();
-    expect(twitterFlag.label).toBe("Twitter");
+    expect(browserFlag2).toBeDefined();
+    expect(browserFlag2.label).toBe("Browser");
 
     const hatchFlag = body.flags.find(
       (f: { key: string }) =>
@@ -216,7 +208,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         assistantFeatureFlagValues: {
           "feature_flags.browser.enabled": false,
-          "feature_flags.twitter.enabled": false,
+          "feature_flags.guardian-verify-setup.enabled": false,
         },
       }),
     );
@@ -236,11 +228,12 @@ describe("GET /v1/feature-flags handler", () => {
     expect(browserFlag.enabled).toBe(false); // overridden from default true
     expect(browserFlag.defaultEnabled).toBe(true);
 
-    const twitterFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.twitter.enabled",
+    const guardianFlag = body.flags.find(
+      (f: { key: string }) =>
+        f.key === "feature_flags.guardian-verify-setup.enabled",
     );
-    expect(twitterFlag).toBeDefined();
-    expect(twitterFlag.enabled).toBe(false); // overridden from default true
+    expect(guardianFlag).toBeDefined();
+    expect(guardianFlag.enabled).toBe(false); // overridden from default true
   });
 
   test("ignores non-boolean values in assistantFeatureFlagValues", async () => {
@@ -248,7 +241,7 @@ describe("GET /v1/feature-flags handler", () => {
       configPath,
       JSON.stringify({
         assistantFeatureFlagValues: {
-          "feature_flags.twitter.enabled": "no",
+          "feature_flags.browser.enabled": "no",
         },
       }),
     );
@@ -261,12 +254,12 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // twitter should fall back to default since non-boolean was ignored
-    const twitterFlag = body.flags.find(
-      (f: { key: string }) => f.key === "feature_flags.twitter.enabled",
+    // browser should fall back to default since non-boolean was ignored
+    const browserFlag = body.flags.find(
+      (f: { key: string }) => f.key === "feature_flags.browser.enabled",
     );
-    expect(twitterFlag).toBeDefined();
-    expect(twitterFlag.enabled).toBe(twitterFlag.defaultEnabled);
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(browserFlag.defaultEnabled);
   });
 });
 
@@ -307,7 +300,9 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       JSON.stringify({
         twilio: { phoneNumber: "+1234567890" },
         email: { address: "test@example.com" },
-        assistantFeatureFlagValues: { "feature_flags.twitter.enabled": true },
+        assistantFeatureFlagValues: {
+          "feature_flags.guardian-verify-setup.enabled": true,
+        },
       }),
     );
 
@@ -329,7 +324,9 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     expect(config.email).toEqual({ address: "test@example.com" });
     // New section should have both old and new values
     expect(
-      config.assistantFeatureFlagValues["feature_flags.twitter.enabled"],
+      config.assistantFeatureFlagValues[
+        "feature_flags.guardian-verify-setup.enabled"
+      ],
     ).toBe(true);
     expect(
       config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
@@ -384,7 +381,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const oldFormatKeys = [
       "skills.browser.enabled",
-      "skills.twitter.enabled",
+      "skills.guardian-verify-setup.enabled",
       "skills.my-skill.enabled",
     ];
 
@@ -460,7 +457,6 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const validKeys = [
       "feature_flags.browser.enabled",
-      "feature_flags.twitter.enabled",
       "feature_flags.guardian-verify-setup.enabled",
       "feature_flags.hatch-new-assistant.enabled",
     ];
@@ -547,14 +543,14 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const handler = createFeatureFlagsPatchHandler();
     await handler(
       new Request(
-        "http://gateway.test/v1/feature-flags/feature_flags.twitter.enabled",
+        "http://gateway.test/v1/feature-flags/feature_flags.guardian-verify-setup.enabled",
         {
           method: "PATCH",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ enabled: false }),
         },
       ),
-      "feature_flags.twitter.enabled",
+      "feature_flags.guardian-verify-setup.enabled",
     );
 
     // Verify the file is valid JSON and contains all expected data
@@ -565,7 +561,9 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
     ).toBe(true);
     expect(
-      config.assistantFeatureFlagValues["feature_flags.twitter.enabled"],
+      config.assistantFeatureFlagValues[
+        "feature_flags.guardian-verify-setup.enabled"
+      ],
     ).toBe(false);
 
     // Verify no temp files left behind
@@ -582,7 +580,6 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Fire multiple concurrent PATCH requests at the same time
     const flagKeys = [
       "feature_flags.browser.enabled",
-      "feature_flags.twitter.enabled",
       "feature_flags.guardian-verify-setup.enabled",
       "feature_flags.hatch-new-assistant.enabled",
     ];

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "twitter",
-      "scope": "assistant",
-      "key": "feature_flags.twitter.enabled",
-      "label": "Twitter",
-      "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": false
-    },
-    {
       "id": "messaging",
       "scope": "assistant",
       "key": "feature_flags.messaging.enabled",

--- a/gateway/workspace/config.json
+++ b/gateway/workspace/config.json
@@ -1,7 +1,6 @@
 {
   "assistantFeatureFlagValues": {
     "feature_flags.browser.enabled": false,
-    "feature_flags.twitter.enabled": false,
     "feature_flags.guardian-verify-setup.enabled": false,
     "feature_flags.hatch-new-assistant.enabled": false
   }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "twitter",
-      "scope": "assistant",
-      "key": "feature_flags.twitter.enabled",
-      "label": "Twitter",
-      "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": false
-    },
-    {
       "id": "messaging",
       "scope": "assistant",
       "key": "feature_flags.messaging.enabled",


### PR DESCRIPTION
## Summary
- Remove twitter flag entry from all three feature-flag-registry.json files
- Remove twitter system prompt section from system-prompt.ts
- Update test files that enumerate feature flags to remove twitter references

Part of plan: remove-twitter-integration.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
