### PR TITLE
chore: remove dedicated twitter daemon message types and runtime HTTP routes

### DIFF
--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -1,4 +1,4 @@
-// External service integrations: Slack, Telegram, Twitter, Vercel, ingress, guardian.
+// External service integrations: Slack, Telegram, Vercel, ingress, guardian.
 
 import type { ChannelId } from "../../channels/types.js";
 
@@ -29,19 +29,6 @@ export interface VercelApiConfigRequest {
   apiToken?: string;
 }
 
-export interface TwitterIntegrationConfigRequest {
-  type: "twitter_integration_config";
-  action:
-    | "get"
-    | "set_mode"
-    | "set_local_client"
-    | "clear_local_client"
-    | "disconnect";
-  mode?: "local_byo" | "managed";
-  clientId?: string;
-  clientSecret?: string;
-}
-
 export interface TelegramConfigRequest {
   type: "telegram_config";
   action: "get" | "set" | "clear" | "set_commands" | "setup";
@@ -68,14 +55,6 @@ export interface ChannelVerificationSessionRequest {
   purpose?: "guardian" | "trusted_contact";
   /** Contact-channel ID for the absorbed contact-channel verify flow. */
   contactChannelId?: string;
-}
-
-export interface TwitterAuthStartRequest {
-  type: "twitter_auth_start";
-}
-
-export interface TwitterAuthStatusRequest {
-  type: "twitter_auth_status";
 }
 
 export interface IntegrationListRequest {
@@ -137,28 +116,6 @@ export interface VercelApiConfigResponse {
   error?: string;
 }
 
-export interface ManagedPrerequisites {
-  /** Whether twitter.integrationMode is set to "managed" in config. */
-  integrationModeManaged: boolean;
-  /** Whether the assistant API key credential exists in secure storage. */
-  assistantApiKeyPresent: boolean;
-  /** Whether the platform base URL is configured (platform registration resolvable). */
-  platformAssistantIdResolvable: boolean;
-}
-
-export interface TwitterIntegrationConfigResponse {
-  type: "twitter_integration_config_response";
-  success: boolean;
-  mode?: "local_byo" | "managed";
-  managedAvailable: boolean;
-  /** Detailed prerequisite status for managed Twitter availability. */
-  managedPrerequisites?: ManagedPrerequisites;
-  localClientConfigured: boolean;
-  connected: boolean;
-  accountInfo?: string;
-  error?: string;
-}
-
 export interface TelegramConfigResponse {
   type: "telegram_config_response";
   success: boolean;
@@ -211,23 +168,6 @@ export interface ChannelVerificationSessionResponse {
   pendingBootstrap?: boolean;
 }
 
-export interface TwitterAuthResult {
-  type: "twitter_auth_result";
-  success: boolean;
-  accountInfo?: string;
-  /** Machine-readable error code for programmatic handling (e.g. "managed_missing_api_key", "managed_auth_via_platform"). */
-  errorCode?: string;
-  error?: string;
-}
-
-export interface TwitterAuthStatusResponse {
-  type: "twitter_auth_status_response";
-  connected: boolean;
-  accountInfo?: string;
-  mode?: "local_byo" | "managed";
-  error?: string;
-}
-
 export interface IntegrationListResponse {
   type: "integration_list_response";
   integrations: Array<{
@@ -277,11 +217,8 @@ export type _IntegrationsClientMessages =
   | IngressConfigRequest
   | PlatformConfigRequest
   | VercelApiConfigRequest
-  | TwitterIntegrationConfigRequest
   | TelegramConfigRequest
   | ChannelVerificationSessionRequest
-  | TwitterAuthStartRequest
-  | TwitterAuthStatusRequest
   | IntegrationListRequest
   | IntegrationConnectRequest
   | IntegrationDisconnectRequest
@@ -293,11 +230,8 @@ export type _IntegrationsServerMessages =
   | IngressConfigResponse
   | PlatformConfigResponse
   | VercelApiConfigResponse
-  | TwitterIntegrationConfigResponse
   | TelegramConfigResponse
   | ChannelVerificationSessionResponse
-  | TwitterAuthResult
-  | TwitterAuthStatusResponse
   | IntegrationListResponse
   | IntegrationConnectResult
   | OAuthConnectResultResponse

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -411,8 +411,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // OAuth / integrations
   { endpoint: "integrations/oauth/start", scopes: ["settings.write"] },
-  { endpoint: "integrations/twitter/auth/start", scopes: ["settings.write"] },
-  { endpoint: "integrations/twitter/auth/status", scopes: ["settings.read"] },
 
   // Workspace files
   { endpoint: "workspace-files", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -1,30 +1,17 @@
 /**
  * HTTP route handlers for settings, identity/avatar, voice config,
- * OAuth connect, Twitter auth, and workspace files.
+ * OAuth connect, and workspace files.
  *
  * Handles settings, identity/avatar, voice config,
- * OAuth connect, Twitter auth, and workspace files.
+ * OAuth connect, and workspace files.
  *   - handlers/config-tools.ts (tool_names_list, tool_permission_simulate, env_vars_request)
  */
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import {
-  getPlatformAssistantId,
-  getPlatformBaseUrl,
-} from "../../config/env.js";
-import {
-  getNestedValue,
-  invalidateConfigCache,
-  loadConfig,
-  loadRawConfig,
-  saveRawConfig,
-  setNestedValue,
-} from "../../config/loader.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
-import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import {
   getProviderProfile,
@@ -46,7 +33,6 @@ import {
 import { getAllTools, getTool } from "../../tools/registry.js";
 import { isSideEffectTool } from "../../tools/side-effects.js";
 import { setAvatarTool } from "../../tools/system/avatar-generator.js";
-import { ConfigError } from "../../util/errors.js";
 import { pathExists } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -249,227 +235,6 @@ async function handleOAuthConnectStart(body: {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err, service: body.service }, "OAuth connect flow failed");
     return httpError("INTERNAL_ERROR", sanitizeOAuthError(message), 500);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Twitter auth
-// ---------------------------------------------------------------------------
-
-function sanitizeTwitterAuthError(message: string): string {
-  const lower = message.toLowerCase();
-  if (lower.includes("timed out")) {
-    return "Twitter authentication timed out. Please try again.";
-  }
-  if (lower.includes("user_cancelled") || lower.includes("cancelled")) {
-    return "Twitter authentication was cancelled.";
-  }
-  if (lower.includes("denied") || lower.includes("invalid_grant")) {
-    return "Twitter denied the authorization request. Please try again.";
-  }
-  return "Twitter authentication failed. Please try again.";
-}
-
-async function handleTwitterAuthStart(): Promise<Response> {
-  try {
-    assertMetadataWritable();
-  } catch {
-    return httpError(
-      "UNPROCESSABLE_ENTITY",
-      "Credential metadata file has an unrecognized version. Cannot store OAuth credentials.",
-      422,
-    );
-  }
-
-  try {
-    const raw = loadRawConfig();
-    const mode =
-      (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
-      "local_byo";
-    if (mode === "managed") {
-      const apiKey = getSecureKey("credential:vellum:assistant_api_key");
-      if (!apiKey) {
-        return Response.json(
-          {
-            ok: false,
-            error:
-              "An AssistantAPIKey is required for managed Twitter. Run assistant setup.",
-            errorCode: "managed_missing_api_key",
-          },
-          { status: 400 },
-        );
-      }
-      return Response.json(
-        {
-          ok: false,
-          error:
-            "Managed Twitter authentication is handled through the Vellum platform. Open Settings to connect.",
-          errorCode: "managed_auth_via_platform",
-        },
-        { status: 400 },
-      );
-    }
-    if (mode !== "local_byo") {
-      return httpError(
-        "BAD_REQUEST",
-        'Twitter integration mode must be "local_byo" to use this flow.',
-        400,
-      );
-    }
-
-    const clientId = getSecureKey("credential:integration:twitter:client_id");
-    if (!clientId) {
-      return httpError(
-        "BAD_REQUEST",
-        "No Twitter client credentials configured. Please set up your Client ID first.",
-        400,
-      );
-    }
-
-    const clientSecret =
-      getSecureKey("credential:integration:twitter:client_secret") || undefined;
-
-    let config;
-    try {
-      config = loadConfig();
-    } catch (err) {
-      const detail = err instanceof ConfigError ? err.message : String(err);
-      return httpError(
-        "INTERNAL_ERROR",
-        `Unable to load config: ${detail}`,
-        500,
-      );
-    }
-
-    try {
-      getPublicBaseUrl(config);
-    } catch {
-      return httpError(
-        "BAD_REQUEST",
-        "Set ingress.publicBaseUrl (or INGRESS_PUBLIC_BASE_URL) so OAuth callbacks can route through /webhooks/oauth/callback on the gateway.",
-        400,
-      );
-    }
-
-    let authUrl: string | undefined;
-
-    const result = await orchestrateOAuthConnect({
-      service: "integration:twitter",
-      clientId,
-      clientSecret,
-      isInteractive: true,
-      openUrl: (url: string) => {
-        authUrl = url;
-      },
-      allowedTools: ["twitter_post"],
-    });
-
-    if (!result.success) {
-      log.error(
-        { err: result.error },
-        "Twitter OAuth orchestrator returned error",
-      );
-      return httpError(
-        "INTERNAL_ERROR",
-        result.safeError
-          ? result.error
-          : sanitizeTwitterAuthError(result.error),
-        500,
-      );
-    }
-
-    if (result.deferred) {
-      return Response.json({
-        ok: true,
-        deferred: true,
-        authUrl: result.authUrl,
-      });
-    }
-
-    // Persist accountInfo to config
-    if (result.accountInfo) {
-      try {
-        const raw2 = loadRawConfig();
-        setNestedValue(raw2, "twitter.accountInfo", result.accountInfo);
-        saveRawConfig(raw2);
-        invalidateConfigCache();
-      } catch {
-        // Non-fatal
-      }
-    }
-
-    return Response.json({
-      ok: true,
-      accountInfo: result.accountInfo,
-      ...(authUrl ? { authUrl } : {}),
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Twitter OAuth flow failed");
-    return httpError("INTERNAL_ERROR", sanitizeTwitterAuthError(message), 500);
-  }
-}
-
-function handleTwitterAuthStatus(): Response {
-  try {
-    const accessToken = getSecureKey(
-      "credential:integration:twitter:access_token",
-    );
-    const raw = loadRawConfig();
-    const mode =
-      (getNestedValue(raw, "twitter.integrationMode") as
-        | "local_byo"
-        | "managed"
-        | undefined) ?? "local_byo";
-    const accountInfo = getNestedValue(raw, "twitter.accountInfo") as
-      | string
-      | undefined;
-
-    // Managed prerequisites
-    const integrationModeManaged = mode === "managed";
-    const assistantApiKeyPresent = !!getSecureKey(
-      "credential:vellum:assistant_api_key",
-    );
-    const platformBaseUrlFromEnv = getPlatformBaseUrl();
-    const platformBaseUrlFromConfig = (
-      raw?.platform as Record<string, unknown> | undefined
-    )?.baseUrl as string | undefined;
-    const platformAssistantIdResolvable = !!(
-      (platformBaseUrlFromEnv || platformBaseUrlFromConfig) &&
-      (getSecureKey("credential:vellum:platform_assistant_id") ||
-        getPlatformAssistantId())
-    );
-
-    const managedPrerequisites = {
-      integrationModeManaged,
-      assistantApiKeyPresent,
-      platformAssistantIdResolvable,
-    };
-    const managedAvailable =
-      integrationModeManaged &&
-      assistantApiKeyPresent &&
-      platformAssistantIdResolvable;
-
-    // Local client configured
-    const localClientConfigured = !!getSecureKey(
-      "credential:integration:twitter:client_id",
-    );
-
-    // In managed mode, connected is always false (auth goes through platform)
-    const connected = mode === "managed" ? false : !!accessToken;
-
-    return Response.json({
-      connected,
-      accountInfo: accountInfo ?? undefined,
-      mode,
-      managedAvailable,
-      managedPrerequisites,
-      localClientConfigured,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to get Twitter auth status");
-    return httpError("INTERNAL_ERROR", message, 500);
   }
 }
 
@@ -806,20 +571,6 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
         };
         return handleOAuthConnectStart(body);
       },
-    },
-
-    // Twitter auth
-    {
-      endpoint: "integrations/twitter/auth/start",
-      method: "POST",
-      policyKey: "integrations/twitter/auth/start",
-      handler: async () => handleTwitterAuthStart(),
-    },
-    {
-      endpoint: "integrations/twitter/auth/status",
-      method: "GET",
-      policyKey: "integrations/twitter/auth/status",
-      handler: () => handleTwitterAuthStatus(),
     },
 
     // Workspace files (list/read -- distinct from workspace-routes.ts tree/file)


### PR DESCRIPTION
## Summary
- Remove all Twitter-specific IPC message types from integrations.ts
- Remove Twitter auth handlers and routes from settings-routes.ts
- Remove Twitter auth policy entries from route-policy.ts

Part of plan: remove-twitter-integration.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
