### PR TITLE
fix: disambiguate Sentry.Attachment in CrashReportView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -112,12 +112,12 @@ struct CrashReportView: View {
 
             // Attach the full crash log file and any companion files (e.g. spindump
             // .tar.gz archives) so they are available in Sentry for download.
-            var attachments: [Attachment] = [
-                Attachment(path: urlCopy.path, filename: urlCopy.lastPathComponent),
+            var attachments: [Sentry.Attachment] = [
+                Sentry.Attachment(path: urlCopy.path, filename: urlCopy.lastPathComponent),
             ]
             for companion in companions {
                 attachments.append(
-                    Attachment(path: companion.path, filename: companion.lastPathComponent)
+                    Sentry.Attachment(path: companion.path, filename: companion.lastPathComponent)
                 )
             }
 


### PR DESCRIPTION
## Summary
- Fully qualify `Sentry.Attachment` in `CrashReportView.swift` to resolve ambiguity with `VellumAssistantShared.Attachment` (typealias for `UserMessageAttachment`)
- This fixes the macOS build failure in CI where the compiler couldn't determine which `Attachment` type was intended

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22932923107/job/66558148696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
