### PR TITLE
fix: remove dead proxy-reuse guard in prepareSessionForMessage

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -639,16 +639,12 @@ export class DaemonServer {
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Non-desktop sessions (CLI,
     // channels, headless) fall back to local execution.
-    // Reuse the existing proxy if the session is actively processing a
-    // host bash request to avoid orphaning in-flight requests.
     if (resolvedInterface === "macos" || resolvedInterface === "ios") {
-      if (!session.isProcessing() || !session.hostBashProxy) {
-        session.setHostBashProxy(
-          new HostBashProxy(session.getCurrentSender(), (requestId) => {
-            pendingInteractions.resolve(requestId);
-          }),
-        );
-      }
+      session.setHostBashProxy(
+        new HostBashProxy(session.getCurrentSender(), (requestId) => {
+          pendingInteractions.resolve(requestId);
+        }),
+      );
     } else {
       session.setHostBashProxy(undefined);
     }


### PR DESCRIPTION
The condition `!session.isProcessing() || !session.hostBashProxy` was dead code — prepareSessionForMessage already throws if isProcessing() is true, so the check always short-circuits. Simplified to unconditionally create a new HostBashProxy for macos/ios interfaces.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/15157
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
