### PR TITLE
docs: document host_bash interaction kind in runtime AGENTS.md

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -25,6 +25,15 @@ Approvals are **orthogonal to message sending**. The assistant asks for approval
 
 Do NOT couple approval handling to message sending. Do NOT add run/status tracking to the send path.
 
+### Host bash (desktop proxy execution)
+
+Host bash allows the assistant to execute shell commands on the desktop host machine via the client, rather than in the daemon's own sandbox.
+
+- **Discovery**: Clients discover pending host bash requests via SSE events (`host_bash_request`) which include a `requestId`.
+- **Resolution**: Clients execute the command on the host and respond via:
+  - `POST /v1/host-bash-result` — `{ requestId, stdout, stderr, exitCode, timedOut }`
+- **Tracking**: Uses the same `pending-interactions` tracker as approvals, with `kind: "host_bash"`. The endpoint validates the interaction kind before resolving.
+
 ### Channel approvals (Telegram, SMS)
 
 Channel approval flows use `requestId` (not `runId`) as the primary identifier:


### PR DESCRIPTION
Added documentation for the host_bash_request discovery event and POST /v1/host-bash-result resolution endpoint to the runtime AGENTS.md, completing the documentation gap noted in PR #15166.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/15166
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
