### PR TITLE
fix: skip host_bash interactions in removeBySession to prevent orphaning

### DIFF
--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -79,13 +79,18 @@ export function getByConversation(
 }
 
 /**
- * Remove all pending interactions (confirmation, secret, and host_bash)
- * for a given session. Used when auto-denying all pending interactions
- * (e.g. new user message).
+ * Remove pending confirmation and secret interactions for a given session.
+ * Used when auto-denying all pending interactions (e.g. new user message).
+ *
+ * host_bash interactions are intentionally skipped — they represent in-flight
+ * tool executions proxied to the client, not confirmations to auto-deny.
+ * Removing them would orphan the request: the client would POST to
+ * /v1/host-bash-result after completing the command, get a 404, and the
+ * proxy timer would fire with a spurious timeout error.
  */
 export function removeBySession(session: Session): void {
   for (const [requestId, interaction] of pending) {
-    if (interaction.session === session) {
+    if (interaction.session === session && interaction.kind !== "host_bash") {
       pending.delete(requestId);
     }
   }


### PR DESCRIPTION
## Summary
When a new message arrives while the session is processing, `removeBySession` was removing all pending interactions including in-flight `host_bash` proxy requests. This caused the client's POST to `/v1/host-bash-result` to return 404, and the proxy timer to fire with a spurious timeout error for a command that actually completed on the client.

Fix: skip `host_bash` interactions in `removeBySession` — they are in-flight tool executions, not confirmations to auto-deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
