### PR TITLE
ci: remove redundant iOS simulator build step

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: iOS Build
     runs-on: macos-15
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,11 +44,7 @@ jobs:
             ios-deriveddata-${{ hashFiles('clients/Package.resolved') }}-
             ios-deriveddata-
 
-      - name: Build for simulator
-        working-directory: clients/ios
-        run: ./build.sh
-
-      - name: Run iOS tests
+      - name: Build & test
         working-directory: clients/ios
         run: ./build.sh test
 


### PR DESCRIPTION
## Summary
- Remove the separate "Build for simulator" step from `ci-main-ios.yaml` — `xcodebuild test` already builds before running tests, so the prior step was a full redundant compilation
- Reduce timeout from 25 to 20 minutes to reflect the faster pipeline

## Original prompt
these two wins in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
