### PR TITLE
ci: cache Homebrew XcodeGen in iOS CI

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -22,8 +22,22 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Cache Homebrew XcodeGen
+        id: cache-xcodegen
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/Cellar/xcodegen
+            /opt/homebrew/Cellar/xcodegen
+          key: xcodegen-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit != 'true'
         run: brew install xcodegen
+
+      - name: Link XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit == 'true'
+        run: brew link xcodegen 2>/dev/null || true
 
       - name: Design token guard
         run: bash clients/scripts/check-design-tokens.sh --mode=strict


### PR DESCRIPTION
## Summary
- Cache the Homebrew XcodeGen Cellar directory across CI runs so `brew install xcodegen` is only needed on cache misses
- On cache hits, run `brew link` to restore the symlinks without downloading or compiling anything

## Original prompt
these two wins in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
