### PR TITLE
fix: Enter/Shift+Enter select line instead of inserting newline in cmd+enter mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
@@ -4,7 +4,8 @@ import AppKit
 /// Routes Return key presses in the composer based on modifier keys and the user's send-mode preference.
 /// In default mode, Shift+Return is the only newline shortcut and Option+Return
 /// is treated as send via the bridge. In cmd-enter mode, only Cmd+Return sends;
-/// all other combinations defer to SwiftUI's `.onSubmit` handler.
+/// all other Return variants insert a newline via the bridge so the event is
+/// consumed before SwiftUI's `.onSubmit` can interfere with the field selection.
 enum ComposerReturnKeyRouting {
     enum Action: Equatable {
         case bridgeSend
@@ -18,15 +19,18 @@ enum ComposerReturnKeyRouting {
         // equality checks.
         let keys = modifiers.intersection([.shift, .command, .control, .option])
 
-        if !cmdEnterToSend {
-            if keys == .shift {
-                return .bridgeInsertNewline
-            }
-            if keys == .option {
-                return .bridgeSend
-            }
+        if cmdEnterToSend {
+            if keys == .command { return .bridgeSend }
+            // All non-Cmd Return variants insert a newline via the bridge.
+            // Deferring to `.onSubmit` caused SwiftUI to select the line
+            // instead of inserting a newline.
+            return .bridgeInsertNewline
         }
-        if cmdEnterToSend && keys == .command {
+
+        if keys == .shift {
+            return .bridgeInsertNewline
+        }
+        if keys == .option {
             return .bridgeSend
         }
         return .deferToSubmit
@@ -50,18 +54,6 @@ enum ComposerReturnKeyRouting {
         case .deferToSubmit:
             return false
         }
-    }
-
-    static func handleSubmit(
-        cmdEnterToSend: Bool,
-        textView: NSTextView?,
-        onSend: () -> Void
-    ) {
-        if cmdEnterToSend {
-            insertNewline(into: textView)
-            return
-        }
-        onSend()
     }
 
     private static func insertNewline(into textView: NSTextView?) {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -369,18 +369,11 @@ struct ComposerView: View {
     }
 
     private func handleComposerSubmit() {
-        #if os(macOS)
-        // `.onSubmit` fires on all Return variants, so keep the actual
-        // send-vs-newline behavior in the shared return-key contract.
-        ComposerReturnKeyRouting.handleSubmit(
-            cmdEnterToSend: cmdEnterToSend,
-            textView: NSApp.keyWindow?.firstResponder as? NSTextView
-        ) {
-            performSendAction()
-        }
-        #else
+        // On macOS, the bridge consumes all Return variants that should insert
+        // a newline (cmd-enter mode) or trigger a bridge-level send. The only
+        // Return events that reach `.onSubmit` are plain Return in default mode,
+        // which always means "send".
         performSendAction()
-        #endif
     }
 
     // MARK: - Text Entry Mode

--- a/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
@@ -34,9 +34,9 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
 
     // MARK: - Cmd-enter mode (cmdEnterToSend: true)
 
-    func testCmdEnterMode_plainReturn_defersToSubmit() {
+    func testCmdEnterMode_plainReturn_insertsNewline() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [])
-        XCTAssertEqual(action, .deferToSubmit)
+        XCTAssertEqual(action, .bridgeInsertNewline)
     }
 
     func testCmdEnterMode_cmdReturn_sends() {
@@ -44,14 +44,14 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
         XCTAssertEqual(action, .bridgeSend)
     }
 
-    func testCmdEnterMode_shiftReturn_defersToSubmit() {
+    func testCmdEnterMode_shiftReturn_insertsNewline() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [.shift])
-        XCTAssertEqual(action, .deferToSubmit)
+        XCTAssertEqual(action, .bridgeInsertNewline)
     }
 
-    func testCmdEnterMode_optionReturn_defersToSubmit() {
+    func testCmdEnterMode_optionReturn_insertsNewline() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [.option])
-        XCTAssertEqual(action, .deferToSubmit)
+        XCTAssertEqual(action, .bridgeInsertNewline)
     }
 
     // MARK: - Extra modifier flags (capsLock, function, etc.)
@@ -95,36 +95,6 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
         XCTAssertTrue(consumed)
         XCTAssertEqual(textView.string, "hello\n")
         XCTAssertEqual(sendCount, 0)
-    }
-
-    func testCmdEnterModeSubmitInsertsNewlineInsteadOfSending() {
-        let textView = makeTextView(with: "hello")
-        var sendCount = 0
-
-        ComposerReturnKeyRouting.handleSubmit(
-            cmdEnterToSend: true,
-            textView: textView
-        ) {
-            sendCount += 1
-        }
-
-        XCTAssertEqual(textView.string, "hello\n")
-        XCTAssertEqual(sendCount, 0)
-    }
-
-    func testDefaultModeSubmitSendsInsteadOfInsertingNewline() {
-        let textView = makeTextView(with: "hello")
-        var sendCount = 0
-
-        ComposerReturnKeyRouting.handleSubmit(
-            cmdEnterToSend: false,
-            textView: textView
-        ) {
-            sendCount += 1
-        }
-
-        XCTAssertEqual(textView.string, "hello")
-        XCTAssertEqual(sendCount, 1)
     }
 
     private func makeTextView(with text: String) -> NSTextView {


### PR DESCRIPTION
## Summary
- In cmd+enter mode, plain Enter and Shift+Enter were deferring to SwiftUI's `.onSubmit`, which caused the text field to select the line content instead of inserting a newline
- Fix routes all non-Cmd Return variants to `bridgeInsertNewline` in cmd-enter mode, so the AppKit event monitor consumes the event before SwiftUI can interfere
- Removed the now-dead `handleSubmit` method and simplified `handleComposerSubmit` since `.onSubmit` only fires in default mode (where it always means "send")

## Original prompt
fix Enter/Shift+Enter selecting the whole line instead of inserting a newline when cmd+enter to send is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
