### PR TITLE
fix: resolve ListItem type ambiguity in macOS tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 // MARK: - Markdown Table Support
 
 /// A segment of message content — either plain text or a parsed table.
-struct ListItem: Hashable {
+struct MarkdownListItem: Hashable {
     let indent: Int
     let ordered: Bool
     let number: Int      // meaningful only when ordered == true
@@ -19,7 +19,7 @@ enum MarkdownSegment: Hashable {
     case heading(level: Int, text: String)
     case codeBlock(language: String?, code: String)
     case horizontalRule
-    case list(items: [ListItem])
+    case list(items: [MarkdownListItem])
 }
 
 /// Returns true if `line` is a markdown heading (1-6 `#` chars followed by a space).
@@ -42,8 +42,8 @@ func isHorizontalRule(_ line: String) -> Bool {
     return stripped.allSatisfy { $0 == ch }
 }
 
-/// Returns a `ListItem` if the line looks like a list entry, otherwise nil.
-func parseListLine(_ line: String) -> ListItem? {
+/// Returns a `MarkdownListItem` if the line looks like a list entry, otherwise nil.
+func parseListLine(_ line: String) -> MarkdownListItem? {
     // Measure indent (count leading spaces, tabs count as 4)
     var indent = 0
     for ch in line {
@@ -55,14 +55,14 @@ func parseListLine(_ line: String) -> ListItem? {
 
     // Unordered: `- `, `* `, `+ `
     if (trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ")) {
-        return ListItem(indent: indent, ordered: false, number: 0, text: String(trimmed.dropFirst(2)))
+        return MarkdownListItem(indent: indent, ordered: false, number: 0, text: String(trimmed.dropFirst(2)))
     }
     // Ordered: `1. `, `2. `, etc.
     let digits = trimmed.prefix(while: { $0.isNumber })
     if !digits.isEmpty {
         let rest = trimmed.dropFirst(digits.count)
         if rest.hasPrefix(". ") {
-            return ListItem(indent: indent, ordered: true, number: Int(digits) ?? 1,
+            return MarkdownListItem(indent: indent, ordered: true, number: Int(digits) ?? 1,
                             text: String(rest.dropFirst(2)))
         }
     }
@@ -160,7 +160,7 @@ func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
         // --- List detection (consecutive list lines) ---
         if parseListLine(lines[i]) != nil {
             flushText()
-            var items: [ListItem] = []
+            var items: [MarkdownListItem] = []
             while i < lines.count, let item = parseListLine(lines[i]) {
                 items.append(item)
                 i += 1

--- a/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
@@ -210,7 +210,7 @@ private enum SegmentGroup {
     case selectableRun([MarkdownSegment])
     case heading(level: Int, text: String)
     case codeBlock(language: String?, code: String)
-    case list(items: [ListItem], ordered: Bool)
+    case list(items: [MarkdownListItem], ordered: Bool)
     case table(headers: [String], rows: [[String]])
     case image(alt: String, url: String)
     case horizontalRule

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -178,7 +178,7 @@ private enum SegmentGroup {
     case selectableRun([MarkdownSegment])
     case heading(level: Int, text: String)
     case codeBlock(language: String?, code: String)
-    case list(items: [ListItem], ordered: Bool)
+    case list(items: [MarkdownListItem], ordered: Bool)
     case table(headers: [String], rows: [[String]])
     case image(alt: String, url: String)
     case horizontalRule


### PR DESCRIPTION
## Summary
- Renamed `ListItem` in `ChatMarkdownParser.swift` to `MarkdownListItem` to resolve ambiguity with the identically-named `ListItem` in `GeneratedAPITypes.swift`
- Updated references in `MarkdownPerformanceTests.swift` and `MessageListAnchorPerformanceTests.swift`
- Fixes macOS CI test compilation failure

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22933422786/job/66559606235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
