### PR TITLE
Fix composer button hover flicker and cursor inconsistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -491,7 +491,7 @@ struct ComposerView: View {
             }
         }
         .padding(.trailing, -(VSpacing.lg - VSpacing.sm))
-        .animation(VAnimation.spring, value: canSend)
+        .animation(VAnimation.fast, value: canSend)
     }
 
     // MARK: - Dictation Inline Mode

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -56,10 +56,9 @@ public struct VIconButton: View {
         }
         .focused($isFocused)
         .buttonStyle(VIconButtonStyle(isActive: isActive, isHovered: isHovered, isFocused: isFocused, size: size, variant: variant))
-        .onHover { hovering in
+        .pointerCursor(onHover: { hovering in
             isHovered = hovering
-        }
-        .pointerCursor()
+        })
         .accessibilityLabel(label)
         .modifier(OptionalHelpModifier(tooltip: tooltip))
     }
@@ -131,8 +130,6 @@ public struct VIconButtonStyle: ButtonStyle {
             .focusEffectDisabled()
             .scaleEffect(configuration.isPressed ? 0.97 : 1)
             .animation(VAnimation.fast, value: configuration.isPressed)
-            .animation(VAnimation.fast, value: isHovered)
-            .animation(VAnimation.fast, value: isFocused)
     }
 
     private func backgroundColor(isPressed: Bool) -> Color {

--- a/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
@@ -11,8 +11,12 @@ import AppKit
 ///
 /// Respects the SwiftUI disabled state: when the view is disabled via `.disabled(true)`,
 /// the pointer cursor is suppressed.
+///
+/// Accepts an optional `onHover` callback so callers can consolidate hover tracking
+/// into a single `.onHover` handler, avoiding competing hover registrations.
 struct PointerCursorModifier: ViewModifier {
     @Environment(\.isEnabled) private var isEnabled
+    var onHover: ((Bool) -> Void)?
 
     #if os(macOS)
     @State private var didPushCursor = false
@@ -23,9 +27,13 @@ struct PointerCursorModifier: ViewModifier {
         if #available(macOS 15.0, *) {
             content
                 .pointerStyle(isEnabled ? .link : nil)
+                .onHover { hovering in
+                    onHover?(hovering)
+                }
         } else {
             content
                 .onHover { hovering in
+                    onHover?(hovering)
                     if hovering && isEnabled {
                         NSCursor.pointingHand.push()
                         didPushCursor = true
@@ -49,6 +57,9 @@ struct PointerCursorModifier: ViewModifier {
         }
         #else
         content
+            .onHover { hovering in
+                onHover?(hovering)
+            }
         #endif
     }
 }
@@ -57,6 +68,11 @@ public extension View {
     /// Applies a pointing-hand cursor when the user hovers over this view.
     func pointerCursor() -> some View {
         modifier(PointerCursorModifier())
+    }
+
+    /// Applies a pointing-hand cursor and calls `onHover` in a single hover handler.
+    func pointerCursor(onHover: @escaping (Bool) -> Void) -> some View {
+        modifier(PointerCursorModifier(onHover: onHover))
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes finicky hover states on composer buttons — flashing, missing hover state, and inconsistent cursor (pointer vs default).

## Changes
- **VIconButton.swift**: Remove competing `.animation()` modifiers for `isHovered`/`isFocused` that caused overlapping animation contexts. Consolidate `.onHover` + `.pointerCursor()` into single handler.
- **PointerCursorModifier.swift**: Add `onHover` callback parameter so callers can consolidate hover tracking and cursor changes into one `.onHover` registration.
- **ComposerView.swift**: Replace spring animation (0.3s) with fast animation (0.15s) on composer action buttons to reduce hover detection interference during button transitions.

## Root causes
1. Triple `.animation()` modifiers in VIconButtonStyle created competing animation contexts — rapid hover toggling at button edges caused overlapping 0.15s animations that flashed
2. Dual `.onHover` handlers (one for hover state, one inside `.pointerCursor()`) fired out of sync on macOS 14, causing cursor to briefly revert to default
3. Spring animation on parent HStack interfered with hover detection during button appear/disappear transitions

## Test plan
- [ ] Hover over composer buttons — no flashing/flickering
- [ ] Move cursor across button edges rapidly — hover state should be stable
- [ ] Verify pointer cursor appears consistently on hover
- [ ] Verify button press scale animation still works
- [ ] Test with empty input (dictate/voice buttons visible) and with text input (send button visible)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
