### PR TITLE
fix: add version component to XcodeGen cache key in iOS CI

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -29,7 +29,7 @@ jobs:
           path: |
             /usr/local/Cellar/xcodegen
             /opt/homebrew/Cellar/xcodegen
-          key: xcodegen-${{ runner.os }}-${{ runner.arch }}
+          key: xcodegen-v1-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install XcodeGen
         if: steps.cache-xcodegen.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -26,8 +26,22 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Cache Homebrew XcodeGen
+        id: cache-xcodegen
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/Cellar/xcodegen
+            /opt/homebrew/Cellar/xcodegen
+          key: xcodegen-v1-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit != 'true'
         run: brew install xcodegen
+
+      - name: Link XcodeGen
+        if: steps.cache-xcodegen.outputs.cache-hit == 'true'
+        run: brew link xcodegen 2>/dev/null || true
 
       - name: Clear stale SPM artifact cache
         run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts


### PR DESCRIPTION
Addresses feedback on #15184 from both Codex and Devin. Adds a manually-bumped version prefix (`v1`) to the XcodeGen cache key so it can be invalidated when a new version is needed. Also harmonizes caching between main and PR iOS CI workflows — `pr-ios.yaml` now uses the same cache pattern as `ci-main-ios.yaml`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
