### PR TITLE
fix: restore host bash proxy guard to prevent concurrent turn races

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -639,14 +639,19 @@ export class DaemonServer {
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Non-desktop sessions (CLI,
     // channels, headless) fall back to local execution.
-    if (resolvedInterface === "macos" || resolvedInterface === "ios") {
-      session.setHostBashProxy(
-        new HostBashProxy(session.getCurrentSender(), (requestId) => {
-          pendingInteractions.resolve(requestId);
-        }),
-      );
-    } else {
-      session.setHostBashProxy(undefined);
+    // Guard: don't replace an active proxy during concurrent turn races —
+    // another request may have started processing between the isProcessing()
+    // check above and the await on ensureActorScopedHistory().
+    if (!session.isProcessing() || !session.hostBashProxy) {
+      if (resolvedInterface === "macos" || resolvedInterface === "ios") {
+        session.setHostBashProxy(
+          new HostBashProxy(session.getCurrentSender(), (requestId) => {
+            pendingInteractions.resolve(requestId);
+          }),
+        );
+      } else {
+        session.setHostBashProxy(undefined);
+      }
     }
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({


### PR DESCRIPTION
Addresses Codex feedback on #15176. Restores the conditional guard that prevents replacing an active host bash proxy during concurrent message submissions, which could break in-flight host-bash requests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
