### PR TITLE
fix: resolve DictationContext type ambiguity in macOS tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -4,16 +4,6 @@ import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "DictationContext")
 
-/// Context captured at Fn-hold activation time, describing the user's current app state.
-/// This is the Swift-side struct — it will be mapped to message types in M3.
-struct DictationContext {
-    let bundleIdentifier: String
-    let appName: String
-    let windowTitle: String
-    let selectedText: String?
-    let cursorInTextField: Bool
-}
-
 /// Captures the user's current context (frontmost app, window, selection, text field status)
 /// at voice dictation activation time using Accessibility APIs.
 struct DictationContextCapture {


### PR DESCRIPTION
## Summary
- Removed the hand-written `DictationContext` struct from `DictationContextCapture.swift` — it was identical to the generated one in `GeneratedAPITypes.swift` and caused `'DictationContext' is ambiguous for type lookup` compile errors in `VoiceInputManagerTests.swift`
- Same pattern as the recent `ListItem` → `MarkdownListItem` fix (#15186), but here we can simply delete the duplicate since the generated type has identical fields

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22933614464/job/66560164518

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
