### PR TITLE
fix: remove dead DerivedData cache step and restore timeout in iOS CI

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: iOS Build
     runs-on: macos-15
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,15 +48,6 @@ jobs:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ios-spm-${{ hashFiles('clients/Package.resolved') }}
           restore-keys: ios-spm-
-
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
-        with:
-          path: clients/ios/dist/DerivedData
-          key: ios-deriveddata-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/ios/project.yml', 'clients/shared/**/*.swift', 'clients/ios/**/*.swift') }}
-          restore-keys: |
-            ios-deriveddata-${{ hashFiles('clients/Package.resolved') }}-
-            ios-deriveddata-
 
       - name: Build & test
         working-directory: clients/ios


### PR DESCRIPTION
Addresses feedback on #15182 from both Codex and Devin. Removes the unused DerivedData cache step (./build.sh test doesn't use -derivedDataPath) and restores the timeout to 25 minutes since builds no longer benefit from DerivedData caching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
