### PR TITLE
fix: add missing VellumAssistantShared import in DictationContextCapture

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationContextCapture.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import AppKit
+import VellumAssistantShared
 import os
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "DictationContext")


### PR DESCRIPTION
## Summary
- PR #15190 removed the duplicate local `DictationContext` struct from `DictationContextCapture.swift` to resolve type ambiguity with `GeneratedAPITypes`, but forgot to add `import VellumAssistantShared` so the file can see the canonical `DictationContext` type from the shared module
- Adds the missing `import VellumAssistantShared` to fix the macOS build

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22933844037/job/66560822094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
