### PR TITLE
fix: restructure host bash proxy guard so non-desktop sessions always clear stale proxies

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -642,16 +642,16 @@ export class DaemonServer {
     // Guard: don't replace an active proxy during concurrent turn races —
     // another request may have started processing between the isProcessing()
     // check above and the await on ensureActorScopedHistory().
-    if (!session.isProcessing() || !session.hostBashProxy) {
-      if (resolvedInterface === "macos" || resolvedInterface === "ios") {
+    if (resolvedInterface === "macos" || resolvedInterface === "ios") {
+      if (!session.isProcessing() || !session.hostBashProxy) {
         session.setHostBashProxy(
           new HostBashProxy(session.getCurrentSender(), (requestId) => {
             pendingInteractions.resolve(requestId);
           }),
         );
-      } else {
-        session.setHostBashProxy(undefined);
       }
+    } else {
+      session.setHostBashProxy(undefined);
     }
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({


### PR DESCRIPTION
Fixes a bug where the race-window guard in server.ts wrapped both the proxy-creation AND proxy-clearing branches, preventing non-desktop interfaces from clearing stale desktop proxies during concurrent turn races. Restructures the conditional to match conversation-routes.ts: the guard only wraps proxy creation, while the else branch always executes.

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/15189
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
