### PR TITLE
feat: move screen watch tool into bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/screen-watch/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-watch/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: screen-watch
+description: Observe the screen at regular intervals with OCR
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "\U0001F441\uFE0F"
+  vellum:
+    display-name: "Screen Watch"
+    user-invocable: true
+---
+
+Start observing the screen at regular intervals for a specified duration. Captures OCR text from the active window and provides periodic commentary.
+
+## Usage
+
+Use `start_screen_watch` when the user wants you to monitor what's happening on their screen. The tool captures OCR text from the active window at configurable intervals and provides commentary based on a specified focus area.
+
+## Parameters
+
+- **focus_area** (required) — What to focus on observing
+- **duration_minutes** — How long to watch in minutes (1-15, default 5)
+- **interval_seconds** — Seconds between screen captures (5-30, default 10)
+
+## Constraints
+
+- Only one active watch session per conversation at a time
+- Duration is clamped to 1-15 minutes
+- Capture interval is clamped to 5-30 seconds

--- a/assistant/src/config/bundled-skills/screen-watch/TOOLS.json
+++ b/assistant/src/config/bundled-skills/screen-watch/TOOLS.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "start_screen_watch",
+      "description": "Start observing the screen at regular intervals for a specified duration. Captures OCR text from the active window and provides periodic commentary.",
+      "category": "observation",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "duration_minutes": {
+            "type": "number",
+            "description": "How long to watch in minutes (1-15, default 5)"
+          },
+          "interval_seconds": {
+            "type": "number",
+            "description": "Seconds between screen captures (5-30, default 10)"
+          },
+          "focus_area": {
+            "type": "string",
+            "description": "What to focus on observing"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are watching and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["focus_area"]
+      },
+      "executor": "tools/start-screen-watch.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/screen-watch/tools/start-screen-watch.ts
+++ b/assistant/src/config/bundled-skills/screen-watch/tools/start-screen-watch.ts
@@ -1,0 +1,12 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { screenWatchTool } from "../../../../tools/watch/screen-watch.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return screenWatchTool.execute(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -140,6 +140,8 @@ import * as scheduleCreate from "./bundled-skills/schedule/tools/schedule-create
 import * as scheduleDelete from "./bundled-skills/schedule/tools/schedule-delete.js";
 import * as scheduleList from "./bundled-skills/schedule/tools/schedule-list.js";
 import * as scheduleUpdate from "./bundled-skills/schedule/tools/schedule-update.js";
+// ── screen-watch ─────────────────────────────────────────────────────────────
+import * as startScreenWatch from "./bundled-skills/screen-watch/tools/start-screen-watch.js";
 // ── slack ────────────────────────────────────────────────────────────────────
 import * as slackAddReaction from "./bundled-skills/slack/tools/slack-add-reaction.js";
 import * as slackChannelDetails from "./bundled-skills/slack/tools/slack-channel-details.js";
@@ -323,6 +325,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["playbooks:tools/playbook-list.ts", playbookList],
   ["playbooks:tools/playbook-update.ts", playbookUpdate],
   ["playbooks:tools/playbook-delete.ts", playbookDelete],
+
+  // screen-watch
+  ["screen-watch:tools/start-screen-watch.ts", startScreenWatch],
 
   // schedule
   ["schedule:tools/schedule-create.ts", scheduleCreate],

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -19,7 +19,6 @@ import { navigateSettingsTabTool } from "./system/navigate-settings.js";
 import { openSystemSettingsTool } from "./system/open-system-settings.js";
 import { voiceConfigUpdateTool } from "./system/voice-config.js";
 import type { Tool } from "./types.js";
-import { screenWatchTool } from "./watch/screen-watch.js";
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects.
@@ -82,7 +81,6 @@ export const explicitTools: Tool[] = [
   memoryDeleteTool,
   memoryRecallTool,
   credentialStoreTool,
-  screenWatchTool,
   voiceConfigUpdateTool,
   setAvatarTool,
   openSystemSettingsTool,


### PR DESCRIPTION
## Summary
- Move start_screen_watch from eager core registration into a new `screen-watch` bundled skill
- Create SKILL.md, TOOLS.json, and executor script
- Remove from tool-manifest.ts explicitTools

Part of plan: reduce-always-loaded-tools.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
