### PR TITLE
feat: move swarm_delegate tool into bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/orchestration/SKILL.md
+++ b/assistant/src/config/bundled-skills/orchestration/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: orchestration
+description: Decompose complex tasks into parallel specialist subtasks
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "\U0001F500"
+  vellum:
+    display-name: "Orchestration"
+    user-invocable: true
+---
+
+Use `swarm_delegate` when facing complex multi-part tasks that benefit from parallel execution. The tool decomposes an objective into independent specialist subtasks, runs them concurrently, and synthesises the results.
+
+## When to use
+
+- The request involves **multiple independent work streams** (e.g. research + coding + review).
+- Tasks can run in parallel without sequential dependencies.
+- The combined work would take significantly longer if done serially.
+
+## When NOT to use
+
+- Simple single-step requests — just do them directly.
+- Tasks that are inherently sequential (each step depends on the previous result).
+- Requests where the user is asking for a quick answer, not a deep workflow.
+
+## Tips
+
+- Provide a clear, specific `objective`. The planner uses it to decompose the work.
+- Pass relevant `context` about the codebase or project when available.
+- The `max_workers` parameter caps concurrency (1-6); the default comes from config.

--- a/assistant/src/config/bundled-skills/orchestration/TOOLS.json
+++ b/assistant/src/config/bundled-skills/orchestration/TOOLS.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "swarm_delegate",
+      "description": "Decompose a complex task into parallel specialist subtasks and execute them concurrently. Use this for multi-part tasks that benefit from parallel research, coding, and review.",
+      "category": "orchestration",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "objective": {
+            "type": "string",
+            "description": "The complex task to decompose and execute in parallel"
+          },
+          "context": {
+            "type": "string",
+            "description": "Optional additional context about the task or codebase"
+          },
+          "max_workers": {
+            "type": "number",
+            "description": "Maximum concurrent workers (1-6, default from config)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["objective"]
+      },
+      "executor": "tools/swarm-delegate.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/orchestration/tools/swarm-delegate.ts
+++ b/assistant/src/config/bundled-skills/orchestration/tools/swarm-delegate.ts
@@ -1,0 +1,170 @@
+import { getConfig } from "../../../../config/loader.js";
+import { getFailoverProvider } from "../../../../providers/registry.js";
+import { createClaudeCodeBackend } from "../../../../swarm/backend-claude-code.js";
+import { resolveSwarmLimits } from "../../../../swarm/limits.js";
+import { executeSwarm } from "../../../../swarm/orchestrator.js";
+import { generatePlan } from "../../../../swarm/router-planner.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import { truncate } from "../../../../util/truncate.js";
+
+const log = getLogger("swarm-delegate");
+
+/** Tracks active swarm sessions to prevent nested invocation per-session. */
+const activeSessions = new Set<string>();
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const objective = input.objective as string;
+  const extraContext = input.context as string | undefined;
+  const maxWorkersOverride = input.max_workers as number | undefined;
+
+  // Check if swarm is enabled
+  const config = getConfig();
+  if (!config.swarm.enabled) {
+    return {
+      content:
+        "Swarm orchestration is disabled in config (swarm.enabled = false). Execute the task directly instead.",
+      isError: false,
+    };
+  }
+
+  // Early abort check
+  if (context.signal?.aborted) {
+    return { content: "Cancelled", isError: true };
+  }
+
+  // Recursion guard — scoped to session so independent sessions are not blocked
+  const sessionKey = context.sessionId;
+  if (activeSessions.has(sessionKey)) {
+    return {
+      content:
+        "Error: A swarm is already executing in this session. Nested swarm invocation is not allowed.",
+      isError: true,
+    };
+  }
+
+  activeSessions.add(sessionKey);
+  try {
+    const limits = resolveSwarmLimits({
+      maxWorkers: maxWorkersOverride ?? config.swarm.maxWorkers,
+      maxTasks: config.swarm.maxTasks,
+      maxRetriesPerTask: config.swarm.maxRetriesPerTask,
+      workerTimeoutSec: config.swarm.workerTimeoutSec,
+      roleTimeoutsSec: config.swarm.roleTimeoutsSec,
+    });
+
+    // Generate plan
+    context.onOutput?.("Planning task decomposition...\n");
+    const planProvider = getFailoverProvider(
+      config.provider,
+      config.providerOrder,
+    );
+    const plan = await generatePlan({
+      objective: extraContext
+        ? `${objective}\n\nContext: ${extraContext}`
+        : objective,
+      provider: planProvider,
+      modelIntent: config.swarm.plannerModelIntent,
+      limits,
+    });
+
+    context.onOutput?.(`Plan: ${plan.tasks.length} tasks\n`);
+    for (const task of plan.tasks) {
+      context.onOutput?.(
+        `  - [${task.role}] ${task.id}: ${truncate(task.objective, 80)}\n`,
+      );
+    }
+    context.onOutput?.("\nExecuting...\n");
+
+    if (context.signal?.aborted) {
+      return { content: "Cancelled before execution", isError: true };
+    }
+
+    // Execute
+    const backend = createClaudeCodeBackend();
+    let synthesisProvider: typeof planProvider | undefined;
+    try {
+      synthesisProvider = getFailoverProvider(
+        config.provider,
+        config.providerOrder,
+      );
+    } catch {
+      // No provider available for synthesis — will use fallback
+    }
+
+    const summary = await executeSwarm({
+      plan,
+      limits,
+      backend,
+      workingDir: context.workingDir,
+      modelIntent: config.swarm.synthesizerModelIntent,
+      synthesisProvider,
+      synthesisModelIntent: config.swarm.synthesizerModelIntent,
+      signal: context.signal,
+      onStatus: (event) => {
+        switch (event.kind) {
+          case "task_started":
+            context.onOutput?.(`[START] ${event.taskId}\n`);
+            break;
+          case "task_completed":
+            context.onOutput?.(`[DONE]  ${event.taskId}\n`);
+            break;
+          case "task_failed":
+            context.onOutput?.(`[FAIL]  ${event.taskId}\n`);
+            break;
+          case "task_blocked":
+            context.onOutput?.(`[BLOCK] ${event.taskId}\n`);
+            break;
+          case "done":
+            context.onOutput?.(`\nSwarm completed.\n`);
+            break;
+        }
+      },
+    });
+
+    // Format result
+    const lines: string[] = [];
+    lines.push(summary.finalAnswer);
+    lines.push("");
+    lines.push(`---`);
+    lines.push(
+      `Tasks: ${summary.stats.completed} completed, ${summary.stats.failed} failed, ${summary.stats.blocked} blocked`,
+    );
+    lines.push(`Duration: ${summary.stats.totalDurationMs}ms`);
+
+    if (summary.stats.failed > 0 || summary.stats.blocked > 0) {
+      lines.push("");
+      lines.push("### Issues");
+      for (const r of summary.results) {
+        if (r.status === "failed") {
+          lines.push(`- **${r.taskId}** (failed): ${r.summary}`);
+        }
+      }
+    }
+
+    return {
+      content: lines.join("\n"),
+      isError: summary.stats.completed === 0,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Swarm execution failed");
+    return {
+      content: `Swarm error: ${message}`,
+      isError: true,
+    };
+  } finally {
+    activeSessions.delete(sessionKey);
+  }
+}
+
+/** Clear all active sessions — only for testing. */
+export function _resetSwarmActive(): void {
+  activeSessions.clear();
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -126,6 +126,8 @@ import * as sequenceResume from "./bundled-skills/messaging/tools/sequence-resum
 import * as sequenceUpdate from "./bundled-skills/messaging/tools/sequence-update.js";
 // ── notifications ───────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── orchestration ───────────────────────────────────────────────────────────
+import * as swarmDelegate from "./bundled-skills/orchestration/tools/swarm-delegate.js";
 // ── phone-calls ─────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -312,6 +314,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
+
+  // orchestration
+  ["orchestration:tools/swarm-delegate.ts", swarmDelegate],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -8,7 +8,6 @@ import { executeSwarm } from "../../swarm/orchestrator.js";
 import { generatePlan } from "../../swarm/router-planner.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
-import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("swarm-delegate");
@@ -204,8 +203,6 @@ export const swarmDelegateTool: Tool = {
     }
   },
 };
-
-registerTool(swarmDelegateTool);
 
 /** Clear all active sessions — only for testing. */
 export function _resetSwarmActive(): void {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -41,7 +41,6 @@ import "./network/web-search.js";
 import "./skills/delete-managed.js";
 import "./skills/load.js";
 import "./skills/scaffold-managed.js";
-import "./swarm/delegate.js";
 import "./system/request-permission.js";
 import "./terminal/shell.js";
 
@@ -68,7 +67,6 @@ export const eagerModuleToolNames: string[] = [
   "request_system_permission",
   "asset_search",
   "asset_materialize",
-  "swarm_delegate",
   "view_image",
 ];
 
@@ -91,8 +89,9 @@ export const explicitTools: Tool[] = [
 
 // ── Lazy tool descriptors ───────────────────────────────────────────
 // Tools that defer module loading until first invocation.
-// bash and swarm_delegate were previously lazy but are now eagerly registered
-// via side-effect imports above, preserving their full definitions (including
-// the `reason` field on bash) and fixing bun --compile module-not-found crashes.
+// bash was previously lazy but is now eagerly registered via side-effect
+// imports above, preserving its full definition (including the `reason` field)
+// and fixing bun --compile module-not-found crashes.
+// swarm_delegate has been moved to the orchestration bundled skill.
 
 export const lazyTools: LazyToolDescriptor[] = [];


### PR DESCRIPTION
## Summary
- Move swarm_delegate from eager core registration into a new `orchestration` bundled skill
- Create SKILL.md, TOOLS.json, and executor script with nested-invocation guard
- Remove registerTool() side effect from delegate.ts, keep exports
- Remove from tool-manifest.ts eager imports

Part of plan: reduce-always-loaded-tools.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
