### PR TITLE
feat: move settings tools into bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/settings/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: settings
+description: Manage assistant voice, avatar, and system settings
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "\u2699\uFE0F"
+  vellum:
+    display-name: "Settings"
+    user-invocable: true
+---
+
+Tools for managing assistant settings: voice configuration (TTS voice, PTT activation key, wake word), avatar generation, system settings navigation, and in-app settings tab navigation.

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -1,0 +1,104 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "voice_config_update",
+      "description": "Update a voice configuration setting (TTS voice ID, PTT activation key, wake word enabled/keyword/timeout). Changes take effect immediately.",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "setting": {
+            "type": "string",
+            "enum": [
+              "activation_key",
+              "wake_word_enabled",
+              "wake_word_keyword",
+              "wake_word_timeout",
+              "tts_voice_id"
+            ],
+            "description": "The voice setting to change"
+          },
+          "value": {
+            "description": "The new value for the setting (type depends on setting)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are changing and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        }
+      },
+      "executor": "tools/voice-config-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "set_avatar",
+      "description": "Generate a custom avatar image from a text description. Saves the result as the assistant's avatar.",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A text description of the desired avatar appearance, e.g. \"a friendly purple cat with green eyes wearing a tiny hat\"."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["description"]
+      },
+      "executor": "tools/set-avatar.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "open_system_settings",
+      "description": "Open a specific macOS System Settings pane (e.g. Microphone or Speech Recognition privacy). Use this to guide the user through granting permissions that can only be toggled in System Settings.",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "pane": {
+            "type": "string",
+            "enum": ["microphone", "speech_recognition"],
+            "description": "The System Settings pane to open"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["pane"]
+      },
+      "executor": "tools/open-system-settings.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "navigate_settings_tab",
+      "description": "Open the Vellum settings panel to a specific tab (e.g. Voice, Connect, Trust). Use this when the user needs to review or adjust settings visually.",
+      "category": "system",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "tab": {
+            "type": "string",
+            "enum": ["Voice", "Connect", "Trust", "Model", "Scheduling"],
+            "description": "The settings tab to navigate to"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["tab"]
+      },
+      "executor": "tools/navigate-settings-tab.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -1,0 +1,41 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+const SETTINGS_TABS = [
+  "Voice",
+  "Connect",
+  "Trust",
+  "Model",
+  "Scheduling",
+] as const;
+
+type SettingsTab = (typeof SETTINGS_TABS)[number];
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const tab = input.tab as string;
+  if (!SETTINGS_TABS.includes(tab as SettingsTab)) {
+    return {
+      content: `Error: unknown tab "${tab}". Valid tabs: ${SETTINGS_TABS.join(
+        ", ",
+      )}`,
+      isError: true,
+    };
+  }
+
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "navigate_settings",
+      tab,
+    });
+  }
+
+  return {
+    content: `Opened settings to the ${tab} tab.`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-skills/settings/tools/open-system-settings.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/open-system-settings.ts
@@ -1,0 +1,52 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+const PANES = {
+  microphone: {
+    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+    label: "Microphone privacy",
+    instruction: "Please toggle Vellum Assistant on.",
+  },
+  speech_recognition: {
+    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition",
+    label: "Speech Recognition privacy",
+    instruction: "Please toggle Vellum Assistant on.",
+  },
+} as const;
+
+type PaneName = keyof typeof PANES;
+
+const VALID_PANES = Object.keys(PANES) as PaneName[];
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const pane = input.pane as string;
+  if (!VALID_PANES.includes(pane as PaneName)) {
+    return {
+      content: `Error: unknown pane "${pane}". Valid panes: ${VALID_PANES.join(
+        ", ",
+      )}`,
+      isError: true,
+    };
+  }
+
+  const meta = PANES[pane as PaneName];
+
+  // Send open_url to the client — the x-apple.systempreferences: scheme
+  // opens System Settings directly without a browser confirmation dialog.
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "open_url",
+      url: meta.url,
+    });
+  }
+
+  return {
+    content: `Opened System Settings to ${meta.label}. ${meta.instruction}`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-skills/settings/tools/set-avatar.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/set-avatar.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { routedGenerateAvatar } from "../../../../media/avatar-router.js";
+import { ManagedAvatarError } from "../../../../media/avatar-types.js";
+import { mapGeminiError } from "../../../../media/gemini-image-service.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import { getWorkspaceDir } from "../../../../util/platform.js";
+
+const log = getLogger("avatar-generator");
+
+/** Canonical path where the custom avatar PNG is stored. */
+function getAvatarPath(): string {
+  return join(getWorkspaceDir(), "data", "avatar", "custom-avatar.png");
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const description = input.description;
+  if (typeof description !== "string" || description.trim() === "") {
+    return {
+      content: "Error: description is required and must be a non-empty string.",
+      isError: true,
+    };
+  }
+
+  try {
+    log.info({ description: description.trim() }, "Generating avatar");
+
+    const prompt =
+      `Create an avatar image based on this description: ${description.trim()}\n\n` +
+      "Style: cute, friendly, work-safe illustration. " +
+      "Vibrant but soft colors. Simple and recognizable at small sizes (28px). " +
+      "Circular or rounded composition filling the canvas. " +
+      "Subtle background color (not white or transparent).";
+
+    const result = await routedGenerateAvatar(prompt);
+    if (!result.imageBase64) {
+      return {
+        content: "Error: No image data returned. Please try again.",
+        isError: true,
+      };
+    }
+    const pngBuffer = Buffer.from(result.imageBase64, "base64");
+
+    const avatarPath = getAvatarPath();
+    const avatarDir = dirname(avatarPath);
+
+    const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
+    mkdirSync(avatarDir, { recursive: true });
+    writeFileSync(tmpPath, pngBuffer);
+    renameSync(tmpPath, avatarPath);
+
+    log.info(
+      {
+        avatarPath,
+        pathUsed: result.pathUsed,
+        correlationId: result.correlationId,
+      },
+      "Avatar saved successfully",
+    );
+
+    // Side-effect hook in tool-side-effects.ts broadcasts avatar_updated to all clients.
+
+    return {
+      content: "Avatar updated! Your new avatar will appear shortly.",
+      isError: false,
+    };
+  } catch (error) {
+    if (error instanceof ManagedAvatarError) {
+      if (error.statusCode === 429) {
+        log.warn(
+          { correlationId: error.correlationId },
+          "Avatar generation rate limited",
+        );
+        return {
+          content:
+            "Avatar generation is rate limited. Please wait and try again.",
+          isError: true,
+        };
+      }
+      if (error.statusCode === 503) {
+        log.warn(
+          { correlationId: error.correlationId },
+          "Avatar generation service unavailable",
+        );
+        return {
+          content: "Avatar generation service is temporarily unavailable.",
+          isError: true,
+        };
+      }
+      const detail =
+        error.message || "Avatar generation failed. Please try again.";
+      log.error(
+        { error: detail, correlationId: error.correlationId },
+        "Managed avatar generation failed",
+      );
+      return {
+        content: `Avatar generation failed: ${detail}`,
+        isError: true,
+      };
+    }
+
+    const message = mapGeminiError(error);
+    log.error({ error: message }, "Avatar generation failed");
+    return {
+      content: `Avatar generation failed: ${message}`,
+      isError: true,
+    };
+  }
+}

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -1,0 +1,187 @@
+import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../../../config/loader.js";
+import { normalizeActivationKey } from "../../../../daemon/handlers/config-voice.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+/**
+ * Valid voice config settings and their UserDefaults key mappings.
+ */
+const VOICE_SETTINGS = {
+  activation_key: {
+    userDefaultsKey: "pttActivationKey",
+    type: "string" as const,
+  },
+  wake_word_enabled: {
+    userDefaultsKey: "wakeWordEnabled",
+    type: "boolean" as const,
+  },
+  wake_word_keyword: {
+    userDefaultsKey: "wakeWordKeyword",
+    type: "string" as const,
+  },
+  wake_word_timeout: {
+    userDefaultsKey: "wakeWordTimeoutSeconds",
+    type: "number" as const,
+  },
+  tts_voice_id: { userDefaultsKey: "ttsVoiceId", type: "string" as const },
+} as const;
+
+type VoiceSettingName = keyof typeof VOICE_SETTINGS;
+
+const VALID_SETTINGS = Object.keys(VOICE_SETTINGS) as VoiceSettingName[];
+
+const VALID_TIMEOUTS = [5, 10, 15, 30, 60];
+
+const FRIENDLY_NAMES: Record<VoiceSettingName, string> = {
+  activation_key: "PTT activation key",
+  wake_word_enabled: "Wake word",
+  wake_word_keyword: "Wake word keyword",
+  wake_word_timeout: "Wake word timeout",
+  tts_voice_id: "ElevenLabs voice",
+};
+
+function validateSetting(
+  setting: string,
+  value: unknown,
+):
+  | { ok: true; coerced: string | boolean | number }
+  | { ok: false; error: string } {
+  if (!VALID_SETTINGS.includes(setting as VoiceSettingName)) {
+    return {
+      ok: false,
+      error: `Unknown setting "${setting}". Valid settings: ${VALID_SETTINGS.join(
+        ", ",
+      )}`,
+    };
+  }
+
+  switch (setting) {
+    case "activation_key": {
+      if (typeof value !== "string" || value.length === 0) {
+        return {
+          ok: false,
+          error: "activation_key must be a non-empty string",
+        };
+      }
+      const result = normalizeActivationKey(value);
+      if (!result.ok) {
+        return { ok: false, error: result.reason };
+      }
+      return { ok: true, coerced: result.value };
+    }
+    case "wake_word_enabled": {
+      if (typeof value === "boolean") return { ok: true, coerced: value };
+      if (value === "true") return { ok: true, coerced: true };
+      if (value === "false") return { ok: true, coerced: false };
+      return {
+        ok: false,
+        error: 'wake_word_enabled must be a boolean (or "true"/"false" string)',
+      };
+    }
+    case "wake_word_keyword": {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return {
+          ok: false,
+          error: "wake_word_keyword must be a non-empty string",
+        };
+      }
+      return { ok: true, coerced: value.trim() };
+    }
+    case "wake_word_timeout": {
+      const num = typeof value === "number" ? value : Number(value);
+      if (Number.isNaN(num) || !VALID_TIMEOUTS.includes(num)) {
+        return {
+          ok: false,
+          error: `wake_word_timeout must be one of: ${VALID_TIMEOUTS.join(
+            ", ",
+          )}`,
+        };
+      }
+      return { ok: true, coerced: num };
+    }
+    case "tts_voice_id": {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return {
+          ok: false,
+          error:
+            "tts_voice_id must be a non-empty string (ElevenLabs voice ID)",
+        };
+      }
+      const trimmed = value.trim();
+      if (!/^[a-zA-Z0-9]+$/.test(trimmed)) {
+        return {
+          ok: false,
+          error:
+            "tts_voice_id must contain only alphanumeric characters (ElevenLabs voice ID format)",
+        };
+      }
+      return { ok: true, coerced: trimmed };
+    }
+    default:
+      return { ok: false, error: `Unknown setting "${setting}"` };
+  }
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const setting = input.setting as string | undefined;
+  const value = input.value;
+
+  if (!setting) {
+    return {
+      content: `Error: "setting" is required. Valid settings: ${VALID_SETTINGS.join(
+        ", ",
+      )}`,
+      isError: true,
+    };
+  }
+
+  if (value === undefined) {
+    return {
+      content: `Error: "value" is required for setting "${setting}".`,
+      isError: true,
+    };
+  }
+
+  const validation = validateSetting(setting, value);
+  if (!validation.ok) {
+    return { content: `Error: ${validation.error}`, isError: true };
+  }
+
+  const meta = VOICE_SETTINGS[setting as VoiceSettingName];
+  const friendlyName = FRIENDLY_NAMES[setting as VoiceSettingName];
+
+  // Send client_settings_update message to write to UserDefaults
+  if (context.sendToClient) {
+    context.sendToClient({
+      type: "client_settings_update",
+      key: meta.userDefaultsKey,
+      value: validation.coerced,
+    });
+  }
+
+  // For tts_voice_id, also persist to the config file (elevenlabs.voiceId)
+  // so phone calls and other consumers pick it up.
+  if (setting === "tts_voice_id") {
+    const raw = loadRawConfig();
+    setNestedValue(raw, "elevenlabs.voiceId", validation.coerced);
+    saveRawConfig(raw);
+    invalidateConfigCache();
+  }
+
+  return {
+    content: `${friendlyName} updated to ${JSON.stringify(
+      validation.coerced,
+    )}. The change has been broadcast to the desktop client.`,
+    isError: false,
+  };
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -140,6 +140,11 @@ import * as scheduleCreate from "./bundled-skills/schedule/tools/schedule-create
 import * as scheduleDelete from "./bundled-skills/schedule/tools/schedule-delete.js";
 import * as scheduleList from "./bundled-skills/schedule/tools/schedule-list.js";
 import * as scheduleUpdate from "./bundled-skills/schedule/tools/schedule-update.js";
+// ── settings ─────────────────────────────────────────────────────────────────
+import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
+import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
+import * as setAvatar from "./bundled-skills/settings/tools/set-avatar.js";
+import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
 // ── slack ────────────────────────────────────────────────────────────────────
 import * as slackAddReaction from "./bundled-skills/slack/tools/slack-add-reaction.js";
 import * as slackChannelDetails from "./bundled-skills/slack/tools/slack-channel-details.js";
@@ -329,6 +334,12 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["schedule:tools/schedule-list.ts", scheduleList],
   ["schedule:tools/schedule-update.ts", scheduleUpdate],
   ["schedule:tools/schedule-delete.ts", scheduleDelete],
+
+  // settings
+  ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
+  ["settings:tools/set-avatar.ts", setAvatar],
+  ["settings:tools/open-system-settings.ts", openSystemSettings],
+  ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],
 
   // slack
   ["slack:tools/slack-scan-digest.ts", slackScanDigest],

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -14,10 +14,6 @@ import {
   memoryUpdateTool,
 } from "./memory/register.js";
 import type { LazyToolDescriptor } from "./registry.js";
-import { setAvatarTool } from "./system/avatar-generator.js";
-import { navigateSettingsTabTool } from "./system/navigate-settings.js";
-import { openSystemSettingsTool } from "./system/open-system-settings.js";
-import { voiceConfigUpdateTool } from "./system/voice-config.js";
 import type { Tool } from "./types.js";
 import { screenWatchTool } from "./watch/screen-watch.js";
 
@@ -83,10 +79,6 @@ export const explicitTools: Tool[] = [
   memoryRecallTool,
   credentialStoreTool,
   screenWatchTool,
-  voiceConfigUpdateTool,
-  setAvatarTool,
-  openSystemSettingsTool,
-  navigateSettingsTabTool,
 ];
 
 // ── Lazy tool descriptors ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Move 4 settings tools (voice_config_update, set_avatar, open_system_settings, navigate_settings_tab) from eager core registration into a new `settings` bundled skill
- Create SKILL.md, TOOLS.json, and executor scripts for each tool
- Remove from tool-manifest.ts explicitTools and add to bundled-tool-registry.ts

Part of plan: reduce-always-loaded-tools.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
