### PR TITLE
Add host_file proxy request message types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -21,6 +21,7 @@ export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/host-bash.js";
+export * from "./message-types/host-file.js";
 export * from "./message-types/inbox.js";
 export * from "./message-types/integrations.js";
 export * from "./message-types/memory.js";
@@ -68,6 +69,7 @@ import type {
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
+import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type {
   _InboxClientMessages,
   _InboxServerMessages,
@@ -178,6 +180,7 @@ export type ServerMessage =
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
   | _HostBashServerMessages
+  | _HostFileServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages
   | _SchedulesServerMessages

--- a/assistant/src/daemon/message-types/host-file.ts
+++ b/assistant/src/daemon/message-types/host-file.ts
@@ -1,0 +1,44 @@
+// Host file proxy types.
+// Enables proxying file operations to the desktop client (host machine)
+// when running as a managed assistant.
+
+// === Server → Client ===
+
+export interface HostFileReadRequest {
+  type: "host_file_request";
+  requestId: string;
+  sessionId: string;
+  operation: "read";
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface HostFileWriteRequest {
+  type: "host_file_request";
+  requestId: string;
+  sessionId: string;
+  operation: "write";
+  path: string;
+  content: string;
+}
+
+export interface HostFileEditRequest {
+  type: "host_file_request";
+  requestId: string;
+  sessionId: string;
+  operation: "edit";
+  path: string;
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+export type HostFileRequest =
+  | HostFileReadRequest
+  | HostFileWriteRequest
+  | HostFileEditRequest;
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostFileServerMessages = HostFileRequest;


### PR DESCRIPTION
## Summary
- Add HostFileRequest discriminated union type (read/write/edit operations) to message protocol
- Enable proxying file operations to the desktop client in managed mode

Part of plan: host-file-proxy.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
