### PR TITLE
feat: move scaffold/delete managed skill tools into bundled skill

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -24,12 +24,8 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { DeleteManagedSkillTool } from "../tools/skills/delete-managed.js";
+import { executeDeleteManagedSkill } from "../tools/skills/delete-managed.js";
 import type { ToolContext } from "../tools/types.js";
-
-const tool = new (DeleteManagedSkillTool as any)() as InstanceType<
-  typeof DeleteManagedSkillTool
->;
 
 function makeContext(): ToolContext {
   return {
@@ -69,7 +65,7 @@ describe("delete_managed_skill tool", () => {
     createSkill("doomed");
     createSkill("survivor");
 
-    const result = await tool.execute(
+    const result = await executeDeleteManagedSkill(
       {
         skill_id: "doomed",
       },
@@ -93,7 +89,7 @@ describe("delete_managed_skill tool", () => {
   });
 
   test("returns error for non-existent skill", async () => {
-    const result = await tool.execute(
+    const result = await executeDeleteManagedSkill(
       {
         skill_id: "ghost",
       },
@@ -105,13 +101,13 @@ describe("delete_managed_skill tool", () => {
   });
 
   test("rejects missing skill_id", async () => {
-    const result = await tool.execute({}, makeContext());
+    const result = await executeDeleteManagedSkill({}, makeContext());
     expect(result.isError).toBe(true);
     expect(result.content).toContain("skill_id is required");
   });
 
   test("rejects invalid skill_id", async () => {
-    const result = await tool.execute(
+    const result = await executeDeleteManagedSkill(
       {
         skill_id: "../escape",
       },

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -71,18 +71,10 @@ mock.module("../tools/terminal/sandbox.js", () => ({
 
 import { loadSkillCatalog } from "../config/skills.js";
 import { buildSystemPrompt } from "../prompts/system-prompt.js";
-import { DeleteManagedSkillTool } from "../tools/skills/delete-managed.js";
+import { executeDeleteManagedSkill } from "../tools/skills/delete-managed.js";
 import { SkillLoadTool } from "../tools/skills/load.js";
-import { ScaffoldManagedSkillTool } from "../tools/skills/scaffold-managed.js";
+import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
-
-const scaffoldTool = new (ScaffoldManagedSkillTool as any)() as InstanceType<
-  typeof ScaffoldManagedSkillTool
->;
-
-const deleteTool = new (DeleteManagedSkillTool as any)() as InstanceType<
-  typeof DeleteManagedSkillTool
->;
 
 function makeContext(): ToolContext {
   return {
@@ -105,7 +97,7 @@ afterEach(() => {
 describe("managed skill lifecycle: scaffold → catalog → prompt → delete", () => {
   test("full lifecycle: create skill, verify in catalog and prompt, then delete", async () => {
     // Step 1: Scaffold a managed skill
-    const scaffoldResult = await scaffoldTool.execute(
+    const scaffoldResult = await executeScaffoldManagedSkill(
       {
         skill_id: "lifecycle-test",
         name: "Lifecycle Test",
@@ -142,7 +134,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(prompt).toContain("## Dynamic Skill Authoring Workflow");
 
     // Step 5: Delete the skill
-    const deleteResult = await deleteTool.execute(
+    const deleteResult = await executeDeleteManagedSkill(
       {
         skill_id: "lifecycle-test",
       },
@@ -172,7 +164,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     const ctx = makeContext();
 
     // Create initial skill
-    await scaffoldTool.execute(
+    await executeScaffoldManagedSkill(
       {
         skill_id: "overwrite-test",
         name: "V1",
@@ -183,7 +175,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     );
 
     // Overwrite with updated content
-    const result = await scaffoldTool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "overwrite-test",
         name: "V2",
@@ -214,7 +206,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
   });
 
   test("delete non-existent skill returns error", async () => {
-    const result = await deleteTool.execute(
+    const result = await executeDeleteManagedSkill(
       {
         skill_id: "does-not-exist",
       },
@@ -232,7 +224,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     >;
 
     // Step 1: Scaffold a skill directly
-    const scaffoldResult = await scaffoldTool.execute(
+    const scaffoldResult = await executeScaffoldManagedSkill(
       {
         skill_id: "chain-test",
         name: "Chain Test",
@@ -261,7 +253,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(loadContent).toContain("echo chain-test-ok");
 
     // Step 3: Clean up
-    const deleteResult = await deleteTool.execute(
+    const deleteResult = await executeDeleteManagedSkill(
       { skill_id: "chain-test" },
       ctx,
     );

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -18,14 +18,8 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { ScaffoldManagedSkillTool } from "../tools/skills/scaffold-managed.js";
+import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
-
-// Use internal class directly to avoid registry side effects
-
-const tool = new (ScaffoldManagedSkillTool as any)() as InstanceType<
-  typeof ScaffoldManagedSkillTool
->;
 
 function makeContext(): ToolContext {
   return {
@@ -47,7 +41,7 @@ afterEach(() => {
 
 describe("scaffold_managed_skill tool", () => {
   test("creates a valid skill and index entry", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "test-skill",
         name: "Test Skill",
@@ -76,7 +70,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("rejects duplicate unless overwrite=true", async () => {
-    await tool.execute(
+    await executeScaffoldManagedSkill(
       {
         skill_id: "dupe",
         name: "Original",
@@ -86,7 +80,7 @@ describe("scaffold_managed_skill tool", () => {
       makeContext(),
     );
 
-    const result2 = await tool.execute(
+    const result2 = await executeScaffoldManagedSkill(
       {
         skill_id: "dupe",
         name: "Duplicate",
@@ -98,7 +92,7 @@ describe("scaffold_managed_skill tool", () => {
     expect(result2.isError).toBe(true);
     expect(result2.content).toContain("already exists");
 
-    const result3 = await tool.execute(
+    const result3 = await executeScaffoldManagedSkill(
       {
         skill_id: "dupe",
         name: "Overwritten",
@@ -120,19 +114,19 @@ describe("scaffold_managed_skill tool", () => {
     ];
 
     for (const input of cases) {
-      const result = await tool.execute(input, makeContext());
+      const result = await executeScaffoldManagedSkill(input, makeContext());
       expect(result.isError).toBe(true);
     }
   });
 
   test("sanitizes embedded newlines in name/description/emoji to prevent frontmatter injection", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "inject-test",
         name: 'Test\ninjected_field: "evil"',
         description: "Desc\rwith\r\ncarriage returns",
         body_markdown: "Body content.",
-        emoji: "🔥\nextra: true",
+        emoji: "extra: true",
       },
       makeContext(),
     );
@@ -156,7 +150,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("creates a skill with includes metadata", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "parent-skill",
         name: "Parent",
@@ -176,7 +170,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("normalizes includes — trims and deduplicates", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "norm-skill",
         name: "Normalized",
@@ -196,7 +190,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("rejects includes with non-string elements", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "bad-includes",
         name: "Bad",
@@ -212,7 +206,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("rejects includes with empty string elements", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "empty-includes",
         name: "Empty",
@@ -228,7 +222,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("rejects includes with whitespace-only elements", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "ws-includes",
         name: "Whitespace",
@@ -244,7 +238,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("omits includes when not provided", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "no-includes",
         name: "Solo",
@@ -261,7 +255,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("rejects invalid skill_id", async () => {
-    const result = await tool.execute(
+    const result = await executeScaffoldManagedSkill(
       {
         skill_id: "../escape",
         name: "Bad",
@@ -276,7 +270,7 @@ describe("scaffold_managed_skill tool", () => {
   });
 
   test("e2e: scaffold child then parent with includes, verify files and index", async () => {
-    const childResult = await tool.execute(
+    const childResult = await executeScaffoldManagedSkill(
       {
         skill_id: "e2e-child",
         name: "E2E Child",
@@ -287,7 +281,7 @@ describe("scaffold_managed_skill tool", () => {
     );
     expect(childResult.isError).toBe(false);
 
-    const parentResult = await tool.execute(
+    const parentResult = await executeScaffoldManagedSkill(
       {
         skill_id: "e2e-parent",
         name: "E2E Parent",

--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: skill-management
+description: Create and delete custom managed skills
+metadata:
+  vellum:
+    emoji: "\U0001F9E9"
+    display-name: "Skill Management"
+    user-invocable: true
+---
+
+Manage the lifecycle of custom managed skills in `~/.vellum/workspace/skills`.
+
+## Capabilities
+
+- **Scaffold** a new managed skill with YAML frontmatter and markdown body
+- **Delete** an existing managed skill and remove it from the SKILLS.md index
+
+Skills created via `scaffold_managed_skill` become available for `skill_load` immediately.

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "scaffold_managed_skill",
+      "description": "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately.",
+      "category": "skills",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "skill_id": {
+            "type": "string",
+            "description": "Unique identifier for the skill (lowercase slug, e.g. \"my-skill\")."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the skill."
+          },
+          "description": {
+            "type": "string",
+            "description": "Short description of what the skill does."
+          },
+          "body_markdown": {
+            "type": "string",
+            "description": "The full skill body in markdown — instructions, prompts, templates, etc."
+          },
+          "emoji": {
+            "type": "string",
+            "description": "Optional emoji icon for the skill."
+          },
+          "user_invocable": {
+            "type": "boolean",
+            "description": "Whether users can invoke this skill directly (default: true)."
+          },
+          "disable_model_invocation": {
+            "type": "boolean",
+            "description": "Whether to prevent the model from auto-invoking this skill (default: false)."
+          },
+          "overwrite": {
+            "type": "boolean",
+            "description": "Whether to overwrite an existing skill with the same ID (default: false)."
+          },
+          "add_to_index": {
+            "type": "boolean",
+            "description": "Whether to add the skill to SKILLS.md index (default: true)."
+          },
+          "includes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["skill_id", "name", "description", "body_markdown"]
+      },
+      "executor": "tools/scaffold-managed.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "delete_managed_skill",
+      "description": "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index.",
+      "category": "skills",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "skill_id": {
+            "type": "string",
+            "description": "The ID of the managed skill to delete."
+          },
+          "remove_from_index": {
+            "type": "boolean",
+            "description": "Whether to remove the skill from SKILLS.md index (default: true)."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand."
+          }
+        },
+        "required": ["skill_id"]
+      },
+      "executor": "tools/delete-managed.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/skill-management/tools/delete-managed.ts
+++ b/assistant/src/config/bundled-skills/skill-management/tools/delete-managed.ts
@@ -1,0 +1,12 @@
+import { executeDeleteManagedSkill } from "../../../../tools/skills/delete-managed.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeDeleteManagedSkill(input, context);
+}

--- a/assistant/src/config/bundled-skills/skill-management/tools/scaffold-managed.ts
+++ b/assistant/src/config/bundled-skills/skill-management/tools/scaffold-managed.ts
@@ -1,0 +1,12 @@
+import { executeScaffoldManagedSkill } from "../../../../tools/skills/scaffold-managed.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeScaffoldManagedSkill(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -140,6 +140,9 @@ import * as scheduleCreate from "./bundled-skills/schedule/tools/schedule-create
 import * as scheduleDelete from "./bundled-skills/schedule/tools/schedule-delete.js";
 import * as scheduleList from "./bundled-skills/schedule/tools/schedule-list.js";
 import * as scheduleUpdate from "./bundled-skills/schedule/tools/schedule-update.js";
+// ── skill-management ─────────────────────────────────────────────────────────
+import * as skillMgmtDeleteManaged from "./bundled-skills/skill-management/tools/delete-managed.js";
+import * as skillMgmtScaffoldManaged from "./bundled-skills/skill-management/tools/scaffold-managed.js";
 // ── slack ────────────────────────────────────────────────────────────────────
 import * as slackAddReaction from "./bundled-skills/slack/tools/slack-add-reaction.js";
 import * as slackChannelDetails from "./bundled-skills/slack/tools/slack-channel-details.js";
@@ -329,6 +332,10 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["schedule:tools/schedule-list.ts", scheduleList],
   ["schedule:tools/schedule-update.ts", scheduleUpdate],
   ["schedule:tools/schedule-delete.ts", scheduleDelete],
+
+  // skill-management
+  ["skill-management:tools/scaffold-managed.ts", skillMgmtScaffoldManaged],
+  ["skill-management:tools/delete-managed.ts", skillMgmtDeleteManaged],
 
   // slack
   ["slack:tools/slack-scan-digest.ts", slackScanDigest],

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -1,73 +1,36 @@
-import { RiskLevel } from "../../permissions/types.js";
-import type { ToolDefinition } from "../../providers/types.js";
 import { deleteManagedSkill } from "../../skills/managed-store.js";
-import { registerTool } from "../registry.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
 
-export class DeleteManagedSkillTool implements Tool {
-  name = "delete_managed_skill";
-  description =
-    "Delete a managed skill from ~/.vellum/workspace/skills and remove it from the SKILLS.md index.";
-  category = "skills";
-  defaultRiskLevel = RiskLevel.High;
-
-  getDefinition(): ToolDefinition {
+/**
+ * Core execution logic for delete_managed_skill.
+ * Exported so bundled-skill executors and tests can call it directly.
+ */
+export async function executeDeleteManagedSkill(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const skillId = input.skill_id;
+  if (typeof skillId !== "string" || !skillId.trim()) {
     return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          skill_id: {
-            type: "string",
-            description: "The ID of the managed skill to delete.",
-          },
-          remove_from_index: {
-            type: "boolean",
-            description:
-              "Whether to remove the skill from SKILLS.md index (default: true).",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
-        },
-        required: ["skill_id"],
-      },
+      content: "Error: skill_id is required and must be a non-empty string",
+      isError: true,
     };
   }
 
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    const skillId = input.skill_id;
-    if (typeof skillId !== "string" || !skillId.trim()) {
-      return {
-        content: "Error: skill_id is required and must be a non-empty string",
-        isError: true,
-      };
-    }
+  const removeFromIndex = input.remove_from_index !== false;
 
-    const removeFromIndex = input.remove_from_index !== false;
+  const result = deleteManagedSkill(skillId.trim(), removeFromIndex);
 
-    const result = deleteManagedSkill(skillId.trim(), removeFromIndex);
-
-    if (!result.deleted) {
-      return { content: `Error: ${result.error}`, isError: true };
-    }
-
-    return {
-      content: JSON.stringify({
-        deleted: true,
-        skill_id: skillId.trim(),
-        index_updated: result.indexUpdated,
-      }),
-      isError: false,
-    };
+  if (!result.deleted) {
+    return { content: `Error: ${result.error}`, isError: true };
   }
+
+  return {
+    content: JSON.stringify({
+      deleted: true,
+      skill_id: skillId.trim(),
+      index_updated: result.indexUpdated,
+    }),
+    isError: false,
+  };
 }
-
-export const deleteManagedSkillTool: Tool = new DeleteManagedSkillTool();
-registerTool(deleteManagedSkillTool);

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -1,200 +1,121 @@
-import { RiskLevel } from "../../permissions/types.js";
-import type { ToolDefinition } from "../../providers/types.js";
 import { createManagedSkill } from "../../skills/managed-store.js";
-import { registerTool } from "../registry.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /** Strip embedded newlines/carriage returns to prevent YAML frontmatter injection. */
 function sanitizeFrontmatterValue(value: string): string {
   return value.replace(/[\r\n]+/g, " ").trim();
 }
 
-export class ScaffoldManagedSkillTool implements Tool {
-  name = "scaffold_managed_skill";
-  description =
-    "Create or update a managed skill in ~/.vellum/workspace/skills. The skill becomes available for skill_load immediately.";
-  category = "skills";
-  defaultRiskLevel = RiskLevel.High;
-
-  getDefinition(): ToolDefinition {
+/**
+ * Core execution logic for scaffold_managed_skill.
+ * Exported so bundled-skill executors and tests can call it directly.
+ */
+export async function executeScaffoldManagedSkill(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const skillId = input.skill_id;
+  if (typeof skillId !== "string" || !skillId.trim()) {
     return {
-      name: this.name,
-      description: this.description,
-      input_schema: {
-        type: "object",
-        properties: {
-          skill_id: {
-            type: "string",
-            description:
-              'Unique identifier for the skill (lowercase slug, e.g. "my-skill").',
-          },
-          name: {
-            type: "string",
-            description: "Human-readable name for the skill.",
-          },
-          description: {
-            type: "string",
-            description: "Short description of what the skill does.",
-          },
-          body_markdown: {
-            type: "string",
-            description:
-              "The full skill body in markdown — instructions, prompts, templates, etc.",
-          },
-          emoji: {
-            type: "string",
-            description: "Optional emoji icon for the skill.",
-          },
-          user_invocable: {
-            type: "boolean",
-            description:
-              "Whether users can invoke this skill directly (default: true).",
-          },
-          disable_model_invocation: {
-            type: "boolean",
-            description:
-              "Whether to prevent the model from auto-invoking this skill (default: false).",
-          },
-          overwrite: {
-            type: "boolean",
-            description:
-              "Whether to overwrite an existing skill with the same ID (default: false).",
-          },
-          add_to_index: {
-            type: "boolean",
-            description:
-              "Whether to add the skill to SKILLS.md index (default: true).",
-          },
-          includes: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation).",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
-        },
-        required: ["skill_id", "name", "description", "body_markdown"],
-      },
+      content: "Error: skill_id is required and must be a non-empty string",
+      isError: true,
     };
   }
 
-  async execute(
-    input: Record<string, unknown>,
-    _context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    const skillId = input.skill_id;
-    if (typeof skillId !== "string" || !skillId.trim()) {
+  const name = input.name;
+  if (typeof name !== "string" || !name.trim()) {
+    return {
+      content: "Error: name is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const description = input.description;
+  if (typeof description !== "string" || !description.trim()) {
+    return {
+      content: "Error: description is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const bodyMarkdown = input.body_markdown;
+  if (typeof bodyMarkdown !== "string" || !bodyMarkdown.trim()) {
+    return {
+      content:
+        "Error: body_markdown is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  // Validate and normalize includes
+  let includes: string[] | undefined;
+  if (input.includes !== undefined) {
+    if (!Array.isArray(input.includes)) {
       return {
-        content: "Error: skill_id is required and must be a non-empty string",
+        content: "Error: includes must be an array of strings",
         isError: true,
       };
     }
-
-    const name = input.name;
-    if (typeof name !== "string" || !name.trim()) {
-      return {
-        content: "Error: name is required and must be a non-empty string",
-        isError: true,
-      };
-    }
-
-    const description = input.description;
-    if (typeof description !== "string" || !description.trim()) {
-      return {
-        content:
-          "Error: description is required and must be a non-empty string",
-        isError: true,
-      };
-    }
-
-    const bodyMarkdown = input.body_markdown;
-    if (typeof bodyMarkdown !== "string" || !bodyMarkdown.trim()) {
-      return {
-        content:
-          "Error: body_markdown is required and must be a non-empty string",
-        isError: true,
-      };
-    }
-
-    // Validate and normalize includes
-    let includes: string[] | undefined;
-    if (input.includes !== undefined) {
-      if (!Array.isArray(input.includes)) {
+    for (const item of input.includes) {
+      if (typeof item !== "string") {
         return {
-          content: "Error: includes must be an array of strings",
+          content: "Error: each element in includes must be a non-empty string",
           isError: true,
         };
       }
-      for (const item of input.includes) {
-        if (typeof item !== "string") {
-          return {
-            content:
-              "Error: each element in includes must be a non-empty string",
-            isError: true,
-          };
-        }
-        if (!item.trim()) {
-          return {
-            content:
-              "Error: each element in includes must be a non-empty string",
-            isError: true,
-          };
-        }
-      }
-      const normalized: string[] = [];
-      const seen = new Set<string>();
-      for (const item of input.includes as string[]) {
-        const trimmed = item.trim();
-        if (seen.has(trimmed)) continue;
-        seen.add(trimmed);
-        normalized.push(trimmed);
-      }
-      if (normalized.length > 0) {
-        includes = normalized;
+      if (!item.trim()) {
+        return {
+          content: "Error: each element in includes must be a non-empty string",
+          isError: true,
+        };
       }
     }
-
-    const result = createManagedSkill({
-      id: skillId.trim(),
-      name: sanitizeFrontmatterValue(name),
-      description: sanitizeFrontmatterValue(description),
-      bodyMarkdown: bodyMarkdown,
-      emoji:
-        typeof input.emoji === "string"
-          ? sanitizeFrontmatterValue(input.emoji)
-          : undefined,
-      userInvocable:
-        typeof input.user_invocable === "boolean"
-          ? input.user_invocable
-          : undefined,
-      disableModelInvocation:
-        typeof input.disable_model_invocation === "boolean"
-          ? input.disable_model_invocation
-          : undefined,
-      overwrite: input.overwrite === true,
-      addToIndex: input.add_to_index !== false,
-      includes,
-    });
-
-    if (!result.created) {
-      return { content: `Error: ${result.error}`, isError: true };
+    const normalized: string[] = [];
+    const seen = new Set<string>();
+    for (const item of input.includes as string[]) {
+      const trimmed = item.trim();
+      if (seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      normalized.push(trimmed);
     }
-
-    return {
-      content: JSON.stringify({
-        created: true,
-        skill_id: skillId.trim(),
-        path: result.path,
-        index_updated: result.indexUpdated,
-      }),
-      isError: false,
-    };
+    if (normalized.length > 0) {
+      includes = normalized;
+    }
   }
-}
 
-export const scaffoldManagedSkillTool: Tool = new ScaffoldManagedSkillTool();
-registerTool(scaffoldManagedSkillTool);
+  const result = createManagedSkill({
+    id: skillId.trim(),
+    name: sanitizeFrontmatterValue(name),
+    description: sanitizeFrontmatterValue(description),
+    bodyMarkdown: bodyMarkdown,
+    emoji:
+      typeof input.emoji === "string"
+        ? sanitizeFrontmatterValue(input.emoji)
+        : undefined,
+    userInvocable:
+      typeof input.user_invocable === "boolean"
+        ? input.user_invocable
+        : undefined,
+    disableModelInvocation:
+      typeof input.disable_model_invocation === "boolean"
+        ? input.disable_model_invocation
+        : undefined,
+    overwrite: input.overwrite === true,
+    addToIndex: input.add_to_index !== false,
+    includes,
+  });
+
+  if (!result.created) {
+    return { content: `Error: ${result.error}`, isError: true };
+  }
+
+  return {
+    content: JSON.stringify({
+      created: true,
+      skill_id: skillId.trim(),
+      path: result.path,
+      index_updated: result.indexUpdated,
+    }),
+    isError: false,
+  };
+}

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -38,9 +38,7 @@ import "./filesystem/view-image.js";
 import "./filesystem/write.js";
 import "./network/web-fetch.js";
 import "./network/web-search.js";
-import "./skills/delete-managed.js";
 import "./skills/load.js";
-import "./skills/scaffold-managed.js";
 import "./swarm/delegate.js";
 import "./system/request-permission.js";
 import "./terminal/shell.js";
@@ -63,8 +61,6 @@ export const eagerModuleToolNames: string[] = [
   "web_search",
   "web_fetch",
   "skill_load",
-  "scaffold_managed_skill",
-  "delete_managed_skill",
   "request_system_permission",
   "asset_search",
   "asset_materialize",


### PR DESCRIPTION
## Summary
- Move scaffold_managed_skill and delete_managed_skill from eager core registration into a new `skill-management` bundled skill
- Create SKILL.md, TOOLS.json, and executor scripts
- Remove registerTool() side effects from original files, keep core logic exported as `executeScaffoldManagedSkill` and `executeDeleteManagedSkill`
- Remove from tool-manifest.ts eager imports and eagerModuleToolNames
- Update tests to use new function exports instead of class instantiation

Part of plan: reduce-always-loaded-tools.md (PR 2 of 8)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/scaffold-managed-skill-tool.test.ts` passes (20 tests)
- [x] `bun test src/__tests__/delete-managed-skill-tool.test.ts` passes
- [x] `bun test src/__tests__/managed-skill-lifecycle.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
