### PR TITLE
Handle host_file_request in desktop client with local file operations

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -352,6 +352,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `host_bash_request` message for proxy command execution.
     public var onHostBashRequest: ((HostBashRequest) -> Void)?
 
+    /// Called when the daemon sends a `host_file_request` message for proxy file operations.
+    public var onHostFileRequest: ((HostFileRequest) -> Void)?
+
     /// Called when the daemon sends a `task_routed` message (e.g. escalation from text_qa to CU).
     public var onTaskRouted: ((TaskRoutedMessage) -> Void)?
 

--- a/clients/shared/Network/DaemonMessageRouter.swift
+++ b/clients/shared/Network/DaemonMessageRouter.swift
@@ -81,6 +81,9 @@ extension DaemonClient {
         case .hostBashRequest(let msg):
             onHostBashRequest?(msg)
             handleHostBashRequest(msg)
+        case .hostFileRequest(let msg):
+            onHostFileRequest?(msg)
+            handleHostFileRequest(msg)
         case .taskRouted(let msg):
             onTaskRouted?(msg)
         case .dictationResponse(let msg):
@@ -345,6 +348,26 @@ extension DaemonClient {
         }
     }
     #endif
+
+    // MARK: - Host File Proxy
+
+    /// Handle a host_file_request by executing the file operation locally
+    /// and posting the result back to the daemon.
+    func handleHostFileRequest(_ msg: HostFileRequest) {
+        #if os(macOS)
+        httpTransport?.executeHostFileRequest(msg)
+        #else
+        log.warning("Received host_file_request on iOS — local file operations not supported")
+        Task {
+            let result = HostFileResultPayload(
+                requestId: msg.requestId,
+                content: "Host file operations are not supported on iOS",
+                isError: true
+            )
+            await httpTransport?.postHostFileResult(result)
+        }
+        #endif
+    }
 
     // MARK: - Host Bash Proxy
 

--- a/clients/shared/Network/HTTPDaemonClient+HostFile.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostFile.swift
@@ -1,0 +1,212 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HostFile")
+
+// MARK: - Host File Proxy Execution
+
+extension HTTPTransport {
+
+    /// Post the result of a host file operation back to the daemon.
+    func postHostFileResult(_ result: HostFileResultPayload, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .hostFileResult) else {
+            log.error("Failed to build URL for host_file_result")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(result)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    switch refreshResult {
+                    case .success:
+                        await postHostFileResult(result, isRetry: true)
+                    case .terminalFailure:
+                        break
+                    case .transientFailure:
+                        log.error("Host file result failed: authentication error after 401 refresh")
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("Host file result failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("Host file result error: \(error.localizedDescription)")
+        }
+    }
+
+    #if os(macOS)
+    /// Execute a host file request locally and post the result back to the daemon.
+    /// Dispatches by operation: read, write, or edit.
+    func executeHostFileRequest(_ request: HostFileRequest) {
+        Task.detached {
+            let result: HostFileResultPayload
+
+            do {
+                switch request.operation {
+                case "read":
+                    let content = try Self.readFile(
+                        path: request.path,
+                        offset: request.offset,
+                        limit: request.limit
+                    )
+                    result = HostFileResultPayload(
+                        requestId: request.requestId,
+                        content: content,
+                        isError: false
+                    )
+
+                case "write":
+                    let message = try Self.writeFile(
+                        path: request.path,
+                        content: request.content ?? ""
+                    )
+                    result = HostFileResultPayload(
+                        requestId: request.requestId,
+                        content: message,
+                        isError: false
+                    )
+
+                case "edit":
+                    let message = try Self.editFile(
+                        path: request.path,
+                        oldString: request.oldString ?? "",
+                        newString: request.newString ?? "",
+                        replaceAll: request.replaceAll ?? false
+                    )
+                    result = HostFileResultPayload(
+                        requestId: request.requestId,
+                        content: message,
+                        isError: false
+                    )
+
+                default:
+                    result = HostFileResultPayload(
+                        requestId: request.requestId,
+                        content: "Unknown file operation: \(request.operation)",
+                        isError: true
+                    )
+                }
+            } catch {
+                result = HostFileResultPayload(
+                    requestId: request.requestId,
+                    content: "File operation failed: \(error.localizedDescription)",
+                    isError: true
+                )
+            }
+
+            log.debug("Host file completed — requestId=\(request.requestId, privacy: .public) op=\(request.operation, privacy: .public) isError=\(result.isError)")
+            await self.postHostFileResult(result)
+        }
+    }
+
+    // MARK: - File Operations
+
+    /// Read a file and return its content formatted with line numbers.
+    /// Matches the daemon's `FileSystemOps.readFileSafe` output format.
+    private static func readFile(path: String, offset: Int?, limit: Int?) throws -> String {
+        let fileContent = try String(contentsOfFile: path, encoding: .utf8)
+        var lines = fileContent.components(separatedBy: "\n")
+
+        // Apply offset (1-based line number)
+        let startIndex = max((offset ?? 1) - 1, 0)
+        if startIndex > 0 && startIndex < lines.count {
+            lines = Array(lines[startIndex...])
+        } else if startIndex >= lines.count {
+            return ""
+        }
+
+        // Apply limit
+        if let limit, limit > 0, limit < lines.count {
+            lines = Array(lines[..<limit])
+        }
+
+        // Format with line numbers matching daemon output format
+        let lineNumberStart = max(offset ?? 1, 1)
+        let maxLineNumber = lineNumberStart + lines.count - 1
+        let numberWidth = String(maxLineNumber).count
+        let formatted = lines.enumerated().map { index, line in
+            let lineNumber = lineNumberStart + index
+            let paddedNumber = String(repeating: " ", count: max(0, numberWidth - String(lineNumber).count)) + "\(lineNumber)"
+            return "\(paddedNumber)\t\(line)"
+        }
+
+        return formatted.joined(separator: "\n")
+    }
+
+    /// Write content to a file, creating parent directories as needed.
+    private static func writeFile(path: String, content: String) throws -> String {
+        let fileURL = URL(fileURLWithPath: path)
+        let parentDir = fileURL.deletingLastPathComponent().path
+
+        // Create parent directories if needed
+        try FileManager.default.createDirectory(
+            atPath: parentDir,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        try content.data(using: .utf8)?.write(to: fileURL)
+        return "Successfully wrote to \(path)"
+    }
+
+    /// Edit a file by finding and replacing a string.
+    /// If `replaceAll` is true, replaces all occurrences.
+    /// If `replaceAll` is false, verifies exactly one match exists.
+    private static func editFile(path: String, oldString: String, newString: String, replaceAll: Bool) throws -> String {
+        guard oldString != newString else {
+            throw FileOperationError.sameStrings
+        }
+
+        var content = try String(contentsOfFile: path, encoding: .utf8)
+
+        if replaceAll {
+            let count = content.components(separatedBy: oldString).count - 1
+            guard count > 0 else {
+                throw FileOperationError.noMatch
+            }
+            content = content.replacingOccurrences(of: oldString, with: newString)
+            try content.data(using: .utf8)?.write(to: URL(fileURLWithPath: path))
+            return "Successfully replaced \(count) occurrence\(count == 1 ? "" : "s") in \(path)"
+        } else {
+            // Count occurrences
+            let count = content.components(separatedBy: oldString).count - 1
+            guard count > 0 else {
+                throw FileOperationError.noMatch
+            }
+            guard count == 1 else {
+                throw FileOperationError.multipleMatches(count)
+            }
+            content = content.replacingOccurrences(of: oldString, with: newString)
+            try content.data(using: .utf8)?.write(to: URL(fileURLWithPath: path))
+            return "Successfully edited \(path)"
+        }
+    }
+
+    /// Errors specific to host file operations.
+    private enum FileOperationError: LocalizedError {
+        case noMatch
+        case multipleMatches(Int)
+        case sameStrings
+
+        var errorDescription: String? {
+            switch self {
+            case .noMatch:
+                return "old_string not found in file"
+            case .multipleMatches(let count):
+                return "old_string found \(count) times in file — must be unique (use replace_all to replace all occurrences)"
+            case .sameStrings:
+                return "old_string and new_string are identical — no changes needed"
+            }
+        }
+    }
+    #endif
+}

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -417,6 +417,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case hostBashResult
 
+        // Host File Proxy
+        case hostFileResult
+
         // BTW side-chain
         case btw
 
@@ -817,6 +820,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case .hostBashResult:
             return ("/v1/host-bash-result", nil)
+        // Host File Proxy
+        case .hostFileResult:
+            return ("/v1/host-file-result", nil)
         // BTW side-chain
         case .btw:
             return ("/v1/btw", nil)
@@ -1200,6 +1206,9 @@ public final class HTTPTransport {
         // Host Bash Proxy
         case .hostBashResult:
             return ("\(prefix)/host-bash-result/", nil)
+        // Host File Proxy
+        case .hostFileResult:
+            return ("\(prefix)/host-file-result/", nil)
         // BTW side-chain
         case .btw:
             return ("\(prefix)/btw/", nil)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1535,6 +1535,49 @@ public struct HostBashResultPayload: Codable, Sendable {
     }
 }
 
+// MARK: - Host File Proxy
+
+/// Request from the daemon to execute a file operation on the host machine.
+/// The desktop client receives this via SSE, performs the operation locally,
+/// and POSTs the result back to `/v1/host-file-result`.
+public struct HostFileRequest: Decodable, Sendable {
+    public let type: String
+    public let requestId: String
+    public let sessionId: String
+    public let operation: String  // "read", "write", "edit"
+    public let path: String
+    // Read fields
+    public let offset: Int?
+    public let limit: Int?
+    // Write fields
+    public let content: String?
+    // Edit fields
+    public let oldString: String?
+    public let newString: String?
+    public let replaceAll: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case type, requestId, sessionId, operation, path
+        case offset, limit, content
+        case oldString = "old_string"
+        case newString = "new_string"
+        case replaceAll = "replace_all"
+    }
+}
+
+/// Payload posted back to the daemon with the result of a host file operation.
+public struct HostFileResultPayload: Codable, Sendable {
+    public let requestId: String
+    public let content: String
+    public let isError: Bool
+
+    public init(requestId: String, content: String, isError: Bool) {
+        self.requestId = requestId
+        self.content = content
+        self.isError = isError
+    }
+}
+
 /// Server-side assistant activity lifecycle event.
 /// Backed by generated `AssistantActivityState`.
 public typealias AssistantActivityStateMessage = AssistantActivityState
@@ -2217,6 +2260,7 @@ public enum ServerMessage: Decodable, Sendable {
     case tokenRotated(TokenRotatedMessage)
     case identityChanged(IdentityChanged)
     case hostBashRequest(HostBashRequest)
+    case hostFileRequest(HostFileRequest)
     case pong
     case unknown(String)
 
@@ -2655,6 +2699,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_bash_request":
             let message = try HostBashRequest(from: decoder)
             self = .hostBashRequest(message)
+        case "host_file_request":
+            let message = try HostFileRequest(from: decoder)
+            self = .hostFileRequest(message)
         case "pong":
             self = .pong
         default:


### PR DESCRIPTION
## Summary
- Add HostFileRequest/HostFileResultPayload types and ServerMessage decoding in Swift
- Route host_file_request to executeHostFileRequest on macOS, error response on iOS
- Implement local file read (with line numbers), write (with mkdir -p), and edit (with match validation)
- Add POST /v1/host-file-result endpoint support with 401 retry

Part of plan: host-file-proxy.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
