### PR TITLE
Add HostFileProxy class with /v1/host-file-result endpoint

### DIFF
--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const { HostFileProxy } = await import("../daemon/host-file-proxy.js");
+
+describe("HostFileProxy", () => {
+  let proxy: InstanceType<typeof HostFileProxy>;
+  let sentMessages: unknown[];
+  let sendToClient: (msg: unknown) => void;
+
+  function setup(onInternalResolve?: (requestId: string) => void) {
+    sentMessages = [];
+    sendToClient = (msg: unknown) => sentMessages.push(msg);
+    proxy = new HostFileProxy(sendToClient, onInternalResolve);
+  }
+
+  afterEach(() => {
+    proxy?.dispose();
+  });
+
+  describe("request/resolve lifecycle (happy path)", () => {
+    test("sends host_file_request and resolves with content", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+      );
+
+      // Verify the request was sent to the client
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_file_request");
+      expect(sent.sessionId).toBe("session-1");
+      expect(sent.operation).toBe("read");
+      expect(sent.path).toBe("/tmp/test.txt");
+      expect(typeof sent.requestId).toBe("string");
+
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      // Simulate client response
+      proxy.resolve(requestId, {
+        content: "file contents here",
+        isError: false,
+      });
+
+      const result = await resultPromise;
+      expect(result.content).toBe("file contents here");
+      expect(result.isError).toBe(false);
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+    });
+
+    test("resolves error responses correctly", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/nonexistent",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, {
+        content: "ENOENT: no such file or directory",
+        isError: true,
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("ENOENT");
+    });
+
+    test("handles write operations", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "write",
+          path: "/tmp/output.txt",
+          content: "new content",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.operation).toBe("write");
+      expect(sent.content).toBe("new content");
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        content: "File written successfully",
+        isError: false,
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+
+    test("handles edit operations", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "edit",
+          path: "/tmp/file.txt",
+          old_string: "foo",
+          new_string: "bar",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.operation).toBe("edit");
+      expect(sent.old_string).toBe("foo");
+      expect(sent.new_string).toBe("bar");
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        content: "Edit applied successfully",
+        isError: false,
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+  });
+
+  describe("timeout", () => {
+    test("tracks pending state before timeout fires", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/slow.txt",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      // Resolve to avoid test hanging (actual 30s timeout too long for test)
+      proxy.resolve(requestId, {
+        content: "",
+        isError: false,
+      });
+
+      await resultPromise;
+    });
+  });
+
+  describe("abort signal", () => {
+    test("resolves with abort result when signal fires", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      controller.abort();
+
+      const result = await resultPromise;
+      expect(result.content).toBe("Aborted");
+      expect(result.isError).toBe(true);
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+    });
+
+    test("returns immediately if signal already aborted", async () => {
+      setup();
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      expect(result.content).toBe("Aborted");
+      expect(result.isError).toBe(true);
+      expect(sentMessages).toHaveLength(0); // No message sent
+    });
+  });
+
+  describe("isAvailable", () => {
+    test("returns false by default (no client connected)", () => {
+      setup();
+      expect(proxy.isAvailable()).toBe(false);
+    });
+
+    test("returns true after updateSender with clientConnected=true", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
+      expect(proxy.isAvailable()).toBe(true);
+    });
+
+    test("returns false after updateSender with clientConnected=false", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
+      expect(proxy.isAvailable()).toBe(true);
+      proxy.updateSender(sendToClient, false);
+      expect(proxy.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("dispose", () => {
+    test("rejects all pending requests", () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      proxy.dispose();
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+      expect(resultPromise).rejects.toThrow("Host file proxy disposed");
+    });
+  });
+
+  describe("updateSender", () => {
+    test("uses updated sender for new requests", async () => {
+      setup();
+
+      const newMessages: unknown[] = [];
+      proxy.updateSender((msg) => newMessages.push(msg), true);
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+      );
+
+      expect(sentMessages).toHaveLength(0); // Old sender not used
+      expect(newMessages).toHaveLength(1); // New sender used
+
+      const sent = newMessages[0] as Record<string, unknown>;
+      proxy.resolve(sent.requestId as string, {
+        content: "updated content",
+        isError: false,
+      });
+
+      await resultPromise;
+    });
+  });
+
+  describe("resolve with unknown requestId", () => {
+    test("silently ignores unknown requestId", () => {
+      setup();
+      // Should not throw
+      proxy.resolve("unknown-id", {
+        content: "",
+        isError: false,
+      });
+    });
+  });
+
+  describe("onInternalResolve callback", () => {
+    test("fires on abort", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+      await resultPromise;
+
+      expect(resolvedIds).toEqual([requestId]);
+    });
+
+    test("fires for each pending request on dispose", () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      // Create two pending requests and catch rejections from dispose
+      const p1 = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/a.txt",
+        },
+        "session-1",
+      );
+      const p2 = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/b.txt",
+        },
+        "session-1",
+      );
+      p1.catch(() => {}); // Expected rejection on dispose
+      p2.catch(() => {}); // Expected rejection on dispose
+
+      const ids = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(ids).toHaveLength(2);
+
+      proxy.dispose();
+
+      expect(resolvedIds).toHaveLength(2);
+      expect(resolvedIds).toContain(ids[0]);
+      expect(resolvedIds).toContain(ids[1]);
+    });
+
+    test("does not fire on normal client-initiated resolve", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const resultPromise = proxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: "",
+          operation: "read",
+          path: "/tmp/test.txt",
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      // Normal resolve from client — should NOT trigger onInternalResolve
+      proxy.resolve(requestId, {
+        content: "file contents",
+        isError: false,
+      });
+
+      await resultPromise;
+      expect(resolvedIds).toEqual([]);
+    });
+  });
+});

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -35,6 +35,7 @@ import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { truncate } from "../../util/truncate.js";
 import { HostBashProxy } from "../host-bash-proxy.js";
+import { HostFileProxy } from "../host-file-proxy.js";
 import type {
   CancelRequest,
   ConfirmationResponse,
@@ -157,6 +158,12 @@ export function makeEventSender(params: {
         session,
         conversationId,
         kind: "host_bash",
+      });
+    } else if (event.type === "host_file_request") {
+      pendingInteractions.register(event.requestId, {
+        session,
+        conversationId,
+        kind: "host_file",
       });
     }
 
@@ -420,6 +427,10 @@ export async function handleSessionCreate(
         pendingInteractions.resolve(requestId);
       });
       session.setHostBashProxy(proxy);
+      const fileProxy = new HostFileProxy(sendEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
+      session.setHostFileProxy(fileProxy);
     }
     session.updateClient(sendEvent, false);
     session

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -1,0 +1,123 @@
+import { v4 as uuid } from "uuid";
+
+import type { ToolExecutionResult } from "../tools/types.js";
+import { AssistantError, ErrorCode } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import type { ServerMessage } from "./message-protocol.js";
+import type { HostFileRequest } from "./message-types/host-file.js";
+
+const log = getLogger("host-file-proxy");
+
+interface PendingRequest {
+  resolve: (result: ToolExecutionResult) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class HostFileProxy {
+  private pending = new Map<string, PendingRequest>();
+  private sendToClient: (msg: ServerMessage) => void;
+  private onInternalResolve?: (requestId: string) => void;
+  private clientConnected = false;
+
+  constructor(
+    sendToClient: (msg: ServerMessage) => void,
+    onInternalResolve?: (requestId: string) => void,
+  ) {
+    this.sendToClient = sendToClient;
+    this.onInternalResolve = onInternalResolve;
+  }
+
+  updateSender(
+    sendToClient: (msg: ServerMessage) => void,
+    clientConnected: boolean,
+  ): void {
+    this.sendToClient = sendToClient;
+    this.clientConnected = clientConnected;
+  }
+
+  request(
+    input: HostFileRequest,
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<ToolExecutionResult> {
+    if (signal?.aborted) {
+      return Promise.resolve({ content: "Aborted", isError: true });
+    }
+
+    const requestId = uuid();
+
+    return new Promise<ToolExecutionResult>((resolve, reject) => {
+      // File operations should be fast — 30 second timeout.
+      const timeoutSec = 30;
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        this.onInternalResolve?.(requestId);
+        log.warn(
+          { requestId, operation: input.operation },
+          "Host file proxy request timed out",
+        );
+        resolve({
+          content: "Host file proxy timed out waiting for client response",
+          isError: true,
+        });
+      }, timeoutSec * 1000);
+
+      this.pending.set(requestId, { resolve, reject, timer });
+
+      if (signal) {
+        const onAbort = () => {
+          if (this.pending.has(requestId)) {
+            clearTimeout(timer);
+            this.pending.delete(requestId);
+            this.onInternalResolve?.(requestId);
+            resolve({ content: "Aborted", isError: true });
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      this.sendToClient({
+        ...input,
+        requestId,
+        sessionId,
+      } as ServerMessage);
+    });
+  }
+
+  resolve(
+    requestId: string,
+    response: { content: string; isError: boolean },
+  ): void {
+    const entry = this.pending.get(requestId);
+    if (!entry) {
+      log.warn({ requestId }, "No pending host file request for response");
+      return;
+    }
+    clearTimeout(entry.timer);
+    this.pending.delete(requestId);
+    entry.resolve({ content: response.content, isError: response.isError });
+  }
+
+  hasPendingRequest(requestId: string): boolean {
+    return this.pending.has(requestId);
+  }
+
+  isAvailable(): boolean {
+    return this.clientConnected;
+  }
+
+  dispose(): void {
+    for (const [requestId, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      this.onInternalResolve?.(requestId);
+      entry.reject(
+        new AssistantError(
+          "Host file proxy disposed",
+          ErrorCode.INTERNAL_ERROR,
+        ),
+      );
+    }
+    this.pending.clear();
+  }
+}

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,6 +47,7 @@ import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
+import { HostFileProxy } from "./host-file-proxy.js";
 import type {
   ServerMessage,
   SurfaceData,
@@ -158,6 +159,7 @@ export class Session {
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
   /** @internal */ hostBashProxy?: HostBashProxy;
+  /** @internal */ hostFileProxy?: HostFileProxy;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
@@ -374,6 +376,7 @@ export class Session {
     this.secretPrompter.updateSender(sendToClient);
     this.traceEmitter.updateSender(sendToClient);
     this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
+    this.hostFileProxy?.updateSender(sendToClient, !hasNoClient);
   }
 
   /** Returns the current sendToClient reference for identity comparison. */
@@ -417,6 +420,7 @@ export class Session {
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
     this.hostBashProxy?.dispose();
+    this.hostFileProxy?.dispose();
     disposeSession(this);
   }
 
@@ -585,6 +589,20 @@ export class Session {
       this.hostBashProxy.dispose();
     }
     this.hostBashProxy = proxy;
+  }
+
+  resolveHostFile(
+    requestId: string,
+    response: { content: string; isError: boolean },
+  ): void {
+    this.hostFileProxy?.resolve(requestId, response);
+  }
+
+  setHostFileProxy(proxy: HostFileProxy | undefined): void {
+    if (this.hostFileProxy && this.hostFileProxy !== proxy) {
+      this.hostFileProxy.dispose();
+    }
+    this.hostFileProxy = proxy;
   }
 
   // ── Server-authoritative state signals ─────────────────────────────

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -126,6 +126,7 @@ import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
+import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
@@ -938,6 +939,7 @@ export class RuntimeHttpServer {
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),
       ...hostBashRouteDefinitions(),
+      ...hostFileRouteDefinitions(),
       ...(this.getSkillContext
         ? skillRouteDefinitions({
             getSkillContext: this.getSkillContext,

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,12 +1,12 @@
 /**
  * In-memory tracker that maps requestId to session info for pending
- * confirmation, secret, and host_bash interactions.
+ * confirmation, secret, host_bash, and host_file interactions.
  *
- * When the agent loop emits a confirmation_request, secret_request, or
- * host_bash_request, the onEvent callback registers the interaction here.
- * Standalone HTTP endpoints (/v1/confirm, /v1/secret, /v1/trust-rules,
- * /v1/host-bash-result) look up the session from this tracker to resolve
- * the interaction.
+ * When the agent loop emits a confirmation_request, secret_request,
+ * host_bash_request, or host_file_request, the onEvent callback registers
+ * the interaction here. Standalone HTTP endpoints (/v1/confirm, /v1/secret,
+ * /v1/trust-rules, /v1/host-bash-result, /v1/host-file-result) look up
+ * the session from this tracker to resolve the interaction.
  */
 
 import type { Session } from "../daemon/session.js";
@@ -29,7 +29,7 @@ export interface ConfirmationDetails {
 export interface PendingInteraction {
   session: Session;
   conversationId: string;
-  kind: "confirmation" | "secret" | "host_bash";
+  kind: "confirmation" | "secret" | "host_bash" | "host_file";
   confirmationDetails?: ConfirmationDetails;
 }
 
@@ -82,15 +82,20 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given session.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash interactions are intentionally skipped — they represent in-flight
- * tool executions proxied to the client, not confirmations to auto-deny.
- * Removing them would orphan the request: the client would POST to
- * /v1/host-bash-result after completing the command, get a 404, and the
- * proxy timer would fire with a spurious timeout error.
+ * host_bash and host_file interactions are intentionally skipped — they
+ * represent in-flight tool executions proxied to the client, not
+ * confirmations to auto-deny. Removing them would orphan the request: the
+ * client would POST to /v1/host-bash-result or /v1/host-file-result after
+ * completing the operation, get a 404, and the proxy timer would fire with
+ * a spurious timeout error.
  */
 export function removeBySession(session: Session): void {
   for (const [requestId, interaction] of pending) {
-    if (interaction.session === session && interaction.kind !== "host_bash") {
+    if (
+      interaction.session === session &&
+      interaction.kind !== "host_bash" &&
+      interaction.kind !== "host_file"
+    ) {
       pending.delete(requestId);
     }
   }

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -1,0 +1,79 @@
+/**
+ * Route handler for host file result submissions.
+ *
+ * Resolves pending host file proxy requests by requestId when the desktop
+ * client returns execution results via HTTP.
+ */
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
+import type { AuthContext } from "../auth/types.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+/**
+ * POST /v1/host-file-result — resolve a pending host file request by requestId.
+ * Requires AuthContext with guardian-bound actor.
+ */
+export async function handleHostFileResult(
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const body = (await req.json()) as {
+    requestId?: string;
+    content?: string;
+    isError?: boolean;
+  };
+
+  const { requestId, content, isError } = body;
+
+  if (!requestId || typeof requestId !== "string") {
+    return httpError("BAD_REQUEST", "requestId is required", 400);
+  }
+
+  // Peek first (non-destructive) so we can validate the interaction kind
+  // without accidentally consuming a confirmation or secret interaction.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    return httpError(
+      "NOT_FOUND",
+      "No pending interaction found for this requestId",
+      404,
+    );
+  }
+
+  if (peeked.kind !== "host_file") {
+    return httpError(
+      "CONFLICT",
+      `Pending interaction is of kind "${peeked.kind}", expected "host_file"`,
+      409,
+    );
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
+
+  interaction.session.resolveHostFile(requestId, {
+    content: content ?? "",
+    isError: isError ?? false,
+  });
+
+  return Response.json({ accepted: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function hostFileRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "host-file-result",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleHostFileResult(req, authContext),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add HostFileProxy class following HostBashProxy pattern with 30s timeout
- Add POST /v1/host-file-result HTTP endpoint for client result posting
- Update pending-interactions to track host_file kind and skip in removeBySession
- Wire HostFileProxy into session and session handlers for desktop clients

Part of plan: host-file-proxy.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
