### PR TITLE
test: add guard test asserting exactly 13 always-loaded tools

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guard test: always-loaded tool count
+ *
+ * This test asserts the exact set of tools that are active when no client is
+ * connected, no host proxy is available, no attachments are present, and no
+ * special channel capabilities exist. This represents the minimal "always-loaded"
+ * baseline that is sent to the LLM on every turn.
+ *
+ * Adding a tool to this set increases token cost for every request. If this test
+ * fails because a new tool was added, update the assertion below and justify
+ * the token cost increase in the PR description.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+
+import {
+  buildToolDefinitions,
+  isToolActiveForContext,
+  type SkillProjectionContext,
+} from "../daemon/session-tool-setup.js";
+import {
+  __resetRegistryForTesting,
+  initializeTools,
+} from "../tools/registry.js";
+
+afterAll(() => {
+  __resetRegistryForTesting();
+});
+
+describe("always-loaded tool count", () => {
+  test("should be exactly 13", async () => {
+    await initializeTools();
+    const allDefs = buildToolDefinitions();
+
+    // Minimal context: no client, no host proxy, no attachments, no capabilities
+    const minimalContext: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: new Map(),
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 0,
+      hasNoClient: true,
+      hostBashProxy: undefined,
+      hasAttachments: false,
+      channelCapabilities: undefined,
+    };
+
+    const activeTools = allDefs.filter((def) =>
+      isToolActiveForContext(def.name, minimalContext),
+    );
+    const activeNames = activeTools.map((t) => t.name).sort();
+
+    const expectedNames = [
+      "bash",
+      "credential_store",
+      "file_edit",
+      "file_read",
+      "file_write",
+      "memory_delete",
+      "memory_recall",
+      "memory_save",
+      "memory_update",
+      "skill_load",
+      "view_image",
+      "web_fetch",
+      "web_search",
+    ].sort();
+
+    expect(activeNames).toEqual(expectedNames);
+    expect(activeTools.length).toBe(13);
+  });
+});


### PR DESCRIPTION
## Summary
- Add guard test that asserts exactly 13 tools are always-loaded (no client, no host proxy, no attachments)
- Prevents accidental regression of token-optimized tool loading
- Expected tools: bash, file_read, file_write, file_edit, view_image, web_search, web_fetch, skill_load, memory_save, memory_update, memory_delete, memory_recall, credential_store

Part of plan: reduce-always-loaded-tools.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
