### PR TITLE
Connect host_file_read/write/edit tools to HostFileProxy for client-side execution

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -102,6 +102,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   callSessionId?: string;
   /** Optional proxy for delegating host_bash execution to a connected client. */
   hostBashProxy?: import("./host-bash-proxy.js").HostBashProxy;
+  /** Optional proxy for delegating host_file_read/write/edit execution to a connected client. */
+  hostFileProxy?: import("./host-file-proxy.js").HostFileProxy;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -181,6 +183,7 @@ export function createToolExecutor(
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       toolUseId,
       hostBashProxy: ctx.hostBashProxy,
+      hostFileProxy: ctx.hostFileProxy,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -48,7 +48,7 @@ class HostFileEditTool implements Tool {
 
   async execute(
     input: Record<string, unknown>,
-    _context: ToolContext,
+    context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const rawPath = input.path as string;
     if (!rawPath || typeof rawPath !== "string") {
@@ -86,6 +86,25 @@ class HostFileEditTool implements Tool {
     }
 
     const replaceAll = input.replace_all === true;
+
+    // Proxy to connected client for execution on the user's machine
+    // when a capable client is available (managed/cloud-hosted mode).
+    if (context.hostFileProxy?.isAvailable()) {
+      return context.hostFileProxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: context.sessionId,
+          operation: "edit",
+          path: rawPath,
+          old_string: oldString as string,
+          new_string: newString as string,
+          replace_all: replaceAll,
+        },
+        context.sessionId,
+        context.signal,
+      );
+    }
 
     const ops = new FileSystemOps(hostPolicy);
 

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -42,7 +42,7 @@ class HostFileReadTool implements Tool {
 
   async execute(
     input: Record<string, unknown>,
-    _context: ToolContext,
+    context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const rawPath = input.path as string;
     if (!rawPath || typeof rawPath !== "string") {
@@ -50,6 +50,24 @@ class HostFileReadTool implements Tool {
         content: "Error: path is required and must be a string",
         isError: true,
       };
+    }
+
+    // Proxy to connected client for execution on the user's machine
+    // when a capable client is available (managed/cloud-hosted mode).
+    if (context.hostFileProxy?.isAvailable()) {
+      return context.hostFileProxy.request(
+        {
+          type: "host_file_request",
+          requestId: "", // proxy generates its own
+          sessionId: context.sessionId,
+          operation: "read",
+          path: rawPath,
+          offset: typeof input.offset === "number" ? input.offset : undefined,
+          limit: typeof input.limit === "number" ? input.limit : undefined,
+        },
+        context.sessionId,
+        context.signal,
+      );
     }
 
     const ops = new FileSystemOps(hostPolicy);

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -40,7 +40,7 @@ class HostFileWriteTool implements Tool {
 
   async execute(
     input: Record<string, unknown>,
-    _context: ToolContext,
+    context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const rawPath = input.path as string;
     if (!rawPath || typeof rawPath !== "string") {
@@ -56,6 +56,23 @@ class HostFileWriteTool implements Tool {
         content: "Error: content is required and must be a string",
         isError: true,
       };
+    }
+
+    // Proxy to connected client for execution on the user's machine
+    // when a capable client is available (managed/cloud-hosted mode).
+    if (context.hostFileProxy?.isAvailable()) {
+      return context.hostFileProxy.request(
+        {
+          type: "host_file_request",
+          requestId: "",
+          sessionId: context.sessionId,
+          operation: "write",
+          path: rawPath,
+          content: fileContent,
+        },
+        context.sessionId,
+        context.signal,
+      );
     }
 
     const ops = new FileSystemOps(hostPolicy);

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -171,6 +171,8 @@ export interface ToolContext {
   toolUseId?: string;
   /** Optional proxy for delegating host_bash execution to a connected client (managed/cloud-hosted mode). */
   hostBashProxy?: import("../daemon/host-bash-proxy.js").HostBashProxy;
+  /** Optional proxy for delegating host_file_read/write/edit execution to a connected client (managed/cloud-hosted mode). */
+  hostFileProxy?: import("../daemon/host-file-proxy.js").HostFileProxy;
 }
 
 export interface DiffInfo {


### PR DESCRIPTION
## Summary
- Add hostFileProxy field to ToolContext and ToolSetupContext interfaces
- Wire host_file_read/write/edit to delegate to proxy when a capable client is connected
- Preserve local fallback execution when no proxy is available (CLI, API-only)
- Input validation runs before proxying in all cases

Part of plan: host-file-proxy.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
