### PR TITLE
fix: resolve @MainActor isolation errors in host file operations

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostFile.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostFile.swift
@@ -112,7 +112,7 @@ extension HTTPTransport {
 
     /// Read a file and return its content formatted with line numbers.
     /// Matches the daemon's `FileSystemOps.readFileSafe` output format.
-    private static func readFile(path: String, offset: Int?, limit: Int?) throws -> String {
+    private nonisolated static func readFile(path: String, offset: Int?, limit: Int?) throws -> String {
         let fileContent = try String(contentsOfFile: path, encoding: .utf8)
         var lines = fileContent.components(separatedBy: "\n")
 
@@ -143,7 +143,7 @@ extension HTTPTransport {
     }
 
     /// Write content to a file, creating parent directories as needed.
-    private static func writeFile(path: String, content: String) throws -> String {
+    private nonisolated static func writeFile(path: String, content: String) throws -> String {
         let fileURL = URL(fileURLWithPath: path)
         let parentDir = fileURL.deletingLastPathComponent().path
 
@@ -161,7 +161,7 @@ extension HTTPTransport {
     /// Edit a file by finding and replacing a string.
     /// If `replaceAll` is true, replaces all occurrences.
     /// If `replaceAll` is false, verifies exactly one match exists.
-    private static func editFile(path: String, oldString: String, newString: String, replaceAll: Bool) throws -> String {
+    private nonisolated static func editFile(path: String, oldString: String, newString: String, replaceAll: Bool) throws -> String {
         guard oldString != newString else {
             throw FileOperationError.sameStrings
         }


### PR DESCRIPTION
## Summary
- Mark `readFile`, `writeFile`, and `editFile` static methods as `nonisolated` in `HTTPDaemonClient+HostFile.swift`
- These pure file I/O methods don't access any main-actor state but inherited `@MainActor` isolation from `HTTPTransport`, causing build errors when called from `Task.detached`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22934280628

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
