### PR TITLE
feat: track hasAttachments on Session for conditional asset tool loading

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -35,7 +35,7 @@ describe("always-loaded tool count", () => {
     // Minimal context: no client, no host proxy, no attachments, no capabilities
     const minimalContext: SkillProjectionContext = {
       skillProjectionState: new Map(),
-      skillProjectionCache: new Map(),
+      skillProjectionCache: {},
       coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: true,

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -1174,3 +1174,30 @@ export function applyRuntimeInjections(
 
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Attachment detection
+// ---------------------------------------------------------------------------
+
+/** Content block types that indicate user-uploaded attachments. */
+const ATTACHMENT_CONTENT_TYPES = new Set(["image", "file"]);
+
+/**
+ * Scan conversation messages for user-uploaded attachment content blocks
+ * (image or file). Returns true as soon as any attachment is found.
+ *
+ * Used to set the one-way `hasAttachments` flag on Session so that asset
+ * tools (asset_search, asset_materialize) are included in tool definitions
+ * only when the conversation contains attachments.
+ */
+export function messagesContainAttachments(messages: Message[]): boolean {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    for (const block of message.content) {
+      if (ATTACHMENT_CONTENT_TYPES.has(block.type)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -90,6 +90,7 @@ import type {
   ChannelCapabilities,
   TrustContext,
 } from "./session-runtime-assembly.js";
+import { messagesContainAttachments } from "./session-runtime-assembly.js";
 import type { SkillProjectionCache } from "./session-skill-tools.js";
 import {
   createSurfaceMutex,
@@ -155,6 +156,7 @@ export class Session {
   /** @internal */ currentRequestId?: string;
   /** @internal */ conflictGate = new ConflictGate();
   /** @internal */ hasNoClient = false;
+  /** @internal */ hasAttachments = false;
   /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
@@ -357,7 +359,13 @@ export class Session {
   // ── Lifecycle ────────────────────────────────────────────────────
 
   async loadFromDb(): Promise<void> {
-    return loadFromDbImpl(this);
+    await loadFromDbImpl(this);
+    // Scan loaded history for attachment content blocks so that asset
+    // tools are available when resuming a conversation that already had
+    // attachments. One-way: once true it stays true for the session.
+    if (!this.hasAttachments && messagesContainAttachments(this.messages)) {
+      this.hasAttachments = true;
+    }
   }
 
   async ensureActorScopedHistory(): Promise<void> {
@@ -697,6 +705,11 @@ export class Session {
   ): Promise<string> {
     if (!this.processing) {
       await this.ensureActorScopedHistory();
+    }
+    // One-way flag: once an attachment arrives, asset tools stay available
+    // for the remainder of the session.
+    if (!this.hasAttachments && attachments.length > 0) {
+      this.hasAttachments = true;
     }
     return persistUserMessageImpl(
       this,


### PR DESCRIPTION
## Summary
- Add `hasAttachments` property to Session (default false)
- Set it to true when user messages contain image/attachment content blocks
- Scan loaded history on `loadFromDb` so resumed conversations with attachments also get asset tools
- Add `messagesContainAttachments` helper to `session-runtime-assembly.ts`
- Fix upstream type error in `always-loaded-tools-guard.test.ts` (`Map` -> `{}` for `SkillProjectionCache`)

This enables the conditional asset tool filtering added in PR 5 — asset tools (asset_search, asset_materialize) are now excluded from tool definitions until the first attachment arrives, reducing the always-loaded tool count.

Part of plan: reduce-always-loaded-tools.md (PR 6 of 8)

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `always-loaded-tools-guard.test.ts` passes (confirms 13 always-loaded tools)
- [x] `session-tool-setup-tools-disabled.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
