### PR TITLE
fix: update tests for tools moved to bundled skills

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -128,33 +128,24 @@ describe("tool registry host tools", () => {
 });
 
 describe("tool registry dynamic-tools tools", () => {
-  test("registers scaffold, delete, and skill_load tools", async () => {
+  test("registers skill_load tool", async () => {
     await initializeTools();
 
-    const dynamicToolNames = [
-      "scaffold_managed_skill",
-      "delete_managed_skill",
-      "skill_load",
-    ] as const;
-
-    for (const toolName of dynamicToolNames) {
-      const tool = getTool(toolName);
-      expect(tool).toBeDefined();
-    }
+    const tool = getTool("skill_load");
+    expect(tool).toBeDefined();
 
     const definitionNames = getAllToolDefinitions().map((def) => def.name);
-    for (const toolName of dynamicToolNames) {
-      expect(definitionNames).toContain(toolName);
-    }
+    expect(definitionNames).toContain("skill_load");
   });
 
-  test("scaffold and delete are registered as High risk", async () => {
+  test("scaffold and delete are NOT in the core tool registry (moved to bundled skill)", async () => {
     await initializeTools();
-    for (const name of ["scaffold_managed_skill", "delete_managed_skill"]) {
-      const tool = getTool(name);
-      expect(tool).toBeDefined();
-      expect(tool?.defaultRiskLevel).toBe(RiskLevel.High);
-    }
+    // scaffold_managed_skill and delete_managed_skill moved to the
+    // skill-management bundled skill — they are no longer registered as core
+    // tools. Their High risk classification is handled by classifyRisk() in
+    // checker.ts so security behavior is preserved.
+    expect(getTool("scaffold_managed_skill")).toBeUndefined();
+    expect(getTool("delete_managed_skill")).toBeUndefined();
   });
 
   test("skill_load is registered as Low risk", async () => {
@@ -176,29 +167,31 @@ describe("tool manifest", () => {
   });
 
   test("manifest declares expected core lazy tools", () => {
-    // bash and swarm_delegate moved from lazy to eager registration
+    // bash moved from lazy to eager registration
+    // swarm_delegate moved to the orchestration bundled skill
     const lazyNames = new Set(lazyTools.map((t) => t.name));
     expect(lazyNames.has("bash")).toBe(false);
     expect(lazyNames.has("evaluate_typescript_code")).toBe(false);
     expect(lazyNames.has("claude_code")).toBe(false);
     expect(lazyNames.has("swarm_delegate")).toBe(false);
-    // Verify they are in eager tools instead
+    // bash is in eager tools; swarm_delegate is now a bundled skill tool
     expect(eagerModuleToolNames).toContain("bash");
-    expect(eagerModuleToolNames).toContain("swarm_delegate");
+    expect(eagerModuleToolNames).not.toContain("swarm_delegate");
     expect(eagerModuleToolNames).not.toContain("version");
   });
 
   test("eager module tool names list contains expected count", () => {
-    expect(eagerModuleToolNames.length).toBe(14);
+    expect(eagerModuleToolNames.length).toBe(11);
   });
 
-  test("explicit tools list includes memory, credential, and watch tools", () => {
+  test("explicit tools list includes memory and credential tools", () => {
     const names = explicitTools.map((t) => t.name);
     expect(names).toContain("memory_recall");
     expect(names).toContain("memory_save");
     expect(names).toContain("memory_update");
     expect(names).toContain("credential_store");
-    expect(names).toContain("start_screen_watch");
+    // start_screen_watch moved to the screen-watch bundled skill
+    expect(names).not.toContain("start_screen_watch");
   });
 
   test("registered tool count is at least eager + lazy + host", async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -540,6 +540,17 @@ async function classifyRiskUncached(
   if (toolName === "network_request") return RiskLevel.Medium;
   if (toolName === "skill_load") return RiskLevel.Low;
 
+  // Skill mutation tools are always High risk — they write or delete persistent
+  // skill source code. These tools moved from core tool registry to bundled
+  // skills, but their security classification must remain High regardless of
+  // whether they appear in the tool registry.
+  if (
+    toolName === "scaffold_managed_skill" ||
+    toolName === "delete_managed_skill"
+  ) {
+    return RiskLevel.High;
+  }
+
   // Escalate host file mutations targeting skill source paths to High risk.
   // The host variants fall through to the tool registry (Medium) by default,
   // but writing to skill source code is a privilege-escalation vector.


### PR DESCRIPTION
## Summary

- Add hardcoded `High` risk classification in `classifyRisk()` for `scaffold_managed_skill` and `delete_managed_skill` — these tools moved from the core tool registry to the skill-management bundled skill, but their security classification must remain High regardless of registry presence
- Update `registry.test.ts` to reflect that `scaffold_managed_skill` and `delete_managed_skill` are no longer core registry tools (they live in the bundled skill), `swarm_delegate` is no longer in `eagerModuleToolNames` (moved to orchestration bundled skill), count is now 11 (not 14), and `start_screen_watch` is no longer in `explicitTools` (moved to screen-watch bundled skill)
- Update `checker.test.ts` imports for managed skill tools are still present but now rely on the hardcoded risk path rather than registry registration

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22934294957/job/66562135906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
