### PR TITLE
fix: guard proxy teardown during concurrent turns to prevent race condition

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -650,7 +650,7 @@ export class DaemonServer {
           }),
         );
       }
-    } else {
+    } else if (!session.isProcessing()) {
       session.setHostBashProxy(undefined);
     }
     session.setCommandIntent(options?.commandIntent ?? null);


### PR DESCRIPTION
Adds an isProcessing guard on the else branch when clearing hostBashProxy for non-desktop sessions. This prevents tearing down an active proxy during the race window where another turn became active after ensureActorScopedHistory(), which could abort in-flight desktop commands.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
