### PR TITLE
fix: remove proxy gate from host tools so CLI/headless sessions retain host capabilities

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,18 +28,17 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 13", async () => {
+  test("should be exactly 17", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
-    // Minimal context: no client, no host proxy, no attachments, no capabilities
+    // Minimal context: no client, no attachments, no capabilities
     const minimalContext: SkillProjectionContext = {
       skillProjectionState: new Map(),
       skillProjectionCache: {},
       coreToolNames: new Set(),
       toolsDisabledDepth: 0,
       hasNoClient: true,
-      hostBashProxy: undefined,
       hasAttachments: false,
       channelCapabilities: undefined,
     };
@@ -55,6 +54,10 @@ describe("always-loaded tool count", () => {
       "file_edit",
       "file_read",
       "file_write",
+      "host_bash",
+      "host_file_edit",
+      "host_file_read",
+      "host_file_write",
       "memory_delete",
       "memory_recall",
       "memory_save",
@@ -66,6 +69,6 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(13);
+    expect(activeTools.length).toBe(17);
   });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -502,8 +502,6 @@ export interface SkillProjectionContext {
   };
   /** True when no client is connected (HTTP-only). */
   readonly hasNoClient?: boolean;
-  /** Host bash proxy — presence indicates host tools should be available. */
-  readonly hostBashProxy?: { isAvailable(): boolean };
   /** True when the conversation has user-uploaded attachments. */
   hasAttachments?: boolean;
 }
@@ -539,7 +537,9 @@ export function isToolActiveForContext(
     return ctx.channelCapabilities?.supportsDynamicUi ?? !ctx.hasNoClient;
   }
   if (HOST_TOOL_NAMES.has(name)) {
-    return !!ctx.hostBashProxy;
+    // Host tools are always available — they have local execution fallbacks
+    // for non-desktop sessions (CLI, headless) when no proxy is connected.
+    return true;
   }
   if (ASSET_TOOL_NAMES.has(name)) {
     return ctx.hasAttachments ?? true;


### PR DESCRIPTION
Host tools (host_file_read, host_file_write, host_file_edit, host_bash) have local execution fallbacks for non-desktop sessions, so they should always be included in tool definitions. The previous filter gated them on hostBashProxy existence, which broke CLI/headless workflows.

Changes:
- Remove `!!ctx.hostBashProxy` gate from `isToolActiveForContext` — host tools now always return true
- Remove dead `hostBashProxy` property from `SkillProjectionContext` interface (no longer referenced)
- Update always-loaded tools guard test: 13 → 17 (host_bash, host_file_read, host_file_write, host_file_edit now always included)

Addresses review feedback on #15196.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
