### PR TITLE
fix: lower browser-skill test count floors after tool migrations

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -43,10 +43,11 @@ describe("browser skill cutover — startup tool payload", () => {
 
   test("total tool definition count reflects removal of 14 browser tools", () => {
     const definitions = getAllToolDefinitions();
-    // Startup has ~31 definitions (no browser tools).
+    // Startup has ~20 definitions after moving scaffold/settings/skill-management
+    // tools to bundled skills (no browser tools).
     // Allow wider drift for unrelated tool additions while still failing if
-    // browser tools are reintroduced at startup (+10 definitions).
-    expect(definitions.length).toBeGreaterThanOrEqual(25);
+    // browser tools are reintroduced at startup (+14 definitions).
+    expect(definitions.length).toBeGreaterThanOrEqual(15);
     expect(definitions.length).toBeLessThanOrEqual(50);
   });
 

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -78,10 +78,11 @@ describe("browser skill migration end-state", () => {
 
   test("startup tool definition count is reduced (no browser tools)", () => {
     const definitions = getAllToolDefinitions();
-    // Startup has ~15 eager + ~11 explicit definitions (no browser tools).
+    // Startup has ~9 definitions after moving scaffold/settings/skill-management
+    // tools to bundled skills (no browser tools).
     // Allow wider drift for unrelated tool additions while still failing if
     // browser tools are reintroduced at startup (+14 definitions).
-    expect(definitions.length).toBeGreaterThanOrEqual(10);
+    expect(definitions.length).toBeGreaterThanOrEqual(5);
     expect(definitions.length).toBeLessThanOrEqual(50);
 
     const defNames = definitions.map((d) => d.name);


### PR DESCRIPTION
## Summary
- Lower `toBeGreaterThanOrEqual` floor in `browser-skill-baseline-tool-payload.test.ts` from 25 → 15 to reflect the reduced startup tool count (~20) after scaffold/settings/skill-management tools were moved to bundled skills
- Lower `toBeGreaterThanOrEqual` floor in `browser-skill-endstate.test.ts` from 10 → 5 to reflect the reduced startup tool count (~9) in that test's mocked config context
- Update comments to reflect the new actual counts

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22934565254/job/66562980597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
