### PR TITLE
fix: register host_file_request in pending interactions for HTTP message paths

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -131,8 +131,9 @@ function resolveCanonicalRequestSourceType(
 
 /**
  * Build an onEvent callback that registers pending interactions when the agent
- * loop emits confirmation_request or secret_request events. This ensures that
- * channel approval interception can look up the session by requestId.
+ * loop emits confirmation_request, secret_request, host_bash_request, or
+ * host_file_request events. This ensures that channel approval interception
+ * can look up the session by requestId.
  */
 function makePendingInteractionRegistrar(
   session: Session,
@@ -205,6 +206,12 @@ function makePendingInteractionRegistrar(
         session,
         conversationId,
         kind: "host_bash",
+      });
+    } else if (msg.type === "host_file_request") {
+      pendingInteractions.register(msg.requestId, {
+        session,
+        conversationId,
+        kind: "host_file",
       });
     }
   };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -363,8 +363,9 @@ export function handleListMessages(
  * assistant event hub, maintaining ordered delivery through a serial chain.
  *
  * Also registers pending interactions when confirmation_request,
- * secret_request, or host_bash_request events flow through, so
- * standalone approval/result endpoints can look up the session by requestId.
+ * secret_request, host_bash_request, or host_file_request events flow
+ * through, so standalone approval/result endpoints can look up the session
+ * by requestId.
  */
 function makeHubPublisher(
   deps: SendMessageDeps,
@@ -440,6 +441,12 @@ function makeHubPublisher(
         session,
         conversationId,
         kind: "host_bash",
+      });
+    } else if (msg.type === "host_file_request") {
+      pendingInteractions.register(msg.requestId, {
+        session,
+        conversationId,
+        kind: "host_file",
       });
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-file-proxy.md.

**Gap:** Missing host_file_request pending interaction registration in server.ts and conversation-routes.ts
**What was expected:** host_file_request events should be registered in pendingInteractions in all message paths
**What was found:** Only the SSE session handler registered them; the two HTTP message paths did not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
