### PR TITLE
fix: wire HostFileProxy lifecycle in HTTP message and reconnection paths

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -57,6 +57,7 @@ import type {
 } from "./handlers/shared.js";
 import type { SkillOperationContext } from "./handlers/skills.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
+import { HostFileProxy } from "./host-file-proxy.js";
 import type { ServerMessage } from "./message-protocol.js";
 import {
   DEFAULT_MEMORY_POLICY,
@@ -650,8 +651,16 @@ export class DaemonServer {
           }),
         );
       }
+      if (!session.isProcessing() || !session.hostFileProxy) {
+        session.setHostFileProxy(
+          new HostFileProxy(session.getCurrentSender(), (requestId) => {
+            pendingInteractions.resolve(requestId);
+          }),
+        );
+      }
     } else if (!session.isProcessing()) {
       session.setHostBashProxy(undefined);
+      session.setHostFileProxy(undefined);
     }
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -17,6 +17,7 @@ import {
 import { getConfig } from "../../config/loader.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
+import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
   buildModelInfoEvent,
@@ -626,8 +627,15 @@ export async function handleSendMessage(
       });
       session.setHostBashProxy(proxy);
     }
+    if (!session.isProcessing() || !session.hostFileProxy) {
+      const fileProxy = new HostFileProxy(onEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
+      session.setHostFileProxy(fileProxy);
+    }
   } else {
     session.setHostBashProxy(undefined);
+    session.setHostFileProxy(undefined);
   }
   // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   // Called after setHostBashProxy so updateSender targets the current proxy.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-file-proxy.md.

**Gap:** Missing HostFileProxy creation/clearing in server.ts and conversation-routes.ts
**What was expected:** HostFileProxy should be managed alongside HostBashProxy in all session lifecycle paths
**What was found:** Only the SSE session handler created HostFileProxy; reconnection paths were missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
