### PR TITLE
fix: add setHostFileProxy to mock sessions in route tests

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -117,6 +117,7 @@ function makeIdleSession(opts?: {
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (
@@ -179,6 +180,7 @@ function makeConfirmationEmittingSession(opts?: {
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -170,6 +170,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -244,6 +245,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -314,6 +316,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: (requestId: string) =>
         requestId === "tool-approval-live",
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -388,6 +391,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "tool-req-code-1",
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -458,6 +462,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-reject-1",
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -522,6 +527,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       trustContext: undefined,
       hasPendingConfirmation: (id: string) => id === "pending-1",
       setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -202,6 +202,7 @@ function makeSession() {
     trustContext: undefined,
     hasPendingConfirmation: () => false,
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     usageStats: {
       inputTokens: 1000,
       outputTokens: 500,

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -168,6 +168,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     setTrustContext: () => {},
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     emitConfirmationStateChanged: () => {},
     emitActivityState: () => {},
     setTurnChannelContext: () => {},

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -116,6 +116,7 @@ function makeCompletingSession(): Session {
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -171,6 +172,7 @@ function makeHangingSession(): Session {
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -254,6 +256,7 @@ function makePendingApprovalSession(
     usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
     updateClient: () => {},
     setHostBashProxy: () => {},
+    setHostFileProxy: () => {},
     hasAnyPendingConfirmation: () => pending.size > 0,
     hasPendingConfirmation: (candidateRequestId: string) =>
       pending.has(candidateRequestId),


### PR DESCRIPTION
## Summary
- Mock session objects in HTTP route tests had `setHostBashProxy` but were missing `setHostFileProxy`, which was added in #15215
- Added `setHostFileProxy: () => {}` to all affected mock sessions across 5 test files

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22934818325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
