### PR TITLE
fix: clean up HostFileProxy.request() API to match HostBashProxy pattern

### DIFF
--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -6,6 +6,12 @@ import { getLogger } from "../util/logger.js";
 import type { ServerMessage } from "./message-protocol.js";
 import type { HostFileRequest } from "./message-types/host-file.js";
 
+/** Clean input type for callers — transport envelope fields are added by the proxy. */
+export type HostFileInput = Omit<
+  HostFileRequest,
+  "type" | "requestId" | "sessionId"
+>;
+
 const log = getLogger("host-file-proxy");
 
 interface PendingRequest {
@@ -37,7 +43,7 @@ export class HostFileProxy {
   }
 
   request(
-    input: HostFileRequest,
+    input: HostFileInput,
     sessionId: string,
     signal?: AbortSignal,
   ): Promise<ToolExecutionResult> {
@@ -79,6 +85,7 @@ export class HostFileProxy {
 
       this.sendToClient({
         ...input,
+        type: "host_file_request",
         requestId,
         sessionId,
       } as ServerMessage);

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -92,9 +92,6 @@ class HostFileEditTool implements Tool {
     if (context.hostFileProxy?.isAvailable()) {
       return context.hostFileProxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: context.sessionId,
           operation: "edit",
           path: rawPath,
           old_string: oldString as string,

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -57,9 +57,6 @@ class HostFileReadTool implements Tool {
     if (context.hostFileProxy?.isAvailable()) {
       return context.hostFileProxy.request(
         {
-          type: "host_file_request",
-          requestId: "", // proxy generates its own
-          sessionId: context.sessionId,
           operation: "read",
           path: rawPath,
           offset: typeof input.offset === "number" ? input.offset : undefined,

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -63,9 +63,6 @@ class HostFileWriteTool implements Tool {
     if (context.hostFileProxy?.isAvailable()) {
       return context.hostFileProxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: context.sessionId,
           operation: "write",
           path: rawPath,
           content: fileContent,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for host-file-proxy.md.

**Gap:** HostFileProxy.request() required callers to pass dummy transport-layer fields
**What was expected:** Clean input type matching HostBashProxy pattern
**What was found:** Callers had to construct full HostFileRequest with requestId: '' and sessionId that gets overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
