### PR TITLE
fix: use distributive omit for HostFileInput type

### DIFF
--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -23,9 +23,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -61,9 +58,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/nonexistent",
         },
@@ -88,9 +82,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "write",
           path: "/tmp/output.txt",
           content: "new content",
@@ -117,9 +108,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "edit",
           path: "/tmp/file.txt",
           old_string: "foo",
@@ -150,9 +138,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/slow.txt",
         },
@@ -180,9 +165,6 @@ describe("HostFileProxy", () => {
       const controller = new AbortController();
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -210,9 +192,6 @@ describe("HostFileProxy", () => {
 
       const result = await proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -253,9 +232,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -282,9 +258,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -323,9 +296,6 @@ describe("HostFileProxy", () => {
       const controller = new AbortController();
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },
@@ -349,9 +319,6 @@ describe("HostFileProxy", () => {
       // Create two pending requests and catch rejections from dispose
       const p1 = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/a.txt",
         },
@@ -359,9 +326,6 @@ describe("HostFileProxy", () => {
       );
       const p2 = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/b.txt",
         },
@@ -388,9 +352,6 @@ describe("HostFileProxy", () => {
 
       const resultPromise = proxy.request(
         {
-          type: "host_file_request",
-          requestId: "",
-          sessionId: "",
           operation: "read",
           path: "/tmp/test.txt",
         },

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -6,8 +6,13 @@ import { getLogger } from "../util/logger.js";
 import type { ServerMessage } from "./message-protocol.js";
 import type { HostFileRequest } from "./message-types/host-file.js";
 
+/** Distributive omit that preserves union variant fields. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
 /** Clean input type for callers — transport envelope fields are added by the proxy. */
-export type HostFileInput = Omit<
+export type HostFileInput = DistributiveOmit<
   HostFileRequest,
   "type" | "requestId" | "sessionId"
 >;


### PR DESCRIPTION
## Summary
- `Omit<Union, Keys>` doesn't distribute over discriminated unions in TypeScript, so fields like `old_string`, `offset`, and `content` were being dropped from `HostFileInput`
- Fixed by using a `DistributiveOmit` helper that distributes the omit over each union member
- Updated tests to use the new `request()` API (omitting `type`, `requestId`, `sessionId` which the proxy adds internally)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22935052176/job/66564562362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
