### PR TITLE
fix: match daemon line number format in Swift host file read

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostFile.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostFile.swift
@@ -129,14 +129,14 @@ extension HTTPTransport {
             lines = Array(lines[..<limit])
         }
 
-        // Format with line numbers matching daemon output format
+        // Format with line numbers matching daemon output format:
+        // 6-char right-padded line number + 2 spaces + content
+        // e.g. "     1  line content"
         let lineNumberStart = max(offset ?? 1, 1)
-        let maxLineNumber = lineNumberStart + lines.count - 1
-        let numberWidth = String(maxLineNumber).count
         let formatted = lines.enumerated().map { index, line in
             let lineNumber = lineNumberStart + index
-            let paddedNumber = String(repeating: " ", count: max(0, numberWidth - String(lineNumber).count)) + "\(lineNumber)"
-            return "\(paddedNumber)\t\(line)"
+            let padded = String(repeating: " ", count: max(0, 6 - String(lineNumber).count)) + "\(lineNumber)"
+            return "\(padded)  \(line)"
         }
 
         return formatted.joined(separator: "\n")


### PR DESCRIPTION
## Summary
Fixes line number format inconsistency between daemon-local and proxy file reads.

**Gap:** Swift client used tab-separated dynamic-width line numbers
**Fix:** Match daemon's exact format (6-char padded number + 2 spaces separator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
