### PR TITLE
fix: address review round 2 gaps for reduce-always-loaded-tools plan

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -97,12 +97,6 @@ import { RiskLevel } from "../permissions/types.js";
 import { getTool, registerTool } from "../tools/registry.js";
 import type { Tool } from "../tools/types.js";
 
-// Import managed skill tools so they register in the tool registry.
-// Without this, classifyRisk falls through to RiskLevel.Medium (unknown tool)
-// instead of the declared RiskLevel.High — producing wrong test behavior.
-import "../tools/skills/scaffold-managed.js";
-import "../tools/skills/delete-managed.js";
-
 // Register a mock skill-origin tool for testing default-ask policy.
 const mockSkillTool: Tool = {
   name: "skill_test_tool",

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -542,7 +542,7 @@ export function isToolActiveForContext(
     return true;
   }
   if (ASSET_TOOL_NAMES.has(name)) {
-    return ctx.hasAttachments ?? true;
+    return ctx.hasAttachments ?? false;
   }
   if (CLIENT_CAPABILITY_TOOL_NAMES.has(name)) {
     return !ctx.hasNoClient;

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -568,7 +568,7 @@ export function buildSwarmGuidanceSection(): string {
   return [
     "## Parallel Task Orchestration",
     "",
-    'Use `swarm_delegate` only when a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"). For single-focus tasks, work directly — do not decompose them into a swarm.',
+    'When a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"), load the `orchestration` skill using `skill_load` first, then use `swarm_delegate` to decompose and run them in parallel. For single-focus tasks, work directly — do not decompose them into a swarm.',
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Change asset tools default from `?? true` to `?? false` so they only load when attachments are present
- Update system prompt swarm/orchestration guidance to direct model to load the orchestration skill first
- Remove dead side-effect imports in checker.test.ts for migrated skill-management tools

Part of plan: reduce-always-loaded-tools.md (review round 2 fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
