### PR TITLE
Refactor system prompt assembly into independently editable section modules

### DIFF
--- a/assistant/src/prompts/sections/core.ts
+++ b/assistant/src/prompts/sections/core.ts
@@ -2,7 +2,7 @@ import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { CLI_HELP_REFERENCE } from "../../cli/reference.js";
-import { getBaseDataDir, getIsContainerized } from "../../config/env-registry.js";
+import { getBaseDataDir } from "../../config/env-registry.js";
 import { getConfig } from "../../config/loader.js";
 import { resolveBundledDir } from "../../util/bundled-asset.js";
 import { getLogger } from "../../util/logger.js";

--- a/assistant/src/prompts/sections/core.ts
+++ b/assistant/src/prompts/sections/core.ts
@@ -1,0 +1,231 @@
+import { copyFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { CLI_HELP_REFERENCE } from "../../cli/reference.js";
+import { getBaseDataDir, getIsContainerized } from "../../config/env-registry.js";
+import { getConfig } from "../../config/loader.js";
+import { resolveBundledDir } from "../../util/bundled-asset.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  getWorkspaceDir,
+  getWorkspacePromptPath,
+} from "../../util/platform.js";
+
+const log = getLogger("system-prompt");
+
+const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
+
+let cachedCliHelp: string | undefined;
+
+/** @internal Reset the CLI help cache — exposed for testing only. */
+export function _resetCliHelpCache(): void {
+  cachedCliHelp = undefined;
+}
+
+/**
+ * Copy template prompt files into the data directory if they don't already exist.
+ * Called once during daemon startup so users always have discoverable files to edit.
+ *
+ * BOOTSTRAP.md is handled separately: it is only created when *none* of the core
+ * prompt files existed beforehand (a truly fresh install).  This prevents the
+ * daemon from recreating the file on every restart after the user deletes it to
+ * signal that onboarding is complete.
+ */
+export function ensurePromptFiles(): void {
+  const templatesDir = resolveBundledDir(
+    import.meta.dirname ?? __dirname,
+    "../templates",
+    "templates",
+  );
+
+  // Track whether this is a fresh workspace (no core prompt files exist yet).
+  const isFirstRun = PROMPT_FILES.every(
+    (file) => !existsSync(getWorkspacePromptPath(file)),
+  );
+
+  for (const file of PROMPT_FILES) {
+    const dest = getWorkspacePromptPath(file);
+    if (existsSync(dest)) continue;
+
+    const src = join(templatesDir, file);
+    try {
+      if (!existsSync(src)) {
+        log.warn({ src }, "Prompt template not found, skipping");
+        continue;
+      }
+      copyFileSync(src, dest);
+      log.info({ file, dest }, "Created prompt file from template");
+    } catch (err) {
+      log.warn({ err, file }, "Failed to create prompt file from template");
+    }
+  }
+
+  // Only seed BOOTSTRAP.md on a truly fresh install so that deleting it
+  // reliably signals onboarding completion across daemon restarts.
+  if (isFirstRun) {
+    const bootstrapDest = getWorkspacePromptPath("BOOTSTRAP.md");
+    if (!existsSync(bootstrapDest)) {
+      const bootstrapSrc = join(templatesDir, "BOOTSTRAP.md");
+      try {
+        if (existsSync(bootstrapSrc)) {
+          copyFileSync(bootstrapSrc, bootstrapDest);
+          log.info(
+            { file: "BOOTSTRAP.md", dest: bootstrapDest },
+            "Created BOOTSTRAP.md for first-run onboarding",
+          );
+        }
+      } catch (err) {
+        log.warn(
+          { err, file: "BOOTSTRAP.md" },
+          "Failed to create BOOTSTRAP.md from template",
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Returns true when BOOTSTRAP.md has been deleted from the workspace,
+ * signalling the first-run ritual is complete.
+ */
+export function isOnboardingComplete(): boolean {
+  const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
+  return !existsSync(bootstrapPath);
+}
+
+/**
+ * Strip lines starting with `_` (comment convention for prompt .md files)
+ * and collapse any resulting consecutive blank lines.
+ *
+ * Lines inside fenced code blocks (``` or ~~~ delimiters per CommonMark)
+ * are never stripped, so code examples with `_`-prefixed identifiers are preserved.
+ */
+export function stripCommentLines(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  let openFenceChar: string | null = null;
+  const filtered = normalized.split("\n").filter((line) => {
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (!openFenceChar) {
+        openFenceChar = char;
+      } else if (char === openFenceChar) {
+        openFenceChar = null;
+      }
+    }
+    if (openFenceChar) return true;
+    return !line.trimStart().startsWith("_");
+  });
+  return filtered
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function readPromptFile(path: string): string | null {
+  if (!existsSync(path)) return null;
+
+  try {
+    const content = stripCommentLines(readFileSync(path, "utf-8"));
+    if (content.length === 0) return null;
+    log.debug({ path }, "Loaded prompt file");
+    return content;
+  } catch (err) {
+    log.warn({ err, path }, "Failed to read prompt file");
+    return null;
+  }
+}
+
+export function buildContainerizedSection(): string {
+  const baseDataDir = getBaseDataDir() ?? "$BASE_DATA_DIR";
+  return [
+    "## Running in a Container — Data Persistence",
+    "",
+    `You are running inside a container. Only the directory \`${baseDataDir}\` is mounted to a persistent volume.`,
+    "",
+    "**Any new files or data you create MUST be written inside that directory, or they will be lost when the container restarts.**",
+    "",
+    "Rules:",
+    `- Always store new data, notes, memories, configs, and downloads under \`${baseDataDir}\``,
+    "- Never write persistent data to system directories, `/tmp`, or paths outside the mounted volume",
+    "- When in doubt, prefer paths nested under the data directory",
+    "- If you create a file that is only needed temporarily (scratch files, intermediate outputs, download staging), delete it when you are done — disk space on the persistent volume is finite and will grow unboundedly if temp files are not cleaned up",
+  ].join("\n");
+}
+
+export function buildConfigSection(): string {
+  // Always use `file_edit` (not `host_file_edit`) for workspace files — file_edit
+  // handles sandbox path mapping internally, and host_file_edit is permission-gated
+  // which would trigger approval prompts for routine workspace updates.
+  const hostWorkspaceDir = getWorkspaceDir();
+
+  const config = getConfig();
+  const configPreamble = `Your configuration directory is \`${hostWorkspaceDir}/\`.`;
+
+  return [
+    "## Configuration",
+    `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
+    `${configPreamble} **Always use \`file_read\` and \`file_edit\` (not \`host_file_read\` / \`host_file_edit\`) for these files** — they are inside your sandbox working directory and do not require host access or user approval:`,
+    "",
+    "- `IDENTITY.md` — Your name, nature, personality, and emoji. Updated during the first-run ritual.",
+    "- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.",
+    "- `USER.md` — Profile of your user. Update as you learn about them over time.",
+    "- `HEARTBEAT.md` — Checklist for periodic heartbeat runs. When heartbeat is enabled, the assistant runs this checklist on a timer and flags anything that needs attention. Edit this file to control what gets checked each run.",
+    "- `BOOTSTRAP.md` — First-run ritual script (only present during onboarding; you delete it when done).",
+    "- `UPDATES.md` — Release update notes (created automatically on new releases; delete when updates are actioned).",
+    "- `skills/` — Directory of installed skills (loaded automatically at startup).",
+    "",
+    "### Heartbeat",
+    "",
+    "The heartbeat feature runs your `HEARTBEAT.md` checklist periodically in a background thread. To enable it, set `heartbeat.enabled: true` and `heartbeat.intervalMs` (default: 3600000 = 1 hour) in `config.json`. You can also set `heartbeat.activeHoursStart` and `heartbeat.activeHoursEnd` (0-23) to restrict runs to certain hours. When asked to set up a heartbeat, edit both the config and `HEARTBEAT.md` directly — no restart is needed for checklist changes, but toggling `heartbeat.enabled` requires a daemon restart.",
+    "",
+    "### Proactive Workspace Editing",
+    "",
+    `You MUST actively update your workspace files as you learn. You don't need to ask your user whether it's okay — just briefly explain what you're updating, then use \`file_edit\` to make targeted edits.`,
+    "",
+    "**USER.md** — update when you learn:",
+    "- Their name or what they prefer to be called",
+    "- Projects they're working on, tools they use, languages they code in",
+    "- Communication preferences (concise vs detailed, formal vs casual)",
+    "- Interests, hobbies, or context that helps you assist them better",
+    "- Anything else about your user that will help you serve them better",
+    "",
+    "**SOUL.md** — update when you notice:",
+    "- They prefer a different tone or interaction style (add to Personality or User-Specific Behavior)",
+    '- A behavioral pattern worth codifying (e.g. "always explain before acting", "skip preamble")',
+    "- You've adapted in a way that's working well and should persist",
+    "- You decide to change your personality to better serve your user",
+    "",
+    "**IDENTITY.md** — update when:",
+    "- They rename you or change your role",
+    "- Your avatar appearance changes (update the `## Avatar` section with a description of the new look)",
+    "",
+    "When reading or updating workspace files, always use the sandbox tools (`file_read`, `file_edit`). Never use `host_file_read` or `host_file_edit` for workspace files — those are for host-only resources outside your workspace.",
+    "",
+    "When updating, read the file first, then make a targeted edit. Include all useful information, but don't bloat the files over time",
+  ].join("\n");
+}
+
+export function buildCliReferenceSection(): string {
+  if (cachedCliHelp === undefined) {
+    cachedCliHelp = CLI_HELP_REFERENCE.trim();
+  }
+
+  return [
+    "## Assistant CLI",
+    "",
+    "The `assistant` CLI is installed on the user's machine and available via `bash`.",
+    "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
+    "- Use `assistant credentials ...` for stored secrets and credential metadata.",
+    "- Use `assistant oauth token <service>` for connected integration tokens.",
+    "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
+    "- Use `assistant platform status` for platform-linked deployment and auth context.",
+    "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",
+    "",
+    "```",
+    cachedCliHelp,
+    "```",
+    "",
+    "Run `assistant <command> --help` for detailed help on any subcommand.",
+  ].join("\n");
+}

--- a/assistant/src/prompts/sections/operations.ts
+++ b/assistant/src/prompts/sections/operations.ts
@@ -1,0 +1,269 @@
+import { getNestedValue, loadRawConfig } from "../../config/loader.js";
+import { listCredentialMetadata } from "../../tools/credentials/metadata-store.js";
+import { isMacOS } from "../../util/platform.js";
+
+export function buildPostToolResponseSection(): string {
+  return [
+    "## Tool Call Timing",
+    "",
+    "**Call tools FIRST, explain AFTER:**",
+    "- When a user request requires a tool, call it immediately at the start of your response",
+    "- If the request needs multiple tool steps, stay silent while you work and respond once you have concrete results",
+    '- Do NOT narrate retries or internal process chatter (for example: "hmm", "that didn\'t work", "let me try...")',
+    "- Speak mid-workflow only when you need user input (permission, clarification, or blocker)",
+    "- Do NOT provide conversational preamble before calling tools",
+    "",
+    "Example (CORRECT):",
+    "  → Call document_create",
+    "  → Call document_update",
+    '  → Text: "Drafted and filled your blog post. Review and tell me what to change."',
+    "",
+    "Example (WRONG):",
+    '  → Text: "I\'ll try one approach... hmm not that... trying again..."',
+    "  → Call document_create",
+    "",
+    "For permission-gated tools, send one short context sentence immediately before the tool call so the user can make an informed allow/deny decision.",
+  ].join("\n");
+}
+
+export function buildToolPermissionSection(): string {
+  return [
+    "## Tool Permissions",
+    "",
+    "Some tools (host_bash, host_file_write, host_file_edit, host_file_read) require your user's approval before they run. When you call one of these tools, your user sees **Allow / Don't Allow** buttons in the chat directly below your message.",
+    "",
+    "**CRITICAL RULE:** You MUST ALWAYS output a text message BEFORE calling any tool that requires approval. NEVER call a permission-gated tool without preceding text. Your user needs context to decide whether to allow.",
+    "",
+    '**IMPORTANT:** If your user has already granted broad approval for the current conversation (e.g. via "Allow for 10 minutes", "Allow for this thread", or "Always Allow"), do NOT ask for permission again. Instead, just briefly describe what you\'re about to do and proceed. Only ask "Can you allow?" on the FIRST tool call when you haven\'t been granted permission yet.',
+    "",
+    "Your text should follow this pattern:",
+    "1. **Acknowledge** the request conversationally.",
+    '2. **Explain what you need at a high level** (e.g. "I\'ll need to look through your Downloads folder"). Do NOT include raw terminal commands or backtick code. Keep it non-technical.',
+    "3. **State safety** in plain language. Is it read-only? Will it change anything?",
+    "4. **Ask for permission** only if this is the first time and you haven't been previously approved. If you have been approved, just say what you're doing.",
+    "",
+    "Style rules:",
+    '- NEVER use em dashes (the long dash). Use commas, periods, or "and" instead.',
+    "- NEVER show raw commands in backticks like `ls -lt ~/Downloads`. Describe the action in plain English.",
+    "- Keep it conversational, like you're talking to a friend.",
+    "",
+    'First time (no prior approval): "To show your recent downloads, I\'ll need to look through your Downloads folder. This is read-only. Can you allow this?"',
+    'Already approved: "Let me check your Downloads folder real quick."',
+    'Bad: "I\'ll run `ls -lt ~/Desktop/`" (raw command), or calling a tool with no preceding text.',
+    "",
+    "### Handling Permission Denials",
+    "",
+    'When your user denies a tool permission (clicks "Don\'t Allow"), you will receive an error indicating the denial. Follow these rules:',
+    "",
+    "1. **Do NOT immediately retry the tool call.** Retrying without waiting creates another permission prompt, which is annoying and disrespectful of the user's decision.",
+    "2. **Acknowledge the denial.** Tell the user that the action was not performed because they chose not to allow it.",
+    "3. **Ask before retrying.** Ask if they would like you to try again, or if they would prefer a different approach.",
+    "4. **Wait for an explicit response.** Only retry the tool call after the user explicitly confirms they want you to try again.",
+    "5. **Offer alternatives.** If possible, suggest alternative approaches that might not require the denied permission.",
+    "",
+    "Example:",
+    '- Tool denied → "No problem! I wasn\'t able to access your Downloads folder since you chose not to allow it. Would you like me to try again, or is there another way I can help?"',
+    "",
+    "### Always-Available Tools (No Approval Required)",
+    "",
+    "- **file_read** on your workspace directory — You can freely read any file under your `.vellum` workspace at any time. Use this proactively to check files, load context, and inform your responses without asking. **Always use `file_read` for workspace files (IDENTITY.md, USER.md, SOUL.md, etc.), never `host_file_read`.**",
+    "- **web_search** — You can search the web at any time without approval. Use this to look up documentation, current information, or anything you need.",
+  ].join("\n");
+}
+
+export function buildSystemPermissionSection(): string {
+  return [
+    "## System Permissions",
+    "",
+    'When a tool execution fails with a permission/access error (e.g. "Operation not permitted", "EACCES", sandbox denial), use `request_system_permission` to ask your user to grant the required macOS permission through System Settings.',
+    "",
+    "Common cases:",
+    "- Reading files in ~/Documents, ~/Desktop, ~/Downloads → `full_disk_access`",
+    "- Screen capture / recording → `screen_recording`",
+    "- Accessibility / UI automation → `accessibility`",
+    "",
+    "Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.",
+  ].join("\n");
+}
+
+export function buildAttachmentSection(): string {
+  return [
+    "## Sending Files to the User",
+    "",
+    "To deliver any file you create or download (images, videos, PDFs, audio, etc.) to the user, you MUST include a self-closing XML tag in your response text:",
+    "",
+    "```",
+    '<vellum-attachment source="sandbox" path="scratch/output.png" />',
+    "```",
+    "",
+    "**CRITICAL:** This tag is the ONLY way files reach the user. If you save a file to disk but do not include the tag, the user will NOT see it. Always emit the tag after creating or downloading a file.",
+    "",
+    "- `source`: `sandbox` (default, files inside the sandbox working directory) or `host` (absolute paths on the host filesystem — requires user approval).",
+    "- `path`: Required. Relative path for sandbox, absolute path for host.",
+    "- `filename`: Optional override for the delivered filename (defaults to the basename of the path).",
+    "- `mime_type`: Optional MIME type override (inferred from the file extension if omitted).",
+    "",
+    'Example: `<vellum-attachment source="sandbox" path="scratch/chart.png" />`',
+    "",
+    "Limits: up to 5 attachments per turn, 20 MB each. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
+    "",
+    "### Inline Images and GIFs",
+    "Embed images/GIFs inline using markdown: `![description](URL)`. Do NOT wrap in code fences.",
+  ].join("\n");
+}
+
+export function buildInChatConfigurationSection(): string {
+  return [
+    "## In-Chat Configuration",
+    "",
+    "When the user needs to configure a value (API keys, OAuth credentials, webhook URLs, or any setting that can be changed from the Settings page), **always collect it conversationally in the chat first** rather than directing them to the Settings page.",
+    "",
+    "**How to collect credentials and secrets:**",
+    '- Use `credential_store` with `action: "prompt"` to present a secure input field. The value never appears in the conversation.',
+    '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser. Some services (e.g. Twitter/X) define their own auth flow via dedicated skill instructions — check the service\'s skill documentation for provider-specific setup steps.',
+    "- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate config tool to persist the value.",
+    "",
+    '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',
+    "",
+    "**Never tell the user to go to Settings to enter a value.** The Settings page is for reviewing and updating existing configuration, not for initial setup. Always prefer the in-chat flow for first-time configuration.",
+    "",
+    "### Avatar Customisation",
+    "",
+    'You can change your avatar appearance using the `set_avatar` tool. When the user asks to change, update, or customise your avatar, use `set_avatar` with a `description` parameter describing the desired appearance (e.g. "a friendly purple cat with green eyes wearing a tiny hat"). The tool generates an avatar image and updates all connected clients automatically. If managed avatar generation is configured, no local API key is needed.',
+    "",
+    "**After generating a new avatar**, always update the `## Avatar` section in `IDENTITY.md` with a brief description of the current avatar appearance. This ensures you remember what you look like across sessions. Example:",
+    "```",
+    "## Avatar",
+    "A friendly purple cat with green eyes wearing a tiny hat",
+    "```",
+  ].join("\n");
+}
+
+export function buildStarterTaskPlaybookSection(): string {
+  return [
+    "## Starter Task Playbooks",
+    "",
+    "When the user clicks a starter task card in the dashboard, you receive a deterministic kickoff message in the format `[STARTER_TASK:<task_id>]`. Follow the playbook for that task exactly.",
+    "",
+    "### Kickoff intent contract",
+    '- `[STARTER_TASK:make_it_yours]` — "Make it yours" color personalisation flow',
+    '- `[STARTER_TASK:research_topic]` — "Research something for me" flow',
+    '- `[STARTER_TASK:research_to_ui]` — "Turn it into a webpage or interactive UI" flow',
+    "",
+    "### Playbook: make_it_yours",
+    "Goal: Help the user choose an accent color preference for apps and interfaces.",
+    "",
+    "1. If the user's locale is missing or has `confidence: low` in USER.md, briefly confirm their location/language before proceeding.",
+    "2. Present a concise set of accent color options (e.g. 5-7 curated colors with names and hex codes). Keep it short and scannable.",
+    '3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").',
+    '4. Confirm the selection: "I\'ll set your accent color to **{label}** ({hex}). Sound good?"',
+    "5. On confirmation:",
+    '   - Use `app_file_edit` to update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.',
+    "   - Use `app_file_edit` to update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.",
+    "6. If the user declines or wants to skip, set `make_it_yours` to `skipped` in USER.md and move on.",
+    "",
+    "### Playbook: research_topic",
+    "Goal: Research a topic the user is interested in and summarise findings.",
+    "",
+    '1. Ask the user what topic they\'d like researched. Be specific: "What would you like me to look into?"',
+    "2. Once given a topic, use available tools (web search, browser, etc.) to gather information.",
+    "3. Synthesise the findings into a clear, well-structured summary.",
+    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_topic` to `done`.",
+    "",
+    "### Playbook: research_to_ui",
+    "Goal: Transform research (from a prior research_topic task or current conversation context) into a visual webpage or interactive UI.",
+    "",
+    "1. Check the conversation history for prior research content. If none exists, ask the user what content they'd like visualised.",
+    "2. Synthesise the research into a polished, interactive HTML page using `app_create`.",
+    "3. Follow all Dynamic UI quality standards (anti-AI-slop rules, design tokens, hover states, etc.).",
+    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_to_ui` to `done`.",
+    "",
+    "### General rules for all starter tasks",
+    "- Update the relevant task status in the `## Onboarding Tasks` section of USER.md as you progress (`in_progress` when starting, `done` when complete).",
+    "- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.",
+    "- Keep responses concise and action-oriented. Avoid lengthy explanations of what you're about to do.",
+    "- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.",
+  ].join("\n");
+}
+
+export function buildSwarmGuidanceSection(): string {
+  return [
+    "## Parallel Task Orchestration",
+    "",
+    'When a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"), load the `orchestration` skill using `skill_load` first, then use `swarm_delegate` to decompose and run them in parallel. For single-focus tasks, work directly — do not decompose them into a swarm.',
+  ].join("\n");
+}
+
+export function buildAccessPreferenceSection(): string {
+  return [
+    "## External Service Access Preference",
+    "",
+    "When interacting with external services (GitHub, Slack, Linear, Jira, cloud providers, etc.),",
+    "follow this priority order:",
+    "",
+    "1. **Sandbox first (`bash`)** — Always try to do things in your own sandbox environment first.",
+    "   If a tool (git, curl, jq, etc.) is not installed, install it yourself using `bash`",
+    "   (e.g. `apt-get install -y git`). The sandbox is your own machine — you have full control.",
+    "   Only fall back to host tools when you genuinely need access to the user's local files,",
+    "   environment, or host-specific resources (e.g. their local git repos, host-installed CLIs",
+    "   with existing auth, macOS-specific apps).",
+    "2. **CLI tools via host_bash** — If you need access to the user's host environment and a CLI",
+    "   is installed on their machine (gh, slack, linear, jira, aws, gcloud, etc.), use it.",
+    "   CLIs handle auth, pagination, and output formatting.",
+    "   Use --json or equivalent flags for structured output when available.",
+    "3. **Direct API calls via host_bash** — Use curl/httpie with API tokens from credential_store.",
+    "   Faster and more reliable than browser automation.",
+    "4. **web_fetch** — For public endpoints or simple API calls that don't need auth.",
+    "5. **Browser automation as last resort** — Only when the task genuinely requires a browser",
+    "   (e.g., no API exists, visual interaction needed, or OAuth consent screen).",
+    "",
+    "Before reaching for host tools or browser automation, ask yourself:",
+    "- Can I do this entirely in my sandbox? (install tools, clone repos, run commands)",
+    "- Do I actually need something from the user's host machine?",
+    "",
+    "If you can do it in your sandbox, do it there. Only use host tools when you need the user's",
+    "local files, credentials, or host-specific capabilities.",
+    ...(isMacOS()
+      ? [
+          "",
+          "On macOS, also consider the `macos-automation` skill for interacting with native apps",
+          "(Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript.",
+          "",
+          "### Foreground Computer Use — Last Resort",
+          "",
+          "Foreground computer use (`computer_use_request_control`) takes over the user's cursor and",
+          "keyboard. It is disruptive and should be your LAST resort. Prefer this hierarchy:",
+          "",
+          "1. **CLI tools / osascript** — Use `host_bash` with shell commands or `osascript` with",
+          "   AppleScript to accomplish tasks in the background without interrupting the user.",
+          "2. **Background computer use** — If you must interact with a GUI app, prefer AppleScript",
+          '   automation (e.g. `tell application "Safari" to set URL of current tab to ...`).',
+          "3. **Foreground computer use** — Only escalate via `computer_use_request_control` when",
+          "   the task genuinely cannot be done any other way (e.g. complex multi-step GUI interactions",
+          "   with no scripting support) or the user explicitly asks you to take control.",
+        ]
+      : []),
+  ].join("\n");
+}
+
+export function buildIntegrationSection(): string {
+  const allCreds = listCredentialMetadata();
+  // Show OAuth2-connected services (those with oauth2TokenUrl in metadata)
+  const oauthCreds = allCreds.filter(
+    (c) => c.oauth2TokenUrl && c.field === "access_token",
+  );
+  if (oauthCreds.length === 0) return "";
+
+  const raw = loadRawConfig();
+  const lines = ["## Connected Services", ""];
+  for (const cred of oauthCreds) {
+    const acctInfo = getNestedValue(
+      raw,
+      `integrations.accountInfo.${cred.service}`,
+    ) as string | undefined;
+    const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
+    lines.push(`- **${cred.service}**: ${state}`);
+  }
+
+  return lines.join("\n");
+}

--- a/assistant/src/prompts/sections/persistence.ts
+++ b/assistant/src/prompts/sections/persistence.ts
@@ -1,0 +1,66 @@
+export function buildMemoryPersistenceSection(): string {
+  return [
+    "## Memory Persistence",
+    "",
+    "Your memory does not survive session restarts. If you want to remember something, **save it**.",
+    "",
+    "- Use `memory_save` for facts, preferences, learnings, and anything worth recalling later.",
+    "- Update workspace files (USER.md, SOUL.md) for profile and personality changes.",
+    '- When someone says "remember this," save it immediately — don\'t rely on keeping it in context.',
+    "- When you make a mistake, save the lesson so future-you doesn't repeat it.",
+    "",
+    "Saved > unsaved. Always.",
+  ].join("\n");
+}
+
+export function buildMemoryRecallSection(): string {
+  return [
+    "## Memory Recall",
+    "",
+    "You have access to a `memory_recall` tool for deep memory retrieval. Use it when:",
+    "",
+    "- The user asks about past conversations, decisions, or context you don't have in the current window",
+    "- You need to recall specific facts, preferences, or project details",
+    "- The auto-injected memory context doesn't contain what you need",
+    "- The user references something from a previous session",
+    "",
+    "The tool searches across semantic, lexical, entity graph, and recency sources. Be specific in your query for best results.",
+  ].join("\n");
+}
+
+export function buildWorkspaceReflectionSection(): string {
+  return [
+    "## Workspace Reflection",
+    "",
+    "Before you finish responding to a conversation, pause and consider: did you learn anything worth saving?",
+    "",
+    "- Did your user share personal facts (name, role, timezone, preferences)?",
+    "- Did they correct your behavior or express a preference about how you communicate?",
+    "- Did they mention a project, tool, or workflow you should remember?",
+    "- Did you adapt your style in a way that worked well and should persist?",
+    "",
+    "If yes, briefly explain what you're updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.",
+  ].join("\n");
+}
+
+export function buildLearningMemorySection(): string {
+  return [
+    "## Learning from Mistakes",
+    "",
+    "When you make a mistake, hit a dead end, or discover something non-obvious, save it to memory so you don't repeat it.",
+    "",
+    'Use `memory_save` with `kind: "learning"` for:',
+    "- **Mistakes and corrections** — wrong assumptions, failed approaches, gotchas you ran into",
+    "- **Discoveries** — undocumented behaviors, surprising API quirks, things that weren't obvious",
+    "- **Working solutions** — the approach that actually worked after trial and error",
+    "- **Tool/service insights** — rate limits, auth flows, CLI flags that matter",
+    "",
+    "The statement should capture both what happened and the takeaway. Write it as advice to your future self.",
+    "",
+    "Examples:",
+    '- `memory_save({ kind: "learning", subject: "macOS Shortcuts CLI", statement: "shortcuts CLI requires full disk access to export shortcuts — if permission is denied, guide the user to grant it in System Settings rather than retrying." })`',
+    '- `memory_save({ kind: "learning", subject: "Gmail API pagination", statement: "Gmail search returns max 100 results per page. Always check nextPageToken and loop if the user asks for \'all\' messages." })`',
+    "",
+    "Don't overthink it. If you catch yourself thinking \"I'll remember that for next time,\" save it.",
+  ].join("\n");
+}

--- a/assistant/src/prompts/sections/routing.ts
+++ b/assistant/src/prompts/sections/routing.ts
@@ -1,0 +1,212 @@
+import { resolveUserPronouns, resolveUserReference } from "../user-reference.js";
+
+export function buildTaskScheduleReminderRoutingSection(): string {
+  return [
+    "## Tool Routing: Tasks vs Schedules vs Notifications",
+    "",
+    'Three tools, each for a different purpose. Load the "Time-Based Actions" skill for the full decision framework.',
+    "",
+    "| Tool | Purpose |",
+    "|------|---------|",
+    '| `task_list_add` | Track work — no time trigger ("add to my tasks", "remind me to X" without a time) |',
+    '| `schedule_create` | Any time-based automation — recurring cron/RRULE ("every day at 9am") OR one-shot future alert with `fire_at` ("remind me at 3pm") |',
+    "| `send_notification` | **Immediate-only** — fires instantly, NO delay capability |",
+    "",
+    "### Critical: `send_notification` is immediate-only",
+    "NEVER use `send_notification` for future-time requests — it fires NOW. Use `schedule_create` with `fire_at` for any delayed alert.",
+    "",
+    "### Quick routing rules",
+    "- Future time, one-shot → `schedule_create` with `fire_at`",
+    "- Recurring pattern → `schedule_create`",
+    "- No time, track as work → `task_list_add`",
+    "- Instant alert → `send_notification`",
+    "- Modify existing task → `task_list_update` (NOT `task_list_add`)",
+    "- Remove task → `task_list_remove` (NOT `task_list_update`)",
+    "",
+    "### Entity type routing: work items vs task templates",
+    "",
+    "Two entity types with separate ID spaces — do NOT mix:",
+    "- **Work items** (task queue) — task_list_add, task_list_show, task_list_update, task_list_remove",
+    "- **Task templates** (reusable definitions) — task_save, task_list, task_run, task_delete",
+    "",
+    'If an error says "entity mismatch", read the corrective action and selector fields it provides to pick the right tool.',
+    "",
+  ].join("\n");
+}
+
+export function buildVerificationRoutingSection(): string {
+  return [
+    "## Routing: Guardian Verification",
+    "",
+    "When the user wants to verify their identity as the trusted guardian for a messaging channel, load the **Guardian Verify Setup** skill.",
+    'Interpret phrasing like "help me set myself up as your guardian" as the user asking to verify themselves as guardian (not asking the assistant to self-assign permissions).',
+    'Do not give conceptual "I cannot set myself as guardian" explanations unless the user explicitly asks a conceptual/security question.',
+    "",
+    "### Trigger phrases",
+    '- "verify guardian"',
+    '- "verify my Telegram account"',
+    '- "verify phone channel"',
+    '- "verify my phone number"',
+    '- "set up guardian verification"',
+    "",
+    "### What it does",
+    "The skill walks through outbound guardian verification for phone or Telegram:",
+    "1. Confirm channel (phone, telegram)",
+    "2. Collect destination (phone number or Telegram handle/chat ID)",
+    "3. Start outbound verification via runtime HTTP API",
+    "4. Guide the user through code entry, resend, or cancel",
+    "",
+    'Load with: `skill_load` using `skill: "guardian-verify-setup"`',
+    "",
+    "### Exclusivity rules",
+    "- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.",
+    "- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.",
+    '- If the user asks to "load phone-calls and guardian verification", prioritize `guardian-verify-setup` and continue the verification flow. Only load `phone-calls` if the user also asks to configure or place regular calls.',
+    '- If the user has already explicitly specified a channel (e.g., "verify my phone for voice", "verify my Telegram"), do not re-ask which channel unless the input is contradictory.',
+  ].join("\n");
+}
+
+export function buildVoiceSetupRoutingSection(): string {
+  return [
+    "## Routing: Voice Setup & Troubleshooting",
+    "",
+    "Voice features include push-to-talk (PTT), wake word detection, and text-to-speech.",
+    "",
+    "### Quick changes — use `voice_config_update` directly",
+    '- "Change my PTT key to ctrl" — call `voice_config_update` with `setting: "activation_key"`',
+    '- "Enable wake word" — call `voice_config_update` with `setting: "wake_word_enabled"`, `value: true`',
+    '- "Set my wake word to jarvis" — call `voice_config_update` with `setting: "wake_word_keyword"`',
+    '- "Set wake word timeout to 30 seconds" — call `voice_config_update` with `setting: "wake_word_timeout"`',
+    "",
+    "For simple setting changes, use the tool directly without loading the voice-setup skill.",
+    "",
+    "### Guided setup or troubleshooting — load the voice-setup skill",
+    'Load with: `skill_load` using `skill: "voice-setup"`',
+    "",
+    "**Trigger phrases:**",
+    '- "Help me set up voice"',
+    '- "Set up push-to-talk"',
+    '- "Configure voice / PTT / wake word"',
+    '- "PTT isn\'t working" / "push-to-talk not working"',
+    '- "Recording but no text"',
+    '- "Wake word not detecting"',
+    '- "Microphone not working"',
+    '- "Set up ElevenLabs" / "configure TTS"',
+    "",
+    "### Disambiguation",
+    "- Voice setup (this skill) = **local PTT, wake word, microphone permissions** on the Mac desktop app.",
+    "- Phone calls skill = **Twilio-powered voice calls** over the phone network. Completely separate.",
+    '- If the user says "voice" in the context of phone calls or Twilio, load `phone-calls` instead.',
+  ].join("\n");
+}
+
+export function buildPhoneCallsRoutingSection(): string {
+  return [
+    "## Routing: Phone Calls",
+    "",
+    "When the user asks to set up phone calling, place a call, configure Twilio for voice, or anything related to outbound/inbound phone calls, load the **Phone Calls** skill.",
+    "",
+    "### Trigger phrases",
+    '- "Set up phone calling" / "enable calls"',
+    '- "Make a call to..." / "call [number/business]"',
+    '- "Configure Twilio" (in context of voice calls)',
+    '- "Can you make phone calls?"',
+    '- "Set up my phone number" (for calling)',
+    "",
+    "### What it does",
+    "The skill handles the full phone calling lifecycle:",
+    "1. Twilio credential setup (delegates to twilio-setup skill)",
+    "2. Public ingress configuration (delegates to public-ingress skill)",
+    "3. Enabling the calls feature",
+    "4. Placing outbound calls and receiving inbound calls",
+    "5. Voice quality configuration (standard Twilio TTS or ElevenLabs)",
+    "",
+    'Load with: `skill_load` using `skill: "phone-calls"`',
+    "",
+    "### Exclusivity rules",
+    "- Do NOT improvise Twilio setup instructions from general knowledge — always load the skill first.",
+    "- Do NOT confuse with voice-setup (local PTT/wake word/microphone) or guardian-verify-setup (channel verification).",
+    '- If the user says "voice" in the context of phone calls or Twilio, load phone-calls, not voice-setup.',
+    "- For guardian voice verification specifically, load guardian-verify-setup instead.",
+  ].join("\n");
+}
+
+export function buildChannelAwarenessSection(): string {
+  return [
+    "## Channel Awareness & Trust Gating",
+    "",
+    "Each turn may include a `<channel_capabilities>` block in the user message describing what the current channel supports. Use this to adapt your behaviour:",
+    "",
+    "### Channel-specific rules",
+    "- When `dashboard_capable` is `false`, never reference the dashboard UI, settings panels, dynamic pages, or visual pickers. Present data as formatted text.",
+    "- When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`.",
+    "- When `supports_voice_input` is `false`, do not ask the user to speak or use their microphone.",
+    "- Non-dashboard channels should defer dashboard-specific actions. Tell the user they can complete those steps later from the desktop app.",
+    "",
+    "### Permission ask trust gating",
+    "- Do NOT proactively ask for elevated permissions (microphone, computer control, file access) until the trust stage field `firstConversationComplete` in USER.md is `true`.",
+    "- Even after `firstConversationComplete`, only ask for permissions that are relevant to the current channel capabilities.",
+    "- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.",
+    "- Do not ask for computer-control permissions on non-dashboard channels.",
+    "- When you do request a permission, be transparent about what it enables and why you need it.",
+    "",
+    "### Push-to-talk awareness",
+    "- The `<channel_capabilities>` block may include `ptt_activation_key` and `ptt_enabled` fields indicating the user's push-to-talk configuration.",
+    '- You can change the push-to-talk activation key using the `voice_config_update` tool. The key is provided as a JSON PTTActivator payload (e.g. `{"kind":"modifierOnly","modifierFlags":8388608}` for Fn).',
+    "- When the user asks about voice input or push-to-talk settings, use the tool to apply changes directly rather than directing them to settings.",
+    "- When `microphone_permission_granted` is `false`, guide the user to grant microphone access in System Settings before using voice features.",
+    "",
+    "### Group chat etiquette",
+    "- In group chats, you are a **participant**, not the user's proxy. Think before you speak.",
+    "- **Respond when:** directly mentioned, you can add genuine value, something witty fits naturally, or correcting important misinformation.",
+    '- **Stay silent when:** it\'s casual banter between humans, someone already answered, your response would just be "yeah" or "nice", or the conversation flows fine without you.',
+    "- **The human rule:** humans don't respond to every message in a group chat. Neither should you. Quality over quantity.",
+    "- On platforms with reactions (Discord, Slack), use emoji reactions naturally to acknowledge without cluttering.",
+    "",
+    "### Platform formatting",
+    "- **Discord/WhatsApp:** Do not use markdown tables — use bullet lists instead.",
+    "- **Discord links:** Wrap multiple links in `<>` to suppress embeds.",
+    "- **WhatsApp:** No markdown headers — use **bold** or CAPS for emphasis.",
+  ].join("\n");
+}
+
+export function buildChannelCommandIntentSection(): string {
+  return [
+    "## Channel Command Intents",
+    "",
+    "Some channel turns include a `<channel_command_context>` block indicating the user triggered a bot command (e.g. Telegram `/start`).",
+    "",
+    "### `/start` command",
+    "When `command_type` is `start`:",
+    "- Generate a warm, friendly greeting as if the user just arrived for the first time.",
+    "- Keep it brief (1-3 sentences). Do not be verbose or list capabilities.",
+    '- If the user message is `/start` verbatim, treat the entire user intent as "I just started chatting with this bot, say hello."',
+    "- If a `payload` field is present (deep link), acknowledge what the payload references if you recognise it, but still greet warmly.",
+    '- Do NOT reset the conversation, clear history, or treat this as a "new conversation" command.',
+    "- Do NOT mention `/start` or any slash commands in your response.",
+    "- Respond in the same language as the user's locale if available from channel context, otherwise default to English.",
+  ].join("\n");
+}
+
+export function buildExternalCommsIdentitySection(): string {
+  const userRef = resolveUserReference();
+  const userPronouns = resolveUserPronouns();
+  const lines = [
+    "## External Communications Identity",
+    "",
+    "When communicating with people outside your user's household (phone calls, messages to non-guardian contacts, emails to third parties, etc.):",
+    "",
+    `- Refer to yourself as an **assistant**, not an "AI assistant" or "artificial intelligence". Keep identity framing simple and natural.`,
+    `- When introducing who you represent, say you are acting on behalf of **${userRef}**.`,
+  ];
+  if (userPronouns) {
+    lines.push(
+      `- Your user's pronouns are **${userPronouns}**. Use these when referring to your user in the third person.`,
+    );
+  }
+  lines.push(
+    "- Do not volunteer that you are an AI unless directly asked. If asked, answer honestly.",
+    "- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.",
+  );
+  return lines.join("\n");
+}

--- a/assistant/src/prompts/sections/skills.ts
+++ b/assistant/src/prompts/sections/skills.ts
@@ -1,0 +1,130 @@
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { skillFlagKey } from "../../config/skill-state.js";
+import { loadSkillCatalog, type SkillSummary } from "../../config/skills.js";
+
+export function appendSkillsCatalog(basePrompt: string): string {
+  const skills = loadSkillCatalog();
+  const config = getConfig();
+
+  // Filter out skills whose assistant feature flag is explicitly OFF
+  const flagFiltered = skills.filter((s) => {
+    const flagKey = skillFlagKey(s);
+    return !flagKey || isAssistantFeatureFlagEnabled(flagKey, config);
+  });
+
+  const sections: string[] = [basePrompt];
+
+  const catalog = formatSkillsCatalog(flagFiltered);
+  if (catalog) sections.push(catalog);
+
+  sections.push(buildDynamicSkillWorkflowSection(config, flagFiltered));
+
+  return sections.join("\n\n");
+}
+
+function buildDynamicSkillWorkflowSection(
+  _config: import("../../config/schema.js").AssistantConfig,
+  activeSkills: SkillSummary[],
+): string {
+  const lines = [
+    "## Dynamic Skill Authoring Workflow",
+    "",
+    "When no existing tool or skill can satisfy a request:",
+    "1. Validate the gap — confirm no existing tool/skill covers it.",
+    "2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).",
+    '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
+    "4. Persist with `scaffold_managed_skill` only after user consent.",
+    "5. Load with `skill_load` before use.",
+    "",
+    "**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.",
+    "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
+  ];
+
+  const activeSkillIds = new Set(activeSkills.map((s) => s.id));
+
+  if (activeSkillIds.has("browser")) {
+    lines.push(
+      "",
+      "### Browser Skill Prerequisite",
+      'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
+    );
+  }
+
+  if (activeSkillIds.has("messaging")) {
+    lines.push(
+      "",
+      "### Messaging Skill",
+      'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Build a dynamic description for the mcp-setup skill that includes
+ * configured MCP server names, so the model knows which servers exist.
+ */
+function getMcpSetupDescription(): string {
+  const config = getConfig();
+  const servers = config.mcp?.servers;
+  if (!servers || Object.keys(servers).length === 0) {
+    return "Add, authenticate, list, and remove MCP (Model Context Protocol) servers";
+  }
+
+  const serverNames = Object.keys(servers);
+  return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load this skill to check status, authenticate, or add/remove servers.`;
+}
+
+function formatSkillsCatalog(skills: SkillSummary[]): string {
+  // Filter out skills with disableModelInvocation or unsupported OS
+  const visible = skills.filter((s) => {
+    if (s.disableModelInvocation) return false;
+    const os = s.metadata?.os;
+    if (os && os.length > 0 && !os.includes(process.platform)) return false;
+    return true;
+  });
+  if (visible.length === 0) return "";
+
+  const lines = ["<available_skills>"];
+  for (const skill of visible) {
+    const idAttr = escapeXml(skill.id);
+    const nameAttr = escapeXml(skill.displayName);
+    const descAttr =
+      skill.id === "mcp-setup"
+        ? escapeXml(getMcpSetupDescription())
+        : escapeXml(skill.description);
+    const locAttr = escapeXml(skill.directoryPath);
+    const credAttr = skill.credentialSetupFor
+      ? ` credential-setup-for="${escapeXml(skill.credentialSetupFor)}"`
+      : "";
+    lines.push(
+      `<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}"${credAttr} />`,
+    );
+  }
+  lines.push("</available_skills>");
+
+  return [
+    "## Available Skills",
+    "The following skills are available. Before executing one, call the `skill_load` tool with its `id` to load the full instructions.",
+    "When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill.",
+    "",
+    lines.join("\n"),
+    "",
+    "### Installing additional skills",
+    "If `skill_load` fails because a skill is not found, additional first-party skills may be available in the Vellum catalog.",
+    "Use `bash` to discover and install them:",
+    "- `assistant skills list` — list all available catalog skills",
+    "- `assistant skills install <skill-id>` — install a skill, then retry `skill_load`",
+  ].join("\n");
+}

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,8 +1,7 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
-
 import {
   buildCliReferenceSection,
   buildConfigSection,
@@ -50,7 +49,6 @@ export {
   isOnboardingComplete,
   stripCommentLines,
 } from "./sections/core.js";
-
 export {
   buildAccessPreferenceSection,
   buildAttachmentSection,
@@ -62,14 +60,12 @@ export {
   buildSystemPermissionSection,
   buildToolPermissionSection,
 } from "./sections/operations.js";
-
 export {
   buildLearningMemorySection,
   buildMemoryPersistenceSection,
   buildMemoryRecallSection,
   buildWorkspaceReflectionSection,
 } from "./sections/persistence.js";
-
 export {
   buildChannelAwarenessSection,
   buildChannelCommandIntentSection,
@@ -79,7 +75,6 @@ export {
   buildVerificationRoutingSection,
   buildVoiceSetupRoutingSection,
 } from "./sections/routing.js";
-
 export { appendSkillsCatalog } from "./sections/skills.js";
 
 /**

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,103 +1,86 @@
-import { copyFileSync, existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-
-import { CLI_HELP_REFERENCE } from "../cli/reference.js";
+import { getIsContainerized } from "../config/env-registry.js";
+import { getConfig } from "../config/loader.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
-import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
-import { skillFlagKey } from "../config/skill-state.js";
-import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
-import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
-import { resolveBundledDir } from "../util/bundled-asset.js";
-import { getLogger } from "../util/logger.js";
+import { getWorkspacePromptPath } from "../util/platform.js";
+
 import {
-  getWorkspaceDir,
-  getWorkspacePromptPath,
-  isMacOS,
-} from "../util/platform.js";
-import { resolveUserPronouns, resolveUserReference } from "./user-reference.js";
+  buildCliReferenceSection,
+  buildConfigSection,
+  buildContainerizedSection,
+  isOnboardingComplete,
+  readPromptFile,
+} from "./sections/core.js";
+import {
+  buildAccessPreferenceSection,
+  buildAttachmentSection,
+  buildInChatConfigurationSection,
+  buildIntegrationSection,
+  buildPostToolResponseSection,
+  buildStarterTaskPlaybookSection,
+  buildSwarmGuidanceSection,
+  buildSystemPermissionSection,
+  buildToolPermissionSection,
+} from "./sections/operations.js";
+import {
+  buildLearningMemorySection,
+  buildMemoryPersistenceSection,
+  buildMemoryRecallSection,
+  buildWorkspaceReflectionSection,
+} from "./sections/persistence.js";
+import {
+  buildChannelAwarenessSection,
+  buildChannelCommandIntentSection,
+  buildExternalCommsIdentitySection,
+  buildPhoneCallsRoutingSection,
+  buildTaskScheduleReminderRoutingSection,
+  buildVerificationRoutingSection,
+  buildVoiceSetupRoutingSection,
+} from "./sections/routing.js";
+import { appendSkillsCatalog } from "./sections/skills.js";
 
-const log = getLogger("system-prompt");
+// ── Re-exports ──
+// Preserve the public API so existing importers continue to work.
 
-const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
+export {
+  _resetCliHelpCache,
+  buildCliReferenceSection,
+  buildConfigSection,
+  buildContainerizedSection,
+  ensurePromptFiles,
+  isOnboardingComplete,
+  stripCommentLines,
+} from "./sections/core.js";
 
-let cachedCliHelp: string | undefined;
+export {
+  buildAccessPreferenceSection,
+  buildAttachmentSection,
+  buildInChatConfigurationSection,
+  buildIntegrationSection,
+  buildPostToolResponseSection,
+  buildStarterTaskPlaybookSection,
+  buildSwarmGuidanceSection,
+  buildSystemPermissionSection,
+  buildToolPermissionSection,
+} from "./sections/operations.js";
 
-/** @internal Reset the CLI help cache — exposed for testing only. */
-export function _resetCliHelpCache(): void {
-  cachedCliHelp = undefined;
-}
+export {
+  buildLearningMemorySection,
+  buildMemoryPersistenceSection,
+  buildMemoryRecallSection,
+  buildWorkspaceReflectionSection,
+} from "./sections/persistence.js";
 
-/**
- * Copy template prompt files into the data directory if they don't already exist.
- * Called once during daemon startup so users always have discoverable files to edit.
- *
- * BOOTSTRAP.md is handled separately: it is only created when *none* of the core
- * prompt files existed beforehand (a truly fresh install).  This prevents the
- * daemon from recreating the file on every restart after the user deletes it to
- * signal that onboarding is complete.
- */
-export function ensurePromptFiles(): void {
-  const templatesDir = resolveBundledDir(
-    import.meta.dirname ?? __dirname,
-    "templates",
-    "templates",
-  );
+export {
+  buildChannelAwarenessSection,
+  buildChannelCommandIntentSection,
+  buildExternalCommsIdentitySection,
+  buildPhoneCallsRoutingSection,
+  buildTaskScheduleReminderRoutingSection,
+  buildVerificationRoutingSection,
+  buildVoiceSetupRoutingSection,
+} from "./sections/routing.js";
 
-  // Track whether this is a fresh workspace (no core prompt files exist yet).
-  const isFirstRun = PROMPT_FILES.every(
-    (file) => !existsSync(getWorkspacePromptPath(file)),
-  );
-
-  for (const file of PROMPT_FILES) {
-    const dest = getWorkspacePromptPath(file);
-    if (existsSync(dest)) continue;
-
-    const src = join(templatesDir, file);
-    try {
-      if (!existsSync(src)) {
-        log.warn({ src }, "Prompt template not found, skipping");
-        continue;
-      }
-      copyFileSync(src, dest);
-      log.info({ file, dest }, "Created prompt file from template");
-    } catch (err) {
-      log.warn({ err, file }, "Failed to create prompt file from template");
-    }
-  }
-
-  // Only seed BOOTSTRAP.md on a truly fresh install so that deleting it
-  // reliably signals onboarding completion across daemon restarts.
-  if (isFirstRun) {
-    const bootstrapDest = getWorkspacePromptPath("BOOTSTRAP.md");
-    if (!existsSync(bootstrapDest)) {
-      const bootstrapSrc = join(templatesDir, "BOOTSTRAP.md");
-      try {
-        if (existsSync(bootstrapSrc)) {
-          copyFileSync(bootstrapSrc, bootstrapDest);
-          log.info(
-            { file: "BOOTSTRAP.md", dest: bootstrapDest },
-            "Created BOOTSTRAP.md for first-run onboarding",
-          );
-        }
-      } catch (err) {
-        log.warn(
-          { err, file: "BOOTSTRAP.md" },
-          "Failed to create BOOTSTRAP.md from template",
-        );
-      }
-    }
-  }
-}
-
-/**
- * Returns true when BOOTSTRAP.md has been deleted from the workspace,
- * signalling the first-run ritual is complete.
- */
-export function isOnboardingComplete(): boolean {
-  const bootstrapPath = getWorkspacePromptPath("BOOTSTRAP.md");
-  return !existsSync(bootstrapPath);
-}
+export { appendSkillsCatalog } from "./sections/skills.js";
 
 /**
  * Build the system prompt from ~/.vellum prompt files,
@@ -126,7 +109,7 @@ export function buildSystemPrompt(): string {
   // ── Core sections ──
   const parts: string[] = [];
   parts.push(
-    "IMPORTANT: Never use em dashes (—) in your messages. Use commas, periods, or just start a new sentence instead.",
+    "IMPORTANT: Never use em dashes (\u2014) in your messages. Use commas, periods, or just start a new sentence instead.",
   );
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
@@ -134,7 +117,7 @@ export function buildSystemPrompt(): string {
   if (bootstrap) {
     parts.push(
       "# First-Run Ritual\n\n" +
-        "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
+        "BOOTSTRAP.md is present \u2014 this is your first conversation. Follow its instructions.\n\n" +
         bootstrap,
     );
   }
@@ -150,7 +133,7 @@ export function buildSystemPrompt(): string {
         "Use your judgment to decide when and how to surface updates to the user:",
         "- Inform the user about updates that are relevant to what they are doing or asking about.",
         "- Apply assistant-relevant changes (e.g., new tools, behavior adjustments) without forced announcement.",
-        "- Do not interrupt the user with updates unprompted — weave them naturally into conversation when relevant.",
+        "- Do not interrupt the user with updates unprompted \u2014 weave them naturally into conversation when relevant.",
         "- When you are satisfied all updates have been actioned or communicated, delete `UPDATES.md` to signal completion.",
       ].join("\n"),
     );
@@ -191,811 +174,4 @@ export function buildSystemPrompt(): string {
   parts.push(buildLearningMemorySection());
 
   return appendSkillsCatalog(parts.join("\n\n"));
-}
-
-function buildTaskScheduleReminderRoutingSection(): string {
-  return [
-    "## Tool Routing: Tasks vs Schedules vs Notifications",
-    "",
-    'Three tools, each for a different purpose. Load the "Time-Based Actions" skill for the full decision framework.',
-    "",
-    "| Tool | Purpose |",
-    "|------|---------|",
-    '| `task_list_add` | Track work — no time trigger ("add to my tasks", "remind me to X" without a time) |',
-    '| `schedule_create` | Any time-based automation — recurring cron/RRULE ("every day at 9am") OR one-shot future alert with `fire_at` ("remind me at 3pm") |',
-    "| `send_notification` | **Immediate-only** — fires instantly, NO delay capability |",
-    "",
-    "### Critical: `send_notification` is immediate-only",
-    "NEVER use `send_notification` for future-time requests — it fires NOW. Use `schedule_create` with `fire_at` for any delayed alert.",
-    "",
-    "### Quick routing rules",
-    "- Future time, one-shot → `schedule_create` with `fire_at`",
-    "- Recurring pattern → `schedule_create`",
-    "- No time, track as work → `task_list_add`",
-    "- Instant alert → `send_notification`",
-    "- Modify existing task → `task_list_update` (NOT `task_list_add`)",
-    "- Remove task → `task_list_remove` (NOT `task_list_update`)",
-    "",
-    "### Entity type routing: work items vs task templates",
-    "",
-    "Two entity types with separate ID spaces — do NOT mix:",
-    "- **Work items** (task queue) — task_list_add, task_list_show, task_list_update, task_list_remove",
-    "- **Task templates** (reusable definitions) — task_save, task_list, task_run, task_delete",
-    "",
-    'If an error says "entity mismatch", read the corrective action and selector fields it provides to pick the right tool.',
-    "",
-  ].join("\n");
-}
-
-export function buildVerificationRoutingSection(): string {
-  return [
-    "## Routing: Guardian Verification",
-    "",
-    "When the user wants to verify their identity as the trusted guardian for a messaging channel, load the **Guardian Verify Setup** skill.",
-    'Interpret phrasing like "help me set myself up as your guardian" as the user asking to verify themselves as guardian (not asking the assistant to self-assign permissions).',
-    'Do not give conceptual "I cannot set myself as guardian" explanations unless the user explicitly asks a conceptual/security question.',
-    "",
-    "### Trigger phrases",
-    '- "verify guardian"',
-    '- "verify my Telegram account"',
-    '- "verify phone channel"',
-    '- "verify my phone number"',
-    '- "set up guardian verification"',
-    "",
-    "### What it does",
-    "The skill walks through outbound guardian verification for phone or Telegram:",
-    "1. Confirm channel (phone, telegram)",
-    "2. Collect destination (phone number or Telegram handle/chat ID)",
-    "3. Start outbound verification via runtime HTTP API",
-    "4. Guide the user through code entry, resend, or cancel",
-    "",
-    'Load with: `skill_load` using `skill: "guardian-verify-setup"`',
-    "",
-    "### Exclusivity rules",
-    "- Guardian verification intents must only be handled by `guardian-verify-setup` — load it exclusively.",
-    "- Do NOT load `phone-calls` for guardian verification intent routing. The phone-calls skill does not orchestrate verification flows.",
-    '- If the user asks to "load phone-calls and guardian verification", prioritize `guardian-verify-setup` and continue the verification flow. Only load `phone-calls` if the user also asks to configure or place regular calls.',
-    '- If the user has already explicitly specified a channel (e.g., "verify my phone for voice", "verify my Telegram"), do not re-ask which channel unless the input is contradictory.',
-  ].join("\n");
-}
-
-function buildAttachmentSection(): string {
-  return [
-    "## Sending Files to the User",
-    "",
-    "To deliver any file you create or download (images, videos, PDFs, audio, etc.) to the user, you MUST include a self-closing XML tag in your response text:",
-    "",
-    "```",
-    '<vellum-attachment source="sandbox" path="scratch/output.png" />',
-    "```",
-    "",
-    "**CRITICAL:** This tag is the ONLY way files reach the user. If you save a file to disk but do not include the tag, the user will NOT see it. Always emit the tag after creating or downloading a file.",
-    "",
-    "- `source`: `sandbox` (default, files inside the sandbox working directory) or `host` (absolute paths on the host filesystem — requires user approval).",
-    "- `path`: Required. Relative path for sandbox, absolute path for host.",
-    "- `filename`: Optional override for the delivered filename (defaults to the basename of the path).",
-    "- `mime_type`: Optional MIME type override (inferred from the file extension if omitted).",
-    "",
-    'Example: `<vellum-attachment source="sandbox" path="scratch/chart.png" />`',
-    "",
-    "Limits: up to 5 attachments per turn, 20 MB each. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
-    "",
-    "### Inline Images and GIFs",
-    "Embed images/GIFs inline using markdown: `![description](URL)`. Do NOT wrap in code fences.",
-  ].join("\n");
-}
-
-export function buildStarterTaskPlaybookSection(): string {
-  return [
-    "## Starter Task Playbooks",
-    "",
-    "When the user clicks a starter task card in the dashboard, you receive a deterministic kickoff message in the format `[STARTER_TASK:<task_id>]`. Follow the playbook for that task exactly.",
-    "",
-    "### Kickoff intent contract",
-    '- `[STARTER_TASK:make_it_yours]` — "Make it yours" color personalisation flow',
-    '- `[STARTER_TASK:research_topic]` — "Research something for me" flow',
-    '- `[STARTER_TASK:research_to_ui]` — "Turn it into a webpage or interactive UI" flow',
-    "",
-    "### Playbook: make_it_yours",
-    "Goal: Help the user choose an accent color preference for apps and interfaces.",
-    "",
-    "1. If the user's locale is missing or has `confidence: low` in USER.md, briefly confirm their location/language before proceeding.",
-    "2. Present a concise set of accent color options (e.g. 5-7 curated colors with names and hex codes). Keep it short and scannable.",
-    '3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").',
-    '4. Confirm the selection: "I\'ll set your accent color to **{label}** ({hex}). Sound good?"',
-    "5. On confirmation:",
-    '   - Use `app_file_edit` to update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.',
-    "   - Use `app_file_edit` to update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.",
-    "6. If the user declines or wants to skip, set `make_it_yours` to `skipped` in USER.md and move on.",
-    "",
-    "### Playbook: research_topic",
-    "Goal: Research a topic the user is interested in and summarise findings.",
-    "",
-    '1. Ask the user what topic they\'d like researched. Be specific: "What would you like me to look into?"',
-    "2. Once given a topic, use available tools (web search, browser, etc.) to gather information.",
-    "3. Synthesise the findings into a clear, well-structured summary.",
-    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_topic` to `done`.",
-    "",
-    "### Playbook: research_to_ui",
-    "Goal: Transform research (from a prior research_topic task or current conversation context) into a visual webpage or interactive UI.",
-    "",
-    "1. Check the conversation history for prior research content. If none exists, ask the user what content they'd like visualised.",
-    "2. Synthesise the research into a polished, interactive HTML page using `app_create`.",
-    "3. Follow all Dynamic UI quality standards (anti-AI-slop rules, design tokens, hover states, etc.).",
-    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_to_ui` to `done`.",
-    "",
-    "### General rules for all starter tasks",
-    "- Update the relevant task status in the `## Onboarding Tasks` section of USER.md as you progress (`in_progress` when starting, `done` when complete).",
-    "- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.",
-    "- Keep responses concise and action-oriented. Avoid lengthy explanations of what you're about to do.",
-    "- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.",
-  ].join("\n");
-}
-
-function buildInChatConfigurationSection(): string {
-  return [
-    "## In-Chat Configuration",
-    "",
-    "When the user needs to configure a value (API keys, OAuth credentials, webhook URLs, or any setting that can be changed from the Settings page), **always collect it conversationally in the chat first** rather than directing them to the Settings page.",
-    "",
-    "**How to collect credentials and secrets:**",
-    '- Use `credential_store` with `action: "prompt"` to present a secure input field. The value never appears in the conversation.',
-    '- For OAuth flows, use `credential_store` with `action: "oauth2_connect"` to handle the authorization in-browser. Some services (e.g. Twitter/X) define their own auth flow via dedicated skill instructions — check the service\'s skill documentation for provider-specific setup steps.',
-    "- For non-secret config values (e.g. a public URL, a webhook URL), ask the user directly in the conversation and use the appropriate config tool to persist the value.",
-    "",
-    '**After saving a value**, confirm success with a message like: "Great, saved! You can always update this from the Settings page."',
-    "",
-    "**Never tell the user to go to Settings to enter a value.** The Settings page is for reviewing and updating existing configuration, not for initial setup. Always prefer the in-chat flow for first-time configuration.",
-    "",
-    "### Avatar Customisation",
-    "",
-    'You can change your avatar appearance using the `set_avatar` tool. When the user asks to change, update, or customise your avatar, use `set_avatar` with a `description` parameter describing the desired appearance (e.g. "a friendly purple cat with green eyes wearing a tiny hat"). The tool generates an avatar image and updates all connected clients automatically. If managed avatar generation is configured, no local API key is needed.',
-    "",
-    "**After generating a new avatar**, always update the `## Avatar` section in `IDENTITY.md` with a brief description of the current avatar appearance. This ensures you remember what you look like across sessions. Example:",
-    "```",
-    "## Avatar",
-    "A friendly purple cat with green eyes wearing a tiny hat",
-    "```",
-  ].join("\n");
-}
-
-export function buildVoiceSetupRoutingSection(): string {
-  return [
-    "## Routing: Voice Setup & Troubleshooting",
-    "",
-    "Voice features include push-to-talk (PTT), wake word detection, and text-to-speech.",
-    "",
-    "### Quick changes — use `voice_config_update` directly",
-    '- "Change my PTT key to ctrl" — call `voice_config_update` with `setting: "activation_key"`',
-    '- "Enable wake word" — call `voice_config_update` with `setting: "wake_word_enabled"`, `value: true`',
-    '- "Set my wake word to jarvis" — call `voice_config_update` with `setting: "wake_word_keyword"`',
-    '- "Set wake word timeout to 30 seconds" — call `voice_config_update` with `setting: "wake_word_timeout"`',
-    "",
-    "For simple setting changes, use the tool directly without loading the voice-setup skill.",
-    "",
-    "### Guided setup or troubleshooting — load the voice-setup skill",
-    'Load with: `skill_load` using `skill: "voice-setup"`',
-    "",
-    "**Trigger phrases:**",
-    '- "Help me set up voice"',
-    '- "Set up push-to-talk"',
-    '- "Configure voice / PTT / wake word"',
-    '- "PTT isn\'t working" / "push-to-talk not working"',
-    '- "Recording but no text"',
-    '- "Wake word not detecting"',
-    '- "Microphone not working"',
-    '- "Set up ElevenLabs" / "configure TTS"',
-    "",
-    "### Disambiguation",
-    "- Voice setup (this skill) = **local PTT, wake word, microphone permissions** on the Mac desktop app.",
-    "- Phone calls skill = **Twilio-powered voice calls** over the phone network. Completely separate.",
-    '- If the user says "voice" in the context of phone calls or Twilio, load `phone-calls` instead.',
-  ].join("\n");
-}
-
-export function buildPhoneCallsRoutingSection(): string {
-  return [
-    "## Routing: Phone Calls",
-    "",
-    "When the user asks to set up phone calling, place a call, configure Twilio for voice, or anything related to outbound/inbound phone calls, load the **Phone Calls** skill.",
-    "",
-    "### Trigger phrases",
-    '- "Set up phone calling" / "enable calls"',
-    '- "Make a call to..." / "call [number/business]"',
-    '- "Configure Twilio" (in context of voice calls)',
-    '- "Can you make phone calls?"',
-    '- "Set up my phone number" (for calling)',
-    "",
-    "### What it does",
-    "The skill handles the full phone calling lifecycle:",
-    "1. Twilio credential setup (delegates to twilio-setup skill)",
-    "2. Public ingress configuration (delegates to public-ingress skill)",
-    "3. Enabling the calls feature",
-    "4. Placing outbound calls and receiving inbound calls",
-    "5. Voice quality configuration (standard Twilio TTS or ElevenLabs)",
-    "",
-    'Load with: `skill_load` using `skill: "phone-calls"`',
-    "",
-    "### Exclusivity rules",
-    "- Do NOT improvise Twilio setup instructions from general knowledge — always load the skill first.",
-    "- Do NOT confuse with voice-setup (local PTT/wake word/microphone) or guardian-verify-setup (channel verification).",
-    '- If the user says "voice" in the context of phone calls or Twilio, load phone-calls, not voice-setup.',
-    "- For guardian voice verification specifically, load guardian-verify-setup instead.",
-  ].join("\n");
-}
-
-function buildToolPermissionSection(): string {
-  return [
-    "## Tool Permissions",
-    "",
-    "Some tools (host_bash, host_file_write, host_file_edit, host_file_read) require your user's approval before they run. When you call one of these tools, your user sees **Allow / Don't Allow** buttons in the chat directly below your message.",
-    "",
-    "**CRITICAL RULE:** You MUST ALWAYS output a text message BEFORE calling any tool that requires approval. NEVER call a permission-gated tool without preceding text. Your user needs context to decide whether to allow.",
-    "",
-    '**IMPORTANT:** If your user has already granted broad approval for the current conversation (e.g. via "Allow for 10 minutes", "Allow for this thread", or "Always Allow"), do NOT ask for permission again. Instead, just briefly describe what you\'re about to do and proceed. Only ask "Can you allow?" on the FIRST tool call when you haven\'t been granted permission yet.',
-    "",
-    "Your text should follow this pattern:",
-    "1. **Acknowledge** the request conversationally.",
-    '2. **Explain what you need at a high level** (e.g. "I\'ll need to look through your Downloads folder"). Do NOT include raw terminal commands or backtick code. Keep it non-technical.',
-    "3. **State safety** in plain language. Is it read-only? Will it change anything?",
-    "4. **Ask for permission** only if this is the first time and you haven't been previously approved. If you have been approved, just say what you're doing.",
-    "",
-    "Style rules:",
-    '- NEVER use em dashes (the long dash). Use commas, periods, or "and" instead.',
-    "- NEVER show raw commands in backticks like `ls -lt ~/Downloads`. Describe the action in plain English.",
-    "- Keep it conversational, like you're talking to a friend.",
-    "",
-    'First time (no prior approval): "To show your recent downloads, I\'ll need to look through your Downloads folder. This is read-only. Can you allow this?"',
-    'Already approved: "Let me check your Downloads folder real quick."',
-    'Bad: "I\'ll run `ls -lt ~/Desktop/`" (raw command), or calling a tool with no preceding text.',
-    "",
-    "### Handling Permission Denials",
-    "",
-    'When your user denies a tool permission (clicks "Don\'t Allow"), you will receive an error indicating the denial. Follow these rules:',
-    "",
-    "1. **Do NOT immediately retry the tool call.** Retrying without waiting creates another permission prompt, which is annoying and disrespectful of the user's decision.",
-    "2. **Acknowledge the denial.** Tell the user that the action was not performed because they chose not to allow it.",
-    "3. **Ask before retrying.** Ask if they would like you to try again, or if they would prefer a different approach.",
-    "4. **Wait for an explicit response.** Only retry the tool call after the user explicitly confirms they want you to try again.",
-    "5. **Offer alternatives.** If possible, suggest alternative approaches that might not require the denied permission.",
-    "",
-    "Example:",
-    '- Tool denied → "No problem! I wasn\'t able to access your Downloads folder since you chose not to allow it. Would you like me to try again, or is there another way I can help?"',
-    "",
-    "### Always-Available Tools (No Approval Required)",
-    "",
-    "- **file_read** on your workspace directory — You can freely read any file under your `.vellum` workspace at any time. Use this proactively to check files, load context, and inform your responses without asking. **Always use `file_read` for workspace files (IDENTITY.md, USER.md, SOUL.md, etc.), never `host_file_read`.**",
-    "- **web_search** — You can search the web at any time without approval. Use this to look up documentation, current information, or anything you need.",
-  ].join("\n");
-}
-
-function buildSystemPermissionSection(): string {
-  return [
-    "## System Permissions",
-    "",
-    'When a tool execution fails with a permission/access error (e.g. "Operation not permitted", "EACCES", sandbox denial), use `request_system_permission` to ask your user to grant the required macOS permission through System Settings.',
-    "",
-    "Common cases:",
-    "- Reading files in ~/Documents, ~/Desktop, ~/Downloads → `full_disk_access`",
-    "- Screen capture / recording → `screen_recording`",
-    "- Accessibility / UI automation → `accessibility`",
-    "",
-    "Do NOT explain how to open System Settings manually — the tool handles it with a clickable button.",
-  ].join("\n");
-}
-
-export function buildChannelAwarenessSection(): string {
-  return [
-    "## Channel Awareness & Trust Gating",
-    "",
-    "Each turn may include a `<channel_capabilities>` block in the user message describing what the current channel supports. Use this to adapt your behaviour:",
-    "",
-    "### Channel-specific rules",
-    "- When `dashboard_capable` is `false`, never reference the dashboard UI, settings panels, dynamic pages, or visual pickers. Present data as formatted text.",
-    "- When `supports_dynamic_ui` is `false`, do not call `ui_show`, `ui_update`, or `app_create`.",
-    "- When `supports_voice_input` is `false`, do not ask the user to speak or use their microphone.",
-    "- Non-dashboard channels should defer dashboard-specific actions. Tell the user they can complete those steps later from the desktop app.",
-    "",
-    "### Permission ask trust gating",
-    "- Do NOT proactively ask for elevated permissions (microphone, computer control, file access) until the trust stage field `firstConversationComplete` in USER.md is `true`.",
-    "- Even after `firstConversationComplete`, only ask for permissions that are relevant to the current channel capabilities.",
-    "- Do not ask for microphone permissions on channels where `supports_voice_input` is `false`.",
-    "- Do not ask for computer-control permissions on non-dashboard channels.",
-    "- When you do request a permission, be transparent about what it enables and why you need it.",
-    "",
-    "### Push-to-talk awareness",
-    "- The `<channel_capabilities>` block may include `ptt_activation_key` and `ptt_enabled` fields indicating the user's push-to-talk configuration.",
-    '- You can change the push-to-talk activation key using the `voice_config_update` tool. The key is provided as a JSON PTTActivator payload (e.g. `{"kind":"modifierOnly","modifierFlags":8388608}` for Fn).',
-    "- When the user asks about voice input or push-to-talk settings, use the tool to apply changes directly rather than directing them to settings.",
-    "- When `microphone_permission_granted` is `false`, guide the user to grant microphone access in System Settings before using voice features.",
-    "",
-    "### Group chat etiquette",
-    "- In group chats, you are a **participant**, not the user's proxy. Think before you speak.",
-    "- **Respond when:** directly mentioned, you can add genuine value, something witty fits naturally, or correcting important misinformation.",
-    '- **Stay silent when:** it\'s casual banter between humans, someone already answered, your response would just be "yeah" or "nice", or the conversation flows fine without you.',
-    "- **The human rule:** humans don't respond to every message in a group chat. Neither should you. Quality over quantity.",
-    "- On platforms with reactions (Discord, Slack), use emoji reactions naturally to acknowledge without cluttering.",
-    "",
-    "### Platform formatting",
-    "- **Discord/WhatsApp:** Do not use markdown tables — use bullet lists instead.",
-    "- **Discord links:** Wrap multiple links in `<>` to suppress embeds.",
-    "- **WhatsApp:** No markdown headers — use **bold** or CAPS for emphasis.",
-  ].join("\n");
-}
-
-export function buildChannelCommandIntentSection(): string {
-  return [
-    "## Channel Command Intents",
-    "",
-    "Some channel turns include a `<channel_command_context>` block indicating the user triggered a bot command (e.g. Telegram `/start`).",
-    "",
-    "### `/start` command",
-    "When `command_type` is `start`:",
-    "- Generate a warm, friendly greeting as if the user just arrived for the first time.",
-    "- Keep it brief (1-3 sentences). Do not be verbose or list capabilities.",
-    '- If the user message is `/start` verbatim, treat the entire user intent as "I just started chatting with this bot, say hello."',
-    "- If a `payload` field is present (deep link), acknowledge what the payload references if you recognise it, but still greet warmly.",
-    '- Do NOT reset the conversation, clear history, or treat this as a "new conversation" command.',
-    "- Do NOT mention `/start` or any slash commands in your response.",
-    "- Respond in the same language as the user's locale if available from channel context, otherwise default to English.",
-  ].join("\n");
-}
-
-export function buildExternalCommsIdentitySection(): string {
-  const userRef = resolveUserReference();
-  const userPronouns = resolveUserPronouns();
-  const lines = [
-    "## External Communications Identity",
-    "",
-    "When communicating with people outside your user's household (phone calls, messages to non-guardian contacts, emails to third parties, etc.):",
-    "",
-    `- Refer to yourself as an **assistant**, not an "AI assistant" or "artificial intelligence". Keep identity framing simple and natural.`,
-    `- When introducing who you represent, say you are acting on behalf of **${userRef}**.`,
-  ];
-  if (userPronouns) {
-    lines.push(
-      `- Your user's pronouns are **${userPronouns}**. Use these when referring to your user in the third person.`,
-    );
-  }
-  lines.push(
-    "- Do not volunteer that you are an AI unless directly asked. If asked, answer honestly.",
-    "- This is guidance for natural, human-like communication — not a hard constraint. Occasional variations are acceptable.",
-  );
-  return lines.join("\n");
-}
-
-export function buildSwarmGuidanceSection(): string {
-  return [
-    "## Parallel Task Orchestration",
-    "",
-    'When a task has **multiple independent parts** that benefit from parallel execution (e.g. "research X, implement Y, and review Z"), load the `orchestration` skill using `skill_load` first, then use `swarm_delegate` to decompose and run them in parallel. For single-focus tasks, work directly — do not decompose them into a swarm.',
-  ].join("\n");
-}
-
-function buildAccessPreferenceSection(): string {
-  return [
-    "## External Service Access Preference",
-    "",
-    "When interacting with external services (GitHub, Slack, Linear, Jira, cloud providers, etc.),",
-    "follow this priority order:",
-    "",
-    "1. **Sandbox first (`bash`)** — Always try to do things in your own sandbox environment first.",
-    "   If a tool (git, curl, jq, etc.) is not installed, install it yourself using `bash`",
-    "   (e.g. `apt-get install -y git`). The sandbox is your own machine — you have full control.",
-    "   Only fall back to host tools when you genuinely need access to the user's local files,",
-    "   environment, or host-specific resources (e.g. their local git repos, host-installed CLIs",
-    "   with existing auth, macOS-specific apps).",
-    "2. **CLI tools via host_bash** — If you need access to the user's host environment and a CLI",
-    "   is installed on their machine (gh, slack, linear, jira, aws, gcloud, etc.), use it.",
-    "   CLIs handle auth, pagination, and output formatting.",
-    "   Use --json or equivalent flags for structured output when available.",
-    "3. **Direct API calls via host_bash** — Use curl/httpie with API tokens from credential_store.",
-    "   Faster and more reliable than browser automation.",
-    "4. **web_fetch** — For public endpoints or simple API calls that don't need auth.",
-    "5. **Browser automation as last resort** — Only when the task genuinely requires a browser",
-    "   (e.g., no API exists, visual interaction needed, or OAuth consent screen).",
-    "",
-    "Before reaching for host tools or browser automation, ask yourself:",
-    "- Can I do this entirely in my sandbox? (install tools, clone repos, run commands)",
-    "- Do I actually need something from the user's host machine?",
-    "",
-    "If you can do it in your sandbox, do it there. Only use host tools when you need the user's",
-    "local files, credentials, or host-specific capabilities.",
-    ...(isMacOS()
-      ? [
-          "",
-          "On macOS, also consider the `macos-automation` skill for interacting with native apps",
-          "(Messages, Contacts, Calendar, Mail, Reminders, Music, Finder, etc.) via osascript.",
-          "",
-          "### Foreground Computer Use — Last Resort",
-          "",
-          "Foreground computer use (`computer_use_request_control`) takes over the user's cursor and",
-          "keyboard. It is disruptive and should be your LAST resort. Prefer this hierarchy:",
-          "",
-          "1. **CLI tools / osascript** — Use `host_bash` with shell commands or `osascript` with",
-          "   AppleScript to accomplish tasks in the background without interrupting the user.",
-          "2. **Background computer use** — If you must interact with a GUI app, prefer AppleScript",
-          '   automation (e.g. `tell application "Safari" to set URL of current tab to ...`).',
-          "3. **Foreground computer use** — Only escalate via `computer_use_request_control` when",
-          "   the task genuinely cannot be done any other way (e.g. complex multi-step GUI interactions",
-          "   with no scripting support) or the user explicitly asks you to take control.",
-        ]
-      : []),
-  ].join("\n");
-}
-
-function buildIntegrationSection(): string {
-  const allCreds = listCredentialMetadata();
-  // Show OAuth2-connected services (those with oauth2TokenUrl in metadata)
-  const oauthCreds = allCreds.filter(
-    (c) => c.oauth2TokenUrl && c.field === "access_token",
-  );
-  if (oauthCreds.length === 0) return "";
-
-  const raw = loadRawConfig();
-  const lines = ["## Connected Services", ""];
-  for (const cred of oauthCreds) {
-    const acctInfo = getNestedValue(
-      raw,
-      `integrations.accountInfo.${cred.service}`,
-    ) as string | undefined;
-    const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
-    lines.push(`- **${cred.service}**: ${state}`);
-  }
-
-  return lines.join("\n");
-}
-
-function buildMemoryPersistenceSection(): string {
-  return [
-    "## Memory Persistence",
-    "",
-    "Your memory does not survive session restarts. If you want to remember something, **save it**.",
-    "",
-    "- Use `memory_save` for facts, preferences, learnings, and anything worth recalling later.",
-    "- Update workspace files (USER.md, SOUL.md) for profile and personality changes.",
-    '- When someone says "remember this," save it immediately — don\'t rely on keeping it in context.',
-    "- When you make a mistake, save the lesson so future-you doesn't repeat it.",
-    "",
-    "Saved > unsaved. Always.",
-  ].join("\n");
-}
-
-function buildMemoryRecallSection(): string {
-  return [
-    "## Memory Recall",
-    "",
-    "You have access to a `memory_recall` tool for deep memory retrieval. Use it when:",
-    "",
-    "- The user asks about past conversations, decisions, or context you don't have in the current window",
-    "- You need to recall specific facts, preferences, or project details",
-    "- The auto-injected memory context doesn't contain what you need",
-    "- The user references something from a previous session",
-    "",
-    "The tool searches across semantic, lexical, entity graph, and recency sources. Be specific in your query for best results.",
-  ].join("\n");
-}
-
-function buildWorkspaceReflectionSection(): string {
-  return [
-    "## Workspace Reflection",
-    "",
-    "Before you finish responding to a conversation, pause and consider: did you learn anything worth saving?",
-    "",
-    "- Did your user share personal facts (name, role, timezone, preferences)?",
-    "- Did they correct your behavior or express a preference about how you communicate?",
-    "- Did they mention a project, tool, or workflow you should remember?",
-    "- Did you adapt your style in a way that worked well and should persist?",
-    "",
-    "If yes, briefly explain what you're updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.",
-  ].join("\n");
-}
-
-function buildLearningMemorySection(): string {
-  return [
-    "## Learning from Mistakes",
-    "",
-    "When you make a mistake, hit a dead end, or discover something non-obvious, save it to memory so you don't repeat it.",
-    "",
-    'Use `memory_save` with `kind: "learning"` for:',
-    "- **Mistakes and corrections** — wrong assumptions, failed approaches, gotchas you ran into",
-    "- **Discoveries** — undocumented behaviors, surprising API quirks, things that weren't obvious",
-    "- **Working solutions** — the approach that actually worked after trial and error",
-    "- **Tool/service insights** — rate limits, auth flows, CLI flags that matter",
-    "",
-    "The statement should capture both what happened and the takeaway. Write it as advice to your future self.",
-    "",
-    "Examples:",
-    '- `memory_save({ kind: "learning", subject: "macOS Shortcuts CLI", statement: "shortcuts CLI requires full disk access to export shortcuts — if permission is denied, guide the user to grant it in System Settings rather than retrying." })`',
-    '- `memory_save({ kind: "learning", subject: "Gmail API pagination", statement: "Gmail search returns max 100 results per page. Always check nextPageToken and loop if the user asks for \'all\' messages." })`',
-    "",
-    "Don't overthink it. If you catch yourself thinking \"I'll remember that for next time,\" save it.",
-  ].join("\n");
-}
-
-function buildContainerizedSection(): string {
-  const baseDataDir = getBaseDataDir() ?? "$BASE_DATA_DIR";
-  return [
-    "## Running in a Container — Data Persistence",
-    "",
-    `You are running inside a container. Only the directory \`${baseDataDir}\` is mounted to a persistent volume.`,
-    "",
-    "**Any new files or data you create MUST be written inside that directory, or they will be lost when the container restarts.**",
-    "",
-    "Rules:",
-    `- Always store new data, notes, memories, configs, and downloads under \`${baseDataDir}\``,
-    "- Never write persistent data to system directories, `/tmp`, or paths outside the mounted volume",
-    "- When in doubt, prefer paths nested under the data directory",
-    "- If you create a file that is only needed temporarily (scratch files, intermediate outputs, download staging), delete it when you are done — disk space on the persistent volume is finite and will grow unboundedly if temp files are not cleaned up",
-  ].join("\n");
-}
-
-function buildPostToolResponseSection(): string {
-  return [
-    "## Tool Call Timing",
-    "",
-    "**Call tools FIRST, explain AFTER:**",
-    "- When a user request requires a tool, call it immediately at the start of your response",
-    "- If the request needs multiple tool steps, stay silent while you work and respond once you have concrete results",
-    '- Do NOT narrate retries or internal process chatter (for example: "hmm", "that didn\'t work", "let me try...")',
-    "- Speak mid-workflow only when you need user input (permission, clarification, or blocker)",
-    "- Do NOT provide conversational preamble before calling tools",
-    "",
-    "Example (CORRECT):",
-    "  → Call document_create",
-    "  → Call document_update",
-    '  → Text: "Drafted and filled your blog post. Review and tell me what to change."',
-    "",
-    "Example (WRONG):",
-    '  → Text: "I\'ll try one approach... hmm not that... trying again..."',
-    "  → Call document_create",
-    "",
-    "For permission-gated tools, send one short context sentence immediately before the tool call so the user can make an informed allow/deny decision.",
-  ].join("\n");
-}
-
-function buildConfigSection(): string {
-  // Always use `file_edit` (not `host_file_edit`) for workspace files — file_edit
-  // handles sandbox path mapping internally, and host_file_edit is permission-gated
-  // which would trigger approval prompts for routine workspace updates.
-  const hostWorkspaceDir = getWorkspaceDir();
-
-  const config = getConfig();
-  const configPreamble = `Your configuration directory is \`${hostWorkspaceDir}/\`.`;
-
-  return [
-    "## Configuration",
-    `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
-    `${configPreamble} **Always use \`file_read\` and \`file_edit\` (not \`host_file_read\` / \`host_file_edit\`) for these files** — they are inside your sandbox working directory and do not require host access or user approval:`,
-    "",
-    "- `IDENTITY.md` — Your name, nature, personality, and emoji. Updated during the first-run ritual.",
-    "- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.",
-    "- `USER.md` — Profile of your user. Update as you learn about them over time.",
-    "- `HEARTBEAT.md` — Checklist for periodic heartbeat runs. When heartbeat is enabled, the assistant runs this checklist on a timer and flags anything that needs attention. Edit this file to control what gets checked each run.",
-    "- `BOOTSTRAP.md` — First-run ritual script (only present during onboarding; you delete it when done).",
-    "- `UPDATES.md` — Release update notes (created automatically on new releases; delete when updates are actioned).",
-    "- `skills/` — Directory of installed skills (loaded automatically at startup).",
-    "",
-    "### Heartbeat",
-    "",
-    "The heartbeat feature runs your `HEARTBEAT.md` checklist periodically in a background thread. To enable it, set `heartbeat.enabled: true` and `heartbeat.intervalMs` (default: 3600000 = 1 hour) in `config.json`. You can also set `heartbeat.activeHoursStart` and `heartbeat.activeHoursEnd` (0-23) to restrict runs to certain hours. When asked to set up a heartbeat, edit both the config and `HEARTBEAT.md` directly — no restart is needed for checklist changes, but toggling `heartbeat.enabled` requires a daemon restart.",
-    "",
-    "### Proactive Workspace Editing",
-    "",
-    `You MUST actively update your workspace files as you learn. You don't need to ask your user whether it's okay — just briefly explain what you're updating, then use \`file_edit\` to make targeted edits.`,
-    "",
-    "**USER.md** — update when you learn:",
-    "- Their name or what they prefer to be called",
-    "- Projects they're working on, tools they use, languages they code in",
-    "- Communication preferences (concise vs detailed, formal vs casual)",
-    "- Interests, hobbies, or context that helps you assist them better",
-    "- Anything else about your user that will help you serve them better",
-    "",
-    "**SOUL.md** — update when you notice:",
-    "- They prefer a different tone or interaction style (add to Personality or User-Specific Behavior)",
-    '- A behavioral pattern worth codifying (e.g. "always explain before acting", "skip preamble")',
-    "- You've adapted in a way that's working well and should persist",
-    "- You decide to change your personality to better serve your user",
-    "",
-    "**IDENTITY.md** — update when:",
-    "- They rename you or change your role",
-    "- Your avatar appearance changes (update the `## Avatar` section with a description of the new look)",
-    "",
-    "When reading or updating workspace files, always use the sandbox tools (`file_read`, `file_edit`). Never use `host_file_read` or `host_file_edit` for workspace files — those are for host-only resources outside your workspace.",
-    "",
-    "When updating, read the file first, then make a targeted edit. Include all useful information, but don't bloat the files over time",
-  ].join("\n");
-}
-
-export function buildCliReferenceSection(): string {
-  if (cachedCliHelp === undefined) {
-    cachedCliHelp = CLI_HELP_REFERENCE.trim();
-  }
-
-  return [
-    "## Assistant CLI",
-    "",
-    "The `assistant` CLI is installed on the user's machine and available via `bash`.",
-    "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
-    "- Use `assistant credentials ...` for stored secrets and credential metadata.",
-    "- Use `assistant oauth token <service>` for connected integration tokens.",
-    "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
-    "- Use `assistant platform status` for platform-linked deployment and auth context.",
-    "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",
-    "",
-    "```",
-    cachedCliHelp,
-    "```",
-    "",
-    "Run `assistant <command> --help` for detailed help on any subcommand.",
-  ].join("\n");
-}
-
-/**
- * Strip lines starting with `_` (comment convention for prompt .md files)
- * and collapse any resulting consecutive blank lines.
- *
- * Lines inside fenced code blocks (``` or ~~~ delimiters per CommonMark)
- * are never stripped, so code examples with `_`-prefixed identifiers are preserved.
- */
-export function stripCommentLines(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n");
-  let openFenceChar: string | null = null;
-  const filtered = normalized.split("\n").filter((line) => {
-    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const char = fenceMatch[1][0];
-      if (!openFenceChar) {
-        openFenceChar = char;
-      } else if (char === openFenceChar) {
-        openFenceChar = null;
-      }
-    }
-    if (openFenceChar) return true;
-    return !line.trimStart().startsWith("_");
-  });
-  return filtered
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-function readPromptFile(path: string): string | null {
-  if (!existsSync(path)) return null;
-
-  try {
-    const content = stripCommentLines(readFileSync(path, "utf-8"));
-    if (content.length === 0) return null;
-    log.debug({ path }, "Loaded prompt file");
-    return content;
-  } catch (err) {
-    log.warn({ err, path }, "Failed to read prompt file");
-    return null;
-  }
-}
-
-function appendSkillsCatalog(basePrompt: string): string {
-  const skills = loadSkillCatalog();
-  const config = getConfig();
-
-  // Filter out skills whose assistant feature flag is explicitly OFF
-  const flagFiltered = skills.filter((s) => {
-    const flagKey = skillFlagKey(s);
-    return !flagKey || isAssistantFeatureFlagEnabled(flagKey, config);
-  });
-
-  const sections: string[] = [basePrompt];
-
-  const catalog = formatSkillsCatalog(flagFiltered);
-  if (catalog) sections.push(catalog);
-
-  sections.push(buildDynamicSkillWorkflowSection(config, flagFiltered));
-
-  return sections.join("\n\n");
-}
-
-function buildDynamicSkillWorkflowSection(
-  _config: import("../config/schema.js").AssistantConfig,
-  activeSkills: SkillSummary[],
-): string {
-  const lines = [
-    "## Dynamic Skill Authoring Workflow",
-    "",
-    "When no existing tool or skill can satisfy a request:",
-    "1. Validate the gap — confirm no existing tool/skill covers it.",
-    "2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).",
-    '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
-    "4. Persist with `scaffold_managed_skill` only after user consent.",
-    "5. Load with `skill_load` before use.",
-    "",
-    "**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.",
-    "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
-  ];
-
-  const activeSkillIds = new Set(activeSkills.map((s) => s.id));
-
-  if (activeSkillIds.has("browser")) {
-    lines.push(
-      "",
-      "### Browser Skill Prerequisite",
-      'If you need browser capabilities (navigating web pages, clicking elements, extracting content) and `browser_*` tools are not available, load the "browser" skill first using `skill_load`.',
-    );
-  }
-
-  if (activeSkillIds.has("messaging")) {
-    lines.push(
-      "",
-      "### Messaging Skill",
-      'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
-    );
-  }
-
-  return lines.join("\n");
-}
-
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
-/**
- * Build a dynamic description for the mcp-setup skill that includes
- * configured MCP server names, so the model knows which servers exist.
- */
-function getMcpSetupDescription(): string {
-  const config = getConfig();
-  const servers = config.mcp?.servers;
-  if (!servers || Object.keys(servers).length === 0) {
-    return "Add, authenticate, list, and remove MCP (Model Context Protocol) servers";
-  }
-
-  const serverNames = Object.keys(servers);
-  return `Manage MCP servers. Configured: ${serverNames.join(", ")}. Load this skill to check status, authenticate, or add/remove servers.`;
-}
-
-function formatSkillsCatalog(skills: SkillSummary[]): string {
-  // Filter out skills with disableModelInvocation or unsupported OS
-  const visible = skills.filter((s) => {
-    if (s.disableModelInvocation) return false;
-    const os = s.metadata?.os;
-    if (os && os.length > 0 && !os.includes(process.platform)) return false;
-    return true;
-  });
-  if (visible.length === 0) return "";
-
-  const lines = ["<available_skills>"];
-  for (const skill of visible) {
-    const idAttr = escapeXml(skill.id);
-    const nameAttr = escapeXml(skill.displayName);
-    const descAttr =
-      skill.id === "mcp-setup"
-        ? escapeXml(getMcpSetupDescription())
-        : escapeXml(skill.description);
-    const locAttr = escapeXml(skill.directoryPath);
-    const credAttr = skill.credentialSetupFor
-      ? ` credential-setup-for="${escapeXml(skill.credentialSetupFor)}"`
-      : "";
-    lines.push(
-      `<skill id="${idAttr}" name="${nameAttr}" description="${descAttr}" location="${locAttr}"${credAttr} />`,
-    );
-  }
-  lines.push("</available_skills>");
-
-  return [
-    "## Available Skills",
-    "The following skills are available. Before executing one, call the `skill_load` tool with its `id` to load the full instructions.",
-    "When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill.",
-    "",
-    lines.join("\n"),
-    "",
-    "### Installing additional skills",
-    "If `skill_load` fails because a skill is not found, additional first-party skills may be available in the Vellum catalog.",
-    "Use `bash` to discover and install them:",
-    "- `assistant skills list` — list all available catalog skills",
-    "- `assistant skills install <skill-id>` — install a skill, then retry `skill_load`",
-  ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Extract prompt builders from monolithic system-prompt.ts into focused section modules (core, routing, operations, persistence, skills)
- Keep buildSystemPrompt() as a thin composition layer with byte-for-byte equivalent output
- Update tests to import from new section modules

Part of plan: cut-system-prompt.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
