### PR TITLE
Move onboarding starter-task playbooks into a dedicated skill or deterministic kickoff handler

### DIFF
--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 const TEST_DIR = join(
@@ -57,88 +57,130 @@ mock.module("../util/logger.js", () => ({
   pruneOldLogFiles: () => 0,
 }));
 
-const { buildStarterTaskPlaybookSection, buildSystemPrompt } =
-  await import("../prompts/system-prompt.js");
+const { resolveStarterTaskIntent } = await import(
+  "../daemon/starter-task-intent.js"
+);
+const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
 
-describe("buildStarterTaskPlaybookSection", () => {
-  test("returns a string with the section heading", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("## Starter Task Playbooks");
+// ---------------------------------------------------------------------------
+// resolveStarterTaskIntent
+// ---------------------------------------------------------------------------
+
+describe("resolveStarterTaskIntent", () => {
+  test("detects [STARTER_TASK:make_it_yours] and rewrites to skill load", () => {
+    const result = resolveStarterTaskIntent("[STARTER_TASK:make_it_yours]");
+    expect(result.kind).toBe("starter_task");
+    if (result.kind === "starter_task") {
+      expect(result.taskId).toBe("make_it_yours");
+      expect(result.rewrittenContent).toContain("onboarding-starter-tasks");
+      expect(result.rewrittenContent).toContain("skill_load");
+      expect(result.rewrittenContent).toContain("make_it_yours");
+    }
   });
 
-  test("documents all three kickoff intents", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("[STARTER_TASK:make_it_yours]");
-    expect(section).toContain("[STARTER_TASK:research_topic]");
-    expect(section).toContain("[STARTER_TASK:research_to_ui]");
+  test("detects [STARTER_TASK:research_topic]", () => {
+    const result = resolveStarterTaskIntent("[STARTER_TASK:research_topic]");
+    expect(result.kind).toBe("starter_task");
+    if (result.kind === "starter_task") {
+      expect(result.taskId).toBe("research_topic");
+      expect(result.rewrittenContent).toContain("research_topic");
+    }
   });
 
-  test("includes the make_it_yours playbook", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("### Playbook: make_it_yours");
-    expect(section).toContain("accent color");
-    expect(section).toContain("Dashboard Color Preference");
-    expect(section).toContain("user_selected");
+  test("detects [STARTER_TASK:research_to_ui]", () => {
+    const result = resolveStarterTaskIntent("[STARTER_TASK:research_to_ui]");
+    expect(result.kind).toBe("starter_task");
+    if (result.kind === "starter_task") {
+      expect(result.taskId).toBe("research_to_ui");
+      expect(result.rewrittenContent).toContain("research_to_ui");
+    }
   });
 
-  test("make_it_yours uses app_file_edit instead of invalid ui_show config_update", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("app_file_edit");
-    expect(section).not.toContain("config_update");
-    expect(section).not.toContain('surface_type: "config_update"');
+  test("returns none for ordinary messages", () => {
+    const result = resolveStarterTaskIntent("Hello, how are you?");
+    expect(result.kind).toBe("none");
   });
 
-  test("includes the research_topic playbook", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("### Playbook: research_topic");
-    expect(section).toContain("web search");
+  test("returns none for partial matches", () => {
+    const result = resolveStarterTaskIntent(
+      "Can you do [STARTER_TASK:make_it_yours] for me?",
+    );
+    expect(result.kind).toBe("none");
   });
 
-  test("includes the research_to_ui playbook", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("### Playbook: research_to_ui");
-    expect(section).toContain("app_create");
+  test("returns none for empty string", () => {
+    const result = resolveStarterTaskIntent("");
+    expect(result.kind).toBe("none");
   });
 
-  test("includes general rules section", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("### General rules for all starter tasks");
-  });
-
-  test("enforces trust gating in general rules", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("trust gating");
-    expect(section).toContain("do NOT ask for elevated permissions");
-  });
-
-  test("references USER.md onboarding tasks for status tracking", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("## Onboarding Tasks");
-    expect(section).toContain("in_progress");
-    expect(section).toContain("done");
-    expect(section).toContain("deferred_to_dashboard");
-  });
-
-  test("make_it_yours playbook handles locale confirmation", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("locale");
-    expect(section).toContain("confidence: low");
-  });
-
-  test("make_it_yours playbook includes confirmation step", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("Confirm the selection");
-    expect(section).toContain("Sound good?");
-  });
-
-  test("research_to_ui playbook references dynamic UI quality standards", () => {
-    const section = buildStarterTaskPlaybookSection();
-    expect(section).toContain("Dynamic UI quality standards");
-    expect(section).toContain("anti-AI-slop");
+  test("handles whitespace around the kickoff message", () => {
+    const result = resolveStarterTaskIntent(
+      "  [STARTER_TASK:make_it_yours]  ",
+    );
+    expect(result.kind).toBe("starter_task");
   });
 });
 
-describe("starter task playbook integration with buildSystemPrompt", () => {
+// ---------------------------------------------------------------------------
+// SKILL.md existence and content
+// ---------------------------------------------------------------------------
+
+describe("onboarding-starter-tasks SKILL.md", () => {
+  const skillPath = resolve(
+    import.meta.dirname ?? __dirname,
+    "../../../skills/onboarding-starter-tasks/SKILL.md",
+  );
+
+  test("SKILL.md file exists", () => {
+    expect(existsSync(skillPath)).toBe(true);
+  });
+
+  test("SKILL.md contains all three playbooks", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("## Playbook: make_it_yours");
+    expect(content).toContain("## Playbook: research_topic");
+    expect(content).toContain("## Playbook: research_to_ui");
+  });
+
+  test("SKILL.md covers USER.md status updates", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("## Onboarding Tasks");
+    expect(content).toContain("in_progress");
+    expect(content).toContain("done");
+    expect(content).toContain("deferred_to_dashboard");
+  });
+
+  test("SKILL.md covers trust gating", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("trust gating");
+    expect(content).toContain("do NOT ask for elevated permissions");
+  });
+
+  test("SKILL.md covers locale confirmation for make_it_yours", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("locale");
+    expect(content).toContain("confidence: low");
+  });
+
+  test("SKILL.md covers Dynamic UI quality for research_to_ui", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("Dynamic UI quality standards");
+    expect(content).toContain("anti-AI-slop");
+  });
+
+  test("SKILL.md includes kickoff intent contract", () => {
+    const content = readFileSync(skillPath, "utf-8");
+    expect(content).toContain("[STARTER_TASK:make_it_yours]");
+    expect(content).toContain("[STARTER_TASK:research_topic]");
+    expect(content).toContain("[STARTER_TASK:research_to_ui]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// System prompt no longer embeds full playbooks
+// ---------------------------------------------------------------------------
+
+describe("system prompt starter task routing", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -149,37 +191,23 @@ describe("starter task playbook integration with buildSystemPrompt", () => {
     }
   });
 
-  test("buildSystemPrompt includes the starter task playbook section when BOOTSTRAP.md exists", () => {
+  test("system prompt contains routing section, not full playbooks", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
     const result = buildSystemPrompt();
-    expect(result).toContain("## Starter Task Playbooks");
-  });
-
-  test("buildSystemPrompt omits starter task playbooks after onboarding is complete", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    // No BOOTSTRAP.md → onboarding complete
-    const result = buildSystemPrompt();
+    expect(result).toContain("## Routing: Starter Tasks");
     expect(result).not.toContain("## Starter Task Playbooks");
+    expect(result).not.toContain("### Playbook: make_it_yours");
+    expect(result).not.toContain("### Playbook: research_topic");
+    expect(result).not.toContain("### Playbook: research_to_ui");
   });
 
-  test("starter task playbook and channel awareness both present during onboarding", () => {
+  test("system prompt routing section is present regardless of onboarding state", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
     const result = buildSystemPrompt();
-    const starterIdx = result.indexOf("## Starter Task Playbooks");
-    const channelIdx = result.indexOf("## Channel Awareness & Trust Gating");
-    expect(starterIdx).toBeGreaterThan(-1);
-    expect(channelIdx).toBeGreaterThan(-1);
-  });
-
-  test("all three kickoff intents present in full system prompt during onboarding", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
-    const result = buildSystemPrompt();
-    expect(result).toContain("[STARTER_TASK:make_it_yours]");
-    expect(result).toContain("[STARTER_TASK:research_topic]");
-    expect(result).toContain("[STARTER_TASK:research_to_ui]");
+    expect(result).toContain("## Routing: Starter Tasks");
+    // Full playbooks are NOT in the system prompt even during onboarding
+    expect(result).not.toContain("### Playbook: make_it_yours");
   });
 
   test("system prompt does not contain invalid config_update surface type (bare)", () => {

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -319,15 +319,13 @@ describe("buildSystemPrompt", () => {
       expect(result).not.toContain("use `app_update` to change the HTML");
     });
 
-    test("onboarding playbook does not reference Home Base for accent color", () => {
-      // Starter task playbooks only included during onboarding (BOOTSTRAP.md exists)
+    test("starter task playbooks are not embedded in the system prompt", () => {
+      // Playbooks are now in the onboarding-starter-tasks skill, loaded on demand
       writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# First run");
       const result = buildSystemPrompt();
-      // The make_it_yours playbook should not reference Home Base anymore
-      expect(result).not.toContain("Home Base dashboard");
-      expect(result).not.toContain(
-        "using `app_update` to regenerate the Home Base HTML",
-      );
+      expect(result).not.toContain("## Starter Task Playbooks");
+      expect(result).not.toContain("### Playbook: make_it_yours");
+      expect(result).toContain("## Routing: Starter Tasks");
     });
   });
 

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -42,6 +42,7 @@ import {
   type SlashContext,
 } from "./session-slash.js";
 import type { TraceEmitter } from "./trace-emitter.js";
+import { resolveStarterTaskIntent } from "./starter-task-intent.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("session-process");
@@ -401,6 +402,23 @@ export async function drainQueue(
       agentLoopContent = verificationIntent.rewrittenContent;
       session.preactivatedSkillIds = ["guardian-verify-setup"];
     }
+
+    // Starter task intent interception for queued messages.
+    // Deterministic [STARTER_TASK:<task_id>] messages load the
+    // onboarding-starter-tasks skill instead of relying on the
+    // playbook being embedded in the global system prompt.
+    const starterIntent = resolveStarterTaskIntent(resolvedContent);
+    if (starterIntent.kind === "starter_task") {
+      log.info(
+        {
+          conversationId: session.conversationId,
+          taskId: starterIntent.taskId,
+        },
+        "Starter task intent intercepted in queue — forcing skill flow",
+      );
+      agentLoopContent = starterIntent.rewrittenContent;
+      session.preactivatedSkillIds = ["onboarding-starter-tasks"];
+    }
   }
 
   // Try to persist and run the dequeued message. If persistUserMessage
@@ -726,6 +744,22 @@ export async function processMessage(
       );
       agentLoopContent = verificationIntent.rewrittenContent;
       session.preactivatedSkillIds = ["guardian-verify-setup"];
+    }
+
+    // Starter task intent interception — deterministic [STARTER_TASK:<task_id>]
+    // messages load the onboarding-starter-tasks skill instead of relying on
+    // the playbook being embedded in the global system prompt.
+    const starterIntent = resolveStarterTaskIntent(resolvedContent);
+    if (starterIntent.kind === "starter_task") {
+      log.info(
+        {
+          conversationId: session.conversationId,
+          taskId: starterIntent.taskId,
+        },
+        "Starter task intent intercepted — forcing skill flow",
+      );
+      agentLoopContent = starterIntent.rewrittenContent;
+      session.preactivatedSkillIds = ["onboarding-starter-tasks"];
     }
   }
 

--- a/assistant/src/daemon/starter-task-intent.ts
+++ b/assistant/src/daemon/starter-task-intent.ts
@@ -1,0 +1,48 @@
+// Starter task intent resolution for deterministic kickoff routing.
+// Exports `resolveStarterTaskIntent` as the single public entry point.
+// When a `[STARTER_TASK:<task_id>]` kickoff message is detected, the session
+// pipeline rewrites the message to force immediate loading of the
+// onboarding-starter-tasks skill, ensuring the full playbook is available
+// without embedding it in the global system prompt.
+
+export type StarterTaskIntentResult =
+  | { kind: "none" }
+  | {
+      kind: "starter_task";
+      taskId: string;
+      rewrittenContent: string;
+    };
+
+/** Pattern matching `[STARTER_TASK:<task_id>]` kickoff messages. */
+const STARTER_TASK_PATTERN = /^\[STARTER_TASK:(\w+)\]$/;
+
+/**
+ * Resolves starter task intent from user text.
+ *
+ * Detects deterministic `[STARTER_TASK:<task_id>]` kickoff messages sent by
+ * the dashboard when a user clicks a starter task card. On match, builds a
+ * rewritten instruction that forces the onboarding-starter-tasks skill to load.
+ */
+export function resolveStarterTaskIntent(
+  text: string,
+): StarterTaskIntentResult {
+  const trimmed = text.trim();
+  const match = STARTER_TASK_PATTERN.exec(trimmed);
+  if (!match) {
+    return { kind: "none" };
+  }
+
+  const taskId = match[1];
+
+  const lines = [
+    `The user clicked the "${taskId}" starter task card.`,
+    'Please invoke the "Onboarding Starter Tasks" skill (ID: onboarding-starter-tasks) immediately using skill_load.',
+    `Then follow the playbook for task "${taskId}" exactly.`,
+  ];
+
+  return {
+    kind: "starter_task",
+    taskId,
+    rewrittenContent: lines.join("\n"),
+  };
+}

--- a/assistant/src/prompts/sections/operations.ts
+++ b/assistant/src/prompts/sections/operations.ts
@@ -139,50 +139,11 @@ export function buildInChatConfigurationSection(): string {
   ].join("\n");
 }
 
-export function buildStarterTaskPlaybookSection(): string {
+export function buildStarterTaskRoutingSection(): string {
   return [
-    "## Starter Task Playbooks",
+    "## Routing: Starter Tasks",
     "",
-    "When the user clicks a starter task card in the dashboard, you receive a deterministic kickoff message in the format `[STARTER_TASK:<task_id>]`. Follow the playbook for that task exactly.",
-    "",
-    "### Kickoff intent contract",
-    '- `[STARTER_TASK:make_it_yours]` — "Make it yours" color personalisation flow',
-    '- `[STARTER_TASK:research_topic]` — "Research something for me" flow',
-    '- `[STARTER_TASK:research_to_ui]` — "Turn it into a webpage or interactive UI" flow',
-    "",
-    "### Playbook: make_it_yours",
-    "Goal: Help the user choose an accent color preference for apps and interfaces.",
-    "",
-    "1. If the user's locale is missing or has `confidence: low` in USER.md, briefly confirm their location/language before proceeding.",
-    "2. Present a concise set of accent color options (e.g. 5-7 curated colors with names and hex codes). Keep it short and scannable.",
-    '3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").',
-    '4. Confirm the selection: "I\'ll set your accent color to **{label}** ({hex}). Sound good?"',
-    "5. On confirmation:",
-    '   - Use `app_file_edit` to update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.',
-    "   - Use `app_file_edit` to update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.",
-    "6. If the user declines or wants to skip, set `make_it_yours` to `skipped` in USER.md and move on.",
-    "",
-    "### Playbook: research_topic",
-    "Goal: Research a topic the user is interested in and summarise findings.",
-    "",
-    '1. Ask the user what topic they\'d like researched. Be specific: "What would you like me to look into?"',
-    "2. Once given a topic, use available tools (web search, browser, etc.) to gather information.",
-    "3. Synthesise the findings into a clear, well-structured summary.",
-    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_topic` to `done`.",
-    "",
-    "### Playbook: research_to_ui",
-    "Goal: Transform research (from a prior research_topic task or current conversation context) into a visual webpage or interactive UI.",
-    "",
-    "1. Check the conversation history for prior research content. If none exists, ask the user what content they'd like visualised.",
-    "2. Synthesise the research into a polished, interactive HTML page using `app_create`.",
-    "3. Follow all Dynamic UI quality standards (anti-AI-slop rules, design tokens, hover states, etc.).",
-    "4. Update the `## Onboarding Tasks` section in USER.md: set `research_to_ui` to `done`.",
-    "",
-    "### General rules for all starter tasks",
-    "- Update the relevant task status in the `## Onboarding Tasks` section of USER.md as you progress (`in_progress` when starting, `done` when complete).",
-    "- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.",
-    "- Keep responses concise and action-oriented. Avoid lengthy explanations of what you're about to do.",
-    "- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.",
+    "Starter task kickoff messages use the format `[STARTER_TASK:<task_id>]`. These are handled by the runtime which automatically loads the `onboarding-starter-tasks` skill with the full playbook. No action needed in the base prompt.",
   ].join("\n");
 }
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -6,7 +6,6 @@ import {
   buildCliReferenceSection,
   buildConfigSection,
   buildContainerizedSection,
-  isOnboardingComplete,
   readPromptFile,
 } from "./sections/core.js";
 import {
@@ -15,7 +14,7 @@ import {
   buildInChatConfigurationSection,
   buildIntegrationSection,
   buildPostToolResponseSection,
-  buildStarterTaskPlaybookSection,
+  buildStarterTaskRoutingSection,
   buildSwarmGuidanceSection,
   buildSystemPermissionSection,
   buildToolPermissionSection,
@@ -55,7 +54,7 @@ export {
   buildInChatConfigurationSection,
   buildIntegrationSection,
   buildPostToolResponseSection,
-  buildStarterTaskPlaybookSection,
+  buildStarterTaskRoutingSection,
   buildSwarmGuidanceSection,
   buildSystemPermissionSection,
   buildToolPermissionSection,
@@ -156,9 +155,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildPhoneCallsRoutingSection());
   parts.push(buildChannelCommandIntentSection());
 
-  if (!isOnboardingComplete()) {
-    parts.push(buildStarterTaskPlaybookSection());
-  }
+  parts.push(buildStarterTaskRoutingSection());
   parts.push(buildSystemPermissionSection());
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildAccessPreferenceSection());

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -202,6 +202,19 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "onboarding-starter-tasks",
+      "name": "onboarding-starter-tasks",
+      "description": "Playbooks for onboarding starter task cards (make_it_yours, research_topic, research_to_ui)",
+      "metadata": {
+        "emoji": "\ud83d\ude80",
+        "vellum": {
+          "display-name": "Onboarding Starter Tasks",
+          "user-invocable": "false"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "notion",
       "name": "notion",
       "description": "Read and write Notion pages and databases using the Notion API",

--- a/skills/onboarding-starter-tasks/SKILL.md
+++ b/skills/onboarding-starter-tasks/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: onboarding-starter-tasks
+description: Playbooks for onboarding starter task cards (make_it_yours, research_topic, research_to_ui)
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🚀"
+  vellum:
+    display-name: "Onboarding Starter Tasks"
+    user-invocable: false
+---
+
+You are executing an onboarding starter task. The user clicked a starter task card in the dashboard and the system sent a deterministic kickoff message in the format `[STARTER_TASK:<task_id>]`. Follow the playbook for that task exactly.
+
+## Kickoff intent contract
+
+- `[STARTER_TASK:make_it_yours]` -- "Make it yours" color personalisation flow
+- `[STARTER_TASK:research_topic]` -- "Research something for me" flow
+- `[STARTER_TASK:research_to_ui]` -- "Turn it into a webpage or interactive UI" flow
+
+## Playbook: make_it_yours
+
+Goal: Help the user choose an accent color preference for apps and interfaces.
+
+1. If the user's locale is missing or has `confidence: low` in USER.md, briefly confirm their location/language before proceeding.
+2. Present a concise set of accent color options (e.g. 5-7 curated colors with names and hex codes). Keep it short and scannable.
+3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").
+4. Confirm the selection: "I'll set your accent color to **{label}** ({hex}). Sound good?"
+5. On confirmation:
+   - Use `app_file_edit` to update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.
+   - Use `app_file_edit` to update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.
+6. If the user declines or wants to skip, set `make_it_yours` to `skipped` in USER.md and move on.
+
+## Playbook: research_topic
+
+Goal: Research a topic the user is interested in and summarise findings.
+
+1. Ask the user what topic they'd like researched. Be specific: "What would you like me to look into?"
+2. Once given a topic, use available tools (web search, browser, etc.) to gather information.
+3. Synthesise the findings into a clear, well-structured summary.
+4. Update the `## Onboarding Tasks` section in USER.md: set `research_topic` to `done`.
+
+## Playbook: research_to_ui
+
+Goal: Transform research (from a prior research_topic task or current conversation context) into a visual webpage or interactive UI.
+
+1. Check the conversation history for prior research content. If none exists, ask the user what content they'd like visualised.
+2. Synthesise the research into a polished, interactive HTML page using `app_create`.
+3. Follow all Dynamic UI quality standards (anti-AI-slop rules, design tokens, hover states, etc.).
+4. Update the `## Onboarding Tasks` section in USER.md: set `research_to_ui` to `done`.
+
+## General rules for all starter tasks
+
+- Update the relevant task status in the `## Onboarding Tasks` section of USER.md as you progress (`in_progress` when starting, `done` when complete).
+- Respect trust gating: do NOT ask for elevated permissions during any starter task flow. These are introductory experiences.
+- Keep responses concise and action-oriented. Avoid lengthy explanations of what you're about to do.
+- If the user deviates from the flow, adapt gracefully. Complete the task if possible, or mark it as `deferred_to_dashboard`.


### PR DESCRIPTION
## Summary
- Create `skills/onboarding-starter-tasks/SKILL.md` with full playbook content (make_it_yours, research_topic, research_to_ui) including USER.md status updates, trust gating, locale confirmation, and app-builder quality expectations
- Add `assistant/src/daemon/starter-task-intent.ts` resolver to detect `[STARTER_TASK:<task_id>]` kickoff messages and rewrite them to force skill loading (following the verification-session-intent pattern)
- Wire starter task intent interception in `session-process.ts` (both `processMessage` and `drainQueue` paths) to preactivate the onboarding-starter-tasks skill
- Replace `buildStarterTaskPlaybookSection()` with a minimal 3-line `buildStarterTaskRoutingSection()` that defers to the runtime skill-load mechanism
- Update tests to verify skill-load behavior and SKILL.md content instead of expecting full playbooks embedded in the system prompt

## Test plan
- [ ] Verify `resolveStarterTaskIntent` correctly detects all three `[STARTER_TASK:]` variants
- [ ] Verify SKILL.md contains all playbook content (trust gating, locale, status updates, quality standards)
- [ ] Verify system prompt no longer contains full playbooks (only the routing section)
- [ ] Verify starter task flows still work end-to-end when dashboard sends kickoff messages

Part of plan: cut-system-prompt.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
