### PR TITLE
Keep only the global persistence essentials and move rare workflows into dedicated docs or skills

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -71,7 +71,7 @@ mock.module("../config/loader.js", () => ({
 
 const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
 
-describe("Dynamic Skill Authoring Workflow prompt section", () => {
+describe("Skill Authoring fallback in system prompt", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -82,36 +82,26 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     }
   });
 
-  test("buildSystemPrompt includes dynamic skill workflow section", () => {
+  test("buildSystemPrompt includes compact skill authoring fallback", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
+    expect(result).toContain("## Skill Authoring");
+    expect(result).toContain("skill-authoring");
   });
 
-  test("workflow section mentions scaffold and delete tools and bun run workflow", () => {
+  test("fallback does NOT include the full dynamic workflow details", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    expect(result).toContain("bun run /tmp/vellum-eval/snippet.ts");
-    expect(result).toContain("scaffold_managed_skill");
-    expect(result).toContain("delete_managed_skill");
+    // The old section embedded bun run, scaffold_managed_skill, and retry limits
+    expect(result).not.toContain("bun run /tmp/vellum-eval/snippet.ts");
+    expect(result).not.toContain("3 attempts");
+    expect(result).not.toContain("## Dynamic Skill Authoring Workflow");
   });
 
-  test("workflow section includes user confirmation warning", () => {
+  test("fallback still mentions user confirmation requirement", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
     const result = buildSystemPrompt();
-    expect(result).toContain("explicit user confirmation");
-  });
-
-  test("workflow section includes retry limit guidance", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("3 attempts");
-  });
-
-  test("workflow section includes session eviction note", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("recreated session");
+    expect(result).toContain("user confirmation");
   });
 
   test("prompt still includes available skills catalog when skills exist", () => {
@@ -127,7 +117,7 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("## Available Skills");
     expect(result).toContain('id="test-skill"');
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
+    expect(result).toContain("skill_load");
   });
 
   test("prompt is additive with IDENTITY/SOUL/USER files", () => {
@@ -139,13 +129,7 @@ describe("Dynamic Skill Authoring Workflow prompt section", () => {
     expect(result).toContain("Identity here");
     expect(result).toContain("Soul here");
     expect(result).toContain("User here");
-    expect(result).toContain("## Dynamic Skill Authoring Workflow");
-  });
-
-  test("workflow section includes skill_load instruction", () => {
-    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
-    const result = buildSystemPrompt();
-    expect(result).toContain("skill_load");
+    expect(result).toContain("## Skill Authoring");
   });
 
   test("system prompt includes browser skill prerequisite guidance", () => {

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -131,7 +131,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     const prompt = buildSystemPrompt();
     expect(prompt).toContain("lifecycle-test");
     expect(prompt).toContain("Lifecycle Test");
-    expect(prompt).toContain("## Dynamic Skill Authoring Workflow");
+    expect(prompt).toContain("## Skill Authoring");
 
     // Step 5: Delete the skill
     const deleteResult = await executeDeleteManagedSkill(

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -191,7 +191,7 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain('id="release-checklist"');
     expect(result).toContain('name="Release Checklist"');
     expect(result).toContain('description="Deployment checks."');
-    expect(result).toContain("call the `skill_load` tool with its `id`");
+    expect(result).toContain("skill_load");
   });
 
   test("keeps SOUL.md and IDENTITY.md additive with skills", () => {
@@ -263,18 +263,16 @@ describe("buildSystemPrompt", () => {
     expect(section).toContain("Do NOT improvise Twilio setup instructions");
   });
 
-  test("includes memory persistence section", () => {
+  test("includes compact persistence section", () => {
     const result = buildSystemPrompt();
-    expect(result).toContain("## Memory Persistence");
+    expect(result).toContain("## Memory & Workspace Persistence");
     expect(result).toContain("memory_save");
-    expect(result).toContain("Saved > unsaved. Always.");
+    expect(result).toContain("memory_recall");
   });
 
   test("config section uses workspace directory from platform util", () => {
     const result = buildSystemPrompt();
-    expect(result).toContain(
-      `Your configuration directory is \`${TEST_DIR}/\`.`,
-    );
+    expect(result).toContain(`\`${TEST_DIR}/\``);
   });
 
   test("omits user skills from catalog when none are configured", () => {
@@ -362,7 +360,7 @@ describe("buildSystemPrompt", () => {
   test("config section lists UPDATES.md", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("`UPDATES.md`");
-    expect(result).toContain("Release update notes");
+    expect(result).toContain("Release notes");
   });
 
   test("strips comment lines starting with _ from prompt files", () => {

--- a/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
@@ -1,30 +1,25 @@
 /**
  * Tests for buildCliReferenceSection — verifies the CLI reference section
- * included in the system prompt has the expected structure and caching behaviour.
+ * included in the system prompt has the expected structure.
+ *
+ * The full CLI help text is no longer embedded in the prompt. Instead the
+ * section provides a compact summary and directs the model to `--help`.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-import {
-  _resetCliHelpCache,
-  buildCliReferenceSection,
-} from "../system-prompt.js";
+import { buildCliReferenceSection } from "../system-prompt.js";
 
 describe("buildCliReferenceSection", () => {
-  beforeEach(() => {
-    _resetCliHelpCache();
-  });
-
   test("includes the Assistant CLI heading", () => {
     const result = buildCliReferenceSection();
     expect(result).toContain("## Assistant CLI");
   });
 
-  test("includes CLI help text with command listings", () => {
+  test("directs the model to --help for full command list", () => {
     const result = buildCliReferenceSection();
-    // The reference is a side-effect-free snapshot of the top-level CLI help.
-    expect(result).toContain("Usage:");
-    expect(result).toContain("Commands:");
+    expect(result).toContain("assistant --help");
+    expect(result).toContain("assistant <command> --help");
   });
 
   test("mentions bash as the way to invoke the CLI", () => {
@@ -34,27 +29,16 @@ describe("buildCliReferenceSection", () => {
 
   test("routes account and auth work through documented assistant CLI commands", () => {
     const result = buildCliReferenceSection();
-    expect(result).toContain(
-      "prefer real `assistant` CLI workflows over any legacy account-record abstraction",
-    );
     expect(result).toContain("assistant credentials");
     expect(result).toContain("assistant oauth token <service>");
     expect(result).toContain("assistant mcp auth <name>");
     expect(result).toContain("assistant platform status");
   });
 
-  test("result is cached — calling twice returns the same string", () => {
-    const first = buildCliReferenceSection();
-    const second = buildCliReferenceSection();
-    expect(first).toBe(second);
-  });
-
-  test("cache is reset by _resetCliHelpCache", () => {
-    const first = buildCliReferenceSection();
-    _resetCliHelpCache();
-    const second = buildCliReferenceSection();
-    // Content should be identical even after reset (same CLI program),
-    // but they should be independently computed strings.
-    expect(first).toEqual(second);
+  test("does not embed the full CLI help reference block", () => {
+    const result = buildCliReferenceSection();
+    // The old section included Usage:/Commands: in a fenced code block
+    expect(result).not.toContain("Usage: assistant [options] [command]");
+    expect(result).not.toContain("Commands:");
   });
 });

--- a/assistant/src/prompts/sections/core.ts
+++ b/assistant/src/prompts/sections/core.ts
@@ -1,7 +1,6 @@
 import { copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { CLI_HELP_REFERENCE } from "../../cli/reference.js";
 import { getBaseDataDir } from "../../config/env-registry.js";
 import { getConfig } from "../../config/loader.js";
 import { resolveBundledDir } from "../../util/bundled-asset.js";
@@ -14,13 +13,6 @@ import {
 const log = getLogger("system-prompt");
 
 const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
-
-let cachedCliHelp: string | undefined;
-
-/** @internal Reset the CLI help cache — exposed for testing only. */
-export function _resetCliHelpCache(): void {
-  cachedCliHelp = undefined;
-}
 
 /**
  * Copy template prompt files into the data directory if they don't already exist.
@@ -160,72 +152,32 @@ export function buildConfigSection(): string {
   const hostWorkspaceDir = getWorkspaceDir();
 
   const config = getConfig();
-  const configPreamble = `Your configuration directory is \`${hostWorkspaceDir}/\`.`;
 
   return [
     "## Configuration",
     `- **Active model**: \`${config.model}\` (provider: ${config.provider})`,
-    `${configPreamble} **Always use \`file_read\` and \`file_edit\` (not \`host_file_read\` / \`host_file_edit\`) for these files** — they are inside your sandbox working directory and do not require host access or user approval:`,
+    `- **Workspace**: \`${hostWorkspaceDir}/\`. **Always use \`file_read\` / \`file_edit\`** (not \`host_file_*\`) for these files — they are inside your sandbox and do not require host approval.`,
     "",
-    "- `IDENTITY.md` — Your name, nature, personality, and emoji. Updated during the first-run ritual.",
-    "- `SOUL.md` — Core principles, personality, and evolution guidance. Your behavioral foundation.",
-    "- `USER.md` — Profile of your user. Update as you learn about them over time.",
-    "- `HEARTBEAT.md` — Checklist for periodic heartbeat runs. When heartbeat is enabled, the assistant runs this checklist on a timer and flags anything that needs attention. Edit this file to control what gets checked each run.",
-    "- `BOOTSTRAP.md` — First-run ritual script (only present during onboarding; you delete it when done).",
-    "- `UPDATES.md` — Release update notes (created automatically on new releases; delete when updates are actioned).",
-    "- `skills/` — Directory of installed skills (loaded automatically at startup).",
+    "Workspace files:",
+    "- `IDENTITY.md` — Name, personality, emoji. `SOUL.md` — Behavioral foundation. `USER.md` — User profile.",
+    "- `HEARTBEAT.md` — Periodic checklist (enable via `heartbeat.enabled` in `config.json`). `BOOTSTRAP.md` — First-run ritual (delete when done).",
+    "- `UPDATES.md` — Release notes (delete when actioned). `skills/` — Installed skills.",
     "",
-    "### Heartbeat",
-    "",
-    "The heartbeat feature runs your `HEARTBEAT.md` checklist periodically in a background thread. To enable it, set `heartbeat.enabled: true` and `heartbeat.intervalMs` (default: 3600000 = 1 hour) in `config.json`. You can also set `heartbeat.activeHoursStart` and `heartbeat.activeHoursEnd` (0-23) to restrict runs to certain hours. When asked to set up a heartbeat, edit both the config and `HEARTBEAT.md` directly — no restart is needed for checklist changes, but toggling `heartbeat.enabled` requires a daemon restart.",
-    "",
-    "### Proactive Workspace Editing",
-    "",
-    `You MUST actively update your workspace files as you learn. You don't need to ask your user whether it's okay — just briefly explain what you're updating, then use \`file_edit\` to make targeted edits.`,
-    "",
-    "**USER.md** — update when you learn:",
-    "- Their name or what they prefer to be called",
-    "- Projects they're working on, tools they use, languages they code in",
-    "- Communication preferences (concise vs detailed, formal vs casual)",
-    "- Interests, hobbies, or context that helps you assist them better",
-    "- Anything else about your user that will help you serve them better",
-    "",
-    "**SOUL.md** — update when you notice:",
-    "- They prefer a different tone or interaction style (add to Personality or User-Specific Behavior)",
-    '- A behavioral pattern worth codifying (e.g. "always explain before acting", "skip preamble")',
-    "- You've adapted in a way that's working well and should persist",
-    "- You decide to change your personality to better serve your user",
-    "",
-    "**IDENTITY.md** — update when:",
-    "- They rename you or change your role",
-    "- Your avatar appearance changes (update the `## Avatar` section with a description of the new look)",
-    "",
-    "When reading or updating workspace files, always use the sandbox tools (`file_read`, `file_edit`). Never use `host_file_read` or `host_file_edit` for workspace files — those are for host-only resources outside your workspace.",
-    "",
-    "When updating, read the file first, then make a targeted edit. Include all useful information, but don't bloat the files over time",
+    "Update workspace files proactively as you learn -- explain briefly what you are updating, then use `file_edit`. Read first, edit targeted, don't bloat.",
   ].join("\n");
 }
 
 export function buildCliReferenceSection(): string {
-  if (cachedCliHelp === undefined) {
-    cachedCliHelp = CLI_HELP_REFERENCE.trim();
-  }
-
   return [
     "## Assistant CLI",
     "",
-    "The `assistant` CLI is installed on the user's machine and available via `bash`.",
-    "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
-    "- Use `assistant credentials ...` for stored secrets and credential metadata.",
-    "- Use `assistant oauth token <service>` for connected integration tokens.",
-    "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
-    "- Use `assistant platform status` for platform-linked deployment and auth context.",
-    "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",
+    "The `assistant` CLI is available via `bash`. Prefer it for account, auth, and integration work:",
+    "- `assistant credentials ...` — stored secrets and credential metadata",
+    "- `assistant oauth token <service>` — connected integration tokens",
+    "- `assistant mcp auth <name>` — MCP server OAuth login",
+    "- `assistant platform status` — platform deployment and auth context",
+    "- If a bundled skill documents a service-specific `assistant <service>` flow, follow that CLI exactly.",
     "",
-    "```",
-    cachedCliHelp,
-    "```",
-    "",
-    "Run `assistant <command> --help` for detailed help on any subcommand.",
+    "Run `assistant --help` for the full command list and `assistant <command> --help` for subcommand details.",
   ].join("\n");
 }

--- a/assistant/src/prompts/sections/persistence.ts
+++ b/assistant/src/prompts/sections/persistence.ts
@@ -1,66 +1,20 @@
-export function buildMemoryPersistenceSection(): string {
+/**
+ * Compact memory and workspace persistence contract.
+ *
+ * Merges the former Memory Persistence, Memory Recall, Workspace Reflection,
+ * and Learning from Mistakes sections into a single section that covers all
+ * persistence responsibilities without repeating the same save/update idea.
+ */
+export function buildPersistenceSection(): string {
   return [
-    "## Memory Persistence",
+    "## Memory & Workspace Persistence",
     "",
-    "Your memory does not survive session restarts. If you want to remember something, **save it**.",
+    "Your memory does not survive session restarts. Save anything worth keeping.",
     "",
-    "- Use `memory_save` for facts, preferences, learnings, and anything worth recalling later.",
-    "- Update workspace files (USER.md, SOUL.md) for profile and personality changes.",
-    '- When someone says "remember this," save it immediately — don\'t rely on keeping it in context.',
-    "- When you make a mistake, save the lesson so future-you doesn't repeat it.",
+    "- **`memory_save`** — durable facts, preferences, learnings, and corrections. Use `kind: \"learning\"` for mistakes and discoveries. Write statements as advice to your future self.",
+    "- **`memory_recall`** — search past memories when context is missing or the user references a previous session. Be specific in your query.",
+    "- **Workspace files** (USER.md, SOUL.md, IDENTITY.md) — update proactively as you learn about your user, adapt your style, or change identity. Read first, then make targeted edits with `file_edit`.",
     "",
-    "Saved > unsaved. Always.",
-  ].join("\n");
-}
-
-export function buildMemoryRecallSection(): string {
-  return [
-    "## Memory Recall",
-    "",
-    "You have access to a `memory_recall` tool for deep memory retrieval. Use it when:",
-    "",
-    "- The user asks about past conversations, decisions, or context you don't have in the current window",
-    "- You need to recall specific facts, preferences, or project details",
-    "- The auto-injected memory context doesn't contain what you need",
-    "- The user references something from a previous session",
-    "",
-    "The tool searches across semantic, lexical, entity graph, and recency sources. Be specific in your query for best results.",
-  ].join("\n");
-}
-
-export function buildWorkspaceReflectionSection(): string {
-  return [
-    "## Workspace Reflection",
-    "",
-    "Before you finish responding to a conversation, pause and consider: did you learn anything worth saving?",
-    "",
-    "- Did your user share personal facts (name, role, timezone, preferences)?",
-    "- Did they correct your behavior or express a preference about how you communicate?",
-    "- Did they mention a project, tool, or workflow you should remember?",
-    "- Did you adapt your style in a way that worked well and should persist?",
-    "",
-    "If yes, briefly explain what you're updating, then update the relevant workspace file (USER.md, SOUL.md, or IDENTITY.md) as part of your response.",
-  ].join("\n");
-}
-
-export function buildLearningMemorySection(): string {
-  return [
-    "## Learning from Mistakes",
-    "",
-    "When you make a mistake, hit a dead end, or discover something non-obvious, save it to memory so you don't repeat it.",
-    "",
-    'Use `memory_save` with `kind: "learning"` for:',
-    "- **Mistakes and corrections** — wrong assumptions, failed approaches, gotchas you ran into",
-    "- **Discoveries** — undocumented behaviors, surprising API quirks, things that weren't obvious",
-    "- **Working solutions** — the approach that actually worked after trial and error",
-    "- **Tool/service insights** — rate limits, auth flows, CLI flags that matter",
-    "",
-    "The statement should capture both what happened and the takeaway. Write it as advice to your future self.",
-    "",
-    "Examples:",
-    '- `memory_save({ kind: "learning", subject: "macOS Shortcuts CLI", statement: "shortcuts CLI requires full disk access to export shortcuts — if permission is denied, guide the user to grant it in System Settings rather than retrying." })`',
-    '- `memory_save({ kind: "learning", subject: "Gmail API pagination", statement: "Gmail search returns max 100 results per page. Always check nextPageToken and loop if the user asks for \'all\' messages." })`',
-    "",
-    "Don't overthink it. If you catch yourself thinking \"I'll remember that for next time,\" save it.",
+    'When someone says "remember this," save it immediately. When you make a mistake, save the lesson. Before finishing a response, consider whether you learned anything worth persisting.',
   ].join("\n");
 }

--- a/assistant/src/prompts/sections/skills.ts
+++ b/assistant/src/prompts/sections/skills.ts
@@ -18,27 +18,18 @@ export function appendSkillsCatalog(basePrompt: string): string {
   const catalog = formatSkillsCatalog(flagFiltered);
   if (catalog) sections.push(catalog);
 
-  sections.push(buildDynamicSkillWorkflowSection(config, flagFiltered));
+  sections.push(buildSkillFallbackSection(flagFiltered));
 
   return sections.join("\n\n");
 }
 
-function buildDynamicSkillWorkflowSection(
-  _config: import("../../config/schema.js").AssistantConfig,
+function buildSkillFallbackSection(
   activeSkills: SkillSummary[],
 ): string {
   const lines = [
-    "## Dynamic Skill Authoring Workflow",
+    "## Skill Authoring",
     "",
-    "When no existing tool or skill can satisfy a request:",
-    "1. Validate the gap — confirm no existing tool/skill covers it.",
-    "2. Draft a TypeScript snippet exporting a `default` or `run` function (`(input: unknown) => unknown | Promise<unknown>`).",
-    '3. Test the snippet by writing it to a temp file with `bash` (e.g., `bash command="mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << \'SNIPPET_EOF\'\\n...\\nSNIPPET_EOF"`) and running it with `bash command="bun run /tmp/vellum-eval/snippet.ts"`. Do not use `file_write` for temp files outside the working directory. Iterate until it passes (max 3 attempts, then ask the user). Clean up temp files after.',
-    "4. Persist with `scaffold_managed_skill` only after user consent.",
-    "5. Load with `skill_load` before use.",
-    "",
-    "**Never persist or delete skills without explicit user confirmation.** To remove: `delete_managed_skill`.",
-    "After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.",
+    "When no existing tool or skill can satisfy a request, load the `skill-authoring` skill for the full scaffold/test/persist workflow. Never persist or delete skills without explicit user confirmation.",
   ];
 
   const activeSkillIds = new Set(activeSkills.map((s) => s.id));
@@ -116,15 +107,10 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
 
   return [
     "## Available Skills",
-    "The following skills are available. Before executing one, call the `skill_load` tool with its `id` to load the full instructions.",
-    "When a credential is missing, check if any skill declares `credential-setup-for` matching that service — if so, load that skill.",
+    "Call `skill_load` with a skill's `id` to load its full instructions before use. When a credential is missing, check for a skill with a matching `credential-setup-for` attribute.",
     "",
     lines.join("\n"),
     "",
-    "### Installing additional skills",
-    "If `skill_load` fails because a skill is not found, additional first-party skills may be available in the Vellum catalog.",
-    "Use `bash` to discover and install them:",
-    "- `assistant skills list` — list all available catalog skills",
-    "- `assistant skills install <skill-id>` — install a skill, then retry `skill_load`",
+    "Additional first-party skills: `assistant skills list` / `assistant skills install <id>`.",
   ].join("\n");
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -20,12 +20,7 @@ import {
   buildSystemPermissionSection,
   buildToolPermissionSection,
 } from "./sections/operations.js";
-import {
-  buildLearningMemorySection,
-  buildMemoryPersistenceSection,
-  buildMemoryRecallSection,
-  buildWorkspaceReflectionSection,
-} from "./sections/persistence.js";
+import { buildPersistenceSection } from "./sections/persistence.js";
 import {
   buildChannelAwarenessSection,
   buildChannelCommandIntentSection,
@@ -41,7 +36,6 @@ import { appendSkillsCatalog } from "./sections/skills.js";
 // Preserve the public API so existing importers continue to work.
 
 export {
-  _resetCliHelpCache,
   buildCliReferenceSection,
   buildConfigSection,
   buildContainerizedSection,
@@ -60,12 +54,7 @@ export {
   buildSystemPermissionSection,
   buildToolPermissionSection,
 } from "./sections/operations.js";
-export {
-  buildLearningMemorySection,
-  buildMemoryPersistenceSection,
-  buildMemoryRecallSection,
-  buildWorkspaceReflectionSection,
-} from "./sections/persistence.js";
+export { buildPersistenceSection } from "./sections/persistence.js";
 export {
   buildChannelAwarenessSection,
   buildChannelCommandIntentSection,
@@ -163,10 +152,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildSwarmGuidanceSection());
   parts.push(buildAccessPreferenceSection());
   parts.push(buildIntegrationSection());
-  parts.push(buildMemoryPersistenceSection());
-  parts.push(buildMemoryRecallSection());
-  parts.push(buildWorkspaceReflectionSection());
-  parts.push(buildLearningMemorySection());
+  parts.push(buildPersistenceSection());
 
   return appendSkillsCatalog(parts.join("\n\n"));
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -202,19 +202,6 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
-      "id": "onboarding-starter-tasks",
-      "name": "onboarding-starter-tasks",
-      "description": "Playbooks for onboarding starter task cards (make_it_yours, research_topic, research_to_ui)",
-      "metadata": {
-        "emoji": "\ud83d\ude80",
-        "vellum": {
-          "display-name": "Onboarding Starter Tasks",
-          "user-invocable": "false"
-        }
-      },
-      "compatibility": "Designed for Vellum personal assistants"
-    },
-    {
       "id": "notion",
       "name": "notion",
       "description": "Read and write Notion pages and databases using the Notion API",
@@ -256,6 +243,19 @@
           "includes": [
             "browser"
           ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
+      "id": "onboarding-starter-tasks",
+      "name": "onboarding-starter-tasks",
+      "description": "Playbooks for onboarding starter task cards (make_it_yours, research_topic, research_to_ui)",
+      "metadata": {
+        "emoji": "🚀",
+        "vellum": {
+          "display-name": "Onboarding Starter Tasks",
+          "user-invocable": "false"
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -306,6 +306,18 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "skill-authoring",
+      "name": "skill-authoring",
+      "description": "Create, test, and manage custom skills when no existing tool or skill satisfies a request.",
+      "metadata": {
+        "emoji": "🛠️",
+        "vellum": {
+          "display-name": "Skill Authoring"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "skills-catalog",
       "name": "skills-catalog",
       "description": "Discover bundled skills and search/install community skills from Clawhub",

--- a/skills/skill-authoring/SKILL.md
+++ b/skills/skill-authoring/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: skill-authoring
+description: Create, test, and manage custom skills when no existing tool or skill satisfies a request.
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🛠️"
+  vellum:
+    display-name: "Skill Authoring"
+---
+
+## Dynamic Skill Authoring Workflow
+
+When no existing tool or skill can satisfy a request, follow this workflow to create a new one.
+
+### 1. Validate the gap
+
+Confirm no existing tool or skill covers the request. Check `<available_skills>` and installed tools before proceeding.
+
+### 2. Draft a snippet
+
+Write a TypeScript snippet exporting a `default` or `run` function:
+
+```typescript
+export default function run(input: unknown): unknown | Promise<unknown> {
+  // ...
+}
+```
+
+### 3. Test the snippet
+
+Write the snippet to a temp file with `bash` and run it with `bun`:
+
+```bash
+mkdir -p /tmp/vellum-eval && cat > /tmp/vellum-eval/snippet.ts << 'SNIPPET_EOF'
+// ... your snippet ...
+SNIPPET_EOF
+bun run /tmp/vellum-eval/snippet.ts
+```
+
+Do not use `file_write` for temp files outside the working directory. Iterate until the snippet passes (max 3 attempts, then ask the user for guidance). Clean up temp files after testing.
+
+### 4. Persist the skill
+
+Only after explicit user consent, persist with `scaffold_managed_skill`. Provide:
+
+- `skill_id` — kebab-case identifier
+- `name` — human-readable name
+- `description` — one-sentence summary
+- `body_markdown` — the full SKILL.md body content
+
+### 5. Load and use
+
+Load the new skill with `skill_load` before use.
+
+### Deleting skills
+
+To remove a skill, use `delete_managed_skill`. **Never persist or delete skills without explicit user confirmation.**
+
+### Session eviction
+
+After a skill is written or deleted, the next turn may run in a recreated session due to file-watcher eviction. Continue normally.


### PR DESCRIPTION
## Summary
- Merge four memory/workspace sections into one compact persistence contract
- Replace embedded CLI help with a short summary pointing to --help
- Move dynamic skill authoring workflow into skills/skill-authoring/SKILL.md
- Trim skills catalog surrounding prose to minimum needed for skill_load

Part of plan: cut-system-prompt.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
