### PR TITLE
fix: guard proxy teardown in conversation-routes.ts to prevent disrupting in-flight turns

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -640,7 +640,7 @@ export async function handleSendMessage(
       });
       session.setHostFileProxy(fileProxy);
     }
-  } else {
+  } else if (!session.isProcessing()) {
     session.setHostBashProxy(undefined);
     session.setHostFileProxy(undefined);
   }


### PR DESCRIPTION
Review feedback on #15209 identified that conversation-routes.ts was missing the isProcessing() guard on proxy teardown that server.ts already had. A non-desktop request arriving while a desktop turn is processing would unconditionally clear the host bash/file proxies, breaking in-flight tool calls. Adds the same guard pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
