### PR TITLE
fix: raise browser-skill endstate test floor to 15 and fix comment

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -78,11 +78,11 @@ describe("browser skill migration end-state", () => {
 
   test("startup tool definition count is reduced (no browser tools)", () => {
     const definitions = getAllToolDefinitions();
-    // Startup has ~9 definitions after moving scaffold/settings/skill-management
+    // Startup has ~20 definitions after moving scaffold/settings/skill-management
     // tools to bundled skills (no browser tools).
     // Allow wider drift for unrelated tool additions while still failing if
     // browser tools are reintroduced at startup (+14 definitions).
-    expect(definitions.length).toBeGreaterThanOrEqual(5);
+    expect(definitions.length).toBeGreaterThanOrEqual(15);
     expect(definitions.length).toBeLessThanOrEqual(50);
 
     const defNames = definitions.map((d) => d.name);


### PR DESCRIPTION
Review feedback on #15212 identified that the endstate test floor of 5 was too low to catch regressions, and the comment incorrectly said ~9 definitions when actual count is ~20. Raises floor to 15 and fixes the comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
