### PR TITLE
fix: scan full DB messages for hasAttachments to detect attachments in compacted history

### DIFF
--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -78,6 +78,7 @@ export interface LoadFromDbContext {
   contextCompactedAt: number | null;
   trustContext?: { trustClass: TrustClass };
   loadedHistoryTrustClass?: TrustClass;
+  hasAttachments?: boolean;
 }
 
 export interface AbortContext {
@@ -180,6 +181,20 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
   }
 
   ctx.loadedHistoryTrustClass = trustClass;
+
+  // Scan ALL db messages (including compacted ones) for attachments so that
+  // asset tools remain available after context compaction.
+  if (
+    ctx.contextCompactedMessageCount > 0 &&
+    dbMessages.some(
+      (m) =>
+        m.role === "user" &&
+        (m.content.includes('"type":"image"') ||
+          m.content.includes('"type":"file"')),
+    )
+  ) {
+    ctx.hasAttachments = true;
+  }
 
   log.info(
     { conversationId: ctx.conversationId, count: ctx.messages.length },

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -363,6 +363,8 @@ export class Session {
     // Scan loaded history for attachment content blocks so that asset
     // tools are available when resuming a conversation that already had
     // attachments. One-way: once true it stays true for the session.
+    // Also picks up the hasAttachments flag set by loadFromDbImpl which
+    // scans compacted (sliced-off) messages that aren't in this.messages.
     if (!this.hasAttachments && messagesContainAttachments(this.messages)) {
       this.hasAttachments = true;
     }


### PR DESCRIPTION
Codex review on #15206 identified that loadFromDb() sets hasAttachments by scanning this.messages, which only contains post-compaction messages. Attachments in compacted history are missed, causing asset tools to be filtered out. Fix: scan the full dbMessages array before slicing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
