### PR TITLE
feat: add image file support to file_read tool

### DIFF
--- a/assistant/src/__tests__/file-read-tool.test.ts
+++ b/assistant/src/__tests__/file-read-tool.test.ts
@@ -92,3 +92,89 @@ describe("file_read tool (sandbox)", () => {
     expect(result.content).toContain("outside the working directory");
   });
 });
+
+// ── Image file support ────────────────────────────────────────────────
+
+// Minimal valid JPEG: FF D8 FF E0 header
+const JPEG_HEADER = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01,
+  0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+]);
+
+// Minimal valid PNG header
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52,
+]);
+
+describe("file_read image support", () => {
+  test("returns image content block for .jpg file", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "photo.jpg"), JPEG_HEADER);
+
+    const result = await fileReadTool.execute(
+      { path: "photo.jpg" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Image loaded");
+    expect(result.content).toContain("image/jpeg");
+    expect((result as any).contentBlocks).toBeDefined();
+    expect((result as any).contentBlocks[0].type).toBe("image");
+    expect((result as any).contentBlocks[0].source.media_type).toBe(
+      "image/jpeg",
+    );
+  });
+
+  test("returns image content block for .png file", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "screenshot.png"), PNG_HEADER);
+
+    const result = await fileReadTool.execute(
+      { path: "screenshot.png" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("image/png");
+    expect((result as any).contentBlocks).toBeDefined();
+  });
+
+  test("ignores offset/limit for image files", async () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "img.jpg"), JPEG_HEADER);
+
+    const result = await fileReadTool.execute(
+      { path: "img.jpg", offset: 5, limit: 10 },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Image loaded");
+  });
+
+  test("returns error for missing image file", async () => {
+    const dir = makeTempDir();
+
+    const result = await fileReadTool.execute(
+      { path: "missing.jpg" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("file not found");
+  });
+
+  test("blocks image path traversal outside working dir", async () => {
+    const dir = makeTempDir();
+
+    const result = await fileReadTool.execute(
+      { path: "../../etc/secret.png" },
+      makeContext(dir),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside the working directory");
+  });
+});

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -1,13 +1,20 @@
+import { extname } from "node:path";
+
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { registerTool } from "../registry.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
+import {
+  IMAGE_EXTENSIONS,
+  readImageFile,
+} from "../shared/filesystem/image-read.js";
 import { sandboxPolicy } from "../shared/filesystem/path-policy.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 class FileReadTool implements Tool {
   name = "file_read";
-  description = "Read the contents of a file";
+  description =
+    "Read the contents of a file. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis.";
   category = "filesystem";
   defaultRiskLevel = RiskLevel.Low;
 
@@ -52,6 +59,16 @@ class FileReadTool implements Tool {
         content: "Error: path is required and must be a string",
         isError: true,
       };
+    }
+
+    // For image files, delegate to the shared image reader.
+    const ext = extname(rawPath).toLowerCase();
+    if (IMAGE_EXTENSIONS.has(ext)) {
+      const pathCheck = sandboxPolicy(rawPath, context.workingDir);
+      if (!pathCheck.ok) {
+        return { content: `Error: ${pathCheck.error}`, isError: true };
+      }
+      return readImageFile(pathCheck.resolved);
     }
 
     const ops = new FileSystemOps((path, opts) =>


### PR DESCRIPTION
## Summary
- `file_read` now detects image extensions and delegates to `readImageFile()` from the shared module
- Updated tool description to mention image support
- Added tests for image reading via `file_read` (JPEG, PNG, offset/limit ignored, missing file, path traversal)

## Original prompt
Fold the `view_image` tool into the `file_read` tool — PR 2 of 3: make file_read handle image files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
