### PR TITLE
feat: add `skill_execute` dispatch tool definition

### DIFF
--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -1,0 +1,53 @@
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { registerTool } from "../registry.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+export class SkillExecuteTool implements Tool {
+  name = "skill_execute";
+  description =
+    "Execute a tool provided by a loaded skill. Use this instead of calling skill tools directly. The skill's instructions (from skill_load) describe available tools and their parameters.";
+  category = "skills";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          tool: {
+            type: "string",
+            description:
+              "The skill tool name to execute (e.g. 'browser_navigate', 'task_create')",
+          },
+          input: {
+            type: "object",
+            description:
+              "Tool-specific parameters as documented in the skill's instructions",
+          },
+          reason: {
+            type: "string",
+            description:
+              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update.",
+          },
+        },
+        required: ["tool", "input"],
+      },
+    };
+  }
+
+  async execute(
+    _input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    return {
+      content:
+        "skill_execute should be intercepted at session level. If you see this error, the session dispatch is not configured.",
+      isError: true,
+    };
+  }
+}
+
+registerTool(new SkillExecuteTool());

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -33,6 +33,7 @@ import "./filesystem/view-image.js";
 import "./filesystem/write.js";
 import "./network/web-fetch.js";
 import "./network/web-search.js";
+import "./skills/execute.js";
 import "./skills/load.js";
 import "./system/request-permission.js";
 import "./terminal/shell.js";
@@ -54,6 +55,7 @@ export const eagerModuleToolNames: string[] = [
   "file_edit",
   "web_search",
   "web_fetch",
+  "skill_execute",
   "skill_load",
   "request_system_permission",
   "asset_search",


### PR DESCRIPTION
## Summary
- Add new `skill_execute` tool that will serve as a dispatch mechanism for invoking loaded skill tools
- Register it as an eager module in the tool manifest so it's available at daemon startup
- Tool's execute() is a safety-net stub — actual dispatch will be wired at the session level in a follow-up PR

Part of plan: skill-meta-dispatch.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
