### PR TITLE
feat: include tool parameter schemas in `skill_load` output

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -98,6 +98,35 @@ function writeSkillWithIncludes(
   );
 }
 
+function writeToolsJson(
+  skillId: string,
+  tools: Array<{
+    name: string;
+    description: string;
+    category?: string;
+    risk?: string;
+    input_schema?: Record<string, unknown>;
+    executor?: string;
+    execution_target?: string;
+  }>,
+): void {
+  const skillDir = join(TEST_DIR, "skills", skillId);
+  mkdirSync(skillDir, { recursive: true });
+  const manifest = {
+    version: 1,
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      category: t.category ?? "general",
+      risk: t.risk ?? "low",
+      input_schema: t.input_schema ?? { type: "object", properties: {} },
+      executor: t.executor ?? "scripts/run.sh",
+      execution_target: t.execution_target ?? "host",
+    })),
+  };
+  writeFileSync(join(skillDir, "TOOLS.json"), JSON.stringify(manifest));
+}
+
 async function executeSkillLoad(
   input: Record<string, unknown>,
 ): Promise<{ content: string; isError: boolean }> {
@@ -688,6 +717,137 @@ describe("skill_load tool", () => {
     expect(result.content).toContain("Included Skills (immediate): none");
     expect(result.content).toMatch(
       /<loaded_skill id="empty-includes" version="v1:[a-f0-9]{64}" \/>/,
+    );
+  });
+
+  test("skill with TOOLS.json includes tool schemas section in output", async () => {
+    writeSkill(
+      "skill-with-tools",
+      "Skill With Tools",
+      "Has tools",
+      "Main body.",
+    );
+    writeToolsJson("skill-with-tools", [
+      {
+        name: "deploy_app",
+        description: "Deploy the application to production",
+        input_schema: {
+          type: "object",
+          properties: {
+            environment: {
+              type: "string",
+              description: "Target environment",
+            },
+            force: {
+              type: "boolean",
+              description: "Force deploy even if checks fail",
+            },
+          },
+          required: ["environment"],
+        },
+      },
+      {
+        name: "rollback_app",
+        description: "Rollback to previous version",
+        input_schema: {
+          type: "object",
+          properties: {
+            version: {
+              type: "string",
+              description: "Version to rollback to",
+            },
+          },
+          required: ["version"],
+        },
+      },
+    ]);
+    writeFileSync(
+      join(TEST_DIR, "skills", "SKILLS.md"),
+      "- skill-with-tools\n",
+    );
+
+    const result = await executeSkillLoad({ skill: "skill-with-tools" });
+    expect(result.isError).toBe(false);
+
+    // Should contain the Available Tools section header
+    expect(result.content).toContain("## Available Tools");
+
+    // Should instruct the LLM to use skill_execute
+    expect(result.content).toContain(
+      "Use `skill_execute` to call these tools.",
+    );
+
+    // Should contain tool names as headings
+    expect(result.content).toContain("### deploy_app");
+    expect(result.content).toContain("### rollback_app");
+
+    // Should contain tool descriptions
+    expect(result.content).toContain("Deploy the application to production");
+    expect(result.content).toContain("Rollback to previous version");
+
+    // Should list parameters with types and required/optional markers
+    expect(result.content).toContain(
+      "- environment (string, required): Target environment",
+    );
+    expect(result.content).toContain(
+      "- force (boolean, optional): Force deploy even if checks fail",
+    );
+    expect(result.content).toContain(
+      "- version (string, required): Version to rollback to",
+    );
+  });
+
+  test("skill without TOOLS.json does not include tool schemas section", async () => {
+    writeSkill("no-tools", "No Tools", "No tools manifest", "Body.");
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-tools\n");
+
+    const result = await executeSkillLoad({ skill: "no-tools" });
+    expect(result.isError).toBe(false);
+    expect(result.content).not.toContain("## Available Tools");
+    expect(result.content).not.toContain("skill_execute");
+  });
+
+  test("included child skill with TOOLS.json has its tool schemas in output", async () => {
+    writeSkillWithIncludes(
+      "parent-tools",
+      "Parent Tools",
+      "Parent with tooled child",
+      "Parent body.",
+      ["child-tools"],
+    );
+    writeSkill("child-tools", "Child Tools", "Child with tools", "Child body.");
+    writeToolsJson("child-tools", [
+      {
+        name: "child_action",
+        description: "A child tool action",
+        input_schema: {
+          type: "object",
+          properties: {
+            target: {
+              type: "string",
+              description: "Action target",
+            },
+          },
+          required: ["target"],
+        },
+      },
+    ]);
+    writeFileSync(
+      join(TEST_DIR, "skills", "SKILLS.md"),
+      "- parent-tools\n- child-tools\n",
+    );
+
+    const result = await executeSkillLoad({ skill: "parent-tools" });
+    expect(result.isError).toBe(false);
+
+    // The child skill's tool schemas should appear
+    expect(result.content).toContain("### child_action");
+    expect(result.content).toContain("A child tool action");
+    expect(result.content).toContain(
+      "- target (string, required): Action target",
+    );
+    expect(result.content).toContain(
+      "Use `skill_execute` to call these tools.",
     );
   });
 });

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -1,7 +1,10 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { skillFlagKey } from "../../config/skill-state.js";
-import type { SkillSummary } from "../../config/skills.js";
+import type { SkillSummary, SkillToolManifest } from "../../config/skills.js";
 import { loadSkillBySelector, loadSkillCatalog } from "../../config/skills.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -9,12 +12,83 @@ import {
   indexCatalogById,
   validateIncludes,
 } from "../../skills/include-graph.js";
+import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
 import { getLogger } from "../../util/logger.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("skill-load");
+
+/**
+ * Attempt to load and parse TOOLS.json from a skill directory.
+ * Returns undefined if the file doesn't exist or fails to parse.
+ */
+function loadToolManifest(
+  directoryPath: string,
+): SkillToolManifest | undefined {
+  const manifestPath = join(directoryPath, "TOOLS.json");
+  if (!existsSync(manifestPath)) {
+    return undefined;
+  }
+  try {
+    return parseToolManifestFile(manifestPath);
+  } catch (err) {
+    log.warn(
+      { err, manifestPath },
+      "Failed to parse TOOLS.json for tool schema output",
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Format a skill tool manifest into a human-readable "Available Tools" section
+ * that instructs the LLM to use `skill_execute` to invoke the tools.
+ */
+function formatToolSchemas(manifest: SkillToolManifest): string {
+  const lines: string[] = [
+    "## Available Tools",
+    "",
+    "Use `skill_execute` to call these tools.",
+    "",
+  ];
+
+  for (const tool of manifest.tools) {
+    lines.push(`### ${tool.name}`);
+    lines.push(tool.description);
+
+    const schema = tool.input_schema;
+    const properties = schema.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    if (properties && Object.keys(properties).length > 0) {
+      const requiredSet = new Set<string>(
+        Array.isArray(schema.required) ? (schema.required as string[]) : [],
+      );
+
+      lines.push("Parameters:");
+      for (const [paramName, paramDef] of Object.entries(properties)) {
+        const paramType =
+          typeof paramDef.type === "string" ? paramDef.type : "any";
+        const requiredLabel = requiredSet.has(paramName)
+          ? "required"
+          : "optional";
+        const descPart =
+          typeof paramDef.description === "string"
+            ? `: ${paramDef.description}`
+            : "";
+        lines.push(
+          `- ${paramName} (${paramType}, ${requiredLabel})${descPart}`,
+        );
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
 
 export class SkillLoadTool implements Tool {
   name = "skill_load";
@@ -115,6 +189,12 @@ export class SkillLoadTool implements Tool {
 
     const body = skill.body.length > 0 ? skill.body : "(No body content)";
 
+    // Load tool schemas for the main skill
+    const mainManifest = loadToolManifest(skill.directoryPath);
+    const toolSchemasSection = mainManifest
+      ? formatToolSchemas(mainManifest)
+      : undefined;
+
     // Build immediate children metadata section and load included skill bodies
     let immediateChildrenSection: string;
     const includedBodies: string[] = [];
@@ -140,6 +220,14 @@ export class SkillLoadTool implements Tool {
           includedBodies.push(
             `--- Included Skill: ${childLoaded.skill.displayName} (${childId}) ---\n${childLoaded.skill.body}`,
           );
+
+          // Load tool schemas for the included skill
+          const childManifest = loadToolManifest(
+            childLoaded.skill.directoryPath,
+          );
+          if (childManifest) {
+            includedBodies.push(formatToolSchemas(childManifest));
+          }
         }
       }
       immediateChildrenSection = `Included Skills (immediate):\n${childLines.join(
@@ -198,6 +286,7 @@ export class SkillLoadTool implements Tool {
         "",
         body,
         "",
+        ...(toolSchemasSection ? [toolSchemasSection, ""] : []),
         ...includedBodies.flatMap((b) => [b, ""]),
         immediateChildrenSection,
         "",


### PR DESCRIPTION
## Summary
- Enhance `skill_load` to append a structured 'Available Tools' section with tool names, descriptions, and parameter schemas parsed from TOOLS.json
- Include tool schemas for child skills loaded via the include graph
- Instruct the LLM to use `skill_execute` to invoke these tools

Part of plan: skill-meta-dispatch.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
