### PR TITLE
feat: wire session-level `skill_execute` dispatch through full executor pipeline

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -206,6 +206,7 @@ const TOOL_FRIENDLY_NAMES: Record<string, string> = {
   app_create: "app",
   app_update: "app",
   skill_load: "skill",
+  skill_execute: "skill",
   app_file_edit: "app file",
   app_file_write: "app file",
 };

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -139,6 +139,7 @@ const TOOL_FRIENDLY_LABEL: Record<string, string> = {
   app_create: "Create App",
   app_update: "Update App",
   skill_load: "Load Skill",
+  skill_execute: "Run Skill Tool",
   app_file_edit: "Edit App File",
   app_file_write: "Write App File",
 };
@@ -1352,12 +1353,7 @@ export async function runAgentLoopImpl(
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {
-        ctx.emitActivityState(
-          "idle",
-          "generation_cancelled",
-          "global",
-          reqId,
-        );
+        ctx.emitActivityState("idle", "generation_cancelled", "global", reqId);
         ctx.traceEmitter.emit(
           "generation_cancelled",
           "Generation cancelled by user",

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -34,6 +34,7 @@ import {
 import type {
   ProxyApprovalCallback,
   ProxyApprovalRequest,
+  ToolContext,
   ToolExecutionResult,
   ToolLifecycleEventHandler,
 } from "../tools/types.js";
@@ -157,7 +158,9 @@ export function createToolExecutor(
       markDoordashStepInProgress(ctx, input);
     }
 
-    const result = await executor.execute(name, input, {
+    // Build the context object shared by both the skill_execute interception
+    // path and the regular executor path.
+    const toolContext: ToolContext = {
       workingDir: ctx.workingDir,
       sessionId: ctx.conversationId,
       conversationId: ctx.conversationId,
@@ -324,7 +327,38 @@ export function createToolExecutor(
             : ("deny" as const),
         };
       },
-    });
+    };
+
+    // Intercept skill_execute: extract the real tool name and input, then
+    // route through the full executor pipeline so the underlying tool's
+    // risk level, permission checks, hooks, and lifecycle events all fire
+    // with the real tool name.
+    if (name === "skill_execute") {
+      const toolName = typeof input.tool === "string" ? input.tool : "";
+      const toolInput =
+        input.input != null && typeof input.input === "object"
+          ? (input.input as Record<string, unknown>)
+          : {};
+
+      if (!toolName) {
+        return {
+          content:
+            'Error: skill_execute requires a "tool" parameter with the tool name',
+          isError: true,
+        };
+      }
+
+      const result = await executor.execute(toolName, toolInput, toolContext);
+
+      runPostExecutionSideEffects(toolName, toolInput, result, {
+        ctx,
+        broadcastToAllClients,
+      });
+
+      return result;
+    }
+
+    const result = await executor.execute(name, input, toolContext);
 
     runPostExecutionSideEffects(name, input, result, {
       ctx,


### PR DESCRIPTION
## Summary
- Intercept `skill_execute` tool calls at the session level to extract the real tool name and input
- Route through the full `ToolExecutor.execute()` pipeline so permissions, hooks, lifecycle events, and secret detection all fire with the actual skill tool name
- Add friendly name mappings for status line and confirmation chips

Part of plan: skill-meta-dispatch.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
