### PR TITLE
fix: export eager tool instances to survive registry resets in tests

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -62,12 +62,13 @@ describe("always-loaded tool count", () => {
       "memory_recall",
       "memory_save",
       "memory_update",
+      "skill_execute",
       "skill_load",
       "web_fetch",
       "web_search",
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(16);
+    expect(activeTools.length).toBe(17);
   });
 });

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -161,4 +161,5 @@ class FileEditTool implements Tool {
   }
 }
 
-registerTool(new FileEditTool());
+export const fileEditTool = new FileEditTool();
+registerTool(fileEditTool);

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -103,4 +103,5 @@ class FileReadTool implements Tool {
   }
 }
 
-registerTool(new FileReadTool());
+export const fileReadTool = new FileReadTool();
+registerTool(fileReadTool);

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -97,4 +97,5 @@ class FileWriteTool implements Tool {
   }
 }
 
-registerTool(new FileWriteTool());
+export const fileWriteTool = new FileWriteTool();
+registerTool(fileWriteTool);

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -882,4 +882,5 @@ class WebFetchTool implements Tool {
   }
 }
 
-registerTool(new WebFetchTool());
+export const webFetchTool = new WebFetchTool();
+registerTool(webFetchTool);

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -382,4 +382,5 @@ class WebSearchTool implements Tool {
   }
 }
 
-registerTool(new WebSearchTool());
+export const webSearchTool = new WebSearchTool();
+registerTool(webSearchTool);

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -50,4 +50,5 @@ export class SkillExecuteTool implements Tool {
   }
 }
 
-registerTool(new SkillExecuteTool());
+export const skillExecuteTool = new SkillExecuteTool();
+registerTool(skillExecuteTool);

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -298,4 +298,5 @@ export class SkillLoadTool implements Tool {
   }
 }
 
-registerTool(new SkillLoadTool());
+export const skillLoadTool = new SkillLoadTool();
+registerTool(skillLoadTool);

--- a/assistant/src/tools/system/request-permission.ts
+++ b/assistant/src/tools/system/request-permission.ts
@@ -110,4 +110,5 @@ class RequestSystemPermissionTool implements Tool {
   }
 }
 
-registerTool(new RequestSystemPermissionTool());
+export const requestSystemPermissionTool = new RequestSystemPermissionTool();
+registerTool(requestSystemPermissionTool);

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,18 +6,33 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
+import { assetMaterializeTool } from "./assets/materialize.js";
+import { assetSearchTool } from "./assets/search.js";
 import { credentialStoreTool } from "./credentials/vault.js";
+import { fileEditTool } from "./filesystem/edit.js";
+import { fileReadTool } from "./filesystem/read.js";
+import { fileWriteTool } from "./filesystem/write.js";
 import {
   memoryDeleteTool,
   memoryRecallTool,
   memorySaveTool,
   memoryUpdateTool,
 } from "./memory/register.js";
+import { webFetchTool } from "./network/web-fetch.js";
+import { webSearchTool } from "./network/web-search.js";
 import type { LazyToolDescriptor } from "./registry.js";
+import { skillExecuteTool } from "./skills/execute.js";
+import { skillLoadTool } from "./skills/load.js";
+import { requestSystemPermissionTool } from "./system/request-permission.js";
+import { shellTool } from "./terminal/shell.js";
 import type { Tool } from "./types.js";
 
 // ── Eager side-effect modules ───────────────────────────────────────
-// These static imports trigger top-level `registerTool()` side effects.
+// These static imports trigger top-level `registerTool()` side effects on
+// first evaluation. The named imports above serve double duty: they give us
+// module-level references to each tool instance so that initializeTools()
+// can explicitly re-register them after a test registry reset (ESM caching
+// prevents side effects from re-running on subsequent imports).
 //
 // IMPORTANT: These MUST be static imports (not dynamic `await import()`).
 // When the daemon is compiled with `bun --compile`, dynamic imports with
@@ -25,17 +40,6 @@ import type { Tool } from "./types.js";
 // filesystem root rather than the module's own directory, causing
 // "Cannot find module './filesystem/read.js'" crashes in production builds.
 // Static imports are resolved at bundle time and are always safe.
-import "./assets/materialize.js";
-import "./assets/search.js";
-import "./filesystem/edit.js";
-import "./filesystem/read.js";
-import "./filesystem/write.js";
-import "./network/web-fetch.js";
-import "./network/web-search.js";
-import "./skills/execute.js";
-import "./skills/load.js";
-import "./system/request-permission.js";
-import "./terminal/shell.js";
 
 // loadEagerModules is a no-op now that all eager registrations happen via
 // static imports above. Kept for API compatibility with registry.ts callers.
@@ -62,10 +66,26 @@ export const eagerModuleToolNames: string[] = [
 ];
 
 // ── Explicit tool instances ─────────────────────────────────────────
-// Tools exported as instances — registered by initializeTools() without
-// relying on import side effects.
+// Tools registered by initializeTools() via explicit instance references.
+// This includes both previously-eager tools (referenced here so they survive
+// a test registry reset) and tools that have always been explicit.
 
 export const explicitTools: Tool[] = [
+  // Previously-eager tools — kept here so initializeTools() can re-register
+  // them after __resetRegistryForTesting() clears the registry (ESM caching
+  // prevents their side-effect registrations from re-running).
+  shellTool,
+  fileReadTool,
+  fileWriteTool,
+  fileEditTool,
+  webFetchTool,
+  webSearchTool,
+  skillExecuteTool,
+  skillLoadTool,
+  requestSystemPermissionTool,
+  assetSearchTool,
+  assetMaterializeTool,
+  // Always-explicit tools
   memorySaveTool,
   memoryUpdateTool,
   memoryDeleteTool,


### PR DESCRIPTION
## Summary
- Export named instances from all eager-module tools (filesystem, network, skills, system, terminal) so `initializeTools()` can explicitly re-register them after `__resetRegistryForTesting()` clears the registry
- Add all eager tool instances to `explicitTools` in `tool-manifest.ts` so they survive ESM-cached test resets and are always included in the core tools snapshot
- Fix `always-loaded-tools-guard` to include `skill_execute` (added in #15235) and correct the count assertion from 16 to 17

Root cause: When a test called `__resetRegistryForTesting()` before `initializeTools()`, ESM caching prevented eager module side-effects from re-running, leaving only 9 non-proxy tools in the registry. The `browser-skill-endstate` test then saw 9 instead of the expected ≥15, causing the CI failure at job 66574929758.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22938493496/job/66574929758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
