### PR TITLE
fix: add default trust rule for skill_execute

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -209,6 +209,15 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
+  const skillExecuteRule: DefaultRuleTemplate = {
+    id: "default:allow-skill_execute-global",
+    tool: "skill_execute",
+    pattern: "skill_execute:*",
+    scope: "everywhere",
+    decision: "allow",
+    priority: 100,
+  };
+
   // Browser tools were previously core-registered with RiskLevel.Low (auto-allowed).
   // After migration to skill-provided tools, default allow rules preserve the
   // same frictionless UX so they don't trigger permission prompts.
@@ -288,6 +297,7 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     updatesDeleteRule,
     ...skillSourceMutationRules,
     skillLoadRule,
+    skillExecuteRule,
     browserNavigateRule,
     ...browserToolRules,
     ...uiSurfaceRules,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-meta-dispatch.md.

**Gap:** Missing default trust rule for skill_execute
**What was expected:** skill_execute should have a default allow trust rule matching the skill_load pattern
**What was found:** permissions/defaults.ts has skill_load rule but no skill_execute equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
