### PR TITLE
fix: deduplicate Available Tools headers in skill_load output

### DIFF
--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -45,14 +45,23 @@ function loadToolManifest(
 /**
  * Format a skill tool manifest into a human-readable "Available Tools" section
  * that instructs the LLM to use `skill_execute` to invoke the tools.
+ *
+ * When `childSkillName` is provided, a lighter sub-heading is used instead of
+ * the full `## Available Tools` header + preamble, avoiding duplicate headers
+ * when parent and child skills both have TOOLS.json.
  */
-function formatToolSchemas(manifest: SkillToolManifest): string {
-  const lines: string[] = [
-    "## Available Tools",
-    "",
-    "Use `skill_execute` to call these tools.",
-    "",
-  ];
+function formatToolSchemas(
+  manifest: SkillToolManifest,
+  childSkillName?: string,
+): string {
+  const lines: string[] = childSkillName
+    ? [`### Tools from ${childSkillName}`, ""]
+    : [
+        "## Available Tools",
+        "",
+        "Use `skill_execute` to call these tools.",
+        "",
+      ];
 
   for (const tool of manifest.tools) {
     lines.push(`### ${tool.name}`);
@@ -221,12 +230,14 @@ export class SkillLoadTool implements Tool {
             `--- Included Skill: ${childLoaded.skill.displayName} (${childId}) ---\n${childLoaded.skill.body}`,
           );
 
-          // Load tool schemas for the included skill
+          // Load tool schemas for the included skill (lighter sub-heading)
           const childManifest = loadToolManifest(
             childLoaded.skill.directoryPath,
           );
           if (childManifest) {
-            includedBodies.push(formatToolSchemas(childManifest));
+            includedBodies.push(
+              formatToolSchemas(childManifest, childLoaded.skill.displayName),
+            );
           }
         }
       }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skill-meta-dispatch.md.

**Gap:** Duplicate '## Available Tools' headers when parent and child skills both have TOOLS.json
**What was expected:** A single clean Available Tools section
**What was found:** formatToolSchemas() always emits the full header, producing duplicates for parent+child combos

**Fix:** Added optional `childSkillName` parameter to `formatToolSchemas()`. When formatting child skill tool schemas, it now emits `### Tools from <child-skill-name>` instead of the full `## Available Tools` header, and the `Use skill_execute to call these tools.` preamble only appears once in the parent section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)