### PR TITLE
refactor: collapse avatar generation strategy to single codepath

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock state — mutable variables control per-test behavior
 // ---------------------------------------------------------------------------
 
-let mockStrategy: string = "local_only";
 let mockGeminiKey: string | undefined = "test-gemini-key";
 let mockApiKey: string | undefined = "test-api-key-123";
 let mockBaseUrl = "https://platform.test.vellum.ai";
@@ -33,7 +32,6 @@ const geminiGenerateContentFn = mock(async () => geminiGenerateContentResult);
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     apiKeys: { gemini: mockGeminiKey },
-    avatar: { generationStrategy: mockStrategy },
     platform: { baseUrl: mockBaseUrl },
     imageGenModel: "gemini-2.5-flash-image",
   }),
@@ -189,7 +187,6 @@ describe("avatar E2E integration", () => {
   const originalGeminiKey = process.env.GEMINI_API_KEY;
 
   beforeEach(() => {
-    mockStrategy = "local_only";
     mockGeminiKey = "test-gemini-key";
     mockApiKey = "test-api-key-123";
     mockBaseUrl = "https://platform.test.vellum.ai";
@@ -225,8 +222,7 @@ describe("avatar E2E integration", () => {
   // 1. Managed success E2E
   // -----------------------------------------------------------------------
 
-  test("managed_required success — file written, correct content, success message", async () => {
-    mockStrategy = "managed_required";
+  test("managed success — file written, correct content, success message", async () => {
     mockFetchReturning({
       ok: true,
       status: 200,
@@ -261,43 +257,10 @@ describe("avatar E2E integration", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 2. Managed-required failure E2E — no fallback
+  // 2. Managed failure — falls back to local
   // -----------------------------------------------------------------------
 
-  test("managed_required failure — error surfaced, no file written, no fallback", async () => {
-    mockStrategy = "managed_required";
-    mockFetchReturning({
-      ok: false,
-      status: 500,
-      body: {
-        code: "internal_error",
-        subcode: "server_fault",
-        detail: "Internal server error",
-        retryable: true,
-        correlation_id: "corr-500",
-      },
-    });
-
-    const result = await executeAvatar("a friendly robot");
-
-    // Verify error is surfaced
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("failed");
-
-    // Verify no file was written
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
-    expect(renameSyncFn).not.toHaveBeenCalled();
-
-    // Verify Gemini was never called (no fallback)
-    expect(geminiGenerateContentFn).not.toHaveBeenCalled();
-  });
-
-  // -----------------------------------------------------------------------
-  // 3. Managed-prefer fallback E2E
-  // -----------------------------------------------------------------------
-
-  test("managed_prefer fallback — managed fails, local Gemini used, file written", async () => {
-    mockStrategy = "managed_prefer";
+  test("managed failure — falls back to local Gemini, file written", async () => {
     mockFetchReturning({
       ok: false,
       status: 502,
@@ -325,11 +288,10 @@ describe("avatar E2E integration", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 4. Managed-prefer no-fallback when managed unavailable (no API key)
+  // 3. No managed prerequisites — goes straight to local
   // -----------------------------------------------------------------------
 
-  test("managed_prefer without API key — goes straight to local Gemini", async () => {
-    mockStrategy = "managed_prefer";
+  test("no managed API key — goes straight to local Gemini", async () => {
     mockApiKey = undefined; // No managed API key available
 
     const result = await executeAvatar("a cute cat");
@@ -347,39 +309,24 @@ describe("avatar E2E integration", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 5. Local-only E2E
+  // 4. No managed prerequisites and no local key — error
   // -----------------------------------------------------------------------
 
-  test("local_only — only local Gemini called, managed never contacted", async () => {
-    mockStrategy = "local_only";
-    const fetchMock = mock(() =>
-      Promise.resolve({ ok: true, status: 200, json: async () => ({}) }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  test("no managed API key and no Gemini key — error surfaced", async () => {
+    mockApiKey = undefined;
+    mockGeminiKey = undefined;
 
     const result = await executeAvatar("a whimsical owl");
 
-    // Verify success
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Avatar updated");
-
-    // Verify Gemini was called
-    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
-
-    // Verify managed endpoint was never contacted
-    expect(fetchMock).not.toHaveBeenCalled();
-
-    // Verify file was written
-    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed");
   });
 
   // -----------------------------------------------------------------------
-  // 6. Response validation — bad MIME type
+  // 5. Response validation — bad MIME type
   // -----------------------------------------------------------------------
 
-  test("managed response with disallowed MIME type — rejected, no file written", async () => {
-    mockStrategy = "managed_required";
+  test("managed response with disallowed MIME type — falls back to local", async () => {
     mockFetchReturning({
       ok: true,
       status: 200,
@@ -395,21 +342,17 @@ describe("avatar E2E integration", () => {
 
     const result = await executeAvatar("a cat");
 
-    // Verify error returned
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("failed");
-
-    // Verify no file was written
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
-    expect(renameSyncFn).not.toHaveBeenCalled();
+    // Managed fails validation, falls back to local Gemini
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
   });
 
   // -----------------------------------------------------------------------
-  // 7. Response validation — oversized image
+  // 6. Response validation — oversized image
   // -----------------------------------------------------------------------
 
-  test("managed response with oversized data — rejected, no file written", async () => {
-    mockStrategy = "managed_required";
+  test("managed response with oversized data — falls back to local", async () => {
     const oversizedBase64 = "A".repeat(
       Math.ceil(((AVATAR_MAX_DECODED_BYTES + 100) * 4) / 3),
     );
@@ -425,21 +368,17 @@ describe("avatar E2E integration", () => {
 
     const result = await executeAvatar("a cat");
 
-    // Verify error returned
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("failed");
-
-    // Verify no file was written
-    expect(writeFileSyncFn).not.toHaveBeenCalled();
-    expect(renameSyncFn).not.toHaveBeenCalled();
+    // Managed fails validation, falls back to local Gemini
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
   });
 
   // -----------------------------------------------------------------------
-  // 8. Rate limit user message
+  // 7. Rate limit — falls back to local
   // -----------------------------------------------------------------------
 
-  test("managed 429 response — user-friendly rate limit message", async () => {
-    mockStrategy = "managed_required";
+  test("managed 429 response — falls back to local Gemini", async () => {
     mockFetchReturning({
       ok: false,
       status: 429,
@@ -454,16 +393,17 @@ describe("avatar E2E integration", () => {
 
     const result = await executeAvatar("a cat");
 
-    expect(result.isError).toBe(true);
-    expect(result.content.toLowerCase()).toContain("rate limited");
+    // Falls back to local successfully
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
   });
 
   // -----------------------------------------------------------------------
-  // 9. Correlation ID propagation
+  // 8. Correlation ID propagation
   // -----------------------------------------------------------------------
 
   test("managed success — correlation ID is propagated through the pipeline", async () => {
-    mockStrategy = "managed_required";
     mockFetchReturning({
       ok: true,
       status: 200,

--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock state
 // ---------------------------------------------------------------------------
 
-let mockStrategy: string | undefined;
 let mockGeminiKey: string | undefined = "test-gemini-key";
 let mockManagedAvailable = true;
 let mockManagedResult: unknown;
@@ -27,7 +26,6 @@ const isManagedAvailableFn = mock(() => mockManagedAvailable);
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     apiKeys: { gemini: mockGeminiKey },
-    avatar: { generationStrategy: mockStrategy ?? "local_only" },
   }),
 }));
 
@@ -50,10 +48,7 @@ mock.module("../media/gemini-image-service.js", () => ({
 }));
 
 // Import after mocking
-import {
-  getAvatarStrategy,
-  routedGenerateAvatar,
-} from "../media/avatar-router.js";
+import { routedGenerateAvatar } from "../media/avatar-router.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -84,7 +79,6 @@ function geminiResponse() {
 
 describe("avatar-router", () => {
   beforeEach(() => {
-    mockStrategy = undefined;
     mockGeminiKey = "test-gemini-key";
     mockManagedAvailable = true;
     mockManagedResult = managedResponse();
@@ -95,9 +89,7 @@ describe("avatar-router", () => {
     isManagedAvailableFn.mockClear();
   });
 
-  // 1. managed_required — managed success
-  test("managed_required returns pathUsed managed on success", async () => {
-    mockStrategy = "managed_required";
+  test("uses managed path when available", async () => {
     const result = await routedGenerateAvatar("a cute cat");
     expect(result.pathUsed).toBe("managed");
     expect(result.imageBase64).toBe("base64data");
@@ -106,31 +98,25 @@ describe("avatar-router", () => {
     expect(generateImageFn).not.toHaveBeenCalled();
   });
 
-  // 2. managed_required — managed failure throws, no fallback
-  test("managed_required throws on managed failure without fallback", async () => {
-    mockStrategy = "managed_required";
-    mockManagedError = new Error("upstream error");
-    await expect(routedGenerateAvatar("a cute cat")).rejects.toThrow(
-      "upstream error",
-    );
-    expect(generateImageFn).not.toHaveBeenCalled();
-  });
-
-  // 3. local_only — calls local Gemini, never managed
-  test("local_only calls local Gemini and never managed", async () => {
-    mockStrategy = "local_only";
+  test("falls back to local when managed fails", async () => {
+    mockManagedError = new Error("managed failed");
     const result = await routedGenerateAvatar("a cute cat");
     expect(result.pathUsed).toBe("local");
-    expect(result.imageBase64).toBe("base64data");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
     expect(generateImageFn).toHaveBeenCalledTimes(1);
-    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
   });
 
-  // 4. local_only — missing Gemini API key throws
-  test("local_only throws when Gemini API key is missing", async () => {
-    mockStrategy = "local_only";
+  test("goes to local when managed unavailable", async () => {
+    mockManagedAvailable = false;
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when managed unavailable and no Gemini key", async () => {
+    mockManagedAvailable = false;
     mockGeminiKey = undefined;
-    // Also clear the env var to ensure no fallback
     const saved = process.env.GEMINI_API_KEY;
     delete process.env.GEMINI_API_KEY;
     try {
@@ -143,44 +129,7 @@ describe("avatar-router", () => {
     }
   });
 
-  // 5. managed_prefer — managed success
-  test("managed_prefer returns pathUsed managed on success", async () => {
-    mockStrategy = "managed_prefer";
-    const result = await routedGenerateAvatar("a cute cat");
-    expect(result.pathUsed).toBe("managed");
-    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
-    expect(generateImageFn).not.toHaveBeenCalled();
-  });
-
-  // 6. managed_prefer — managed failure falls back to local
-  test("managed_prefer falls back to local on managed failure", async () => {
-    mockStrategy = "managed_prefer";
-    mockManagedError = new Error("managed failed");
-    const result = await routedGenerateAvatar("a cute cat");
-    expect(result.pathUsed).toBe("local");
-    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
-    expect(generateImageFn).toHaveBeenCalledTimes(1);
-  });
-
-  // 7. managed_prefer — managed unavailable goes directly to local
-  test("managed_prefer goes to local when managed unavailable", async () => {
-    mockStrategy = "managed_prefer";
-    mockManagedAvailable = false;
-    const result = await routedGenerateAvatar("a cute cat");
-    expect(result.pathUsed).toBe("local");
-    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
-    expect(generateImageFn).toHaveBeenCalledTimes(1);
-  });
-
-  // 8. Default strategy is local_only when config key absent
-  test("defaults to local_only when config key is absent", () => {
-    mockStrategy = undefined;
-    expect(getAvatarStrategy()).toBe("local_only");
-  });
-
-  // 10. managed_required passes model to generateManagedAvatar
-  test("managed_required forwards model to generateManagedAvatar", async () => {
-    mockStrategy = "managed_required";
+  test("forwards model to generateManagedAvatar", async () => {
     const result = await routedGenerateAvatar("a cute cat", {
       model: "imagen-3.0-generate-002",
     });
@@ -193,28 +142,8 @@ describe("avatar-router", () => {
     expect(result.pathUsed).toBe("managed");
   });
 
-  // 11. managed_prefer passes model to generateManagedAvatar on success
-  test("managed_prefer forwards model to generateManagedAvatar on success", async () => {
-    mockStrategy = "managed_prefer";
-    const result = await routedGenerateAvatar("a cute cat", {
-      model: "imagen-3.0-generate-002",
-    });
-    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
-    expect(generateManagedAvatarFn).toHaveBeenCalledWith("a cute cat", {
-      correlationId: undefined,
-      model: "imagen-3.0-generate-002",
-    });
-    expect(result.model).toBe("imagen-3.0-generate-002");
-    expect(result.pathUsed).toBe("managed");
-  });
-
-  // 12. model is undefined in result when not provided
-  test("managed_required result has no model when none provided", async () => {
-    mockStrategy = "managed_required";
+  test("model is undefined in result when not provided", async () => {
     const result = await routedGenerateAvatar("a cute cat");
     expect(result.model).toBeUndefined();
   });
-
-  // 9. Removed: Invalid strategy values are now rejected at config parse time
-  // by the Zod schema, so they cannot reach getAvatarStrategy().
 });

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -127,17 +127,14 @@ export {
 export type { NotificationsConfig } from "./schemas/notifications.js";
 export { NotificationsConfigSchema } from "./schemas/notifications.js";
 export type {
-  AvatarConfig,
   DaemonConfig,
   PlatformConfig,
   UiConfig,
 } from "./schemas/platform.js";
 export {
-  AvatarConfigSchema,
   DaemonConfigSchema,
   PlatformConfigSchema,
   UiConfigSchema,
-  VALID_AVATAR_STRATEGIES,
 } from "./schemas/platform.js";
 export type { SandboxConfig } from "./schemas/sandbox.js";
 export { SandboxConfigSchema } from "./schemas/sandbox.js";
@@ -202,7 +199,6 @@ import { McpConfigSchema } from "./schemas/mcp.js";
 import { MemoryConfigSchema } from "./schemas/memory.js";
 import { NotificationsConfigSchema } from "./schemas/notifications.js";
 import {
-  AvatarConfigSchema,
   DaemonConfigSchema,
   PlatformConfigSchema,
   UiConfigSchema,
@@ -316,7 +312,6 @@ export const AssistantConfigSchema = z
     notifications: NotificationsConfigSchema.default(
       NotificationsConfigSchema.parse({}),
     ),
-    avatar: AvatarConfigSchema.default(AvatarConfigSchema.parse({})),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
     assistantFeatureFlagValues: z
       .record(

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -1,21 +1,5 @@
 import { z } from "zod";
 
-export const VALID_AVATAR_STRATEGIES = [
-  "managed_required",
-  "managed_prefer",
-  "local_only",
-] as const;
-
-export const AvatarConfigSchema = z.object({
-  generationStrategy: z
-    .enum(VALID_AVATAR_STRATEGIES, {
-      error: `avatar.generationStrategy must be one of: ${VALID_AVATAR_STRATEGIES.join(", ")}`,
-    })
-    .default("local_only"),
-});
-
-export type AvatarConfig = z.infer<typeof AvatarConfigSchema>;
-
 export const PlatformConfigSchema = z.object({
   baseUrl: z
     .string({ error: "platform.baseUrl must be a string" })

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,15 +1,12 @@
 /**
- * Strategy router for avatar generation.
- * Selects managed platform or local Gemini path based on config.
+ * Avatar generation router.
+ * Tries managed platform path if available, falls back to local Gemini.
  */
 
 import { getConfig } from "../config/loader.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import type {
-  AvatarGenerationResult,
-  AvatarGenerationStrategy,
-} from "./avatar-types.js";
+import type { AvatarGenerationResult } from "./avatar-types.js";
 import { generateImage } from "./gemini-image-service.js";
 import {
   generateManagedAvatar,
@@ -17,10 +14,6 @@ import {
 } from "./managed-avatar-client.js";
 
 const log = getLogger("avatar-router");
-
-export function getAvatarStrategy(): AvatarGenerationStrategy {
-  return getConfig().avatar.generationStrategy;
-}
 
 async function generateLocal(
   prompt: string,
@@ -60,29 +53,10 @@ export async function routedGenerateAvatar(
   prompt: string,
   options?: { correlationId?: string; model?: string },
 ): Promise<AvatarGenerationResult> {
-  const strategy = getAvatarStrategy();
   const correlationId = options?.correlationId;
   const model = options?.model;
 
-  if (strategy === "managed_required") {
-    const managed = await generateManagedAvatar(prompt, {
-      correlationId,
-      model,
-    });
-    return {
-      imageBase64: managed.image.data_base64,
-      mimeType: managed.image.mime_type,
-      pathUsed: "managed",
-      correlationId: managed.correlation_id,
-      model,
-    };
-  }
-
-  if (strategy === "local_only") {
-    return generateLocal(prompt, correlationId);
-  }
-
-  // managed_prefer: try managed first if available, fall back to local
+  // Try managed platform path if available, fall back to local Gemini
   if (isManagedAvailable()) {
     try {
       const managed = await generateManagedAvatar(prompt, {

--- a/assistant/src/media/avatar-types.ts
+++ b/assistant/src/media/avatar-types.ts
@@ -1,8 +1,3 @@
-export type AvatarGenerationStrategy =
-  | "managed_required"
-  | "managed_prefer"
-  | "local_only";
-
 export interface ManagedAvatarImagePayload {
   mime_type: string;
   data_base64: string;


### PR DESCRIPTION
## Summary
- Removed the `avatar.generationStrategy` config knob (`managed_required` | `managed_prefer` | `local_only`) and collapsed to a single codepath: try managed platform if available, fall back to local Gemini
- Deleted `AvatarGenerationStrategy` type, `AvatarConfigSchema`, `VALID_AVATAR_STRATEGIES`, `getAvatarStrategy()`, and the `avatar` field from `AssistantConfigSchema`
- Updated unit and e2e tests to reflect the simplified behavior

## Original prompt
Remove the `avatar.generationStrategy` config and collapse avatar generation to always use `managed_prefer` behavior (try managed if available, fall back to local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
