### PR TITLE
fix: emit skill_execute preamble for child-only tools and fix heading levels

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -840,8 +840,8 @@ describe("skill_load tool", () => {
     const result = await executeSkillLoad({ skill: "parent-tools" });
     expect(result.isError).toBe(false);
 
-    // The child skill's tool schemas should appear
-    expect(result.content).toContain("### child_action");
+    // The child skill's tool schemas should appear (#### level under ### Tools from …)
+    expect(result.content).toContain("#### child_action");
     expect(result.content).toContain("A child tool action");
     expect(result.content).toContain(
       "- target (string, required): Action target",

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -63,8 +63,10 @@ function formatToolSchemas(
         "",
       ];
 
+  const toolHeadingLevel = childSkillName ? "####" : "###";
+
   for (const tool of manifest.tools) {
-    lines.push(`### ${tool.name}`);
+    lines.push(`${toolHeadingLevel} ${tool.name}`);
     lines.push(tool.description);
 
     const schema = tool.input_schema;
@@ -207,6 +209,7 @@ export class SkillLoadTool implements Tool {
     // Build immediate children metadata section and load included skill bodies
     let immediateChildrenSection: string;
     const includedBodies: string[] = [];
+    let anyChildHasTools = false;
     if (skill.includes && skill.includes.length > 0 && catalogIndex) {
       const childLines: string[] = [];
       for (const childId of skill.includes) {
@@ -235,6 +238,7 @@ export class SkillLoadTool implements Tool {
             childLoaded.skill.directoryPath,
           );
           if (childManifest) {
+            anyChildHasTools = true;
             includedBodies.push(
               formatToolSchemas(childManifest, childLoaded.skill.displayName),
             );
@@ -298,6 +302,14 @@ export class SkillLoadTool implements Tool {
         body,
         "",
         ...(toolSchemasSection ? [toolSchemasSection, ""] : []),
+        ...(!toolSchemasSection && anyChildHasTools
+          ? [
+              "## Available Tools",
+              "",
+              "Use `skill_execute` to call these tools.",
+              "",
+            ]
+          : []),
         ...includedBodies.flatMap((b) => [b, ""]),
         immediateChildrenSection,
         "",


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review round 2 for skill-meta-dispatch.md.

**Gap 1:** When only a child skill has TOOLS.json (parent has none), the `skill_execute` usage instruction was never emitted. Now a standalone preamble is added before child tool sections.
**Gap 2:** Child tool names used the same heading level (`###`) as the section header. Now child tool names use `####`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
