### PR TITLE
fix: update tests and CU session for skill_execute dispatch changes

### DIFF
--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -223,16 +223,12 @@ describe("browser skill migration end-state", () => {
         previouslyActiveSkillIds: tracking,
       });
 
-      // Exactly 14 new tool definitions should be projected
-      expect(projection.toolDefinitions).toHaveLength(BROWSER_TOOL_COUNT);
+      // Tool definitions are no longer sent to the LLM (dispatched via
+      // skill_execute), so toolDefinitions is expected to be empty.
+      expect(projection.toolDefinitions).toHaveLength(0);
 
-      // Every browser tool name should be in the projection
-      const projectedNames = projection.toolDefinitions.map((d) => d.name);
-      for (const name of BROWSER_TOOL_NAMES) {
-        expect(projectedNames).toContain(name);
-      }
-
-      // The allowedToolNames set should also contain all browser tools
+      // All 14 browser tools should be registered and tracked in allowedToolNames
+      expect(projection.allowedToolNames.size).toBe(BROWSER_TOOL_COUNT);
       for (const name of BROWSER_TOOL_NAMES) {
         expect(projection.allowedToolNames.has(name)).toBe(true);
       }

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -338,7 +338,10 @@ describe("projectSkillTools feature flag enforcement", () => {
       previouslyActiveSkillIds: prevActive,
     });
 
-    expect(result.toolDefinitions).toHaveLength(2);
+    // Tool definitions are no longer returned (dispatched via skill_execute),
+    // but allowedToolNames should contain the registered tool names.
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.size).toBe(2);
     expect(result.allowedToolNames.has("browser_navigate")).toBe(true);
     expect(result.allowedToolNames.has("browser_click")).toBe(true);
   });
@@ -357,7 +360,8 @@ describe("projectSkillTools feature flag enforcement", () => {
       previouslyActiveSkillIds: prevActive,
     });
 
-    expect(result.toolDefinitions).toHaveLength(1);
+    expect(result.toolDefinitions).toHaveLength(0);
+    expect(result.allowedToolNames.size).toBe(1);
     expect(result.allowedToolNames.has("browser_navigate")).toBe(true);
   });
 
@@ -427,8 +431,8 @@ describe("projectSkillTools feature flag enforcement", () => {
       previouslyActiveSkillIds: prevActive,
     });
 
-    const toolNames = result.toolDefinitions.map((t) => t.name);
-    expect(toolNames).toContain("plain_action");
-    expect(toolNames).not.toContain("browser_navigate");
+    // Tool definitions are no longer returned; check allowedToolNames instead
+    expect(result.allowedToolNames.has("plain_action")).toBe(true);
+    expect(result.allowedToolNames.has("browser_navigate")).toBe(false);
   });
 });

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -191,7 +191,9 @@ describe("buildSystemPrompt", () => {
     expect(result).toContain('id="release-checklist"');
     expect(result).toContain('name="Release Checklist"');
     expect(result).toContain('description="Deployment checks."');
-    expect(result).toContain("call the `skill_load` tool with its `id`");
+    expect(result).toContain(
+      "call `skill_load` to load the full instructions, then use `skill_execute` to invoke the skill's tools.",
+    );
   });
 
   test("keeps SOUL.md and IDENTITY.md additive with skills", () => {

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -795,6 +795,7 @@ describe("Trust Store", () => {
         "host_file_write",
         "memory_recall",
         "scaffold_managed_skill",
+        "skill_execute",
         "skill_load",
         "ui_dismiss",
         "ui_update",

--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -22,7 +22,7 @@ import type {
 } from "../providers/types.js";
 import { allComputerUseTools } from "../tools/computer-use/definitions.js";
 import { ToolExecutor } from "../tools/executor.js";
-import { registerSkillTools } from "../tools/registry.js";
+import { getTool, registerSkillTools } from "../tools/registry.js";
 import type { Tool, ToolExecutionResult } from "../tools/types.js";
 import { allUiSurfaceTools } from "../tools/ui-surface/definitions.js";
 import { getLogger } from "../util/logger.js";
@@ -287,7 +287,7 @@ export class ComputerUseSession {
         cache: this.skillProjectionCache,
       });
 
-      if (projection.toolDefinitions.length === 0) {
+      if (projection.allowedToolNames.size === 0) {
         log.warn(
           { preactivatedSkillIds: this.preactivatedSkillIds },
           "Skill projection produced no tool definitions, falling back to legacy CU tools",
@@ -295,7 +295,14 @@ export class ComputerUseSession {
         return null;
       }
 
-      return projection.toolDefinitions;
+      // Tool definitions are no longer returned from projectSkillTools
+      // (dispatched via skill_execute). Build definitions from the registry.
+      const defs: ToolDefinition[] = [];
+      for (const name of projection.allowedToolNames) {
+        const tool = getTool(name);
+        if (tool) defs.push(tool.getDefinition());
+      }
+      return defs;
     } catch (err) {
       log.warn(
         { err },


### PR DESCRIPTION
## Summary
- Fix CU session `getProjectedCuToolDefinitions()` to check `allowedToolNames.size` instead of `toolDefinitions.length` (which is now always 0 after skill_execute dispatch change), and build definitions from registry
- Update test assertions in 4 test files to match the new `projectSkillTools` behavior (empty `toolDefinitions`, use `allowedToolNames`)
- Add `skill_execute` to trust-store expected default tools list

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22939435839/job/66577686077

🤖 Generated with [Claude Code](https://claude.com/claude-code)