### PR TITLE
feat: preserve native web search blocks in conversation history for multi-turn context

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -906,6 +906,19 @@ export class AnthropicProvider implements Provider {
           is_error: block.is_error,
         };
       }
+      case "server_tool_use":
+        return {
+          type: "server_tool_use",
+          id: block.id,
+          name: block.name,
+          input: block.input,
+        } as unknown as Anthropic.ContentBlockParam;
+      case "web_search_tool_result":
+        return {
+          type: "web_search_tool_result",
+          tool_use_id: block.tool_use_id,
+          content: block.content,
+        } as unknown as Anthropic.ContentBlockParam;
       default: {
         log.warn(
           { blockType: (block as { type: string }).type },
@@ -940,11 +953,23 @@ export class AnthropicProvider implements Provider {
           input: tu.input as Record<string, unknown>,
         };
       }
-      case "server_tool_use":
-      case "web_search_tool_result":
-        // Native Anthropic web search blocks — informational only, silently dropped
-        // by the empty-text filter in sendMessage.
-        return { type: "text", text: "" };
+      case "server_tool_use": {
+        const stu = block as Anthropic.ServerToolUseBlock;
+        return {
+          type: "server_tool_use",
+          id: stu.id,
+          name: stu.name,
+          input: stu.input as Record<string, unknown>,
+        };
+      }
+      case "web_search_tool_result": {
+        const wsr = block as Anthropic.WebSearchToolResultBlock;
+        return {
+          type: "web_search_tool_result",
+          tool_use_id: wsr.tool_use_id,
+          content: wsr.content,
+        };
+      }
       default:
         return {
           type: "text",


### PR DESCRIPTION
## Summary
- Replace empty-text conversion of server_tool_use and web_search_tool_result blocks with proper ServerToolUseContent and WebSearchToolResultContent types
- Add outbound conversion in toAnthropicBlockSafe to round-trip these blocks back to the Anthropic API
- Enables multi-turn conversations that reference native web search results

Part of plan: native-web-search-roundtrip.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
