### PR TITLE
feat: show "Searching the web" status during native web search

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -71,6 +71,7 @@ export type AgentEvent =
       toolUseId: string;
       accumulatedJson: string;
     }
+  | { type: "server_tool_start"; name: string; toolUseId: string }
   | { type: "error"; error: Error }
   | {
       type: "usage";
@@ -312,6 +313,12 @@ export class AgentLoop {
                   toolName: event.toolName,
                   toolUseId: event.toolUseId,
                   accumulatedJson: event.accumulatedJson,
+                });
+              } else if (event.type === "server_tool_start") {
+                onEvent({
+                  type: "server_tool_start",
+                  name: event.name,
+                  toolUseId: event.toolUseId,
                 });
               }
             },

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -817,6 +817,20 @@ export async function dispatchAgentEvent(
     case "tool_result":
       handleToolResult(state, deps, event);
       break;
+    case "server_tool_start": {
+      const friendlyNames: Record<string, string> = {
+        web_search: "Searching the web",
+      };
+      const statusText = friendlyNames[event.name] ?? `Running ${event.name}`;
+      deps.ctx.emitActivityState(
+        "tool_running",
+        "tool_use_start",
+        "assistant_turn",
+        deps.reqId,
+        statusText,
+      );
+      break;
+    }
     case "error":
       handleError(state, deps, event);
       break;

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -679,6 +679,16 @@ export class AnthropicProvider implements Provider {
               toolName: event.content_block.name,
             });
           }
+          if (
+            event.type === "content_block_start" &&
+            event.content_block.type === "server_tool_use"
+          ) {
+            onEvent?.({
+              type: "server_tool_start",
+              name: event.content_block.name,
+              toolUseId: event.content_block.id,
+            });
+          }
           if (event.type === "content_block_stop") {
             if (pendingInputJsonFlush) {
               clearTimeout(pendingInputJsonFlush);

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -116,7 +116,8 @@ export type ProviderEvent =
       toolName: string;
       toolUseId: string;
       accumulatedJson: string;
-    };
+    }
+  | { type: "server_tool_start"; name: string; toolUseId: string };
 
 export interface SendMessageConfig {
   model?: string;


### PR DESCRIPTION
## Summary
- Add `server_tool_start` ProviderEvent type for native server-side tool invocations
- Emit streaming status event when `server_tool_use` content block starts (e.g. web_search)
- Wire through agent loop to session handlers with friendly status text ("Searching the web")

Part of plan: native-web-search-roundtrip.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
