### PR TITLE
fix: update benchmark test assertions for empty toolDefinitions

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -141,8 +141,9 @@ const mockConfig = {
   contextWindow: {
     enabled: true,
     maxInputTokens: 180000,
-    targetBudgetRatio: 0.30,
-    compactThreshold: 0.8,    summaryBudgetRatio: 0.05,
+    targetBudgetRatio: 0.3,
+    compactThreshold: 0.8,
+    summaryBudgetRatio: 0.05,
   },
   thinking: { enabled: false },
 };
@@ -503,7 +504,7 @@ describe("End-to-end session creation benchmark", () => {
       if (i === 0) {
         expect(session.conversationId).toBe(id);
         expect(session.getMessages()).toHaveLength(0);
-        expect(projection.toolDefinitions.length).toBe(testSkillIds.length);
+        expect(projection.allowedToolNames.size).toBe(testSkillIds.length);
       }
       resetSkillToolProjection(session.skillProjectionState);
       session.dispose();

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -279,7 +279,6 @@ describe("Skill projection benchmark", () => {
 
     const elapsed = timeMs(() => {
       const result = projectSkillTools(history);
-      expect(result.toolDefinitions.length).toBeGreaterThan(0);
       expect(result.allowedToolNames.size).toBeGreaterThan(0);
     });
 
@@ -330,12 +329,12 @@ describe("Skill projection benchmark", () => {
     expect(cache.derived!.entries.length).toBe(entriesCountAfterWarm);
     expect(cache.derived!.seenIds.size).toBe(seenIdsSizeAfterWarm);
 
-    // Assert tool definitions are identical between warm and cached calls
-    expect(cachedResult!.toolDefinitions.length).toBe(
-      warmResult.toolDefinitions.length,
+    // Assert allowed tool names are identical between warm and cached calls
+    expect(cachedResult!.allowedToolNames.size).toBe(
+      warmResult.allowedToolNames.size,
     );
-    const warmNames = warmResult.toolDefinitions.map((t) => t.name).sort();
-    const cachedNames = cachedResult!.toolDefinitions.map((t) => t.name).sort();
+    const warmNames = [...warmResult.allowedToolNames].sort();
+    const cachedNames = [...cachedResult!.allowedToolNames].sort();
     expect(cachedNames).toEqual(warmNames);
 
     console.log(`  Cached projection (no change): ${elapsed.toFixed(2)}ms`);
@@ -376,12 +375,12 @@ describe("Skill projection benchmark", () => {
       expect(cache.derived!.entries.length).toBe(snapshotEntriesCount);
       expect(cache.derived!.seenIds.size).toBe(snapshotSeenIdsSize);
 
-      // Tool definitions must match the first call exactly
-      expect(result.toolDefinitions.length).toBe(
-        firstResult.toolDefinitions.length,
+      // Allowed tool names must match the first call exactly
+      expect(result.allowedToolNames.size).toBe(
+        firstResult.allowedToolNames.size,
       );
-      expect(result.toolDefinitions.map((t) => t.name).sort()).toEqual(
-        firstResult.toolDefinitions.map((t) => t.name).sort(),
+      expect([...result.allowedToolNames].sort()).toEqual(
+        [...firstResult.allowedToolNames].sort(),
       );
     }
   });
@@ -399,7 +398,6 @@ describe("Skill projection benchmark", () => {
 
     const elapsed = timeMs(() => {
       const result = projectSkillTools(history);
-      expect(result.toolDefinitions.length).toBeGreaterThan(0);
       expect(result.allowedToolNames.size).toBeGreaterThan(0);
     });
 
@@ -432,7 +430,7 @@ describe("Skill projection benchmark", () => {
         cache,
         previouslyActiveSkillIds: prevActive,
       });
-      expect(result.toolDefinitions.length).toBeGreaterThan(0);
+      expect(result.allowedToolNames.size).toBeGreaterThan(0);
     });
 
     console.log(`  Incremental scan (10 new msgs): ${elapsed.toFixed(2)}ms`);


### PR DESCRIPTION
## Summary
Fixes failing benchmark test assertions after skill-meta-dispatch plan.

**Gap:** `projectSkillTools()` now returns `toolDefinitions: []` but benchmark tests still asserted on `toolDefinitions.length`.

- Updated `skill-projection.benchmark.test.ts`: changed 5 assertions from `toolDefinitions.length`/`toolDefinitions.map()` to `allowedToolNames.size`/spread-and-sort on `allowedToolNames`
- Updated `session-init.benchmark.test.ts`: changed 1 assertion from `projection.toolDefinitions.length` to `projection.allowedToolNames.size`

## Test plan
- [x] `bun test src/__tests__/skill-projection.benchmark.test.ts` — 5 pass
- [x] `bun test src/__tests__/session-init.benchmark.test.ts` — 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
