### PR TITLE
chore: remove orphaned messaging send-notification shim

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/send-notification.ts
@@ -1,1 +1,0 @@
-export { run } from "../../notifications/tools/send-notification.js";


### PR DESCRIPTION
## Summary
- Deleted `assistant/src/config/bundled-skills/messaging/tools/send-notification.ts`, an orphaned re-export shim pointing at the notifications skill's implementation
- The file was not declared in the messaging skill's TOOLS.json or the bundled-tool-registry — it was dead code
- `send_notification` is correctly owned by the `notifications` skill which is always pre-activated

## Original prompt
Remove duplicate messaging/tools/send-notification.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
