### PR TITLE
test: remove orphaned messaging shim import from send-notification-tool test

### DIFF
--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -7,9 +7,6 @@ mock.module("../notifications/emit-signal.js", () => ({
     emitNotificationSignalMock(params),
 }));
 
-// Import from the new canonical location (notifications skill)
-// Backward-compat: the messaging re-export should resolve to the same function
-import { run as messagingRun } from "../config/bundled-skills/messaging/tools/send-notification.js";
 import { run } from "../config/bundled-skills/notifications/tools/send-notification.js";
 
 describe("send-notification tool", () => {
@@ -84,9 +81,5 @@ describe("send-notification tool", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("database unavailable");
     expect(emitNotificationSignalMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("messaging re-export resolves to the same run function", () => {
-    expect(messagingRun).toBe(run);
   });
 });


### PR DESCRIPTION
## Summary
- Removes import of deleted `messaging/tools/send-notification.js` shim from the test file
- Removes the backward-compat test that verified the now-deleted re-export
- The shim was removed in a856e888c but the test wasn't updated, causing CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22940064795/job/66579596356

🤖 Generated with [Claude Code](https://claude.com/claude-code)