### PR TITLE
fix: create bundled-tool-registry generator and sync 8 missing tools

### DIFF
--- a/assistant/scripts/generate-bundled-tool-registry.ts
+++ b/assistant/scripts/generate-bundled-tool-registry.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Generates `src/config/bundled-tool-registry.ts` by reading every
+ * `TOOLS.json` under `src/config/bundled-skills/`.
+ *
+ * Usage:
+ *   cd assistant && bun run scripts/generate-bundled-tool-registry.ts
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "../src/config/bundled-skills");
+const OUTPUT = resolve(
+  import.meta.dir,
+  "../src/config/bundled-tool-registry.ts",
+);
+
+interface ToolEntry {
+  executor: string;
+  [key: string]: unknown;
+}
+
+interface ToolsJson {
+  version: number;
+  tools: ToolEntry[];
+}
+
+/** Convert a kebab-case filename stem to camelCase. */
+function toCamelCase(kebab: string): string {
+  return kebab.replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
+}
+
+/** Build the section separator comment (e.g. `// ── browser ──…`). */
+function sectionComment(skillName: string): string {
+  const inner = ` ${skillName} `;
+  // Target total line width of ~80 chars
+  const remaining = 80 - 3 - inner.length; // 3 for "// "
+  const suffix = "─".repeat(Math.max(1, remaining));
+  return `// ──${inner}${"─".repeat(0)}${suffix}`;
+}
+
+async function main() {
+  const entries = await readdir(ROOT, { withFileTypes: true });
+  const skillDirs = entries
+    .filter((e) => e.isDirectory() && e.name !== "_shared")
+    .map((e) => e.name)
+    .sort();
+
+  // First pass: collect all executors and detect alias collisions.
+  const skills: {
+    name: string;
+    tools: {
+      executor: string;
+      registryKey: string;
+      importPath: string;
+      alias: string;
+    }[];
+  }[] = [];
+
+  // Map from alias → skill that first claimed it (for collision detection).
+  const claimedAliases = new Map<string, string>();
+  // Track which aliases need collision-prefixing.
+  const collidedAliases = new Set<string>();
+
+  for (const skillDir of skillDirs) {
+    const toolsJsonPath = join(ROOT, skillDir, "TOOLS.json");
+    let raw: string;
+    try {
+      raw = await readFile(toolsJsonPath, "utf-8");
+    } catch {
+      // No TOOLS.json — skip this skill.
+      continue;
+    }
+
+    const toolsJson: ToolsJson = JSON.parse(raw);
+    const toolEntries: (typeof skills)[number]["tools"] = [];
+
+    for (const tool of toolsJson.tools) {
+      const executor = tool.executor;
+      const registryKey = `${skillDir}:${executor}`;
+      const importPath = `./bundled-skills/${skillDir}/${executor.replace(".ts", ".js")}`;
+      const stem = basename(executor, ".ts");
+      const baseAlias = toCamelCase(stem);
+
+      const existingSkill = claimedAliases.get(baseAlias);
+      if (existingSkill !== undefined && existingSkill !== skillDir) {
+        collidedAliases.add(baseAlias);
+      }
+      claimedAliases.set(baseAlias, skillDir);
+
+      toolEntries.push({ executor, registryKey, importPath, alias: baseAlias });
+    }
+
+    if (toolEntries.length > 0) {
+      skills.push({ name: skillDir, tools: toolEntries });
+    }
+  }
+
+  // Second pass: resolve collided aliases by adding skill prefix.
+  for (const skill of skills) {
+    for (const tool of skill.tools) {
+      if (collidedAliases.has(tool.alias)) {
+        const prefix = toCamelCase(skill.name);
+        tool.alias = `${prefix}_${tool.alias}`;
+      }
+    }
+  }
+
+  // Check for remaining duplicates within same skill (shouldn't happen but be safe).
+  const finalAliases = new Set<string>();
+  for (const skill of skills) {
+    for (const tool of skill.tools) {
+      if (finalAliases.has(tool.alias)) {
+        // Append skill prefix if not already present.
+        const prefix = toCamelCase(skill.name);
+        if (!tool.alias.startsWith(prefix)) {
+          tool.alias = `${prefix}${tool.alias.charAt(0).toUpperCase()}${tool.alias.slice(1)}`;
+        }
+      }
+      finalAliases.add(tool.alias);
+    }
+  }
+
+  // Generate output.
+  const lines: string[] = [];
+
+  // File header.
+  lines.push(`/**`);
+  lines.push(` * Auto-generated registry of bundled skill tool scripts.`);
+  lines.push(` *`);
+  lines.push(
+    ` * In compiled Bun binaries, bundled tool scripts can't be dynamically`,
+  );
+  lines.push(
+    ` * imported from the filesystem because their relative imports point to`,
+  );
+  lines.push(
+    ` * modules that only exist inside the binary's virtual /$bunfs/ filesystem.`,
+  );
+  lines.push(` *`);
+  lines.push(
+    ` * This registry eagerly imports every bundled tool script so it becomes`,
+  );
+  lines.push(
+    ` * part of the compiled binary.  At runtime, the skill-script-runner`,
+  );
+  lines.push(` * checks this map before falling back to a dynamic import.`);
+  lines.push(` *`);
+  lines.push(` * Regenerate with:`);
+  lines.push(` *   bun run scripts/generate-bundled-tool-registry.ts`);
+  lines.push(` */`);
+  lines.push(
+    `import type { SkillToolScript } from "../tools/skills/script-contract.js";`,
+  );
+
+  // Import statements grouped by skill, sorted by import path within each
+  // group so the output satisfies eslint simple-import-sort.
+  for (const skill of skills) {
+    // Strip `.js` before comparing so `browser-wait-for` sorts before
+    // `browser-wait-for-download`, matching simple-import-sort's order.
+    const sorted = [...skill.tools].sort((a, b) =>
+      a.importPath
+        .replace(/\.js$/, "")
+        .localeCompare(b.importPath.replace(/\.js$/, "")),
+    );
+    lines.push(sectionComment(skill.name));
+    for (const tool of sorted) {
+      lines.push(`import * as ${tool.alias} from "${tool.importPath}";`);
+    }
+  }
+
+  // Registry map.
+  lines.push(``);
+  lines.push(
+    `// ─── Registry ────────────────────────────────────────────────────────────────`,
+  );
+  lines.push(``);
+  lines.push(
+    `/** Key format: \`skillDirBasename:executorPath\` (e.g. \`schedule:tools/schedule-list.ts\`). */`,
+  );
+  lines.push(
+    `export const bundledToolRegistry = new Map<string, SkillToolScript>([`,
+  );
+
+  for (let i = 0; i < skills.length; i++) {
+    const skill = skills[i];
+    lines.push(`  // ${skill.name}`);
+    for (const tool of skill.tools) {
+      const entry = `["${tool.registryKey}", ${tool.alias}]`;
+      // Wrap long lines.
+      if (`  ${entry},`.length > 80) {
+        lines.push(`  [`);
+        lines.push(`    "${tool.registryKey}",`);
+        lines.push(`    ${tool.alias},`);
+        lines.push(`  ],`);
+      } else {
+        lines.push(`  ${entry},`);
+      }
+    }
+
+    if (i < skills.length - 1) {
+      lines.push(``);
+    }
+  }
+
+  lines.push(`]);`);
+  lines.push(``); // trailing newline
+
+  await writeFile(OUTPUT, lines.join("\n"), "utf-8");
+  console.log(`✓ Generated ${OUTPUT}`);
+  console.log(
+    `  ${skills.length} skills, ${skills.reduce((n, s) => n + s.tools.length, 0)} tools`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -13,7 +13,7 @@
  *   bun run scripts/generate-bundled-tool-registry.ts
  */
 import type { SkillToolScript } from "../tools/skills/script-contract.js";
-// ── app-builder ──────────────────────────────────────────────────────────────
+// ── app-builder ────────────────────────────────────────────────────────────────
 import * as appCreate from "./bundled-skills/app-builder/tools/app-create.js";
 import * as appDelete from "./bundled-skills/app-builder/tools/app-delete.js";
 import * as appFileEdit from "./bundled-skills/app-builder/tools/app-file-edit.js";
@@ -24,22 +24,26 @@ import * as appGenerateIcon from "./bundled-skills/app-builder/tools/app-generat
 import * as appList from "./bundled-skills/app-builder/tools/app-list.js";
 import * as appQuery from "./bundled-skills/app-builder/tools/app-query.js";
 import * as appUpdate from "./bundled-skills/app-builder/tools/app-update.js";
+// ── browser ────────────────────────────────────────────────────────────────────
 import * as browserClick from "./bundled-skills/browser/tools/browser-click.js";
 import * as browserClose from "./bundled-skills/browser/tools/browser-close.js";
 import * as browserExtract from "./bundled-skills/browser/tools/browser-extract.js";
 import * as browserFillCredential from "./bundled-skills/browser/tools/browser-fill-credential.js";
-// ── browser ──────────────────────────────────────────────────────────────────
+import * as browserHover from "./bundled-skills/browser/tools/browser-hover.js";
 import * as browserNavigate from "./bundled-skills/browser/tools/browser-navigate.js";
 import * as browserPressKey from "./bundled-skills/browser/tools/browser-press-key.js";
 import * as browserScreenshot from "./bundled-skills/browser/tools/browser-screenshot.js";
+import * as browserScroll from "./bundled-skills/browser/tools/browser-scroll.js";
+import * as browserSelectOption from "./bundled-skills/browser/tools/browser-select-option.js";
 import * as browserSnapshot from "./bundled-skills/browser/tools/browser-snapshot.js";
 import * as browserType from "./bundled-skills/browser/tools/browser-type.js";
 import * as browserWaitFor from "./bundled-skills/browser/tools/browser-wait-for.js";
-// ── chatgpt-import ───────────────────────────────────────────────────────────
-import * as chatgptImport_chatgptImport from "./bundled-skills/chatgpt-import/tools/chatgpt-import.js";
-// ── claude-code ──────────────────────────────────────────────────────────────
+import * as browserWaitForDownload from "./bundled-skills/browser/tools/browser-wait-for-download.js";
+// ── chatgpt-import ─────────────────────────────────────────────────────────────
+import * as chatgptImport from "./bundled-skills/chatgpt-import/tools/chatgpt-import.js";
+// ── claude-code ────────────────────────────────────────────────────────────────
 import * as claudeCode from "./bundled-skills/claude-code/tools/claude-code.js";
-// ── computer-use ─────────────────────────────────────────────────────────────
+// ── computer-use ───────────────────────────────────────────────────────────────
 import * as computerUseClick from "./bundled-skills/computer-use/tools/computer-use-click.js";
 import * as computerUseDone from "./bundled-skills/computer-use/tools/computer-use-done.js";
 import * as computerUseDoubleClick from "./bundled-skills/computer-use/tools/computer-use-double-click.js";
@@ -52,36 +56,38 @@ import * as computerUseRunApplescript from "./bundled-skills/computer-use/tools/
 import * as computerUseScroll from "./bundled-skills/computer-use/tools/computer-use-scroll.js";
 import * as computerUseTypeText from "./bundled-skills/computer-use/tools/computer-use-type-text.js";
 import * as computerUseWait from "./bundled-skills/computer-use/tools/computer-use-wait.js";
+// ── contacts ───────────────────────────────────────────────────────────────────
 import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js";
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
-// ── contacts ─────────────────────────────────────────────────────────────────
 import * as contactUpsert from "./bundled-skills/contacts/tools/contact-upsert.js";
-// ── document ─────────────────────────────────────────────────────────────────
+// ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
-// ── followups ────────────────────────────────────────────────────────────────
+// ── followups ──────────────────────────────────────────────────────────────────
 import * as followupCreate from "./bundled-skills/followups/tools/followup-create.js";
 import * as followupList from "./bundled-skills/followups/tools/followup-list.js";
 import * as followupResolve from "./bundled-skills/followups/tools/followup-resolve.js";
+// ── google-calendar ────────────────────────────────────────────────────────────
 import * as calendarCheckAvailability from "./bundled-skills/google-calendar/tools/calendar-check-availability.js";
 import * as calendarCreateEvent from "./bundled-skills/google-calendar/tools/calendar-create-event.js";
 import * as calendarGetEvent from "./bundled-skills/google-calendar/tools/calendar-get-event.js";
-// ── google-calendar ──────────────────────────────────────────────────────────
 import * as calendarListEvents from "./bundled-skills/google-calendar/tools/calendar-list-events.js";
 import * as calendarRsvp from "./bundled-skills/google-calendar/tools/calendar-rsvp.js";
-// ── image-studio ─────────────────────────────────────────────────────────────
+// ── image-studio ───────────────────────────────────────────────────────────────
 import * as mediaGenerateImage from "./bundled-skills/image-studio/tools/media-generate-image.js";
-// ── knowledge-graph ──────────────────────────────────────────────────────────
+// ── knowledge-graph ────────────────────────────────────────────────────────────
 import * as graphQuery from "./bundled-skills/knowledge-graph/tools/graph-query.js";
+// ── media-processing ───────────────────────────────────────────────────────────
 import * as analyzeKeyframes from "./bundled-skills/media-processing/tools/analyze-keyframes.js";
 import * as extractKeyframes from "./bundled-skills/media-processing/tools/extract-keyframes.js";
 import * as generateClip from "./bundled-skills/media-processing/tools/generate-clip.js";
-// ── media-processing ─────────────────────────────────────────────────────────
 import * as ingestMedia from "./bundled-skills/media-processing/tools/ingest-media.js";
 import * as mediaDiagnostics from "./bundled-skills/media-processing/tools/media-diagnostics.js";
 import * as mediaStatus from "./bundled-skills/media-processing/tools/media-status.js";
 import * as queryMediaEvents from "./bundled-skills/media-processing/tools/query-media-events.js";
+// ── messaging ──────────────────────────────────────────────────────────────────
 import * as gmailArchive from "./bundled-skills/messaging/tools/gmail-archive.js";
+import * as gmailArchiveByQuery from "./bundled-skills/messaging/tools/gmail-archive-by-query.js";
 import * as gmailBatchArchive from "./bundled-skills/messaging/tools/gmail-batch-archive.js";
 import * as gmailBatchLabel from "./bundled-skills/messaging/tools/gmail-batch-label.js";
 import * as gmailDownloadAttachment from "./bundled-skills/messaging/tools/gmail-download-attachment.js";
@@ -103,7 +109,7 @@ import * as gmailVacation from "./bundled-skills/messaging/tools/gmail-vacation.
 import * as googleContacts from "./bundled-skills/messaging/tools/google-contacts.js";
 import * as messagingAnalyzeActivity from "./bundled-skills/messaging/tools/messaging-analyze-activity.js";
 import * as messagingAnalyzeStyle from "./bundled-skills/messaging/tools/messaging-analyze-style.js";
-// ── messaging ────────────────────────────────────────────────────────────────
+import * as messagingArchiveBySender from "./bundled-skills/messaging/tools/messaging-archive-by-sender.js";
 import * as messagingAuthTest from "./bundled-skills/messaging/tools/messaging-auth-test.js";
 import * as messagingDraft from "./bundled-skills/messaging/tools/messaging-draft.js";
 import * as messagingListConversations from "./bundled-skills/messaging/tools/messaging-list-conversations.js";
@@ -112,6 +118,7 @@ import * as messagingRead from "./bundled-skills/messaging/tools/messaging-read.
 import * as messagingReply from "./bundled-skills/messaging/tools/messaging-reply.js";
 import * as messagingSearch from "./bundled-skills/messaging/tools/messaging-search.js";
 import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.js";
+import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 import * as sequenceAnalytics from "./bundled-skills/messaging/tools/sequence-analytics.js";
 import * as sequenceCancel from "./bundled-skills/messaging/tools/sequence-cancel.js";
 import * as sequenceCreate from "./bundled-skills/messaging/tools/sequence-create.js";
@@ -124,48 +131,50 @@ import * as sequenceList from "./bundled-skills/messaging/tools/sequence-list.js
 import * as sequencePause from "./bundled-skills/messaging/tools/sequence-pause.js";
 import * as sequenceResume from "./bundled-skills/messaging/tools/sequence-resume.js";
 import * as sequenceUpdate from "./bundled-skills/messaging/tools/sequence-update.js";
-// ── notifications ───────────────────────────────────────────────────────────
+// ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
-// ── orchestration ───────────────────────────────────────────────────────────
+// ── orchestration ──────────────────────────────────────────────────────────────
 import * as swarmDelegate from "./bundled-skills/orchestration/tools/swarm-delegate.js";
-// ── phone-calls ─────────────────────────────────────────────────────────────
+// ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
 import * as callStatus from "./bundled-skills/phone-calls/tools/call-status.js";
-// ── playbooks ────────────────────────────────────────────────────────────────
+// ── playbooks ──────────────────────────────────────────────────────────────────
 import * as playbookCreate from "./bundled-skills/playbooks/tools/playbook-create.js";
 import * as playbookDelete from "./bundled-skills/playbooks/tools/playbook-delete.js";
 import * as playbookList from "./bundled-skills/playbooks/tools/playbook-list.js";
 import * as playbookUpdate from "./bundled-skills/playbooks/tools/playbook-update.js";
-// ── schedule ─────────────────────────────────────────────────────────────────
+// ── schedule ───────────────────────────────────────────────────────────────────
 import * as scheduleCreate from "./bundled-skills/schedule/tools/schedule-create.js";
 import * as scheduleDelete from "./bundled-skills/schedule/tools/schedule-delete.js";
 import * as scheduleList from "./bundled-skills/schedule/tools/schedule-list.js";
 import * as scheduleUpdate from "./bundled-skills/schedule/tools/schedule-update.js";
-// ── screen-watch ─────────────────────────────────────────────────────────────
+// ── screen-watch ───────────────────────────────────────────────────────────────
 import * as startScreenWatch from "./bundled-skills/screen-watch/tools/start-screen-watch.js";
-// ── settings ─────────────────────────────────────────────────────────────────
+// ── settings ───────────────────────────────────────────────────────────────────
 import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
 import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
 import * as setAvatar from "./bundled-skills/settings/tools/set-avatar.js";
 import * as voiceConfigUpdate from "./bundled-skills/settings/tools/voice-config-update.js";
-// ── skill-management ─────────────────────────────────────────────────────────
-import * as skillMgmtDeleteManaged from "./bundled-skills/skill-management/tools/delete-managed.js";
-import * as skillMgmtScaffoldManaged from "./bundled-skills/skill-management/tools/scaffold-managed.js";
-// ── slack ────────────────────────────────────────────────────────────────────
+// ── skill-management ───────────────────────────────────────────────────────────
+import * as deleteManaged from "./bundled-skills/skill-management/tools/delete-managed.js";
+import * as scaffoldManaged from "./bundled-skills/skill-management/tools/scaffold-managed.js";
+// ── slack ──────────────────────────────────────────────────────────────────────
 import * as slackAddReaction from "./bundled-skills/slack/tools/slack-add-reaction.js";
 import * as slackChannelDetails from "./bundled-skills/slack/tools/slack-channel-details.js";
 import * as slackChannelPermissions from "./bundled-skills/slack/tools/slack-channel-permissions.js";
 import * as slackConfigureChannels from "./bundled-skills/slack/tools/slack-configure-channels.js";
 import * as slackDeleteMessage from "./bundled-skills/slack/tools/slack-delete-message.js";
+import * as slackEditMessage from "./bundled-skills/slack/tools/slack-edit-message.js";
 import * as slackLeaveChannel from "./bundled-skills/slack/tools/slack-leave-channel.js";
 import * as slackScanDigest from "./bundled-skills/slack/tools/slack-scan-digest.js";
+// ── subagent ───────────────────────────────────────────────────────────────────
 import * as subagentAbort from "./bundled-skills/subagent/tools/subagent-abort.js";
 import * as subagentMessage from "./bundled-skills/subagent/tools/subagent-message.js";
 import * as subagentRead from "./bundled-skills/subagent/tools/subagent-read.js";
-// ── subagent ─────────────────────────────────────────────────────────────────
 import * as subagentSpawn from "./bundled-skills/subagent/tools/subagent-spawn.js";
 import * as subagentStatus from "./bundled-skills/subagent/tools/subagent-status.js";
+// ── tasks ──────────────────────────────────────────────────────────────────────
 import * as taskDelete from "./bundled-skills/tasks/tools/task-delete.js";
 import * as taskList from "./bundled-skills/tasks/tools/task-list.js";
 import * as taskListAdd from "./bundled-skills/tasks/tools/task-list-add.js";
@@ -174,11 +183,10 @@ import * as taskListShow from "./bundled-skills/tasks/tools/task-list-show.js";
 import * as taskListUpdate from "./bundled-skills/tasks/tools/task-list-update.js";
 import * as taskQueueRun from "./bundled-skills/tasks/tools/task-queue-run.js";
 import * as taskRun from "./bundled-skills/tasks/tools/task-run.js";
-// ── tasks ────────────────────────────────────────────────────────────────────
 import * as taskSave from "./bundled-skills/tasks/tools/task-save.js";
-// ── transcribe ───────────────────────────────────────────────────────────────
+// ── transcribe ─────────────────────────────────────────────────────────────────
 import * as transcribeMedia from "./bundled-skills/transcribe/tools/transcribe-media.js";
-// ── watcher ──────────────────────────────────────────────────────────────────
+// ── watcher ────────────────────────────────────────────────────────────────────
 import * as watcherCreate from "./bundled-skills/watcher/tools/watcher-create.js";
 import * as watcherDelete from "./bundled-skills/watcher/tools/watcher-delete.js";
 import * as watcherDigest from "./bundled-skills/watcher/tools/watcher-digest.js";
@@ -209,12 +217,16 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["browser:tools/browser-click.ts", browserClick],
   ["browser:tools/browser-type.ts", browserType],
   ["browser:tools/browser-press-key.ts", browserPressKey],
+  ["browser:tools/browser-scroll.ts", browserScroll],
+  ["browser:tools/browser-select-option.ts", browserSelectOption],
+  ["browser:tools/browser-hover.ts", browserHover],
   ["browser:tools/browser-wait-for.ts", browserWaitFor],
   ["browser:tools/browser-extract.ts", browserExtract],
+  ["browser:tools/browser-wait-for-download.ts", browserWaitForDownload],
   ["browser:tools/browser-fill-credential.ts", browserFillCredential],
 
   // chatgpt-import
-  ["chatgpt-import:tools/chatgpt-import.ts", chatgptImport_chatgptImport],
+  ["chatgpt-import:tools/chatgpt-import.ts", chatgptImport],
 
   // claude-code
   ["claude-code:tools/claude-code.ts", claudeCode],
@@ -291,6 +303,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["messaging:tools/messaging-draft.ts", messagingDraft],
   ["messaging:tools/gmail-archive.ts", gmailArchive],
   ["messaging:tools/gmail-batch-archive.ts", gmailBatchArchive],
+  ["messaging:tools/gmail-archive-by-query.ts", gmailArchiveByQuery],
   ["messaging:tools/gmail-label.ts", gmailLabel],
   ["messaging:tools/gmail-batch-label.ts", gmailBatchLabel],
   ["messaging:tools/gmail-trash.ts", gmailTrash],
@@ -307,6 +320,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["messaging:tools/gmail-filters.ts", gmailFilters],
   ["messaging:tools/gmail-vacation.ts", gmailVacation],
   ["messaging:tools/gmail-sender-digest.ts", gmailSenderDigest],
+  ["messaging:tools/messaging-sender-digest.ts", messagingSenderDigest],
+  ["messaging:tools/messaging-archive-by-sender.ts", messagingArchiveBySender],
   ["messaging:tools/gmail-outreach-scan.ts", gmailOutreachScan],
   ["messaging:tools/google-contacts.ts", googleContacts],
   ["messaging:tools/sequence-create.ts", sequenceCreate],
@@ -339,14 +354,14 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["playbooks:tools/playbook-update.ts", playbookUpdate],
   ["playbooks:tools/playbook-delete.ts", playbookDelete],
 
-  // screen-watch
-  ["screen-watch:tools/start-screen-watch.ts", startScreenWatch],
-
   // schedule
   ["schedule:tools/schedule-create.ts", scheduleCreate],
   ["schedule:tools/schedule-list.ts", scheduleList],
   ["schedule:tools/schedule-update.ts", scheduleUpdate],
   ["schedule:tools/schedule-delete.ts", scheduleDelete],
+
+  // screen-watch
+  ["screen-watch:tools/start-screen-watch.ts", startScreenWatch],
 
   // settings
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],
@@ -355,8 +370,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["settings:tools/navigate-settings-tab.ts", navigateSettingsTab],
 
   // skill-management
-  ["skill-management:tools/scaffold-managed.ts", skillMgmtScaffoldManaged],
-  ["skill-management:tools/delete-managed.ts", skillMgmtDeleteManaged],
+  ["skill-management:tools/scaffold-managed.ts", scaffoldManaged],
+  ["skill-management:tools/delete-managed.ts", deleteManaged],
 
   // slack
   ["slack:tools/slack-scan-digest.ts", slackScanDigest],
@@ -364,6 +379,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["slack:tools/slack-configure-channels.ts", slackConfigureChannels],
   ["slack:tools/slack-add-reaction.ts", slackAddReaction],
   ["slack:tools/slack-delete-message.ts", slackDeleteMessage],
+  ["slack:tools/slack-edit-message.ts", slackEditMessage],
   ["slack:tools/slack-leave-channel.ts", slackLeaveChannel],
   ["slack:tools/slack-channel-permissions.ts", slackChannelPermissions],
 


### PR DESCRIPTION
## Summary
- Create `assistant/scripts/generate-bundled-tool-registry.ts` that reads TOOLS.json from all bundled skills and generates the compiled registry
- Regenerate the registry, adding 8 previously missing tool entries (browser-hover, browser-scroll, browser-select-option, browser-wait-for-download, gmail-archive-by-query, messaging-archive-by-sender, messaging-sender-digest, slack-edit-message)

Part of plan: bundled-tool-registry-sync.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)