### PR TITLE
feat: extract gmail skill from messaging monolith

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gmail
+description: Archive, label, draft, triage, unsubscribe, and manage Gmail with smart inbox tools
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "📨"
+  vellum:
+    display-name: "Gmail"
+    user-invocable: true
+    feature-flag: "messaging-gmail"
+---
+
+This skill provides Gmail-specific tools. For cross-platform messaging (send, read, search, reply), use the **messaging** skill. Gmail tools depend on the messaging skill's provider infrastructure — load messaging first if Gmail is not yet connected.
+
+## Email Routing Priority
+
+When the user mentions "email" — sending, reading, checking, decluttering, drafting, or anything else — **always default to the user's own email (Gmail)** unless they explicitly ask about the assistant's own email address (e.g., "set up your email", "send from your address", "check your inbox"). The vast majority of email requests are about the user's Gmail, not the assistant's AgentMail address.
+
+Do not offer AgentMail as an option or mention it unless the user specifically asks. If Gmail is not connected, guide them through Gmail setup — do not suggest AgentMail as an alternative.
+
+## Communication Style
+
+- **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox — that's obviously what they want.
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:gmail has expired."
+- **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
+- **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do — just do it and narrate lightly.
+
+## Connection Setup
+
+### Gmail
+
+1. **Try connecting directly first.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. The tool auto-fills Google's OAuth endpoints and looks up any previously stored client credentials — so this single call may be all that's needed.
+2. **If it fails because no client_id is found:** The user needs to create Google Cloud OAuth credentials first. Load the **google-oauth-setup** skill (which depends on **public-ingress** for the redirect URI):
+   - Call `skill_load` with `skill: "google-oauth-setup"` to load the dependency skill.
+   - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
+     - **message:** "Ready to set up Gmail?"
+     - **detail:** "I'll open a browser where you sign in to Google, then automate everything else — creating a project, enabling APIs, and connecting your account. Takes 2-3 minutes and you can watch in the browser preview panel."
+     - **confirmLabel:** "Get Started"
+     - **cancelLabel:** "Not Now"
+   - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "gmail"`, and `client_id: "<their value>"`. Include `client_secret` too if they provide one. Everything else is auto-filled.
+
+## Error Recovery
+
+When a Gmail tool fails with a token or authorization error:
+
+1. **Try to reconnect silently.** Call `credential_store` with `action: "oauth2_connect"` and `service: "gmail"`. This often resolves expired tokens automatically.
+2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected — let me set that up") and immediately follow the connection setup flow for Gmail (e.g., install and load **google-oauth-setup**). The user came to you to get something done, not to troubleshoot OAuth — make it seamless.
+3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the Gmail tools can't do it, the reconnection flow is the answer.
+4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.
+
+## Capabilities
+
+### Gmail-specific
+
+- **Archive**: Remove message from inbox
+- **Label**: Add/remove labels
+- **Trash**: Move to trash
+- **Unsubscribe**: Unsubscribe via List-Unsubscribe header
+- **Draft (native)**: Create a draft in Gmail's Drafts folder
+
+### Attachments
+
+- **List Attachments**: `gmail_list_attachments` — list all attachments on a message with filename, MIME type, size, and attachment ID
+- **Download Attachment**: `gmail_download_attachment` — download an attachment to the working directory by message ID + attachment ID
+- **Send with Attachments**: `gmail_send_with_attachments` — send an email with file attachments (reads files from disk, builds multipart MIME)
+
+Workflow: use `gmail_list_attachments` to discover attachments, then `gmail_download_attachment` to save them locally.
+
+### Forward & Thread Operations
+
+- **Forward**: `gmail_forward` — forward a message to another recipient, preserving all attachments. Optionally prepend your own text
+- **Summarize Thread**: `gmail_summarize_thread` — LLM-powered thread summary with participants, decisions, open questions, and sentiment
+- **Follow-up Tracking**: `gmail_follow_up` — track/untrack messages for follow-up using a dedicated "Follow-up" label, or list all tracked messages
+
+### Smart Triage
+
+- **Triage**: `gmail_triage` — LLM-powered inbox classification of unread emails into categories: `needs_reply`, `fyi_only`, `can_archive`, `urgent`, `newsletter`, `promotional`
+  - Returns grouped report with reasoning and suggested actions per email
+  - Set `auto_apply: true` to auto-archive `can_archive` emails and label `needs_reply` as "Follow-up"
+  - Custom query support (default: `is:unread in:inbox`)
+
+### Inbox Automation
+
+- **Filters**: `gmail_filters` — list, create, or delete Gmail filters. Filter criteria include from, to, subject, query, has_attachment. Actions include adding/removing labels and forwarding
+- **Vacation Responder**: `gmail_vacation` — get, enable, or disable the vacation auto-responder with custom message, date range, and domain/contact restrictions
+
+### Google Contacts
+
+- **Contacts**: `google_contacts` — list or search Google Contacts by name or email. Returns name, email, phone, and organization
+  - Requires the `contacts.readonly` scope — users may need to re-authorize Gmail to grant this additional permission
+
+## Drafting vs Sending (Gmail)
+
+Gmail uses a **draft-first workflow**. All compose and reply tools create Gmail drafts automatically:
+
+- `messaging_send` (Gmail) → creates a draft in Gmail Drafts
+- `messaging_reply` (Gmail) → creates a threaded draft with reply-all recipients
+- `gmail_draft` → creates a draft
+- `gmail_send_with_attachments` → creates a draft with attachments
+- `gmail_forward` → creates a forward draft
+
+**To actually send**: Use `gmail_send_draft` with the draft ID after the user has reviewed it. Only call `gmail_send_draft` when the user explicitly says "send it" or equivalent.
+
+**Reply-all**: `messaging_reply` for Gmail automatically builds the reply-all recipient list from the thread. You do not need to manually look up recipients.
+
+## Email Threading (Gmail)
+
+When replying to or continuing an email thread:
+
+- Use `messaging_reply` with the thread's `thread_id` — it automatically handles threading, reply-all recipients, and subject lines.
+- The `in_reply_to` field on `gmail_draft` requires the **RFC 822 Message-ID header** (looks like `<CABx...@mail.gmail.com>`), NOT the Gmail message ID (which looks like `18e4a5b2c3d4e5f6`). Get it by reading the thread messages and extracting the `Message-ID` header.
+
+## Gmail Search Syntax
+
+When searching Gmail, the query uses Gmail's search operators:
+
+| Operator         | Example                  | What it finds                       |
+| ---------------- | ------------------------ | ----------------------------------- |
+| `from:`          | `from:alice@example.com` | Messages from a specific sender     |
+| `to:`            | `to:bob@example.com`     | Messages sent to a recipient        |
+| `subject:`       | `subject:meeting`        | Messages with a word in the subject |
+| `newer_than:`    | `newer_than:7d`          | Messages from the last 7 days       |
+| `older_than:`    | `older_than:30d`         | Messages older than 30 days         |
+| `is:unread`      | `is:unread`              | Unread messages                     |
+| `has:attachment` | `has:attachment`         | Messages with attachments           |
+| `label:`         | `label:work`             | Messages with a specific label      |
+
+## Email Decluttering
+
+When a user asks to declutter, clean up, or organize their email — start scanning immediately. Don't ask what kind of cleanup they want or request permission to read their inbox. Go straight to scanning — but once results are ready, always show them via `ui_show` and let the user choose actions before archiving or unsubscribing.
+
+**CRITICAL**: Never call `gmail_batch_archive`, `gmail_archive_by_query`, `gmail_unsubscribe`, or `messaging_archive_by_sender` unless the user has clicked an action button on the table for that specific batch. Each batch of results requires its own explicit user confirmation via the table UI. If the user says "keep going" or "keep decluttering," that means scan and present a new table — NOT auto-archive. Previous batch approvals do not carry forward, but **deselections DO carry forward**: when the user deselects senders from a cleanup table, the system records those deselections as user preferences. Before building the next cleanup table, check `<dynamic-user-profile>` for previously deselected senders and exclude them from future cleanup tables — the user already indicated they want to keep those.
+
+### Workflow
+
+1. **Scan**: Call `gmail_sender_digest`. Default query targets promotions from the last 90 days.
+2. **Present**: Show results as a `ui_show` table with `selectionMode: "multiple"`:
+   - **Columns (exactly 3)**: Sender, Emails Found, Unsub?
+     - **Unsub? cell values**: Use rich cell format: `{ "text": "Yes", "icon": "checkmark.circle.fill", "iconColor": "success" }` when `has_unsubscribe` is true, `{ "text": "No", "icon": "minus.circle", "iconColor": "muted" }` when false.
+   - **Pre-select all rows** (`selected: true`) — users deselect what they want to keep
+   - **Caption**: Include two parts separated by a newline: (1) data scope, e.g. "Newsletters, notifications, and outreach from last 90 days. Deselect anything you want to keep." (adjusted to match the query used), and (2) the Unsub? column legend: "Unsub? — \"Yes\" means these emails contain an unsubscribe link, so I can opt you out automatically. \"No\" means no unsubscribe link was found — these will be archived but you may continue receiving them."
+   - **Action buttons (exactly 2)**: "Archive & Unsubscribe" (primary), "Archive Only" (secondary). **NEVER offer Delete, Trash, or any destructive action.**
+3. **Wait for user action**: Stop and wait. Do NOT proceed to archiving or unsubscribing until the user clicks one of the action buttons on the table. When the user clicks an action button:
+   - **Dismiss the table immediately** with `ui_dismiss` — it collapses to a completion chip
+   - **Show a `task_progress` card** with steps for each phase (e.g., "Archiving 89 senders (2,400 emails)", "Unsubscribing from 72 senders"). Update each step from `in_progress` → `completed` as each phase finishes.
+   - When all senders are processed, set the progress card's `status: "completed"`.
+4. **Act on selection** — batch, don't loop:
+   - **Archive all at once**: Call `gmail_batch_archive` **once** with `scan_id` + **all** selected senders' `id` values in the `sender_ids` array. The tool resolves message IDs server-side and batches the Gmail API calls internally — never loop sender-by-sender.
+   - **Unsubscribe in bulk**: If the action is "Archive & Unsubscribe", call `gmail_unsubscribe` for each sender that has `has_unsubscribe: true` — but emit **all** unsubscribe tool calls in a **single assistant response** (parallel tool use) rather than one-at-a-time across separate turns.
+5. **Accurate summary**: The scan counts are exact — the `message_count` shown in the table matches the number of messages archived. Format: "Cleaned up [total_archived] emails from [sender_count] senders. Unsubscribed from [unsub_count]."
+6. **Ongoing protection offer**: After reporting results, offer auto-archive filters:
+   - "Want me to set up auto-archive filters so future emails from these senders skip your inbox?"
+   - If yes, call `gmail_filters` with `action: "create"` for each sender with `from` set to the sender's email and `remove_label_ids: ["INBOX"]`.
+   - Then offer a recurring declutter schedule: "Want me to scan for new clutter monthly?" If yes, use `schedule_create` to set up a monthly declutter check.
+
+### Edge Cases
+
+- **Zero results**: Tell the user "No newsletter emails found" and suggest broadening the query (e.g. removing the category filter or extending the date range)
+- **Unsubscribe failures**: Report per-sender success/failure; the existing `gmail_unsubscribe` tool handles edge cases
+- **Truncation handling**: The scan covers up to 5,000 messages by default (cap 10,000). If `truncated` is true, the top senders are still captured — don't offer to scan more. Tell the user: "Scanned [N] messages — here are your top senders."
+- **Time budget exceeded**: If the scan returns `time_budget_exceeded: true`, present whatever results were collected. Do not retry or continue — the partial results are useful as-is.
+
+## Scan ID
+
+Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context.
+
+- Pass `scan_id` + `sender_ids` to `gmail_batch_archive` instead of `message_ids`
+- Scan results expire after **30 minutes** — if archiving fails with an expiration error, re-run the scan
+- Raw `message_ids` still work as a fallback for non-scan workflows
+
+## Batch Operations
+
+- Gmail batch tools (`gmail_batch_archive`, `gmail_batch_label`) support `scan_id` + `sender_ids` (preferred) or raw `message_ids`.
+- First scan to get a `scan_id`, then apply batch actions using it.
+- Always confirm with the user before batch operations on large numbers of messages.
+
+## Date Verification
+
+Before composing any email that references a date or time:
+
+1. Check the `<temporal_context>` block in the current turn for today's date and upcoming dates
+2. Verify that "tomorrow" means the day after today's date, "next week" means the upcoming Monday–Friday, etc.
+3. If the email references a date from another message, cross-check it against the temporal context to ensure it's in the future
+
+## Confidence Scores
+
+Medium and high risk tools require a confidence score between 0 and 1:
+
+- **0.9-1.0**: User explicitly requested this exact action
+- **0.7-0.8**: Action is strongly implied by context
+- **0.5-0.6**: Reasonable inference but some ambiguity
+- **Below 0.5**: Ask the user to confirm before proceeding

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -1,0 +1,747 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "gmail_archive",
+      "description": "Archive a Gmail message (remove from inbox). Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID to archive"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-archive.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_batch_archive",
+      "description": "Archive multiple Gmail messages at once. Prefer scan_id + sender_ids (from a prior scan) over raw message_ids. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "scan_id": {
+            "type": "string",
+            "description": "Scan result ID from a prior gmail_sender_digest or gmail_outreach_scan call"
+          },
+          "sender_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Sender IDs to archive (used with scan_id to resolve message IDs server-side)"
+          },
+          "message_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gmail message IDs to archive (fallback — prefer scan_id + sender_ids)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["confidence"]
+      },
+      "executor": "tools/gmail-batch-archive.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_archive_by_query",
+      "description": "Archive ALL Gmail messages matching a search query. Paginates through all results and archives in bulk. Ideal for high-volume senders where message IDs are not pre-collected. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Gmail search query (e.g. \"from:marketing@example.com category:promotions newer_than:90d\")"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["query", "confidence"]
+      },
+      "executor": "tools/gmail-archive-by-query.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_label",
+      "description": "Add or remove labels on a Gmail message. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID"
+          },
+          "add_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Label IDs to add"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Label IDs to remove"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-label.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_batch_label",
+      "description": "Add or remove labels on multiple Gmail messages. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Gmail message IDs"
+          },
+          "add_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Label IDs to add"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Label IDs to remove"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_ids", "confidence"]
+      },
+      "executor": "tools/gmail-batch-label.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_trash",
+      "description": "Move a Gmail message to trash. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID to trash"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-trash.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_unsubscribe",
+      "description": "Unsubscribe from a mailing list by following the List-Unsubscribe header. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "A Gmail message ID from the mailing list to unsubscribe from"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/gmail-unsubscribe.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_draft",
+      "description": "Create a draft email in Gmail. The draft will appear in Gmail Drafts for user review.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Recipient email address"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Email subject line"
+          },
+          "body": {
+            "type": "string",
+            "description": "Email body (plain text)"
+          },
+          "in_reply_to": {
+            "type": "string",
+            "description": "RFC 822 Message-ID header value (e.g. `<CABx...@mail.gmail.com>`), NOT the Gmail message ID. Look up the original message's Message-ID header."
+          },
+          "cc": {
+            "type": "string",
+            "description": "CC recipients (comma-separated email addresses)"
+          },
+          "bcc": {
+            "type": "string",
+            "description": "BCC recipients (comma-separated email addresses)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["to", "subject", "body"]
+      },
+      "executor": "tools/gmail-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_send_draft",
+      "description": "Send an existing Gmail draft. Only use when the user has reviewed and explicitly approved sending.",
+      "category": "gmail",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "draft_id": {
+            "type": "string",
+            "description": "Gmail draft ID to send"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["draft_id", "confidence"]
+      },
+      "executor": "tools/gmail-send-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_list_attachments",
+      "description": "List attachments on a Gmail message with filename, MIME type, size, and attachment ID.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID to list attachments for"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id"]
+      },
+      "executor": "tools/gmail-list-attachments.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_download_attachment",
+      "description": "Download a Gmail attachment to the working directory.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID"
+          },
+          "attachment_id": {
+            "type": "string",
+            "description": "Attachment ID from gmail_list_attachments"
+          },
+          "filename": {
+            "type": "string",
+            "description": "Filename to save as"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "attachment_id", "filename"]
+      },
+      "executor": "tools/gmail-download-attachment.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_send_with_attachments",
+      "description": "Create a Gmail draft with file attachments for review. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Recipient email address"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Email subject line"
+          },
+          "body": {
+            "type": "string",
+            "description": "Email body (plain text)"
+          },
+          "attachment_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Absolute file paths of attachments to include"
+          },
+          "in_reply_to": {
+            "type": "string",
+            "description": "Message-ID header for replies"
+          },
+          "thread_id": {
+            "type": "string",
+            "description": "Thread ID to continue an existing thread"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["to", "subject", "body", "attachment_paths", "confidence"]
+      },
+      "executor": "tools/gmail-send-with-attachments.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_forward",
+      "description": "Create a draft forwarding a Gmail message to another recipient, preserving attachments. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID to forward"
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient email address"
+          },
+          "text": {
+            "type": "string",
+            "description": "Optional text to prepend to the forwarded message"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message_id", "to", "confidence"]
+      },
+      "executor": "tools/gmail-forward.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_summarize_thread",
+      "description": "Summarize a Gmail thread using LLM analysis. Returns participants, key decisions, open questions, and sentiment.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "thread_id": {
+            "type": "string",
+            "description": "Gmail thread ID to summarize"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["thread_id"]
+      },
+      "executor": "tools/gmail-summarize-thread.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_follow_up",
+      "description": "Track, list, or untrack Gmail messages for follow-up using a dedicated label. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["track", "list", "untrack"],
+            "description": "Follow-up action"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Gmail message ID (required for track/untrack)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-follow-up.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_triage",
+      "description": "LLM-powered inbox triage: classify unread emails by urgency and type, optionally auto-apply actions. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "max_results": {
+            "type": "number",
+            "description": "Maximum emails to triage (default 20)"
+          },
+          "auto_apply": {
+            "type": "boolean",
+            "description": "Auto-archive can_archive and label needs_reply as Follow-up (default false)"
+          },
+          "query": {
+            "type": "string",
+            "description": "Gmail search query (default 'is:unread in:inbox')"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["confidence"]
+      },
+      "executor": "tools/gmail-triage.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_filters",
+      "description": "List, create, or delete Gmail filters for inbox automation. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "create", "delete"],
+            "description": "Filter action"
+          },
+          "from": {
+            "type": "string",
+            "description": "Filter criteria: sender (for create)"
+          },
+          "to": {
+            "type": "string",
+            "description": "Filter criteria: recipient (for create)"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Filter criteria: subject contains (for create)"
+          },
+          "query": {
+            "type": "string",
+            "description": "Filter criteria: Gmail query (for create)"
+          },
+          "has_attachment": {
+            "type": "boolean",
+            "description": "Filter criteria: has attachment (for create)"
+          },
+          "add_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Filter action: label IDs to add (for create)"
+          },
+          "remove_label_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Filter action: label IDs to remove (for create)"
+          },
+          "forward": {
+            "type": "string",
+            "description": "Filter action: forward to email (for create)"
+          },
+          "filter_id": {
+            "type": "string",
+            "description": "Filter ID (for delete)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-filters.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_vacation",
+      "description": "Get, enable, or disable Gmail vacation auto-responder. Include a confidence score (0-1).",
+      "category": "gmail",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["get", "enable", "disable"],
+            "description": "Vacation action"
+          },
+          "message": {
+            "type": "string",
+            "description": "Auto-reply message body (required for enable)"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Auto-reply subject (default 'Out of Office')"
+          },
+          "start_time": {
+            "type": "number",
+            "description": "Start time in epoch milliseconds"
+          },
+          "end_time": {
+            "type": "number",
+            "description": "End time in epoch milliseconds"
+          },
+          "restrict_to_contacts": {
+            "type": "boolean",
+            "description": "Only auto-reply to contacts (default false)"
+          },
+          "restrict_to_domain": {
+            "type": "boolean",
+            "description": "Only auto-reply to same domain (default false)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/gmail-vacation.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_sender_digest",
+      "description": "Scan Gmail and group messages by sender to identify high-volume senders (e.g. newsletters). Returns top senders sorted by message count with metadata for bulk cleanup.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Gmail search query (default 'category:promotions newer_than:90d')"
+          },
+          "max_messages": {
+            "type": "number",
+            "description": "Maximum messages to scan (default 5000, cap 10000)"
+          },
+          "max_senders": {
+            "type": "number",
+            "description": "Maximum senders to return (default 50)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 10,000 messages in a single call)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/gmail-sender-digest.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "gmail_outreach_scan",
+      "description": "Scan Gmail for cold outreach emails (sales, recruiting, marketing) using LLM classification. Returns top outreach senders with suggested cleanup actions. Read-only — use gmail_batch_archive and gmail_filters for cleanup.",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "max_messages": {
+            "type": "number",
+            "description": "Maximum messages to scan (default 2000, cap 5000)"
+          },
+          "max_senders": {
+            "type": "number",
+            "description": "Maximum outreach senders to return (default 30)"
+          },
+          "time_range": {
+            "type": "string",
+            "description": "Gmail time range filter (default '90d')"
+          },
+          "min_confidence": {
+            "type": "number",
+            "description": "Minimum confidence threshold 0-1 (default 0.5)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 5,000 messages in a single call)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/gmail-outreach-scan.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "google_contacts",
+      "description": "List or search Google Contacts. Requires contacts.readonly scope (re-authorization may be needed).",
+      "category": "gmail",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "search"],
+            "description": "Contacts action"
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query (for search action)"
+          },
+          "page_size": {
+            "type": "number",
+            "description": "Number of contacts to return (default 50, for list)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Pagination token (for list)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/google-contacts.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive-by-query.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive-by-query.ts
@@ -1,0 +1,80 @@
+import {
+  batchModifyMessages,
+  listMessages,
+} from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+const BATCH_MODIFY_LIMIT = 1000;
+const MAX_MESSAGES = 5000;
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.triggeredBySurfaceAction) {
+    return err(
+      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+    );
+  }
+
+  const query = input.query as string;
+
+  if (!query) {
+    return err("query is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      // Paginate through matching messages, capped to prevent unbounded API/memory usage
+      const allMessageIds: string[] = [];
+      let pageToken: string | undefined;
+      let truncated = false;
+
+      while (allMessageIds.length < MAX_MESSAGES) {
+        const listResp = await listMessages(
+          token,
+          query,
+          Math.min(500, MAX_MESSAGES - allMessageIds.length),
+          pageToken,
+        );
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
+
+      // If we stopped because we hit the cap while more pages existed, flag truncation
+      if (allMessageIds.length >= MAX_MESSAGES && pageToken) {
+        truncated = true;
+      }
+
+      if (allMessageIds.length === 0) {
+        return ok("No messages matched the query. Nothing archived.");
+      }
+
+      // Archive in chunks of BATCH_MODIFY_LIMIT (Gmail's per-call limit)
+      for (let i = 0; i < allMessageIds.length; i += BATCH_MODIFY_LIMIT) {
+        const chunk = allMessageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+        await batchModifyMessages(token, chunk, { removeLabelIds: ["INBOX"] });
+      }
+
+      const summary = `Archived ${allMessageIds.length} message(s) matching query: ${query}`;
+      if (truncated) {
+        return ok(
+          `${summary}\n\nNote: this operation was capped at ${MAX_MESSAGES} messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,
+        );
+      }
+      return ok(summary);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -1,0 +1,29 @@
+import { modifyMessage } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      await modifyMessage(token, messageId, { removeLabelIds: ["INBOX"] });
+      return ok("Message archived.");
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-archive.ts
@@ -1,0 +1,56 @@
+import { batchModifyMessages } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { getSenderMessageIds } from "./scan-result-store.js";
+import { err, ok } from "./shared.js";
+
+const BATCH_MODIFY_LIMIT = 1000;
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.triggeredBySurfaceAction) {
+    return err(
+      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+    );
+  }
+
+  const scanId = input.scan_id as string | undefined;
+  const senderIds = input.sender_ids as string[] | undefined;
+  let messageIds = input.message_ids as string[] | undefined;
+
+  // Resolve message IDs from scan store if scan_id is provided
+  if (scanId && senderIds?.length) {
+    const resolved = getSenderMessageIds(scanId, senderIds);
+    if (!resolved) {
+      return err(
+        "Scan results have expired (30-minute window). Please re-run the scan to get fresh results.",
+      );
+    }
+    messageIds = resolved;
+  }
+
+  if (!messageIds?.length) {
+    return err(
+      "Either message_ids or scan_id + sender_ids is required, and must resolve to at least one message.",
+    );
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
+        const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+        await batchModifyMessages(token, chunk, { removeLabelIds: ["INBOX"] });
+      }
+      return ok(`Archived ${messageIds.length} message(s).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-batch-label.ts
@@ -1,0 +1,34 @@
+import { batchModifyMessages } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageIds = input.message_ids as string[];
+  const addLabelIds = input.add_label_ids as string[] | undefined;
+  const removeLabelIds = input.remove_label_ids as string[] | undefined;
+
+  if (!messageIds?.length) {
+    return err("message_ids is required and must not be empty.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      await batchModifyMessages(token, messageIds, {
+        addLabelIds,
+        removeLabelIds,
+      });
+      return ok(`Labels updated on ${messageIds.length} message(s).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-download-attachment.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-download-attachment.ts
@@ -1,0 +1,47 @@
+import { writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+import { getAttachment } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const attachmentId = input.attachment_id as string;
+  const filename = input.filename as string;
+
+  if (!messageId) return err("message_id is required.");
+  if (!attachmentId) return err("attachment_id is required.");
+  if (!filename) return err("filename is required.");
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const attachment = await getAttachment(token, messageId, attachmentId);
+
+      // Gmail returns base64url; convert to standard base64 then to Buffer
+      const base64 = attachment.data.replace(/-/g, "+").replace(/_/g, "/");
+      const buffer = Buffer.from(base64, "base64");
+
+      const outputDir = context.workingDir ?? process.cwd();
+      // Sanitize filename: strip path separators to prevent traversal attacks from crafted MIME filenames
+      const safeName = basename(filename).replace(/\.\./g, "_");
+      const outputPath = resolve(outputDir, safeName);
+      if (!outputPath.startsWith(outputDir))
+        return err("Invalid filename: path traversal detected.");
+      await writeFile(outputPath, buffer);
+
+      return ok(`Attachment saved to ${outputPath} (${buffer.length} bytes).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -1,0 +1,44 @@
+import { createDraft } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const inReplyTo = input.in_reply_to as string | undefined;
+  const cc = input.cc as string | undefined;
+  const bcc = input.bcc as string | undefined;
+
+  if (!to) return err("to is required.");
+  if (!subject) return err("subject is required.");
+  if (!body) return err("body is required.");
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const draft = await createDraft(
+        token,
+        to,
+        subject,
+        body,
+        inReplyTo,
+        cc,
+        bcc,
+      );
+      return ok(
+        `Draft created (ID: ${draft.id}). It will appear in your Gmail Drafts.`,
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -1,0 +1,83 @@
+import {
+  createFilter,
+  deleteFilter,
+  listFilters,
+} from "../../../../messaging/providers/gmail/client.js";
+import type {
+  GmailFilterAction,
+  GmailFilterCriteria,
+} from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (list, create, or delete).");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case "list": {
+          const filters = await listFilters(token);
+          if (filters.length === 0) {
+            return ok("No filters configured.");
+          }
+          return ok(JSON.stringify(filters, null, 2));
+        }
+
+        case "create": {
+          const criteria: GmailFilterCriteria = {};
+          if (input.from) criteria.from = input.from as string;
+          if (input.to) criteria.to = input.to as string;
+          if (input.subject) criteria.subject = input.subject as string;
+          if (input.query) criteria.query = input.query as string;
+          if (input.has_attachment !== undefined)
+            criteria.hasAttachment = input.has_attachment as boolean;
+
+          const filterAction: GmailFilterAction = {};
+          if (input.add_label_ids)
+            filterAction.addLabelIds = input.add_label_ids as string[];
+          if (input.remove_label_ids)
+            filterAction.removeLabelIds = input.remove_label_ids as string[];
+          if (input.forward) filterAction.forward = input.forward as string;
+
+          if (Object.keys(criteria).length === 0) {
+            return err(
+              "At least one filter criteria is required (from, to, subject, query, or has_attachment).",
+            );
+          }
+
+          const filter = await createFilter(token, criteria, filterAction);
+          return ok(`Filter created (ID: ${filter.id}).`);
+        }
+
+        case "delete": {
+          const filterId = input.filter_id as string;
+          if (!filterId) return err("filter_id is required for delete action.");
+
+          await deleteFilter(token, filterId);
+          return ok("Filter deleted.");
+        }
+
+        default:
+          return err(
+            `Unknown action "${action}". Use list, create, or delete.`,
+          );
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -1,0 +1,102 @@
+import {
+  batchGetMessages,
+  createLabel,
+  listLabels,
+  listMessages,
+  modifyMessage,
+} from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+const FOLLOW_UP_LABEL_NAME = "Follow-up";
+
+async function getOrCreateFollowUpLabel(token: string): Promise<string> {
+  const labels = await listLabels(token);
+  const existing = labels.find((l) => l.name === FOLLOW_UP_LABEL_NAME);
+  if (existing) return existing.id;
+
+  const created = await createLabel(token, FOLLOW_UP_LABEL_NAME);
+  return created.id;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (track, list, or untrack).");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case "track": {
+          const messageId = input.message_id as string;
+          if (!messageId)
+            return err("message_id is required for track action.");
+
+          const labelId = await getOrCreateFollowUpLabel(token);
+          await modifyMessage(token, messageId, { addLabelIds: [labelId] });
+          return ok("Message marked for follow-up.");
+        }
+
+        case "list": {
+          const labelId = await getOrCreateFollowUpLabel(token);
+          const listResp = await listMessages(token, undefined, 50, undefined, [
+            labelId,
+          ]);
+          const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+          if (messageIds.length === 0) {
+            return ok("No messages are currently tracked for follow-up.");
+          }
+
+          const messages = await batchGetMessages(
+            token,
+            messageIds,
+            "metadata",
+            ["From", "Subject", "Date"],
+          );
+          const items = messages.map((m) => {
+            const headers = m.payload?.headers ?? [];
+            const from =
+              headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+            const subject =
+              headers.find((h) => h.name.toLowerCase() === "subject")?.value ??
+              "";
+            const date =
+              headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+            return { id: m.id, threadId: m.threadId, from, subject, date };
+          });
+
+          return ok(JSON.stringify(items, null, 2));
+        }
+
+        case "untrack": {
+          const messageId = input.message_id as string;
+          if (!messageId)
+            return err("message_id is required for untrack action.");
+
+          const labelId = await getOrCreateFollowUpLabel(token);
+          await modifyMessage(token, messageId, { removeLabelIds: [labelId] });
+          return ok("Follow-up tracking removed from message.");
+        }
+
+        default:
+          return err(
+            `Unknown action "${action}". Use track, list, or untrack.`,
+          );
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -1,0 +1,142 @@
+import {
+  createDraftRaw,
+  getAttachment,
+  getMessage,
+} from "../../../../messaging/providers/gmail/client.js";
+import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
+import type { GmailMessagePart } from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+function extractHeader(
+  headers: Array<{ name: string; value: string }> | undefined,
+  name: string,
+): string {
+  return (
+    headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ??
+    ""
+  );
+}
+
+function extractPlainTextBody(part: GmailMessagePart | undefined): string {
+  if (!part) return "";
+  if (part.mimeType === "text/plain" && part.body?.data) {
+    return Buffer.from(
+      part.body.data.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    ).toString("utf-8");
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      const text = extractPlainTextBody(child);
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+interface AttachmentRef {
+  attachmentId: string;
+  filename: string;
+  mimeType: string;
+}
+
+function collectAttachmentRefs(
+  parts: GmailMessagePart[] | undefined,
+): AttachmentRef[] {
+  if (!parts) return [];
+  const result: AttachmentRef[] = [];
+  for (const part of parts) {
+    if (part.filename && part.body?.attachmentId) {
+      result.push({
+        attachmentId: part.body.attachmentId,
+        filename: part.filename,
+        mimeType: part.mimeType ?? "application/octet-stream",
+      });
+    }
+    if (part.parts) result.push(...collectAttachmentRefs(part.parts));
+  }
+  return result;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const forwardTo = input.to as string;
+  const additionalText = input.text as string | undefined;
+
+  if (!messageId) return err("message_id is required.");
+  if (!forwardTo) return err("to is required.");
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const message = await getMessage(token, messageId, "full");
+      const headers = message.payload?.headers ?? [];
+      const originalFrom = extractHeader(headers, "From");
+      const originalDate = extractHeader(headers, "Date");
+      const originalSubject = extractHeader(headers, "Subject");
+      const originalBody = extractPlainTextBody(message.payload);
+
+      const forwardHeader = [
+        additionalText ? `${additionalText}\n\n` : "",
+        "---------- Forwarded message ----------",
+        `From: ${originalFrom}`,
+        `Date: ${originalDate}`,
+        `Subject: ${originalSubject}`,
+        "",
+        originalBody,
+      ].join("\n");
+
+      const subject = originalSubject.startsWith("Fwd:")
+        ? originalSubject
+        : `Fwd: ${originalSubject}`;
+
+      // Collect and download attachments from the original message
+      const attachmentRefs = collectAttachmentRefs(message.payload?.parts);
+      const attachments = await Promise.all(
+        attachmentRefs.map(async (ref) => {
+          const att = await getAttachment(token, messageId, ref.attachmentId);
+          const data = Buffer.from(
+            att.data.replace(/-/g, "+").replace(/_/g, "/"),
+            "base64",
+          );
+          return { filename: ref.filename, mimeType: ref.mimeType, data };
+        }),
+      );
+
+      if (attachments.length > 0) {
+        const raw = buildMultipartMime({
+          to: forwardTo,
+          subject,
+          body: forwardHeader,
+          attachments,
+        });
+        const draft = await createDraftRaw(token, raw);
+        return ok(
+          `Forward draft created to ${forwardTo} with ${attachments.length} attachment(s) (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+        );
+      }
+
+      const raw = buildMultipartMime({
+        to: forwardTo,
+        subject,
+        body: forwardHeader,
+        attachments: [],
+      });
+      const draft = await createDraftRaw(token, raw);
+      return ok(
+        `Forward draft created to ${forwardTo} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -1,0 +1,31 @@
+import { modifyMessage } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+  const addLabelIds = input.add_label_ids as string[] | undefined;
+  const removeLabelIds = input.remove_label_ids as string[] | undefined;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      await modifyMessage(token, messageId, { addLabelIds, removeLabelIds });
+      return ok("Labels updated.");
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-list-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-list-attachments.ts
@@ -1,0 +1,67 @@
+import { getMessage } from "../../../../messaging/providers/gmail/client.js";
+import type { GmailMessagePart } from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+interface AttachmentInfo {
+  partId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  attachmentId: string;
+}
+
+/** Recursively walk the MIME parts tree to find attachments. */
+function collectAttachments(
+  parts: GmailMessagePart[] | undefined,
+): AttachmentInfo[] {
+  if (!parts) return [];
+  const result: AttachmentInfo[] = [];
+  for (const part of parts) {
+    if (part.filename && part.body?.attachmentId) {
+      result.push({
+        partId: part.partId ?? "",
+        filename: part.filename,
+        mimeType: part.mimeType ?? "application/octet-stream",
+        size: part.body.size ?? 0,
+        attachmentId: part.body.attachmentId,
+      });
+    }
+    if (part.parts) {
+      result.push(...collectAttachments(part.parts));
+    }
+  }
+  return result;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const message = await getMessage(token, messageId, "full");
+      const attachments = collectAttachments(message.payload?.parts);
+
+      if (attachments.length === 0) {
+        return ok("No attachments found on this message.");
+      }
+
+      return ok(JSON.stringify(attachments, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -1,0 +1,297 @@
+import type { EmailMetadata } from "../../../../messaging/email-classifier.js";
+import {
+  classifyOutreach,
+  type OutreachClassification,
+} from "../../../../messaging/outreach-classifier.js";
+import {
+  batchGetMessages,
+  listMessages,
+} from "../../../../messaging/providers/gmail/client.js";
+import type { GmailMessage } from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { storeScanResult } from "./scan-result-store.js";
+import { err, ok } from "./shared.js";
+
+const MAX_MESSAGES_CAP = 5000;
+const MAX_IDS_PER_SENDER = 5000;
+const MAX_SAMPLE_SUBJECTS = 3;
+
+interface OutreachSenderAggregation {
+  displayName: string;
+  email: string;
+  messageCount: number;
+  newestMessageId: string;
+  oldestDate: string;
+  newestDate: string;
+  messageIds: string[];
+  hasMore: boolean;
+  sampleSubjects: string[];
+  outreachTypes: string[];
+  confidenceSum: number;
+}
+
+/** Parse "Display Name <email@example.com>" into parts. */
+function parseFrom(from: string): { displayName: string; email: string } {
+  const match = from.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return {
+      displayName: match[1].replace(/^["']|["']$/g, "").trim(),
+      email: match[2].toLowerCase(),
+    };
+  }
+  const bare = from.trim().toLowerCase();
+  return { displayName: "", email: bare };
+}
+
+function buildSuggestedActions(email: string, count: number): string[] {
+  const actions: string[] = [`Archive all ${count} messages`];
+  if (count >= 2) {
+    actions.push(`Create filter to auto-archive future emails from ${email}`);
+  }
+  if (count >= 3) {
+    const domain = email.split("@")[1];
+    if (domain) {
+      actions.push(
+        `Create filter to auto-archive future emails from @${domain}`,
+      );
+    }
+  }
+  return actions;
+}
+
+/** Find the most common string in an array. */
+function mostCommon(items: string[]): string {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item, (counts.get(item) ?? 0) + 1);
+  }
+  let best = items[0] ?? "other";
+  let bestCount = 0;
+  for (const [item, count] of counts) {
+    if (count > bestCount) {
+      best = item;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const maxMessages = Math.min(
+    (input.max_messages as number) ?? 2000,
+    MAX_MESSAGES_CAP,
+  );
+  const maxSenders = (input.max_senders as number) ?? 30;
+  const timeRange = (input.time_range as string) ?? "90d";
+  const minConfidence = (input.min_confidence as number) ?? 0.5;
+  const inputPageToken = input.page_token as string | undefined;
+
+  const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      // Pipeline: fire metadata fetches for each page of IDs as they arrive
+      const allMessageIds: string[] = [];
+      const fetchPromises: Promise<GmailMessage[]>[] = [];
+      let pageToken: string | undefined = inputPageToken;
+      let truncated = false;
+      let timeBudgetExceeded = false;
+      const metadataHeaders = ["From", "Subject", "Date"];
+      const startTime = Date.now();
+      const TIME_BUDGET_MS = 90_000;
+
+      while (allMessageIds.length < maxMessages) {
+        if (Date.now() - startTime > TIME_BUDGET_MS) {
+          timeBudgetExceeded = true;
+          truncated = true;
+          break;
+        }
+        const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+        const listResp = await listMessages(token, query, pageSize, pageToken);
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        fetchPromises.push(
+          batchGetMessages(
+            token,
+            ids,
+            "metadata",
+            metadataHeaders,
+            "id,internalDate,payload/headers",
+          ),
+        );
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
+
+      if (allMessageIds.length >= maxMessages && pageToken) {
+        truncated = true;
+      }
+
+      if (allMessageIds.length === 0) {
+        return ok(
+          JSON.stringify({
+            senders: [],
+            total_scanned: 0,
+            outreach_detected: 0,
+            message: "No emails found matching the query.",
+          }),
+        );
+      }
+
+      const messages = (await Promise.all(fetchPromises)).flat();
+
+      // Build EmailMetadata for the classifier
+      const emailMetadata: EmailMetadata[] = messages.map((msg) => {
+        const headers = msg.payload?.headers ?? [];
+        const from =
+          headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+        const subject =
+          headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+        return { id: msg.id, from, subject, snippet: "", labels: [] };
+      });
+
+      // Classify in batches
+      const classifications = await classifyOutreach(emailMetadata);
+
+      // Index classifications by message ID
+      const classificationMap = new Map<string, OutreachClassification>();
+      for (const c of classifications) {
+        if (c.isOutreach) {
+          classificationMap.set(c.id, c);
+        }
+      }
+
+      // Aggregate by sender email (only outreach-classified messages)
+      const senderMap = new Map<string, OutreachSenderAggregation>();
+
+      for (const msg of messages) {
+        const classification = classificationMap.get(msg.id);
+        if (!classification) continue;
+
+        const headers = msg.payload?.headers ?? [];
+        const fromHeader =
+          headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+        const subject =
+          headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+        const dateStr =
+          headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+
+        const { displayName, email } = parseFrom(fromHeader);
+        if (!email) continue;
+
+        let agg = senderMap.get(email);
+        if (!agg) {
+          agg = {
+            displayName,
+            email,
+            messageCount: 0,
+            newestMessageId: msg.id,
+            oldestDate: dateStr,
+            newestDate: dateStr,
+            messageIds: [],
+            hasMore: false,
+            sampleSubjects: [],
+            outreachTypes: [],
+            confidenceSum: 0,
+          };
+          senderMap.set(email, agg);
+        }
+
+        agg.messageCount++;
+        agg.outreachTypes.push(classification.outreachType);
+        agg.confidenceSum += classification.confidence;
+
+        if (!agg.displayName && displayName) agg.displayName = displayName;
+
+        if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+          agg.messageIds.push(msg.id);
+        } else {
+          agg.hasMore = true;
+        }
+
+        // Track date range
+        const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+        const oldestEpoch = agg.oldestDate
+          ? new Date(agg.oldestDate).getTime()
+          : Infinity;
+        const newestEpoch = agg.newestDate
+          ? new Date(agg.newestDate).getTime()
+          : 0;
+
+        if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+          agg.oldestDate = dateStr || agg.oldestDate;
+        }
+        if (msgEpoch > newestEpoch) {
+          agg.newestDate = dateStr || agg.newestDate;
+          agg.newestMessageId = msg.id;
+        }
+
+        if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+          agg.sampleSubjects.push(subject);
+        }
+      }
+
+      // Sort by message count desc, filter by confidence, take top N
+      const qualified = [...senderMap.values()]
+        .map((s) => ({
+          ...s,
+          avgConfidence:
+            s.messageCount > 0 ? s.confidenceSum / s.messageCount : 0,
+          outreachType: mostCommon(s.outreachTypes),
+        }))
+        .filter((s) => s.avgConfidence >= minConfidence)
+        .sort((a, b) => b.messageCount - a.messageCount);
+
+      const totalOutreachDetected = qualified.length;
+      const sorted = qualified.slice(0, maxSenders);
+
+      const senders = sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        display_name: s.displayName || s.email.split("@")[0],
+        email: s.email,
+        message_count: s.messageCount,
+        outreach_type: s.outreachType,
+        confidence: Math.round(s.avgConfidence * 100) / 100,
+        newest_message_id: s.newestMessageId,
+        oldest_date: s.oldestDate,
+        newest_date: s.newestDate,
+        search_query: `from:${s.email}`,
+        sample_subjects: s.sampleSubjects,
+        suggested_actions: buildSuggestedActions(s.email, s.messageCount),
+      }));
+
+      // Store message IDs server-side to keep them out of LLM context
+      const scanId = storeScanResult(
+        sorted.map((s) => ({
+          id: Buffer.from(s.email).toString("base64url"),
+          messageIds: s.messageIds,
+          newestMessageId: s.newestMessageId,
+          newestUnsubscribableMessageId: null,
+        })),
+      );
+
+      return ok(
+        JSON.stringify({
+          scan_id: scanId,
+          senders,
+          total_scanned: allMessageIds.length,
+          outreach_detected: totalOutreachDetected,
+          ...(truncated ? { truncated: true } : {}),
+          ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        }),
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -1,0 +1,26 @@
+import { sendDraft } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const draftId = input.draft_id as string;
+  if (!draftId) return err("draft_id is required.");
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const msg = await sendDraft(token, draftId);
+      return ok(`Draft sent (Message ID: ${msg.id}).`);
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-with-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-with-attachments.ts
@@ -1,0 +1,97 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+
+import { createDraftRaw } from "../../../../messaging/providers/gmail/client.js";
+import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+const MIME_MAP: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".zip": "application/zip",
+  ".gz": "application/gzip",
+  ".tar": "application/x-tar",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".ppt": "application/vnd.ms-powerpoint",
+  ".pptx":
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".wav": "audio/wav",
+  ".txt": "text/plain",
+  ".html": "text/html",
+  ".css": "text/css",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".csv": "text/csv",
+};
+
+function guessMimeType(filePath: string): string {
+  return (
+    MIME_MAP[extname(filePath).toLowerCase()] ?? "application/octet-stream"
+  );
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const attachmentPaths = input.attachment_paths as string[];
+  const inReplyTo = input.in_reply_to as string | undefined;
+  const threadId = input.thread_id as string | undefined;
+
+  if (!to) return err("to is required.");
+  if (!subject) return err("subject is required.");
+  if (!body) return err("body is required.");
+  if (!attachmentPaths?.length)
+    return err("attachment_paths is required and must not be empty.");
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const attachments = await Promise.all(
+        attachmentPaths.map(async (filePath) => {
+          const data = await readFile(filePath);
+          const filename = basename(filePath);
+          const mimeType = guessMimeType(filePath);
+          return { filename, mimeType, data };
+        }),
+      );
+
+      const raw = buildMultipartMime({
+        to,
+        subject,
+        body,
+        inReplyTo,
+        attachments,
+      });
+      const draft = await createDraftRaw(token, raw, threadId);
+
+      const filenames = attachments.map((a) => a.filename).join(", ");
+      return ok(
+        `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -1,0 +1,245 @@
+import {
+  batchGetMessages,
+  listMessages,
+} from "../../../../messaging/providers/gmail/client.js";
+import type { GmailMessage } from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { storeScanResult } from "./scan-result-store.js";
+import { err, ok } from "./shared.js";
+
+const MAX_MESSAGES_CAP = 10000;
+const MAX_IDS_PER_SENDER = 5000;
+const MAX_SAMPLE_SUBJECTS = 3;
+
+interface SenderAggregation {
+  displayName: string;
+  email: string;
+  messageCount: number;
+  hasUnsubscribe: boolean;
+  newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+  newestUnsubscribableEpoch: number;
+  oldestDate: string;
+  newestDate: string;
+  messageIds: string[];
+  hasMore: boolean;
+  sampleSubjects: string[];
+}
+
+/** Parse "Display Name <email@example.com>" into parts. */
+function parseFrom(from: string): { displayName: string; email: string } {
+  const match = from.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return {
+      displayName: match[1].replace(/^["']|["']$/g, "").trim(),
+      email: match[2].toLowerCase(),
+    };
+  }
+  // Bare email address
+  const bare = from.trim().toLowerCase();
+  return { displayName: "", email: bare };
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const query = (input.query as string) ?? "category:promotions newer_than:90d";
+  const maxMessages = Math.min(
+    (input.max_messages as number) ?? 5000,
+    MAX_MESSAGES_CAP,
+  );
+  const maxSenders = (input.max_senders as number) ?? 50;
+  const inputPageToken = input.page_token as string | undefined;
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      // Pipeline: fire metadata fetches for each page of IDs as they arrive,
+      // overlapping fetch latency with pagination latency
+      const allMessageIds: string[] = [];
+      const fetchPromises: Promise<GmailMessage[]>[] = [];
+      let pageToken: string | undefined = inputPageToken;
+      let truncated = false;
+      let timeBudgetExceeded = false;
+      const metadataHeaders = ["From", "List-Unsubscribe", "Subject", "Date"];
+      const startTime = Date.now();
+      const TIME_BUDGET_MS = 90_000;
+
+      while (allMessageIds.length < maxMessages) {
+        if (Date.now() - startTime > TIME_BUDGET_MS) {
+          timeBudgetExceeded = true;
+          truncated = true;
+          break;
+        }
+        const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+        const listResp = await listMessages(token, query, pageSize, pageToken);
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        fetchPromises.push(
+          batchGetMessages(
+            token,
+            ids,
+            "metadata",
+            metadataHeaders,
+            "id,internalDate,payload/headers",
+          ),
+        );
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
+
+      // If we stopped because we hit the cap but there were still more pages, flag truncation
+      if (allMessageIds.length >= maxMessages && pageToken) {
+        truncated = true;
+      }
+
+      if (allMessageIds.length === 0) {
+        return ok(
+          JSON.stringify({
+            senders: [],
+            total_scanned: 0,
+            message:
+              "No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).",
+          }),
+        );
+      }
+
+      const messages = (await Promise.all(fetchPromises)).flat();
+
+      // Group by sender email
+      const senderMap = new Map<string, SenderAggregation>();
+
+      for (const msg of messages) {
+        const headers = msg.payload?.headers ?? [];
+        const fromHeader =
+          headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+        const subject =
+          headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+        const dateStr =
+          headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+        const listUnsub = headers.find(
+          (h) => h.name.toLowerCase() === "list-unsubscribe",
+        )?.value;
+
+        const { displayName, email } = parseFrom(fromHeader);
+        if (!email) continue;
+
+        let agg = senderMap.get(email);
+        if (!agg) {
+          agg = {
+            displayName,
+            email,
+            messageCount: 0,
+            hasUnsubscribe: false,
+            newestMessageId: msg.id,
+            newestUnsubscribableMessageId: null,
+            newestUnsubscribableEpoch: 0,
+            oldestDate: dateStr,
+            newestDate: dateStr,
+            messageIds: [],
+            hasMore: false,
+            sampleSubjects: [],
+          };
+          senderMap.set(email, agg);
+        }
+
+        agg.messageCount++;
+
+        if (listUnsub) agg.hasUnsubscribe = true;
+
+        // Use displayName from earliest message that has one
+        if (!agg.displayName && displayName) agg.displayName = displayName;
+
+        // Track message IDs (cap at MAX_IDS_PER_SENDER)
+        if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+          agg.messageIds.push(msg.id);
+        } else {
+          agg.hasMore = true;
+        }
+
+        // Track date range — compare using internalDate (epoch ms) for reliability
+        const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+        const oldestEpoch = agg.oldestDate
+          ? new Date(agg.oldestDate).getTime()
+          : Infinity;
+        const newestEpoch = agg.newestDate
+          ? new Date(agg.newestDate).getTime()
+          : 0;
+
+        if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+          agg.oldestDate = dateStr || agg.oldestDate;
+        }
+        if (msgEpoch > newestEpoch) {
+          agg.newestDate = dateStr || agg.newestDate;
+          agg.newestMessageId = msg.id;
+        }
+
+        // Track the newest message that actually has List-Unsubscribe so
+        // gmail_unsubscribe() is called with a message that carries the header
+        if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
+          agg.newestUnsubscribableMessageId = msg.id;
+          agg.newestUnsubscribableEpoch = msgEpoch;
+        }
+
+        // Collect sample subjects
+        if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+          agg.sampleSubjects.push(subject);
+        }
+      }
+
+      // Sort by message count descending, take top N
+      const sorted = [...senderMap.values()]
+        .sort((a, b) => b.messageCount - a.messageCount)
+        .slice(0, maxSenders);
+
+      const resultSenders = sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        display_name: s.displayName || s.email.split("@")[0],
+        email: s.email,
+        message_count: s.messageCount,
+        has_unsubscribe: s.hasUnsubscribe,
+        // When unsubscribe is available, point to a message that carries the header
+        newest_message_id:
+          s.hasUnsubscribe && s.newestUnsubscribableMessageId
+            ? s.newestUnsubscribableMessageId
+            : s.newestMessageId,
+        oldest_date: s.oldestDate,
+        newest_date: s.newestDate,
+        // Preserve original query filters so follow-up searches stay scoped
+        search_query: `from:${s.email} ${query}`,
+        sample_subjects: s.sampleSubjects,
+      }));
+
+      // Store message IDs server-side to keep them out of LLM context
+      const scanId = storeScanResult(
+        sorted.map((s) => ({
+          id: Buffer.from(s.email).toString("base64url"),
+          messageIds: s.messageIds,
+          newestMessageId: s.newestMessageId,
+          newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+        })),
+      );
+
+      return ok(
+        JSON.stringify({
+          scan_id: scanId,
+          senders: resultSenders,
+          total_scanned: allMessageIds.length,
+          query_used: query,
+          ...(truncated ? { truncated: true } : {}),
+          ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+          note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_batch_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
+        }),
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-summarize-thread.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-summarize-thread.ts
@@ -1,0 +1,87 @@
+import {
+  batchGetMessages,
+  listMessages,
+} from "../../../../messaging/providers/gmail/client.js";
+import type {
+  GmailMessage,
+  GmailMessagePart,
+} from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { summarizeThread } from "../../../../messaging/thread-summarizer.js";
+import type { ThreadMessage } from "../../../../messaging/types.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+function extractHeader(
+  headers: Array<{ name: string; value: string }> | undefined,
+  name: string,
+): string {
+  return (
+    headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ??
+    ""
+  );
+}
+
+function extractPlainTextBody(part: GmailMessagePart | undefined): string {
+  if (!part) return "";
+  if (part.mimeType === "text/plain" && part.body?.data) {
+    return Buffer.from(
+      part.body.data.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    ).toString("utf-8");
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      const text = extractPlainTextBody(child);
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+function gmailToThreadMessage(msg: GmailMessage): ThreadMessage {
+  const from = extractHeader(msg.payload?.headers, "From");
+  const senderName = from.replace(/<[^>]+>/, "").trim() || from;
+  return {
+    id: msg.id,
+    sender: senderName,
+    body: extractPlainTextBody(msg.payload),
+    timestamp: Number(msg.internalDate ?? 0),
+    channel: "email",
+  };
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const threadId = input.thread_id as string;
+
+  if (!threadId) {
+    return err("thread_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const listResp = await listMessages(token, `thread:${threadId}`, 50);
+      const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+      if (messageIds.length === 0) {
+        return err("No messages found in this thread.");
+      }
+
+      const messages = await batchGetMessages(token, messageIds, "full");
+      const threadMessages = messages.map(gmailToThreadMessage);
+      const summary = await summarizeThread(threadMessages);
+
+      return ok(JSON.stringify(summary, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -1,0 +1,29 @@
+import { trashMessage } from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      await trashMessage(token, messageId);
+      return ok("Message moved to trash.");
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-triage.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-triage.ts
@@ -1,0 +1,135 @@
+import {
+  type ClassifiedEmail,
+  classifyEmails,
+  type EmailMetadata,
+} from "../../../../messaging/email-classifier.js";
+import {
+  batchGetMessages,
+  batchModifyMessages,
+  createLabel,
+  listLabels,
+  listMessages,
+} from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+const FOLLOW_UP_LABEL_NAME = "Follow-up";
+
+async function getOrCreateLabel(token: string, name: string): Promise<string> {
+  const labels = await listLabels(token);
+  const existing = labels.find((l) => l.name === name);
+  if (existing) return existing.id;
+  const created = await createLabel(token, name);
+  return created.id;
+}
+
+function groupByCategory(
+  classifications: ClassifiedEmail[],
+): Record<string, ClassifiedEmail[]> {
+  const groups: Record<string, ClassifiedEmail[]> = {};
+  for (const c of classifications) {
+    (groups[c.category] ??= []).push(c);
+  }
+  return groups;
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const maxResults = (input.max_results as number) ?? 20;
+  const autoApply = (input.auto_apply as boolean) ?? false;
+  const query = (input.query as string) ?? "is:unread in:inbox";
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const listResp = await listMessages(token, query, maxResults);
+      const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+      if (messageIds.length === 0) {
+        return ok("No messages to triage.");
+      }
+
+      const messages = await batchGetMessages(token, messageIds, "metadata", [
+        "From",
+        "Subject",
+      ]);
+      const emailMetadata: EmailMetadata[] = messages.map((m) => {
+        const headers = m.payload?.headers ?? [];
+        return {
+          id: m.id,
+          from:
+            headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "",
+          subject:
+            headers.find((h) => h.name.toLowerCase() === "subject")?.value ??
+            "",
+          snippet: m.snippet ?? "",
+          labels: m.labelIds ?? [],
+        };
+      });
+
+      const result = await classifyEmails(emailMetadata);
+
+      if (result.classifications.length === 0) {
+        return ok("Classification unavailable. Try again later.");
+      }
+
+      const groups = groupByCategory(result.classifications);
+      const actions: string[] = [];
+
+      if (autoApply) {
+        // Archive can_archive emails
+        const archivable = groups["can_archive"] ?? [];
+        if (archivable.length > 0) {
+          await batchModifyMessages(
+            token,
+            archivable.map((c) => c.id),
+            { removeLabelIds: ["INBOX"] },
+          );
+          actions.push(`Archived ${archivable.length} message(s)`);
+        }
+
+        // Label needs_reply as Follow-up
+        const needsReply = groups["needs_reply"] ?? [];
+        if (needsReply.length > 0) {
+          const followUpLabelId = await getOrCreateLabel(
+            token,
+            FOLLOW_UP_LABEL_NAME,
+          );
+          await batchModifyMessages(
+            token,
+            needsReply.map((c) => c.id),
+            { addLabelIds: [followUpLabelId] },
+          );
+          actions.push(`Labeled ${needsReply.length} message(s) as Follow-up`);
+        }
+      }
+
+      const report = {
+        total: result.classifications.length,
+        groups: Object.fromEntries(
+          Object.entries(groups).map(([cat, items]) => [
+            cat,
+            items.map((c) => ({
+              id: c.id,
+              reasoning: c.reasoning,
+              suggestedAction: c.suggestedAction,
+              urgencyScore: c.urgencyScore,
+            })),
+          ]),
+        ),
+        actionsApplied: actions,
+      };
+
+      return ok(JSON.stringify(report, null, 2));
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -1,0 +1,124 @@
+import {
+  getMessage,
+  sendMessage,
+} from "../../../../messaging/providers/gmail/client.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import {
+  isPrivateOrLocalHost,
+  resolveHostAddresses,
+  resolveRequestAddress,
+} from "../../../../tools/network/url-safety.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok, pinnedHttpsRequest } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  if (!context.triggeredBySurfaceAction) {
+    return err(
+      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+    );
+  }
+
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      const message = await getMessage(token, messageId, "metadata", [
+        "List-Unsubscribe",
+        "List-Unsubscribe-Post",
+      ]);
+      const headers = message.payload?.headers ?? [];
+      const unsubHeader = headers.find(
+        (h) => h.name.toLowerCase() === "list-unsubscribe",
+      )?.value;
+
+      if (!unsubHeader) {
+        return err(
+          "No List-Unsubscribe header found. Manual unsubscribe may be required.",
+        );
+      }
+
+      const httpsMatch = unsubHeader.match(/<(https:\/\/[^>]+)>/);
+      const mailtoMatch = unsubHeader.match(/<mailto:([^>]+)>/);
+      const postHeader = headers.find(
+        (h) => h.name.toLowerCase() === "list-unsubscribe-post",
+      )?.value;
+
+      if (httpsMatch) {
+        const url = httpsMatch[1];
+        let parsed: URL;
+        let validatedAddresses: string[];
+        try {
+          parsed = new URL(url);
+          if (parsed.protocol !== "https:") {
+            return err("Unsubscribe URL must use HTTPS.");
+          }
+          if (isPrivateOrLocalHost(parsed.hostname)) {
+            return err("Unsubscribe URL points to a private or local address.");
+          }
+          const { addresses, blockedAddress } = await resolveRequestAddress(
+            parsed.hostname,
+            resolveHostAddresses,
+            false,
+          );
+          if (blockedAddress) {
+            return err(
+              "Unsubscribe URL resolves to a private or local address.",
+            );
+          }
+          if (addresses.length === 0) {
+            return err("Unable to resolve unsubscribe URL hostname.");
+          }
+          validatedAddresses = addresses;
+        } catch {
+          return err("Invalid unsubscribe URL.");
+        }
+
+        const method = postHeader ? "POST" : "GET";
+        const reqOpts = postHeader
+          ? {
+              method: "POST" as const,
+              headers: { "Content-Type": "application/x-www-form-urlencoded" },
+              body: postHeader,
+            }
+          : undefined;
+
+        let lastStatus = 0;
+        for (const address of validatedAddresses) {
+          try {
+            lastStatus = await pinnedHttpsRequest(parsed, address, reqOpts);
+            if (lastStatus >= 200 && lastStatus < 400) {
+              return ok(`Successfully unsubscribed via HTTPS ${method}.`);
+            }
+          } catch {
+            continue;
+          }
+        }
+        return err(`Unsubscribe request failed: ${lastStatus}`);
+      }
+
+      if (mailtoMatch) {
+        const mailtoAddr = mailtoMatch[1].split("?")[0];
+        await sendMessage(token, mailtoAddr, "Unsubscribe", "Unsubscribe");
+        return ok(`Unsubscribe email sent to ${mailtoAddr}.`);
+      }
+
+      return err(
+        "No supported unsubscribe method found (requires https: or mailto: URL).",
+      );
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -1,0 +1,70 @@
+import {
+  getVacation,
+  updateVacation,
+} from "../../../../messaging/providers/gmail/client.js";
+import type { GmailVacationSettings } from "../../../../messaging/providers/gmail/types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (get, enable, or disable).");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case "get": {
+          const settings = await getVacation(token);
+          return ok(JSON.stringify(settings, null, 2));
+        }
+
+        case "enable": {
+          const message = input.message as string;
+          if (!message)
+            return err("message is required when enabling vacation responder.");
+
+          const settings: GmailVacationSettings = {
+            enableAutoReply: true,
+            responseSubject: (input.subject as string) ?? "Out of Office",
+            responseBodyPlainText: message,
+            restrictToContacts:
+              (input.restrict_to_contacts as boolean) ?? false,
+            restrictToDomain: (input.restrict_to_domain as boolean) ?? false,
+          };
+
+          if (input.start_time) settings.startTime = String(input.start_time);
+          if (input.end_time) settings.endTime = String(input.end_time);
+
+          const updated = await updateVacation(token, settings);
+          return ok(
+            `Vacation responder enabled.\n${JSON.stringify(updated, null, 2)}`,
+          );
+        }
+
+        case "disable": {
+          await updateVacation(token, { enableAutoReply: false });
+          return ok("Vacation responder disabled.");
+        }
+
+        default:
+          return err(
+            `Unknown action "${action}". Use get, enable, or disable.`,
+          );
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/google-contacts.ts
@@ -1,0 +1,80 @@
+import {
+  listContacts,
+  searchContacts,
+} from "../../../../messaging/providers/gmail/people-client.js";
+import type { Person } from "../../../../messaging/providers/gmail/people-types.js";
+import { getMessagingProvider } from "../../../../messaging/registry.js";
+import { withValidToken } from "../../../../security/token-manager.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+function formatContact(person: Person): Record<string, unknown> {
+  const name = person.names?.[0];
+  const email = person.emailAddresses?.[0];
+  const phone = person.phoneNumbers?.[0];
+  const org = person.organizations?.[0];
+
+  return {
+    name: name?.displayName ?? "Unknown",
+    email: email?.value ?? null,
+    phone: phone?.value ?? null,
+    organization: org?.name ?? null,
+    title: org?.title ?? null,
+  };
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (list or search).");
+  }
+
+  try {
+    const provider = getMessagingProvider("gmail");
+    return withValidToken(provider.credentialService, async (token) => {
+      switch (action) {
+        case "list": {
+          const pageSize = (input.page_size as number) ?? 50;
+          const pageToken = input.page_token as string | undefined;
+
+          const resp = await listContacts(token, pageSize, pageToken);
+          const contacts = (resp.connections ?? []).map(formatContact);
+
+          const result: Record<string, unknown> = {
+            contacts,
+            total: resp.totalPeople ?? contacts.length,
+          };
+          if (resp.nextPageToken) result.nextPageToken = resp.nextPageToken;
+
+          return ok(JSON.stringify(result, null, 2));
+        }
+
+        case "search": {
+          const query = input.query as string;
+          if (!query) return err("query is required for search action.");
+
+          const resp = await searchContacts(token, query);
+          const contacts = (resp.results ?? []).map((r) =>
+            formatContact(r.person),
+          );
+
+          return ok(
+            JSON.stringify({ contacts, total: contacts.length }, null, 2),
+          );
+        }
+
+        default:
+          return err(`Unknown action "${action}". Use list or search.`);
+      }
+    });
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/scan-result-store.ts
@@ -1,0 +1,100 @@
+import { randomBytes } from "crypto";
+
+interface SenderData {
+  messageIds: string[];
+  newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+}
+
+interface ScanEntry {
+  senders: Map<string, SenderData>;
+  createdAt: number;
+}
+
+const MAX_ENTRIES = 16;
+const TTL_MS = 30 * 60_000; // 30 minutes
+
+const _store = new Map<string, ScanEntry>();
+
+/** Store scan results and return a unique scan ID. */
+export function storeScanResult(
+  senders: Array<{
+    id: string;
+    messageIds: string[];
+    newestMessageId: string;
+    newestUnsubscribableMessageId: string | null;
+  }>,
+): string {
+  const scanId = randomBytes(8).toString("hex");
+
+  // LRU eviction: remove oldest if at capacity
+  if (_store.size >= MAX_ENTRIES) {
+    const oldest = _store.keys().next().value;
+    if (oldest !== undefined) _store.delete(oldest);
+  }
+
+  const senderMap = new Map<string, SenderData>();
+  for (const s of senders) {
+    senderMap.set(s.id, {
+      messageIds: s.messageIds,
+      newestMessageId: s.newestMessageId,
+      newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+    });
+  }
+
+  _store.set(scanId, { senders: senderMap, createdAt: Date.now() });
+  return scanId;
+}
+
+/** Retrieve message IDs for the given senders from a scan result. */
+export function getSenderMessageIds(
+  scanId: string,
+  senderIds: string[],
+): string[] | null {
+  const entry = _store.get(scanId);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    _store.delete(scanId);
+    return null;
+  }
+  // LRU: move to end
+  _store.delete(scanId);
+  _store.set(scanId, entry);
+
+  const ids: string[] = [];
+  for (const sid of senderIds) {
+    const data = entry.senders.get(sid);
+    if (data) ids.push(...data.messageIds);
+  }
+  return ids;
+}
+
+/** Retrieve metadata for a single sender from a scan result. */
+export function getSenderMetadata(
+  scanId: string,
+  senderId: string,
+): {
+  newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+} | null {
+  const entry = _store.get(scanId);
+  if (!entry) return null;
+  if (Date.now() - entry.createdAt > TTL_MS) {
+    _store.delete(scanId);
+    return null;
+  }
+  const data = entry.senders.get(senderId);
+  if (!data) return null;
+  return {
+    newestMessageId: data.newestMessageId,
+    newestUnsubscribableMessageId: data.newestUnsubscribableMessageId,
+  };
+}
+
+/** Clear the store (for tests). */
+export function clearScanStore(): void {
+  _store.clear();
+}
+
+/** Visible for testing: override TTL check by returning internal store reference. */
+export const _internals = { store: _store, TTL_MS };

--- a/assistant/src/config/bundled-skills/gmail/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/shared.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared utilities for gmail skill tools.
+ */
+
+import {
+  request as httpsRequest,
+  type RequestOptions as HttpsRequestOptions,
+} from "node:https";
+
+import type { ToolExecutionResult } from "../../../../tools/types.js";
+
+export function ok(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+export function err(message: string): ToolExecutionResult {
+  return { content: message, isError: true };
+}
+
+/** Make an HTTPS request pinned to a specific resolved IP to prevent DNS rebinding. */
+export function pinnedHttpsRequest(
+  target: URL,
+  resolvedAddress: string,
+  options?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const reqOpts: HttpsRequestOptions = {
+      method: options?.method ?? "GET",
+      hostname: resolvedAddress,
+      port: target.port ? Number(target.port) : undefined,
+      path: `${target.pathname}${target.search}`,
+      headers: { host: target.host, ...options?.headers },
+      servername: target.hostname,
+    };
+    const req = httpsRequest(reqOpts, (res) => {
+      res.resume();
+      resolve(res.statusCode ?? 0);
+    });
+    req.once("error", reject);
+    if (options?.body) req.write(options.body);
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary
- Create new `gmail` bundled skill with SKILL.md, TOOLS.json, and 21 tool scripts
- Copy all gmail_* tools plus google_contacts from the messaging skill into their own standalone skill
- Includes shared.ts (ok/err/pinnedHttpsRequest) and scan-result-store.ts for declutter workflows
- Comprehensive SKILL.md with Gmail-specific docs extracted from original messaging SKILL.md

Part of plan: split-messaging-skill.md (PR 2 of 3)

## Test plan
- [x] `bunx tsc --noEmit` passes (no type errors in new files)
- [x] TOOLS.json is valid JSON with 21 tools
- [x] All executor paths in TOOLS.json point to existing files
- [x] All categories set to "gmail"
- [x] Prettier and ESLint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
