### PR TITLE
test: add bundled-tool-registry guard to catch TOOLS.json drift

### DIFF
--- a/assistant/src/config/__tests__/bundled-tool-registry-guard.test.ts
+++ b/assistant/src/config/__tests__/bundled-tool-registry-guard.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Guard test that validates bundled-tool-registry.ts stays in sync with
+ * TOOLS.json declarations across all bundled skills.
+ *
+ * If this test fails, run:
+ *   cd assistant && bun run scripts/generate-bundled-tool-registry.ts
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BUNDLED_SKILLS_DIR = join(import.meta.dir, "..", "bundled-skills");
+const REGISTRY_PATH = join(import.meta.dir, "..", "bundled-tool-registry.ts");
+
+interface ToolEntry {
+  executor: string;
+  [key: string]: unknown;
+}
+
+interface ToolsJson {
+  version: number;
+  tools: ToolEntry[];
+}
+
+/** Collect all expected registry keys from TOOLS.json files. */
+function collectToolsJsonKeys(): Set<string> {
+  const keys = new Set<string>();
+  const entries = readdirSync(BUNDLED_SKILLS_DIR, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === "_shared") continue;
+
+    const toolsJsonPath = join(BUNDLED_SKILLS_DIR, entry.name, "TOOLS.json");
+    let raw: string;
+    try {
+      raw = readFileSync(toolsJsonPath, "utf-8");
+    } catch {
+      // No TOOLS.json — skip this skill.
+      continue;
+    }
+
+    const toolsJson: ToolsJson = JSON.parse(raw);
+    for (const tool of toolsJson.tools) {
+      keys.add(`${entry.name}:${tool.executor}`);
+    }
+  }
+
+  return keys;
+}
+
+/** Extract all registry keys from bundled-tool-registry.ts source. */
+function collectRegistryKeys(): Set<string> {
+  const source = readFileSync(REGISTRY_PATH, "utf-8");
+  const keys = new Set<string>();
+  // Match both inline `["key", alias]` and multi-line `[\n    "key",` formats.
+  // Registry keys always follow the pattern `skillName:tools/something.ts`.
+  const pattern = /"([^"]+:tools\/[^"]+\.ts)"/g;
+  for (const match of source.matchAll(pattern)) {
+    keys.add(match[1]);
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bundled-tool-registry guard", () => {
+  const toolsJsonKeys = collectToolsJsonKeys();
+  const registryKeys = collectRegistryKeys();
+
+  test("every TOOLS.json executor has a registry entry", () => {
+    const violations: string[] = [];
+
+    for (const key of toolsJsonKeys) {
+      if (!registryKeys.has(key)) {
+        violations.push(key);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "TOOLS.json declares executors that are missing from bundled-tool-registry.ts.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Run 'cd assistant && bun run scripts/generate-bundled-tool-registry.ts' to fix.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+
+  test("registry has no stale entries", () => {
+    const violations: string[] = [];
+
+    for (const key of registryKeys) {
+      if (!toolsJsonKeys.has(key)) {
+        violations.push(key);
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "bundled-tool-registry.ts contains entries not found in any TOOLS.json.",
+        "",
+        "Violations:",
+        ...violations.map((v) => `  - ${v}`),
+        "",
+        "Run 'cd assistant && bun run scripts/generate-bundled-tool-registry.ts' to fix.",
+      ].join("\n");
+      expect(violations, message).toEqual([]);
+    }
+  });
+});

--- a/assistant/src/config/bundled-skills/sequences/SKILL.md
+++ b/assistant/src/config/bundled-skills/sequences/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sequences
+description: Create and manage automated email drip sequences with enrollment, scheduling, and analytics
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "📧"
+  vellum:
+    display-name: "Email Sequences"
+    user-invocable: true
+---
+
+You are an email sequence assistant. Use the sequence tools to help users create and manage automated multi-step email drip campaigns.
+
+## Capabilities
+
+### Sequence Management
+
+- **Create**: Build multi-step email sequences with configurable delays, subject lines, body prompts, and per-step approval gates
+- **List**: View all sequences with status and active enrollment counts
+- **Get**: Inspect a sequence's full configuration, steps, and enrollment breakdown
+- **Update**: Modify a sequence's name, description, status, steps, or exit-on-reply behavior
+- **Delete**: Remove a sequence and cancel all its active enrollments
+
+### Enrollment
+
+- **Enroll**: Add one or more contacts (by email) to a sequence, with optional personalization context
+- **Enrollment List**: View enrollments filtered by sequence or status (active, paused, completed, replied, cancelled, failed)
+- **Import**: Bulk-import contacts from a CSV/TSV file into a sequence (preview mode by default, then confirm to enroll)
+
+### Lifecycle Control
+
+- **Pause**: Pause an entire sequence (halts all enrollments) or pause a single enrollment
+- **Resume**: Resume a paused sequence so enrollments are processed on the next scheduler tick
+- **Cancel**: Cancel a specific enrollment, removing the contact from the sequence
+
+### Analytics
+
+- **Dashboard**: View aggregate metrics across all sequences — total sends, reply rates, completion rates
+- **Step Funnel**: Drill into a specific sequence to see per-step send counts, reach, and drop-off
+
+## Usage Notes
+
+- Sequences require a messaging channel (e.g. `"gmail"`) to be connected before enrollments can be processed.
+- By default, sequences exit when the contact replies (`exit_on_reply: true`). Set to `false` for sequences that should always complete all steps.
+- The `sequence_import` tool runs in preview mode by default. Call it once to inspect the parsed contacts, then call again with `auto_enroll: true` to enroll them.
+- Step delays are specified in seconds. Use common conversions: 1 hour = 3600, 1 day = 86400, 1 week = 604800.

--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -1,0 +1,397 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "sequence_create",
+      "description": "Create an email sequence with multiple steps and delay intervals.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the sequence"
+          },
+          "channel": {
+            "type": "string",
+            "description": "Messaging channel (e.g. \"gmail\")"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "delay_seconds": {
+                  "type": "number",
+                  "description": "Delay before sending this step (in seconds)"
+                },
+                "subject": {
+                  "type": "string",
+                  "description": "Subject line template"
+                },
+                "body_prompt": {
+                  "type": "string",
+                  "description": "Prompt or body text for this step"
+                },
+                "reply_to_thread": {
+                  "type": "boolean",
+                  "description": "Whether to reply in the existing thread (default true for step 2+)"
+                },
+                "require_approval": {
+                  "type": "boolean",
+                  "description": "Whether to require user approval before sending (default false)"
+                }
+              },
+              "required": ["body_prompt"]
+            },
+            "description": "Ordered list of sequence steps"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the sequence"
+          },
+          "exit_on_reply": {
+            "type": "boolean",
+            "description": "Whether to stop the sequence when the contact replies (default true)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["name", "channel", "steps"]
+      },
+      "executor": "tools/sequence-create.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_list",
+      "description": "List all email sequences with their status and enrollment counts.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["active", "paused", "archived"],
+            "description": "Filter by sequence status"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/sequence-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_get",
+      "description": "Get detailed information about a sequence including steps, enrollment counts, and status breakdown.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Sequence ID"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["id"]
+      },
+      "executor": "tools/sequence-get.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_update",
+      "description": "Update a sequence's name, description, status, steps, or exit-on-reply setting.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Sequence ID to update"
+          },
+          "name": {
+            "type": "string",
+            "description": "New name"
+          },
+          "description": {
+            "type": "string",
+            "description": "New description"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "paused", "archived"],
+            "description": "New status"
+          },
+          "exit_on_reply": {
+            "type": "boolean",
+            "description": "Whether to exit on contact reply"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "delay_seconds": {
+                  "type": "number",
+                  "description": "Delay before sending this step (in seconds)"
+                },
+                "subject": {
+                  "type": "string",
+                  "description": "Subject line template"
+                },
+                "body_prompt": {
+                  "type": "string",
+                  "description": "Prompt or body text for this step"
+                },
+                "reply_to_thread": {
+                  "type": "boolean",
+                  "description": "Whether to reply in the existing thread"
+                },
+                "require_approval": {
+                  "type": "boolean",
+                  "description": "Whether to require user approval before sending"
+                }
+              },
+              "required": ["body_prompt"]
+            },
+            "description": "Replacement steps (replaces all existing steps)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["id"]
+      },
+      "executor": "tools/sequence-update.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_delete",
+      "description": "Delete a sequence and cancel all its active enrollments.",
+      "category": "sequences",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Sequence ID to delete"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["id"]
+      },
+      "executor": "tools/sequence-delete.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_enroll",
+      "description": "Enroll one or more contacts into a sequence. Accepts comma-separated emails or an array.",
+      "category": "sequences",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Sequence ID to enroll contacts in"
+          },
+          "emails": {
+            "description": "Email address(es) to enroll \u2014 comma-separated string or array",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "context": {
+            "type": "object",
+            "description": "Optional context object with personalization variables for the enrolled contacts"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["sequence_id", "emails"]
+      },
+      "executor": "tools/sequence-enroll.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_enrollment_list",
+      "description": "List enrollments for a sequence, optionally filtered by status.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Filter by sequence ID"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "completed",
+              "replied",
+              "cancelled",
+              "failed"
+            ],
+            "description": "Filter by enrollment status"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/sequence-enrollment-list.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_pause",
+      "description": "Pause a sequence (stops processing all enrollments) or cancel a specific enrollment.",
+      "category": "sequences",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Sequence ID to pause"
+          },
+          "enrollment_id": {
+            "type": "string",
+            "description": "Specific enrollment ID to cancel (alternative to pausing whole sequence)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/sequence-pause.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_resume",
+      "description": "Resume a paused sequence. Active enrollments will be processed on the next scheduler tick.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Sequence ID to resume"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["sequence_id"]
+      },
+      "executor": "tools/sequence-resume.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_cancel",
+      "description": "Cancel a specific enrollment, removing the contact from the sequence.",
+      "category": "sequences",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "enrollment_id": {
+            "type": "string",
+            "description": "Enrollment ID to cancel"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["enrollment_id"]
+      },
+      "executor": "tools/sequence-cancel.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_import",
+      "description": "Import contacts from a CSV/TSV file and enroll them in a sequence. First call shows a preview; set auto_enroll=true to enroll.",
+      "category": "sequences",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "file_path": {
+            "type": "string",
+            "description": "Absolute path to the CSV/TSV file"
+          },
+          "sequence_id": {
+            "type": "string",
+            "description": "Sequence ID to enroll contacts in"
+          },
+          "auto_enroll": {
+            "type": "boolean",
+            "description": "Set to true to enroll contacts (default false = preview mode)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["file_path", "sequence_id"]
+      },
+      "executor": "tools/sequence-import.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "sequence_analytics",
+      "description": "View sequence analytics dashboard with send/reply/completion metrics, per-step funnel, and recent activity.",
+      "category": "sequences",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "sequence_id": {
+            "type": "string",
+            "description": "Optional sequence ID for detailed step funnel view"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/sequence-analytics.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-analytics.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-analytics.ts
@@ -1,0 +1,101 @@
+import {
+  getDashboardData,
+  getStepMetrics,
+} from "../../../../sequence/analytics.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string | undefined;
+
+  const data = getDashboardData();
+
+  const lines: string[] = [];
+
+  // ── Summary ─────────────────────────────────────────────────────
+  lines.push("=== Sequence Analytics Dashboard ===");
+  lines.push("");
+  lines.push(`Total sequences:     ${data.summary.totalSequences}`);
+  lines.push(`Active sequences:    ${data.summary.activeSequences}`);
+  lines.push(`Active enrollments:  ${data.summary.activeEnrollments}`);
+  lines.push(`Sends today:         ${data.summary.sendsToday}`);
+  lines.push(
+    `Overall reply rate:  ${(data.summary.overallReplyRate * 100).toFixed(1)}%`,
+  );
+
+  // ── Per-sequence table ──────────────────────────────────────────
+  if (data.sequences.length > 0) {
+    lines.push("");
+    lines.push("--- Per-Sequence Metrics ---");
+    for (const m of data.sequences) {
+      lines.push("");
+      lines.push(`  ${m.sequenceName} (${m.status})`);
+      lines.push(
+        `    Enrolled: ${m.totalEnrollments}  Active: ${m.activeEnrollments}  Sends: ${m.sends}`,
+      );
+      lines.push(
+        `    Replied: ${m.replies}  Completed: ${m.completions}  Failed: ${m.failures}  Cancelled: ${m.cancellations}`,
+      );
+      lines.push(
+        `    Reply rate: ${(m.replyRate * 100).toFixed(
+          1,
+        )}%  Completion rate: ${(m.completionRate * 100).toFixed(1)}%`,
+      );
+      if (m.avgTimeToReplyMs != null) {
+        const hours = Math.round(m.avgTimeToReplyMs / (1000 * 60 * 60));
+        lines.push(`    Avg time to reply: ${hours}h`);
+      }
+    }
+  }
+
+  // ── Step funnel (if specific sequence requested) ────────────────
+  if (sequenceId) {
+    const steps = getStepMetrics(sequenceId);
+    if (steps.length > 0) {
+      lines.push("");
+      lines.push("--- Step Funnel ---");
+      for (const s of steps) {
+        const bar = "#".repeat(
+          Math.max(
+            1,
+            Math.round(
+              (s.enrollmentsReached /
+                Math.max(1, steps[0].enrollmentsReached)) *
+                20,
+            ),
+          ),
+        );
+        lines.push(
+          `  Step ${s.stepIndex + 1}: "${s.subject}" — ${s.sends} sends, ${
+            s.enrollmentsReached
+          } reached, ${(s.dropOff * 100).toFixed(0)}% drop-off`,
+        );
+        lines.push(`    ${bar}`);
+      }
+    }
+  }
+
+  // ── Recent activity ─────────────────────────────────────────────
+  if (data.recentEvents.length > 0) {
+    lines.push("");
+    lines.push("--- Recent Activity ---");
+    for (const e of data.recentEvents.slice(0, 10)) {
+      const time = new Date(e.createdAt).toISOString();
+      const step = e.stepIndex !== undefined ? ` step ${e.stepIndex + 1}` : "";
+      lines.push(
+        `  [${time}] ${e.eventType}${step} — enrollment ${e.enrollmentId.slice(
+          0,
+          8,
+        )}...`,
+      );
+    }
+  }
+
+  return ok(lines.join("\n"));
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-cancel.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-cancel.ts
@@ -1,0 +1,27 @@
+import { exitEnrollment, getEnrollment } from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const enrollmentId = input.enrollment_id as string;
+  if (!enrollmentId) return err("enrollment_id is required.");
+
+  try {
+    const enrollment = getEnrollment(enrollmentId);
+    if (!enrollment) return err(`Enrollment not found: ${enrollmentId}`);
+    if (enrollment.status !== "active" && enrollment.status !== "paused") {
+      return ok(`Enrollment already in terminal state: ${enrollment.status}`);
+    }
+
+    exitEnrollment(enrollmentId, "cancelled");
+    return ok(`Enrollment for ${enrollment.contactEmail} cancelled.`);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
@@ -1,0 +1,47 @@
+import { createSequence } from "../../../../sequence/store.js";
+import type { SequenceStep } from "../../../../sequence/types.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const name = input.name as string;
+  const channel = input.channel as string;
+  const stepsRaw = input.steps as Array<Record<string, unknown>> | undefined;
+  const description = input.description as string | undefined;
+  const exitOnReply = input.exit_on_reply as boolean | undefined;
+
+  if (!name) return err("name is required.");
+  if (!channel) return err("channel is required.");
+  if (!stepsRaw || stepsRaw.length === 0)
+    return err("steps array is required and must have at least one step.");
+
+  try {
+    const steps: SequenceStep[] = stepsRaw.map((s, i) => ({
+      index: i,
+      delaySeconds: (s.delay_seconds as number) ?? 0,
+      subjectTemplate: (s.subject as string) ?? `Step ${i + 1}`,
+      bodyPrompt: (s.body_prompt as string) ?? "",
+      replyToThread: (s.reply_to_thread as boolean) ?? i > 0,
+      requireApproval: (s.require_approval as boolean) ?? false,
+    }));
+
+    const sequence = createSequence({
+      name,
+      channel,
+      steps,
+      description,
+      exitOnReply,
+    });
+    return ok(
+      `Sequence created (ID: ${sequence.id}).\n\nName: ${sequence.name}\nChannel: ${sequence.channel}\nSteps: ${steps.length}\nExit on reply: ${sequence.exitOnReply}\nStatus: ${sequence.status}`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-delete.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-delete.ts
@@ -1,0 +1,26 @@
+import { deleteSequence, getSequence } from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const id = input.id as string;
+  if (!id) return err("id is required.");
+
+  try {
+    const seq = getSequence(id);
+    if (!seq) return err(`Sequence not found: ${id}`);
+
+    deleteSequence(id);
+    return ok(
+      `Sequence "${seq.name}" deleted. All active enrollments have been cancelled.`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-enroll.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-enroll.ts
@@ -1,0 +1,59 @@
+import { enrollContact, getSequence } from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string;
+  const emails = input.emails as string | string[];
+  const context = input.context as Record<string, unknown> | undefined;
+
+  if (!sequenceId) return err("sequence_id is required.");
+  if (!emails) return err("emails is required (string or array).");
+
+  try {
+    const seq = getSequence(sequenceId);
+    if (!seq) return err(`Sequence not found: ${sequenceId}`);
+
+    // Support comma-separated string or array
+    const emailList = Array.isArray(emails)
+      ? emails
+      : emails
+          .split(",")
+          .map((e) => e.trim())
+          .filter(Boolean);
+
+    if (emailList.length === 0) return err("No valid emails provided.");
+
+    const results: string[] = [];
+    let successCount = 0;
+    for (const email of emailList) {
+      try {
+        const enrollment = enrollContact({
+          sequenceId,
+          contactEmail: email,
+          context,
+        });
+        results.push(`  ${email} — enrolled (ID: ${enrollment.id})`);
+        successCount++;
+      } catch (e) {
+        results.push(
+          `  ${email} — failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+
+    return ok(
+      `Enrolled ${successCount}/${emailList.length} contact(s) in "${
+        seq.name
+      }":\n${results.join("\n")}`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-enrollment-list.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-enrollment-list.ts
@@ -1,0 +1,30 @@
+import { listEnrollments } from "../../../../sequence/store.js";
+import type { EnrollmentStatus } from "../../../../sequence/types.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string | undefined;
+  const status = input.status as EnrollmentStatus | undefined;
+
+  try {
+    const enrollments = listEnrollments({ sequenceId, status });
+    if (enrollments.length === 0) return ok("No enrollments found.");
+
+    const lines = enrollments.map((e) => {
+      const nextAt = e.nextStepAt
+        ? new Date(e.nextStepAt).toISOString()
+        : "n/a";
+      return `- ${e.contactEmail} (ID: ${e.id}) — step ${e.currentStep}, status: ${e.status}, next: ${nextAt}`;
+    });
+    return ok(`${enrollments.length} enrollment(s):\n${lines.join("\n")}`);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-get.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-get.ts
@@ -1,0 +1,57 @@
+import {
+  countActiveEnrollments,
+  getSequence,
+  listEnrollments,
+} from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const id = input.id as string;
+  if (!id) return err("id is required.");
+
+  try {
+    const seq = getSequence(id);
+    if (!seq) return err(`Sequence not found: ${id}`);
+
+    const activeCount = countActiveEnrollments(id);
+    const allEnrollments = listEnrollments({ sequenceId: id });
+    const statusCounts = allEnrollments.reduce(
+      (acc, e) => {
+        acc[e.status] = (acc[e.status] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    const lines = [
+      `Name: ${seq.name}`,
+      `ID: ${seq.id}`,
+      `Status: ${seq.status}`,
+      `Channel: ${seq.channel}`,
+      `Exit on reply: ${seq.exitOnReply}`,
+      seq.description ? `Description: ${seq.description}` : null,
+      "",
+      `Steps (${seq.steps.length}):`,
+      ...seq.steps.map(
+        (s) =>
+          `  ${s.index + 1}. "${s.subjectTemplate}" — delay: ${
+            s.delaySeconds
+          }s${s.requireApproval ? " [approval required]" : ""}`,
+      ),
+      "",
+      `Enrollments: ${allEnrollments.length} total, ${activeCount} active`,
+      ...Object.entries(statusCounts).map(([k, v]) => `  ${k}: ${v}`),
+    ].filter((line): line is string => line != null);
+
+    return ok(lines.join("\n"));
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
@@ -1,0 +1,98 @@
+import { bulkEnroll, parseContactFile } from "../../../../sequence/importer.js";
+import { getSequence } from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const filePath = input.file_path as string;
+  const sequenceId = input.sequence_id as string;
+  const autoEnroll = input.auto_enroll as boolean | undefined;
+
+  if (!filePath) return err("file_path is required.");
+  if (!sequenceId) return err("sequence_id is required.");
+
+  try {
+    const seq = getSequence(sequenceId);
+    if (!seq) return err(`Sequence not found: ${sequenceId}`);
+
+    const parsed = parseContactFile(filePath);
+
+    if (parsed.contacts.length === 0 && parsed.errors.length > 0) {
+      return err(
+        `No valid contacts found.\n\nErrors:\n${parsed.errors
+          .map((e) => `  Row ${e.row}: ${e.reason}`)
+          .join("\n")}`,
+      );
+    }
+
+    // Preview mode (default) — show what would happen
+    if (!autoEnroll) {
+      const lines = [
+        `Parsed ${parsed.contacts.length} valid contact(s) from file.`,
+      ];
+      if (parsed.errors.length > 0) {
+        lines.push(`${parsed.errors.length} row(s) skipped:`);
+        for (const e of parsed.errors.slice(0, 10)) {
+          lines.push(`  Row ${e.row}: ${e.reason}`);
+        }
+        if (parsed.errors.length > 10)
+          lines.push(`  ... and ${parsed.errors.length - 10} more`);
+      }
+      lines.push("");
+      lines.push(`Sample contacts:`);
+      for (const c of parsed.contacts.slice(0, 5)) {
+        lines.push(`  ${c.email}${c.name ? ` (${c.name})` : ""}`);
+      }
+      if (parsed.contacts.length > 5)
+        lines.push(`  ... and ${parsed.contacts.length - 5} more`);
+      lines.push("");
+      lines.push(
+        `Call again with auto_enroll=true to enroll all ${parsed.contacts.length} contacts in "${seq.name}".`,
+      );
+      return ok(lines.join("\n"));
+    }
+
+    // Enroll mode
+    const result = bulkEnroll(sequenceId, parsed.contacts);
+
+    const lines = [
+      `Enrollment complete for "${seq.name}":`,
+      `  Enrolled: ${result.enrolled.length}`,
+      `  Skipped:  ${result.skipped.length}`,
+      `  Failed:   ${result.failed.length}`,
+    ];
+
+    if (result.skipped.length > 0) {
+      lines.push("");
+      lines.push("Skipped:");
+      for (const s of result.skipped.slice(0, 10)) {
+        lines.push(`  ${s.email} — ${s.reason}`);
+      }
+    }
+
+    if (result.failed.length > 0) {
+      lines.push("");
+      lines.push("Failed:");
+      for (const f of result.failed.slice(0, 10)) {
+        lines.push(`  ${f.email} — ${f.reason}`);
+      }
+    }
+
+    if (parsed.errors.length > 0) {
+      lines.push("");
+      lines.push(
+        `${parsed.errors.length} row(s) in file had errors (not enrolled).`,
+      );
+    }
+
+    return ok(lines.join("\n"));
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-list.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-list.ts
@@ -1,0 +1,30 @@
+import {
+  countActiveEnrollments,
+  listSequences,
+} from "../../../../sequence/store.js";
+import type { SequenceStatus } from "../../../../sequence/types.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const status = input.status as SequenceStatus | undefined;
+
+  try {
+    const seqs = listSequences(status ? { status } : undefined);
+    if (seqs.length === 0) return ok("No sequences found.");
+
+    const lines = seqs.map((s) => {
+      const enrollments = countActiveEnrollments(s.id);
+      return `- ${s.name} (ID: ${s.id}) — ${s.status}, ${s.steps.length} steps, ${enrollments} active enrollments, channel: ${s.channel}`;
+    });
+    return ok(`${seqs.length} sequence(s):\n${lines.join("\n")}`);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-pause.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-pause.ts
@@ -1,0 +1,48 @@
+import {
+  getEnrollment,
+  getSequence,
+  pauseEnrollment,
+  updateSequence,
+} from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string | undefined;
+  const enrollmentId = input.enrollment_id as string | undefined;
+
+  if (!sequenceId && !enrollmentId)
+    return err("Either sequence_id or enrollment_id is required.");
+
+  try {
+    if (enrollmentId) {
+      const enrollment = getEnrollment(enrollmentId);
+      if (!enrollment) return err(`Enrollment not found: ${enrollmentId}`);
+      if (enrollment.status !== "active")
+        return err(`Enrollment is not active (status: ${enrollment.status}).`);
+      pauseEnrollment(enrollmentId);
+      return ok(
+        `Enrollment ${enrollmentId} paused. Resume it later to continue from step ${
+          enrollment.currentStep + 1
+        }.`,
+      );
+    }
+
+    const seq = getSequence(sequenceId!);
+    if (!seq) return err(`Sequence not found: ${sequenceId}`);
+    if (seq.status === "paused") return ok("Sequence is already paused.");
+
+    updateSequence(sequenceId!, { status: "paused" });
+    return ok(
+      `Sequence "${seq.name}" paused. Active enrollments will not be processed until resumed.`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-resume.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-resume.ts
@@ -1,0 +1,27 @@
+import { getSequence, updateSequence } from "../../../../sequence/store.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const sequenceId = input.sequence_id as string;
+  if (!sequenceId) return err("sequence_id is required.");
+
+  try {
+    const seq = getSequence(sequenceId);
+    if (!seq) return err(`Sequence not found: ${sequenceId}`);
+    if (seq.status === "active") return ok("Sequence is already active.");
+
+    updateSequence(sequenceId, { status: "active" });
+    return ok(
+      `Sequence "${seq.name}" resumed. Active enrollments will be processed on the next scheduler tick.`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
@@ -1,0 +1,56 @@
+import { updateSequence } from "../../../../sequence/store.js";
+import type {
+  SequenceStatus,
+  SequenceStep,
+} from "../../../../sequence/types.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const id = input.id as string;
+  if (!id) return err("id is required.");
+
+  const name = input.name as string | undefined;
+  const description = input.description as string | undefined;
+  const status = input.status as SequenceStatus | undefined;
+  const exitOnReply = input.exit_on_reply as boolean | undefined;
+  const stepsRaw = input.steps as Array<Record<string, unknown>> | undefined;
+
+  try {
+    const steps = stepsRaw?.map(
+      (s, i): SequenceStep => ({
+        index: i,
+        delaySeconds: (s.delay_seconds as number) ?? 0,
+        subjectTemplate: (s.subject as string) ?? `Step ${i + 1}`,
+        bodyPrompt: (s.body_prompt as string) ?? "",
+        replyToThread: (s.reply_to_thread as boolean) ?? i > 0,
+        requireApproval: (s.require_approval as boolean) ?? false,
+      }),
+    );
+
+    if (steps !== undefined && steps.length === 0) {
+      return err(
+        "steps must not be empty. A sequence requires at least one step.",
+      );
+    }
+
+    const updated = updateSequence(id, {
+      name,
+      description,
+      status,
+      exitOnReply,
+      steps,
+    });
+    if (!updated) return err(`Sequence not found: ${id}`);
+
+    return ok(`Sequence updated: ${updated.name} (${updated.status})`);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/sequences/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/shared.ts
@@ -1,0 +1,9 @@
+import type { ToolExecutionResult } from "../../../../tools/types.js";
+
+export function ok(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+export function err(message: string): ToolExecutionResult {
+  return { content: message, isError: true };
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -118,18 +118,18 @@ import * as messagingReply from "./bundled-skills/messaging/tools/messaging-repl
 import * as messagingSearch from "./bundled-skills/messaging/tools/messaging-search.js";
 import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.js";
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
-import * as sequenceAnalytics from "./bundled-skills/messaging/tools/sequence-analytics.js";
-import * as sequenceCancel from "./bundled-skills/messaging/tools/sequence-cancel.js";
-import * as sequenceCreate from "./bundled-skills/messaging/tools/sequence-create.js";
-import * as sequenceDelete from "./bundled-skills/messaging/tools/sequence-delete.js";
-import * as sequenceEnroll from "./bundled-skills/messaging/tools/sequence-enroll.js";
-import * as sequenceEnrollmentList from "./bundled-skills/messaging/tools/sequence-enrollment-list.js";
-import * as sequenceGet from "./bundled-skills/messaging/tools/sequence-get.js";
-import * as sequenceImport from "./bundled-skills/messaging/tools/sequence-import.js";
-import * as sequenceList from "./bundled-skills/messaging/tools/sequence-list.js";
-import * as sequencePause from "./bundled-skills/messaging/tools/sequence-pause.js";
-import * as sequenceResume from "./bundled-skills/messaging/tools/sequence-resume.js";
-import * as sequenceUpdate from "./bundled-skills/messaging/tools/sequence-update.js";
+import * as messaging_sequenceAnalytics from "./bundled-skills/messaging/tools/sequence-analytics.js";
+import * as messaging_sequenceCancel from "./bundled-skills/messaging/tools/sequence-cancel.js";
+import * as messaging_sequenceCreate from "./bundled-skills/messaging/tools/sequence-create.js";
+import * as messaging_sequenceDelete from "./bundled-skills/messaging/tools/sequence-delete.js";
+import * as messaging_sequenceEnroll from "./bundled-skills/messaging/tools/sequence-enroll.js";
+import * as messaging_sequenceEnrollmentList from "./bundled-skills/messaging/tools/sequence-enrollment-list.js";
+import * as messaging_sequenceGet from "./bundled-skills/messaging/tools/sequence-get.js";
+import * as messaging_sequenceImport from "./bundled-skills/messaging/tools/sequence-import.js";
+import * as messaging_sequenceList from "./bundled-skills/messaging/tools/sequence-list.js";
+import * as messaging_sequencePause from "./bundled-skills/messaging/tools/sequence-pause.js";
+import * as messaging_sequenceResume from "./bundled-skills/messaging/tools/sequence-resume.js";
+import * as messaging_sequenceUpdate from "./bundled-skills/messaging/tools/sequence-update.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
 // ── orchestration ──────────────────────────────────────────────────────────────
@@ -150,6 +150,19 @@ import * as scheduleList from "./bundled-skills/schedule/tools/schedule-list.js"
 import * as scheduleUpdate from "./bundled-skills/schedule/tools/schedule-update.js";
 // ── screen-watch ───────────────────────────────────────────────────────────────
 import * as startScreenWatch from "./bundled-skills/screen-watch/tools/start-screen-watch.js";
+// ── sequences ──────────────────────────────────────────────────────────────────
+import * as sequences_sequenceAnalytics from "./bundled-skills/sequences/tools/sequence-analytics.js";
+import * as sequences_sequenceCancel from "./bundled-skills/sequences/tools/sequence-cancel.js";
+import * as sequences_sequenceCreate from "./bundled-skills/sequences/tools/sequence-create.js";
+import * as sequences_sequenceDelete from "./bundled-skills/sequences/tools/sequence-delete.js";
+import * as sequences_sequenceEnroll from "./bundled-skills/sequences/tools/sequence-enroll.js";
+import * as sequences_sequenceEnrollmentList from "./bundled-skills/sequences/tools/sequence-enrollment-list.js";
+import * as sequences_sequenceGet from "./bundled-skills/sequences/tools/sequence-get.js";
+import * as sequences_sequenceImport from "./bundled-skills/sequences/tools/sequence-import.js";
+import * as sequences_sequenceList from "./bundled-skills/sequences/tools/sequence-list.js";
+import * as sequences_sequencePause from "./bundled-skills/sequences/tools/sequence-pause.js";
+import * as sequences_sequenceResume from "./bundled-skills/sequences/tools/sequence-resume.js";
+import * as sequences_sequenceUpdate from "./bundled-skills/sequences/tools/sequence-update.js";
 // ── settings ───────────────────────────────────────────────────────────────────
 import * as navigateSettingsTab from "./bundled-skills/settings/tools/navigate-settings-tab.js";
 import * as openSystemSettings from "./bundled-skills/settings/tools/open-system-settings.js";
@@ -322,18 +335,21 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["messaging:tools/messaging-archive-by-sender.ts", messagingArchiveBySender],
   ["messaging:tools/gmail-outreach-scan.ts", gmailOutreachScan],
   ["messaging:tools/google-contacts.ts", googleContacts],
-  ["messaging:tools/sequence-create.ts", sequenceCreate],
-  ["messaging:tools/sequence-list.ts", sequenceList],
-  ["messaging:tools/sequence-get.ts", sequenceGet],
-  ["messaging:tools/sequence-update.ts", sequenceUpdate],
-  ["messaging:tools/sequence-delete.ts", sequenceDelete],
-  ["messaging:tools/sequence-enroll.ts", sequenceEnroll],
-  ["messaging:tools/sequence-enrollment-list.ts", sequenceEnrollmentList],
-  ["messaging:tools/sequence-pause.ts", sequencePause],
-  ["messaging:tools/sequence-resume.ts", sequenceResume],
-  ["messaging:tools/sequence-cancel.ts", sequenceCancel],
-  ["messaging:tools/sequence-import.ts", sequenceImport],
-  ["messaging:tools/sequence-analytics.ts", sequenceAnalytics],
+  ["messaging:tools/sequence-create.ts", messaging_sequenceCreate],
+  ["messaging:tools/sequence-list.ts", messaging_sequenceList],
+  ["messaging:tools/sequence-get.ts", messaging_sequenceGet],
+  ["messaging:tools/sequence-update.ts", messaging_sequenceUpdate],
+  ["messaging:tools/sequence-delete.ts", messaging_sequenceDelete],
+  ["messaging:tools/sequence-enroll.ts", messaging_sequenceEnroll],
+  [
+    "messaging:tools/sequence-enrollment-list.ts",
+    messaging_sequenceEnrollmentList,
+  ],
+  ["messaging:tools/sequence-pause.ts", messaging_sequencePause],
+  ["messaging:tools/sequence-resume.ts", messaging_sequenceResume],
+  ["messaging:tools/sequence-cancel.ts", messaging_sequenceCancel],
+  ["messaging:tools/sequence-import.ts", messaging_sequenceImport],
+  ["messaging:tools/sequence-analytics.ts", messaging_sequenceAnalytics],
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
@@ -360,6 +376,23 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // screen-watch
   ["screen-watch:tools/start-screen-watch.ts", startScreenWatch],
+
+  // sequences
+  ["sequences:tools/sequence-create.ts", sequences_sequenceCreate],
+  ["sequences:tools/sequence-list.ts", sequences_sequenceList],
+  ["sequences:tools/sequence-get.ts", sequences_sequenceGet],
+  ["sequences:tools/sequence-update.ts", sequences_sequenceUpdate],
+  ["sequences:tools/sequence-delete.ts", sequences_sequenceDelete],
+  ["sequences:tools/sequence-enroll.ts", sequences_sequenceEnroll],
+  [
+    "sequences:tools/sequence-enrollment-list.ts",
+    sequences_sequenceEnrollmentList,
+  ],
+  ["sequences:tools/sequence-pause.ts", sequences_sequencePause],
+  ["sequences:tools/sequence-resume.ts", sequences_sequenceResume],
+  ["sequences:tools/sequence-cancel.ts", sequences_sequenceCancel],
+  ["sequences:tools/sequence-import.ts", sequences_sequenceImport],
+  ["sequences:tools/sequence-analytics.ts", sequences_sequenceAnalytics],
 
   // settings
   ["settings:tools/voice-config-update.ts", voiceConfigUpdate],


### PR DESCRIPTION
## Summary
- Add guard test that validates `bundled-tool-registry.ts` stays in sync with TOOLS.json declarations across all bundled skills
- Test catches both missing entries (new tool added to TOOLS.json but not registry) and stale entries (registry has tool not in any TOOLS.json)
- Error messages include the exact regeneration command to fix drift
- Also regenerates the registry to sync with the `sequences` skill that was added after PR 1

Part of plan: bundled-tool-registry-sync.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
