### PR TITLE
fix: add token estimates for server_tool_use and web_search_tool_result blocks

### DIFF
--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -7,6 +7,7 @@ const TOOL_BLOCK_OVERHEAD_TOKENS = 16;
 const IMAGE_BLOCK_TOKENS = 1024;
 const IMAGE_BLOCK_OVERHEAD_TOKENS = 16;
 const FILE_BLOCK_OVERHEAD_TOKENS = 48;
+const WEB_SEARCH_RESULT_TOKENS = 800;
 const OTHER_BLOCK_TOKENS = 16;
 const SYSTEM_PROMPT_OVERHEAD_TOKENS = 8;
 const GEMINI_INLINE_FILE_MIME_TYPES = new Set(["application/pdf"]);
@@ -84,6 +85,16 @@ export function estimateContentBlockTokens(
       return TEXT_BLOCK_OVERHEAD_TOKENS + estimateTextTokens(block.thinking);
     case "redacted_thinking":
       return TEXT_BLOCK_OVERHEAD_TOKENS + estimateTextTokens(block.data);
+    case "server_tool_use":
+      return (
+        TOOL_BLOCK_OVERHEAD_TOKENS +
+        estimateTextTokens(block.name) +
+        estimateTextTokens(stableJson(block.input))
+      );
+    case "web_search_tool_result":
+      return (
+        WEB_SEARCH_RESULT_TOKENS + estimateTextTokens(stableJson(block.content))
+      );
     default:
       return OTHER_BLOCK_TOKENS;
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for native-web-search-roundtrip.md.

**Gap:** Token estimator underestimates web_search_tool_result blocks
**What was expected:** Reasonable token estimates for all content block types
**What was found:** Default case returned 16 tokens for web_search_tool_result blocks that can contain substantial encrypted content

- Added `server_tool_use` case mirroring `tool_use` (overhead + name + input)
- Added `web_search_tool_result` case with 800-token baseline + serialized content size to prevent context window undercount

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
