### PR TITLE
fix: handle server_tool_use and web_search_tool_result in text extraction for memory indexing

### DIFF
--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -45,6 +45,12 @@ export function extractTextFromStoredMessageContent(raw: string): string {
             );
           }
           break;
+        case "server_tool_use":
+          lines.push(`[web search: ${block.name}]`);
+          break;
+        case "web_search_tool_result":
+          lines.push("[web search results]");
+          break;
         default:
           lines.push("<unknown_content_block />");
       }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for native-web-search-roundtrip.md.

**Gap:** `extractTextFromStoredMessageContent` returns generic placeholder for new block types
**What was expected:** Semantically meaningful text for memory indexing
**What was found:** `server_tool_use` and `web_search_tool_result` blocks fell through to default, producing `<unknown_content_block />`

- Added `server_tool_use` case → `[web search: <name>]`
- Added `web_search_tool_result` case → `[web search results]` (content is opaque/encrypted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
