### PR TITLE
refactor: move google_contacts tool from messaging to contacts skill

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -419,6 +419,10 @@ assistant contacts invites revoke <invite_id> --json
 
 Replace `<invite_id>` with the invite's `id` from the list response. The same revoke command is used for both Telegram and voice invites.
 
+## Google Contacts
+
+Use `google_contacts` to list or search the user's Google Contacts by name or email. Returns name, email, phone, and organization. Requires the `contacts.readonly` OAuth scope — users may need to re-authorize Gmail to grant this additional permission.
+
 ## Contact Fields
 
 - **displayName** -- the contact's name (required)

--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -121,6 +121,41 @@
       },
       "executor": "tools/contact-merge.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "google_contacts",
+      "description": "List or search Google Contacts. Requires contacts.readonly scope (re-authorization may be needed).",
+      "category": "contacts",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "search"],
+            "description": "Contacts action"
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query (for search action)"
+          },
+          "page_size": {
+            "type": "number",
+            "description": "Number of contacts to return (default 50, for list)"
+          },
+          "page_token": {
+            "type": "string",
+            "description": "Pagination token (for list)"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/google-contacts.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -9,7 +9,14 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok } from "./shared.js";
+
+function ok(text: string): ToolExecutionResult {
+  return { content: text, isError: false };
+}
+
+function err(text: string): ToolExecutionResult {
+  return { content: text, isError: true };
+}
 
 function formatContact(person: Person): Record<string, unknown> {
   const name = person.names?.[0];

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -84,11 +84,6 @@ Workflow: use `gmail_list_attachments` to discover attachments, then `gmail_down
 - **Filters**: `gmail_filters` — list, create, or delete Gmail filters. Filter criteria include from, to, subject, query, has_attachment. Actions include adding/removing labels and forwarding
 - **Vacation Responder**: `gmail_vacation` — get, enable, or disable the vacation auto-responder with custom message, date range, and domain/contact restrictions
 
-### Google Contacts
-
-- **Contacts**: `google_contacts` — list or search Google Contacts by name or email. Returns name, email, phone, and organization
-  - Requires the `contacts.readonly` scope — users may need to re-authorize Gmail to grant this additional permission
-
 ## Drafting vs Sending (Gmail)
 
 Gmail uses a **draft-first workflow**. All compose and reply tools create Gmail drafts automatically:

--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -685,41 +685,6 @@
       },
       "executor": "tools/gmail-outreach-scan.ts",
       "execution_target": "host"
-    },
-    {
-      "name": "google_contacts",
-      "description": "List or search Google Contacts. Requires contacts.readonly scope (re-authorization may be needed).",
-      "category": "gmail",
-      "risk": "low",
-      "input_schema": {
-        "type": "object",
-        "properties": {
-          "action": {
-            "type": "string",
-            "enum": ["list", "search"],
-            "description": "Contacts action"
-          },
-          "query": {
-            "type": "string",
-            "description": "Search query (for search action)"
-          },
-          "page_size": {
-            "type": "number",
-            "description": "Number of contacts to return (default 50, for list)"
-          },
-          "page_token": {
-            "type": "string",
-            "description": "Pagination token (for list)"
-          },
-          "reason": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
-          }
-        },
-        "required": ["action"]
-      },
-      "executor": "tools/google-contacts.ts",
-      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -58,6 +58,7 @@ import * as computerUseWait from "./bundled-skills/computer-use/tools/computer-u
 import * as contactMerge from "./bundled-skills/contacts/tools/contact-merge.js";
 import * as contactSearch from "./bundled-skills/contacts/tools/contact-search.js";
 import * as contactUpsert from "./bundled-skills/contacts/tools/contact-upsert.js";
+import * as googleContacts from "./bundled-skills/contacts/tools/google-contacts.js";
 // ── document ───────────────────────────────────────────────────────────────────
 import * as documentCreate from "./bundled-skills/document/tools/document-create.js";
 import * as documentUpdate from "./bundled-skills/document/tools/document-update.js";
@@ -85,7 +86,6 @@ import * as gmailTrash from "./bundled-skills/gmail/tools/gmail-trash.js";
 import * as gmailTriage from "./bundled-skills/gmail/tools/gmail-triage.js";
 import * as gmailUnsubscribe from "./bundled-skills/gmail/tools/gmail-unsubscribe.js";
 import * as gmailVacation from "./bundled-skills/gmail/tools/gmail-vacation.js";
-import * as googleContacts from "./bundled-skills/gmail/tools/google-contacts.js";
 // ── google-calendar ────────────────────────────────────────────────────────────
 import * as calendarCheckAvailability from "./bundled-skills/google-calendar/tools/calendar-check-availability.js";
 import * as calendarCreateEvent from "./bundled-skills/google-calendar/tools/calendar-create-event.js";
@@ -247,6 +247,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["contacts:tools/contact-upsert.ts", contactUpsert],
   ["contacts:tools/contact-search.ts", contactSearch],
   ["contacts:tools/contact-merge.ts", contactMerge],
+  ["contacts:tools/google-contacts.ts", googleContacts],
 
   // document
   ["document:tools/document-create.ts", documentCreate],
@@ -277,7 +278,6 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["gmail:tools/gmail-vacation.ts", gmailVacation],
   ["gmail:tools/gmail-sender-digest.ts", gmailSenderDigest],
   ["gmail:tools/gmail-outreach-scan.ts", gmailOutreachScan],
-  ["gmail:tools/google-contacts.ts", googleContacts],
 
   // google-calendar
   ["google-calendar:tools/calendar-list-events.ts", calendarListEvents],


### PR DESCRIPTION
## Summary
- Move `google_contacts` tool from the `messaging` skill to the `contacts` skill where it belongs
- Reduces the messaging skill tool count by 1, putting contact management with other contact tools
- Update SKILL.md docs, TOOLS.json declarations, and bundled-tool-registry.ts

## Original prompt
Move google_contacts tool from the messaging skill to the contacts skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
