### PR TITLE
fix: update sequence tools test count after pause/resume/cancel removal

### DIFF
--- a/assistant/src/__tests__/messaging-skill-split.test.ts
+++ b/assistant/src/__tests__/messaging-skill-split.test.ts
@@ -66,9 +66,6 @@ describe("Messaging skill split", () => {
     "sequence_delete",
     "sequence_enroll",
     "sequence_enrollment_list",
-    "sequence_pause",
-    "sequence_resume",
-    "sequence_cancel",
     "sequence_import",
     "sequence_analytics",
   ];
@@ -104,11 +101,11 @@ describe("Messaging skill split", () => {
     }
   });
 
-  test("sequences/TOOLS.json contains all 12 expected sequence_* tool names", () => {
+  test("sequences/TOOLS.json contains all 9 expected sequence_* tool names", () => {
     const names: string[] = sequencesManifest.tools.map(
       (t: { name: string }) => t.name,
     );
-    expect(names).toHaveLength(12);
+    expect(names).toHaveLength(9);
     for (const name of expectedSequenceToolNames) {
       expect(names).toContain(name);
     }


### PR DESCRIPTION
## Summary
- `sequence_pause`, `sequence_resume`, and `sequence_cancel` were removed from the sequences skill (their functionality merged into `sequence_update`), but the test still expected 12 tools and listed them in `expectedSequenceToolNames`
- Updated test count from 12 → 9 and removed the three deleted tools from the expected list

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22940714329/job/66581530185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
