### PR TITLE
fix: handle server_tool_use and web_search_tool_result in conversation export formatter

### DIFF
--- a/assistant/src/export/formatter.ts
+++ b/assistant/src/export/formatter.ts
@@ -51,6 +51,12 @@ function extractText(blocks: ContentBlock[]): string {
           parts.push(`[Result: ${truncate(block.content ?? "", 500)}]`);
         }
         break;
+      case "server_tool_use":
+        parts.push(`[Web search: ${block.name ?? "web_search"}]`);
+        break;
+      case "web_search_tool_result":
+        parts.push("[Web search results]");
+        break;
     }
   }
   return parts.join("\n");


### PR DESCRIPTION
## Summary
- Adds `server_tool_use` and `web_search_tool_result` cases to the `extractText` switch in the conversation export formatter
- Web search blocks now render as `[Web search: web_search]` and `[Web search results]` markers instead of being silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
