### PR TITLE
fix: gracefully degrade web search blocks in OpenAI and Gemini providers

### DIFF
--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -306,6 +306,12 @@ export class GeminiProvider implements Provider {
           });
           break;
         }
+        case "server_tool_use":
+          parts.push({ text: `[Web search: ${block.name}]` });
+          break;
+        case "web_search_tool_result":
+          parts.push({ text: "[Web search results]" });
+          break;
         // thinking, redacted_thinking — not applicable for Gemini
       }
     }

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -306,6 +306,12 @@ export class OpenAIProvider implements Provider {
             },
           });
           break;
+        case "server_tool_use":
+          textParts.push(`[Web search: ${block.name}]`);
+          break;
+        case "web_search_tool_result":
+          textParts.push("[Web search results]");
+          break;
         // thinking, redacted_thinking, image — not applicable for OpenAI assistant messages
       }
     }
@@ -358,6 +364,15 @@ export class OpenAIProvider implements Provider {
             type: "text",
             text: this.fileBlockToText(block),
           });
+          break;
+        case "server_tool_use":
+          parts.push({
+            type: "text",
+            text: `[Web search: ${block.name}]`,
+          });
+          break;
+        case "web_search_tool_result":
+          parts.push({ type: "text", text: "[Web search results]" });
           break;
       }
     }


### PR DESCRIPTION
## Summary
- When conversation history with native web search blocks (`server_tool_use`, `web_search_tool_result`) is sent through OpenAI or Gemini providers (e.g., during failover), convert them to text summaries instead of silently dropping them
- `server_tool_use` blocks degrade to `[Web search: <name>]`
- `web_search_tool_result` blocks degrade to `[Web search results]`

## Test plan
- [x] `bunx tsc --noEmit` passes cleanly
- [x] Pre-commit hooks (formatting, linting) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
