### PR TITLE
fix: update messaging-skill-split test after sequence lifecycle tool merge

### DIFF
--- a/assistant/src/__tests__/messaging-skill-split.test.ts
+++ b/assistant/src/__tests__/messaging-skill-split.test.ts
@@ -59,9 +59,6 @@ describe("Messaging skill split", () => {
     "sequence_delete",
     "sequence_enroll",
     "sequence_enrollment_list",
-    "sequence_pause",
-    "sequence_resume",
-    "sequence_cancel",
     "sequence_import",
     "sequence_analytics",
   ];


### PR DESCRIPTION
## Summary
- Remove `sequence_pause`, `sequence_resume`, and `sequence_cancel` from `expectedSequenceToolNames` in `messaging-skill-split.test.ts` — these were merged into `sequence_update` in #15285 but the test wasn't updated
- Fixes the CI failure first seen at https://github.com/vellum-ai/vellum-assistant/actions/runs/22940979580/job/66582328529

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22940979580/job/66582328529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
