### PR TITLE
fix: wire gmail and sequences feature flags correctly

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   vellum:
     display-name: "Gmail"
     user-invocable: true
-    feature-flag: "messaging-gmail"
+    feature-flag: "gmail"
 ---
 
 This skill provides Gmail-specific tools. For cross-platform messaging (send, read, search, reply), use the **messaging** skill. Gmail tools depend on the messaging skill's provider infrastructure — load messaging first if Gmail is not yet connected.

--- a/assistant/src/config/bundled-skills/sequences/SKILL.md
+++ b/assistant/src/config/bundled-skills/sequences/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   vellum:
     display-name: "Email Sequences"
     user-invocable: true
+    feature-flag: "sequences"
 ---
 
 You are an email sequence assistant. Use the sequence tools to help users create and manage automated multi-step email drip campaigns.

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -106,6 +106,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "gmail",
+      "scope": "assistant",
+      "key": "feature_flags.gmail.enabled",
+      "label": "Gmail",
+      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "defaultEnabled": true
+    },
+    {
       "id": "sequences",
       "scope": "assistant",
       "key": "feature_flags.sequences.enabled",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -106,6 +106,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "gmail",
+      "scope": "assistant",
+      "key": "feature_flags.gmail.enabled",
+      "label": "Gmail",
+      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "defaultEnabled": true
+    },
+    {
       "id": "sequences",
       "scope": "assistant",
       "key": "feature_flags.sequences.enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -106,6 +106,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "gmail",
+      "scope": "assistant",
+      "key": "feature_flags.gmail.enabled",
+      "label": "Gmail",
+      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "defaultEnabled": true
+    },
+    {
       "id": "sequences",
       "scope": "assistant",
       "key": "feature_flags.sequences.enabled",


### PR DESCRIPTION
## Summary
- Change gmail SKILL.md `feature-flag` from `"messaging-gmail"` to `"gmail"` — the old value produced a key (`feature_flags.messaging-gmail.enabled`) that didn't match the registry key (`feature_flags.messaging.gmail.enabled`), so the skill couldn't be properly gated
- Add `gmail` flag to the feature flag registry (was missing)
- Add `feature-flag: "sequences"` to sequences SKILL.md frontmatter (was missing)

Part of plan: split-messaging-skill.md (fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
