### PR TITLE
chore: remove dead tool files after batch tool merges

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -248,6 +248,21 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["followups:tools/followup-list.ts", followupList],
   ["followups:tools/followup-resolve.ts", followupResolve],
 
+  // gmail
+  ["gmail:tools/gmail-archive.ts", gmailArchive],
+  ["gmail:tools/gmail-label.ts", gmailLabel],
+  ["gmail:tools/gmail-trash.ts", gmailTrash],
+  ["gmail:tools/gmail-unsubscribe.ts", gmailUnsubscribe],
+  ["gmail:tools/gmail-draft.ts", gmailDraft],
+  ["gmail:tools/gmail-send-draft.ts", gmailSendDraft],
+  ["gmail:tools/gmail-attachments.ts", gmailAttachments],
+  ["gmail:tools/gmail-forward.ts", gmailForward],
+  ["gmail:tools/gmail-follow-up.ts", gmailFollowUp],
+  ["gmail:tools/gmail-filters.ts", gmailFilters],
+  ["gmail:tools/gmail-vacation.ts", gmailVacation],
+  ["gmail:tools/gmail-sender-digest.ts", gmailSenderDigest],
+  ["gmail:tools/gmail-outreach-scan.ts", gmailOutreachScan],
+
   // google-calendar
   ["google-calendar:tools/calendar-list-events.ts", calendarListEvents],
   ["google-calendar:tools/calendar-get-event.ts", calendarGetEvent],
@@ -271,21 +286,6 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["media-processing:tools/analyze-keyframes.ts", analyzeKeyframes],
   ["media-processing:tools/query-media-events.ts", queryMediaEvents],
   ["media-processing:tools/generate-clip.ts", generateClip],
-
-  // gmail
-  ["gmail:tools/gmail-archive.ts", gmailArchive],
-  ["gmail:tools/gmail-label.ts", gmailLabel],
-  ["gmail:tools/gmail-trash.ts", gmailTrash],
-  ["gmail:tools/gmail-unsubscribe.ts", gmailUnsubscribe],
-  ["gmail:tools/gmail-draft.ts", gmailDraft],
-  ["gmail:tools/gmail-send-draft.ts", gmailSendDraft],
-  ["gmail:tools/gmail-attachments.ts", gmailAttachments],
-  ["gmail:tools/gmail-forward.ts", gmailForward],
-  ["gmail:tools/gmail-follow-up.ts", gmailFollowUp],
-  ["gmail:tools/gmail-filters.ts", gmailFilters],
-  ["gmail:tools/gmail-vacation.ts", gmailVacation],
-  ["gmail:tools/gmail-sender-digest.ts", gmailSenderDigest],
-  ["gmail:tools/gmail-outreach-scan.ts", gmailOutreachScan],
 
   // messaging
   ["messaging:tools/messaging-auth-test.ts", messagingAuthTest],


### PR DESCRIPTION
## Summary
- Verifies no remaining references to deleted tool names (gmail_batch_archive, gmail_batch_label, gmail_list_attachments, gmail_download_attachment, gmail_send_with_attachments, gmail_archive_by_query, messaging_reply)
- Removes any dead .ts files that survived PRs 1-5 in either gmail/ or messaging/ skill directories
- Regenerates bundled-tool-registry.ts to confirm clean state (only change is alphabetical reordering of gmail section)

Part of plan: merge-batch-tools.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
