### PR TITLE
fix: update computer-use tool count in registry test after click consolidation

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -510,7 +510,7 @@ describe("computer-use registration split", () => {
   // Start each test from a completely empty registry so assertions are
   // non-vacuous — the split functions must actually register tools.
 
-  test("registerComputerUseActionTools registers all 12 CU action tools and nothing else", async () => {
+  test("registerComputerUseActionTools registers all 10 CU action tools and nothing else", async () => {
     const { registerComputerUseActionTools } =
       await import("../tools/computer-use/registry.js");
 
@@ -520,7 +520,7 @@ describe("computer-use registration split", () => {
     registerComputerUseActionTools();
 
     const registered = getAllTools();
-    expect(registered).toHaveLength(12);
+    expect(registered).toHaveLength(10);
     expect(registered.every((t) => t.name.startsWith("computer_use_"))).toBe(
       true,
     );


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-llm-tools.md.

**Gap:** Failing registry test — computer-use tool count mismatch
**What was expected:** Test should assert 10 computer-use tools after consolidation
**What was found:** Test still asserts 12 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
