### PR TITLE
fix: remove 'triage' from gmail feature flag description after gmail_triage removal

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -110,7 +110,7 @@
       "scope": "assistant",
       "key": "feature_flags.gmail.enabled",
       "label": "Gmail",
-      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "description": "Enable Gmail management skill (archive, label, declutter)",
       "defaultEnabled": true
     },
     {

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -110,7 +110,7 @@
       "scope": "assistant",
       "key": "feature_flags.gmail.enabled",
       "label": "Gmail",
-      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "description": "Enable Gmail management skill (archive, label, declutter)",
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -110,7 +110,7 @@
       "scope": "assistant",
       "key": "feature_flags.gmail.enabled",
       "label": "Gmail",
-      "description": "Enable Gmail management skill (archive, label, triage, declutter)",
+      "description": "Enable Gmail management skill (archive, label, declutter)",
       "defaultEnabled": true
     },
     {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-llm-tools.md.

**Gap:** Feature flag description mentions triage for a removed tool
**What was expected:** Description should not reference removed capabilities
**What was found:** gmail feature flag description still says (archive, label, triage, declutter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)