### PR TITLE
fix: correct messaging SKILL.md to use query param for messaging_archive_by_sender

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -198,12 +198,9 @@ When a user asks to declutter, clean up, or organize their email:
    - **Caption**: Data scope, e.g. "Newsletters, notifications, and outreach from last 90 days. Deselect anything you want to keep."
    - **Action button (exactly 1)**: "Archive Selected" (primary). **NEVER offer Delete, Trash, or any destructive action.**
 3. **Wait for user action**: Stop and wait. Do NOT proceed until the user clicks the action button.
-4. **Act on selection**: Call `messaging_archive_by_sender` **once** with `scan_id` + all selected senders' `id` values.
+4. **Act on selection**: For each selected sender, call `messaging_archive_by_sender` with a `query` built from the sender's email address (e.g., `from:newsletter@example.com category:promotions newer_than:90d`). Use the `search_query` field from the sender digest results if available, or construct a `from:<email>` query matching the original scan's scope.
 5. **Accurate summary**: Format: "Cleaned up [total_archived] emails from [sender_count] senders."
 
-### Scan ID
+### Query-Based Archiving
 
-Scan tools (`messaging_sender_digest`) return a `scan_id` that references message IDs stored server-side. This keeps thousands of message IDs out of the conversation context.
-
-- Pass `scan_id` + `sender_ids` to `messaging_archive_by_sender` instead of `message_ids`
-- Scan results expire after **30 minutes** — if archiving fails with an expiration error, re-run the scan
+Unlike Gmail's `gmail_archive` (which supports `scan_id` + `sender_ids`), `messaging_archive_by_sender` is query-based. Build `from:<email>` queries from the sender digest results to target specific senders. Include the same date/category filters used in the original scan to keep the scope consistent.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-llm-tools.md.

**Gap:** Messaging SKILL.md instructs LLM to use nonexistent parameters on messaging_archive_by_sender
**What was expected:** SKILL.md should reference the actual query parameter
**What was found:** SKILL.md references scan_id + sender_ids which don't exist on this tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
