### PR TITLE
fix: update stale tool count assertions in computer-use session lifecycle test

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -142,7 +142,7 @@ describe("ComputerUseSession lifecycle", () => {
     expect(session.getState()).toBe("error");
   });
 
-  test("CU session passes exactly 12 computer_use_* tools to the agent loop", async () => {
+  test("CU session passes exactly 10 computer_use_* tools to the agent loop", async () => {
     let capturedTools: string[] = [];
     const provider: Provider = {
       name: "mock",
@@ -250,7 +250,7 @@ describe("ComputerUseSession lifecycle", () => {
     expect(completes[0].isResponse).toBe(true);
   });
 
-  test("default construction preactivates computer-use skill and provides 12 CU tools", async () => {
+  test("default construction preactivates computer-use skill and provides 10 CU tools", async () => {
     let capturedTools: string[] = [];
     const provider: Provider = {
       name: "mock",
@@ -291,7 +291,7 @@ describe("ComputerUseSession lifecycle", () => {
     });
 
     const cuTools = capturedTools.filter((n) => n.startsWith("computer_use_"));
-    expect(cuTools).toHaveLength(12);
+    expect(cuTools).toHaveLength(10);
   });
 
   test("constructor accepts preactivatedSkillIds parameter", () => {


### PR DESCRIPTION
## Summary
- Updates two test assertions in `computer-use-session-lifecycle.test.ts` from 12 to 10 CU tools to match the actual tool count after click variants were consolidated in #15270
- Also fixes the misleading test name ("exactly 12") to say "exactly 10"
- The registry test was already fixed in #15293; this completes the cleanup for the lifecycle test

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22941349600/job/66583446619

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
