### PR TITLE
fix: correct SKILL.md to show only gmail_archive supports scan_id

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -157,8 +157,9 @@ Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` tha
 
 ## Batch Operations
 
-- Gmail batch tools (`gmail_archive`, `gmail_label`) support `scan_id` + `sender_ids` (preferred) or raw `message_ids`.
-- First scan to get a `scan_id`, then apply batch actions using it.
+- `gmail_archive` supports `scan_id` + `sender_ids` (preferred for declutter workflows) or raw `message_ids`.
+- `gmail_label` supports `message_id` or `message_ids` only — it does not accept `scan_id`.
+- First scan to get a `scan_id`, then use `gmail_archive` to batch-archive by sender.
 - Always confirm with the user before batch operations on large numbers of messages.
 
 ## Date Verification


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for merge-batch-tools.md.

**Gap:** SKILL.md claims gmail_label supports scan_id + sender_ids
**What was expected:** Only gmail_archive supports scan_id + sender_ids
**What was found:** Documentation incorrectly listed gmail_label as supporting scan_id + sender_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
