### PR TITLE
fix: add surface action guard to message_ids batch path in gmail_archive

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -97,7 +97,12 @@ export async function run(
     }
     messageIds = resolved;
   } else if (messageIds?.length) {
-    // Use message_ids directly
+    // Batch message_ids path requires surface action confirmation
+    if (!context.triggeredBySurfaceAction) {
+      return err(
+        "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+      );
+    }
   } else if (messageId) {
     // Single message path
     try {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for merge-batch-tools.md.

**Gap:** Missing triggeredBySurfaceAction guard on message_ids batch path
**What was expected:** Batch archive via message_ids should require surface action confirmation
**What was found:** The message_ids branch fell through to batch code without the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
