### PR TITLE
fix: sidebar items stay selected when clicked again

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -291,13 +291,13 @@ extension AppDelegate {
                 }
             },
             CommandPaletteAction(id: "settings", icon: VIcon.settings.rawValue, label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
-                self?.mainWindow?.windowState.togglePanel(.settings)
+                self?.mainWindow?.windowState.showPanel(.settings)
             },
             CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Things", shortcutHint: nil) { [weak self] in
-                self?.mainWindow?.windowState.showAppsPanel()
+                self?.mainWindow?.windowState.showPanel(.apps)
             },
             CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in
-                self?.mainWindow?.windowState.togglePanel(.intelligence)
+                self?.mainWindow?.windowState.showPanel(.intelligence)
             },
             CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in
                 self?.mainWindow?.windowState.navigateBack()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -213,25 +213,11 @@ public final class MainWindowState: ObservableObject {
         }
     }
 
-    // MARK: - Panel Toggling
+    // MARK: - Panel Navigation
 
-    func togglePanel(_ panel: SidePanelType) {
-        if case .panel(let current) = selection, current == panel {
-            selection = nil
-        } else {
-            selection = .panel(panel)
-        }
-        if case .panel(let p) = selection, p == panel {
-            lastActivePanelString = String(describing: panel)
-        } else {
-            lastActivePanelString = nil
-        }
-    }
-
-    /// Navigate directly to the Apps panel (always full-width, no toggle).
-    func showAppsPanel() {
-        selection = .panel(.apps)
-        lastActivePanelString = String(describing: SidePanelType.apps)
+    func showPanel(_ panel: SidePanelType) {
+        selection = .panel(panel)
+        lastActivePanelString = String(describing: panel)
     }
 
     func refreshAPIKeyStatus(isConnected: Bool) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -184,13 +184,13 @@ extension MainWindowView {
 
             // MARK: Nav Items (fixed)
             SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence)) {
-                windowState.togglePanel(.intelligence)
+                windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps)) {
-                windowState.showAppsPanel()
+                windowState.showPanel(.apps)
             }
             SidebarNavRow(icon: VIcon.clipboardList.rawValue, label: "Tasks", isActive: windowState.selection == .panel(.taskQueue)) {
-                windowState.togglePanel(.taskQueue)
+                windowState.showPanel(.taskQueue)
             }
 
             // Divider between nav items and threads
@@ -477,13 +477,13 @@ extension MainWindowView {
             }
 
             SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
-                windowState.togglePanel(.intelligence)
+                windowState.showPanel(.intelligence)
             }
             SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
-                windowState.showAppsPanel()
+                windowState.showPanel(.apps)
             }
             SidebarNavRow(icon: VIcon.clipboardList.rawValue, label: "Tasks", isActive: windowState.selection == .panel(.taskQueue), isExpanded: false) {
-                windowState.togglePanel(.taskQueue)
+                windowState.showPanel(.taskQueue)
             }
 
             sidebarSectionDivider(isExpanded: false)

--- a/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAppsNavigationTests.swift
@@ -4,24 +4,24 @@ import XCTest
 @MainActor
 final class MainWindowAppsNavigationTests: XCTestCase {
 
-    // MARK: - showAppsPanel()
+    // MARK: - showPanel(.apps)
 
     func testShowAppsPanelSetsSelectionToApps() {
         let state = MainWindowState(hasAPIKey: false)
         state.selection = .thread(UUID())
 
-        state.showAppsPanel()
+        state.showPanel(.apps)
 
         XCTAssertEqual(state.selection, .panel(.apps))
     }
 
     func testShowAppsPanelIsIdempotent() {
         let state = MainWindowState(hasAPIKey: false)
-        state.showAppsPanel()
+        state.showPanel(.apps)
         XCTAssertEqual(state.selection, .panel(.apps))
 
         // Calling again should remain on apps, not toggle away.
-        state.showAppsPanel()
+        state.showPanel(.apps)
         XCTAssertEqual(state.selection, .panel(.apps))
     }
 
@@ -33,10 +33,10 @@ final class MainWindowAppsNavigationTests: XCTestCase {
         state.selection = .appEditing(appId: "test-app", threadId: threadId)
 
         // Now navigate to apps panel.
-        state.showAppsPanel()
+        state.showPanel(.apps)
 
         XCTAssertEqual(state.selection, .panel(.apps))
-        // isConversationVisible should be false for apps panel after showAppsPanel.
+        // isConversationVisible should be false for apps panel after showPanel(.apps).
         XCTAssertFalse(state.isConversationVisible)
     }
 
@@ -51,7 +51,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
         state.dismissOverlay()
 
         // After dismissing, navigating to apps should not show conversation.
-        state.showAppsPanel()
+        state.showPanel(.apps)
         XCTAssertFalse(state.isConversationVisible)
     }
 
@@ -63,7 +63,7 @@ final class MainWindowAppsNavigationTests: XCTestCase {
         state.closeDynamicPanel()
 
         // After closing dynamic panel, apps should not show conversation.
-        state.showAppsPanel()
+        state.showPanel(.apps)
         XCTAssertFalse(state.isConversationVisible)
     }
 }

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -26,8 +26,8 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
 
     func testRepeatedShowAppsPanelNoDuplicates() {
         let state = MainWindowState(hasAPIKey: false)
-        state.showAppsPanel()
-        state.showAppsPanel()
+        state.showPanel(.apps)
+        state.showPanel(.apps)
 
         // Second call is from == to, so only 1 entry in back stack
         XCTAssertEqual(state.navigationHistory.backStack.count, 1)


### PR DESCRIPTION
## Summary
- Replaced `togglePanel()` with `showPanel()` — clicking an already-active sidebar item (Intelligence, Things, Tasks) now stays on that panel instead of toggling back to the home screen
- Unified `togglePanel()` and `showAppsPanel()` into a single `showPanel(_ panel:)` method since they now share the same behavior
- Updated all call sites (sidebar views, command palette, keyboard shortcuts) and tests

## Original prompt
If I have "Intelligence" (or any other sidebar item) selected, clicking it again shouldn't bring me back to the home screen, it should keep me in the item I'm currently in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
