### PR TITLE
fix: only suppress ENOENT in tool registry generator

### DIFF
--- a/assistant/scripts/generate-bundled-tool-registry.ts
+++ b/assistant/scripts/generate-bundled-tool-registry.ts
@@ -68,9 +68,12 @@ async function main() {
     let raw: string;
     try {
       raw = await readFile(toolsJsonPath, "utf-8");
-    } catch {
-      // No TOOLS.json — skip this skill.
-      continue;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // No TOOLS.json — skip this skill.
+        continue;
+      }
+      throw err;
     }
 
     const toolsJson: ToolsJson = JSON.parse(raw);


### PR DESCRIPTION
The generate-bundled-tool-registry.ts script was silently swallowing all I/O errors when reading TOOLS.json manifests. Now only ENOENT (missing file) is suppressed; other errors (permissions, transient FS failures) are re-thrown to surface build failures immediately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
