### PR TITLE
fix: skip proxy sender updates when preserving proxies during active turn

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -379,14 +379,17 @@ export class Session {
   updateClient(
     sendToClient: (msg: ServerMessage) => void,
     hasNoClient = false,
+    opts?: { skipProxySenderUpdate?: boolean },
   ): void {
     this.sendToClient = sendToClient;
     this.hasNoClient = hasNoClient;
     this.prompter.updateSender(sendToClient);
     this.secretPrompter.updateSender(sendToClient);
     this.traceEmitter.updateSender(sendToClient);
-    this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
-    this.hostFileProxy?.updateSender(sendToClient, !hasNoClient);
+    if (!opts?.skipProxySenderUpdate) {
+      this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
+      this.hostFileProxy?.updateSender(sendToClient, !hasNoClient);
+    }
   }
 
   /** Returns the current sendToClient reference for identity comparison. */

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -646,7 +646,15 @@ export async function handleSendMessage(
   }
   // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   // Called after setHostBashProxy so updateSender targets the current proxy.
-  session.updateClient(onEvent, !isInteractiveInterface);
+  // When proxies are preserved during an active turn (non-desktop request while
+  // processing), skip updating proxy senders to avoid degrading them.
+  const preservingProxies =
+    session.isProcessing() &&
+    sourceInterface !== "macos" &&
+    sourceInterface !== "ios";
+  session.updateClient(onEvent, !isInteractiveInterface, {
+    skipProxySenderUpdate: preservingProxies,
+  });
 
   const attachments = hasAttachments
     ? smDeps.resolveAttachments(attachmentIds)


### PR DESCRIPTION
When a non-desktop interface sends a message to a session with active desktop proxies, the updateClient call was degrading the preserved proxies by replacing their senders. This caused host bash/file requests to fall back to local execution for the rest of the turn. Fix: add skipProxySenderUpdate option to updateClient and use it when proxies are being preserved during an active processing turn.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
