### PR TITLE
fix: preserve managed avatar errors when local fallback unavailable

### DIFF
--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -71,6 +71,15 @@ export async function routedGenerateAvatar(
         model,
       };
     } catch (err) {
+      const config = getConfig();
+      const geminiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+      if (!geminiKey) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Managed avatar generation failed and no local Gemini key configured; re-throwing",
+        );
+        throw err;
+      }
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
         "Managed avatar generation failed, falling back to local Gemini",

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -3,7 +3,6 @@ import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { routedGenerateAvatar } from "../../media/avatar-router.js";
-import { ManagedAvatarError } from "../../media/avatar-types.js";
 import { mapGeminiError } from "../../media/gemini-image-service.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -108,40 +107,6 @@ export const setAvatarTool: Tool = {
         isError: false,
       };
     } catch (error) {
-      if (error instanceof ManagedAvatarError) {
-        if (error.statusCode === 429) {
-          log.warn(
-            { correlationId: error.correlationId },
-            "Avatar generation rate limited",
-          );
-          return {
-            content:
-              "Avatar generation is rate limited. Please wait and try again.",
-            isError: true,
-          };
-        }
-        if (error.statusCode === 503) {
-          log.warn(
-            { correlationId: error.correlationId },
-            "Avatar generation service unavailable",
-          );
-          return {
-            content: "Avatar generation service is temporarily unavailable.",
-            isError: true,
-          };
-        }
-        const detail =
-          error.message || "Avatar generation failed. Please try again.";
-        log.error(
-          { error: detail, correlationId: error.correlationId },
-          "Managed avatar generation failed",
-        );
-        return {
-          content: `Avatar generation failed: ${detail}`,
-          isError: true,
-        };
-      }
-
       const message = mapGeminiError(error);
       log.error({ error: message }, "Avatar generation failed");
       return {


### PR DESCRIPTION
When generateManagedAvatar fails in managed-only deployments (no Gemini key), re-throw the managed error instead of falling through to local generation which would produce a confusing ConfigError. Also removes dead ManagedAvatarError handling in avatar-generator.ts that became unreachable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
