### PR TITLE
fix: include web search query in memory extraction text

### DIFF
--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -45,9 +45,14 @@ export function extractTextFromStoredMessageContent(raw: string): string {
             );
           }
           break;
-        case "server_tool_use":
-          lines.push(`[web search: ${block.name}]`);
+        case "server_tool_use": {
+          const query =
+            typeof block.input?.query === "string"
+              ? block.input.query
+              : block.name;
+          lines.push(`[web search: ${query}]`);
           break;
+        }
         case "web_search_tool_result":
           lines.push("[web search results]");
           break;


### PR DESCRIPTION
server_tool_use blocks carry the actual search query in input.query, but the text extraction was only recording the generic tool name. This produced low-signal boilerplate that passed semantic density checks and polluted memory. Now extracts the actual query for meaningful memory indexing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
