### PR TITLE
fix: enforce required args for sequence_update variants

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "sequence_update",
-      "description": "Update a sequence or manage an enrollment's lifecycle. For sequences: change name, description, status (active/paused/archived), steps, or exit-on-reply. For enrollments: pause, resume, or cancel via enrollment_id + enrollment_action.",
+      "description": "Update a sequence or manage an enrollment's lifecycle. Two modes: (1) Sequence-level — pass `id` to change name, description, status (active/paused/archived), steps, or exit-on-reply. (2) Enrollment-level — pass `enrollment_id` + `enrollment_action` to pause, resume, or cancel an enrollment. Exactly one mode must be used per call.",
       "category": "sequences",
       "risk": "medium",
       "input_schema": {
@@ -181,7 +181,11 @@
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
-        }
+        },
+        "anyOf": [
+          { "required": ["id"] },
+          { "required": ["enrollment_id", "enrollment_action"] }
+        ]
       },
       "executor": "tools/sequence-update.ts",
       "execution_target": "host"


### PR DESCRIPTION
The merged sequence_update schema no longer required identifier fields, allowing the model to emit calls that fail at runtime. Adds anyOf constraint to require either id (sequence-level) or enrollment_id + enrollment_action (enrollment-level). Also clarifies the two-mode usage in the tool description.

Addresses feedback on #15264.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
