### PR TITLE
fix: pass thread_id in non-attachment Gmail draft path

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -192,6 +192,9 @@ export async function run(
           subject ?? "",
           text,
           inReplyTo,
+          undefined,
+          undefined,
+          threadId,
         );
         return ok(
           `Gmail draft created (ID: ${draft.id}). Review it in your Gmail Drafts, then tell me to send it or send it yourself from Gmail.`,


### PR DESCRIPTION
When gmail_send_with_attachment was merged into gmail_send, the non-attachment code path was not passing thread_id to the Gmail API, causing replies without attachments to lose their thread context. Now both paths consistently pass thread_id.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
