### PR TITLE
fix: add missing await on withValidToken in gmail-attachments

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -58,7 +58,7 @@ export async function run(
   if (action === "list") {
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         const message = await getMessage(token, messageId, "full");
         const attachments = collectAttachments(message.payload?.parts);
 
@@ -82,7 +82,7 @@ export async function run(
 
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         const attachment = await getAttachment(token, messageId, attachmentId);
 
         // Gmail returns base64url; convert to standard base64 then to Buffer


### PR DESCRIPTION
## Summary
- Added missing `await` on two `withValidToken` calls in `gmail-attachments.ts` (lines 61 and 85)
- Without `await`, the try/catch blocks could not catch token refresh errors, causing unhandled promise rejections

Addresses review feedback from #15271.

The other two review items (duplicate tool files between gmail/messaging, duplicate gmail section in registry) were already resolved in the merged PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
