### PR TITLE
fix: enforce per-op required args and correct action text in memory_manage

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -26,55 +26,69 @@ export const memoryRecallDefinition: ToolDefinition = {
   },
 };
 
+const memoryManageProperties = {
+  op: {
+    type: "string" as const,
+    enum: ["save", "update", "delete"],
+    description: "The operation to perform",
+  },
+  memory_id: {
+    type: "string" as const,
+    description: "ID of existing memory item (required for update/delete)",
+  },
+  statement: {
+    type: "string" as const,
+    description:
+      "The fact or preference to remember (required for save/update, 1-2 sentences)",
+  },
+  kind: {
+    type: "string" as const,
+    enum: [
+      "preference",
+      "fact",
+      "decision",
+      "profile",
+      "relationship",
+      "event",
+      "opinion",
+      "instruction",
+      "style",
+      "playbook",
+      "learning",
+    ],
+    description: "Category of the memory item (required for save)",
+  },
+  subject: {
+    type: "string" as const,
+    description: "Short subject/topic label, 2-8 words (optional, save only)",
+  },
+  reason: {
+    type: "string" as const,
+    description:
+      "Brief non-technical explanation shown to the user as a status update",
+  },
+};
+
 export const memoryManageDefinition: ToolDefinition = {
   name: "memory_manage",
   description:
     "Save, update, or delete memory items. Use 'save' for new information worth remembering, 'update' to correct existing items, 'delete' to remove outdated items.",
   input_schema: {
     type: "object",
-    properties: {
-      op: {
-        type: "string",
-        enum: ["save", "update", "delete"],
-        description: "The operation to perform",
+    properties: memoryManageProperties,
+    anyOf: [
+      {
+        properties: { op: { const: "save" } },
+        required: ["op", "statement", "kind"],
       },
-      memory_id: {
-        type: "string",
-        description: "ID of existing memory item (required for update/delete)",
+      {
+        properties: { op: { const: "update" } },
+        required: ["op", "memory_id", "statement"],
       },
-      statement: {
-        type: "string",
-        description:
-          "The fact or preference to remember (required for save/update, 1-2 sentences)",
+      {
+        properties: { op: { const: "delete" } },
+        required: ["op", "memory_id"],
       },
-      kind: {
-        type: "string",
-        enum: [
-          "preference",
-          "fact",
-          "decision",
-          "profile",
-          "relationship",
-          "event",
-          "opinion",
-          "instruction",
-          "style",
-          "playbook",
-          "learning",
-        ],
-        description: "Category of the memory item (required for save)",
-      },
-      subject: {
-        type: "string",
-        description:
-          "Short subject/topic label, 2-8 words (optional, save only)",
-      },
-      reason: {
-        type: "string",
-        description:
-          "Brief non-technical explanation shown to the user as a status update",
-      },
-    },
-    required: ["op"],
+    ],
   },
 };

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -905,7 +905,12 @@ public struct ToolCallData: Identifiable, Equatable {
         case "web_search":
             return inputSummary.isEmpty ? "Searched the web" : "Searched for \"\(truncated(inputSummary, to: 50))\""
         case "memory_manage":
-            return "Saved a memory"
+            let op = inputRawDict?["op"]?.value as? String ?? "save"
+            switch op {
+            case "update": return "Updated a memory"
+            case "delete": return "Deleted a memory"
+            default: return "Saved a memory"
+            }
         case "memory_recall":
             return inputSummary.isEmpty ? "Recalled memories" : "Recalled info about \"\(truncated(inputSummary, to: 40))\""
         case "task_run":


### PR DESCRIPTION
memory_manage schema only required op, allowing runtime failures for save/update/delete. Added conditional required constraints per operation via anyOf. Also fixed action text in Swift client to show 'Updated a memory' or 'Deleted a memory' instead of always 'Saved a memory'.

Addresses review feedback on #15286.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
