### PR TITLE
fix: guard sequence pause/resume against archived sequences

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
@@ -41,6 +41,13 @@ export async function run(
             return err(
               `Enrollment is not active (status: ${enrollment.status}).`,
             );
+          const parentSeq = enrollment.sequenceId
+            ? getSequence(enrollment.sequenceId)
+            : null;
+          if (parentSeq && parentSeq.status === "archived")
+            return err(
+              `Cannot pause enrollment — parent sequence "${parentSeq.name}" is archived.`,
+            );
           pauseEnrollment(enrollmentId);
           return ok(
             `Enrollment ${enrollmentId} paused. Resume it later to continue from step ${


### PR DESCRIPTION
Added validation to reject pause enrollment action when the parent sequence is archived. The resume case already had this guard (blocks on non-active parent). The risk level concern is moot — pause/resume are now enrollment_action modes within sequence_update, which is already risk: medium.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
