### PR TITLE
fix: include messageId in message_complete to fix diagnostics export

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -180,6 +180,8 @@ export interface MessageComplete {
   type: "message_complete";
   sessionId?: string;
   attachments?: UserMessageAttachment[];
+  /** Database ID of the persisted assistant message, if any. */
+  messageId?: string;
 }
 
 export interface ErrorMessage {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1401,6 +1401,9 @@ export async function runAgentLoopImpl(
           ...(emittedAttachments.length > 0
             ? { attachments: emittedAttachments }
             : {}),
+          ...(state.lastAssistantMessageId
+            ? { messageId: state.lastAssistantMessageId }
+            : {}),
         });
       }
     }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -591,6 +591,13 @@ extension ChatViewModel {
             guard belongsToSession(complete.sessionId) else { return }
             // Flush any buffered streaming text before finalizing the message.
             flushStreamingBuffer()
+            // Backfill the daemon's persisted message ID so diagnostics exports
+            // can anchor to it without requiring a history reload.
+            if let messageId = complete.messageId,
+               let msgId = currentAssistantMessageId,
+               let idx = messages.firstIndex(where: { $0.id == msgId }) {
+                messages[idx].daemonMessageId = messageId
+            }
             // Strip heavy binary data from old messages to cap memory growth.
             trimOldMessagesIfNeeded()
             let wasRefinement = isWorkspaceRefinementInFlight || cancelledDuringRefinement

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2646,11 +2646,13 @@ public struct MessageComplete: Codable, Sendable {
     public let type: String
     public let sessionId: String?
     public let attachments: [UserMessageAttachment]?
+    public let messageId: String?
 
-    public init(type: String, sessionId: String? = nil, attachments: [UserMessageAttachment]? = nil) {
+    public init(type: String, sessionId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.attachments = attachments
+        self.messageId = messageId
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -792,8 +792,8 @@ extension AssistantThinkingDelta {
 public typealias MessageCompleteMessage = MessageComplete
 
 extension MessageComplete {
-    public init(sessionId: String? = nil, attachments: [UserMessageAttachment]? = nil) {
-        self.init(type: "message_complete", sessionId: sessionId, attachments: attachments)
+    public init(sessionId: String? = nil, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
+        self.init(type: "message_complete", sessionId: sessionId, attachments: attachments, messageId: messageId)
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `messageId` field to the `message_complete` event so the client can populate `daemonMessageId` on freshly streamed messages
- On the client, backfill `daemonMessageId` from `message_complete` so the export report button has an anchor even without a history reload
- Fixes "Failed to export report: Anchor message not found" when clicking the bug icon on a message that was streamed in the current session

## Original prompt
I get this error when trying to export debug logs by clicking the button under the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
