### PR TITLE
fix: replace DispatchGroup.wait() with async notify in host bash

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -142,7 +142,11 @@ extension HTTPTransport {
             }
 
             process.waitUntilExit()
-            pipeGroup.wait()
+            await withCheckedContinuation { continuation in
+                pipeGroup.notify(queue: .global()) {
+                    continuation.resume()
+                }
+            }
             timerSource.cancel()
 
             let stdout = String(data: stdoutBox.value, encoding: .utf8) ?? ""


### PR DESCRIPTION
## Summary
- Replace `DispatchGroup.wait()` with `withCheckedContinuation` + `DispatchGroup.notify()` in `HTTPDaemonClient+HostBash.swift` to fix Swift 6 warning about `wait()` being unavailable from async contexts

## Original prompt
Fix these warnings: `instance method 'wait' is unavailable from asynchronous contexts; Use a TaskGroup instead; this is an error in the Swift 6 language mode` in `HTTPDaemonClient+HostBash.swift:145`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
