### PR TITLE
fix: handle ManagedAvatarError status codes in avatar generator

### DIFF
--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -3,6 +3,7 @@ import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { routedGenerateAvatar } from "../../media/avatar-router.js";
+import { ManagedAvatarError } from "../../media/avatar-types.js";
 import { mapGeminiError } from "../../media/gemini-image-service.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -107,6 +108,34 @@ export const setAvatarTool: Tool = {
         isError: false,
       };
     } catch (error) {
+      if (error instanceof ManagedAvatarError) {
+        log.error(
+          {
+            error: error.message,
+            statusCode: error.statusCode,
+            code: error.code,
+          },
+          "Avatar generation failed (managed)",
+        );
+        if (error.statusCode === 429) {
+          return {
+            content:
+              "Avatar generation is currently rate limited. Please try again in a moment.",
+            isError: true,
+          };
+        }
+        if (error.statusCode >= 500) {
+          return {
+            content:
+              "Avatar generation is temporarily unavailable. Please try again later.",
+            isError: true,
+          };
+        }
+        return {
+          content: `Avatar generation failed: ${error.message}`,
+          isError: true,
+        };
+      }
       const message = mapGeminiError(error);
       log.error({ error: message }, "Avatar generation failed");
       return {


### PR DESCRIPTION
## Summary
- Add `ManagedAvatarError`-specific handling in the avatar generator catch block
- Map 429 to a "rate limited" message and 5xx to "temporarily unavailable" instead of falling through to the generic `mapGeminiError` which only recognizes Gemini `ApiError` instances

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22942916976/job/66588275893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
