### PR TITLE
fix: make generic 4xx provider errors retryable

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -201,7 +201,7 @@ describe("classifySessionError", () => {
       );
       const result = classifySessionError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
-      expect(result.retryable).toBe(false);
+      expect(result.retryable).toBe(true);
     });
   });
 
@@ -314,18 +314,18 @@ describe("classifySessionError", () => {
       expect(result.retryable).toBe(true);
     });
 
-    it("classifies ProviderError with 401 as PROVIDER_API (not retryable)", () => {
+    it("classifies ProviderError with 401 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Unauthorized", "anthropic", 401);
       const result = classifySessionError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
-      expect(result.retryable).toBe(false);
+      expect(result.retryable).toBe(true);
     });
 
-    it("classifies ProviderError with 400 as PROVIDER_API (not retryable)", () => {
+    it("classifies ProviderError with 400 as PROVIDER_API (retryable)", () => {
       const err = new ProviderError("Bad request", "anthropic", 400);
       const result = classifySessionError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_API");
-      expect(result.retryable).toBe(false);
+      expect(result.retryable).toBe(true);
     });
 
     it("ProviderError without statusCode falls back to regex", () => {

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -203,7 +203,7 @@ function classifyCore(
       return {
         code: "PROVIDER_API",
         userMessage: "The AI provider rejected the request.",
-        retryable: false,
+        retryable: true,
       };
     }
   }


### PR DESCRIPTION
## Summary

- The catch-all 4xx error handler in `session-error.ts` was marking generic provider rejections as `retryable: false`, which prevented the Retry button from appearing in the macOS client
- The UI's recovery suggestion already says "click Retry" for `.providerApi` errors, but the button was hidden due to the backend classification
- Changed the fallback to `retryable: true` — the truly non-retryable 4xx cases (context too large, billing, invalid API key) are already handled by specific checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
