### PR TITLE
fix: remove top-level anyOf from memory_manage tool schema

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -76,19 +76,6 @@ export const memoryManageDefinition: ToolDefinition = {
   input_schema: {
     type: "object",
     properties: memoryManageProperties,
-    anyOf: [
-      {
-        properties: { op: { const: "save" } },
-        required: ["op", "statement", "kind"],
-      },
-      {
-        properties: { op: { const: "update" } },
-        required: ["op", "memory_id", "statement"],
-      },
-      {
-        properties: { op: { const: "delete" } },
-        required: ["op", "memory_id"],
-      },
-    ],
+    required: ["op"],
   },
 };


### PR DESCRIPTION
## Summary
- Remove `anyOf` from the top level of the `memory_manage` tool's `input_schema` — Anthropic's API rejects `oneOf`/`allOf`/`anyOf` at the schema root, causing "The AI provider rejected the request" errors in the desktop app
- Replace with `required: ["op"]`; per-operation required args are already validated at runtime in the handler

## Original prompt
Remove the top-level `anyOf` from the `memory_manage` tool schema in `assistant/src/tools/memory/definitions.ts` and replace it with a simple `required: ["op"]`. The `anyOf` was added in commit 11b28029e but Anthropic's API rejects `anyOf`/`allOf`/`oneOf` at the top level of tool input schemas, causing "The AI provider rejected the request" errors. The handler already validates per-operation required args at runtime, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
