### PR TITLE
fix: use oneOf for mutually exclusive sequence_update modes

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -182,7 +182,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "anyOf": [
+        "oneOf": [
           { "required": ["id"] },
           { "required": ["enrollment_id", "enrollment_action"] }
         ]


### PR DESCRIPTION
Change anyOf to oneOf in the sequence_update tool schema to enforce that only one mode (sequence-level or enrollment-level) can be specified per request. With anyOf, a request including both `id` and `enrollment_id`/`enrollment_action` was schema-valid even though the description says exactly one mode is allowed. oneOf rejects such mixed-input requests at validation time.

Addresses review feedback on #15306.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
