### PR TITLE
fix: allow pausing enrollments on archived sequences to prevent scheduler churn

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
@@ -41,13 +41,6 @@ export async function run(
             return err(
               `Enrollment is not active (status: ${enrollment.status}).`,
             );
-          const parentSeq = enrollment.sequenceId
-            ? getSequence(enrollment.sequenceId)
-            : null;
-          if (parentSeq && parentSeq.status === "archived")
-            return err(
-              `Cannot pause enrollment — parent sequence "${parentSeq.name}" is archived.`,
-            );
           pauseEnrollment(enrollmentId);
           return ok(
             `Enrollment ${enrollmentId} paused. Resume it later to continue from step ${


### PR DESCRIPTION
Relax the archived sequence guard to allow pause operations on enrollments, preventing infinite scheduling cycles while still blocking resume on archived sequences.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
