### PR TITLE
fix: add missing await on withValidToken in all gmail/google-contacts tools

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -45,7 +45,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       switch (action) {
         case "list": {
           const pageSize = (input.page_size as number) ?? 50;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -36,7 +36,7 @@ export async function run(
 
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         const allMessageIds: string[] = [];
         let pageToken: string | undefined;
         let truncated = false;
@@ -107,7 +107,7 @@ export async function run(
     // Single message path
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         await modifyMessage(token, messageId, { removeLabelIds: ["INBOX"] });
         return ok("Message archived.");
       });
@@ -127,7 +127,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       if (messageIds.length === 1) {
         await modifyMessage(token, messageIds[0], {
           removeLabelIds: ["INBOX"],

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -24,7 +24,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       const draft = await createDraft(
         token,
         to,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -27,7 +27,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       switch (action) {
         case "list": {
           const filters = await listFilters(token);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -36,7 +36,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       switch (action) {
         case "track": {
           const messageId = input.message_id as string;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -77,7 +77,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       const message = await getMessage(token, messageId, "full");
       const headers = message.payload?.headers ?? [];
       const originalFrom = extractHeader(headers, "From");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -22,7 +22,7 @@ export async function run(
   if (messageIds && messageIds.length > 0) {
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         await batchModifyMessages(token, messageIds, {
           addLabelIds,
           removeLabelIds,
@@ -37,7 +37,7 @@ export async function run(
   if (messageId) {
     try {
       const provider = getMessagingProvider("gmail");
-      return withValidToken(provider.credentialService, async (token) => {
+      return await withValidToken(provider.credentialService, async (token) => {
         await modifyMessage(token, messageId, { addLabelIds, removeLabelIds });
         return ok("Labels updated.");
       });

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -57,7 +57,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       // Pipeline: fire metadata fetches for each page of IDs as they arrive
       const allMessageIds: string[] = [];
       const fetchPromises: Promise<GmailMessage[]>[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -16,7 +16,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       const msg = await sendDraft(token, draftId);
       return ok(`Draft sent (Message ID: ${msg.id}).`);
     });

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -59,7 +59,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       // Pipeline: fire metadata fetches for each page of IDs as they arrive,
       // overlapping fetch latency with pagination latency
       const allMessageIds: string[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -19,7 +19,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       await trashMessage(token, messageId);
       return ok("Message moved to trash.");
     });

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -33,7 +33,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       const message = await getMessage(token, messageId, "metadata", [
         "List-Unsubscribe",
         "List-Unsubscribe-Post",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -23,7 +23,7 @@ export async function run(
 
   try {
     const provider = getMessagingProvider("gmail");
-    return withValidToken(provider.credentialService, async (token) => {
+    return await withValidToken(provider.credentialService, async (token) => {
       switch (action) {
         case "get": {
           const settings = await getVacation(token);


### PR DESCRIPTION
Add missing await on withValidToken calls inside try/catch blocks across all gmail and google-contacts tool files so that rejections are properly caught.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
