### PR TITLE
fix: convert waitUntilExit to async terminationHandler in host bash

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -105,22 +105,6 @@ extension HTTPTransport {
             }
             timerSource.resume()
 
-            do {
-                try process.run()
-            } catch {
-                timerSource.cancel()
-                log.error("Failed to launch host bash process: \(error.localizedDescription)")
-                let result = HostBashResultPayload(
-                    requestId: request.requestId,
-                    stdout: "",
-                    stderr: "Failed to launch process: \(error.localizedDescription)",
-                    exitCode: nil,
-                    timedOut: false
-                )
-                await self.postHostBashResult(result)
-                return
-            }
-
             // Read stdout and stderr concurrently to avoid deadlock.
             // If we read sequentially and the process fills one pipe's buffer
             // (~64 KB), the process blocks on that write, the other pipe never
@@ -141,11 +125,38 @@ extension HTTPTransport {
                 pipeGroup.leave()
             }
 
-            process.waitUntilExit()
-            await withCheckedContinuation { continuation in
-                pipeGroup.notify(queue: .global()) {
-                    continuation.resume()
+            // Use terminationHandler + continuation instead of waitUntilExit()
+            // so the cooperative thread pool thread is suspended (not blocked)
+            // for the duration of the bash command. terminationHandler is set
+            // before process.run() to avoid a race where the process exits
+            // before the handler is installed.
+            do {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                    process.terminationHandler = { _ in
+                        pipeGroup.notify(queue: .global()) {
+                            continuation.resume()
+                        }
+                    }
+                    do {
+                        try process.run()
+                    } catch {
+                        // Clear the handler since we never started
+                        process.terminationHandler = nil
+                        continuation.resume(throwing: error)
+                    }
                 }
+            } catch {
+                timerSource.cancel()
+                log.error("Failed to launch host bash process: \(error.localizedDescription)")
+                let result = HostBashResultPayload(
+                    requestId: request.requestId,
+                    stdout: "",
+                    stderr: "Failed to launch process: \(error.localizedDescription)",
+                    exitCode: nil,
+                    timedOut: false
+                )
+                await self.postHostBashResult(result)
+                return
             }
             timerSource.cancel()
 


### PR DESCRIPTION
Replace the synchronous `process.waitUntilExit()` with an async `terminationHandler` + continuation pattern in `HTTPDaemonClient+HostBash.swift`, following the same approach used in `AssistantCli.swift`.

This avoids blocking one of Swift's cooperative thread pool threads for the entire duration of a bash command (up to 120s default timeout).

Key changes:
- Set `terminationHandler` before `process.run()` to avoid race conditions
- Use `withCheckedThrowingContinuation` to suspend instead of block
- `terminationHandler` waits for pipe group completion before resuming, ensuring stdout/stderr are fully read
- On launch failure, handler is cleared and continuation resumes with the error

Addresses review feedback on #15312.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
