### PR TITLE
fix: remove stale gitlink, update ARCHITECTURE.md, and exclude 401 from retryable 4xx

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -812,7 +812,7 @@ The daemon classifies errors via `classifySessionError()` in `session-error.ts`.
 
 Classification uses a two-tier strategy:
 
-1. **Structured provider errors**: If the error is a `ProviderError` with a `statusCode`, the status code determines the category deterministically — `429` maps to `PROVIDER_RATE_LIMIT` (retryable), `5xx` to `PROVIDER_API` (retryable), other `4xx` to `PROVIDER_API` (not retryable).
+1. **Structured provider errors**: If the error is a `ProviderError` with a `statusCode`, the status code determines the category deterministically — `401` maps to `PROVIDER_BILLING` (not retryable, invalid/expired key), `429` maps to `PROVIDER_RATE_LIMIT` (retryable), `5xx` to `PROVIDER_API` (retryable), other `4xx` to `PROVIDER_API` (retryable) unless a message pattern matches a more specific non-retryable category (context-too-large, billing).
 2. **Regex fallback**: For non-provider errors or `ProviderError` without a status code, regex pattern matching against the error message detects network failures, rate limits, and API errors. Phase-specific overrides handle regeneration contexts.
 
 Debug details are capped at 4,000 characters to prevent oversized payloads.

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -159,6 +159,13 @@ function classifyCore(
         retryable: false,
       };
     }
+    if (error.statusCode === 401) {
+      return {
+        code: "PROVIDER_BILLING",
+        userMessage: "Your API key is invalid or expired.",
+        retryable: false,
+      };
+    }
     if (error.statusCode === 429) {
       return {
         code: "PROVIDER_RATE_LIMIT",


### PR DESCRIPTION
Remove accidentally committed .worktrees gitlink, update ARCHITECTURE.md to reflect that generic 4xx errors are now retryable, and add a specific non-retryable case for 401 Unauthorized to prevent futile retry loops.

Addresses feedback on #15314.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
