### PR TITLE
test: add cross-provider web search block degradation tests

### DIFF
--- a/assistant/src/__tests__/cross-provider-web-search.test.ts
+++ b/assistant/src/__tests__/cross-provider-web-search.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+/** A conversation with web search blocks in history (as Anthropic would produce). */
+function webSearchConversation(): Message[] {
+  return [
+    userMsg("Search for something"),
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "server_tool_use",
+          id: "stu_abc123",
+          name: "web_search",
+          input: { query: "test query" },
+        } satisfies ContentBlock,
+        {
+          type: "text",
+          text: "Here are the results.",
+        } satisfies ContentBlock,
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "stu_abc123",
+          content: [
+            {
+              type: "web_search_result",
+              url: "https://example.com",
+              title: "Example",
+              encrypted_content: "enc_abc",
+            },
+          ],
+        } satisfies ContentBlock,
+      ],
+    },
+    userMsg("Thanks, now do something else"),
+  ];
+}
+
+/** A message containing only a web_search_tool_result block (edge case). */
+function webSearchResultOnlyMessage(): Message[] {
+  return [
+    userMsg("Search for something"),
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "server_tool_use",
+          id: "stu_only",
+          name: "web_search",
+          input: { query: "lonely query" },
+        } satisfies ContentBlock,
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "stu_only",
+          content: [
+            {
+              type: "web_search_result",
+              url: "https://example.com",
+              title: "Example",
+              encrypted_content: "enc_xyz",
+            },
+          ],
+        } satisfies ContentBlock,
+      ],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Mock OpenAI SDK
+// ---------------------------------------------------------------------------
+
+let lastOpenAIParams: Record<string, unknown> | null = null;
+
+mock.module("openai", () => {
+  class FakeAPIError extends Error {
+    status: number;
+    headers: Record<string, string>;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.headers = {};
+      this.name = "APIError";
+    }
+  }
+
+  return {
+    default: class MockOpenAI {
+      static APIError = FakeAPIError;
+      constructor(_args: Record<string, unknown>) {}
+      chat = {
+        completions: {
+          create: (params: Record<string, unknown>) => {
+            lastOpenAIParams = JSON.parse(JSON.stringify(params));
+            return (async function* () {
+              yield {
+                choices: [
+                  {
+                    delta: { content: "OK" },
+                    finish_reason: "stop",
+                  },
+                ],
+                usage: { prompt_tokens: 10, completion_tokens: 5 },
+                model: "gpt-4o",
+              };
+            })();
+          },
+        },
+      };
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock Gemini SDK
+// ---------------------------------------------------------------------------
+
+let lastGeminiParams: Record<string, unknown> | null = null;
+
+mock.module("@google/genai", () => {
+  class FakeApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = "ApiError";
+    }
+  }
+
+  return {
+    ApiError: FakeApiError,
+    GoogleGenAI: class MockGoogleGenAI {
+      constructor(_args: Record<string, unknown>) {}
+      models = {
+        generateContentStream: (params: Record<string, unknown>) => {
+          lastGeminiParams = JSON.parse(JSON.stringify(params));
+          return (async function* () {
+            yield {
+              text: "OK",
+              candidates: [{ finishReason: "STOP" }],
+              usageMetadata: {
+                promptTokenCount: 10,
+                candidatesTokenCount: 5,
+              },
+              modelVersion: "gemini-2.0-flash",
+            };
+          })();
+        },
+      };
+    },
+  };
+});
+
+// Import providers after mocking
+import { GeminiProvider } from "../providers/gemini/client.js";
+import { OpenAIProvider } from "../providers/openai/client.js";
+
+// ---------------------------------------------------------------------------
+// OpenAI provider tests
+// ---------------------------------------------------------------------------
+
+describe("Cross-Provider Web Search — OpenAI", () => {
+  beforeEach(() => {
+    lastOpenAIParams = null;
+  });
+
+  test("degrades server_tool_use in assistant message to text placeholder", async () => {
+    const provider = new OpenAIProvider("sk-test", "gpt-4o");
+    await provider.sendMessage(webSearchConversation());
+
+    const messages = lastOpenAIParams!.messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toContain("[Web search: web_search]");
+    expect(assistantMsg!.content).toContain("Here are the results.");
+  });
+
+  test("degrades web_search_tool_result in user message to text placeholder", async () => {
+    const provider = new OpenAIProvider("sk-test", "gpt-4o");
+    await provider.sendMessage(webSearchConversation());
+
+    const messages = lastOpenAIParams!.messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+
+    const userMsgs = messages.filter((m) => m.role === "user");
+    const hasWebSearchResult = userMsgs.some((m) => {
+      if (typeof m.content === "string") return false;
+      if (Array.isArray(m.content)) {
+        return (m.content as Array<{ type: string; text?: string }>).some(
+          (part) =>
+            part.type === "text" && part.text === "[Web search results]",
+        );
+      }
+      return false;
+    });
+    expect(hasWebSearchResult).toBe(true);
+  });
+
+  test("handles message containing only web_search_tool_result", async () => {
+    const provider = new OpenAIProvider("sk-test", "gpt-4o");
+    await provider.sendMessage(webSearchResultOnlyMessage());
+
+    const messages = lastOpenAIParams!.messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.content).toContain("[Web search: web_search]");
+
+    const userMsgs = messages.filter((m) => m.role === "user");
+    const hasWebSearchResult = userMsgs.some((m) => {
+      if (typeof m.content === "string") return false;
+      if (Array.isArray(m.content)) {
+        return (m.content as Array<{ type: string; text?: string }>).some(
+          (part) =>
+            part.type === "text" && part.text === "[Web search results]",
+        );
+      }
+      return false;
+    });
+    expect(hasWebSearchResult).toBe(true);
+  });
+
+  test("does not produce tool_calls for server_tool_use blocks", async () => {
+    const provider = new OpenAIProvider("sk-test", "gpt-4o");
+    await provider.sendMessage(webSearchConversation());
+
+    const messages = lastOpenAIParams!.messages as Array<{
+      role: string;
+      tool_calls?: unknown[];
+    }>;
+
+    const assistantMsg = messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.tool_calls).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemini provider tests
+// ---------------------------------------------------------------------------
+
+describe("Cross-Provider Web Search — Gemini", () => {
+  beforeEach(() => {
+    lastGeminiParams = null;
+  });
+
+  test("degrades server_tool_use in model message to text placeholder", async () => {
+    const provider = new GeminiProvider("key-test", "gemini-2.0-flash");
+    await provider.sendMessage(webSearchConversation());
+
+    const contents = lastGeminiParams!.contents as Array<{
+      role: string;
+      parts: Array<{ text?: string; functionCall?: unknown }>;
+    }>;
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+
+    const webSearchPart = modelContent!.parts.find(
+      (p) => p.text === "[Web search: web_search]",
+    );
+    expect(webSearchPart).toBeDefined();
+
+    const textPart = modelContent!.parts.find(
+      (p) => p.text === "Here are the results.",
+    );
+    expect(textPart).toBeDefined();
+  });
+
+  test("degrades web_search_tool_result in user message to text placeholder", async () => {
+    const provider = new GeminiProvider("key-test", "gemini-2.0-flash");
+    await provider.sendMessage(webSearchConversation());
+
+    const contents = lastGeminiParams!.contents as Array<{
+      role: string;
+      parts: Array<{ text?: string }>;
+    }>;
+
+    const userContents = contents.filter((c) => c.role === "user");
+    const hasWebSearchResult = userContents.some((c) =>
+      c.parts.some((p) => p.text === "[Web search results]"),
+    );
+    expect(hasWebSearchResult).toBe(true);
+  });
+
+  test("handles message containing only web_search_tool_result", async () => {
+    const provider = new GeminiProvider("key-test", "gemini-2.0-flash");
+    await provider.sendMessage(webSearchResultOnlyMessage());
+
+    const contents = lastGeminiParams!.contents as Array<{
+      role: string;
+      parts: Array<{ text?: string; functionCall?: unknown }>;
+    }>;
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    const webSearchPart = modelContent!.parts.find(
+      (p) => p.text === "[Web search: web_search]",
+    );
+    expect(webSearchPart).toBeDefined();
+
+    const userContents = contents.filter((c) => c.role === "user");
+    const hasWebSearchResult = userContents.some((c) =>
+      c.parts.some((p) => p.text === "[Web search results]"),
+    );
+    expect(hasWebSearchResult).toBe(true);
+  });
+
+  test("does not produce functionCall parts for server_tool_use blocks", async () => {
+    const provider = new GeminiProvider("key-test", "gemini-2.0-flash");
+    await provider.sendMessage(webSearchConversation());
+
+    const contents = lastGeminiParams!.contents as Array<{
+      role: string;
+      parts: Array<{ text?: string; functionCall?: unknown }>;
+    }>;
+
+    const modelContent = contents.find((c) => c.role === "model");
+    expect(modelContent).toBeDefined();
+    const functionCallParts = modelContent!.parts.filter(
+      (p) => p.functionCall !== undefined,
+    );
+    expect(functionCallParts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Add tests verifying that server_tool_use and web_search_tool_result content blocks are properly degraded to text placeholders when replayed through OpenAI and Gemini providers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
