### PR TITLE
fix: include messageId in generation_handoff event for diagnostics parity

### DIFF
--- a/assistant/src/daemon/message-types/sessions.ts
+++ b/assistant/src/daemon/message-types/sessions.ts
@@ -273,6 +273,8 @@ export interface GenerationHandoff {
   requestId?: string;
   queuedCount: number;
   attachments?: UserMessageAttachment[];
+  /** Database ID of the persisted assistant message, if any. */
+  messageId?: string;
 }
 
 export interface ModelInfo {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1384,6 +1384,9 @@ export async function runAgentLoopImpl(
           ...(emittedAttachments.length > 0
             ? { attachments: emittedAttachments }
             : {}),
+          ...(state.lastAssistantMessageId
+            ? { messageId: state.lastAssistantMessageId }
+            : {}),
         });
       } else {
         ctx.emitActivityState("idle", "message_complete", "global", reqId);

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -959,6 +959,11 @@ extension ChatViewModel {
             // Keep isSending = true — daemon is handing off to next queued message
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
+                // Backfill the daemon's persisted message ID so diagnostics exports
+                // can anchor to it without requiring a history reload.
+                if let messageId = handoff.messageId {
+                    messages[index].daemonMessageId = messageId
+                }
                 messages[index].isStreaming = false
                 messages[index].streamingCodePreview = nil
                 messages[index].streamingCodeToolName = nil

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1770,13 +1770,15 @@ public struct GenerationHandoff: Codable, Sendable {
     public let requestId: String?
     public let queuedCount: Int
     public let attachments: [UserMessageAttachment]?
+    public let messageId: String?
 
-    public init(type: String, sessionId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil) {
+    public init(type: String, sessionId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.requestId = requestId
         self.queuedCount = queuedCount
         self.attachments = attachments
+        self.messageId = messageId
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -979,8 +979,8 @@ public struct GenerationCancelledMessage: Decodable, Sendable {
 public typealias GenerationHandoffMessage = GenerationHandoff
 
 extension GenerationHandoff {
-    public init(sessionId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil) {
-        self.init(type: "generation_handoff", sessionId: sessionId, requestId: requestId, queuedCount: queuedCount, attachments: attachments)
+    public init(sessionId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, messageId: String? = nil) {
+        self.init(type: "generation_handoff", sessionId: sessionId, requestId: requestId, queuedCount: queuedCount, attachments: attachments, messageId: messageId)
     }
 }
 


### PR DESCRIPTION
Add messageId to the generation_handoff SSE event and update the Swift client to backfill daemonMessageId on handoff, matching the message_complete behavior for rehydration and diagnostics export.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
