### PR TITLE
fix: clear proxy availability for queued non-desktop messages during active turn

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -118,6 +118,8 @@ export interface ProcessSessionContext {
   setTurnChannelContext(ctx: TurnChannelContext): void;
   getTurnInterfaceContext(): TurnInterfaceContext | null;
   setTurnInterfaceContext(ctx: TurnInterfaceContext): void;
+  /** Mark host proxies as unavailable so tool execution uses local fallback. */
+  clearProxyAvailability(): void;
   emitActivityState(
     phase:
       | "idle"
@@ -263,6 +265,13 @@ export async function drainQueue(
   );
   if (queuedInterfaceCtx) {
     session.setTurnInterfaceContext(queuedInterfaceCtx);
+  }
+
+  // Non-interactive queued messages (channel requests) must not execute tools
+  // via the desktop host proxy. Clear proxy availability so isAvailable()
+  // returns false and tool execution falls back to local.
+  if (next.isInteractive === false) {
+    session.clearProxyAvailability();
   }
 
   // Resolve slash commands for queued messages

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -397,6 +397,12 @@ export class Session {
     return this.sendToClient;
   }
 
+  /** Mark host proxies as unavailable so tool execution uses local fallback. */
+  clearProxyAvailability(): void {
+    this.hostBashProxy?.updateSender(this.sendToClient, false);
+    this.hostFileProxy?.updateSender(this.sendToClient, false);
+  }
+
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
   }


### PR DESCRIPTION
When a non-desktop message arrives mid-turn and skipProxySenderUpdate is set, the proxy's clientConnected stays true from the active desktop session. When the queue later drains and processes the non-desktop message, hostBashProxy.isAvailable()/hostFileProxy.isAvailable() incorrectly return true, causing tools to execute via the desktop proxy instead of local fallback.

Fix: Add clearProxyAvailability() to Session and call it in drainQueue when a non-interactive (channel) message is dequeued, ensuring proxy availability is explicitly set to false before the agent loop runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
