### PR TITLE
fix: align 401 test assertion with PROVIDER_BILLING classification

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -314,11 +314,11 @@ describe("classifySessionError", () => {
       expect(result.retryable).toBe(true);
     });
 
-    it("classifies ProviderError with 401 as PROVIDER_API (retryable)", () => {
+    it("classifies ProviderError with 401 as PROVIDER_BILLING (non-retryable)", () => {
       const err = new ProviderError("Unauthorized", "anthropic", 401);
       const result = classifySessionError(err, baseCtx);
-      expect(result.code).toBe("PROVIDER_API");
-      expect(result.retryable).toBe(true);
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.retryable).toBe(false);
     });
 
     it("classifies ProviderError with 400 as PROVIDER_API (retryable)", () => {


### PR DESCRIPTION
## Summary
- Updated `session-error.test.ts` to expect `PROVIDER_BILLING` (non-retryable) for 401 status codes, matching the classifier change in #15321 that excluded 401 from retryable 4xx errors.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22944396373/job/66593060371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
