### PR TITLE
fix: close pipe write ends on process.run() failure to prevent GCD thread leak

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -142,6 +142,10 @@ extension HTTPTransport {
                     } catch {
                         // Clear the handler since we never started
                         process.terminationHandler = nil
+                        // Close the write ends so readDataToEndOfFile() returns
+                        // immediately, unblocking the GCD reader threads.
+                        try? stdoutPipe.fileHandleForWriting.close()
+                        try? stderrPipe.fileHandleForWriting.close()
                         continuation.resume(throwing: error)
                     }
                 }


### PR DESCRIPTION
## Summary
- When process.run() fails in host bash, the pipe readers (readDataToEndOfFile) were blocking forever because write ends were never closed
- Added try? stdoutPipe/stderrPipe.fileHandleForWriting.close() in the error path before resuming the continuation
- This unblocks the GCD reader threads and prevents resource leaks on failed launches

Addresses review feedback from PR #15320
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
