### PR TITLE
fix: gate host tools on client presence to prevent unchecked execution

### DIFF
--- a/assistant/src/__tests__/always-loaded-tools-guard.test.ts
+++ b/assistant/src/__tests__/always-loaded-tools-guard.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe("always-loaded tool count", () => {
-  test("should be exactly 17", async () => {
+  test("should be exactly 11 (no-client baseline excludes host tools)", async () => {
     await initializeTools();
     const allDefs = buildToolDefinitions();
 
@@ -48,16 +48,15 @@ describe("always-loaded tool count", () => {
     );
     const activeNames = activeTools.map((t) => t.name).sort();
 
+    // Host tools (host_bash, host_file_*) are excluded when no client is
+    // connected — without a human in the loop, the guardian auto-approve
+    // path would allow unchecked host command execution.
     const expectedNames = [
       "bash",
       "credential_store",
       "file_edit",
       "file_read",
       "file_write",
-      "host_bash",
-      "host_file_edit",
-      "host_file_read",
-      "host_file_write",
       "memory_manage",
       "memory_recall",
       "skill_execute",
@@ -67,6 +66,6 @@ describe("always-loaded tool count", () => {
     ].sort();
 
     expect(activeNames).toEqual(expectedNames);
-    expect(activeTools.length).toBe(15);
+    expect(activeTools.length).toBe(11);
   });
 });

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -571,9 +571,10 @@ export function isToolActiveForContext(
     return ctx.channelCapabilities?.supportsDynamicUi ?? !ctx.hasNoClient;
   }
   if (HOST_TOOL_NAMES.has(name)) {
-    // Host tools are always available — they have local execution fallbacks
-    // for non-desktop sessions (CLI, headless) when no proxy is connected.
-    return true;
+    // Host tools require a connected client — without one, there is no human
+    // to approve execution and the guardian auto-approve path would allow
+    // unchecked host command execution on the daemon host.
+    return !ctx.hasNoClient;
   }
   if (ASSET_TOOL_NAMES.has(name)) {
     return ctx.hasAttachments ?? false;


### PR DESCRIPTION
## Summary

- Gate `host_bash` / `host_file_*` tool projection on `!ctx.hasNoClient` instead of unconditionally returning `true`, so host tools are only projected when a human client is connected
- Without a connected client, non-interactive guardian sessions auto-approve host tools, enabling unchecked command execution on the daemon host — this closes that path for both managed/remote and local background sessions
- Update always-loaded tools guard test to reflect the reduced baseline (15 → 11 tools when no client)

## Original prompt

it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
