### PR TITLE
fix: restore proxy availability for interactive messages after non-interactive drain

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -120,6 +120,8 @@ export interface ProcessSessionContext {
   setTurnInterfaceContext(ctx: TurnInterfaceContext): void;
   /** Mark host proxies as unavailable so tool execution uses local fallback. */
   clearProxyAvailability(): void;
+  /** Restore host proxy availability based on whether a real client is connected. */
+  restoreProxyAvailability(): void;
   emitActivityState(
     phase:
       | "idle"
@@ -272,6 +274,10 @@ export async function drainQueue(
   // returns false and tool execution falls back to local.
   if (next.isInteractive === false) {
     session.clearProxyAvailability();
+  } else {
+    // Restore proxy availability for interactive messages in case a prior
+    // non-interactive drain disabled it.
+    session.restoreProxyAvailability();
   }
 
   // Resolve slash commands for queued messages

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -403,6 +403,14 @@ export class Session {
     this.hostFileProxy?.updateSender(this.sendToClient, false);
   }
 
+  /** Restore host proxy availability based on whether a real client is connected. */
+  restoreProxyAvailability(): void {
+    if (!this.hasNoClient) {
+      this.hostBashProxy?.updateSender(this.sendToClient, true);
+      this.hostFileProxy?.updateSender(this.sendToClient, true);
+    }
+  }
+
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
   }


### PR DESCRIPTION
When drainQueue() processes a non-interactive message, it calls clearProxyAvailability() to prevent channel requests from using the desktop host proxy. However, if the next queued message is interactive, the proxies remain disabled because nothing restores them. This adds restoreProxyAvailability() to Session and calls it in the else branch of drainQueue, so interactive messages correctly use the host proxy after a non-interactive message has been processed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
