### PR TITLE
fix: handle missing anchor message in diagnostics export race condition

### DIFF
--- a/assistant/src/__tests__/diagnostics-export.test.ts
+++ b/assistant/src/__tests__/diagnostics-export.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for the diagnostics export route handler.
+ *
+ * Validates anchor message resolution, including the fallback chain
+ * (specific ID → most recent assistant → any message → empty conversation).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "diagnostics-export-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
+import { diagnosticsRouteDefinitions } from "../runtime/routes/diagnostics-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const routes = diagnosticsRouteDefinitions();
+const exportRoute = routes.find((r) => r.endpoint === "diagnostics/export")!;
+
+async function callExport(body: Record<string, unknown>): Promise<Response> {
+  const req = new Request("http://localhost/v1/diagnostics/export", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const url = new URL(req.url);
+  return exportRoute.handler({
+    req,
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: {},
+  });
+}
+
+const db = () => getSqlite();
+
+function seedConversation(id: string): void {
+  const now = Date.now();
+  db().run(
+    "INSERT INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    [id, "Test", now, now],
+  );
+}
+
+function seedMessage(
+  id: string,
+  conversationId: string,
+  role: string,
+  content: string,
+  createdAt: number,
+): void {
+  db().run(
+    "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
+    [id, conversationId, role, content, createdAt],
+  );
+}
+
+function cleanDb(): void {
+  db().run("DELETE FROM messages");
+  db().run("DELETE FROM conversations");
+}
+
+beforeEach(() => {
+  cleanDb();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("diagnostics export", () => {
+  test("returns 400 when conversationId is missing", async () => {
+    const res = await callExport({});
+    expect(res.status).toBe(400);
+  });
+
+  test("succeeds with specific anchorMessageId", async () => {
+    const convId = "conv-1";
+    const msgId = "msg-assistant-1";
+    const now = Date.now();
+
+    seedConversation(convId);
+    seedMessage("msg-user-1", convId, "user", "hello", now - 1000);
+    seedMessage(msgId, convId, "assistant", "world", now);
+
+    const res = await callExport({
+      conversationId: convId,
+      anchorMessageId: msgId,
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; filePath: string };
+    expect(json.success).toBe(true);
+    expect(json.filePath).toContain("diagnostics-");
+  });
+
+  test("falls back to most recent assistant message when anchorMessageId is omitted", async () => {
+    const convId = "conv-2";
+    const now = Date.now();
+
+    seedConversation(convId);
+    seedMessage("msg-user-1", convId, "user", "hello", now - 1000);
+    seedMessage("msg-assistant-1", convId, "assistant", "world", now);
+
+    const res = await callExport({ conversationId: convId });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean };
+    expect(json.success).toBe(true);
+  });
+
+  test("falls back to any message when no assistant messages exist (race condition fix)", async () => {
+    const convId = "conv-3";
+    const now = Date.now();
+
+    seedConversation(convId);
+    // Only a user message — assistant response hasn't been persisted yet
+    seedMessage("msg-user-1", convId, "user", "hello", now);
+
+    const res = await callExport({ conversationId: convId });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; filePath: string };
+    expect(json.success).toBe(true);
+    expect(json.filePath).toContain("diagnostics-");
+  });
+
+  test("succeeds with empty conversation (no messages at all)", async () => {
+    const convId = "conv-4";
+
+    seedConversation(convId);
+    // No messages at all — conversation was just created
+
+    const res = await callExport({ conversationId: convId });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean; filePath: string };
+    expect(json.success).toBe(true);
+    expect(json.filePath).toContain("diagnostics-");
+  });
+
+  test("falls back to any-message when anchorMessageId is provided but not found", async () => {
+    const convId = "conv-5";
+    const now = Date.now();
+
+    seedConversation(convId);
+    seedMessage("msg-user-1", convId, "user", "hello", now);
+
+    // anchorMessageId doesn't exist — should fall through all the way
+    const res = await callExport({
+      conversationId: convId,
+      anchorMessageId: "nonexistent-msg-id",
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean };
+    expect(json.success).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -179,7 +179,12 @@ async function handleDiagnosticsExport(body: {
   try {
     const db = getDb();
 
-    // 1. Find the anchor message
+    // 1. Find the anchor message.
+    // Try in order: specific ID → most recent assistant message → any message.
+    // The final fallback handles the race condition where the user clicks
+    // "export" before message_complete fires and the assistant message has
+    // been persisted — the user message and in-flight tool/usage data are
+    // still captured.
     let anchorMessage;
     if (anchorMessageId) {
       anchorMessage = db
@@ -192,7 +197,8 @@ async function handleDiagnosticsExport(body: {
           ),
         )
         .get();
-    } else {
+    }
+    if (!anchorMessage) {
       anchorMessage = db
         .select()
         .from(messages)
@@ -206,30 +212,52 @@ async function handleDiagnosticsExport(body: {
         .limit(1)
         .get();
     }
-
     if (!anchorMessage) {
-      return httpError("NOT_FOUND", "Anchor message not found", 404);
+      anchorMessage = db
+        .select()
+        .from(messages)
+        .where(eq(messages.conversationId, conversationId))
+        .orderBy(desc(messages.createdAt))
+        .limit(1)
+        .get();
     }
 
-    // 2. Find the preceding user message
-    const precedingUserMessage = db
-      .select()
-      .from(messages)
-      .where(
-        and(
-          eq(messages.conversationId, conversationId),
-          eq(messages.role, "user"),
-          lte(messages.createdAt, anchorMessage.createdAt),
-        ),
-      )
-      .orderBy(desc(messages.createdAt))
-      .limit(1)
-      .get();
+    // 2. Compute the export time range.
+    // When an anchor message exists, scope to the preceding user message
+    // through the anchor. When no messages exist at all (empty conversation
+    // or race condition), use the current timestamp so the export still
+    // captures any in-flight usage/tool data.
+    const now = Date.now();
+    let rangeEnd: number;
+    let rangeStart: number;
+    let usageRangeEnd: number;
 
-    const rangeStart =
-      precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
-    const rangeEnd = anchorMessage.createdAt;
-    const usageRangeEnd = anchorMessage.createdAt + 5000;
+    if (anchorMessage) {
+      const precedingUserMessage = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.conversationId, conversationId),
+            eq(messages.role, "user"),
+            lte(messages.createdAt, anchorMessage.createdAt),
+          ),
+        )
+        .orderBy(desc(messages.createdAt))
+        .limit(1)
+        .get();
+
+      rangeStart =
+        precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
+      rangeEnd = anchorMessage.createdAt;
+      usageRangeEnd = anchorMessage.createdAt + 5000;
+    } else {
+      // No messages at all — use the current time so we capture any
+      // in-flight LLM usage or tool invocations.
+      rangeStart = now - 60_000;
+      rangeEnd = now;
+      usageRangeEnd = now + 5000;
+    }
 
     // 3. Query all messages in the range
     const rangeMessages = db
@@ -297,7 +325,7 @@ async function handleDiagnosticsExport(body: {
         version: "1.1",
         exportedAt: new Date().toISOString(),
         conversationId,
-        messageId: anchorMessage.id,
+        messageId: anchorMessage?.id ?? null,
       };
       writeFileSync(
         join(tempDir, "manifest.json"),


### PR DESCRIPTION
## Summary
- Fix race condition where diagnostics export fails with "Anchor message not found" when clicked before `message_complete` fires
- Change anchor resolution from a hard 404 to a three-tier fallback chain: specific ID → most recent assistant message → any message → empty conversation (using current timestamp)
- Add test coverage for all anchor resolution paths including the race condition scenario

## Original prompt
Fix the "Anchor message not found" error in the diagnostics export handler. The bug is a race condition: when the user clicks export before `message_complete` fires, the assistant message hasn't been persisted to the DB yet, and `daemonMessageId` is nil. The fallback query finds no assistant messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
