### PR TITLE
fix: widen diagnostics export range when anchor is non-assistant message

### DIFF
--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -249,8 +249,16 @@ async function handleDiagnosticsExport(body: {
 
       rangeStart =
         precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
-      rangeEnd = anchorMessage.createdAt;
-      usageRangeEnd = anchorMessage.createdAt + 5000;
+
+      // When the anchor is not an assistant message (e.g. the fallback "any
+      // message" path hit because the assistant reply hasn't been persisted
+      // yet), extend the range to the current time so in-flight tool
+      // invocations and usage recorded after the user message are captured.
+      const anchorIsAssistant = anchorMessage.role === "assistant";
+      rangeEnd = anchorIsAssistant ? anchorMessage.createdAt : now;
+      usageRangeEnd = anchorIsAssistant
+        ? anchorMessage.createdAt + 5000
+        : now + 5000;
     } else {
       // No messages at all — use the current time so we capture any
       // in-flight LLM usage or tool invocations.


### PR DESCRIPTION
When the diagnostics export falls back to a non-assistant anchor message (race condition path), extends rangeEnd to Date.now() instead of the anchor timestamp. This ensures in-flight tool invocations and usage data recorded after the user message are captured in the export.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
