### PR TITLE
fix: restrict proxy restore to desktop interfaces in queue drain

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -275,9 +275,15 @@ export async function drainQueue(
   if (next.isInteractive === false) {
     session.clearProxyAvailability();
   } else {
-    // Restore proxy availability for interactive messages in case a prior
-    // non-interactive drain disabled it.
-    session.restoreProxyAvailability();
+    // Restore proxy availability only for desktop-originating turns (macos/ios)
+    // in case a prior non-interactive drain disabled it. Non-desktop interactive
+    // interfaces (CLI, Vellum) should not re-enable desktop host proxies.
+    const interfaceCtx =
+      queuedInterfaceCtx ?? session.getTurnInterfaceContext();
+    const sourceInterface = interfaceCtx?.userMessageInterface;
+    if (sourceInterface === "macos" || sourceInterface === "ios") {
+      session.restoreProxyAvailability();
+    }
   }
 
   // Resolve slash commands for queued messages


### PR DESCRIPTION
Narrows restoreProxyAvailability() in drainQueue to only fire for desktop-originating turns (macos/ios). Previously it ran for all interactive turns including CLI/Vellum, which could incorrectly re-enable desktop proxies for non-desktop queued turns after a non-interactive drain.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
