### PR TITLE
feat(flags): add settings developer nav assistant flag

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Email Sequences",
       "description": "Enable email sequence management skill",
       "defaultEnabled": true
+    },
+    {
+      "id": "settings-developer-nav",
+      "scope": "assistant",
+      "key": "feature_flags.settings-developer-nav.enabled",
+      "label": "Settings Developer Nav",
+      "description": "Control Developer nav visibility in macOS settings",
+      "defaultEnabled": false
     }
   ]
 }

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Email Sequences",
       "description": "Enable email sequence management skill",
       "defaultEnabled": true
+    },
+    {
+      "id": "settings-developer-nav",
+      "scope": "assistant",
+      "key": "feature_flags.settings-developer-nav.enabled",
+      "label": "Settings Developer Nav",
+      "description": "Control Developer nav visibility in macOS settings",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Email Sequences",
       "description": "Enable email sequence management skill",
       "defaultEnabled": true
+    },
+    {
+      "id": "settings-developer-nav",
+      "scope": "assistant",
+      "key": "feature_flags.settings-developer-nav.enabled",
+      "label": "Settings Developer Nav",
+      "description": "Control Developer nav visibility in macOS settings",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
Adds settings-developer-nav feature flag to control Developer nav visibility in macOS settings. Part of #15333.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
