### PR TITLE
refactor(macos-settings): general/developer IA and nav structure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -594,7 +594,7 @@ extension AppDelegate {
 
     /// Opens the settings panel and navigates to a specific tab.
     public func showSettingsTab(_ tab: String) {
-        if let settingsTab = SettingsTab.fromLegacyRawValue(tab, isDevMode: services.settingsStore.isDevMode) {
+        if let settingsTab = SettingsTab.fromRawValue(tab) {
             services.settingsStore.pendingSettingsTab = settingsTab
         }
         showSettingsWindow(nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -2,61 +2,34 @@ import SwiftUI
 import VellumAssistantShared
 
 enum SettingsTab: String {
-    case account = "Account"
+    case general = "General"
     case channels = "Channels"
     case modelsAndServices = "Models & Services"
     case voice = "Voice"
-    case permissions = "Permissions"
+    case permissionsAndPrivacy = "Permissions & Privacy"
     case automation = "Automation"
     case appearance = "Appearance"
-    case privacy = "Privacy"
     case contacts = "Contacts"
-    case advanced = "Advanced"
-    case sentryTesting = "Sentry Testing"
+    case developer = "Developer"
 
-    /// Tabs shown in the sidebar. Contacts requires a feature flag; Advanced is only visible in dev mode.
-    static func visibleTabs(isDevMode: Bool, contactsEnabled: Bool = false, sentryTestingEnabled: Bool = false) -> [SettingsTab] {
+    /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
+    static func primaryTabs(contactsEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [
-            .account, .channels, .modelsAndServices, .voice,
-            .automation, .appearance, .permissions, .privacy
+            .general, .channels, .modelsAndServices, .voice,
+            .automation, .appearance, .permissionsAndPrivacy
         ]
         if contactsEnabled {
             tabs.append(.contacts)
         }
-        if isDevMode {
-            tabs.append(.advanced)
-        }
-        if sentryTestingEnabled {
-            tabs.append(.sentryTesting)
-        }
         return tabs
     }
 
-    /// Maps legacy tab names (from HTTP or saved state) to current tabs.
-    /// The `isDevMode` parameter gates dev-only tabs so external callers
-    /// (e.g. daemon HTTP) cannot navigate to them when dev mode is off.
-    static func fromLegacyRawValue(_ value: String, isDevMode: Bool = false, contactsEnabled: Bool = false, sentryTestingEnabled: Bool = false) -> SettingsTab? {
-        let tab: SettingsTab?
-        // Try current values first
-        if let direct = SettingsTab(rawValue: value) {
-            tab = direct
-        } else {
-            // Map legacy names
-            switch value {
-            case "Connect": tab = .account
-            case "Integrations": tab = .modelsAndServices
-            case "Trust": tab = .permissions
-            case "Schedules": tab = .automation
-            case "Heartbeat": tab = .automation
-            case "Advanced": tab = .advanced
-            default: tab = nil
-            }
-        }
+    /// Resolves a tab name string to a SettingsTab. Only accepts current canonical names.
+    static func fromRawValue(_ value: String, contactsEnabled: Bool = false, developerEnabled: Bool = false) -> SettingsTab? {
+        guard let tab = SettingsTab(rawValue: value) else { return nil }
         // Block feature-flagged tabs when disabled
         if tab == .contacts && !contactsEnabled { return nil }
-        // Block dev-only tabs when dev mode is disabled
-        if tab == .advanced && !isDevMode { return nil }
-        if tab == .sentryTesting && !sentryTestingEnabled { return nil }
+        if tab == .developer && !developerEnabled { return nil }
         return tab
     }
 }
@@ -91,11 +64,11 @@ struct SettingsPanel: View {
     @State private var notificationsGranted: Bool = false
     @State private var notificationBadgesGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
-    @State private var selectedTab: SettingsTab = .account
+    @State private var selectedTab: SettingsTab = .general
     @State private var isContactsEnabled: Bool = false
-    @State private var isSentryTestingEnabled: Bool = false
+    @State private var isDeveloperEnabled: Bool = false
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
-    private static let sentryTestingFeatureFlagKey = "sentry_testing_enabled"
+    private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -154,8 +127,7 @@ struct SettingsPanel: View {
         .task {
             // Refresh permission status and feature flags when the view appears
             await refreshPermissionStatus()
-            await loadContactsFeatureFlag()
-            isSentryTestingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.sentryTestingFeatureFlagKey)
+            await loadFeatureFlags()
         }
         .onAppear {
             store.refreshAPIKeyState()
@@ -163,7 +135,7 @@ struct SettingsPanel: View {
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
             if let pending = store.pendingSettingsTab {
-                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(pending) {
+                if allVisibleTabs.contains(pending) {
                     selectedTab = pending
                 }
                 store.pendingSettingsTab = nil
@@ -171,7 +143,7 @@ struct SettingsPanel: View {
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(tab) {
+                if allVisibleTabs.contains(tab) {
                     selectedTab = tab
                 }
                 store.pendingSettingsTab = nil
@@ -182,7 +154,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
             if let tab = notification.object as? SettingsTab {
-                guard SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled).contains(tab) else { return }
+                guard allVisibleTabs.contains(tab) else { return }
                 selectedTab = tab
             }
         }
@@ -192,12 +164,12 @@ struct SettingsPanel: View {
                 if key == Self.contactsFeatureFlagKey {
                     isContactsEnabled = enabled
                     if !enabled && selectedTab == .contacts {
-                        selectedTab = .account
+                        selectedTab = .general
                     }
-                } else if key == Self.sentryTestingFeatureFlagKey {
-                    isSentryTestingEnabled = enabled
-                    if !enabled && selectedTab == .sentryTesting {
-                        selectedTab = .account
+                } else if key == Self.developerFeatureFlagKey {
+                    isDeveloperEnabled = enabled
+                    if !enabled && selectedTab == .developer {
+                        selectedTab = .general
                     }
                 }
             }
@@ -241,14 +213,31 @@ struct SettingsPanel: View {
 
     // MARK: - Nav Sidebar
 
+    /// All currently visible tabs (primary + gated bottom tabs).
+    private var allVisibleTabs: [SettingsTab] {
+        var tabs = SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled)
+        if isDeveloperEnabled {
+            tabs.append(.developer)
+        }
+        return tabs
+    }
+
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled, sentryTestingEnabled: isSentryTestingEnabled), id: \.self) { tab in
+            ForEach(SettingsTab.primaryTabs(contactsEnabled: isContactsEnabled), id: \.self) { tab in
                 SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
                     selectedTab = tab
                 }
             }
             Spacer()
+            if isDeveloperEnabled {
+                Divider()
+                    .padding(.trailing, VSpacing.md)
+                SettingsNavRow(tab: .developer, isSelected: selectedTab == .developer) {
+                    selectedTab = .developer
+                }
+                .padding(.bottom, VSpacing.sm)
+            }
         }
         .padding(.top, VSpacing.lg)
         .padding(.trailing, VSpacing.sm)
@@ -259,7 +248,7 @@ struct SettingsPanel: View {
     @ViewBuilder
     private var selectedTabContent: some View {
         switch selectedTab {
-        case .account:
+        case .general:
             SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
         case .channels:
             SettingsChannelsTab(store: store, daemonClient: daemonClient)
@@ -267,24 +256,19 @@ struct SettingsPanel: View {
             integrationsContent
         case .voice:
             VoiceSettingsView(store: store)
-        case .permissions:
-            permissionsContent
+        case .permissionsAndPrivacy:
+            permissionsAndPrivacyContent
         case .automation:
             SettingsAutomationTab(daemonClient: daemonClient, showingReminders: $showingReminders, showingScheduledTasks: $showingScheduledTasks, showingHeartbeatConfig: $showingHeartbeatConfig, showingHeartbeatRuns: $showingHeartbeatRuns)
         case .appearance:
             SettingsAppearanceTab(store: store)
-        case .privacy:
-            SettingsPrivacyTab(daemonClient: daemonClient, store: store)
         case .contacts:
             ContactsContainerView(daemonClient: daemonClient, store: store)
-        case .advanced:
-            if store.isDevMode {
-                SettingsAdvancedDevTab(store: store, daemonClient: daemonClient)
-            } else {
-                SettingsAccountTab(store: store, daemonClient: daemonClient, authManager: authManager, onClose: onClose)
-            }
-        case .sentryTesting:
-            SettingsDebugTab()
+        case .developer:
+            Text("Developer")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
     }
 
@@ -593,9 +577,9 @@ struct SettingsPanel: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Permissions Tab
+    // MARK: - Permissions & Privacy Tab
 
-    private var permissionsContent: some View {
+    private var permissionsAndPrivacyContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // PERMISSIONS section (OS permissions)
             VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -712,6 +696,9 @@ struct SettingsPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
 
+            // PRIVACY section (merged from SettingsPrivacyTab)
+            SettingsPrivacyTab(daemonClient: daemonClient, store: store)
+
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -752,24 +739,31 @@ struct SettingsPanel: View {
         notificationBadgesGranted = await PermissionManager.notificationBadgeStatus() == .granted
     }
 
-    // MARK: - Contacts Feature Flag
+    // MARK: - Feature Flag Loading
 
-    private func loadContactsFeatureFlag() async {
+    private func loadFeatureFlags() async {
         if let daemonClient {
             do {
                 let flags = try await daemonClient.getFeatureFlags()
-                if let flag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {
-                    isContactsEnabled = flag.enabled
-                    return
+                if let contactsFlag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {
+                    isContactsEnabled = contactsFlag.enabled
                 }
+                if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
+                    isDeveloperEnabled = developerFlag.enabled
+                }
+                return
             } catch {
                 // Fall through to local config fallback.
             }
         }
         let config = WorkspaceConfigIO.read()
-        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool],
-           let enabled = canonicalFlags[Self.contactsFeatureFlagKey] {
-            isContactsEnabled = enabled
+        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool] {
+            if let contactsEnabled = canonicalFlags[Self.contactsFeatureFlagKey] {
+                isContactsEnabled = contactsEnabled
+            }
+            if let developerEnabled = canonicalFlags[Self.developerFeatureFlagKey] {
+                isDeveloperEnabled = developerEnabled
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Rebuild settings tab enum with new IA: `general` replaces `account`, `permissionsAndPrivacy` merges permissions + privacy, `developer` tab added (feature-flag gated, bottom-pinned)
- Remove legacy alias handling in `fromLegacyRawValue` — only canonical names accepted via new `fromRawValue`
- Developer feature flag (`settings-developer-nav`) loaded alongside contacts flag; developer row renders at bottom with divider separator

## Test plan
- [ ] Verify General tab renders the existing Account content
- [ ] Verify Permissions & Privacy tab shows both permissions and privacy sections
- [ ] Verify Developer tab appears at bottom only when `settings-developer-nav` flag is enabled
- [ ] Verify fallback to General when a gated tab becomes unavailable
- [ ] Verify daemon navigation via `showSettingsTab` still works with new canonical names

Part of #15333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
