### PR TITLE
Settings UI polish: button sizing, toggle redesign, media embeds

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -104,10 +104,9 @@ struct SettingsPanel: View {
                     ScrollView {
                         selectedTabContent
                             .padding(.top, VSpacing.lg)
-                            .padding(.leading, VSpacing.lg)
                             .padding(.trailing, VSpacing.xl)
                             .padding(.bottom, VSpacing.xl)
-                            .frame(maxWidth: 700, alignment: .top)
+                            .frame(maxWidth: 900, alignment: .top)
                             .frame(maxWidth: .infinity)
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -81,7 +81,7 @@ struct GatewaySettingsCard: View {
 
                 // Running badge — only shown when gateway is reachable
                 if store.gatewayReachable == true {
-                    VButton(label: "Running", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
+                    VButton(label: "Running", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
                 }
 
                 Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
@@ -130,7 +130,7 @@ struct GatewaySettingsCard: View {
 
                 // Save button at the bottom
                 HStack {
-                    VButton(label: "Save", style: .primary) {
+                    VButton(label: "Save", style: .primary, size: .medium) {
                         store.saveIngressPublicBaseUrl(gatewayUrlText)
                         isGatewayUrlFocused = false
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -110,16 +110,16 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingGlobalHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined) {
+                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
                             stopRecording()
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Record", style: .outlined, size: .medium) {
                                 startRecording()
                             }
                             if !store.globalHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Unbind", style: .outlined, size: .medium) {
                                     store.globalHotkeyShortcut = ""
                                 }
                             }
@@ -150,16 +150,16 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingQuickInputHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined) {
+                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
                             stopRecording()
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
+                            VButton(label: "Record", style: .outlined, size: .medium) {
                                 startRecordingQuickInput()
                             }
                             if !store.quickInputHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
+                                VButton(label: "Unbind", style: .outlined, size: .medium) {
                                     store.quickInputHotkeyShortcut = ""
                                     store.quickInputHotkeyKeyCode = 0
                                 }
@@ -229,14 +229,18 @@ struct SettingsAppearanceTab: View {
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.textSecondary)
 
-                    VInlineActionField(text: $newAllowlistDomain, placeholder: "Add domain (e.g. example.com)", actionLabel: "Add") {
-                        let domain = newAllowlistDomain
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !domain.isEmpty else { return }
-                        var domains = store.mediaEmbedVideoAllowlistDomains
-                        domains.append(domain)
-                        store.setMediaEmbedVideoAllowlistDomains(domains)
-                        newAllowlistDomain = ""
+                    HStack(spacing: VSpacing.sm) {
+                        TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
+                            .vInputStyle()
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .onSubmit {
+                                addAllowlistDomain()
+                            }
+
+                        VButton(label: "Add", style: .primary, size: .medium, isDisabled: newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            addAllowlistDomain()
+                        }
                     }
 
                     ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
@@ -246,21 +250,16 @@ struct SettingsAppearanceTab: View {
                                 .foregroundColor(VColor.textSecondary)
                                 .textSelection(.enabled)
                             Spacer()
-                            Button {
+                            VIconButton(label: "Remove domain", icon: VIcon.trash.rawValue, iconOnly: true, variant: .danger) {
                                 var domains = store.mediaEmbedVideoAllowlistDomains
                                 domains.removeAll { $0 == domain }
                                 store.setMediaEmbedVideoAllowlistDomains(domains)
-                            } label: {
-                                VIconView(.trash, size: 14)
-                                    .foregroundColor(VColor.error)
                             }
-                            .buttonStyle(.plain)
-                            .pointerCursor()
                         }
                         .padding(.vertical, VSpacing.xs)
                     }
 
-                    VButton(label: "Reset to Defaults", style: .secondary) {
+                    VButton(label: "Reset to Defaults", style: .secondary, size: .medium) {
                         store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -270,6 +269,17 @@ struct SettingsAppearanceTab: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
         }
+    }
+
+    // MARK: - Allowlist
+
+    private func addAllowlistDomain() {
+        let domain = newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !domain.isEmpty else { return }
+        var domains = store.mediaEmbedVideoAllowlistDomains
+        domains.append(domain)
+        store.setMediaEmbedVideoAllowlistDomains(domains)
+        newAllowlistDomain = ""
     }
 
     // MARK: - Shortcut Recording

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -196,8 +196,8 @@ struct SettingsChannelsTab: View {
             // Bot credential row
             if store.telegramHasBotToken {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
@@ -206,7 +206,7 @@ struct SettingsChannelsTab: View {
             } else if telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary) {
+                VButton(label: "Set Up", style: .secondary, size: .medium) {
                     telegramSetupExpanded = true
                 }
             }
@@ -274,10 +274,9 @@ struct SettingsChannelsTab: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .secondary) {
+                        VButton(label: "Revoke", style: .secondary, size: .medium, isDisabled: store.telegramRevokingMemberIds.contains(member.id)) {
                             store.revokeTelegramApprovedMember(memberId: member.id)
                         }
-                        .disabled(store.telegramRevokingMemberIds.contains(member.id))
                     }
                 }
             }
@@ -317,13 +316,12 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary) {
+                    VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                         store.saveTelegramToken(botToken: telegramBotTokenText)
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
                     }
-                    .disabled(telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    VButton(label: "Cancel", style: .tertiary) {
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         telegramSetupExpanded = false
                         telegramBotTokenText = ""
                     }
@@ -347,8 +345,8 @@ struct SettingsChannelsTab: View {
 
             if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.slackChannelSaveInProgress) {
                         store.clearSlackChannelConfig()
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -358,7 +356,7 @@ struct SettingsChannelsTab: View {
             } else if slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary) {
+                VButton(label: "Set Up", style: .secondary, size: .medium) {
                     slackChannelSetupExpanded = true
                 }
             }
@@ -423,10 +421,9 @@ struct SettingsChannelsTab: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .secondary) {
+                        VButton(label: "Revoke", style: .secondary, size: .medium, isDisabled: store.slackRevokingMemberIds.contains(member.id)) {
                             store.revokeSlackApprovedMember(memberId: member.id)
                         }
-                        .disabled(store.slackRevokingMemberIds.contains(member.id))
                     }
                 }
             }
@@ -471,7 +468,13 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary) {
+                    VButton(
+                        label: "Connect",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ) {
                         store.saveSlackChannelConfig(
                             botToken: slackChannelBotTokenInput,
                             appToken: slackChannelAppTokenInput
@@ -480,11 +483,7 @@ struct SettingsChannelsTab: View {
                         slackChannelAppTokenInput = ""
                         slackChannelSetupExpanded = false
                     }
-                    .disabled(
-                        slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    )
-                    VButton(label: "Cancel", style: .tertiary) {
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         slackChannelSetupExpanded = false
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -510,15 +509,15 @@ struct SettingsChannelsTab: View {
             // Credentials row
             if store.twilioHasCredentials {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 }
             } else if twilioSetupExpanded {
                 twilioCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary) {
+                VButton(label: "Set Up", style: .secondary, size: .medium) {
                     twilioSetupExpanded = true
                 }
             }
@@ -585,15 +584,15 @@ struct SettingsChannelsTab: View {
             // Credentials row
             if store.twilioHasCredentials {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 }
             } else if voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary) {
+                VButton(label: "Set Up", style: .secondary, size: .medium) {
                     voiceSetupExpanded = true
                 }
             }
@@ -673,7 +672,13 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary) {
+                    VButton(
+                        label: "Connect",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                            twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ) {
                         store.saveTwilioCredentials(
                             accountSid: twilioAccountSidText,
                             authToken: twilioAuthTokenText
@@ -682,11 +687,7 @@ struct SettingsChannelsTab: View {
                         twilioAuthTokenText = ""
                         twilioSetupExpanded = false
                     }
-                    .disabled(
-                        twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
-                        twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    )
-                    VButton(label: "Cancel", style: .tertiary) {
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         twilioSetupExpanded = false
                         twilioAccountSidText = ""
                         twilioAuthTokenText = ""
@@ -724,7 +725,13 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary) {
+                    VButton(
+                        label: "Connect",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: voiceAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                            voiceAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ) {
                         store.saveTwilioCredentials(
                             accountSid: voiceAccountSidText,
                             authToken: voiceAuthTokenText
@@ -733,11 +740,7 @@ struct SettingsChannelsTab: View {
                         voiceAuthTokenText = ""
                         voiceSetupExpanded = false
                     }
-                    .disabled(
-                        voiceAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
-                        voiceAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    )
-                    VButton(label: "Cancel", style: .tertiary) {
+                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         voiceSetupExpanded = false
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
@@ -793,8 +796,7 @@ struct SettingsChannelsTab: View {
             }
 
             if let action {
-                VButton(label: action.label, style: action.style, action: action.action)
-                    .disabled(action.disabled)
+                VButton(label: action.label, style: action.style, size: .medium, isDisabled: action.disabled, action: action.action)
             }
         }
     }
@@ -905,7 +907,7 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.warning)
             }
         } else {
-            VButton(label: "Pair Device", leftIcon: VIcon.qrCode.rawValue, style: .primary) {
+            VButton(label: "Pair Device", leftIcon: VIcon.qrCode.rawValue, style: .primary, size: .medium) {
                 showingPairingQR = true
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -398,7 +398,7 @@ struct SettingsDeveloperTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                 }
-                VButton(label: "Retire", style: .danger) {
+                VButton(label: "Retire", style: .danger, size: .medium) {
                     showingRetireConfirmation = true
                 }
             }
@@ -452,7 +452,7 @@ struct SettingsDeveloperTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    VButton(label: "Hatch...", style: .primary) {
+                    VButton(label: "Hatch...", style: .primary, size: .medium) {
                         showingHatchConfirmation = true
                     }
                     .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
@@ -671,7 +671,7 @@ struct SettingsDeveloperTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    VButton(label: "View", style: .secondary) {
+                    VButton(label: "View", style: .secondary, size: .medium) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
                             .map { ($0.key, $0.value) }
@@ -732,7 +732,7 @@ struct SettingsDeveloperTab: View {
 
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Trigger Fatal Crash", style: .danger) {
+                    VButton(label: "Trigger Fatal Crash", style: .danger, size: .medium) {
                         fatalError("Sentry test crash")
                     }
                     Text("Calls fatalError() — will terminate the app immediately.")
@@ -743,7 +743,7 @@ struct SettingsDeveloperTab: View {
                 Divider().foregroundColor(VColor.divider)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Error", style: .secondary) {
+                    VButton(label: "Send Test Error", style: .secondary, size: .medium) {
                         sendSentryTestEvent(level: .error, label: "error")
                     }
                     Text("Captures a Sentry event with level .error")
@@ -754,7 +754,7 @@ struct SettingsDeveloperTab: View {
                 Divider().foregroundColor(VColor.divider)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Warning", style: .secondary) {
+                    VButton(label: "Send Test Warning", style: .secondary, size: .medium) {
                         sendSentryTestEvent(level: .warning, label: "warning")
                     }
                     Text("Captures a Sentry event with level .warning")
@@ -765,7 +765,7 @@ struct SettingsDeveloperTab: View {
                 Divider().foregroundColor(VColor.divider)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Message", style: .secondary) {
+                    VButton(label: "Send Test Message", style: .secondary, size: .medium) {
                         sendSentryTestEvent(level: .info, label: "info message")
                     }
                     Text("Captures a Sentry event with level .info")
@@ -776,7 +776,7 @@ struct SettingsDeveloperTab: View {
                 Divider().foregroundColor(VColor.divider)
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Test Performance Transaction", style: .secondary) {
+                    VButton(label: "Test Performance Transaction", style: .secondary, size: .medium) {
                         guard isSentryEnabled else {
                             showSentryStatus("Sentry is disabled — transaction not sent.")
                             return

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -42,17 +42,18 @@ struct SettingsGeneralTab: View {
                 .font(VFont.inputLabel)
                 .foregroundColor(VColor.textSecondary)
 
-            TextField("https://platform.vellum.ai", text: $platformUrlText)
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .focused($isPlatformUrlFocused)
+            HStack(spacing: VSpacing.sm) {
+                TextField("https://platform.vellum.ai", text: $platformUrlText)
+                    .vInputStyle()
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .focused($isPlatformUrlFocused)
 
-            VButton(label: "Save", style: .primary) {
-                store.savePlatformBaseUrl(platformUrlText)
-                isPlatformUrlFocused = false
+                VButton(label: "Save", style: .primary, size: .medium, isDisabled: platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                    store.savePlatformBaseUrl(platformUrlText)
+                    isPlatformUrlFocused = false
+                }
             }
-            .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
             Divider().background(VColor.surfaceBorder)
 
@@ -69,17 +70,18 @@ struct SettingsGeneralTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else if authManager.currentUser != nil {
-                VButton(label: "Log Out", style: .danger) {
+                VButton(label: "Log Out", style: .danger, size: .medium) {
                     Task { await authManager.logout() }
                 }
             } else {
                 VButton(
                     label: authManager.isSubmitting ? "Signing in..." : "Sign In",
-                    style: .primary
+                    style: .primary,
+                    size: .medium,
+                    isDisabled: authManager.isSubmitting
                 ) {
                     Task { await authManager.startWorkOSLogin() }
                 }
-                .disabled(authManager.isSubmitting)
             }
 
             if let error = authManager.errorMessage {

--- a/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
@@ -20,11 +20,11 @@ struct SkillDeleteConfirmView: View {
             }
 
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .tertiary, size: .medium) {
                     onCancel()
                 }
 
-                VButton(label: "Delete", style: .danger) {
+                VButton(label: "Delete", style: .danger, size: .medium) {
                     onDelete()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -193,10 +193,9 @@ struct ToolPermissionTesterView: View {
     @ViewBuilder
     private var simulateButton: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary) {
+            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary, size: .medium, isDisabled: !model.canSimulate) {
                 model.simulate()
             }
-            .disabled(!model.canSimulate)
 
             if model.isSimulating {
                 ProgressView()

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -417,8 +417,8 @@ struct VoiceSettingsView: View {
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
-                    VButton(label: "Disconnect", style: .danger) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Disconnect", style: .danger, size: .medium) {
                         store.clearElevenLabsKey()
                         elevenLabsKeyText = ""
                         ttsSetupExpanded = false
@@ -444,19 +444,19 @@ struct VoiceSettingsView: View {
                     }
 
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .secondary, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                        VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                             store.saveElevenLabsKey(elevenLabsKeyText)
                             elevenLabsKeyText = ""
                             ttsSetupExpanded = false
                         }
-                        VButton(label: "Cancel", style: .tertiary) {
+                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
                             ttsSetupExpanded = false
                             elevenLabsKeyText = ""
                         }
                     }
                 }
             } else {
-                VButton(label: "Set Up", style: .secondary) {
+                VButton(label: "Set Up", style: .secondary, size: .medium) {
                     ttsSetupExpanded = true
                 }
             }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -5,10 +5,10 @@ public struct VToggle: View {
     public var label: String? = nil
     @Environment(\.isEnabled) private var isEnabled
 
-    private let trackWidth: CGFloat = 34
-    private let trackHeight: CGFloat = 18
-    private let knobSize: CGFloat = 14
-    private let knobPadding: CGFloat = 2
+    private let trackWidth: CGFloat = 36
+    private let trackHeight: CGFloat = 24
+    private let knobSize: CGFloat = 18
+    private let knobPadding: CGFloat = 3
 
     public init(isOn: Binding<Bool>, label: String? = nil) {
         self._isOn = isOn
@@ -33,7 +33,6 @@ public struct VToggle: View {
             }
         }
         .pointerCursor()
-        .opacity(isEnabled ? 1.0 : 0.5)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityValue(isOn ? "On" : "Off")
@@ -46,21 +45,30 @@ public struct VToggle: View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
             RoundedRectangle(cornerRadius: trackHeight / 2)
-                .fill(isOn ? Forest._600 : VColor.toggleOff)
+                .fill(trackColor)
                 .frame(width: trackWidth, height: trackHeight)
-                .overlay(
-                    RoundedRectangle(cornerRadius: trackHeight / 2)
-                        .stroke(VColor.toggleBorder, lineWidth: 1)
-                        .opacity(isOn ? 0 : 1)
-                )
 
             // Knob
-            RoundedRectangle(cornerRadius: knobSize / 2)
-                .fill(Color.white)
+            Circle()
+                .fill(knobColor)
                 .frame(width: knobSize, height: knobSize)
-                .shadow(color: Color.black.opacity(0.15), radius: 3, x: 0, y: 1)
+                .shadow(color: Color.black.opacity(0.08), radius: 2, x: 0, y: 1)
                 .padding(.horizontal, knobPadding)
         }
+    }
+
+    private var trackColor: Color {
+        if !isEnabled {
+            return VColor.toggleOff
+        }
+        return isOn ? VColor.toggleOn : VColor.toggleOff
+    }
+
+    private var knobColor: Color {
+        if !isEnabled {
+            return VColor.toggleKnobDisabled
+        }
+        return VColor.toggleKnob
     }
 }
 

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -59,7 +59,7 @@ public struct VToggle: View {
 
     private var trackColor: Color {
         if !isEnabled {
-            return VColor.toggleOff
+            return isOn ? VColor.toggleOn.opacity(0.5) : VColor.toggleOff
         }
         return isOn ? VColor.toggleOn : VColor.toggleOff
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -218,8 +218,11 @@ public enum VColor {
     public static let ghostPressed = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let divider = adaptiveColor(light: Stone._300, dark: Moss._700)
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
-    public static let toggleOff = adaptiveColor(light: Stone._200, dark: Moss._600)
+    public static let toggleOn = adaptiveColor(light: Color(hex: 0x2A3825), dark: Color(hex: 0x2A3825))
+    public static let toggleOff = adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Color(hex: 0xE8E6DA))
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)
+    public static let toggleKnob = adaptiveColor(light: Stone._50, dark: Color.white)
+    public static let toggleKnobDisabled = adaptiveColor(light: Color(hex: 0xBDB9A9), dark: Color(hex: 0xBDB9A9))
 
     // Slash command highlight — green tint for /command tokens in composer and chat
     public static let slashCommand = adaptiveColor(light: Forest._500, dark: Forest._300)


### PR DESCRIPTION
## Summary
- Use `size: .medium` on all VButtons across Settings for consistent sizing
- Replace `.disabled()` modifier with VButton's `isDisabled` parameter for proper disabled styling
- Put Platform URL field and Save button on the same row
- Replace `VInlineActionField` with `TextField` + `VButton` for domain allowlist input
- Use `VIconButton` with `variant: .danger` for domain delete buttons in media embeds
- Redesign `VToggle`: 36x24px, no borders, `#2A3825` active color, `#E8E6DA` off surface, `#BDB9A9` disabled knob

## Test plan
- [ ] Verify all Settings buttons render at medium size consistently
- [ ] Verify disabled buttons use VButton's built-in disabled styling
- [ ] Check Platform URL + Save button appear on the same row
- [ ] Test adding/removing domains in Video Domain Allowlist
- [ ] Verify VToggle appearance in all three states: on, off, disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
