### PR TITLE
Remove SMS capability display from iOS Settings and Contacts

### DIFF
--- a/clients/ios/Views/Intelligence/ContactDetailView.swift
+++ b/clients/ios/Views/Intelligence/ContactDetailView.swift
@@ -234,7 +234,7 @@ struct ContactDetailView: View {
         let icon: VIcon = {
             switch type {
             case "email": return .mail
-            case "sms", "phone": return .phone
+            case "phone": return .phone
             case "slack": return .hash
             case "discord": return .messageCircle
             case "telegram": return .send

--- a/clients/ios/Views/Intelligence/ContactsListView.swift
+++ b/clients/ios/Views/Intelligence/ContactsListView.swift
@@ -168,7 +168,7 @@ struct ContactsListView: View {
         let icon: VIcon = {
             switch type {
             case "email": return .mail
-            case "sms", "phone": return .phone
+            case "phone": return .phone
             case "slack": return .hash
             case "discord": return .messageCircle
             case "telegram": return .send

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -105,14 +105,6 @@ struct TwilioSettingsSection: View {
                                                     .background(Color.blue.opacity(0.15))
                                                     .cornerRadius(4)
                                             }
-                                            if number.capabilities.sms {
-                                                Text("SMS")
-                                                    .font(.caption2)
-                                                    .padding(.horizontal, 4)
-                                                    .padding(.vertical, 1)
-                                                    .background(Color.green.opacity(0.15))
-                                                    .cornerRadius(4)
-                                            }
                                         }
                                     }
                                     Spacer()
@@ -184,7 +176,7 @@ struct TwilioSettingsSection: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will remove your Twilio Account SID and Auth Token. Your phone number assignment will be preserved. Voice calls and SMS will stop working until credentials are reconfigured.")
+            Text("This will remove your Twilio Account SID and Auth Token. Your phone number assignment will be preserved. Voice calls will stop working until credentials are reconfigured.")
         }
         .sheet(isPresented: $showProvisionSheet) {
             provisionSheet
@@ -335,11 +327,10 @@ struct TwilioSettingsSection: View {
                   let friendlyName = dict["friendlyName"] as? String,
                   let caps = dict["capabilities"] as? [String: Any] else { return nil }
             let voice = caps["voice"] as? Bool ?? false
-            let sms = caps["sms"] as? Bool ?? false
             return TwilioNumberInfo(
                 phoneNumber: phoneNumber,
                 friendlyName: friendlyName,
-                capabilities: TwilioNumberCapabilities(voice: voice, sms: sms)
+                capabilities: TwilioNumberCapabilities(voice: voice)
             )
         }
     }


### PR DESCRIPTION
## Summary
- Remove SMS capability badge from Twilio number list
- Update clear credentials warning to only mention voice calls
- Remove SMS from contact icon mappings

Part of plan: remove-sms-channel.md (PR 5 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
