### PR TITLE
Remove SMS capability from TwilioNumberCapabilities

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1928,11 +1928,9 @@ public typealias TelegramConfigResponseMessage = TelegramConfigResponse
 /// Capabilities of a Twilio phone number.
 public struct TwilioNumberCapabilities: Codable, Sendable {
     public let voice: Bool
-    public let sms: Bool
 
-    public init(voice: Bool, sms: Bool) {
+    public init(voice: Bool) {
         self.voice = voice
-        self.sms = sms
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove sms property from TwilioNumberCapabilities struct
- Update init to only take voice parameter

Part of plan: remove-sms-channel.md (PR 6 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
