### PR TITLE
Remove SMS channel type from macOS Contacts and ConstellationView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -6,13 +6,13 @@ import VellumAssistantShared
 /// channels with verification status, and action buttons.
 @MainActor
 struct ContactDetailView: View {
-    private static let allChannelTypes = ["telegram", "sms", "email", "whatsapp", "phone", "slack"]
+    private static let allChannelTypes = ["telegram", "email", "whatsapp", "phone", "slack"]
 
-    private static let verificationSupportedChannels: Set<String> = ["telegram", "sms", "phone", "slack"]
+    private static let verificationSupportedChannels: Set<String> = ["telegram", "phone", "slack"]
 
     /// Channels that support 6-digit code invites from this view. Voice invites
     /// require additional fields not available here, so they are excluded.
-    private static let codeInviteChannels: Set<String> = ["telegram", "sms", "email", "whatsapp", "slack"]
+    private static let codeInviteChannels: Set<String> = ["telegram", "email", "whatsapp", "slack"]
 
     let contact: ContactPayload
     var daemonClient: DaemonClient?
@@ -575,7 +575,7 @@ struct ContactDetailView: View {
                         }
                     }
                 } else if let channelHandle = result.channelHandle {
-                    // For channels without a share URL (email, WhatsApp, SMS),
+                    // For channels without a share URL (email, WhatsApp),
                     // show the assistant's channel handle so it can be copied.
                     HStack(spacing: VSpacing.sm) {
                         Text(channelHandle)
@@ -873,8 +873,6 @@ struct ContactDetailView: View {
             return .send
         case "phone":
             return .phoneCall
-        case "sms":
-            return .phoneCall
         case "email":
             return .mail
         case "whatsapp", "slack":
@@ -887,7 +885,6 @@ struct ContactDetailView: View {
     private func channelLabel(for type: String) -> String {
         switch type {
         case "telegram": return "Telegram"
-        case "sms": return "SMS"
         case "email": return "Email"
         case "whatsapp": return "WhatsApp"
         case "phone": return "Voice"
@@ -1175,15 +1172,6 @@ struct ContactDetailView: View {
                         policy: "allow"
                     ),
                     ContactChannelPayload(
-                        id: "ch-3",
-                        type: "sms",
-                        address: "+1555123456",
-                        isPrimary: false,
-                        status: "revoked",
-                        policy: "allow",
-                        revokedReason: "User requested"
-                    ),
-                    ContactChannelPayload(
                         id: "ch-4",
                         type: "slack",
                         address: "#general",
@@ -1230,14 +1218,6 @@ struct ContactDetailView: View {
                         policy: "allow",
                         verifiedAt: Int(Date().timeIntervalSince1970 * 1000) - 86_400_000,
                         verifiedVia: "telegram"
-                    ),
-                    ContactChannelPayload(
-                        id: "ch-g2",
-                        type: "sms",
-                        address: "+15551234567",
-                        isPrimary: false,
-                        status: "active",
-                        policy: "allow"
                     ),
                     ContactChannelPayload(
                         id: "ch-g3",

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -262,7 +262,7 @@ struct ContactsListView: View {
 
     // MARK: - Helpers
 
-    /// Summarizes channel types into a human-readable string (e.g. "Telegram, SMS, Voice").
+    /// Summarizes channel types into a human-readable string (e.g. "Telegram, Voice").
     private func channelSummary(_ channels: [ContactChannelPayload]) -> String {
         let types = Set(channels.map(\.type))
         return types.sorted().map { channelLabel(for: $0) }.joined(separator: ", ")
@@ -272,7 +272,6 @@ struct ContactsListView: View {
     private func channelIcon(for type: String) -> VIcon {
         switch type {
         case "telegram": return .send
-        case "sms": return .messageSquare
         case "phone": return .phoneCall
         case "email": return .mail
         case "slack": return .hash
@@ -284,7 +283,6 @@ struct ContactsListView: View {
     private func channelLabel(for type: String) -> String {
         switch type {
         case "telegram": return "Telegram"
-        case "sms": return "SMS"
         case "phone": return "Voice"
         case "email": return "Email"
         case "slack": return "Slack"
@@ -332,10 +330,6 @@ struct ContactsListView: View {
                         isPrimary: true, status: "verified", policy: "allow"
                     ),
                     ContactChannelPayload(
-                        id: "ch-2", type: "sms", address: "+15551234567",
-                        isPrimary: false, status: "verified", policy: "allow"
-                    ),
-                    ContactChannelPayload(
                         id: "ch-3", type: "phone", address: "+15551234567",
                         isPrimary: false, status: "verified", policy: "allow"
                     ),
@@ -364,7 +358,7 @@ struct ContactsListView: View {
                 interactionCount: 3,
                 channels: [
                     ContactChannelPayload(
-                        id: "ch-5", type: "sms", address: "+15559876543",
+                        id: "ch-5", type: "email", address: "bob@example.com",
                         isPrimary: true, status: "pending", policy: "ask"
                     ),
                 ]

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -94,7 +94,7 @@ func inferCategory(_ skill: SkillInfo) -> SkillCategory {
         || text.contains("chat") || text.contains("phone") || text.contains("phone call")
         || text.contains("voice call") || text.contains("video call")
         || text.contains("contact") || text.contains("notification") || text.contains("followup")
-        || text.contains("sms") || text.contains("slack") || text.contains("telegram") {
+        || text.contains("slack") || text.contains("telegram") {
         return .communication
     }
 


### PR DESCRIPTION
## Summary
- Remove SMS from allChannelTypes, verificationSupportedChannels, and codeInviteChannels
- Remove SMS icon mapping, label mapping, and invite type references
- Remove SMS from ConstellationView channel detection

Part of plan: remove-sms-channel.md (PR 4 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
