### PR TITLE
Remove SMS from runtime source logic and middleware

### DIFF
--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -124,7 +124,6 @@ export async function searchAvailableNumbers(
   areaCode?: string,
 ): Promise<AvailablePhoneNumber[]> {
   const params = new URLSearchParams({
-    SmsEnabled: "true",
     VoiceEnabled: "true",
   });
   if (areaCode) params.set("AreaCode", areaCode);

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -551,7 +551,7 @@ export function listPendingCanonicalGuardianRequestsByDestinationConversation(
  * This bridges inbound guardian replies (which arrive on a specific chat)
  * back to their canonical request records. Unlike the conversation-based
  * variant, this uses the chat-level addressing that channel transports
- * (Telegram, SMS) natively provide — critical for voice-originated
+ * (Telegram) natively provide — critical for voice-originated
  * `pending_question` requests that lack `guardianExternalUserId`.
  */
 export function listPendingCanonicalGuardianRequestsByDestinationChat(

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -250,7 +250,6 @@ export async function executeFollowupAction(
     actionResult = await executeCallBack(request, counterparty);
   } else {
     // decline is already handled in M5 — should not reach the executor.
-    // message_back (SMS) is no longer supported.
     finalizeFollowup(requestId, "failed");
     const errorText = await composeGuardianActionMessageGenerative(
       {

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -29,12 +29,11 @@ export const GATEWAY_SUBPATH_MAP: Record<string, string> = {
   voice: "voice-webhook",
   status: "status",
   "connect-action": "connect-action",
-  sms: "sms",
 };
 
 /**
  * Direct Twilio webhook subpaths that are blocked in gateway_only mode.
- * Includes all public-facing webhook paths (voice, status, connect-action, sms)
+ * Includes all public-facing webhook paths (voice, status, connect-action)
  * because the runtime must never serve as a direct ingress for external webhooks.
  * Internal forwarding endpoints (gateway->runtime) are unaffected.
  */
@@ -42,7 +41,6 @@ export const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set([
   "voice-webhook",
   "status",
   "connect-action",
-  "sms",
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Remove SMS from Twilio validation middleware gateway subpath map and blocked list
- Remove SMS case from invite instruction generator and guardian verification intent regex
- Remove SMS capability from all Twilio REST API interfaces
- Remove SMS references from rebind-secrets-screen, guardian-action-followup-executor, and canonical-guardian-store

Part of plan: remove-sms-channel.md (PR 9 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
