### PR TITLE
Remove SMS channel card and feature flag from macOS Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -9,19 +9,12 @@ import VellumAssistantShared
 struct SettingsChannelsTab: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
-    private static let smsFeatureFlagKey = "feature_flags.sms.enabled"
 
     @State private var showingPairingQR: Bool = false
-    @State private var isSmsFeatureEnabled: Bool = true
 
     // Telegram credential entry
     @State private var telegramBotTokenText = ""
     @State private var telegramSetupExpanded = false
-
-    // Twilio credential entry (SMS card)
-    @State private var twilioAccountSidText = ""
-    @State private var twilioAuthTokenText = ""
-    @State private var twilioSetupExpanded = false
 
     // Twilio credential entry (Voice card)
     @State private var voiceAccountSidText = ""
@@ -52,7 +45,6 @@ struct SettingsChannelsTab: View {
     /// that needs the 1-second countdown timer for expiry/resend cooldown display.
     private var hasAnyOutboundSession: Bool {
         store.telegramOutboundSessionId != nil ||
-        store.smsOutboundSessionId != nil ||
         store.voiceOutboundSessionId != nil ||
         store.slackOutboundSessionId != nil
     }
@@ -73,12 +65,6 @@ struct SettingsChannelsTab: View {
             if store.twilioHasCredentials {
                 store.refreshTwilioNumbers()
             }
-            Task {
-                await loadSmsFeatureFlag()
-                if isSmsFeatureEnabled {
-                    store.refreshChannelVerificationStatus(channel: "sms")
-                }
-            }
             if hasAnyOutboundSession {
                 startCountdownTimer()
             }
@@ -95,7 +81,6 @@ struct SettingsChannelsTab: View {
         }
         .onChange(of: store.twilioHasCredentials) { _, hasCredentials in
             if !hasCredentials {
-                twilioSetupExpanded = false
                 voiceSetupExpanded = false
             } else {
                 store.refreshTwilioNumbers()
@@ -117,9 +102,6 @@ struct SettingsChannelsTab: View {
             telegramCard
             slackChannelCard
             voiceCard
-            if isSmsFeatureEnabled {
-                twilioCard
-            }
             emailCard
         }
     }
@@ -493,81 +475,6 @@ struct SettingsChannelsTab: View {
         }
     }
 
-    // MARK: - SMS (Twilio) Channel Card
-
-    private var twilioCard: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("SMS")
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.textPrimary)
-                Text("Text your assistant using Twilio as the SMS provider")
-                    .font(VFont.sectionDescription)
-                    .foregroundColor(VColor.textMuted)
-            }
-
-            // Credentials row
-            if store.twilioHasCredentials {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
-                        store.clearTwilioCredentials()
-                    }
-                }
-            } else if twilioSetupExpanded {
-                twilioCredentialEntry
-            } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
-                    twilioSetupExpanded = true
-                }
-            }
-
-            // Phone number row (only when credentials exist)
-            if store.twilioHasCredentials {
-                Divider().background(VColor.surfaceBorder)
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text("Phone Number")
-                        .font(VFont.inputLabel)
-                        .foregroundColor(VColor.textSecondary)
-                    VDropdown(
-                        placeholder: "Not Set",
-                        selection: Binding(
-                            get: { store.twilioPhoneNumber ?? "" },
-                            set: { newValue in
-                                store.assignTwilioNumber(phoneNumber: newValue)
-                            }
-                        ),
-                        options: store.twilioNumbers.map { (label: $0.friendlyName, value: $0.phoneNumber) },
-                        emptyValue: ""
-                    )
-                    .frame(maxWidth: 360)
-                }
-            }
-
-            if let warning = store.twilioWarning {
-                Text(warning)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.warning)
-            }
-
-            if let error = store.twilioError {
-                Text(error)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.error)
-            }
-
-            // Verification row (only when credentials exist)
-            if store.twilioHasCredentials {
-                Divider().background(VColor.surfaceBorder)
-                channelVerificationView(channel: "sms")
-            }
-        }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
     // MARK: - Phone Calling Card
 
     private var voiceCard: some View {
@@ -642,59 +549,6 @@ struct SettingsChannelsTab: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Twilio Credential Entry
-
-    private var twilioCredentialEntry: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Account SID and Auth Token")
-                .font(VFont.inputLabel)
-                .foregroundColor(VColor.textSecondary)
-
-            TextField("Account SID", text: $twilioAccountSidText)
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-
-            SecureField("Auth Token", text: $twilioAuthTokenText)
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-
-            if store.twilioSaveInProgress {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Saving...")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-            } else {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(
-                        label: "Connect",
-                        style: .secondary,
-                        size: .medium,
-                        isDisabled: twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
-                            twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ) {
-                        store.saveTwilioCredentials(
-                            accountSid: twilioAccountSidText,
-                            authToken: twilioAuthTokenText
-                        )
-                        twilioAccountSidText = ""
-                        twilioAuthTokenText = ""
-                        twilioSetupExpanded = false
-                    }
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
-                        twilioSetupExpanded = false
-                        twilioAccountSidText = ""
-                        twilioAuthTokenText = ""
-                    }
-                }
-            }
-        }
     }
 
     // MARK: - Voice Credential Entry
@@ -913,33 +767,5 @@ struct SettingsChannelsTab: View {
         }
     }
 
-
-    // MARK: - Feature Flags
-
-    private func loadSmsFeatureFlag() async {
-        // Primary source: gateway feature-flags API.
-        if let daemonClient {
-            do {
-                let flags = try await daemonClient.getFeatureFlags()
-                if let smsFlag = flags.first(where: { $0.key == Self.smsFeatureFlagKey }) {
-                    isSmsFeatureEnabled = smsFlag.enabled
-                    return
-                }
-            } catch {
-                // Fall through to local config fallback.
-            }
-        }
-
-        // Fallback: local workspace config values.
-        let config = WorkspaceConfigIO.read()
-        if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool],
-           let enabled = canonicalFlags[Self.smsFeatureFlagKey] {
-            isSmsFeatureEnabled = enabled
-            return
-        }
-
-        // No legacy `skills.*` fallback in new production code. If canonical
-        // values are absent, keep the default enabled behavior.
-    }
 
 }


### PR DESCRIPTION
## Summary
- Remove the SMS channel card, Twilio SMS credential entry, and SMS feature flag from the macOS Settings Channels tab
- Remove all SMS-related state properties and the `loadSmsFeatureFlag()` function
- Other channels (Mobile, Telegram, Slack, Phone Calling, Email) remain unchanged

Part of plan: remove-sms-channel.md (PR 1 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
