### PR TITLE
Remove SMS from approval, grant, and dispatch test files

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -903,7 +903,7 @@ describe("routing and mode fields", () => {
   });
 
   test("routing hints round-trip through DB raw query", () => {
-    const hints = { target: "sms" };
+    const hints = { target: "telegram" };
     const job = createSchedule({
       name: "Raw round-trip",
       message: "check raw",

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -402,7 +402,7 @@ describe("isVerificationControlPlaneInvocation", () => {
     test("detects endpoint despite malformed percent-encoding elsewhere in command", () => {
       const result = isVerificationControlPlaneInvocation("bash", {
         command:
-          'curl -H "X: %ZZ" http://localhost:3000/v1/channel-verification-sessions -d \'{"channel":"sms"}\'',
+          'curl -H "X: %ZZ" http://localhost:3000/v1/channel-verification-sessions -d \'{"channel":"telegram"}\'',
       });
       expect(result).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Remove SMS from scoped approval grants, security matrix, channel approvals, guardian dispatch, verification intent routing, control plane policy, and schedule store tests

Part of plan: remove-sms-channel.md (PR 21 of 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
