### PR TITLE
fix: replace broken chrome-cdp import in doordash skill with CLI subprocess calls

### DIFF
--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -5,16 +5,48 @@
  * All commands output JSON to stdout. Use --json for machine-readable output.
  */
 
+import { execFile } from "node:child_process";
 import { statSync } from "node:fs";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { Command } from "commander";
 
-import {
-  ensureChromeWithCdp,
-  minimizeChromeWindow,
-  restoreChromeWindow,
-} from "../../../tools/browser/chrome-cdp.js";
+const execFileAsync = promisify(execFile);
+
+async function ensureChromeWithCdp(
+  opts?: { startUrl?: string; port?: number },
+): Promise<{ baseUrl: string; launchedByUs: boolean; userDataDir: string }> {
+  const args = ["browser", "chrome", "launch"];
+  if (opts?.startUrl) args.push("--start-url", opts.startUrl);
+  if (opts?.port) args.push("--port", String(opts.port));
+  const { stdout } = await execFileAsync("assistant", args);
+  const result = JSON.parse(stdout);
+  if (!result.ok) throw new Error(result.error ?? "Chrome launch failed");
+  return result;
+}
+
+async function minimizeChromeWindow(cdpBase?: string): Promise<void> {
+  const args = ["browser", "chrome", "minimize"];
+  if (cdpBase) {
+    const port = new URL(cdpBase).port;
+    if (port) args.push("--port", port);
+  }
+  const { stdout } = await execFileAsync("assistant", args);
+  const result = JSON.parse(stdout);
+  if (!result.ok) throw new Error(result.error ?? "Chrome minimize failed");
+}
+
+async function restoreChromeWindow(cdpBase?: string): Promise<void> {
+  const args = ["browser", "chrome", "restore"];
+  if (cdpBase) {
+    const port = new URL(cdpBase).port;
+    if (port) args.push("--port", port);
+  }
+  const { stdout } = await execFileAsync("assistant", args);
+  const result = JSON.parse(stdout);
+  if (!result.ok) throw new Error(result.error ?? "Chrome restore failed");
+}
 import {
   addToCart,
   getDropoffOptions,

--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -14,9 +14,10 @@ import { Command } from "commander";
 
 const execFileAsync = promisify(execFile);
 
-async function ensureChromeWithCdp(
-  opts?: { startUrl?: string; port?: number },
-): Promise<{ baseUrl: string; launchedByUs: boolean; userDataDir: string }> {
+async function ensureChromeWithCdp(opts?: {
+  startUrl?: string;
+  port?: number;
+}): Promise<{ baseUrl: string; launchedByUs: boolean; userDataDir: string }> {
   const args = ["browser", "chrome", "launch"];
   if (opts?.startUrl) args.push("--start-url", opts.startUrl);
   if (opts?.port) args.push("--port", String(opts.port));


### PR DESCRIPTION
## Summary
Fixes a broken import in the doordash skill that was left over from the move out of bundled-skills.

**Gap:** `skills/doordash/scripts/doordash-cli.ts` imported `ensureChromeWithCdp`, `minimizeChromeWindow`, and `restoreChromeWindow` from `../../../tools/browser/chrome-cdp.js` — a path that resolved at the old location but is broken at the new `skills/` location.

**Fix:** Replace the direct import with local helper functions that shell out to `assistant browser chrome launch/minimize/restore`, following the same portable pattern used by `skills/influencer/scripts/client.ts`. This makes the doordash skill fully self-contained per `skills/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
