### PR TITLE
fix: add package.json for doordash skill commander dependency

### DIFF
--- a/skills/doordash/package.json
+++ b/skills/doordash/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vellum-skills/doordash",
+  "private": true,
+  "dependencies": {
+    "commander": "^13.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for move-skills-to-toplevel.md.

**Gap:** Missing commander dependency after install
**What was expected:** The doordash skill should resolve its commander dependency when installed to ~/.vellum/workspace/skills/doordash/
**What was found:** No package.json exists, so bun install is never run and commander can't be resolved outside the dev repo

Adds a minimal package.json so the existing skill install process (which runs bun install when package.json is present) will install commander.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
