### PR TITLE
fix: Remove stale managed avatar reference from Swift client comment

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -290,7 +290,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
 
         // Provision an AssistantAPIKey for local assistants so they can
-        // call platform APIs (e.g. managed avatar generation).
+        // call platform APIs.
         ensureLocalAssistantApiKey()
 
         if isFirstLaunch {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-managed-avatar.md.

**Gap:** Stale comment in Swift client references managed avatar generation
**What was expected:** Comments should not reference deleted managed avatar generation
**What was found:** AppDelegate.swift comment references 'managed avatar generation' as example of platform API usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
