### PR TITLE
fix: Slack confirmations use DMs and ephemeral instead of public replies

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -314,21 +314,35 @@ export async function enforceIngressAcl(
               );
             }
 
+            // DM the requester so they have a private channel to reply with
+            // the verification code. Sending to the Slack user ID (not
+            // conversationExternalId) auto-opens a DM conversation.
             if (replyCallbackUrl) {
+              const senderUserId = (canonicalSenderId ?? rawSenderId)!;
+              // Strip threadTs from the callback URL — it belongs to the
+              // originating channel thread and would cause errors in the DM.
+              let dmCallbackUrl = replyCallbackUrl;
+              try {
+                const url = new URL(replyCallbackUrl);
+                url.searchParams.delete("threadTs");
+                dmCallbackUrl = url.toString();
+              } catch {
+                // Malformed URL — use as-is
+              }
               try {
                 await deliverChannelReply(
-                  replyCallbackUrl,
+                  dmCallbackUrl,
                   {
-                    chatId: conversationExternalId,
-                    text: "I've notified the owner. They'll share a verification code with you if they approve access.",
+                    chatId: senderUserId,
+                    text: "I've notified the owner. They'll share a verification code with you if they approve access. You can reply with the code here.",
                     assistantId,
                   },
                   mintBearerToken(),
                 );
               } catch (err) {
                 log.error(
-                  { err, conversationExternalId },
-                  "Failed to deliver Slack verification prompt reply",
+                  { err, senderUserId },
+                  "Failed to deliver Slack verification DM to requester",
                 );
               }
             }
@@ -371,14 +385,20 @@ export async function enforceIngressAcl(
           const replyText = guardianNotified
             ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
             : "Sorry, you haven't been approved to message this assistant.";
+          const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
+            chatId: conversationExternalId,
+            text: replyText,
+            assistantId,
+          };
+          // On Slack, send as ephemeral so only the requester sees the rejection
+          if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+            replyPayload.ephemeral = true;
+            replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+          }
           try {
             await deliverChannelReply(
               replyCallbackUrl,
-              {
-                chatId: conversationExternalId,
-                text: replyText,
-                assistantId,
-              },
+              replyPayload,
               mintBearerToken(),
             );
           } catch (err) {
@@ -543,21 +563,31 @@ export async function enforceIngressAcl(
                 );
               }
 
+              // DM the requester (same as non-member path)
               if (replyCallbackUrl) {
+                const senderUserId = (canonicalSenderId ?? rawSenderId)!;
+                let dmCallbackUrl = replyCallbackUrl;
+                try {
+                  const url = new URL(replyCallbackUrl);
+                  url.searchParams.delete("threadTs");
+                  dmCallbackUrl = url.toString();
+                } catch {
+                  // Malformed URL — use as-is
+                }
                 try {
                   await deliverChannelReply(
-                    replyCallbackUrl,
+                    dmCallbackUrl,
                     {
-                      chatId: conversationExternalId,
-                      text: "I've notified the owner. They'll share a verification code with you if they approve access.",
+                      chatId: senderUserId,
+                      text: "I've notified the owner. They'll share a verification code with you if they approve access. You can reply with the code here.",
                       assistantId,
                     },
                     mintBearerToken(),
                   );
                 } catch (err) {
                   log.error(
-                    { err, conversationExternalId },
-                    "Failed to deliver Slack verification prompt reply (inactive member)",
+                    { err, senderUserId },
+                    "Failed to deliver Slack verification DM to requester (inactive member)",
                   );
                 }
               }
@@ -605,14 +635,25 @@ export async function enforceIngressAcl(
             const replyText = guardianNotified
               ? "Hmm looks like you don't have access to talk to me. I'll let them know you tried talking to me and get back to you."
               : "Sorry, you haven't been approved to message this assistant.";
+            const inactiveReplyPayload: Parameters<
+              typeof deliverChannelReply
+            >[1] = {
+              chatId: conversationExternalId,
+              text: replyText,
+              assistantId,
+            };
+            // On Slack, send as ephemeral so only the requester sees the rejection
+            if (
+              sourceChannel === "slack" &&
+              (canonicalSenderId ?? rawSenderId)
+            ) {
+              inactiveReplyPayload.ephemeral = true;
+              inactiveReplyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+            }
             try {
               await deliverChannelReply(
                 replyCallbackUrl,
-                {
-                  chatId: conversationExternalId,
-                  text: replyText,
-                  assistantId,
-                },
+                inactiveReplyPayload,
                 mintBearerToken(),
               );
             } catch (err) {
@@ -640,14 +681,19 @@ export async function enforceIngressAcl(
           "Ingress ACL: member policy deny",
         );
         if (replyCallbackUrl) {
+          const denyPayload: Parameters<typeof deliverChannelReply>[1] = {
+            chatId: conversationExternalId,
+            text: "Sorry, you haven't been approved to message this assistant.",
+            assistantId,
+          };
+          if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+            denyPayload.ephemeral = true;
+            denyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+          }
           try {
             await deliverChannelReply(
               replyCallbackUrl,
-              {
-                chatId: conversationExternalId,
-                text: "Sorry, you haven't been approved to message this assistant.",
-                assistantId,
-              },
+              denyPayload,
               mintBearerToken(),
             );
           } catch (err) {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -149,14 +149,21 @@ export async function handleGuardianReplyIntercept(
   if (routerResult.consumed) {
     // Deliver reply text if the router produced one
     if (routerResult.replyText) {
+      const routerReplyPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: routerResult.replyText,
+        assistantId: canonicalAssistantId,
+      };
+      // On Slack, send guardian management replies (disambiguation, pending
+      // request lists, etc.) as ephemeral so only the guardian sees them.
+      if (sourceChannel === "slack" && rawSenderId) {
+        routerReplyPayload.ephemeral = true;
+        routerReplyPayload.user = rawSenderId;
+      }
       try {
         await deliverChannelReply(
           replyCallbackUrl,
-          {
-            chatId: conversationExternalId,
-            text: routerResult.replyText,
-            assistantId: canonicalAssistantId,
-          },
+          routerReplyPayload,
           mintBearerToken(),
         );
       } catch (err) {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -156,9 +156,9 @@ export async function handleGuardianReplyIntercept(
       };
       // On Slack, send guardian management replies (disambiguation, pending
       // request lists, etc.) as ephemeral so only the guardian sees them.
-      if (sourceChannel === "slack" && rawSenderId) {
+      if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
         routerReplyPayload.ephemeral = true;
-        routerReplyPayload.user = rawSenderId;
+        routerReplyPayload.user = (canonicalSenderId ?? rawSenderId)!;
       }
       try {
         await deliverChannelReply(


### PR DESCRIPTION
## Summary
- **Requester verification prompts** now DM the requester directly (using their Slack user ID) so they have a private channel to reply with the verification code, instead of posting publicly in the channel
- **ACL denial messages** ("you don't have access") use ephemeral delivery on Slack so only the denied user sees them
- **Guardian management replies** (disambiguation, pending request lists) use ephemeral delivery so only the guardian sees them in the channel
- **Slack delivery tracking** added to the canonical guardian store so the reply router discovers pending requests delivered to the guardian's Slack DM

## Context
Pax was posting confirmation messages ("I've notified the owner..."), pending request lists, and denial messages publicly in Slack channel threads. This leaked internal state and was disruptive — see screenshots in the linked issue.

## Test plan
- [ ] Non-member messages in a Slack channel → gets a DM from Pax (not a public reply)
- [ ] Guardian sees access request notification via their configured channels (including Slack DM if bound)
- [ ] Guardian disambiguation replies appear only to the guardian (ephemeral)
- [ ] Requester can reply to the DM with the verification code to complete access
- [ ] Non-Slack channels (Telegram, SMS) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
