### PR TITLE
fix: use bun inline dependency pinning for doordash commander import

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -3,6 +3,7 @@
 - **Skills must be self-contained and portable**
   - Use `scripts/` for supporting logic with inline dependencies
   - When including code assets, utilities, or tools, load the [scripts best practices specification](https://agentskills.io/skill-creation/using-scripts.md) first
+  - **External dependencies in Bun/TypeScript scripts**: pin versions directly in the import path (e.g., `import { Command } from "commander@13.1.0"`). Bun auto-installs missing packages at runtime when no `node_modules` directory is found. Do NOT add a `package.json` or `bun.lock` to skill directories — this disables Bun's auto-install behavior and breaks portability.
   - Do not install CLIs into Vellum or the host system; provide instructions for users to install external packages if needed
   - Do not create new assistant tools and reference them from SKILL.md — this couples skills to Vellum internals and breaks compatibility with other agent systems
   - Do not include a TOOLS.json file in skill directories — skills should rely on CLI tools in `scripts/`, not custom tool definitions

--- a/skills/doordash/package.json
+++ b/skills/doordash/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@vellum-skills/doordash",
-  "private": true,
-  "dependencies": {
-    "commander": "^13.1.0"
-  }
-}

--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -10,7 +10,7 @@ import { statSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
-import { Command } from "commander";
+import { Command } from "commander@13.1.0";
 
 const execFileAsync = promisify(execFile);
 

--- a/skills/doordash/scripts/doordash-entry.ts
+++ b/skills/doordash/scripts/doordash-entry.ts
@@ -10,7 +10,7 @@
  * and use it as the root so `doordash status` works directly.
  */
 
-import { Command } from "commander";
+import { Command } from "commander@13.1.0";
 
 import { registerDoordashCommand } from "./doordash-cli.js";
 


### PR DESCRIPTION
## Summary
- Replace `import { Command } from "commander"` with `import { Command } from "commander@13.1.0"` in doordash skill scripts, using Bun's auto-install feature
- Remove `skills/doordash/package.json` — no longer needed since Bun resolves pinned imports at runtime
- Update `skills/AGENTS.md` with guidance on how to handle external dependencies in Bun/TypeScript skill scripts

Per the [Agent Skills spec](https://agentskills.io/skill-creation/using-scripts#bunx), Bun auto-installs missing packages when no `node_modules` directory is found. Pinning versions in the import path keeps skills self-contained without needing a package.json or bun.lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
