### PR TITLE
Settings UI follow-up: review fixes, shortcut consolidation, toggle colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -841,13 +841,13 @@ struct SettingsPanelEnvVarsSheet: View {
 }
 
 /// Sets the enclosing NSScrollView to overlay style — thin scroller, no track background.
-private struct OverlayScrollerStyle: NSViewRepresentable {
+struct OverlayScrollerStyle: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async {
             guard let scrollView = view.enclosingScrollView else { return }
             scrollView.scrollerStyle = .overlay
-            scrollView.scrollerKnobStyle = .dark
+            scrollView.scrollerKnobStyle = .default
             scrollView.hasHorizontalScroller = false
         }
         return view

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -353,6 +353,15 @@ struct SettingsAppearanceTab: View {
         let utcOffset: String
     }
 
+    /// Stable timezone metadata (city, region, offset label) — computed once.
+    private struct TimezoneMetadata {
+        let identifier: String
+        let city: String
+        let region: String
+        let utcOffset: String
+        let tz: TimeZone
+    }
+
     private var selectedCityPlaceholder: String {
         guard !selectedTimezone.isEmpty,
               let tz = TimeZone(identifier: selectedTimezone) else {
@@ -369,13 +378,9 @@ struct SettingsAppearanceTab: View {
         return tz.localizedName(for: .standard, locale: .current) ?? selectedTimezone
     }
 
-    /// Pre-computed timezone entries (DateFormatter is expensive to create per-item).
-    private static let allTimezoneEntries: [TimezoneEntry] = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h:mm a"
-        let now = Date()
-
-        return knownTimezones.compactMap { id -> TimezoneEntry? in
+    /// Stable metadata cached once; time-sensitive fields computed on access.
+    private static let timezoneMetadata: [TimezoneMetadata] = {
+        knownTimezones.compactMap { id -> TimezoneMetadata? in
             guard let tz = TimeZone(identifier: id) else { return nil }
             let parts = id.components(separatedBy: "/")
             let city = (parts.last ?? id).replacingOccurrences(of: "_", with: " ")
@@ -388,27 +393,35 @@ struct SettingsAppearanceTab: View {
                 ? String(format: "GMT%+d:%02d", hours, minutes)
                 : String(format: "GMT%+d", hours)
 
-            formatter.timeZone = tz
-            let timeStr = formatter.string(from: now)
-
-            let label = "\(offsetStr) — \(city)"
-            return TimezoneEntry(
-                identifier: id, city: city, region: region,
-                displayLabel: label, currentTime: timeStr, utcOffset: offsetStr
-            )
+            return TimezoneMetadata(identifier: id, city: city, region: region, utcOffset: offsetStr, tz: tz)
         }
         .sorted { $0.identifier < $1.identifier }
     }()
 
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+
     private var filteredTimezones: [TimezoneEntry] {
         let query = timezoneSearchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return Self.allTimezoneEntries }
-
-        return Self.allTimezoneEntries.filter {
+        let source = query.isEmpty ? Self.timezoneMetadata : Self.timezoneMetadata.filter {
             $0.city.lowercased().contains(query)
             || $0.region.lowercased().contains(query)
             || $0.utcOffset.lowercased().contains(query)
             || $0.identifier.lowercased().contains(query)
+        }
+        let now = Date()
+        let formatter = Self.timeFormatter
+        return source.map { meta in
+            formatter.timeZone = meta.tz
+            return TimezoneEntry(
+                identifier: meta.identifier, city: meta.city, region: meta.region,
+                displayLabel: "\(meta.utcOffset) — \(meta.city)",
+                currentTime: formatter.string(from: now),
+                utcOffset: meta.utcOffset
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -125,8 +125,10 @@ struct SettingsAppearanceTab: View {
                                     }
                                 }
                             }
-                            .scrollIndicators(.hidden)
                             .frame(maxHeight: 200)
+                            .background {
+                                OverlayScrollerStyle()
+                            }
                             .background(VColor.inputBackground)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                             .overlay(
@@ -181,9 +183,9 @@ struct SettingsAppearanceTab: View {
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
                     if isRecordingGlobalHotkey, let display = recordingDisplayString, !display.isEmpty {
-                        shortcutKeyPill(display)
+                        VShortcutTag(display)
                     } else {
-                        shortcutKeyPill(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
+                        VShortcutTag(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
                     }
 
                     if isRecordingGlobalHotkey {
@@ -221,9 +223,9 @@ struct SettingsAppearanceTab: View {
                         .foregroundColor(VColor.textSecondary)
                     Spacer()
                     if isRecordingQuickInputHotkey, let display = recordingDisplayString, !display.isEmpty {
-                        shortcutKeyPill(display)
+                        VShortcutTag(display)
                     } else {
-                        shortcutKeyPill(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
+                        VShortcutTag(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
                     }
 
                     if isRecordingQuickInputHotkey {
@@ -367,8 +369,13 @@ struct SettingsAppearanceTab: View {
         return tz.localizedName(for: .standard, locale: .current) ?? selectedTimezone
     }
 
-    private var filteredTimezones: [TimezoneEntry] {
-        let entries = Self.knownTimezones.compactMap { id -> TimezoneEntry? in
+    /// Pre-computed timezone entries (DateFormatter is expensive to create per-item).
+    private static let allTimezoneEntries: [TimezoneEntry] = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        let now = Date()
+
+        return knownTimezones.compactMap { id -> TimezoneEntry? in
             guard let tz = TimeZone(identifier: id) else { return nil }
             let parts = id.components(separatedBy: "/")
             let city = (parts.last ?? id).replacingOccurrences(of: "_", with: " ")
@@ -381,10 +388,8 @@ struct SettingsAppearanceTab: View {
                 ? String(format: "GMT%+d:%02d", hours, minutes)
                 : String(format: "GMT%+d", hours)
 
-            let formatter = DateFormatter()
             formatter.timeZone = tz
-            formatter.dateFormat = "h:mm a"
-            let timeStr = formatter.string(from: Date())
+            let timeStr = formatter.string(from: now)
 
             let label = "\(offsetStr) — \(city)"
             return TimezoneEntry(
@@ -393,11 +398,13 @@ struct SettingsAppearanceTab: View {
             )
         }
         .sorted { $0.identifier < $1.identifier }
+    }()
 
+    private var filteredTimezones: [TimezoneEntry] {
         let query = timezoneSearchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return entries }
+        guard !query.isEmpty else { return Self.allTimezoneEntries }
 
-        return entries.filter {
+        return Self.allTimezoneEntries.filter {
             $0.city.lowercased().contains(query)
             || $0.region.lowercased().contains(query)
             || $0.utcOffset.lowercased().contains(query)
@@ -475,26 +482,6 @@ struct SettingsAppearanceTab: View {
         }
     }
 
-    // MARK: - Pill helper
-
-    @ViewBuilder
-    private func shortcutKeyPill(_ text: String) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            ForEach(text.components(separatedBy: " "), id: \.self) { token in
-                Text(token)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        }
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.xs)
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-    }
 }
 
 /// A read-only row displaying a keyboard shortcut and its description.
@@ -508,21 +495,7 @@ private struct ShortcutRow: View {
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
             Spacer()
-            HStack(spacing: VSpacing.sm) {
-                ForEach(shortcut.components(separatedBy: " "), id: \.self) { token in
-                    Text(token)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textSecondary)
-                }
-            }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.xs)
-            .background(VColor.surfaceSubtle)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.xl)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-            )
+            VShortcutTag(shortcut)
         }
         .padding(.vertical, VSpacing.md)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -18,6 +18,7 @@ struct SettingsGeneralTab: View {
         }
         .onAppear {
             Task { await authManager.checkSession() }
+            store.refreshApprovedDevices()
         }
         .sheet(isPresented: $showingPairingQR) {
             PairingQRCodeSheet(

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -26,7 +26,7 @@ public struct VToggle: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     if let label {
                         Text(label)
-                            .font(VFont.bodyBold)
+                            .font(VFont.bodyMedium)
                             .foregroundColor(isEnabled ? VColor.textPrimary : VColor.textMuted)
                     }
                     if let helperText {

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -219,11 +219,11 @@ public enum VColor {
     public static let ghostPressed = adaptiveColor(light: Stone._200, dark: Moss._600)
     public static let divider = adaptiveColor(light: Stone._300, dark: Moss._600)
     public static let hoverOverlay = adaptiveColor(light: Color(hex: 0x000000), dark: Moss._200)
-    public static let toggleOn = adaptiveColor(light: Color(hex: 0x2A3825), dark: Color(hex: 0x2A3825))
-    public static let toggleOff = adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Color(hex: 0xE8E6DA))
+    public static let toggleOn = adaptiveColor(light: Color(hex: 0x2A3825), dark: Forest._600)
+    public static let toggleOff = adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700)
     public static let toggleBorder = adaptiveColor(light: Stone._400, dark: Moss._600)
     public static let toggleKnob = adaptiveColor(light: Stone._50, dark: Color.white)
-    public static let toggleKnobDisabled = adaptiveColor(light: Color(hex: 0xBDB9A9), dark: Color(hex: 0xBDB9A9))
+    public static let toggleKnobDisabled = adaptiveColor(light: Color(hex: 0xBDB9A9), dark: Moss._500)
 
     // Slash command highlight — green tint for /command tokens in composer and chat
     public static let slashCommand = adaptiveColor(light: Forest._500, dark: Forest._300)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -250,8 +250,8 @@ public enum VColor {
     public static let buttonDangerPressed = Color(hex: 0xE0745A)
 
     // Tag & shortcut
-    public static let tagText = Moss._400
-    public static let tagBorder = Moss._100
+    public static let tagText = adaptiveColor(light: Moss._500, dark: Moss._400)
+    public static let tagBorder = adaptiveColor(light: Stone._300, dark: Moss._100)
 
     // Unread indicator
     public static let unreadIndicator = Danger._600


### PR DESCRIPTION
## Summary
- **Review fixes from #15366**: Add missing `refreshApprovedDevices()` in SettingsGeneralTab, fix hardcoded `.dark` scroller knob style to `.default`, cache timezone entries to avoid creating ~400 DateFormatters per keystroke
- **Shortcut consolidation**: Replace duplicate `shortcutKeyPill()` and `ShortcutRow` pill rendering with `VShortcutTag` design system component
- **Toggle polish**: Update label font to `bodyMedium`, fix dark mode colors (lighter active green, proper off-track and disabled knob contrast)

## Test plan
- [ ] Verify toggle colors look correct in both light and dark mode
- [ ] Verify keyboard shortcuts in settings use consistent VShortcutTag styling
- [ ] Verify approved devices list populates on General tab without visiting Channels first
- [ ] Verify settings scrollbar is visible in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
