### PR TITLE
Allow assistant/vellum CLI via bash without permission prompt

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -139,8 +139,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
-  "assistant",
-  "vellum",
 ]);
 
 // High-risk shell programs / patterns
@@ -172,6 +170,15 @@ const HIGH_RISK_PROGRAMS = new Set([
   "kill",
   "killall",
   "pkill",
+]);
+
+// Read-only subcommands for the assistant/vellum CLIs
+const LOW_RISK_CLI_SUBCOMMANDS = new Set([
+  "ps",
+  "doctor",
+  "audit",
+  "completions",
+  "map",
 ]);
 
 // Git subcommands that are low-risk (read-only)
@@ -642,6 +649,16 @@ async function classifyRiskUncached(
           continue;
         }
         // Non-read-only git commands are medium
+        maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      if (prog === "vellum" || prog === "assistant") {
+        const subcommand = seg.args[0];
+        if (subcommand && LOW_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
+          continue;
+        }
+        // Mutating CLI subcommands are medium
         maxRisk = RiskLevel.Medium;
         continue;
       }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -139,6 +139,8 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
+  "assistant",
+  "vellum",
 ]);
 
 // High-risk shell programs / patterns

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -139,6 +139,7 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
+  "assistant",
 ]);
 
 // High-risk shell programs / patterns
@@ -170,15 +171,6 @@ const HIGH_RISK_PROGRAMS = new Set([
   "kill",
   "killall",
   "pkill",
-]);
-
-// Read-only subcommands for the assistant/vellum CLIs
-const LOW_RISK_CLI_SUBCOMMANDS = new Set([
-  "ps",
-  "doctor",
-  "audit",
-  "completions",
-  "map",
 ]);
 
 // Git subcommands that are low-risk (read-only)
@@ -649,16 +641,6 @@ async function classifyRiskUncached(
           continue;
         }
         // Non-read-only git commands are medium
-        maxRisk = RiskLevel.Medium;
-        continue;
-      }
-
-      if (prog === "vellum" || prog === "assistant") {
-        const subcommand = seg.args[0];
-        if (subcommand && LOW_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
-          continue;
-        }
-        // Mutating CLI subcommands are medium
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
## Summary
- Added `assistant` and `vellum` to the `LOW_RISK_PROGRAMS` set in the permission checker
- This allows the assistant to call its own CLI via the `bash` tool without prompting the user for permission (previously classified as medium risk)

## Original prompt
please fix permissions such that the assistant should be able to call the `assistant` CLI using `bash` (not host_bash) without asking the user for permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
