### PR TITLE
fix: use else-if to prevent starter task intent from overwriting verification intent

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -407,17 +407,19 @@ export async function drainQueue(
     // Deterministic [STARTER_TASK:<task_id>] messages load the
     // onboarding-starter-tasks skill instead of relying on the
     // playbook being embedded in the global system prompt.
-    const starterIntent = resolveStarterTaskIntent(resolvedContent);
-    if (starterIntent.kind === "starter_task") {
-      log.info(
-        {
-          conversationId: session.conversationId,
-          taskId: starterIntent.taskId,
-        },
-        "Starter task intent intercepted in queue — forcing skill flow",
-      );
-      agentLoopContent = starterIntent.rewrittenContent;
-      session.preactivatedSkillIds = ["onboarding-starter-tasks"];
+    else {
+      const starterIntent = resolveStarterTaskIntent(resolvedContent);
+      if (starterIntent.kind === "starter_task") {
+        log.info(
+          {
+            conversationId: session.conversationId,
+            taskId: starterIntent.taskId,
+          },
+          "Starter task intent intercepted in queue — forcing skill flow",
+        );
+        agentLoopContent = starterIntent.rewrittenContent;
+        session.preactivatedSkillIds = ["onboarding-starter-tasks"];
+      }
     }
   }
 
@@ -749,17 +751,19 @@ export async function processMessage(
     // Starter task intent interception — deterministic [STARTER_TASK:<task_id>]
     // messages load the onboarding-starter-tasks skill instead of relying on
     // the playbook being embedded in the global system prompt.
-    const starterIntent = resolveStarterTaskIntent(resolvedContent);
-    if (starterIntent.kind === "starter_task") {
-      log.info(
-        {
-          conversationId: session.conversationId,
-          taskId: starterIntent.taskId,
-        },
-        "Starter task intent intercepted — forcing skill flow",
-      );
-      agentLoopContent = starterIntent.rewrittenContent;
-      session.preactivatedSkillIds = ["onboarding-starter-tasks"];
+    else {
+      const starterIntent = resolveStarterTaskIntent(resolvedContent);
+      if (starterIntent.kind === "starter_task") {
+        log.info(
+          {
+            conversationId: session.conversationId,
+            taskId: starterIntent.taskId,
+          },
+          "Starter task intent intercepted — forcing skill flow",
+        );
+        agentLoopContent = starterIntent.rewrittenContent;
+        session.preactivatedSkillIds = ["onboarding-starter-tasks"];
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cut-system-prompt.md.

**Gap:** Starter task intent and verification intent can silently overwrite each other
**What was expected:** Only one intent resolver should match per message
**What was found:** Both resolvers ran unconditionally as sequential if blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
