### PR TITLE
fix: remove Export Logs menu from app and dock menus

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -19,9 +19,6 @@ struct VellumAssistantApp: App {
                 }
                 .disabled(!appDelegate.updateManager.canCheckForUpdates)
                 Divider()
-                Button("Export Logs...") {
-                    appDelegate.exportAssistantLogs()
-                }
                 Button("Send Logs to Vellum") {
                     appDelegate.sendLogsToSentry()
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -320,11 +320,6 @@ extension AppDelegate {
         menu.addItem(galleryItem)
         #endif
 
-        let exportLogsItem = NSMenuItem(title: "Export Logs...", action: #selector(exportAssistantLogs), keyEquivalent: "")
-        exportLogsItem.target = self
-        exportLogsItem.image = VIcon.fileArchive.nsImage
-        menu.addItem(exportLogsItem)
-
         let sendLogsItem = NSMenuItem(title: "Send Logs to Vellum", action: #selector(sendLogsToSentry), keyEquivalent: "")
         sendLogsItem.target = self
         sendLogsItem.image = VIcon.upload.nsImage
@@ -519,10 +514,6 @@ extension AppDelegate {
                 }
             }
         }
-    }
-
-    @objc public func exportAssistantLogs() {
-        LogExporter.exportLogs()
     }
 
     @objc public func sendLogsToSentry() {


### PR DESCRIPTION
## Summary
- Removes the "Export Logs..." menu item from the macOS app menu (SwiftUI `CommandGroup`) and the dock/status-bar menu (AppKit `NSMenu`).
- Removes the now-unused `exportAssistantLogs()` method from `AppDelegate+MenuBar`.
- "Send Logs to Vellum" remains available in both menus.

## Test plan
- [ ] Verify "Export Logs..." no longer appears in the app menu (under the app name)
- [ ] Verify "Export Logs..." no longer appears in the dock/status-bar right-click menu
- [ ] Verify "Send Logs to Vellum" still works in both menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
