### PR TITLE
fix: remove dead LogExporter.exportLogs() method

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -25,32 +25,6 @@ private let log = Logger(
 @MainActor
 enum LogExporter {
 
-    /// Presents an NSSavePanel and writes the tar.gz archive to the chosen location.
-    static func exportLogs() {
-        let panel = NSSavePanel()
-        panel.title = "Export Assistant Logs"
-        panel.nameFieldStringValue = defaultArchiveName()
-        panel.allowedContentTypes = [.gzip]
-        panel.canCreateDirectories = true
-
-        guard panel.runModal() == .OK, let destURL = panel.url else { return }
-
-        Task {
-            do {
-                try await buildArchive(destination: destURL)
-                log.info("Logs exported to \(destURL.path)")
-                NSWorkspace.shared.activateFileViewerSelecting([destURL])
-            } catch {
-                log.error("Log export failed: \(error.localizedDescription)")
-                let alert = NSAlert()
-                alert.messageText = "Export Failed"
-                alert.informativeText = error.localizedDescription
-                alert.alertStyle = .warning
-                alert.runModal()
-            }
-        }
-    }
-
     /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.
     static func sendLogsToSentry() {
         Task {


### PR DESCRIPTION
## Summary
- Removes the now-unused `exportLogs()` method from `LogExporter` (follow-up to #15384 which removed all callers).
- Addresses review feedback from Devin on #15384.

## Test plan
- [ ] Build succeeds — no callers of `exportLogs()` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
