### PR TITLE
fix: remove unused UniformTypeIdentifiers import from LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -2,7 +2,6 @@ import AppKit
 import Foundation
 import os
 @preconcurrency import Sentry
-import UniformTypeIdentifiers
 import VellumAssistantShared
 
 private let log = Logger(


### PR DESCRIPTION
## Summary
- Removes the unused `import UniformTypeIdentifiers` from `LogExporter.swift`, which was only needed for the `.gzip` content type in the removed `exportLogs()` method.
- Addresses review feedback from Devin on #15386.

## Test plan
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
