### PR TITLE
fix: resolve history deserialization crash from missing attachment data

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2798,30 +2798,51 @@ public final class HTTPTransport {
             // (string) and `timestamp` (ISO 8601 string), but HistoryResponseMessage
             // expects `text` and `timestamp` as a Double (ms since epoch). Transform
             // the response to match the expected message format.
+            //
+            // The HTTP API also omits the `data` field from attachments when content
+            // was not requested (returning only metadata like `sizeBytes`), but
+            // UserMessageAttachment.data is non-optional. We backfill missing fields
+            // to avoid decode failures.
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let messages = json["messages"] as? [[String: Any]] {
 
                     let isoFormatter = ISO8601DateFormatter()
                     isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                    let fallbackFormatter = ISO8601DateFormatter()
 
-                    let transformed: [[String: Any]] = messages.map { msg in
+                    let transformed: [[String: Any]] = messages.compactMap { msg in
                         var m = msg
-                        // Rename `content` → `text`
-                        if let content = m.removeValue(forKey: "content") {
+                        // Rename `content` → `text`, defaulting to empty string if absent/null.
+                        let content = m.removeValue(forKey: "content")
+                        if let content, !(content is NSNull) {
                             m["text"] = content
+                        } else {
+                            m["text"] = ""
                         }
                         // Convert ISO 8601 timestamp string → Double (ms since epoch)
                         if let tsString = m["timestamp"] as? String {
                             if let date = isoFormatter.date(from: tsString) {
                                 m["timestamp"] = date.timeIntervalSince1970 * 1000.0
+                            } else if let date = fallbackFormatter.date(from: tsString) {
+                                m["timestamp"] = date.timeIntervalSince1970 * 1000.0
                             } else {
-                                // Fallback: try without fractional seconds
-                                let fallback = ISO8601DateFormatter()
-                                if let date = fallback.date(from: tsString) {
-                                    m["timestamp"] = date.timeIntervalSince1970 * 1000.0
+                                log.warning("Unparseable timestamp in history message, using epoch: \(tsString, privacy: .public)")
+                                m["timestamp"] = 0.0
+                            }
+                        } else if m["timestamp"] == nil || m["timestamp"] is NSNull {
+                            m["timestamp"] = 0.0
+                        }
+                        // Normalize attachments: the HTTP API omits `data` for large
+                        // attachments (returns sizeBytes instead), but
+                        // UserMessageAttachment.data is non-optional String.
+                        if var attachments = m["attachments"] as? [[String: Any]] {
+                            for i in attachments.indices {
+                                if attachments[i]["data"] == nil || attachments[i]["data"] is NSNull {
+                                    attachments[i]["data"] = ""
                                 }
                             }
+                            m["attachments"] = attachments
                         }
                         return m
                     }
@@ -2838,7 +2859,7 @@ public final class HTTPTransport {
                     onMessage?(historyResponse)
                 }
             } catch {
-                log.error("Failed to deserialize history response: \(error)")
+                log.error("Failed to deserialize history response for session \(sessionId, privacy: .public): \(String(describing: error), privacy: .public)")
             }
         } catch {
             log.error("Fetch history error: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary

Fixes a bug where **message history fails to load on macOS** — threads appear in the sidebar but the chat content area shows a permanent skeleton loading state. The daemon is running and returns messages successfully via HTTP, but the client-side deserialization step crashes silently.

## Root Cause

The `fetchHistory()` method in `HTTPDaemonClient.swift` fetches messages from the daemon's `/v1/messages` HTTP endpoint, transforms the response to match the `HistoryResponseMessage` Codable struct, and decodes it. The decode fails because:

**The HTTP API omits the `data` field from attachments** when returning metadata-only responses (it provides `sizeBytes` instead of the full base64 content). However, `UserMessageAttachment.data` is declared as `let data: String` — a **non-optional** field. When `data` is missing from the JSON, `JSONDecoder` throws:

```
Failed to deserialize history response: Error Domain=NSCocoaErrorDomain Code=4865
```

This affects any conversation containing image attachments (screenshots, uploaded images, etc.), which is common in normal usage. The error is logged but the message is privacy-redacted by Apple's logging framework, making it difficult to diagnose without code inspection.

### How it was diagnosed

1. `log stream` showed repeated "Failed to deserialize history response" errors with Code 4865 (type mismatch)
2. Comparing the daemon's HTTP API response structure against the `UserMessageAttachment` Codable struct revealed that messages with image attachments (e.g., `vex-avatar.png`) return `{id, filename, mimeType, sizeBytes, kind}` — no `data` field
3. `UserMessageAttachment.data: String` is non-optional, causing the entire history decode to fail when any single message has a data-less attachment

## Changes

**File: `clients/shared/Network/HTTPDaemonClient.swift`** — `fetchHistory()` method

1. **Backfill missing attachment `data`**: Normalize attachments by inserting an empty string for missing/null `data` fields before JSON decoding, satisfying the non-optional `UserMessageAttachment.data` contract
2. **Null-safe `content` → `text` mapping**: Default to empty string when `content` is null or absent (previously would propagate NSNull, failing the non-optional `text: String` decode)
3. **Timestamp decode safety**: Fall back to epoch (0.0) when ISO 8601 parsing fails for both formatter variants, instead of leaving the original string in the dict (which would fail the `timestamp: Double` decode)
4. **Hoist fallback formatter**: Move the fallback `ISO8601DateFormatter()` allocation outside the per-message map closure to avoid creating a new instance per message
5. **Non-redacted error logging**: Use `privacy: .public` format specifiers so decode failures are diagnosable in `log stream` without needing a debug build

## Why this is safe

- **Non-breaking**: Only changes internal deserialization logic in the HTTP transport layer. No IPC protocol changes, no API changes, no changes to any public types or interfaces.
- **Additive normalization only**: The fix backfills default values for missing fields (empty string for `data`, empty string for `text`, 0.0 for `timestamp`). These are the same defaults that would be used if the fields were declared optional in the generated struct.
- **No behavioral change for well-formed messages**: Messages that already have all fields present pass through the transformation unchanged — the new code only activates when fields are missing/null.
- **Shared code, cross-platform**: `HTTPDaemonClient.swift` is in `clients/shared/`, used by both macOS and iOS. The fix benefits both platforms.

## Test plan

- [ ] Rebuild macOS app from this branch, launch, and verify message history loads (no more skeleton state)
- [ ] Check `log stream` for absence of "Failed to deserialize history response" errors
- [ ] Verify conversations with image attachments load correctly
- [ ] Verify conversations without attachments still load correctly
- [ ] Verify new conversations (send a message) work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
