### PR TITLE
M1: Create schema transformer + schema walker utility

### DIFF
--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ToolDefinition } from "../providers/types.js";
+import {
+  injectReasonField,
+  REASON_SKIP_SET,
+  schemaDefinesProperty,
+} from "../tools/schema-transforms.js";
+
+function makeDef(
+  name: string,
+  schema: object = { type: "object", properties: {}, required: [] },
+): ToolDefinition {
+  return { name, description: `Tool ${name}`, input_schema: schema };
+}
+
+describe("REASON_SKIP_SET", () => {
+  test("contains expected tool names", () => {
+    expect(REASON_SKIP_SET.has("skill_execute")).toBe(true);
+    expect(REASON_SKIP_SET.has("bash")).toBe(true);
+    expect(REASON_SKIP_SET.has("host_bash")).toBe(true);
+    expect(REASON_SKIP_SET.has("request_system_permission")).toBe(true);
+    expect(REASON_SKIP_SET.size).toBe(4);
+  });
+});
+
+describe("injectReasonField", () => {
+  test("injects reason on a tool without it", () => {
+    const defs = [makeDef("my_tool")];
+    const result = injectReasonField(defs);
+    const schema = result[0].input_schema as Record<string, unknown>;
+    const props = schema.properties as Record<string, unknown>;
+    expect(props.reason).toEqual({ type: "string" });
+  });
+
+  test("adds reason to required array", () => {
+    const defs = [
+      makeDef("my_tool", {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: ["foo"],
+      }),
+    ];
+    const result = injectReasonField(defs);
+    const schema = result[0].input_schema as Record<string, unknown>;
+    expect(schema.required).toEqual(["foo", "reason"]);
+  });
+
+  test("creates required array if missing", () => {
+    const defs = [
+      makeDef("my_tool", {
+        type: "object",
+        properties: { foo: { type: "string" } },
+      }),
+    ];
+    const result = injectReasonField(defs);
+    const schema = result[0].input_schema as Record<string, unknown>;
+    expect(schema.required).toEqual(["reason"]);
+  });
+
+  test("skips tools in skip set (returns unchanged)", () => {
+    const defs = [makeDef("bash"), makeDef("host_bash")];
+    const result = injectReasonField(defs);
+    // Should be the exact same object references
+    expect(Object.is(result[0], defs[0])).toBe(true);
+    expect(Object.is(result[1], defs[1])).toBe(true);
+    // No reason injected
+    const schema0 = result[0].input_schema as Record<string, unknown>;
+    const props0 = schema0.properties as Record<string, unknown>;
+    expect("reason" in props0).toBe(false);
+  });
+
+  test("skips tools that already have reason in properties", () => {
+    const defs = [
+      makeDef("my_tool", {
+        type: "object",
+        properties: { reason: { type: "number" } },
+        required: [],
+      }),
+    ];
+    const result = injectReasonField(defs);
+    // Should be the exact same object reference (no clone needed)
+    expect(Object.is(result[0], defs[0])).toBe(true);
+    const schema = result[0].input_schema as Record<string, unknown>;
+    const props = schema.properties as Record<string, unknown>;
+    // Original reason type preserved
+    expect(props.reason).toEqual({ type: "number" });
+  });
+
+  test("does NOT mutate original definition objects", () => {
+    const originalProps = { foo: { type: "string" } };
+    const originalRequired = ["foo"];
+    const originalSchema = {
+      type: "object",
+      properties: originalProps,
+      required: originalRequired,
+    };
+    const defs = [makeDef("my_tool", originalSchema)];
+
+    const result = injectReasonField(defs);
+
+    // Original properties object is untouched
+    expect("reason" in originalProps).toBe(false);
+    // Original required array is untouched
+    expect(originalRequired).toEqual(["foo"]);
+    // Original schema properties ref is the same object
+    expect(Object.is(originalSchema.properties, originalProps)).toBe(true);
+
+    // Result has different object refs
+    const resultSchema = result[0].input_schema as Record<string, unknown>;
+    expect(Object.is(resultSchema, originalSchema)).toBe(false);
+    expect(Object.is(resultSchema.properties, originalProps)).toBe(false);
+    expect(Object.is(resultSchema.required, originalRequired)).toBe(false);
+  });
+
+  test("passes through non-object schemas unchanged", () => {
+    const defs = [makeDef("my_tool", { type: "string" })];
+    const result = injectReasonField(defs);
+    expect(Object.is(result[0], defs[0])).toBe(true);
+  });
+
+  test("passes through schemas without properties unchanged", () => {
+    const defs = [makeDef("my_tool", { type: "object" })];
+    const result = injectReasonField(defs);
+    expect(Object.is(result[0], defs[0])).toBe(true);
+  });
+
+  test("handles empty definitions array", () => {
+    const result = injectReasonField([]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("schemaDefinesProperty", () => {
+  test("returns true for direct properties match", () => {
+    const schema = {
+      type: "object",
+      properties: { reason: { type: "string" } },
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+  });
+
+  test("returns true for property in allOf member", () => {
+    const schema = {
+      allOf: [{ properties: { reason: { type: "string" } } }],
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+  });
+
+  test("returns true for property in oneOf member", () => {
+    const schema = {
+      oneOf: [
+        { properties: { foo: { type: "string" } } },
+        { properties: { reason: { type: "string" } } },
+      ],
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+  });
+
+  test("returns true for property in anyOf member", () => {
+    const schema = {
+      anyOf: [{ properties: { reason: { type: "string" } } }],
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+  });
+
+  test("returns true for nested allOf within oneOf", () => {
+    const schema = {
+      oneOf: [
+        {
+          allOf: [{ properties: { reason: { type: "string" } } }],
+        },
+      ],
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(true);
+  });
+
+  test("returns false when property not defined", () => {
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "string" } },
+    };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(false);
+  });
+
+  test("returns false for $ref (fail-closed)", () => {
+    const schema = { $ref: "#/definitions/Foo" };
+    expect(schemaDefinesProperty(schema, "reason")).toBe(false);
+  });
+
+  test("returns false for null schema", () => {
+    expect(schemaDefinesProperty(null, "reason")).toBe(false);
+  });
+
+  test("returns false for undefined schema", () => {
+    expect(schemaDefinesProperty(undefined, "reason")).toBe(false);
+  });
+
+  test("returns false for non-object schema", () => {
+    expect(schemaDefinesProperty("not-an-object", "reason")).toBe(false);
+    expect(schemaDefinesProperty(42, "reason")).toBe(false);
+    expect(schemaDefinesProperty(true, "reason")).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/schema-transforms.test.ts
+++ b/assistant/src/__tests__/schema-transforms.test.ts
@@ -125,6 +125,28 @@ describe("injectReasonField", () => {
     expect(Object.is(result[0], defs[0])).toBe(true);
   });
 
+  test("skips tools with reason defined inside allOf member (composite schema)", () => {
+    const defs = [
+      makeDef("my_tool", {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        allOf: [
+          {
+            properties: { reason: { type: "string" } },
+          },
+        ],
+        required: [],
+      }),
+    ];
+    const result = injectReasonField(defs);
+    // Should be the exact same object reference (no injection)
+    expect(Object.is(result[0], defs[0])).toBe(true);
+    const schema = result[0].input_schema as Record<string, unknown>;
+    const props = schema.properties as Record<string, unknown>;
+    // Top-level properties should NOT have reason injected
+    expect("reason" in props).toBe(false);
+  });
+
   test("handles empty definitions array", () => {
     const result = injectReasonField([]);
     expect(result).toEqual([]);

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -33,7 +33,7 @@ export function injectReasonField(
     }
 
     const properties = schema.properties as Record<string, unknown>;
-    if ("reason" in properties) {
+    if (schemaDefinesProperty(schema, "reason")) {
       return def;
     }
 

--- a/assistant/src/tools/schema-transforms.ts
+++ b/assistant/src/tools/schema-transforms.ts
@@ -1,0 +1,99 @@
+import type { ToolDefinition } from "../providers/types.js";
+
+/**
+ * Tools that should never have a `reason` field injected into their schema.
+ */
+export const REASON_SKIP_SET = new Set<string>([
+  "skill_execute",
+  "bash",
+  "host_bash",
+  "request_system_permission",
+]);
+
+/**
+ * Injects a `reason` string property into each tool definition's input schema,
+ * unless the tool is in the skip set, already has a reason field, or has a
+ * non-object schema.
+ *
+ * CRITICAL: Never mutates the input definitions — always returns deep clones
+ * for any modified definition, since `getDefinition()` returns shared refs.
+ */
+export function injectReasonField(
+  definitions: ToolDefinition[],
+  skip: Set<string> = REASON_SKIP_SET,
+): ToolDefinition[] {
+  return definitions.map((def) => {
+    if (skip.has(def.name)) {
+      return def;
+    }
+
+    const schema = def.input_schema as Record<string, unknown>;
+    if (schema.type !== "object" || !schema.properties) {
+      return def;
+    }
+
+    const properties = schema.properties as Record<string, unknown>;
+    if ("reason" in properties) {
+      return def;
+    }
+
+    // Deep clone to avoid mutating shared refs
+    const newProperties = { ...properties, reason: { type: "string" } };
+    const existingRequired = Array.isArray(schema.required)
+      ? [...schema.required, "reason"]
+      : ["reason"];
+
+    return {
+      ...def,
+      input_schema: {
+        ...schema,
+        properties: newProperties,
+        required: existingRequired,
+      },
+    };
+  });
+}
+
+/**
+ * Checks whether a JSON Schema defines a given property name.
+ * Walks `allOf`, `oneOf`, `anyOf` recursively.
+ * Fail-closed on `$ref`: returns false if a `$ref` is encountered.
+ */
+export function schemaDefinesProperty(
+  schema: unknown,
+  propertyName: string,
+): boolean {
+  if (schema == null || typeof schema !== "object") {
+    return false;
+  }
+
+  const s = schema as Record<string, unknown>;
+
+  // Fail-closed on $ref — we can't resolve it, so treat as "doesn't define it"
+  if ("$ref" in s) {
+    return false;
+  }
+
+  // Check direct properties
+  if (
+    s.properties &&
+    typeof s.properties === "object" &&
+    propertyName in (s.properties as Record<string, unknown>)
+  ) {
+    return true;
+  }
+
+  // Walk composite keywords
+  for (const keyword of ["allOf", "oneOf", "anyOf"] as const) {
+    const arr = s[keyword];
+    if (Array.isArray(arr)) {
+      for (const member of arr) {
+        if (schemaDefinesProperty(member, propertyName)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- New module `assistant/src/tools/schema-transforms.ts` with `injectReasonField()` transformer, `schemaDefinesProperty()` walker, and `REASON_SKIP_SET`
- Comprehensive test coverage in `assistant/src/__tests__/schema-transforms.test.ts` (20 tests)
- `injectReasonField()` deep-clones definitions to avoid mutating shared refs from registry

## Test plan
- [x] All 20 tests pass (`bun test --filter schema-transforms`)
- [x] Lint and type-check pass

Part of #15399. Closes #15400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
