### PR TITLE
fix: register 'export' actor endpoint policy

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -403,6 +403,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "schedules/cancel", scopes: ["settings.write"] },
 
   // Diagnostics
+  { endpoint: "export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/env-vars", scopes: ["settings.read"] },
 

--- a/playwright/agent-xcode/.build
+++ b/playwright/agent-xcode/.build
@@ -1,0 +1,1 @@
+/Users/maddieabboud/projects/vellum-assistant/playwright/agent-xcode/.build

--- a/playwright/agent-xcode/.build
+++ b/playwright/agent-xcode/.build
@@ -1,1 +1,0 @@
-/Users/maddieabboud/projects/vellum-assistant/playwright/agent-xcode/.build


### PR DESCRIPTION
## Motivation
The `export` endpoint was missing from the actor endpoint policy table, causing actor principals (assistants, svc_gateway, svc_daemon, local) to be denied at the route-policy layer when accessing `GET /export`.

## Changes
- Add `{ endpoint: "export", scopes: ["settings.read"] }` to `ACTOR_ENDPOINTS` in `assistant/src/runtime/auth/route-policy.ts`

## Testing
No new tests needed — this is a single-entry addition to the existing policy table. Route policy unit tests cover the registration loop.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
