### PR TITLE
M2: Apply transformer at session + CU + settings paths

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -23,6 +23,10 @@ import type {
 import { allComputerUseTools } from "../tools/computer-use/definitions.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { getTool, registerSkillTools } from "../tools/registry.js";
+import {
+  injectReasonField,
+  REASON_SKIP_SET,
+} from "../tools/schema-transforms.js";
 import type { Tool, ToolExecutionResult } from "../tools/types.js";
 import { allUiSurfaceTools } from "../tools/ui-surface/definitions.js";
 import { getLogger } from "../util/logger.js";
@@ -581,6 +585,8 @@ export class ComputerUseSession {
       },
     };
 
+    const toolDefsWithReason = injectReasonField(toolDefs, REASON_SKIP_SET);
+
     const cuConfig = getConfig();
     const agentLoop = new AgentLoop(
       compactingProvider,
@@ -590,7 +596,7 @@ export class ComputerUseSession {
         maxInputTokens: cuConfig.contextWindow.maxInputTokens,
         toolChoice: { type: "any" },
       },
-      toolDefs,
+      toolDefsWithReason,
       toolExecutor,
     );
 

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -31,6 +31,10 @@ import {
   getAllToolDefinitions,
   getMcpToolDefinitions,
 } from "../tools/registry.js";
+import {
+  injectReasonField,
+  REASON_SKIP_SET,
+} from "../tools/schema-transforms.js";
 import type {
   ProxyApprovalCallback,
   ProxyApprovalRequest,
@@ -663,6 +667,6 @@ export function createResolveToolsCallback(
       turnAllowed.add(name);
     }
     ctx.allowedToolNames = turnAllowed;
-    return allBaseDefs;
+    return injectReasonField(allBaseDefs, REASON_SKIP_SET);
   };
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -31,6 +31,10 @@ import {
   resolveExecutionTarget,
 } from "../../tools/execution-target.js";
 import { getAllTools, getTool } from "../../tools/registry.js";
+import {
+  injectReasonField,
+  REASON_SKIP_SET,
+} from "../../tools/schema-transforms.js";
 import { isSideEffectTool } from "../../tools/side-effects.js";
 import { setAvatarTool } from "../../tools/system/avatar-generator.js";
 import { pathExists } from "../../util/fs.js";
@@ -309,23 +313,34 @@ function resolveManifestOverride(
 function handleToolNamesList(): Response {
   const tools = getAllTools();
   const nameSet = new Set(tools.map((t) => t.name));
-  const schemas: Record<
-    string,
-    {
-      type: string;
-      properties?: Record<string, unknown>;
-      required?: string[];
-    }
-  > = {};
+  type SchemaShape = {
+    type: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  const schemas: Record<string, SchemaShape> = {};
+
+  // Collect raw definitions from the registry so we can transform them.
+  const rawDefs: import("../../providers/types.js").ToolDefinition[] = [];
   for (const tool of tools) {
     try {
-      const def = tool.getDefinition();
-      schemas[tool.name] = def.input_schema as (typeof schemas)[string];
+      rawDefs.push(tool.getDefinition());
     } catch {
       // Skip tools whose definitions can't be resolved
     }
   }
 
+  // Apply reason injection so settings/debug schemas match runtime behavior.
+  const transformedDefs = injectReasonField(rawDefs, REASON_SKIP_SET);
+  for (const def of transformedDefs) {
+    schemas[def.name] = def.input_schema as SchemaShape;
+  }
+
+  // Skill manifest schemas are served raw (untransformed). Unlike runtime tool
+  // schemas which have `reason` injected via injectReasonField(), skill manifests
+  // reflect the original TOOLS.json content. This is intentional: skill tools are
+  // invoked through skill_execute (which has its own reason field), so their
+  // individual schemas are never sent to the LLM directly.
   try {
     const catalog = loadSkillCatalog();
     for (const skill of catalog) {
@@ -337,8 +352,7 @@ function handleToolNamesList(): Response {
         for (const entry of manifest.tools) {
           if (nameSet.has(entry.name)) continue;
           nameSet.add(entry.name);
-          schemas[entry.name] =
-            entry.input_schema as unknown as (typeof schemas)[string];
+          schemas[entry.name] = entry.input_schema as unknown as SchemaShape;
         }
       } catch {
         // Skip skills whose manifests can't be parsed


### PR DESCRIPTION
## Summary
- Wire up `injectReasonField` at three integration points: main session `resolveTools` callback, computer-use session tool defs, and settings endpoint tool schemas
- Skill manifest schemas are intentionally left untransformed (they go through `skill_execute` which has its own reason field)

## Test plan
- [ ] Verify main session tools have `reason` field injected at runtime
- [ ] Verify CU session tools have `reason` field injected
- [ ] Verify `GET /tools` endpoint returns schemas with `reason` field for registry tools
- [ ] Verify skill manifest schemas served without `reason` injection

Part of #15399. Closes #15401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
