### PR TITLE
M3: MCP stripping + permission cache key exclusion

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -48,7 +48,11 @@ function riskCacheKey(
   workingDir?: string,
   manifestOverride?: ManifestOverride,
 ): string {
-  const inputJson = JSON.stringify(input);
+  // Strip `reason` before computing the cache key — it is cosmetic and varies
+  // per invocation even for identical tool operations, causing unnecessary
+  // cache misses.
+  const { reason: _reason, ...cacheableInput } = input;
+  const inputJson = JSON.stringify(cacheableInput);
   const hash = createHash("sha256")
     .update(inputJson)
     .update("\0")

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -2,6 +2,7 @@ import type { McpServerConfig } from "../../config/schemas/mcp.js";
 import type { McpServerManager } from "../../mcp/manager.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { schemaDefinesProperty } from "../schema-transforms.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
 const riskMap: Record<string, RiskLevel> = {
@@ -36,6 +37,10 @@ export function createMcpTool(
 ): Tool {
   const namespacedName = mcpToolName(serverId, metadata.name);
   const riskLevel = riskMap[serverConfig.defaultRiskLevel] ?? RiskLevel.High;
+  const serverDefinesReason = schemaDefinesProperty(
+    metadata.inputSchema,
+    "reason",
+  );
 
   return {
     name: namespacedName,
@@ -59,7 +64,19 @@ export function createMcpTool(
       _context: ToolContext,
     ): Promise<ToolExecutionResult> {
       try {
-        const result = await manager.callTool(serverId, metadata.name, input);
+        // Strip injected reason before sending to MCP server
+        const { reason: _reason, ...mcpInput } = input as Record<
+          string,
+          unknown
+        > & {
+          reason?: unknown;
+        };
+        const forwardInput = serverDefinesReason ? input : mcpInput;
+        const result = await manager.callTool(
+          serverId,
+          metadata.name,
+          forwardInput,
+        );
         return {
           content: result.content,
           isError: result.isError,


### PR DESCRIPTION
## Summary
- Strip injected `reason` from MCP tool input before forwarding to servers that don't define it in their schema (computed per-tool at creation time via `schemaDefinesProperty`).
- Exclude `reason` from permission risk cache keys to prevent unnecessary cache misses from cosmetic variation.

## Test plan
- [ ] Verify MCP tools that define `reason` in their schema still receive it
- [ ] Verify MCP tools that don't define `reason` do not receive it in forwarded input
- [ ] Verify permission cache hits are not affected by varying `reason` values

Part of #15399. Closes #15402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
