### PR TITLE
refactor: remove per-message avatar overlay from ChatBubble

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -19,7 +19,6 @@ struct ChatBubble: View {
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
     var resolveHttpPort: (() -> Int?) = { nil }
-    var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
@@ -27,7 +26,6 @@ struct ChatBubble: View {
     var isProcessingAfterTools: Bool = false
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
-    @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
     /// Stores async-parsed segments for large messages (>2000 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
@@ -158,9 +156,6 @@ struct ChatBubble: View {
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }
 
-            // Content group with absolutely-positioned avatar so text alignment
-            // stays consistent whether or not the avatar is visible.
-            // Assistant messages reserve left space (28pt avatar + 8pt gap) for the overlay avatar.
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
                     if !isUser && hasInterleavedContent {
                         interleavedContent
@@ -216,21 +211,6 @@ struct ChatBubble: View {
                 // Uses compositingGroup instead of drawingGroup to preserve text selection.
                 // Skipped during streaming to avoid re-compositing on every token delta.
                 .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming))
-                .overlay(alignment: .topLeading) {
-                    if !isUser && showAvatar {
-                        Image(nsImage: appearance.chatAvatarImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 28, height: 28)
-                            .clipShape(Circle())
-                            .overlay(
-                                Circle()
-                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                            )
-                            .offset(x: -(28 + VSpacing.sm), y: 0)
-                    }
-                }
-                .padding(.leading, isUser ? 0 : 28 + VSpacing.sm)
 
             if !isUser { Spacer(minLength: 0) }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1038,7 +1038,6 @@ private struct MessageCellView: View {
                 onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
                 mediaEmbedSettings: mediaEmbedSettings,
                 resolveHttpPort: resolveHttpPort,
-                showAvatar: !previousIsAssistant,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,


### PR DESCRIPTION
## Summary
- Remove the `showAvatar` property and per-message avatar overlay from ChatBubble
- Remove the 36pt left padding that reserved space for the avatar
- Remove unused `appearance` state property (dead code after avatar removal)
- Update MessageListView call site to remove `showAvatar:` parameter

Part of plan: floating-chat-avatar.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
