### PR TITLE
refactor: remove inline avatar from thinking indicator rows and fix assistant-side alignment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -301,22 +301,12 @@ struct MessageListView: View {
 
     @ViewBuilder
     private func thinkingIndicatorRow(displayMessages: [ChatMessage]) -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(nsImage: appearance.chatAvatarImage)
-                .interpolation(.none)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 28, height: 28)
-                .clipShape(Circle())
-                .padding(.top, 2)
-
-            RunningIndicator(
-                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
-                    ? "Waking up..."
-                    : assistantStatusText ?? "Thinking",
-                showIcon: false
-            )
-        }
+        RunningIndicator(
+            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                ? "Waking up..."
+                : assistantStatusText ?? "Thinking",
+            showIcon: false
+        )
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
         .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -456,7 +446,6 @@ struct MessageListView: View {
                             onTap: { onSubagentTap?(subagent.id) }
                         )
                             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
-                            .padding(.leading, 36)
                             .id("subagent-\(subagent.id)")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
@@ -945,22 +934,12 @@ private struct MessageCellView: View {
 
     @ViewBuilder
     private func thinkingIndicatorRow() -> some View {
-        HStack(alignment: .top, spacing: VSpacing.sm) {
-            Image(nsImage: appearance.chatAvatarImage)
-                .interpolation(.none)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 28, height: 28)
-                .clipShape(Circle())
-                .padding(.top, 2)
-
-            RunningIndicator(
-                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
-                    ? "Waking up..."
-                    : assistantStatusText ?? "Thinking",
-                showIcon: false
-            )
-        }
+        RunningIndicator(
+            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                ? "Waking up..."
+                : assistantStatusText ?? "Thinking",
+            showIcon: false
+        )
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
     }
@@ -1055,7 +1034,6 @@ private struct MessageCellView: View {
                 onTap: { onSubagentTap?(subagent.id) }
             )
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
-                .padding(.leading, 36)
                 .id("subagent-\(subagent.id)")
         }
 


### PR DESCRIPTION
## Summary
- Remove the 28x28 avatar circle from both thinking indicator rows
- Simplify HStack wrappers that are no longer needed
- Remove hardcoded .padding(.leading, 36) from subagent rows to align with assistant messages

Part of plan: floating-chat-avatar.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
