### PR TITLE
refactor: remove inline avatar from ChatLoadingSkeleton

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -5,8 +5,6 @@ import VellumAssistantShared
 /// Mimics the real `ChatBubble` layout — a short user message followed by a
 /// multi-line assistant response — so the transition to real content feels seamless.
 struct ChatLoadingSkeleton: View {
-    @State private var appearance = AvatarAppearanceManager.shared
-
     /// Line widths for the multi-line assistant text block.
     /// Varying lengths look more natural than uniform bones.
     private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
@@ -50,7 +48,7 @@ struct ChatLoadingSkeleton: View {
 
     // MARK: - Assistant Message
 
-    /// Left-aligned assistant block with real avatar and six text lines inside
+    /// Left-aligned assistant block with six text lines inside
     /// a subtle bubble, matching real ChatBubble assistant layout.
     private var assistantMessage: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -64,19 +62,6 @@ struct ChatLoadingSkeleton: View {
                 }
             }
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
-            .overlay(alignment: .topLeading) {
-                Image(nsImage: appearance.chatAvatarImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 28, height: 28)
-                    .clipShape(Circle())
-                    .overlay(
-                        Circle()
-                            .strokeBorder(VColor.textMuted.opacity(0.2), lineWidth: 1)
-                    )
-                    .offset(x: -(28 + VSpacing.sm), y: 0)
-            }
-            .padding(.leading, 28 + VSpacing.sm)
 
             Spacer(minLength: 0)
         }


### PR DESCRIPTION
## Summary
- Remove the 28x28 avatar circle from the chat loading skeleton
- Simplify the skeleton layout to show only animated placeholder bars

Part of plan: floating-chat-avatar.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
