### PR TITLE
M4: Skill execute reason propagation

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -339,10 +339,22 @@ export function createToolExecutor(
     // with the real tool name.
     if (name === "skill_execute") {
       const toolName = typeof input.tool === "string" ? input.tool : "";
-      const toolInput =
+      const rawToolInput =
         input.input != null && typeof input.input === "object"
           ? (input.input as Record<string, unknown>)
           : {};
+
+      // Clone to avoid mutating shared input objects
+      const toolInput = { ...rawToolInput };
+
+      // Propagate outer reason when inner input lacks a valid one
+      if (
+        typeof input.reason === "string" &&
+        input.reason &&
+        (typeof toolInput.reason !== "string" || toolInput.reason.length === 0)
+      ) {
+        toolInput.reason = input.reason;
+      }
 
       if (!toolName) {
         return {


### PR DESCRIPTION
## Summary
- Propagate outer `skill_execute` reason to inner tool input when the inner input lacks a valid reason
- Clone input object to avoid shared-object mutation
- Ensures permission prompts for underlying tools have reason context

## Test plan
- [ ] Verify skill_execute with outer reason and no inner reason propagates correctly
- [ ] Verify skill_execute with existing inner reason preserves it
- [ ] Verify input cloning prevents mutation of shared objects

Part of #15399. Closes #15403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
