### PR TITLE
feat: add floating avatar anchored at bottom of chat message list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -312,6 +312,23 @@ struct MessageListView: View {
         .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 
+    @ViewBuilder
+    private var assistantAvatarFooter: some View {
+        HStack {
+            Image(nsImage: appearance.chatAvatarImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 28, height: 28)
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                )
+            Spacer()
+        }
+        .padding(.top, VSpacing.xs)
+    }
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -452,6 +469,18 @@ struct MessageListView: View {
 
                     if shouldShowThinkingIndicator && anchoredThinkingIndex == nil {
                         thinkingIndicatorRow(displayMessages: displayMessages)
+                    }
+
+                    // Floating avatar — anchored at bottom of conversation, Claude-style.
+                    // Shown when the assistant has spoken or is actively thinking,
+                    // but not on user-only threads before the assistant has replied.
+                    // Uses displayMessages (the filtered/visible set) not raw messages,
+                    // since subagent notifications and other hidden items are excluded
+                    // from the rendered list.
+                    if displayMessages.contains(where: { $0.role == .assistant }) || shouldShowThinkingIndicator {
+                        assistantAvatarFooter
+                            .id("avatar-footer")
+                            .transition(.opacity)
                     }
 
                     Color.clear.frame(height: 1)


### PR DESCRIPTION
## Summary
- Add a single 28x28 circular avatar below the last message in the chat (Claude-style)
- Avatar is left-aligned, scrolls with content, and appears only when the assistant has spoken or is thinking
- Uses displayMessages for visibility check to stay consistent with rendered content

Part of plan: floating-chat-avatar.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
