### PR TITLE
feat: add subtle breathing animation to floating chat avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -100,6 +100,8 @@ struct MessageListView: View {
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
+    @State private var avatarBreathing = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Read once at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared ObservableObject.
     @State private var scrollDebounceTask: Task<Void, Never>?
@@ -324,6 +326,29 @@ struct MessageListView: View {
                     Circle()
                         .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
                 )
+                .scaleEffect(reduceMotion ? 1.0 : (avatarBreathing ? 1.0 : 0.92))
+                .opacity(reduceMotion ? 1.0 : (avatarBreathing ? 1.0 : 0.85))
+                .animation(
+                    reduceMotion
+                        ? nil
+                        : Animation.easeInOut(duration: 2.5).repeatForever(autoreverses: true),
+                    value: avatarBreathing
+                )
+                .onAppear {
+                    if !reduceMotion {
+                        avatarBreathing = true
+                    }
+                }
+                .onDisappear {
+                    avatarBreathing = false
+                }
+                .onChange(of: reduceMotion) { newValue in
+                    if newValue {
+                        avatarBreathing = false
+                    } else {
+                        avatarBreathing = true
+                    }
+                }
             Spacer()
         }
         .padding(.top, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -342,7 +342,7 @@ struct MessageListView: View {
                 .onDisappear {
                     avatarBreathing = false
                 }
-                .onChange(of: reduceMotion) { newValue in
+                .onChange(of: reduceMotion) { _, newValue in
                     if newValue {
                         avatarBreathing = false
                     } else {


### PR DESCRIPTION
## Summary
- Add a gentle breathing animation (scale 0.92↔1.0 over 2.5s) to the floating chat avatar
- Add subtle opacity oscillation (0.85↔1.0) to complement the scale animation
- Gate all animations on accessibilityReduceMotion — fully disabled when Reduce Motion is enabled
- Handle runtime toggles of Reduce Motion setting via onChange handler

Part of plan: floating-chat-avatar.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
