### PR TITLE
M5: Remove reason from ~26 tool schemas + update tests

### DIFF
--- a/assistant/src/config/bundled-skills/claude-code/TOOLS.json
+++ b/assistant/src/config/bundled-skills/claude-code/TOOLS.json
@@ -37,10 +37,6 @@
             "type": "string",
             "enum": ["general", "researcher", "coder", "reviewer"],
             "description": "Worker profile that scopes tool access. Defaults to general (backward compatible)."
-          },
-          "reason": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are delegating and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         }
       },

--- a/assistant/src/tools/apps/definitions.ts
+++ b/assistant/src/tools/apps/definitions.ts
@@ -51,11 +51,6 @@ const appOpenTool: Tool = {
             description:
               "Display mode. 'preview' shows an inline preview card in chat. 'workspace' opens the full app in a workspace panel. Defaults to 'workspace'.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["app_id"],
       },

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -95,11 +95,6 @@ const definition: ToolDefinition = {
         description:
           "Path where the file should be written, relative to (or inside) the sandbox working directory.",
       },
-      reason: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are saving and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-      },
     },
     required: ["attachment_id", "destination_path"],
   },

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -298,11 +298,6 @@ const definition: ToolDefinition = {
         type: "number",
         description: `Maximum results to return (default ${DEFAULT_LIMIT}, max ${MAX_RESULTS}).`,
       },
-      reason: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are searching for and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-      },
     },
     required: [],
   },

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -44,11 +44,6 @@ class BrowserNavigateTool implements Tool {
             description:
               "If true, allows navigation to localhost/private-network hosts. Disabled by default for SSRF safety.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["url"],
       },
@@ -80,13 +75,7 @@ class BrowserSnapshotTool implements Tool {
       description: this.description,
       input_schema: {
         type: "object",
-        properties: {
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are inspecting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
-        },
+        properties: {},
       },
     };
   }
@@ -121,11 +110,6 @@ class BrowserScreenshotTool implements Tool {
             type: "boolean",
             description:
               "Capture the full scrollable page instead of just the viewport.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are capturing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
       },
@@ -162,11 +146,6 @@ class BrowserCloseTool implements Tool {
             type: "boolean",
             description:
               "If true, close all browser pages and the browser context. Default: false (close only the current session page).",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
       },
@@ -213,11 +192,6 @@ class BrowserClickTool implements Tool {
             type: "number",
             description:
               "Max time in ms to wait for the element to be clickable (default: 10000).",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are clicking and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
       },
@@ -273,11 +247,6 @@ class BrowserTypeTool implements Tool {
             type: "boolean",
             description: "If true, press Enter after typing the text.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are typing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["text"],
       },
@@ -322,11 +291,6 @@ class BrowserPressKeyTool implements Tool {
           selector: {
             type: "string",
             description: "Optional CSS selector to target.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
         required: ["key"],
@@ -377,11 +341,6 @@ class BrowserScrollTool implements Tool {
           selector: {
             type: "string",
             description: "Optional CSS selector of element to scroll within.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are scrolling to see and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
         required: ["direction"],
@@ -437,11 +396,6 @@ class BrowserSelectOptionTool implements Tool {
             type: "number",
             description: "The zero-based index of the <option> to select.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are selecting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
       },
     };
@@ -482,11 +436,6 @@ class BrowserHoverTool implements Tool {
             type: "string",
             description:
               "A CSS selector to target. Used as fallback when element_id is not available.",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are hovering over and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
       },
@@ -537,11 +486,6 @@ class BrowserWaitForTool implements Tool {
             description:
               "Maximum wait time in milliseconds (default and max: 30000).",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are waiting for and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
       },
     };
@@ -577,11 +521,6 @@ class BrowserExtractTool implements Tool {
             type: "boolean",
             description:
               "If true, include a list of links found on the page (up to 200).",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are extracting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
       },
@@ -633,11 +572,6 @@ class BrowserFillCredentialTool implements Tool {
           press_enter: {
             type: "boolean",
             description: "Press Enter after filling",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are filling in and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
         required: ["service", "field"],

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -123,11 +123,6 @@ export const claudeCodeTool: Tool = {
             description:
               "Worker profile that scopes tool access. Defaults to general (backward compatible).",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are delegating and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
       },
     };

--- a/assistant/src/tools/computer-use/request-computer-control.ts
+++ b/assistant/src/tools/computer-use/request-computer-control.ts
@@ -42,11 +42,6 @@ export const requestComputerControlTool: Tool = {
             description:
               "Concise description of what computer use should accomplish",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["task"],
       },

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -206,11 +206,6 @@ class CredentialStoreTool implements Tool {
             description:
               "Templates describing how to inject this credential into proxied requests (for store and prompt actions)",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["action"],
       },

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -38,13 +38,8 @@ class FileEditTool implements Tool {
             description:
               "Replace all occurrences of old_string instead of requiring a unique match (default: false)",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of why this file is being edited, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
-        required: ["path", "old_string", "new_string", "reason"],
+        required: ["path", "old_string", "new_string"],
       },
     };
   }

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -38,11 +38,6 @@ class FileReadTool implements Tool {
             type: "number",
             description: "Maximum number of lines to read",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are reading and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["path"],
       },

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -28,13 +28,8 @@ class FileWriteTool implements Tool {
             type: "string",
             description: "The content to write to the file",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of why this file is being written, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
-        required: ["path", "content", "reason"],
+        required: ["path", "content"],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -35,13 +35,8 @@ class HostFileEditTool implements Tool {
             description:
               "Replace all occurrences instead of requiring a unique match (default: false)",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of why this file is being edited, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
-        required: ["path", "old_string", "new_string", "reason"],
+        required: ["path", "old_string", "new_string"],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -29,13 +29,8 @@ class HostFileReadTool implements Tool {
             type: "number",
             description: "Maximum number of lines to read",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of why this file is being read, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
-        required: ["path", "reason"],
+        required: ["path"],
       },
     };
   }

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -27,13 +27,8 @@ class HostFileWriteTool implements Tool {
             type: "string",
             description: "The content to write to the file",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of why this file is being written, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
-        required: ["path", "content", "reason"],
+        required: ["path", "content"],
       },
     };
   }

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -62,11 +62,6 @@ const memoryManageProperties = {
     type: "string" as const,
     description: "Short subject/topic label, 2-8 words (optional, save only)",
   },
-  reason: {
-    type: "string" as const,
-    description:
-      "Brief non-technical explanation shown to the user as a status update",
-  },
 };
 
 export const memoryManageDefinition: ToolDefinition = {

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -863,11 +863,6 @@ class WebFetchTool implements Tool {
             description:
               "If true, allows requests to localhost/private-network hosts. Disabled by default for SSRF safety.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are fetching and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["url"],
       },

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -302,11 +302,6 @@ class WebSearchTool implements Tool {
             description:
               'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Only used with Brave provider.',
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are searching for and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["query"],
       },

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -119,11 +119,6 @@ export class SkillLoadTool implements Tool {
             type: "string",
             description: "The skill id or skill name to load.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are loading and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["skill"],
       },

--- a/assistant/src/tools/swarm/delegate.ts
+++ b/assistant/src/tools/swarm/delegate.ts
@@ -44,11 +44,6 @@ export const swarmDelegateTool: Tool = {
             description:
               "Maximum concurrent workers (1-6, default from config)",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are doing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["objective"],
       },

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -40,11 +40,6 @@ export const setAvatarTool: Tool = {
               "A text description of the desired avatar appearance, " +
               'e.g. "a friendly purple cat with green eyes wearing a tiny hat".',
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["description"],
       },

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -126,11 +126,6 @@ export const uiShowTool: Tool = {
             description:
               "Whether to block until the user interacts with an action. Defaults to true when actions are provided.",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are showing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["surface_type", "data"],
       },
@@ -168,11 +163,6 @@ export const uiUpdateTool: Tool = {
             type: "object",
             description: "Partial data to merge into the existing surface data",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are updating and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["surface_id", "data"],
       },
@@ -203,11 +193,6 @@ export const uiDismissTool: Tool = {
           surface_id: {
             type: "string",
             description: "The ID of the surface to dismiss",
-          },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are dismissing and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
           },
         },
         required: ["surface_id"],

--- a/assistant/src/tools/watch/screen-watch.ts
+++ b/assistant/src/tools/watch/screen-watch.ts
@@ -42,11 +42,6 @@ class ScreenWatchTool implements Tool {
             type: "string",
             description: "What to focus on observing",
           },
-          reason: {
-            type: "string",
-            description:
-              "Brief non-technical explanation of what you are watching and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-          },
         },
         required: ["focus_area"],
       },


### PR DESCRIPTION
## Summary
Remove reason property from tool schemas that are now covered by the universal injectReasonField transformer. Keep custom reason descriptions on skip-set tools (bash, host_bash, request_system_permission, skill_execute). Update affected tests. Part of #15399. Closes #15404.

## Test plan
- [x] TypeScript compiles cleanly (`bunx tsc --noEmit`)
- [x] schema-transforms tests pass (21/21)
- [x] claude-code-skill-regression tests pass (5/5)
- [x] browser-skill-endstate tests pass (10/10)
- [x] computer-use-tools tests pass
- [x] swarm-tool tests pass
- [x] credential-vault-unit tests pass
- [x] asset-search-tool and asset-materialize-tool tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
