### PR TITLE
feat: gate Developer tab behind Cmd+D passcode unlock

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -60,6 +60,9 @@ struct SettingsPanel: View {
     @State private var selectedTab: SettingsTab = .general
     @State private var isContactsEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
+    @State private var showingDevUnlock: Bool = false
+    @State private var devUnlockText: String = ""
+    @State private var devUnlockMonitor: Any?
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
 
@@ -182,6 +185,56 @@ struct SettingsPanel: View {
             if let daemonClient {
                 TrustRulesView(daemonClient: daemonClient)
             }
+        }
+        .onAppear {
+            devUnlockMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                if event.modifierFlags.contains(.command),
+                   event.charactersIgnoringModifiers == "d" {
+                    showingDevUnlock = true
+                    devUnlockText = ""
+                    return nil
+                }
+                return event
+            }
+        }
+        .onDisappear {
+            if let monitor = devUnlockMonitor {
+                NSEvent.removeMonitor(monitor)
+                devUnlockMonitor = nil
+            }
+        }
+        .popover(isPresented: $showingDevUnlock) {
+            VStack(spacing: VSpacing.md) {
+                Text("Enter passcode")
+                    .font(VFont.inputLabel)
+                    .foregroundColor(VColor.textSecondary)
+                SecureField("", text: $devUnlockText)
+                    .vInputStyle()
+                    .font(VFont.mono)
+                    .frame(width: 160)
+                    .onSubmit {
+                        if devUnlockText.lowercased() == "dev" {
+                            isDeveloperEnabled = true
+                            showingDevUnlock = false
+                            // Persist the flag so it survives relaunch
+                            Task {
+                                do {
+                                    if let daemonClient {
+                                        try await daemonClient.setFeatureFlag(key: Self.developerFeatureFlagKey, enabled: true)
+                                    } else {
+                                        try WorkspaceConfigIO.merge([
+                                            "assistantFeatureFlagValues": [Self.developerFeatureFlagKey: true]
+                                        ])
+                                    }
+                                } catch {
+                                    // Flag is already set in memory; persistence failure is non-fatal
+                                }
+                            }
+                        }
+                        devUnlockText = ""
+                    }
+            }
+            .padding(VSpacing.lg)
         }
     }
 

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -127,7 +127,7 @@
       "key": "feature_flags.settings-developer-nav.enabled",
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
-      "defaultEnabled": true
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Developer settings tab now defaults to hidden (`defaultEnabled: false` in feature flag registry)
- Press **Cmd+D** anywhere in Settings to open a passcode popover — type "dev" to unlock the Developer tab
- The unlock persists via the feature flag system (daemon API or local workspace config fallback)

## Test plan
- [ ] Open Settings, confirm Developer tab is not visible
- [ ] Press Cmd+D, type "dev" in the passcode field, press Enter
- [ ] Confirm Developer tab appears in the nav sidebar
- [ ] Restart the app, confirm Developer tab is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
