### PR TITLE
Fix progress headline wrapping to multiple lines

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -295,6 +295,8 @@ struct AssistantProgressView: View {
                 Text(headlineText)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                     .animation(.easeInOut(duration: 0.3), value: headlineText)
             }
         }


### PR DESCRIPTION
## Summary
- Add `.lineLimit(1)` and `.truncationMode(.tail)` to the progress headline text in `AssistantProgressView` to prevent long headlines from wrapping to multiple lines

## Test plan
- [ ] Trigger a long progress headline and verify it truncates with ellipsis instead of wrapping
- [ ] Verify normal-length headlines still display fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
