### PR TITLE
fix: migrate integrations.accountInfo.{service} to integrations.{service}.accountInfo

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -109,7 +109,7 @@ function validateWithSchema(raw: Record<string, unknown>): AssistantConfig {
   return cloneDefaultConfig();
 }
 
-function deleteNestedKey(
+export function deleteNestedKey(
   obj: Record<string, unknown>,
   path: (string | number)[],
 ): void {

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -137,17 +137,31 @@ export async function storeOAuth2Tokens(
   if (resolvedAccountInfo) {
     try {
       const {
+        deleteNestedKey,
+        getNestedValue,
         invalidateConfigCache,
         loadRawConfig,
         saveRawConfig,
         setNestedValue,
       } = await import("../config/loader.js");
       const raw = loadRawConfig();
-      setNestedValue(
-        raw,
-        `integrations.accountInfo.${service}`,
-        resolvedAccountInfo,
-      );
+
+      // Migrate old path → new path if needed
+      const oldPath = `integrations.accountInfo.${service}`;
+      const newPath = `integrations.${service}.accountInfo`;
+      const oldValue = getNestedValue(raw, oldPath);
+      if (oldValue != null && getNestedValue(raw, newPath) == null) {
+        setNestedValue(raw, newPath, oldValue);
+      }
+
+      // Write to the new namespaced path
+      setNestedValue(raw, newPath, resolvedAccountInfo);
+
+      // Clean up old path if it existed
+      if (oldValue != null) {
+        deleteNestedKey(raw, ["integrations", "accountInfo", service]);
+      }
+
       saveRawConfig(raw);
       invalidateConfigCache();
     } catch {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -635,10 +635,12 @@ function buildIntegrationSection(): string {
   const raw = loadRawConfig();
   const lines = ["## Connected Services", ""];
   for (const cred of oauthCreds) {
-    const acctInfo = getNestedValue(
+    const acctInfo = (getNestedValue(
       raw,
-      `integrations.accountInfo.${cred.service}`,
-    ) as string | undefined;
+      `integrations.${cred.service}.accountInfo`,
+    ) ?? getNestedValue(raw, `integrations.accountInfo.${cred.service}`)) as
+      | string
+      | undefined;
     const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
     lines.push(`- **${cred.service}**: ${state}`);
   }


### PR DESCRIPTION
## Summary
- Migrate config path from integrations.accountInfo.{service} to integrations.{service}.accountInfo
- Add automatic migration of old path data on next token store
- Update system prompt to read new path with old-path fallback

Part of plan: credential-storage-hygiene.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
