### PR TITLE
fix: emit oauth_connect_result event on deferred flow success/failure

### DIFF
--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -194,6 +194,7 @@ export interface IntegrationConnectResult {
 export interface OAuthConnectResultResponse {
   type: "oauth_connect_result";
   success: boolean;
+  service?: string;
   grantedScopes?: string[];
   accountInfo?: string;
   error?: string;

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -52,6 +52,18 @@ export interface OAuthConnectOptions {
   /** Tools allowed to use the resulting credential. */
   allowedTools?: string[];
 
+  /**
+   * Called when the deferred (non-interactive) flow completes — either
+   * successfully after tokens are stored, or on failure. Lets callers
+   * surface the outcome via SSE events, logs, etc.
+   */
+  onDeferredComplete?: (result: {
+    success: boolean;
+    service: string;
+    accountInfo?: string;
+    error?: string;
+  }) => void;
+
   // Optional overrides — when provided, these take precedence over the
   // provider profile. This lets callers connect custom / unknown providers.
   authUrl?: string;
@@ -214,11 +226,21 @@ export async function orchestrateOAuthConnect(
               },
               "Deferred OAuth2 flow completed — tokens stored",
             );
+            options.onDeferredComplete?.({
+              success: true,
+              service: resolvedService,
+              accountInfo: stored.accountInfo ?? accountInfo,
+            });
           } catch (err) {
             log.error(
               { err, service: resolvedService },
               "Failed to store tokens from deferred OAuth2 flow",
             );
+            options.onDeferredComplete?.({
+              success: false,
+              service: resolvedService,
+              error: err instanceof Error ? err.message : "Unknown error",
+            });
           }
         })
         .catch((err) => {
@@ -226,6 +248,11 @@ export async function orchestrateOAuthConnect(
             { err, service: resolvedService },
             "Deferred OAuth2 flow failed",
           );
+          options.onDeferredComplete?.({
+            success: false,
+            service: resolvedService,
+            error: err instanceof Error ? err.message : "Unknown error",
+          });
         });
 
       return {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -203,6 +203,17 @@ async function handleOAuthConnectStart(body: {
       openUrl: (url: string) => {
         authUrl = url;
       },
+      onDeferredComplete: (deferredResult) => {
+        if (!deferredResult.success) {
+          log.warn(
+            {
+              service: deferredResult.service,
+              err: deferredResult.error,
+            },
+            "Deferred OAuth connect failed",
+          );
+        }
+      },
     });
 
     if (!result.success) {

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -867,6 +867,25 @@ class CredentialStoreTool implements Tool {
           userinfoUrl:
             (input.userinfo_url as string | undefined) ?? profile?.userinfoUrl,
           tokenEndpointAuthMethod,
+          onDeferredComplete: (deferredResult) => {
+            if (deferredResult.success) {
+              log.info(
+                {
+                  service: deferredResult.service,
+                  accountInfo: deferredResult.accountInfo,
+                },
+                "Deferred OAuth connect completed successfully",
+              );
+            } else {
+              log.warn(
+                {
+                  service: deferredResult.service,
+                  err: deferredResult.error,
+                },
+                "Deferred OAuth connect failed",
+              );
+            }
+          },
         });
 
         if (!result.success) {


### PR DESCRIPTION
## Summary
- Add onDeferredComplete callback to OAuthConnectOptions for deferred flow results
- Invoke callback with success/failure details after deferred token storage
- Wire up callers to log warnings on deferred failures

Part of plan: credential-storage-hygiene.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
