### PR TITLE
fix: remove dead code left from avatar migration in MessageCellView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -968,7 +968,6 @@ private struct MessageCellView: View {
     let configuredProviders: Set<String>
 
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
-    @State private var appearance = AvatarAppearanceManager.shared
 
     private func modelPickerView(for msg: ChatMessage) -> some View {
         ModelPickerBubble(
@@ -1055,8 +1054,6 @@ private struct MessageCellView: View {
                       conf.state != .pending else { return nil }
                 return conf
             }()
-
-            let previousIsAssistant = index > 0 && displayMessages[index - 1].role == .assistant
 
             ChatBubble(
                 message: message,


### PR DESCRIPTION
## Summary
Fixes two dead code issues left behind during the floating avatar migration:

- Remove unused `@State private var appearance` from `MessageCellView` — was causing unnecessary SwiftUI view invalidation on avatar changes for every message cell
- Remove unused `previousIsAssistant` variable that was only used for the now-removed `showAvatar:` parameter

Part of plan: floating-chat-avatar.md (review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
