### PR TITLE
M6: System prompt instruction for reason field

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -751,6 +751,8 @@ function buildPostToolResponseSection(): string {
     "  → Call document_create",
     "",
     "For permission-gated tools, send one short context sentence immediately before the tool call so the user can make an informed allow/deny decision.",
+    "",
+    '**Reason field:** For every tool call, include a `reason` parameter — a brief, non-technical explanation of what you are doing and why. This is shown to the user as a live status update. Use simple language a non-technical person would understand (e.g. "Checking your project settings" not "file_read config.ts").',
   ].join("\n");
 }
 


### PR DESCRIPTION
Add system prompt instruction telling the LLM to include a reason field in every tool call. This provides the human-readable status text shown in the progress indicator. Part of #15399. Closes #15405.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
