### PR TITLE
fix: stop storing oauth2ClientSecret in plaintext metadata, read from secure store

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -371,7 +371,7 @@ describe("credential metadata store", () => {
       expect(record!.credentialId).toBe("cred-stable-id");
     });
 
-    test("v2 file is loaded without migration", () => {
+    test("v2 file is migrated to v3 (strips oauth2ClientSecret)", () => {
       const v2Data = {
         version: 2,
         credentials: [
@@ -382,6 +382,7 @@ describe("credential metadata store", () => {
             allowedTools: ["api_request"],
             allowedDomains: ["fal.ai"],
             alias: "fal-primary",
+            oauth2ClientSecret: "should-be-stripped",
             injectionTemplates: [
               {
                 hostPattern: "*.fal.ai",
@@ -402,9 +403,49 @@ describe("credential metadata store", () => {
       expect(record!.alias).toBe("fal-primary");
       expect(record!.injectionTemplates).toHaveLength(1);
       expect(record!.injectionTemplates![0].hostPattern).toBe("*.fal.ai");
+      // oauth2ClientSecret must be stripped by v2→v3 migration
+      expect("oauth2ClientSecret" in record!).toBe(false);
+
+      // On-disk file should be upgraded to v3
+      const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
+      expect(raw.version).toBe(3);
+      expect(raw.credentials[0]).not.toHaveProperty("oauth2ClientSecret");
     });
 
-    test("future version (v3+) returns unknown version and refuses writes", () => {
+    test("v3 file is loaded without migration", () => {
+      const v3Data = {
+        version: 3,
+        credentials: [
+          {
+            credentialId: "cred-v3-001",
+            service: "fal-ai",
+            field: "api_key",
+            allowedTools: ["api_request"],
+            allowedDomains: ["fal.ai"],
+            alias: "fal-primary",
+            injectionTemplates: [
+              {
+                hostPattern: "*.fal.ai",
+                injectionType: "header",
+                headerName: "Authorization",
+                valuePrefix: "Key ",
+              },
+            ],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v3Data, null, 2), "utf-8");
+
+      const record = getCredentialMetadata("fal-ai", "api_key");
+      expect(record).toBeDefined();
+      expect(record!.alias).toBe("fal-primary");
+      expect(record!.injectionTemplates).toHaveLength(1);
+      expect(record!.injectionTemplates![0].hostPattern).toBe("*.fal.ai");
+    });
+
+    test("future version (v4+) returns unknown version and refuses writes", () => {
       const futureData = {
         version: 99,
         credentials: [],
@@ -439,7 +480,7 @@ describe("credential metadata store", () => {
       },
     );
 
-    test("upsert on migrated v1 file saves as v2", () => {
+    test("upsert on migrated v1 file saves as v3", () => {
       const v1Data = {
         version: 1,
         credentials: [
@@ -459,13 +500,13 @@ describe("credential metadata store", () => {
       // Upsert triggers load (migration) + save (at current version)
       upsertCredentialMetadata("github", "token", { alias: "gh-main" });
 
-      // Verify on-disk file is now v2
+      // Verify on-disk file is now v3
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(2);
+      expect(raw.version).toBe(3);
       expect(raw.credentials[0].alias).toBe("gh-main");
     });
 
-    test("v1 load auto-persists as v2 on disk without requiring a write", () => {
+    test("v1 load auto-persists as v3 on disk without requiring a write", () => {
       const v1Data = {
         version: 1,
         credentials: [
@@ -482,11 +523,11 @@ describe("credential metadata store", () => {
       };
       writeFileSync(META_PATH, JSON.stringify(v1Data, null, 2), "utf-8");
 
-      // A read-only operation should still persist the v2 upgrade
+      // A read-only operation should still persist the v3 upgrade
       listCredentialMetadata();
 
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(2);
+      expect(raw.version).toBe(3);
       expect(raw.credentials[0].credentialId).toBe("cred-autopersist");
     });
 
@@ -586,20 +627,20 @@ describe("credential metadata store", () => {
     test("file with non-array credentials field is treated as empty list", () => {
       writeFileSync(
         META_PATH,
-        JSON.stringify({ version: 2, credentials: "not-an-array" }),
+        JSON.stringify({ version: 3, credentials: "not-an-array" }),
         "utf-8",
       );
       expect(listCredentialMetadata()).toEqual([]);
     });
 
     test("file with missing credentials field is treated as empty list", () => {
-      writeFileSync(META_PATH, JSON.stringify({ version: 2 }), "utf-8");
+      writeFileSync(META_PATH, JSON.stringify({ version: 3 }), "utf-8");
       expect(listCredentialMetadata()).toEqual([]);
     });
 
     test("malformed records within credentials array are filtered out", () => {
       const data = {
-        version: 2,
+        version: 3,
         credentials: [
           // Valid record
           {
@@ -709,7 +750,7 @@ describe("credential metadata store", () => {
 
       const raw = readFileSync(META_PATH, "utf-8");
       const parsed = JSON.parse(raw);
-      expect(parsed.version).toBe(2);
+      expect(parsed.version).toBe(3);
       expect(parsed.credentials).toHaveLength(1);
       expect(parsed.credentials[0].service).toBe("slack");
     });
@@ -717,23 +758,23 @@ describe("credential metadata store", () => {
     test("file written by saveFile has version field", () => {
       upsertCredentialMetadata("test", "key");
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(2);
+      expect(raw.version).toBe(3);
     });
   });
 
   // ── Empty credential lists ────────────────────────────────────────
 
   describe("empty credential lists", () => {
-    test("empty v2 file returns empty array", () => {
+    test("empty v3 file returns empty array", () => {
       writeFileSync(
         META_PATH,
-        JSON.stringify({ version: 2, credentials: [] }, null, 2),
+        JSON.stringify({ version: 3, credentials: [] }, null, 2),
         "utf-8",
       );
       expect(listCredentialMetadata()).toEqual([]);
     });
 
-    test("empty v1 file is migrated to v2 with empty credentials", () => {
+    test("empty v1 file is migrated to v3 with empty credentials", () => {
       writeFileSync(
         META_PATH,
         JSON.stringify({ version: 1, credentials: [] }, null, 2),
@@ -741,9 +782,9 @@ describe("credential metadata store", () => {
       );
       expect(listCredentialMetadata()).toEqual([]);
 
-      // Should be persisted as v2
+      // Should be persisted as v3
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(2);
+      expect(raw.version).toBe(3);
       expect(raw.credentials).toEqual([]);
     });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -64,10 +64,11 @@ mock.module("../tools/registry.js", () => ({
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { redactSensitiveFields } from "../security/redaction.js";
-import { setSecureKey } from "../security/secure-keys.js";
+import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
+  getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 
@@ -467,6 +468,91 @@ describe("Invariant 4: credentials only used for allowed purpose", () => {
     expect(!result.authorized && result.reason).toContain(
       "No tools are currently allowed",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 6 — oauth2ClientSecret never in plaintext metadata
+// ---------------------------------------------------------------------------
+
+describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    _setStorePath(STORE_PATH);
+    _resetBackend();
+    _setMetadataPath(join(TEST_DIR, "metadata.json"));
+  });
+
+  afterEach(() => {
+    _setMetadataPath(null);
+    _setStorePath(null);
+    _resetBackend();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test("upsertCredentialMetadata does not accept oauth2ClientSecret", () => {
+    const record = upsertCredentialMetadata(
+      "integration:gmail",
+      "access_token",
+      {
+        oauth2TokenUrl: "https://oauth2.googleapis.com/token",
+        oauth2ClientId: "test-client-id",
+      },
+    );
+    expect("oauth2ClientSecret" in record).toBe(false);
+  });
+
+  test("client secret is read from secure store, not metadata", () => {
+    setSecureKey("credential:integration:gmail:client_secret", "my-secret");
+    upsertCredentialMetadata("integration:gmail", "access_token", {
+      oauth2TokenUrl: "https://oauth2.googleapis.com/token",
+      oauth2ClientId: "test-client-id",
+    });
+
+    const meta = getCredentialMetadata("integration:gmail", "access_token");
+    expect(meta).toBeDefined();
+    expect("oauth2ClientSecret" in meta!).toBe(false);
+
+    // Secret is in secure store
+    expect(getSecureKey("credential:integration:gmail:client_secret")).toBe(
+      "my-secret",
+    );
+  });
+
+  test("v2 metadata with oauth2ClientSecret is stripped on migration", () => {
+    const v2Data = {
+      version: 2,
+      credentials: [
+        {
+          credentialId: "cred-v2-secret",
+          service: "integration:gmail",
+          field: "access_token",
+          allowedTools: [],
+          allowedDomains: [],
+          oauth2TokenUrl: "https://oauth2.googleapis.com/token",
+          oauth2ClientId: "test-client-id",
+          oauth2ClientSecret: "plaintext-secret-should-be-stripped",
+          createdAt: 1700000000000,
+          updatedAt: 1700000000000,
+        },
+      ],
+    };
+    writeFileSync(
+      join(TEST_DIR, "metadata.json"),
+      JSON.stringify(v2Data, null, 2),
+      "utf-8",
+    );
+
+    const meta = getCredentialMetadata("integration:gmail", "access_token");
+    expect(meta).toBeDefined();
+    expect("oauth2ClientSecret" in meta!).toBe(false);
+
+    // Verify on-disk file no longer contains the secret
+    const raw = JSON.parse(
+      readFileSync(join(TEST_DIR, "metadata.json"), "utf-8"),
+    );
+    expect(raw.credentials[0]).not.toHaveProperty("oauth2ClientSecret");
+    expect(raw.version).toBe(3);
   });
 });
 

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -121,7 +121,6 @@ export async function storeOAuth2Tokens(
     grantedScopes,
     oauth2TokenUrl: tokenUrl,
     oauth2ClientId: clientId,
-    oauth2ClientSecret: clientSecret ?? null,
     ...(tokenEndpointAuthMethod
       ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod }
       : {}),

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -175,7 +175,7 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  const clientSecret = meta?.oauth2ClientSecret as string | undefined;
+  const clientSecret = getSecureKey(`credential:${service}:client_secret`);
   const authMethod = meta?.oauth2TokenEndpointAuthMethod as
     | TokenEndpointAuthMethod
     | undefined;

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -27,8 +27,6 @@ export interface CredentialMetadata {
   oauth2TokenUrl?: string;
   /** OAuth2 client ID — paired with oauth2TokenUrl for refresh. */
   oauth2ClientId?: string;
-  /** OAuth2 client secret — for providers that require it (e.g. Slack). Stored in metadata for autonomous refresh. */
-  oauth2ClientSecret?: string;
   /** How the client authenticates at the token endpoint (client_secret_basic or client_secret_post). */
   oauth2TokenEndpointAuthMethod?: string;
   /** Human-friendly name for this credential (e.g. "fal-primary"). */
@@ -40,7 +38,7 @@ export interface CredentialMetadata {
 }
 
 /** Current on-disk schema version. */
-const CURRENT_VERSION = 2;
+const CURRENT_VERSION = 3;
 
 interface MetadataFile {
   version: typeof CURRENT_VERSION;
@@ -120,10 +118,6 @@ function migrateRecordV1toV2(
       typeof record.oauth2ClientId === "string"
         ? record.oauth2ClientId
         : undefined,
-    oauth2ClientSecret:
-      typeof record.oauth2ClientSecret === "string"
-        ? record.oauth2ClientSecret
-        : undefined,
     oauth2TokenEndpointAuthMethod:
       typeof record.oauth2TokenEndpointAuthMethod === "string"
         ? record.oauth2TokenEndpointAuthMethod
@@ -137,6 +131,16 @@ function migrateRecordV1toV2(
   };
 }
 
+/**
+ * Migrate a v2 record to v3 by stripping the oauth2ClientSecret field.
+ * Client secrets are now read exclusively from the secure key store.
+ */
+function migrateRecordV2toV3(record: CredentialMetadata): CredentialMetadata {
+  const { oauth2ClientSecret: _removed, ...rest } =
+    record as CredentialMetadata & { oauth2ClientSecret?: string };
+  return rest;
+}
+
 function loadFile(): LoadResult {
   const raw = readTextFileSync(getMetadataPath());
   if (raw == null) {
@@ -148,7 +152,7 @@ function loadFile(): LoadResult {
       return { version: CURRENT_VERSION, credentials: [] };
     }
     const fileVersion = typeof data.version === "number" ? data.version : 1;
-    if (fileVersion !== 1 && fileVersion !== 2) {
+    if (fileVersion !== 1 && fileVersion !== 2 && fileVersion !== 3) {
       // Unrecognized version (future, fractional, negative, zero) — refuse to touch it
       return { unknownVersion: true };
     }
@@ -159,8 +163,18 @@ function loadFile(): LoadResult {
     const validRecords = rawCredentials.filter(isValidCredentialRecord);
 
     if (fileVersion < CURRENT_VERSION) {
-      // Migrate from v1 to v2 and persist the upgrade so we don't re-migrate on every read
-      const credentials = validRecords.map(migrateRecordV1toV2);
+      // Apply migrations in sequence: v1→v2→v3
+      let credentials: CredentialMetadata[];
+      if (fileVersion === 1) {
+        credentials = validRecords
+          .map(migrateRecordV1toV2)
+          .map(migrateRecordV2toV3);
+      } else {
+        // fileVersion === 2
+        credentials = (validRecords as unknown as CredentialMetadata[]).map(
+          migrateRecordV2toV3,
+        );
+      }
       const migrated: MetadataFile = { version: CURRENT_VERSION, credentials };
       try {
         saveFile(migrated);
@@ -219,8 +233,6 @@ export function upsertCredentialMetadata(
     grantedScopes?: string[];
     oauth2TokenUrl?: string;
     oauth2ClientId?: string;
-    /** Pass `null` to explicitly clear a previously-set client secret. */
-    oauth2ClientSecret?: string | null;
     oauth2TokenEndpointAuthMethod?: string;
     /** Pass `null` to explicitly clear a previously-set alias. */
     alias?: string | null;
@@ -261,13 +273,6 @@ export function upsertCredentialMetadata(
       existing.oauth2TokenUrl = policy.oauth2TokenUrl;
     if (policy?.oauth2ClientId !== undefined)
       existing.oauth2ClientId = policy.oauth2ClientId;
-    if (policy?.oauth2ClientSecret !== undefined) {
-      if (policy.oauth2ClientSecret == null) {
-        delete existing.oauth2ClientSecret;
-      } else {
-        existing.oauth2ClientSecret = policy.oauth2ClientSecret;
-      }
-    }
     if (policy?.oauth2TokenEndpointAuthMethod !== undefined)
       existing.oauth2TokenEndpointAuthMethod =
         policy.oauth2TokenEndpointAuthMethod;
@@ -301,7 +306,6 @@ export function upsertCredentialMetadata(
     grantedScopes: policy?.grantedScopes,
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
-    oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,
     oauth2TokenEndpointAuthMethod: policy?.oauth2TokenEndpointAuthMethod,
     alias: policy?.alias ?? undefined,
     injectionTemplates: policy?.injectionTemplates ?? undefined,


### PR DESCRIPTION
## Summary
- Remove oauth2ClientSecret from plaintext metadata storage
- Read client secret from secure store in token-manager.ts
- Add v2→v3 metadata migration that strips oauth2ClientSecret from existing records
- Add security invariant tests verifying client secret is never in metadata

Part of plan: credential-storage-hygiene.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
