### PR TITLE
M7: Client-side progress UX fixes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -135,7 +135,17 @@ struct AssistantProgressView: View {
             let activeBuildingStatus = toolCalls.last(where: { !$0.isComplete })?.buildingStatus
             return ChatBubble.friendlyRunningLabel(rawName, buildingStatus: activeBuildingStatus)
         case .toolsCompleteThinking:
-            return "Thinking"
+            if let lastTool = toolCalls.last {
+                if let reason = lastTool.reasonDescription, !reason.isEmpty {
+                    return reason
+                }
+                return ChatBubble.friendlyRunningLabel(
+                    lastTool.toolName,
+                    inputSummary: lastTool.inputSummary,
+                    buildingStatus: lastTool.buildingStatus
+                )
+            }
+            return "Working"
         case .processing:
             return ChatBubble.friendlyProcessingLabel(processingStatusText)
         case .complete:

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -66,7 +66,7 @@ extension ChatBubble {
 
     /// Maps raw daemon status text to a friendlier label for the inline indicator.
     static func friendlyProcessingLabel(_ statusText: String?) -> String {
-        guard let text = statusText else { return "Thinking" }
+        guard let text = statusText else { return "Wrapping up" }
         let lower = text.lowercased()
         if lower.contains("skill") { return "Applying capabilities" }
         if lower.contains("processing") { return "Processing results" }


### PR DESCRIPTION
## Summary
- Fix progress indicator to hold last tool's reason/label during gaps between tool calls instead of showing "Thinking"
- Change processing fallback from "Thinking" to "Wrapping up"

Part of #15399. Closes #15406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
