### PR TITLE
revert: revert floating avatar changes for feature branch rework

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -19,6 +19,7 @@ struct ChatBubble: View {
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
     var resolveHttpPort: (() -> Int?) = { nil }
+    var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
@@ -26,6 +27,7 @@ struct ChatBubble: View {
     var isProcessingAfterTools: Bool = false
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
+    @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
     /// Stores async-parsed segments for large messages (>2000 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
@@ -156,6 +158,9 @@ struct ChatBubble: View {
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }
 
+            // Content group with absolutely-positioned avatar so text alignment
+            // stays consistent whether or not the avatar is visible.
+            // Assistant messages reserve left space (28pt avatar + 8pt gap) for the overlay avatar.
             VStack(alignment: isUser ? .trailing : .leading, spacing: VSpacing.sm) {
                     if !isUser && hasInterleavedContent {
                         interleavedContent
@@ -211,6 +216,21 @@ struct ChatBubble: View {
                 // Uses compositingGroup instead of drawingGroup to preserve text selection.
                 // Skipped during streaming to avoid re-compositing on every token delta.
                 .modifier(ConditionalCompositingGroup(isActive: !message.isStreaming))
+                .overlay(alignment: .topLeading) {
+                    if !isUser && showAvatar {
+                        Image(nsImage: appearance.chatAvatarImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 28, height: 28)
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
+                            )
+                            .offset(x: -(28 + VSpacing.sm), y: 0)
+                    }
+                }
+                .padding(.leading, isUser ? 0 : 28 + VSpacing.sm)
 
             if !isUser { Spacer(minLength: 0) }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -5,6 +5,8 @@ import VellumAssistantShared
 /// Mimics the real `ChatBubble` layout — a short user message followed by a
 /// multi-line assistant response — so the transition to real content feels seamless.
 struct ChatLoadingSkeleton: View {
+    @State private var appearance = AvatarAppearanceManager.shared
+
     /// Line widths for the multi-line assistant text block.
     /// Varying lengths look more natural than uniform bones.
     private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
@@ -48,7 +50,7 @@ struct ChatLoadingSkeleton: View {
 
     // MARK: - Assistant Message
 
-    /// Left-aligned assistant block with six text lines inside
+    /// Left-aligned assistant block with real avatar and six text lines inside
     /// a subtle bubble, matching real ChatBubble assistant layout.
     private var assistantMessage: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -62,6 +64,19 @@ struct ChatLoadingSkeleton: View {
                 }
             }
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+            .overlay(alignment: .topLeading) {
+                Image(nsImage: appearance.chatAvatarImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 28, height: 28)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .strokeBorder(VColor.textMuted.opacity(0.2), lineWidth: 1)
+                    )
+                    .offset(x: -(28 + VSpacing.sm), y: 0)
+            }
+            .padding(.leading, 28 + VSpacing.sm)
 
             Spacer(minLength: 0)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -100,8 +100,6 @@ struct MessageListView: View {
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
     @State private var appearance = AvatarAppearanceManager.shared
-    @State private var avatarBreathing = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Read once at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared ObservableObject.
     @State private var scrollDebounceTask: Task<Void, Never>?
@@ -303,55 +301,25 @@ struct MessageListView: View {
 
     @ViewBuilder
     private func thinkingIndicatorRow(displayMessages: [ChatMessage]) -> some View {
-        RunningIndicator(
-            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
-                ? "Waking up..."
-                : assistantStatusText ?? "Thinking",
-            showIcon: false
-        )
-        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
-        .id("thinking-indicator")
-        .transition(.opacity.combined(with: .move(edge: .bottom)))
-    }
-
-    @ViewBuilder
-    private var assistantAvatarFooter: some View {
-        HStack {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
             Image(nsImage: appearance.chatAvatarImage)
+                .interpolation(.none)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 28, height: 28)
                 .clipShape(Circle())
-                .overlay(
-                    Circle()
-                        .strokeBorder(VColor.surfaceBorder, lineWidth: 1)
-                )
-                .scaleEffect(reduceMotion ? 1.0 : (avatarBreathing ? 1.0 : 0.92))
-                .opacity(reduceMotion ? 1.0 : (avatarBreathing ? 1.0 : 0.85))
-                .animation(
-                    reduceMotion
-                        ? nil
-                        : Animation.easeInOut(duration: 2.5).repeatForever(autoreverses: true),
-                    value: avatarBreathing
-                )
-                .onAppear {
-                    if !reduceMotion {
-                        avatarBreathing = true
-                    }
-                }
-                .onDisappear {
-                    avatarBreathing = false
-                }
-                .onChange(of: reduceMotion) { _, newValue in
-                    if newValue {
-                        avatarBreathing = false
-                    } else {
-                        avatarBreathing = true
-                    }
-                }
-            Spacer()
+                .padding(.top, 2)
+
+            RunningIndicator(
+                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                    ? "Waking up..."
+                    : assistantStatusText ?? "Thinking",
+                showIcon: false
+            )
         }
-        .padding(.top, VSpacing.xs)
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+        .id("thinking-indicator")
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 
     var body: some View {
@@ -488,24 +456,13 @@ struct MessageListView: View {
                             onTap: { onSubagentTap?(subagent.id) }
                         )
                             .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                            .padding(.leading, 36)
                             .id("subagent-\(subagent.id)")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
                     }
 
                     if shouldShowThinkingIndicator && anchoredThinkingIndex == nil {
                         thinkingIndicatorRow(displayMessages: displayMessages)
-                    }
-
-                    // Floating avatar — anchored at bottom of conversation, Claude-style.
-                    // Shown when the assistant has spoken or is actively thinking,
-                    // but not on user-only threads before the assistant has replied.
-                    // Uses displayMessages (the filtered/visible set) not raw messages,
-                    // since subagent notifications and other hidden items are excluded
-                    // from the rendered list.
-                    if displayMessages.contains(where: { $0.role == .assistant }) || shouldShowThinkingIndicator {
-                        assistantAvatarFooter
-                            .id("avatar-footer")
-                            .transition(.opacity)
                     }
 
                     Color.clear.frame(height: 1)
@@ -968,6 +925,7 @@ private struct MessageCellView: View {
     let configuredProviders: Set<String>
 
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
+    @State private var appearance = AvatarAppearanceManager.shared
 
     private func modelPickerView(for msg: ChatMessage) -> some View {
         ModelPickerBubble(
@@ -987,12 +945,22 @@ private struct MessageCellView: View {
 
     @ViewBuilder
     private func thinkingIndicatorRow() -> some View {
-        RunningIndicator(
-            label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
-                ? "Waking up..."
-                : assistantStatusText ?? "Thinking",
-            showIcon: false
-        )
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Image(nsImage: appearance.chatAvatarImage)
+                .interpolation(.none)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 28, height: 28)
+                .clipShape(Circle())
+                .padding(.top, 2)
+
+            RunningIndicator(
+                label: !hasEverSentMessage && displayMessages.contains(where: { $0.role == .user })
+                    ? "Waking up..."
+                    : assistantStatusText ?? "Thinking",
+                showIcon: false
+            )
+        }
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
     }
@@ -1055,6 +1023,8 @@ private struct MessageCellView: View {
                 return conf
             }()
 
+            let previousIsAssistant = index > 0 && displayMessages[index - 1].role == .assistant
+
             ChatBubble(
                 message: message,
                 decidedConfirmation: nextDecidedConfirmation,
@@ -1068,6 +1038,7 @@ private struct MessageCellView: View {
                 onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
                 mediaEmbedSettings: mediaEmbedSettings,
                 resolveHttpPort: resolveHttpPort,
+                showAvatar: !previousIsAssistant,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
@@ -1084,6 +1055,7 @@ private struct MessageCellView: View {
                 onTap: { onSubagentTap?(subagent.id) }
             )
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                .padding(.leading, 36)
                 .id("subagent-\(subagent.id)")
         }
 


### PR DESCRIPTION
## Summary
Reverts all 6 PRs from the floating-chat-avatar plan that were incorrectly merged directly to main:
- #15411, #15412, #15413, #15416, #15417, #15426

Issues observed:
- Avatar bouncing/flying animation too aggressive
- Avatar should be larger
- Should stay anchored at bottom

These will be reworked on a feature branch with fixes before re-merging.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
