### PR TITLE
cleanup: stop writing client_id to secure store (already in metadata)

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -230,7 +230,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/ride-shotgun-handler.ts", // learn session cookie persistence
       "daemon/session-messaging.ts", // credential storage during session messaging
-      "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_id/client_secret/access tokens)
+      "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -595,15 +595,14 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("client_id is required");
   });
 
-  test("uses stored client_id from secure storage", async () => {
-    // Store both client_id and client_secret for the service — the
-    // requiresClientSecret guardrail will short-circuit if client_secret
-    // is missing, so we need both to validate that stored client_id
-    // is resolved correctly.
-    setSecureKey(
-      "credential:integration:gmail:client_id",
-      "stored-client-id-123",
-    );
+  test("uses stored client_id from metadata", async () => {
+    // Store client_id in metadata (the canonical source) and client_secret
+    // in the secure store — the requiresClientSecret guardrail will
+    // short-circuit if client_secret is missing, so we need both to
+    // validate that stored client_id is resolved correctly.
+    upsertCredentialMetadata("integration:gmail", "access_token", {
+      oauth2ClientId: "stored-client-id-123",
+    });
     setSecureKey("credential:integration:gmail:client_secret", "test-secret");
 
     const result = await credentialStoreTool.execute(
@@ -624,12 +623,11 @@ describe("credential_store tool — oauth2_connect error paths", () => {
   });
 
   test("rejects when client_secret is missing for service that requires it", async () => {
-    // Store only client_id — client_secret is intentionally absent to
-    // validate the requiresClientSecret guardrail.
-    setSecureKey(
-      "credential:integration:gmail:client_id",
-      "stored-client-id-456",
-    );
+    // Store only client_id in metadata — client_secret is intentionally
+    // absent to validate the requiresClientSecret guardrail.
+    upsertCredentialMetadata("integration:gmail", "access_token", {
+      oauth2ClientId: "stored-client-id-456",
+    });
 
     const result = await credentialStoreTool.execute(
       {

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -97,14 +97,8 @@ export async function storeOAuth2Tokens(
     }
   }
 
-  // Persist client credentials in keychain for defense in depth
-  const clientIdStored = await setSecureKeyAsync(
-    `credential:${service}:client_id`,
-    clientId,
-  );
-  if (!clientIdStored) {
-    throw new Error("Failed to store client_id in secure storage");
-  }
+  // client_id is stored in metadata only (oauth2ClientId field) — not the
+  // secure store. token-manager.ts reads it from meta?.oauth2ClientId.
   if (clientSecret) {
     const clientSecretStored = await setSecureKeyAsync(
       `credential:${service}:client_secret`,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -25,7 +25,10 @@ import {
 } from "../../permissions/checker.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
-import { assertMetadataWritable } from "../../tools/credentials/metadata-store.js";
+import {
+  assertMetadataWritable,
+  getCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
 import {
   type ManifestOverride,
   resolveExecutionTarget,
@@ -162,9 +165,16 @@ async function handleOAuthConnectStart(body: {
 
   const resolvedService = resolveService(body.service);
 
-  let clientId = getSecureKey(`credential:${resolvedService}:client_id`);
+  // client_id is stored in metadata (oauth2ClientId), not the secure store.
+  let clientId = getCredentialMetadata(
+    resolvedService,
+    "access_token",
+  )?.oauth2ClientId;
   if (!clientId && resolvedService !== body.service) {
-    clientId = getSecureKey(`credential:${body.service}:client_id`);
+    clientId = getCredentialMetadata(
+      body.service,
+      "access_token",
+    )?.oauth2ClientId;
   }
 
   if (!clientId) {

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -33,10 +33,10 @@ import { toPolicyFromInput, validatePolicyInput } from "./policy-validate.js";
 const log = getLogger("credential-vault");
 
 /**
- * Look up a stored OAuth field (e.g. client_id or client_secret) for a service.
- * Checks both the canonical and alias service names.
+ * Look up a stored OAuth secret (e.g. client_secret) for a service from the
+ * secure store. Checks both the canonical and alias service names.
  */
-function findStoredOAuthField(
+function findStoredOAuthSecret(
   service: string,
   field: string,
 ): string | undefined {
@@ -49,6 +49,23 @@ function findStoredOAuthField(
   for (const svc of servicesToCheck) {
     const value = getSecureKey(`credential:${svc}:${field}`);
     if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Look up the stored OAuth client_id for a service from credential metadata.
+ * Checks both the canonical and alias service names.
+ */
+function findStoredOAuthClientId(service: string): string | undefined {
+  const servicesToCheck = [service];
+  for (const [alias, canonical] of Object.entries(SERVICE_ALIASES)) {
+    if (canonical === service) servicesToCheck.push(alias);
+    if (alias === service) servicesToCheck.push(canonical);
+  }
+  for (const svc of servicesToCheck) {
+    const meta = getCredentialMetadata(svc, "access_token");
+    if (meta?.oauth2ClientId) return meta.oauth2ClientId;
   }
   return undefined;
 }
@@ -757,13 +774,13 @@ class CredentialStoreTool implements Tool {
         // Fill missing params from provider profile
         const profile = getProviderProfile(service);
 
-        // Look up client_id/client_secret from stored credentials if not provided
+        // Look up client_id from metadata and client_secret from secure store
         const clientId =
           (input.client_id as string | undefined) ??
-          findStoredOAuthField(service, "client_id");
+          findStoredOAuthClientId(service);
         const clientSecret =
           (input.client_secret as string | undefined) ??
-          findStoredOAuthField(service, "client_secret");
+          findStoredOAuthSecret(service, "client_secret");
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
         const inputScopes = input.scopes as string[] | undefined;


### PR DESCRIPTION
## Summary
- Remove redundant client_id write to secure store (canonical source is metadata)
- client_secret remains in secure store only (from PR 2), client_id in metadata only
- Update any callers that expected client_id in secure store

Part of plan: credential-storage-hygiene.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
