### PR TITLE
cleanup: remove empty refresh_token metadata records, add hasRefreshToken flag to access_token metadata

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -294,6 +294,52 @@ describe("credential metadata store", () => {
     });
   });
 
+  // ── v4 Schema: hasRefreshToken ──────────────────────────────────────
+
+  describe("v4 schema — hasRefreshToken", () => {
+    test("creates record with hasRefreshToken", () => {
+      const record = upsertCredentialMetadata("github", "access_token", {
+        hasRefreshToken: true,
+      });
+      expect(record.hasRefreshToken).toBe(true);
+    });
+
+    test("creates record with hasRefreshToken false", () => {
+      const record = upsertCredentialMetadata("github", "access_token", {
+        hasRefreshToken: false,
+      });
+      expect(record.hasRefreshToken).toBe(false);
+    });
+
+    test("defaults hasRefreshToken to undefined when not provided", () => {
+      const record = upsertCredentialMetadata("github", "access_token");
+      expect(record.hasRefreshToken).toBeUndefined();
+    });
+
+    test("updates hasRefreshToken on existing record", () => {
+      upsertCredentialMetadata("github", "access_token", {
+        hasRefreshToken: false,
+      });
+      const updated = upsertCredentialMetadata("github", "access_token", {
+        hasRefreshToken: true,
+      });
+      expect(updated.hasRefreshToken).toBe(true);
+    });
+
+    test("round-trip: hasRefreshToken survives serialization", () => {
+      upsertCredentialMetadata("github", "access_token", {
+        hasRefreshToken: true,
+        allowedTools: ["api_request"],
+      });
+
+      // Re-read from disk
+      const loaded = getCredentialMetadata("github", "access_token");
+      expect(loaded).toBeDefined();
+      expect(loaded!.hasRefreshToken).toBe(true);
+      expect(loaded!.allowedTools).toEqual(["api_request"]);
+    });
+  });
+
   // ── Version migration ──────────────────────────────────────────────
 
   describe("version migration", () => {
@@ -371,7 +417,7 @@ describe("credential metadata store", () => {
       expect(record!.credentialId).toBe("cred-stable-id");
     });
 
-    test("v2 file is migrated to v3 (strips oauth2ClientSecret)", () => {
+    test("v2 file is migrated to v4 (strips oauth2ClientSecret)", () => {
       const v2Data = {
         version: 2,
         credentials: [
@@ -406,13 +452,52 @@ describe("credential metadata store", () => {
       // oauth2ClientSecret must be stripped by v2→v3 migration
       expect("oauth2ClientSecret" in record!).toBe(false);
 
-      // On-disk file should be upgraded to v3
+      // On-disk file should be upgraded to v4
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(3);
+      expect(raw.version).toBe(4);
       expect(raw.credentials[0]).not.toHaveProperty("oauth2ClientSecret");
     });
 
-    test("v3 file is loaded without migration", () => {
+    test("v3 file is migrated to v4 (removes ghost refresh_token records)", () => {
+      const v3Data = {
+        version: 3,
+        credentials: [
+          {
+            credentialId: "cred-v3-at",
+            service: "github",
+            field: "access_token",
+            allowedTools: ["api_request"],
+            allowedDomains: ["github.com"],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+          {
+            credentialId: "cred-v3-rt",
+            service: "github",
+            field: "refresh_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v3Data, null, 2), "utf-8");
+
+      const records = listCredentialMetadata();
+      // Ghost refresh_token record removed
+      expect(records).toHaveLength(1);
+      expect(records[0].field).toBe("access_token");
+      expect(records[0].hasRefreshToken).toBe(true);
+
+      // On-disk file should be upgraded to v4
+      const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
+      expect(raw.version).toBe(4);
+      expect(raw.credentials).toHaveLength(1);
+      expect(raw.credentials[0].field).toBe("access_token");
+    });
+
+    test("v3 file without refresh_token records migrates cleanly", () => {
       const v3Data = {
         version: 3,
         credentials: [
@@ -443,9 +528,105 @@ describe("credential metadata store", () => {
       expect(record!.alias).toBe("fal-primary");
       expect(record!.injectionTemplates).toHaveLength(1);
       expect(record!.injectionTemplates![0].hostPattern).toBe("*.fal.ai");
+      expect(record!.hasRefreshToken).toBeUndefined();
+
+      // On-disk file should be upgraded to v4
+      const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
+      expect(raw.version).toBe(4);
     });
 
-    test("future version (v4+) returns unknown version and refuses writes", () => {
+    test("v3 migration handles multiple services with ghost records", () => {
+      const v3Data = {
+        version: 3,
+        credentials: [
+          {
+            credentialId: "at-github",
+            service: "github",
+            field: "access_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+          {
+            credentialId: "rt-github",
+            service: "github",
+            field: "refresh_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+          {
+            credentialId: "at-slack",
+            service: "slack",
+            field: "access_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+          {
+            credentialId: "at-stripe",
+            service: "stripe",
+            field: "access_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+          {
+            credentialId: "rt-stripe",
+            service: "stripe",
+            field: "refresh_token",
+            allowedTools: [],
+            allowedDomains: [],
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v3Data, null, 2), "utf-8");
+
+      const records = listCredentialMetadata();
+      // refresh_token records removed, only access_token records remain
+      expect(records).toHaveLength(3);
+      expect(records.every((r) => r.field !== "refresh_token")).toBe(true);
+      // github and stripe had refresh tokens
+      const github = records.find((r) => r.service === "github");
+      const slack = records.find((r) => r.service === "slack");
+      const stripe = records.find((r) => r.service === "stripe");
+      expect(github!.hasRefreshToken).toBe(true);
+      expect(slack!.hasRefreshToken).toBeUndefined();
+      expect(stripe!.hasRefreshToken).toBe(true);
+    });
+
+    test("v4 file is loaded without migration", () => {
+      const v4Data = {
+        version: 4,
+        credentials: [
+          {
+            credentialId: "cred-v4-001",
+            service: "fal-ai",
+            field: "api_key",
+            allowedTools: ["api_request"],
+            allowedDomains: ["fal.ai"],
+            alias: "fal-primary",
+            hasRefreshToken: true,
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          },
+        ],
+      };
+      writeFileSync(META_PATH, JSON.stringify(v4Data, null, 2), "utf-8");
+
+      const record = getCredentialMetadata("fal-ai", "api_key");
+      expect(record).toBeDefined();
+      expect(record!.alias).toBe("fal-primary");
+      expect(record!.hasRefreshToken).toBe(true);
+    });
+
+    test("future version (v5+) returns unknown version and refuses writes", () => {
       const futureData = {
         version: 99,
         credentials: [],
@@ -480,7 +661,7 @@ describe("credential metadata store", () => {
       },
     );
 
-    test("upsert on migrated v1 file saves as v3", () => {
+    test("upsert on migrated v1 file saves as v4", () => {
       const v1Data = {
         version: 1,
         credentials: [
@@ -500,13 +681,13 @@ describe("credential metadata store", () => {
       // Upsert triggers load (migration) + save (at current version)
       upsertCredentialMetadata("github", "token", { alias: "gh-main" });
 
-      // Verify on-disk file is now v3
+      // Verify on-disk file is now v4
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(3);
+      expect(raw.version).toBe(4);
       expect(raw.credentials[0].alias).toBe("gh-main");
     });
 
-    test("v1 load auto-persists as v3 on disk without requiring a write", () => {
+    test("v1 load auto-persists as v4 on disk without requiring a write", () => {
       const v1Data = {
         version: 1,
         credentials: [
@@ -523,11 +704,11 @@ describe("credential metadata store", () => {
       };
       writeFileSync(META_PATH, JSON.stringify(v1Data, null, 2), "utf-8");
 
-      // A read-only operation should still persist the v3 upgrade
+      // A read-only operation should still persist the v4 upgrade
       listCredentialMetadata();
 
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(3);
+      expect(raw.version).toBe(4);
       expect(raw.credentials[0].credentialId).toBe("cred-autopersist");
     });
 
@@ -627,20 +808,20 @@ describe("credential metadata store", () => {
     test("file with non-array credentials field is treated as empty list", () => {
       writeFileSync(
         META_PATH,
-        JSON.stringify({ version: 3, credentials: "not-an-array" }),
+        JSON.stringify({ version: 4, credentials: "not-an-array" }),
         "utf-8",
       );
       expect(listCredentialMetadata()).toEqual([]);
     });
 
     test("file with missing credentials field is treated as empty list", () => {
-      writeFileSync(META_PATH, JSON.stringify({ version: 3 }), "utf-8");
+      writeFileSync(META_PATH, JSON.stringify({ version: 4 }), "utf-8");
       expect(listCredentialMetadata()).toEqual([]);
     });
 
     test("malformed records within credentials array are filtered out", () => {
       const data = {
-        version: 3,
+        version: 4,
         credentials: [
           // Valid record
           {
@@ -750,7 +931,7 @@ describe("credential metadata store", () => {
 
       const raw = readFileSync(META_PATH, "utf-8");
       const parsed = JSON.parse(raw);
-      expect(parsed.version).toBe(3);
+      expect(parsed.version).toBe(4);
       expect(parsed.credentials).toHaveLength(1);
       expect(parsed.credentials[0].service).toBe("slack");
     });
@@ -758,23 +939,23 @@ describe("credential metadata store", () => {
     test("file written by saveFile has version field", () => {
       upsertCredentialMetadata("test", "key");
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(3);
+      expect(raw.version).toBe(4);
     });
   });
 
   // ── Empty credential lists ────────────────────────────────────────
 
   describe("empty credential lists", () => {
-    test("empty v3 file returns empty array", () => {
+    test("empty v4 file returns empty array", () => {
       writeFileSync(
         META_PATH,
-        JSON.stringify({ version: 3, credentials: [] }, null, 2),
+        JSON.stringify({ version: 4, credentials: [] }, null, 2),
         "utf-8",
       );
       expect(listCredentialMetadata()).toEqual([]);
     });
 
-    test("empty v1 file is migrated to v3 with empty credentials", () => {
+    test("empty v1 file is migrated to v4 with empty credentials", () => {
       writeFileSync(
         META_PATH,
         JSON.stringify({ version: 1, credentials: [] }, null, 2),
@@ -782,9 +963,9 @@ describe("credential metadata store", () => {
       );
       expect(listCredentialMetadata()).toEqual([]);
 
-      // Should be persisted as v3
+      // Should be persisted as v4
       const raw = JSON.parse(readFileSync(META_PATH, "utf-8"));
-      expect(raw.version).toBe(3);
+      expect(raw.version).toBe(4);
       expect(raw.credentials).toEqual([]);
     });
 

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -14,10 +14,7 @@ import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
-import {
-  deleteCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../tools/credentials/metadata-store.js";
+import { upsertCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
 
@@ -174,14 +171,18 @@ export async function storeOAuth2Tokens(
       tokens.refreshToken,
     );
     if (refreshStored) {
-      upsertCredentialMetadata(service, "refresh_token", {});
+      upsertCredentialMetadata(service, "access_token", {
+        hasRefreshToken: true,
+      });
     }
   } else {
     // Re-auth grants that omit refresh_token must clear any stale stored
     // token — otherwise withValidToken() will attempt refresh with invalid
     // credentials.
     await deleteSecureKeyAsync(`credential:${service}:refresh_token`);
-    deleteCredentialMetadata(service, "refresh_token");
+    upsertCredentialMetadata(service, "access_token", {
+      hasRefreshToken: false,
+    });
   }
 
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -33,12 +33,14 @@ export interface CredentialMetadata {
   alias?: string;
   /** Templates describing how to inject this credential into proxied requests. */
   injectionTemplates?: CredentialInjectionTemplate[];
+  /** Whether a refresh token exists in the secure store for this service. */
+  hasRefreshToken?: boolean;
   createdAt: number;
   updatedAt: number;
 }
 
 /** Current on-disk schema version. */
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 
 interface MetadataFile {
   version: typeof CURRENT_VERSION;
@@ -126,6 +128,10 @@ function migrateRecordV1toV2(
     injectionTemplates: Array.isArray(record.injectionTemplates)
       ? (record.injectionTemplates as CredentialInjectionTemplate[])
       : undefined,
+    hasRefreshToken:
+      typeof record.hasRefreshToken === "boolean"
+        ? record.hasRefreshToken
+        : undefined,
     createdAt: record.createdAt as number,
     updatedAt: record.updatedAt as number,
   };
@@ -141,6 +147,33 @@ function migrateRecordV2toV3(record: CredentialMetadata): CredentialMetadata {
   return rest;
 }
 
+/**
+ * Migrate v3 credentials to v4:
+ * - Delete ghost `refresh_token` metadata records
+ * - Set `hasRefreshToken: true` on corresponding `access_token` records
+ */
+function migrateV3toV4(
+  credentials: CredentialMetadata[],
+): CredentialMetadata[] {
+  // Collect services that had refresh_token ghost records
+  const servicesWithRefresh = new Set<string>();
+  for (const c of credentials) {
+    if (c.field === "refresh_token") {
+      servicesWithRefresh.add(c.service);
+    }
+  }
+
+  // Remove all refresh_token records and set hasRefreshToken on access_token records
+  const filtered = credentials.filter((c) => c.field !== "refresh_token");
+  for (const c of filtered) {
+    if (c.field === "access_token" && servicesWithRefresh.has(c.service)) {
+      c.hasRefreshToken = true;
+    }
+  }
+
+  return filtered;
+}
+
 function loadFile(): LoadResult {
   const raw = readTextFileSync(getMetadataPath());
   if (raw == null) {
@@ -152,7 +185,12 @@ function loadFile(): LoadResult {
       return { version: CURRENT_VERSION, credentials: [] };
     }
     const fileVersion = typeof data.version === "number" ? data.version : 1;
-    if (fileVersion !== 1 && fileVersion !== 2 && fileVersion !== 3) {
+    if (
+      fileVersion !== 1 &&
+      fileVersion !== 2 &&
+      fileVersion !== 3 &&
+      fileVersion !== 4
+    ) {
       // Unrecognized version (future, fractional, negative, zero) — refuse to touch it
       return { unknownVersion: true };
     }
@@ -163,16 +201,22 @@ function loadFile(): LoadResult {
     const validRecords = rawCredentials.filter(isValidCredentialRecord);
 
     if (fileVersion < CURRENT_VERSION) {
-      // Apply migrations in sequence: v1→v2→v3
+      // Apply migrations in sequence: v1→v2→v3→v4
       let credentials: CredentialMetadata[];
       if (fileVersion === 1) {
-        credentials = validRecords
-          .map(migrateRecordV1toV2)
-          .map(migrateRecordV2toV3);
+        credentials = migrateV3toV4(
+          validRecords.map(migrateRecordV1toV2).map(migrateRecordV2toV3),
+        );
+      } else if (fileVersion === 2) {
+        credentials = migrateV3toV4(
+          (validRecords as unknown as CredentialMetadata[]).map(
+            migrateRecordV2toV3,
+          ),
+        );
       } else {
-        // fileVersion === 2
-        credentials = (validRecords as unknown as CredentialMetadata[]).map(
-          migrateRecordV2toV3,
+        // fileVersion === 3
+        credentials = migrateV3toV4(
+          validRecords as unknown as CredentialMetadata[],
         );
       }
       const migrated: MetadataFile = { version: CURRENT_VERSION, credentials };
@@ -238,6 +282,7 @@ export function upsertCredentialMetadata(
     alias?: string | null;
     /** Pass `null` to explicitly clear injection templates. */
     injectionTemplates?: CredentialInjectionTemplate[] | null;
+    hasRefreshToken?: boolean;
   },
 ): CredentialMetadata {
   const result = loadFile();
@@ -290,6 +335,8 @@ export function upsertCredentialMetadata(
         existing.injectionTemplates = policy.injectionTemplates;
       }
     }
+    if (policy?.hasRefreshToken !== undefined)
+      existing.hasRefreshToken = policy.hasRefreshToken;
     existing.updatedAt = now;
     saveFile(data);
     return existing;
@@ -309,6 +356,7 @@ export function upsertCredentialMetadata(
     oauth2TokenEndpointAuthMethod: policy?.oauth2TokenEndpointAuthMethod,
     alias: policy?.alias ?? undefined,
     injectionTemplates: policy?.injectionTemplates ?? undefined,
+    hasRefreshToken: policy?.hasRefreshToken,
     createdAt: now,
     updatedAt: now,
   };


### PR DESCRIPTION
## Summary
- Replace ghost refresh_token metadata records with hasRefreshToken flag on access_token records
- Add v3→v4 migration that cleans up existing ghost records and sets the flag
- No more empty refresh_token records are created going forward

Part of plan: credential-storage-hygiene.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
