### PR TITLE
fix: route guardian Slack reactions through guardian decision primitive

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -51,6 +51,7 @@ import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
   createApprovalRequest,
+  getPendingApprovalForRequest,
   type GuardianApprovalRequest,
 } from "../memory/guardian-approvals.js";
 import * as approvalMessageComposer from "../runtime/approval-message-composer.js";
@@ -245,6 +246,40 @@ describe("guardian grant minting on tool-approval decisions", () => {
 
     deliverSpy.mockRestore();
     composeSpy.mockRestore();
+  });
+
+  test("guardian reaction approve_always is downgraded to one-time approval", async () => {
+    const requestId = "req-grant-reaction-1";
+    const approval = createTestGuardianApproval(requestId, {
+      conversationId: CONVERSATION_ID,
+      channel: "slack",
+      guardianChatId: GUARDIAN_CHAT,
+    });
+    const handleConfirmationResponse = registerPendingInteraction(
+      requestId,
+      CONVERSATION_ID,
+      TOOL_NAME,
+      TOOL_INPUT,
+    );
+
+    const result = await handleApprovalInterception({
+      conversationId: "guardian-conv-1",
+      callbackData: "reaction:white_check_mark",
+      content: "",
+      conversationExternalId: GUARDIAN_CHAT,
+      sourceChannel: "slack",
+      actorExternalId: GUARDIAN_USER,
+      replyCallbackUrl: "https://gateway.test/deliver",
+      trustCtx: makeTrustContext(),
+      assistantId: ASSISTANT_ID,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.type).toBe("guardian_decision_applied");
+    expect(handleConfirmationResponse).toHaveBeenCalledWith(requestId, "allow");
+
+    const updatedApproval = getPendingApprovalForRequest(approval.requestId);
+    expect(updatedApproval).toBeNull();
   });
 
   // ── 2. approve_once for non-tool-approval does NOT mint a grant ──

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -10,6 +10,7 @@ import { applyGuardianDecision } from "../../approvals/guardian-decision-primiti
 import type { ChannelId } from "../../channels/types.js";
 import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
 import {
+  getAllPendingApprovalsByGuardianChat,
   getPendingApprovalForRequest,
   getUnresolvedApprovalForRequest,
   updateApprovalDecision,
@@ -123,7 +124,7 @@ export async function handleApprovalInterception(
   // Only guardians can approve via reaction — non-guardian reactions are
   // silently ignored to prevent self-approval.
   if (callbackData?.startsWith("reaction:")) {
-    if (trustCtx.trustClass !== "guardian") {
+    if (trustCtx.trustClass !== "guardian" || !actorExternalId) {
       return { handled: true, type: "stale_ignored" };
     }
     const reactionDecision = parseReactionCallbackData(callbackData);
@@ -131,13 +132,27 @@ export async function handleApprovalInterception(
       // Unknown emoji — ignore silently
       return { handled: true, type: "stale_ignored" };
     }
-    const pending = getApprovalInfoByConversation(conversationId);
-    if (pending.length === 0) {
+
+    const allPending = getAllPendingApprovalsByGuardianChat(
+      sourceChannel,
+      conversationExternalId,
+    );
+    const guardianPending = allPending.filter(
+      (approval) => approval.guardianExternalUserId === actorExternalId,
+    );
+    if (guardianPending.length !== 1) {
       return { handled: true, type: "stale_ignored" };
     }
-    const result = handleChannelDecision(conversationId, reactionDecision);
+
+    const result = applyGuardianDecision({
+      approval: guardianPending[0],
+      decision: reactionDecision,
+      actorPrincipalId: undefined,
+      actorExternalUserId: actorExternalId,
+      actorChannel: sourceChannel,
+    });
     if (result.applied) {
-      return { handled: true, type: "decision_applied" };
+      return { handled: true, type: "guardian_decision_applied" };
     }
     return { handled: true, type: "stale_ignored" };
   }


### PR DESCRIPTION
### Motivation
- Guardian Slack reactions could directly trigger `approve_10m`/`approve_always` via the reaction path and thereby bypass the guardian primitive that downgrades those modes for guardian-on-behalf approvals. 
- Re-establish the security invariant that guardians cannot create long-lived allowlist rules on behalf of requesters by ensuring reactions go through the same canonical decision path. 
- Add regression coverage to prevent reintroduction of the bypass. 

### Description
- Route `reaction:` callback handling through the unified guardian primitive by calling `applyGuardianDecision` in `assistant/src/runtime/routes/guardian-approval-interception.ts` instead of calling `handleChannelDecision` directly. 
- Narrow reaction applicability to the exact guardian's pending approval by importing and using `getAllPendingApprovalsByGuardianChat` and filtering for `guardianExternalUserId === actorExternalId`, and require `actorExternalId` to be present. 
- Add a regression test `guardian reaction approve_always is downgraded to one-time approval` to `assistant/src/__tests__/guardian-grant-minting.test.ts` and include the needed import (`getPendingApprovalForRequest`) to assert the approval is consumed and downgraded. 

### Testing
- No repository `bun`-based automated tests were executed in this environment because `bun` is unavailable and `bun --version` failed; commit hooks therefore skipped `bun` lint/type checks. 
- Changes were committed successfully (`git commit`) and the new regression test was added; automated test execution is expected in CI. 
- Recommended CI/local commands to validate the fix are: `cd assistant && bunx tsc --noEmit` and `cd assistant && bun test src/__tests__/guardian-grant-minting.test.ts --grep "reaction"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae37b12ad88323ac90b1860f36523d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
