### PR TITLE
refactor: use / as secure key delimiter to avoid ambiguity with service names

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,10 +97,13 @@ declare -a SAFE_LINE_PATTERNS=(
     "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
     # TS/JS: secret/key variable assigned from a function call.
     # E.g. `const clientSecret = getSecureKey(keyVault)` or
-    # `getSecureKey('credential:integration:twitter:client_secret')`.
-    # Allows either no quoted args, or quoted args containing `:` (key paths).
+    # `getSecureKey('credential:integration:twitter:client_secret')` or
+    # `getSecureKey(credentialKey(service, "client_secret"))`.
+    # Allows: no quoted args, quoted args containing `:` (key paths), or
+    # nested function calls like `credentialKey(...)` whose quoted args are
+    # short identifier-like strings (field names, not real secrets).
     # Raw alphanumeric strings like `"sk_live_..."` are still rejected.
-    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'][^\"']*$)"
+    "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'][^\"']*$|[a-zA-Z_][a-zA-Z0-9_]*\([^)]*[\"'][a-z_]+[\"'][^)]*\)[^\"']*$)"
     # TS/JS: property key followed by type annotation or opening brace.
     # E.g. `requiresClientSecret: boolean;` or `client_secret: {`.
     "[Cc]lient[_-]?[Ss]ecret['\"]?:[[:space:]]*(boolean|number)[[:space:]]*[;,]?"
@@ -249,6 +252,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
     # Function-call with quoted key path (colon-separated identifier) — must be whitelisted
     SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || undefined;"
+    # Function-call with nested credentialKey() call — must be whitelisted
+    SAFE_FUNC_CALL_NESTED='const clientSecret = getSecureKey(credentialKey(service, "client_secret"));'
     # Function-call with key path followed by a hardcoded secret fallback — must NOT be whitelisted
     UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || \"sk_live_12345678901234567890\""
     # Function-call with literal secret in args — must NOT be whitelisted
@@ -484,6 +489,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_FUNC_CALL_KEY_PATH" && ! matches_safe_line_pattern "$SAFE_FUNC_CALL_KEY_PATH"; then
         echo -e "${RED}Self-test failed:${NC} function-call with quoted key path false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_FUNC_CALL_NESTED" && ! matches_safe_line_pattern "$SAFE_FUNC_CALL_NESTED"; then
+        echo -e "${RED}Self-test failed:${NC} nested credentialKey() function-call false positive"
         exit 1
     fi
     if matches_secret_pattern "$UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK" && matches_safe_line_pattern "$UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK"; then

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -147,12 +147,12 @@ describe("E2E: secure store and list lifecycle", () => {
     // Value must NOT appear in tool output (invariant 1)
     expect(result.content).not.toContain("ghp_abc123");
     // Value must be in keychain
-    expect(storedKeys.get("credential:github:token")).toBe("ghp_abc123");
+    expect(storedKeys.get("credential/github/token")).toBe("ghp_abc123");
   });
 
   test("list returns service/field pairs without secret values", async () => {
-    storedKeys.set("credential:github:token", "secret1");
-    storedKeys.set("credential:aws:access_key", "secret2");
+    storedKeys.set("credential/github/token", "secret1");
+    storedKeys.set("credential/aws/access_key", "secret2");
     metadataStore.set("github:token", {
       credentialId: "cred-github-token",
       service: "github",
@@ -177,14 +177,14 @@ describe("E2E: secure store and list lifecycle", () => {
   });
 
   test("delete removes credential from keychain", async () => {
-    storedKeys.set("credential:github:token", "secret1");
+    storedKeys.set("credential/github/token", "secret1");
 
     const result = await credentialStoreTool.execute(
       { action: "delete", service: "github", field: "token" },
       makeContext(),
     );
     expect(result.isError).toBe(false);
-    expect(storedKeys.has("credential:github:token")).toBe(false);
+    expect(storedKeys.has("credential/github/token")).toBe(false);
   });
 });
 
@@ -267,7 +267,7 @@ describe("E2E: one-time send override", () => {
     );
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not enabled");
-    expect(storedKeys.has("credential:svc:key")).toBe(false);
+    expect(storedKeys.has("credential/svc/key")).toBe(false);
   });
 
   test("accepts transient_send when config gate is on", async () => {
@@ -285,7 +285,7 @@ describe("E2E: one-time send override", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("NOT saved");
     // Value must NOT be in keychain
-    expect(storedKeys.has("credential:svc:key")).toBe(false);
+    expect(storedKeys.has("credential/svc/key")).toBe(false);
     // Value must NOT appear in output
     expect(result.content).not.toContain("tmp1");
   });
@@ -303,7 +303,7 @@ describe("E2E: one-time send override", () => {
       ctx,
     );
     expect(result.isError).toBe(false);
-    expect(storedKeys.has("credential:svc:key")).toBe(true);
+    expect(storedKeys.has("credential/svc/key")).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -63,6 +63,7 @@ mock.module("../tools/registry.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { credentialKey } from "../security/credential-key.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
@@ -200,6 +201,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
     // Hard boundary: only these production files may import from secure-keys.
     // Any new import must be reviewed for secret-leak risk and added here.
     const ALLOWED_IMPORTERS = new Set([
+      "security/credential-key.ts", // credential key builder + migration
       "config/loader.ts", // config management (API keys)
       "tools/credentials/vault.ts", // credential store tool
       "tools/credentials/broker.ts", // brokered credential access
@@ -503,7 +505,10 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
   });
 
   test("client secret is read from secure store, not metadata", () => {
-    setSecureKey("credential:integration:gmail:client_secret", "my-secret");
+    setSecureKey(
+      credentialKey("integration:gmail", "client_secret"),
+      "my-secret",
+    );
     upsertCredentialMetadata("integration:gmail", "access_token", {
       oauth2TokenUrl: "https://oauth2.googleapis.com/token",
       oauth2ClientId: "test-client-id",
@@ -514,9 +519,9 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
     expect("oauth2ClientSecret" in meta!).toBe(false);
 
     // Secret is in secure store
-    expect(getSecureKey("credential:integration:gmail:client_secret")).toBe(
-      "my-secret",
-    );
+    expect(
+      getSecureKey(credentialKey("integration:gmail", "client_secret")),
+    ).toBe("my-secret");
   });
 
   test("v2 metadata with oauth2ClientSecret is stripped on migration", () => {

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -48,6 +48,7 @@ mock.module("../tools/registry.js", () => ({
 // Imports under test
 // ---------------------------------------------------------------------------
 
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
@@ -411,7 +412,7 @@ describe("credential_store tool — prompt action", () => {
     expect(result.content).not.toContain("prompt-secret-val");
 
     // Verify stored
-    expect(getSecureKey("credential:test-prompt:api_key")).toBe(
+    expect(getSecureKey(credentialKey("test-prompt", "api_key"))).toBe(
       "prompt-secret-val",
     );
   });
@@ -603,7 +604,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     upsertCredentialMetadata("integration:gmail", "access_token", {
       oauth2ClientId: "stored-client-id-123",
     });
-    setSecureKey("credential:integration:gmail:client_secret", "test-secret");
+    setSecureKey(
+      credentialKey("integration:gmail", "client_secret"),
+      "test-secret",
+    );
 
     const result = await credentialStoreTool.execute(
       {
@@ -784,7 +788,7 @@ describe("credential_store tool — store validation edge cases", () => {
     );
 
     // Verify stored
-    expect(getSecureKey("credential:del-test:key")).toBe("secret");
+    expect(getSecureKey(credentialKey("del-test", "key"))).toBe("secret");
     const { getCredentialMetadata } =
       await import("../tools/credentials/metadata-store.js");
     expect(getCredentialMetadata("del-test", "key")).toBeDefined();
@@ -801,7 +805,7 @@ describe("credential_store tool — store validation edge cases", () => {
     expect(result.isError).toBe(false);
 
     // Both should be gone
-    expect(getSecureKey("credential:del-test:key")).toBeUndefined();
+    expect(getSecureKey(credentialKey("del-test", "key"))).toBeUndefined();
     expect(getCredentialMetadata("del-test", "key")).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -71,6 +71,7 @@ mock.module("../security/oauth2.js", () => {
 
 // getCredentialValue is no longer exported (sealed in PR 17) — use getSecureKey directly
 
+import { credentialKey } from "../security/credential-key.js";
 import {
   deleteSecureKey,
   getSecureKey,
@@ -146,7 +147,7 @@ async function executeVault(
         };
       }
 
-      const key = `credential:${service}:${field}`;
+      const key = credentialKey(service, field);
       const ok = setSecureKey(key, value);
       if (!ok) {
         return { content: "Error: failed to store credential", isError: true };
@@ -177,7 +178,7 @@ async function executeVault(
         };
       }
 
-      const key = `credential:${service}:${field}`;
+      const key = credentialKey(service, field);
       const result = deleteSecureKey(key);
       if (result !== "deleted") {
         return {
@@ -579,7 +580,7 @@ describe("credential_store tool", () => {
 
       // Delete the secret directly without going through the tool (simulates
       // a divergence where metadata write failed after secret deletion)
-      deleteSecureKey("credential:svc-a:key");
+      deleteSecureKey(credentialKey("svc-a", "key"));
 
       const result = await credentialStoreTool.execute(
         { action: "list" },
@@ -622,7 +623,7 @@ describe("credential_store tool", () => {
   // -----------------------------------------------------------------------
   describe("delete action", () => {
     test("deletes a stored credential", async () => {
-      setSecureKey("credential:gmail:password", "secret");
+      setSecureKey(credentialKey("gmail", "password"), "secret");
 
       const result = await executeVault({
         action: "delete",
@@ -633,7 +634,7 @@ describe("credential_store tool", () => {
       expect(result.content).toBe("Deleted credential for gmail/password.");
 
       // Verify it's actually gone
-      expect(getSecureKey("credential:gmail:password")).toBeUndefined();
+      expect(getSecureKey(credentialKey("gmail", "password"))).toBeUndefined();
     });
 
     test("returns error for non-existent credential", async () => {
@@ -670,12 +671,14 @@ describe("credential_store tool", () => {
   // -----------------------------------------------------------------------
   describe("credential value access", () => {
     test("credential values are stored via secure keys", () => {
-      setSecureKey("credential:github:token", "ghp_abc123");
-      expect(getSecureKey("credential:github:token")).toBe("ghp_abc123");
+      setSecureKey(credentialKey("github", "token"), "ghp_abc123");
+      expect(getSecureKey(credentialKey("github", "token"))).toBe("ghp_abc123");
     });
 
     test("returns undefined for non-existent credential", () => {
-      expect(getSecureKey("credential:nonexistent:field")).toBeUndefined();
+      expect(
+        getSecureKey(credentialKey("nonexistent", "field")),
+      ).toBeUndefined();
     });
   });
 
@@ -1120,8 +1123,12 @@ describe("credential_store tool", () => {
         value: "github-pass",
       });
 
-      expect(getSecureKey("credential:gmail:password")).toBe("gmail-pass");
-      expect(getSecureKey("credential:github:password")).toBe("github-pass");
+      expect(getSecureKey(credentialKey("gmail", "password"))).toBe(
+        "gmail-pass",
+      );
+      expect(getSecureKey(credentialKey("github", "password"))).toBe(
+        "github-pass",
+      );
     });
 
     test("same service with different fields do not collide", async () => {
@@ -1138,8 +1145,8 @@ describe("credential_store tool", () => {
         value: "backup@example.com",
       });
 
-      expect(getSecureKey("credential:gmail:password")).toBe("pass123");
-      expect(getSecureKey("credential:gmail:recovery_email")).toBe(
+      expect(getSecureKey(credentialKey("gmail", "password"))).toBe("pass123");
+      expect(getSecureKey(credentialKey("gmail", "recovery_email"))).toBe(
         "backup@example.com",
       );
     });
@@ -1188,8 +1195,11 @@ describe("withValidToken refresh deduplication", () => {
     opts?: { expired?: boolean; accessToken?: string },
   ) {
     const accessToken = opts?.accessToken ?? "old-access-token";
-    setSecureKey(`credential:${service}:access_token`, accessToken);
-    setSecureKey(`credential:${service}:refresh_token`, "valid-refresh-token");
+    setSecureKey(credentialKey(service, "access_token"), accessToken);
+    setSecureKey(
+      credentialKey(service, "refresh_token"),
+      "valid-refresh-token",
+    );
     upsertCredentialMetadata(service, "access_token", {
       oauth2TokenUrl: "https://oauth.example.com/token",
       oauth2ClientId: "test-client-id",

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -21,6 +21,7 @@ import { upsertBinding } from "../memory/external-conversation-store.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { isGuardian } from "../runtime/channel-verification-service.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { upsertActiveCallLease } from "./active-call-lease.js";
@@ -197,7 +198,9 @@ export async function resolveCallerIdentity(
     userNumber = getTwilioUserPhoneNumber()!;
     numberSource = "env_var";
   } else {
-    const secureKeyValue = getSecureKey("credential:twilio:user_phone_number");
+    const secureKeyValue = getSecureKey(
+      credentialKey("twilio", "user_phone_number"),
+    );
     if (secureKeyValue) {
       userNumber = secureKeyValue;
       numberSource = "secure_key";

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -4,6 +4,7 @@ import {
   getPublicBaseUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -45,7 +46,7 @@ export function resolveTwilioPhoneNumber(): string {
 export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
-  const authToken = getSecureKey("credential:twilio:auth_token") || "";
+  const authToken = getSecureKey(credentialKey("twilio", "auth_token")) || "";
   const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -7,6 +7,7 @@
  */
 
 import { loadConfig } from "../config/loader.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
@@ -28,7 +29,7 @@ function resolveAccountSid(): string | undefined {
 
 /** Resolve the Twilio Auth Token from the credential store. */
 function resolveAuthToken(): string | undefined {
-  return getSecureKey("credential:twilio:auth_token") || undefined;
+  return getSecureKey(credentialKey("twilio", "auth_token")) || undefined;
 }
 
 /** Resolve Twilio credentials from config (SID) and credential store (token). Throws if not configured. */

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -15,6 +15,7 @@ import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
+import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKey } from "../../../security/secure-keys.js";
 import type { MessagingProvider } from "../../provider.js";
 import type {
@@ -42,7 +43,7 @@ function getBearerToken(): string {
 
 /** Read the Telegram bot token from the credential vault. */
 function getBotToken(): string | undefined {
-  return getSecureKey("credential:telegram:bot_token");
+  return getSecureKey(credentialKey("telegram", "bot_token"));
 }
 
 export const telegramBotMessagingProvider: MessagingProvider = {
@@ -64,7 +65,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   isConnected(): boolean {
     return (
       getBotToken() !== undefined &&
-      !!getSecureKey("credential:telegram:webhook_secret")
+      !!getSecureKey(credentialKey("telegram", "webhook_secret"))
     );
   },
 

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -14,6 +14,7 @@ import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
+import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKey } from "../../../security/secure-keys.js";
 import type { MessagingProvider } from "../../provider.js";
 import type {
@@ -42,8 +43,8 @@ function getBearerToken(): string {
 /** Check whether WhatsApp credentials are stored. */
 function hasWhatsAppCredentials(): boolean {
   return (
-    !!getSecureKey("credential:whatsapp:phone_number_id") &&
-    !!getSecureKey("credential:whatsapp:access_token")
+    !!getSecureKey(credentialKey("whatsapp", "phone_number_id")) &&
+    !!getSecureKey(credentialKey("whatsapp", "access_token"))
   );
 }
 
@@ -73,7 +74,9 @@ export const whatsappMessagingProvider: MessagingProvider = {
       };
     }
 
-    const phoneNumberId = getSecureKey("credential:whatsapp:phone_number_id")!;
+    const phoneNumberId = getSecureKey(
+      credentialKey("whatsapp", "phone_number_id"),
+    )!;
 
     return {
       connected: true,

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -6,6 +6,7 @@
  * orchestrator without duplicating storage logic.
  */
 
+import { credentialKey, migrateKeys } from "../security/credential-key.js";
 import type {
   OAuth2FlowResult,
   TokenEndpointAuthMethod,
@@ -53,6 +54,8 @@ export interface StoreOAuth2TokensParams {
 export async function storeOAuth2Tokens(
   params: StoreOAuth2TokensParams,
 ): Promise<{ accountInfo?: string }> {
+  migrateKeys();
+
   const {
     service,
     tokens,
@@ -68,7 +71,7 @@ export async function storeOAuth2Tokens(
   } = params;
 
   const tokenStored = await setSecureKeyAsync(
-    `credential:${service}:access_token`,
+    credentialKey(service, "access_token"),
     tokens.accessToken,
   );
   if (!tokenStored) {
@@ -98,7 +101,7 @@ export async function storeOAuth2Tokens(
   // secure store. token-manager.ts reads it from meta?.oauth2ClientId.
   if (clientSecret) {
     const clientSecretStored = await setSecureKeyAsync(
-      `credential:${service}:client_secret`,
+      credentialKey(service, "client_secret"),
       clientSecret,
     );
     if (!clientSecretStored) {
@@ -161,7 +164,7 @@ export async function storeOAuth2Tokens(
 
   if (tokens.refreshToken) {
     const refreshStored = await setSecureKeyAsync(
-      `credential:${service}:refresh_token`,
+      credentialKey(service, "refresh_token"),
       tokens.refreshToken,
     );
     if (refreshStored) {
@@ -173,7 +176,7 @@ export async function storeOAuth2Tokens(
     // Re-auth grants that omit refresh_token must clear any stale stored
     // token — otherwise withValidToken() will attempt refresh with invalid
     // credentials.
-    await deleteSecureKeyAsync(`credential:${service}:refresh_token`);
+    await deleteSecureKeyAsync(credentialKey(service, "refresh_token"));
     upsertCredentialMetadata(service, "access_token", {
       hasRefreshToken: false,
     });

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -3,6 +3,7 @@ import { hasTwilioCredentials } from "../calls/twilio-rest.js";
 import { getChannelInvitePolicy } from "../channels/config.js";
 import { loadRawConfig } from "../config/loader.js";
 import { getEmailService } from "../email/service.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { resolveWhatsAppDisplayNumber } from "./channel-invite-transports/whatsapp.js";
 import type {
@@ -90,7 +91,7 @@ const telegramProbe: ChannelProbe = {
   runLocalChecks(): ReadinessCheckResult[] {
     const results: ReadinessCheckResult[] = [];
 
-    const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
+    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
     results.push({
       name: "bot_token",
       passed: hasBotToken,
@@ -100,7 +101,7 @@ const telegramProbe: ChannelProbe = {
     });
 
     const hasWebhookSecret = !!getSecureKey(
-      "credential:telegram:webhook_secret",
+      credentialKey("telegram", "webhook_secret"),
     );
     results.push({
       name: "webhook_secret",
@@ -132,7 +133,8 @@ const emailProbe: ChannelProbe = {
     const results: ReadinessCheckResult[] = [];
 
     const hasApiKey = !!(
-      getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
+      getSecureKey("agentmail") ||
+      getSecureKey(credentialKey("agentmail", "api_key"))
     );
     results.push({
       name: "agentmail_api_key",
@@ -165,7 +167,8 @@ const emailProbe: ChannelProbe = {
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
     // Only worth checking if the API key is present
     const hasApiKey = !!(
-      getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
+      getSecureKey("agentmail") ||
+      getSecureKey(credentialKey("agentmail", "api_key"))
     );
     if (!hasApiKey) return [];
 
@@ -202,7 +205,7 @@ const whatsappProbe: ChannelProbe = {
     const results: ReadinessCheckResult[] = [];
 
     const hasPhoneNumberId = !!getSecureKey(
-      "credential:whatsapp:phone_number_id",
+      credentialKey("whatsapp", "phone_number_id"),
     );
     results.push({
       name: "whatsapp_phone_number_id",
@@ -212,7 +215,9 @@ const whatsappProbe: ChannelProbe = {
         : "WhatsApp phone number ID is not configured",
     });
 
-    const hasAccessToken = !!getSecureKey("credential:whatsapp:access_token");
+    const hasAccessToken = !!getSecureKey(
+      credentialKey("whatsapp", "access_token"),
+    );
     results.push({
       name: "whatsapp_access_token",
       passed: hasAccessToken,
@@ -221,7 +226,9 @@ const whatsappProbe: ChannelProbe = {
         : "WhatsApp access token is not configured",
     });
 
-    const hasAppSecret = !!getSecureKey("credential:whatsapp:app_secret");
+    const hasAppSecret = !!getSecureKey(
+      credentialKey("whatsapp", "app_secret"),
+    );
     results.push({
       name: "whatsapp_app_secret",
       passed: hasAppSecret,
@@ -231,7 +238,7 @@ const whatsappProbe: ChannelProbe = {
     });
 
     const hasWebhookVerifyToken = !!getSecureKey(
-      "credential:whatsapp:webhook_verify_token",
+      credentialKey("whatsapp", "webhook_verify_token"),
     );
     results.push({
       name: "whatsapp_webhook_verify_token",
@@ -278,8 +285,12 @@ const whatsappProbe: ChannelProbe = {
 const slackProbe: ChannelProbe = {
   channel: "slack",
   runLocalChecks(): ReadinessCheckResult[] {
-    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+    const hasBotToken = !!getSecureKey(
+      credentialKey("slack_channel", "bot_token"),
+    );
+    const hasAppToken = !!getSecureKey(
+      credentialKey("slack_channel", "app_token"),
+    );
     return [
       {
         name: "bot_token",

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -23,6 +23,7 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../../permissions/checker.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
@@ -137,9 +138,9 @@ function getClientSecret(
   rawService: string,
 ): string | undefined {
   return (
-    getSecureKey(`credential:${resolvedService}:client_secret`) ??
+    getSecureKey(credentialKey(resolvedService, "client_secret")) ??
     (resolvedService !== rawService
-      ? getSecureKey(`credential:${rawService}:client_secret`)
+      ? getSecureKey(credentialKey(rawService, "client_secret"))
       : undefined) ??
     undefined
   );

--- a/assistant/src/security/credential-key.ts
+++ b/assistant/src/security/credential-key.ts
@@ -1,0 +1,114 @@
+/**
+ * Single source of truth for credential key format in the secure store.
+ *
+ * Keys follow the pattern: credential/{service}/{field}
+ *
+ * Previously, keys used colons as delimiters (credential:service:field),
+ * which was ambiguous when service names contained colons (e.g.
+ * "integration:gmail"). The slash-delimited format avoids this.
+ */
+
+import { getLogger } from "../util/logger.js";
+import {
+  deleteSecureKey,
+  getSecureKey,
+  listSecureKeys,
+  setSecureKey,
+} from "./secure-keys.js";
+
+const log = getLogger("credential-key");
+
+/**
+ * Build a credential key for the secure store.
+ *
+ * @returns A key of the form `credential/{service}/{field}`
+ */
+export function credentialKey(service: string, field: string): string {
+  return `credential/${service}/${field}`;
+}
+
+// ---------------------------------------------------------------------------
+// Migration from colon-delimited keys
+// ---------------------------------------------------------------------------
+
+let migrated = false;
+
+/**
+ * Migrate any legacy colon-delimited credential keys to the new
+ * slash-delimited format. Idempotent: skips keys that already exist
+ * under the new format, and only runs once per process (guarded by a
+ * module-level flag).
+ *
+ * Legacy key format: `credential:<service>:<field>`
+ * New key format:    `credential/<service>/<field>`
+ *
+ * Service names may contain colons (e.g. "integration:gmail"), so the
+ * parsing splits on the first colon after "credential" and the last
+ * colon to extract service and field.
+ */
+export function migrateKeys(): void {
+  if (migrated) return;
+  migrated = true;
+
+  let allKeys: string[];
+  try {
+    allKeys = listSecureKeys();
+  } catch (err) {
+    log.warn({ err }, "Failed to list secure keys during migration");
+    return;
+  }
+
+  const colonKeys = allKeys.filter(
+    (k) => k.startsWith("credential:") && !k.startsWith("credential/"),
+  );
+  if (colonKeys.length === 0) return;
+
+  log.info(
+    { count: colonKeys.length },
+    "Migrating colon-delimited credential keys to slash-delimited format",
+  );
+
+  for (const oldKey of colonKeys) {
+    // Strip the "credential:" prefix
+    const rest = oldKey.slice("credential:".length);
+
+    // Split on the last colon to get field; everything before is the service.
+    // This handles service names with colons (e.g. "integration:gmail").
+    const lastColon = rest.lastIndexOf(":");
+    if (lastColon <= 0) {
+      log.warn({ key: oldKey }, "Skipping malformed credential key");
+      continue;
+    }
+
+    const service = rest.slice(0, lastColon);
+    const field = rest.slice(lastColon + 1);
+    const newKey = credentialKey(service, field);
+
+    // Skip if the new key already exists (idempotent)
+    if (getSecureKey(newKey) !== undefined) {
+      // Clean up old key
+      deleteSecureKey(oldKey);
+      continue;
+    }
+
+    const value = getSecureKey(oldKey);
+    if (value === undefined) {
+      continue;
+    }
+
+    const ok = setSecureKey(newKey, value);
+    if (ok) {
+      deleteSecureKey(oldKey);
+    } else {
+      log.warn(
+        { oldKey, newKey },
+        "Failed to write migrated key; keeping old key",
+      );
+    }
+  }
+}
+
+/** @internal Test-only: reset the migration guard so migrateKeys() runs again. */
+export function _resetMigrationFlag(): void {
+  migrated = false;
+}

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -11,6 +11,7 @@ import {
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
+import { credentialKey, migrateKeys } from "./credential-key.js";
 import { refreshOAuth2Token, type TokenEndpointAuthMethod } from "./oauth2.js";
 import { getSecureKey, setSecureKeyAsync } from "./secure-keys.js";
 
@@ -171,7 +172,7 @@ function isTokenExpired(service: string): boolean {
  * Throws `TokenExpiredError` if refresh is not possible.
  */
 async function doRefresh(service: string): Promise<string> {
-  const refreshToken = getSecureKey(`credential:${service}:refresh_token`);
+  const refreshToken = getSecureKey(credentialKey(service, "refresh_token"));
   if (!refreshToken) {
     throw new TokenExpiredError(
       service,
@@ -198,7 +199,7 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  const clientSecret = getSecureKey(`credential:${service}:client_secret`);
+  const clientSecret = getSecureKey(credentialKey(service, "client_secret"));
   const authMethod = meta?.oauth2TokenEndpointAuthMethod as
     | TokenEndpointAuthMethod
     | undefined;
@@ -242,7 +243,7 @@ async function doRefresh(service: string): Promise<string> {
 
   if (
     !(await setSecureKeyAsync(
-      `credential:${service}:access_token`,
+      credentialKey(service, "access_token"),
       result.accessToken,
     ))
   ) {
@@ -255,7 +256,7 @@ async function doRefresh(service: string): Promise<string> {
   if (result.refreshToken) {
     if (
       !(await setSecureKeyAsync(
-        `credential:${service}:refresh_token`,
+        credentialKey(service, "refresh_token"),
         result.refreshToken,
       ))
     ) {
@@ -293,7 +294,9 @@ export async function withValidToken<T>(
   service: string,
   callback: (token: string) => Promise<T>,
 ): Promise<T> {
-  let token = getSecureKey(`credential:${service}:access_token`);
+  migrateKeys();
+
+  let token = getSecureKey(credentialKey(service, "access_token"));
   if (!token) {
     throw new TokenExpiredError(
       service,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -7,6 +7,7 @@ import {
 } from "../../oauth/provider-profiles.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { credentialKey } from "../../security/credential-key.js";
 import type { TokenEndpointAuthMethod } from "../../security/oauth2.js";
 import {
   deleteSecureKeyAsync,
@@ -47,7 +48,7 @@ function findStoredOAuthSecret(
     if (alias === service) servicesToCheck.push(canonical);
   }
   for (const svc of servicesToCheck) {
-    const value = getSecureKey(`credential:${svc}:${field}`);
+    const value = getSecureKey(credentialKey(svc, field));
     if (value) return value;
   }
   return undefined;
@@ -376,7 +377,7 @@ class CredentialStoreTool implements Tool {
           };
         }
 
-        const key = `credential:${service}:${field}`;
+        const key = credentialKey(service, field);
         const ok = await setSecureKeyAsync(key, value);
         if (!ok) {
           return {
@@ -439,7 +440,7 @@ class CredentialStoreTool implements Tool {
         const entries = allMetadata
           .filter((m) => {
             if (secureKeySet)
-              return secureKeySet.has(`credential:${m.service}:${m.field}`);
+              return secureKeySet.has(credentialKey(m.service, m.field));
             return true;
           })
           .map((m) => {
@@ -489,7 +490,7 @@ class CredentialStoreTool implements Tool {
           };
         }
 
-        const key = `credential:${service}:${field}`;
+        const key = credentialKey(service, field);
         const result = await deleteSecureKeyAsync(key);
         if (result === "error") {
           return {
@@ -729,7 +730,7 @@ class CredentialStoreTool implements Tool {
         }
 
         // Default: persist to keychain
-        const key = `credential:${service}:${field}`;
+        const key = credentialKey(service, field);
         const ok = await setSecureKeyAsync(key, result.value);
         if (!ok) {
           return {


### PR DESCRIPTION
## Summary
- Add `credentialKey(service, field)` helper in `security/credential-key.ts` as single source of truth for key format (`credential/{service}/{field}`)
- Add `migrateKeys()` function that auto-migrates legacy colon-delimited keys on first credential access (idempotent, once-guard)
- Replace all inline `credential:service:field` patterns across 11 production files with `credentialKey()` calls
- Update 4 test files for the new delimiter and add `credential-key.ts` to the ALLOWED_IMPORTERS allowlist
- Update pre-commit hook to whitelist nested `credentialKey()` function-call patterns

Part of plan: credential-storage-hygiene.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
