### PR TITLE
Add version/build info to Sentry errors and log submissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -701,6 +701,7 @@ jobs:
       - name: Build binaries
         run: |
           DISPLAY_VERSION="${{ steps.version.outputs.display_version }}" \
+          COMMIT_SHA="${{ github.sha }}" \
           ./build.sh binaries
 
       - name: Build release .app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1011,6 +1011,8 @@ jobs:
           if [ -n "$DISPLAY_VERSION" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
             DAEMON_FLAGS+=(--define "process.env.APP_VERSION='$DISPLAY_VERSION'")
           fi
+          DAEMON_FLAGS+=(--define "process.env.COMMIT_SHA='${{ github.sha }}'")
+
 
           # Daemon
           (cd "$ASSISTANT_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/node";
 
+import { arch, platform, release } from "node:os";
+
 import { getSentryDsn } from "./config/env.js";
-import { APP_VERSION } from "./version.js";
+import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
@@ -42,8 +44,19 @@ export function initSentry(): void {
   Sentry.init({
     dsn: getSentryDsn(),
     release: `vellum-assistant@${APP_VERSION}`,
+    dist: COMMIT_SHA,
     environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
     sendDefaultPii: false,
+    initialScope: {
+      tags: {
+        commit: COMMIT_SHA,
+        os_platform: platform(),
+        os_release: release(),
+        os_arch: arch(),
+        runtime: "bun",
+        runtime_version: typeof Bun !== "undefined" ? Bun.version : process.version,
+      },
+    },
     beforeSend(event) {
       if (event.exception?.values) {
         event.exception.values = event.exception.values.map((ex) => ({

--- a/assistant/src/version.ts
+++ b/assistant/src/version.ts
@@ -32,3 +32,13 @@ function resolveVersion(): string {
 // Falls back to "0.0.0-dev" for local development, or resolves the dev
 // placeholder to package.json version when explicitly set in CI.
 export const APP_VERSION: string = resolveVersion();
+
+// Commit SHA is embedded at compile time via --define in CI.
+// Falls back to "unknown" for local development.
+function resolveCommitSha(): string {
+  const sha = process.env.COMMIT_SHA;
+  if (!sha || sha === "unknown") return "unknown";
+  return sha;
+}
+
+export const COMMIT_SHA: string = resolveCommitSha();

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -188,6 +188,9 @@ build_binaries() {
     if [ -n "${DISPLAY_VERSION:-}" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
         daemon_flags+=(--define "process.env.APP_VERSION='$DISPLAY_VERSION'")
     fi
+    if [ -n "${COMMIT_SHA:-}" ]; then
+        daemon_flags+=(--define "process.env.COMMIT_SHA='$COMMIT_SHA'")
+    fi
     build_bun_binary "$ASSISTANT_SRC_DIR" "$ASSISTANT_SRC_DIR/src/daemon/main.ts" \
         "$SCRIPT_DIR/daemon-bin" "vellum-daemon" "${daemon_flags[@]}"
     # Copy WASM assets (not bundled by bun --compile)
@@ -356,6 +359,9 @@ if [ "$DAEMON_BIN_NEEDS_BUILD" = true ]; then
     local_daemon_flags=("${DAEMON_EXTERNAL_FLAGS[@]}")
     if [ -n "${DISPLAY_VERSION:-}" ] && [ "$DISPLAY_VERSION" != "0.1.0" ]; then
         local_daemon_flags+=(--define "process.env.APP_VERSION='$DISPLAY_VERSION'")
+    fi
+    if [ -n "${COMMIT_SHA:-}" ]; then
+        local_daemon_flags+=(--define "process.env.COMMIT_SHA='$COMMIT_SHA'")
     fi
     build_bun_binary "$ASSISTANT_SRC_DIR" "$ASSISTANT_SRC_DIR/src/daemon/main.ts" \
         "$SCRIPT_DIR/daemon-bin" "vellum-daemon" "${local_daemon_flags[@]}"

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -154,8 +154,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // lifecycle.ts (init at top, close after config load if flag disabled).
         let collectUsageData = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
         let perfOptIn = collectUsageData && UserDefaults.standard.bool(forKey: "sendPerformanceReports")
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         SentrySDK.start { options in
             options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+            options.releaseName = "vellum-macos@\(appVersion)"
+            options.dist = buildNumber
             options.debug = false
             options.tracesSampleRate = 0.1
             options.configureProfiling = { profilingOptions in

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -62,8 +62,12 @@ import os
         sentrySerialQueue.async {
             let wasDisabled = !SentrySDK.isEnabled
             if wasDisabled {
+                let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+                let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
                 SentrySDK.start { options in
                     options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+                    options.releaseName = "vellum-macos@\(version)"
+                    options.dist = build
                     options.sendDefaultPii = false
                     // Disable crash capture and session tracking so the temporary
                     // restart only sends the explicit event, not incidental crashes.
@@ -132,8 +136,12 @@ import os
             let collectUsageData = UserDefaults.standard.object(forKey: "collectUsageDataEnabled") as? Bool ?? true
             guard collectUsageData else { return }
             let perfOptIn = UserDefaults.standard.bool(forKey: "sendPerformanceReports")
+            let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+            let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
             SentrySDK.start { options in
                 options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+                options.releaseName = "vellum-macos@\(version)"
+                options.dist = build
                 options.debug = false
                 options.tracesSampleRate = 0.1
                 options.configureProfiling = { profilingOptions in


### PR DESCRIPTION
adding this to help me decipher filter/de-noise sentry issues that are coming in from outdated releases

## Summary

- **Assistant daemon**: Add git commit SHA as `dist` and Sentry tag, plus OS platform/arch and Bun runtime version tags to every Sentry event. Inject `COMMIT_SHA` at compile time via `--define` in the release workflow.
- **macOS client**: Set `releaseName` (`vellum-macos@{version}`) and `dist` (build number) on all three `SentrySDK.start` call sites so events are properly tagged with the app version.
- **Build pipeline**: Pass `github.sha` as `COMMIT_SHA` define flag during CI daemon builds.

## Original prompt
--safe are we including version/build info in sentry errors + log submissions? if we are, no action needed. if not, we should start doing that, and tag Timur on the PR we open for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
