### PR TITLE
M2: Allow expanding running tool calls and show live output in StepDetailRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -460,10 +460,10 @@ private struct StepDetailRow: View {
             || toolCall.inputFull.hasSuffix("[truncated]")
     }
 
-    /// Whether this completed tool has detail content to show.
+    /// Whether this tool has detail content to show (running or completed).
     private var hasDetails: Bool {
-        guard toolCall.isComplete else { return false }
         return !toolCall.inputFull.isEmpty || toolCall.inputRawDict != nil
+            || !toolCall.partialOutput.isEmpty
             || (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true))
             || !toolCall.claudeCodeSteps.isEmpty
     }
@@ -669,6 +669,59 @@ private struct StepDetailRow: View {
                         steps: toolCall.claudeCodeSteps,
                         isRunning: false
                     )
+                }
+                .padding(.horizontal, VSpacing.lg)
+            }
+
+            // Live output (streaming, running tools only)
+            if !toolCall.partialOutput.isEmpty && !toolCall.isComplete {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Live output")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                        .textCase(.uppercase)
+
+                    ZStack(alignment: .topTrailing) {
+                        ScrollView {
+                            ScrollViewReader { proxy in
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Text(toolCall.partialOutput)
+                                        .font(VFont.monoSmall)
+                                        .foregroundColor(VColor.textSecondary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .textSelection(.enabled)
+
+                                    Text("")
+                                        .id("bottom")
+                                }
+                                .onChange(of: toolCall.partialOutput) {
+                                    proxy.scrollTo("bottom", anchor: .bottom)
+                                }
+                            }
+                        }
+                        .frame(maxHeight: 200)
+                        .padding(VSpacing.sm)
+                        .background(VColor.background.opacity(0.6))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 0.5)
+                        )
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(toolCall.partialOutput, forType: .string)
+                        } label: {
+                            VIconView(.copy, size: 10)
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 24, height: 24)
+                                .background(VColor.backgroundSubtle)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(VSpacing.xs)
+                        .accessibilityLabel("Copy live output")
+                    }
                 }
                 .padding(.horizontal, VSpacing.lg)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -683,22 +683,13 @@ private struct StepDetailRow: View {
 
                     ZStack(alignment: .topTrailing) {
                         ScrollView {
-                            ScrollViewReader { proxy in
-                                VStack(alignment: .leading, spacing: 0) {
-                                    Text(toolCall.partialOutput)
-                                        .font(VFont.monoSmall)
-                                        .foregroundColor(VColor.textSecondary)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .textSelection(.enabled)
-
-                                    Text("")
-                                        .id("bottom")
-                                }
-                                .onChange(of: toolCall.partialOutput) {
-                                    proxy.scrollTo("bottom", anchor: .bottom)
-                                }
-                            }
+                            Text(toolCall.partialOutput)
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
                         }
+                        .defaultScrollAnchor(.bottom)
                         .frame(maxHeight: 200)
                         .padding(VSpacing.sm)
                         .background(VColor.background.opacity(0.6))


### PR DESCRIPTION
## Summary
- Remove `isComplete` guard from `hasDetails`, allowing users to expand running tool calls to see technical details and live streaming output
- Add a "Live output" section with auto-scrolling `ScrollViewReader` that displays `partialOutput` as chunks stream in
- Follows existing Output section visual patterns (dark background box, max height 200, copy button, monospace text)

Part of #15421.

## Test plan
- [ ] Start a tool call that produces streaming output (e.g., bash command with verbose output)
- [ ] Verify the running tool call row shows a chevron and is expandable
- [ ] Expand the running tool call and verify "Technical details" section appears
- [ ] Verify "Live output" section appears with streaming text that auto-scrolls to bottom
- [ ] Verify copy button works for live output
- [ ] Verify "Live output" section disappears once the tool completes and "Output" section shows final result
- [ ] Verify completed tool calls still expand/collapse correctly with all existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
