### PR TITLE
Streaming output for running tool calls

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -88,6 +88,7 @@ export interface ToolOutputChunk {
   type: "tool_output_chunk";
   chunk: string;
   sessionId?: string;
+  toolUseId?: string;
   subType?: "tool_start" | "tool_complete" | "status";
   subToolName?: string;
   subToolInput?: string;

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -384,6 +384,7 @@ export function handleToolOutputChunk(
       type: "tool_output_chunk",
       chunk: event.chunk,
       sessionId: deps.ctx.conversationId,
+      toolUseId: event.toolUseId,
       subType: structured.subType,
       subToolName: structured.subToolName,
       subToolInput: structured.subToolInput,
@@ -395,6 +396,7 @@ export function handleToolOutputChunk(
       type: "tool_output_chunk",
       chunk: event.chunk,
       sessionId: deps.ctx.conversationId,
+      toolUseId: event.toolUseId,
     });
   }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -460,10 +460,10 @@ private struct StepDetailRow: View {
             || toolCall.inputFull.hasSuffix("[truncated]")
     }
 
-    /// Whether this completed tool has detail content to show.
+    /// Whether this tool has detail content to show (running or completed).
     private var hasDetails: Bool {
-        guard toolCall.isComplete else { return false }
         return !toolCall.inputFull.isEmpty || toolCall.inputRawDict != nil
+            || !toolCall.partialOutput.isEmpty
             || (toolCall.result != nil && !(toolCall.result?.isEmpty ?? true))
             || !toolCall.claudeCodeSteps.isEmpty
     }
@@ -669,6 +669,50 @@ private struct StepDetailRow: View {
                         steps: toolCall.claudeCodeSteps,
                         isRunning: false
                     )
+                }
+                .padding(.horizontal, VSpacing.lg)
+            }
+
+            // Live output (streaming, running tools only)
+            if !toolCall.partialOutput.isEmpty && !toolCall.isComplete {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Live output")
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                        .textCase(.uppercase)
+
+                    ZStack(alignment: .topTrailing) {
+                        ScrollView {
+                            Text(toolCall.partialOutput)
+                                .font(VFont.monoSmall)
+                                .foregroundColor(VColor.textSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .defaultScrollAnchor(.bottom)
+                        .frame(maxHeight: 200)
+                        .padding(VSpacing.sm)
+                        .background(VColor.background.opacity(0.6))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.sm)
+                                .stroke(VColor.surfaceBorder, lineWidth: 0.5)
+                        )
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(toolCall.partialOutput, forType: .string)
+                        } label: {
+                            VIconView(.copy, size: 10)
+                                .foregroundColor(VColor.textMuted)
+                                .frame(width: 24, height: 24)
+                                .background(VColor.backgroundSubtle)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(VSpacing.xs)
+                        .accessibilityLabel("Copy live output")
+                    }
                 }
                 .padding(.horizontal, VSpacing.lg)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -675,7 +675,7 @@ private struct StepDetailRow: View {
 
             // Live output: shown while tool is running, and also as fallback
             // when the tool completed without a final result (cancel/error).
-            if !toolCall.partialOutput.isEmpty && (!toolCall.isComplete || toolCall.result == nil) {
+            if !toolCall.partialOutput.isEmpty && (!toolCall.isComplete || (toolCall.result ?? "").isEmpty) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(toolCall.isComplete ? "Output" : "Live output")
                         .font(VFont.small)

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -673,10 +673,11 @@ private struct StepDetailRow: View {
                 .padding(.horizontal, VSpacing.lg)
             }
 
-            // Live output (streaming, running tools only)
-            if !toolCall.partialOutput.isEmpty && !toolCall.isComplete {
+            // Live output: shown while tool is running, and also as fallback
+            // when the tool completed without a final result (cancel/error).
+            if !toolCall.partialOutput.isEmpty && (!toolCall.isComplete || toolCall.result == nil) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Live output")
+                    Text(toolCall.isComplete ? "Output" : "Live output")
                         .font(VFont.small)
                         .foregroundColor(VColor.textMuted)
                         .textCase(.uppercase)

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -747,6 +747,13 @@ public struct ToolCallData: Identifiable, Equatable {
     public var buildingStatus: String?
     /// Non-technical reason for the tool call, extracted from the `reason` field of tool input.
     public var reasonDescription: String?
+    /// Accumulated streaming output from tool_output_chunk events (plain text only).
+    /// Capped at 5000 characters (keeps the tail when exceeded).
+    public var partialOutput: String = ""
+    /// Monotonically increasing revision counter so that `==` can detect
+    /// changes without expensive full-string comparison. Incremented on
+    /// every write, even when `partialOutput` is at the character cap.
+    public var partialOutputRevision: Int = 0
     /// Sub-tool steps for claude_code tool calls (live progress tracking).
     public var claudeCodeSteps: [ClaudeCodeSubStep] = []
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
@@ -772,6 +779,7 @@ public struct ToolCallData: Identifiable, Equatable {
             // (empty -> populated) without expensive full-string comparison.
             && lhs.inputFullLength == rhs.inputFullLength
             && lhs.inputRawValueLength == rhs.inputRawValueLength
+            && lhs.partialOutputRevision == rhs.partialOutputRevision
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.reasonDescription == rhs.reasonDescription
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1655,6 +1655,8 @@ public struct ChatMessage: Identifiable, Equatable {
             toolCalls[i].inputFull = ""
             toolCalls[i].inputFullLength = 0
             toolCalls[i].inputRawDict = nil
+            toolCalls[i].partialOutput = ""
+            toolCalls[i].partialOutputRevision = 0
         }
         for i in attachments.indices {
             attachments[i].data = ""

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -812,7 +812,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
-            discardPartialOutputBuffer()
+            flushPartialOutputBuffer()
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
@@ -870,7 +870,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
-            discardPartialOutputBuffer()
+            flushPartialOutputBuffer()
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -1700,7 +1700,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
-            discardPartialOutputBuffer()
+            flushPartialOutputBuffer()
             // When the user intentionally cancelled, suppress the error.
             // Otherwise, insert an inline error message so errors are visually
             // distinct from normal assistant replies (rendered with a red box).

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -812,7 +812,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
-            flushPartialOutputBuffer()
+            discardPartialOutputBuffer()
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1368,10 +1368,26 @@ extension ChatViewModel {
             guard belongsToSession(msg.sessionId) else { return }
             guard !isLoadingHistory else { return }
             // Handle structured progress events from claude_code sub-tools
+            // Resolve the target tool call: prefer matching by toolUseId, fall back to positional heuristic.
+            let resolvedStructuredTarget: (msgIndex: Int, tcIndex: Int)? = {
+                if let toolUseId = msg.toolUseId {
+                    for i in stride(from: messages.count - 1, through: 0, by: -1) {
+                        if let tcIdx = messages[i].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                            return (i, tcIdx)
+                        }
+                    }
+                }
+                if let existingId = currentAssistantMessageId,
+                   let mIdx = messages.firstIndex(where: { $0.id == existingId }),
+                   let tcIdx = messages[mIdx].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+                    return (mIdx, tcIdx)
+                }
+                return nil
+            }()
             if let subType = msg.subType, !subType.isEmpty,
-               let existingId = currentAssistantMessageId,
-               let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
-               let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+               let target = resolvedStructuredTarget {
+                let msgIndex = target.msgIndex
+                let tcIndex = target.tcIndex
                 switch subType {
                 case "tool_start":
                     if let toolName = msg.subToolName {
@@ -1408,10 +1424,26 @@ extension ChatViewModel {
                     break
                 }
             } else if msg.subType == nil || msg.subType?.isEmpty == true,
-                      !msg.chunk.isEmpty,
-                      let existingId = currentAssistantMessageId,
-                      let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
-                      let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                      !msg.chunk.isEmpty {
+                // Resolve target tool call: prefer toolUseId, fall back to positional heuristic.
+                let resolvedPlainTarget: (msgIndex: Int, tcIndex: Int)? = {
+                    if let toolUseId = msg.toolUseId {
+                        for i in stride(from: messages.count - 1, through: 0, by: -1) {
+                            if let tcIdx = messages[i].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                                return (i, tcIdx)
+                            }
+                        }
+                    }
+                    if let existingId = currentAssistantMessageId,
+                       let mIdx = messages.firstIndex(where: { $0.id == existingId }),
+                       let tcIdx = messages[mIdx].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                        return (mIdx, tcIdx)
+                    }
+                    return nil
+                }()
+                guard let target = resolvedPlainTarget else { return }
+                let msgIndex = target.msgIndex
+                let tcIndex = target.tcIndex
                 // Append plain-text output chunks to the coalescing buffer.
                 // Structured JSON sub-events (with a valid subType) are handled above;
                 // the subType guard prevents them from leaking raw JSON here.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -479,6 +479,48 @@ extension ChatViewModel {
         }
     }
 
+    // MARK: - Partial Output Coalescing
+
+    /// Flush buffered partial-output chunks into the `messages` array.
+    /// Called on a timer and eagerly on `messageComplete` / `toolResult`.
+    func flushPartialOutputBuffer() {
+        partialOutputFlushTask?.cancel()
+        partialOutputFlushTask = nil
+        guard !partialOutputBuffer.isEmpty else { return }
+        let buffered = partialOutputBuffer
+        partialOutputBuffer = [:]
+        let maxPartialOutput = 5000
+        for (_, entry) in buffered {
+            let msgIndex = entry.msgIndex
+            let tcIndex = entry.tcIndex
+            guard msgIndex < messages.count,
+                  tcIndex < messages[msgIndex].toolCalls.count else { continue }
+            messages[msgIndex].toolCalls[tcIndex].partialOutput.append(entry.content)
+            if messages[msgIndex].toolCalls[tcIndex].partialOutput.count > maxPartialOutput {
+                let excess = messages[msgIndex].toolCalls[tcIndex].partialOutput.count - maxPartialOutput
+                messages[msgIndex].toolCalls[tcIndex].partialOutput.removeFirst(excess)
+            }
+            messages[msgIndex].toolCalls[tcIndex].partialOutputRevision += 1
+        }
+    }
+
+    /// Discard any buffered partial-output chunks without flushing.
+    func discardPartialOutputBuffer() {
+        partialOutputFlushTask?.cancel()
+        partialOutputFlushTask = nil
+        partialOutputBuffer = [:]
+    }
+
+    /// Schedule a partial-output flush after the throttle interval if one isn't already pending.
+    private func schedulePartialOutputFlush() {
+        guard partialOutputFlushTask == nil else { return }
+        partialOutputFlushTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.streamingFlushInterval * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.flushPartialOutputBuffer()
+        }
+    }
+
     public func handleServerMessage(_ message: ServerMessage) {
         switch message {
         case .sessionInfo(let info):
@@ -591,6 +633,7 @@ extension ChatViewModel {
             guard belongsToSession(complete.sessionId) else { return }
             // Flush any buffered streaming text before finalizing the message.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             // Backfill the daemon's persisted message ID so diagnostics exports
             // can anchor to it without requiring a history reload.
             if let messageId = complete.messageId,
@@ -769,6 +812,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
+            discardPartialOutputBuffer()
 
         case .generationCancelled(let cancelled):
             guard belongsToSession(cancelled.sessionId) else { return }
@@ -826,6 +870,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
+            discardPartialOutputBuffer()
             // Reset processing messages to sent
             for i in messages.indices {
                 if messages[i].role == .user && messages[i].status == .processing {
@@ -929,6 +974,7 @@ extension ChatViewModel {
             // stuck in streaming state or cause subsequent deltas to append to it.
             if msg.runStillActive != true {
                 flushStreamingBuffer()
+                flushPartialOutputBuffer()
                 if let existingId = currentAssistantMessageId,
                    let index = messages.firstIndex(where: { $0.id == existingId }) {
                     messages[index].isStreaming = false
@@ -954,6 +1000,7 @@ extension ChatViewModel {
             // Flush buffered text so it lands on the current assistant message
             // before we clear the ID and hand off to the next queued turn.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
             // Keep isSending = true — daemon is handing off to next queued message
@@ -1012,6 +1059,7 @@ extension ChatViewModel {
             // Flush any buffered text so already-received tokens are preserved
             // in the assistant message before we clear the turn state.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -1119,6 +1167,7 @@ extension ChatViewModel {
             guard !isLoadingHistory else { return }
             // Flush buffered text before inserting the confirmation message.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             // Route using sessionId when available (daemon >= v1.x includes
             // the conversationId). Fall back to the timestamp-based heuristic
             // via shouldAcceptConfirmation for older daemons that omit sessionId.
@@ -1171,6 +1220,7 @@ extension ChatViewModel {
             }
             // Flush buffered text so it lands before the tool call in content order.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             // If a chip with the same toolUseId already exists (e.g. toolUseStart
             // arrived before this preview), ignore the late preview.
             if let existingId = currentAssistantMessageId,
@@ -1214,6 +1264,7 @@ extension ChatViewModel {
             guard !isWorkspaceRefinementInFlight else { return }
             // Flush buffered text so it lands before the tool call in content order.
             flushStreamingBuffer()
+            flushPartialOutputBuffer()
             lastToolUseReceivedAt = Date()
             // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
             if msg.toolName == "ui_show" || msg.toolName == "ui_update" || msg.toolName == "ui_dismiss" {
@@ -1357,6 +1408,22 @@ extension ChatViewModel {
                 default:
                     break
                 }
+            } else if msg.subType == nil || msg.subType?.isEmpty == true,
+                      !msg.chunk.isEmpty,
+                      let existingId = currentAssistantMessageId,
+                      let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
+                      let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                // Append plain-text output chunks to the coalescing buffer.
+                // Structured JSON sub-events (with a valid subType) are handled above;
+                // the subType guard prevents them from leaking raw JSON here.
+                let key = "\(msgIndex):\(tcIndex)"
+                if var entry = partialOutputBuffer[key] {
+                    entry.content += msg.chunk
+                    partialOutputBuffer[key] = entry
+                } else {
+                    partialOutputBuffer[key] = (msgIndex: msgIndex, tcIndex: tcIndex, content: msg.chunk)
+                }
+                schedulePartialOutputFlush()
             }
 
         case .toolResult(let msg):
@@ -1364,6 +1431,7 @@ extension ChatViewModel {
             guard !isCancelling else { return }
             guard !isLoadingHistory else { return }
             guard !isWorkspaceRefinementInFlight else { return }
+            flushPartialOutputBuffer()
             // Find the matching tool call.
             // Prefer matching by toolUseId (stable identifier) over positional heuristics.
             var targetMsgIndex: Int?
@@ -1632,6 +1700,7 @@ extension ChatViewModel {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
+            discardPartialOutputBuffer()
             // When the user intentionally cancelled, suppress the error.
             // Otherwise, insert an inline error message so errors are visually
             // distinct from normal assistant replies (rendered with a red box).

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -491,9 +491,8 @@ extension ChatViewModel {
         partialOutputBuffer = [:]
         let maxPartialOutput = 5000
         for (_, entry) in buffered {
-            let msgIndex = entry.msgIndex
             let tcIndex = entry.tcIndex
-            guard msgIndex < messages.count,
+            guard let msgIndex = messages.firstIndex(where: { $0.id == entry.messageId }),
                   tcIndex < messages[msgIndex].toolCalls.count else { continue }
             messages[msgIndex].toolCalls[tcIndex].partialOutput.append(entry.content)
             if messages[msgIndex].toolCalls[tcIndex].partialOutput.count > maxPartialOutput {
@@ -1416,12 +1415,13 @@ extension ChatViewModel {
                 // Append plain-text output chunks to the coalescing buffer.
                 // Structured JSON sub-events (with a valid subType) are handled above;
                 // the subType guard prevents them from leaking raw JSON here.
-                let key = "\(msgIndex):\(tcIndex)"
+                let messageId = messages[msgIndex].id
+                let key = "\(messageId):\(tcIndex)"
                 if var entry = partialOutputBuffer[key] {
                     entry.content += msg.chunk
                     partialOutputBuffer[key] = entry
                 } else {
-                    partialOutputBuffer[key] = (msgIndex: msgIndex, tcIndex: tcIndex, content: msg.chunk)
+                    partialOutputBuffer[key] = (messageId: messageId, tcIndex: tcIndex, content: msg.chunk)
                 }
                 schedulePartialOutputFlush()
             }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2460,6 +2460,9 @@ public final class ChatViewModel: ObservableObject {
             // Older page fetched on demand — prepend before existing messages
             // and expand the display window so the newly loaded messages are
             // visible. The loading indicator is cleared here.
+            // Flush any buffered partial output before prepending — the prepend
+            // shifts positional indices so stale buffer entries would corrupt.
+            flushPartialOutputBuffer()
             self.messages = chatMessages + self.messages
             // Expand the display window by the number of messages prepended so
             // the user sees them immediately. Use Int.max if no more pages exist.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -434,9 +434,10 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - Partial Output Coalescing
 
-    /// Buffered partial-output chunks keyed by a composite "msgIndex:tcIndex" key.
-    /// Each entry holds the message index, tool-call index, and accumulated text.
-    var partialOutputBuffer: [String: (msgIndex: Int, tcIndex: Int, content: String)] = [:]
+    /// Buffered partial-output chunks keyed by "messageUUID:tcIndex".
+    /// Uses stable message UUID instead of positional index so the buffer
+    /// survives message-list mutations (pagination prepend, memory trim).
+    var partialOutputBuffer: [String: (messageId: UUID, tcIndex: Int, content: String)] = [:]
     /// Scheduled flush task for coalescing partial-output writes.
     var partialOutputFlushTask: Task<Void, Never>?
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -879,6 +879,7 @@ public final class ChatViewModel: ObservableObject {
                     self?.isSending = false
                     self?.currentAssistantMessageId = nil
                     self?.discardStreamingBuffer()
+                    self?.discardPartialOutputBuffer()
                     self?.reconnectDebounceTask?.cancel()
                     self?.reconnectDebounceTask = Task { @MainActor [weak self] in
                         defer { if !Task.isCancelled { self?.reconnectDebounceTask = nil } }
@@ -1413,6 +1414,7 @@ public final class ChatViewModel: ObservableObject {
                 }
                 self?.currentAssistantMessageId = nil
                 self?.discardStreamingBuffer()
+                self?.discardPartialOutputBuffer()
                 // If a send-direct was pending when the stream dropped,
                 // dispatch it now so the message isn't silently lost.
                 self?.dispatchPendingSendDirect()
@@ -1610,6 +1612,7 @@ public final class ChatViewModel: ObservableObject {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
+            discardPartialOutputBuffer()
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1656,6 +1659,7 @@ public final class ChatViewModel: ObservableObject {
             currentAssistantHasText = false
             lastContentWasToolCall = false
             discardStreamingBuffer()
+            discardPartialOutputBuffer()
             pendingQueuedCount = 0
             pendingMessageIds = []
             requestIdToMessageId = [:]
@@ -1719,6 +1723,7 @@ public final class ChatViewModel: ObservableObject {
             self.currentAssistantHasText = false
             self.lastContentWasToolCall = false
             self.discardStreamingBuffer()
+            self.discardPartialOutputBuffer()
             self.pendingQueuedCount = 0
             self.pendingMessageIds = []
             self.requestIdToMessageId = [:]
@@ -2479,6 +2484,7 @@ public final class ChatViewModel: ObservableObject {
         // after the messages array is replaced, creating an orphan assistant message
         // or appending text to a stale currentAssistantMessageId.
         discardStreamingBuffer()
+        discardPartialOutputBuffer()
         cancelRefetchTasks()
         currentAssistantMessageId = nil
         currentAssistantHasText = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -431,6 +431,15 @@ public final class ChatViewModel: ObservableObject {
     var streamingDeltaBuffer: String = ""
     /// Scheduled flush work item; cancelled and re-created on each delta.
     var streamingFlushTask: Task<Void, Never>?
+
+    // MARK: - Partial Output Coalescing
+
+    /// Buffered partial-output chunks keyed by a composite "msgIndex:tcIndex" key.
+    /// Each entry holds the message index, tool-call index, and accumulated text.
+    var partialOutputBuffer: [String: (msgIndex: Int, tcIndex: Int, content: String)] = [:]
+    /// Scheduled flush task for coalescing partial-output writes.
+    var partialOutputFlushTask: Task<Void, Never>?
+
     /// Safety timer that force-resets the UI if the daemon never acknowledges
     /// a cancel request (e.g. a stuck tool blocks the generation_cancelled event).
     var cancelTimeoutTask: Task<Void, Never>?
@@ -2543,6 +2552,7 @@ public final class ChatViewModel: ObservableObject {
         subManagerPublishTask?.cancel()
         messageLoopTask?.cancel()
         streamingFlushTask?.cancel()
+        partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()
         loadMoreTimeoutTask?.cancel()
         for task in refetchTasks.values { task.cancel() }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4532,16 +4532,18 @@ public struct ToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
     public let sessionId: String?
+    public let toolUseId: String?
     public let subType: String?
     public let subToolName: String?
     public let subToolInput: String?
     public let subToolIsError: Bool?
     public let subToolId: String?
 
-    public init(type: String, chunk: String, sessionId: String? = nil, subType: String? = nil, subToolName: String? = nil, subToolInput: String? = nil, subToolIsError: Bool? = nil, subToolId: String? = nil) {
+    public init(type: String, chunk: String, sessionId: String? = nil, toolUseId: String? = nil, subType: String? = nil, subToolName: String? = nil, subToolInput: String? = nil, subToolIsError: Bool? = nil, subToolId: String? = nil) {
         self.type = type
         self.chunk = chunk
         self.sessionId = sessionId
+        self.toolUseId = toolUseId
         self.subType = subType
         self.subToolName = subToolName
         self.subToolInput = subToolInput


### PR DESCRIPTION
## Summary
- Add `partialOutput` field to `ToolCallData` to accumulate streaming `tool_output_chunk` content during tool execution, with 100ms coalescing buffer to prevent render churn
- Allow users to expand running tool calls in `AssistantProgressView` to see technical details and live streaming output (bash stdout/stderr)
- After completion, live output section disappears and the existing "Output" section shows the final result as before

## Changes
- `clients/shared/Features/Chat/ChatMessage.swift` — Added `partialOutput`, `partialOutputRevision` fields to `ToolCallData`
- `clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift` — Broadened `toolOutputChunk` handler to accumulate chunks for all tool types with subType guard and coalescing buffer
- `clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift` — Removed `isComplete` guard from `hasDetails`, added live output section with auto-scroll

## Milestone PRs (merged into feature branch)
- #15430: M1 — Add partialOutput field to ToolCallData and accumulate streaming chunks
- #15442: M2 — Allow expanding running tool calls and show live output in StepDetailRow

## Project issue
Closes #15421

## Test plan
- [ ] Build the app and trigger a long-running bash command
- [ ] While running, expand the tool call row — should see technical details and live stdout
- [ ] Verify auto-scroll works but doesn't fight manual scrolling
- [ ] Verify completed tools still show final result in "Output" section
- [ ] Verify non-streaming tools (file_read, etc.) show technical details when expanded during execution

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
