### PR TITLE
fix: add service field to Swift OAuthConnectResultResponse type

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2863,13 +2863,15 @@ public struct NotificationThreadCreated: Codable, Sendable {
 public struct OAuthConnectResultResponse: Codable, Sendable {
     public let type: String
     public let success: Bool
+    public let service: String?
     public let grantedScopes: [String]?
     public let accountInfo: String?
     public let error: String?
 
-    public init(type: String, success: Bool, grantedScopes: [String]? = nil, accountInfo: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, service: String? = nil, grantedScopes: [String]? = nil, accountInfo: String? = nil, error: String? = nil) {
         self.type = type
         self.success = success
+        self.service = service
         self.grantedScopes = grantedScopes
         self.accountInfo = accountInfo
         self.error = error


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for credential-storage-hygiene.md.

**Gap:** Swift OAuthConnectResultResponse missing service field
**What was expected:** Swift type should match TS type which now includes service?: string
**What was found:** The Swift struct did not include the service property

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
