### PR TITLE
Add rate limit diagnostics logging with per-endpoint breakdown

### DIFF
--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -74,6 +74,15 @@ export class RateLimitProvider implements Provider {
 
     if (this.requestTimestamps.length >= limit) {
       const waitSec = Math.ceil((oldestInWindow + 60_000 - now) / 1000);
+      log.warn(
+        {
+          provider: this.name,
+          limit,
+          currentCount: this.requestTimestamps.length,
+          retryAfterSec: waitSec,
+        },
+        `Provider rate limit exceeded: ${limit} requests/minute for ${this.name}`,
+      );
       throw new RateLimitError(
         `Rate limit exceeded: ${limit} requests/minute. Try again in ${waitSec}s.`,
       );
@@ -85,6 +94,14 @@ export class RateLimitProvider implements Provider {
     if (limit <= 0) return;
 
     if (this.sessionTokens >= limit) {
+      log.warn(
+        {
+          provider: this.name,
+          sessionTokens: this.sessionTokens,
+          limit,
+        },
+        `Session token budget exhausted for ${this.name}: ${this.sessionTokens.toLocaleString()}/${limit.toLocaleString()}`,
+      );
       throw new RateLimitError(
         `Session token budget exhausted: ${this.sessionTokens.toLocaleString()}/${limit.toLocaleString()} tokens used. Start a new session to continue.`,
       );

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -60,10 +60,10 @@ All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middle
 
 When the limit is exceeded, the limiter returns 429 and logs a structured warning (module: `rate-limiter`) with the denied endpoint and a breakdown of which endpoints consumed the budget in the current window. This makes it easy to identify whether the cause is rapid thread switching, polling, or unexpected request volume.
 
-Logs are written to rotating daily files at `~/.vellum/assistant-YYYY-MM-DD.log`. To watch rate limit events in real time:
+Logs are written to `~/.vellum/workspace/data/logs/vellum.log` by default. If `logFile.dir` is configured, logs rotate daily as `assistant-YYYY-MM-DD.log` in that directory. To watch rate limit events in real time:
 
 ```bash
-tail -f ~/.vellum/assistant-$(date -u +%Y-%m-%d).log | grep rate-limit
+tail -f ~/.vellum/workspace/data/logs/vellum.log | grep rate-limit
 ```
 
 The provider-level rate limiter (`providers/ratelimit.ts`) also logs warnings (module: `rate-limit`) when request rate or token budget limits are enforced.

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -51,6 +51,23 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 - Guardian approval records in `channelGuardianApprovalRequests` link via `requestId`.
 - The conversational approval engine classifies user intent and resolves via `session.handleConfirmationResponse(requestId, decision)`.
 
+## Rate Limiting & Diagnostics
+
+All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):
+
+- **Authenticated**: 60 requests/minute
+- **Unauthenticated**: 20 requests/minute
+
+When the limit is exceeded, the limiter returns 429 and logs a structured warning (module: `rate-limiter`) with the denied endpoint and a breakdown of which endpoints consumed the budget in the current window. This makes it easy to identify whether the cause is rapid thread switching, polling, or unexpected request volume.
+
+Logs are written to rotating daily files at `~/.vellum/assistant-YYYY-MM-DD.log`. To watch rate limit events in real time:
+
+```bash
+tail -f ~/.vellum/assistant-$(date -u +%Y-%m-%d).log | grep rate-limit
+```
+
+The provider-level rate limiter (`providers/ratelimit.ts`) also logs warnings (module: `rate-limit`) when request rate or token budget limits are enforced.
+
 ## HTTP-Only Transport
 
 HTTP is the sole transport for client-daemon communication. The runtime HTTP server (`assistant/src/runtime/http-server.ts`) is the canonical API surface. Clients connect via HTTP for request/response operations and SSE (`GET /v1/events`) for streaming server-to-client events.

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -532,11 +532,16 @@ export class RuntimeHttpServer {
     if (!isHttpAuthDisabled()) {
       const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
-      const result = token
-        ? apiRateLimiter.check(clientIp)
-        : ipRateLimiter.check(clientIp);
+      const limiter = token ? apiRateLimiter : ipRateLimiter;
+      const limiterKind = token ? "authenticated" : "unauthenticated";
+      const result = limiter.check(clientIp, path);
       if (!result.allowed) {
-        return rateLimitResponse(result);
+        return rateLimitResponse(result, {
+          clientIp,
+          deniedPath: path,
+          limiterKind: limiterKind as "authenticated" | "unauthenticated",
+          pathCounts: limiter.getRecentPathCounts(clientIp),
+        });
       }
       const routerResponse = await this.router.dispatch(
         endpoint,

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -3,7 +3,10 @@
 // Follows the same sliding-window pattern as gateway/src/auth-rate-limiter.ts.
 
 import type { HttpErrorResponse } from "../http-errors.js";
+import { getLogger } from "../../util/logger.js";
 import { isPrivateAddress } from "./auth.js";
+
+const log = getLogger("rate-limiter");
 
 const DEFAULT_MAX_REQUESTS = 60;
 const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
@@ -14,8 +17,13 @@ const DEFAULT_IP_MAX_REQUESTS = 20;
 const DEFAULT_IP_WINDOW_MS = 60_000;
 const MAX_TRACKED_IPS = 50_000;
 
+interface RequestEntry {
+  timestamp: number;
+  path: string;
+}
+
 export class TokenRateLimiter {
-  private requests = new Map<string, number[]>();
+  private requests = new Map<string, RequestEntry[]>();
   private readonly maxRequests: number;
   private readonly windowMs: number;
   private readonly maxTrackedKeys: number;
@@ -34,11 +42,11 @@ export class TokenRateLimiter {
    * Check whether the request should be allowed and record it.
    * Returns rate limit metadata for response headers.
    */
-  check(key: string): RateLimitResult {
+  check(key: string, path?: string): RateLimitResult {
     const now = Date.now();
-    let timestamps = this.requests.get(key);
+    let entries = this.requests.get(key);
 
-    if (!timestamps) {
+    if (!entries) {
       if (this.requests.size >= this.maxTrackedKeys) {
         this.evictStale(now);
         if (this.requests.size >= this.maxTrackedKeys) {
@@ -46,24 +54,24 @@ export class TokenRateLimiter {
           if (oldest !== undefined) this.requests.delete(oldest);
         }
       }
-      timestamps = [];
-      this.requests.set(key, timestamps);
+      entries = [];
+      this.requests.set(key, entries);
     }
 
     const cutoff = now - this.windowMs;
 
-    // Remove expired timestamps from the front
-    while (timestamps.length > 0 && timestamps[0] <= cutoff) {
-      timestamps.shift();
+    // Remove expired entries from the front
+    while (entries.length > 0 && entries[0].timestamp <= cutoff) {
+      entries.shift();
     }
 
-    const remaining = Math.max(0, this.maxRequests - timestamps.length);
+    const remaining = Math.max(0, this.maxRequests - entries.length);
     const resetAt =
-      timestamps.length > 0
-        ? Math.ceil((timestamps[0] + this.windowMs) / 1000)
+      entries.length > 0
+        ? Math.ceil((entries[0].timestamp + this.windowMs) / 1000)
         : Math.ceil((now + this.windowMs) / 1000);
 
-    if (timestamps.length >= this.maxRequests) {
+    if (entries.length >= this.maxRequests) {
       return {
         allowed: false,
         limit: this.maxRequests,
@@ -72,7 +80,7 @@ export class TokenRateLimiter {
       };
     }
 
-    timestamps.push(now);
+    entries.push({ timestamp: now, path: path ?? "unknown" });
 
     return {
       allowed: true,
@@ -82,13 +90,36 @@ export class TokenRateLimiter {
     };
   }
 
+  /**
+   * Return a count of recent requests grouped by path for the given key.
+   * Sorted descending by count. Useful for diagnosing which endpoints
+   * are consuming the rate limit budget.
+   */
+  getRecentPathCounts(key: string): Array<{ path: string; count: number }> {
+    const entries = this.requests.get(key);
+    if (!entries || entries.length === 0) return [];
+
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    const counts = new Map<string, number>();
+    for (const entry of entries) {
+      if (entry.timestamp > cutoff) {
+        counts.set(entry.path, (counts.get(entry.path) ?? 0) + 1);
+      }
+    }
+
+    return Array.from(counts.entries())
+      .map(([path, count]) => ({ path, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
   private evictStale(now: number): void {
     const cutoff = now - this.windowMs;
-    for (const [key, timestamps] of this.requests) {
-      while (timestamps.length > 0 && timestamps[0] <= cutoff) {
-        timestamps.shift();
+    for (const [key, entries] of this.requests) {
+      while (entries.length > 0 && entries[0].timestamp <= cutoff) {
+        entries.shift();
       }
-      if (timestamps.length === 0) {
+      if (entries.length === 0) {
         this.requests.delete(key);
       }
     }
@@ -115,8 +146,31 @@ export function rateLimitHeaders(
 }
 
 /** Return a 429 response with rate limit headers and a Retry-After hint. */
-export function rateLimitResponse(result: RateLimitResult): Response {
+export function rateLimitResponse(
+  result: RateLimitResult,
+  diagnostics?: {
+    clientIp: string;
+    deniedPath: string;
+    limiterKind: "authenticated" | "unauthenticated";
+    pathCounts: Array<{ path: string; count: number }>;
+  },
+): Response {
   const retryAfter = Math.max(1, result.resetAt - Math.ceil(Date.now() / 1000));
+
+  if (diagnostics) {
+    log.warn(
+      {
+        clientIp: diagnostics.clientIp,
+        deniedPath: diagnostics.deniedPath,
+        limiterKind: diagnostics.limiterKind,
+        limit: result.limit,
+        retryAfterSec: retryAfter,
+        recentRequests: diagnostics.pathCounts,
+      },
+      `Rate limited ${diagnostics.limiterKind} request: ${diagnostics.deniedPath} (${result.limit} req/min exceeded)`,
+    );
+  }
+
   const body: HttpErrorResponse = {
     error: { code: "RATE_LIMITED", message: "Too Many Requests" },
   };


### PR DESCRIPTION
## Summary
- When a 429 is returned by the runtime API rate limiter, log a structured warning with the client IP, denied endpoint, limiter kind (auth/unauth), and a **sorted breakdown of which endpoints consumed the budget** in the current sliding window
- Add `log.warn()` to the provider-level `RateLimitProvider` before both `RateLimitError` throws (request rate + token budget) — these were previously completely silent
- Track request paths alongside timestamps in `TokenRateLimiter` with negligible overhead (one extra string per entry)
- Document rate limiting diagnostics and log tailing in `assistant/src/runtime/AGENTS.md`

Example log output on 429:
```
[rate-limiter] Rate limited authenticated request: /v1/messages (60 req/min exceeded)
  clientIp: "127.0.0.1"
  deniedPath: "/v1/messages"
  limiterKind: "authenticated"
  limit: 60
  retryAfterSec: 12
  recentRequests: [
    { path: "/v1/conversations/switch", count: 18 },
    { path: "/v1/messages", count: 16 },
    { path: "/v1/conversations/seen", count: 15 },
    { path: "/v1/events", count: 11 }
  ]
```

To watch rate limit events in real time:
```bash
tail -f ~/.vellum/assistant-$(date -u +%Y-%m-%d).log | grep rate-limit
```

## Test plan
- [x] `bun test src/__tests__/ratelimit.test.ts` — 17/17 pass (provider rate limit logging visible in test output)
- [x] `bunx tsc --noEmit` — clean
- [ ] Reproduce locally by rapidly switching threads ~15 times then sending a message; confirm log output appears in `~/.vellum/assistant-*.log` with the endpoint breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)