### PR TITLE
fix: convert remaining assistant source files to credentialKey() helper

### DIFF
--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -280,7 +281,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
    * middleware) can check availability independently.
    */
   static getAuthToken(): string | null {
-    return getSecureKey("credential:twilio:auth_token") || null;
+    return getSecureKey(credentialKey("twilio", "auth_token")) || null;
   }
 
   /**

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -5,6 +5,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -34,8 +35,12 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
-  const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-  const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
@@ -79,10 +84,10 @@ export async function setSlackChannelConfig(
       };
       if (!data.ok) {
         const storedBotToken = !!getSecureKey(
-          "credential:slack_channel:bot_token",
+          credentialKey("slack_channel", "bot_token"),
         );
         const storedAppToken = !!getSecureKey(
-          "credential:slack_channel:app_token",
+          credentialKey("slack_channel", "app_token"),
         );
         return {
           success: false,
@@ -103,10 +108,10 @@ export async function setSlackChannelConfig(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -118,15 +123,15 @@ export async function setSlackChannelConfig(
     }
 
     const stored = await setSecureKeyAsync(
-      "credential:slack_channel:bot_token",
+      credentialKey("slack_channel", "bot_token"),
       botToken,
     );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -161,10 +166,10 @@ export async function setSlackChannelConfig(
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -176,15 +181,15 @@ export async function setSlackChannelConfig(
     }
 
     const stored = await setSecureKeyAsync(
-      "credential:slack_channel:app_token",
+      credentialKey("slack_channel", "app_token"),
       appToken,
     );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -198,8 +203,12 @@ export async function setSlackChannelConfig(
     upsertCredentialMetadata("slack_channel", "app_token", {});
   }
 
-  const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-  const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
 
   if (hasBotToken && !hasAppToken) {
     warning =
@@ -220,12 +229,20 @@ export async function setSlackChannelConfig(
 }
 
 export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
-  const r1 = await deleteSecureKeyAsync("credential:slack_channel:bot_token");
-  const r2 = await deleteSecureKeyAsync("credential:slack_channel:app_token");
+  const r1 = await deleteSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const r2 = await deleteSecureKeyAsync(
+    credentialKey("slack_channel", "app_token"),
+  );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+    const hasBotToken = !!getSecureKey(
+      credentialKey("slack_channel", "bot_token"),
+    );
+    const hasAppToken = !!getSecureKey(
+      credentialKey("slack_channel", "app_token"),
+    );
     return {
       success: false,
       hasBotToken,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -8,6 +8,7 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
+import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -60,8 +61,10 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
-  const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
-  const hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
@@ -79,7 +82,7 @@ export async function setTelegramConfig(
   // Track provenance so we only rollback tokens that were freshly provided.
   const isNewToken = !!botToken;
   const resolvedToken =
-    botToken || getSecureKey("credential:telegram:bot_token");
+    botToken || getSecureKey(credentialKey("telegram", "bot_token"));
   if (!resolvedToken) {
     return {
       success: false,
@@ -133,7 +136,7 @@ export async function setTelegramConfig(
 
   // Store bot token securely (async — writes broker + encrypted store)
   const stored = await setSecureKeyAsync(
-    "credential:telegram:bot_token",
+    credentialKey("telegram", "bot_token"),
     resolvedToken,
   );
   if (!stored) {
@@ -156,12 +159,14 @@ export async function setTelegramConfig(
   invalidateConfigCache();
 
   // Ensure webhook secret exists (generate if missing)
-  let hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  let hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
     const secretStored = await setSecureKeyAsync(
-      "credential:telegram:webhook_secret",
+      credentialKey("telegram", "webhook_secret"),
       webhookSecret,
     );
     if (secretStored) {
@@ -172,7 +177,7 @@ export async function setTelegramConfig(
       // When the token came from secure storage it was already valid
       // configuration; deleting it would destroy working state.
       if (isNewToken) {
-        await deleteSecureKeyAsync("credential:telegram:bot_token");
+        await deleteSecureKeyAsync(credentialKey("telegram", "bot_token"));
         deleteCredentialMetadata("telegram", "bot_token");
       }
       // Always revert the config write — the botUsername was written
@@ -222,7 +227,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   // The gateway reconcile short-circuits when credentials are absent,
   // so we must call the Telegram API directly while the token is still
   // available.
-  const botToken = getSecureKey("credential:telegram:bot_token");
+  const botToken = getSecureKey(credentialKey("telegram", "bot_token"));
   if (botToken) {
     try {
       await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`);
@@ -234,13 +239,15 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
     }
   }
 
-  const r1 = await deleteSecureKeyAsync("credential:telegram:bot_token");
-  const r2 = await deleteSecureKeyAsync("credential:telegram:webhook_secret");
+  const r1 = await deleteSecureKeyAsync(credentialKey("telegram", "bot_token"));
+  const r2 = await deleteSecureKeyAsync(
+    credentialKey("telegram", "webhook_secret"),
+  );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
+    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
     const hasWebhookSecret = !!getSecureKey(
-      "credential:telegram:webhook_secret",
+      credentialKey("telegram", "webhook_secret"),
     );
     return {
       success: false,
@@ -272,7 +279,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 export async function setTelegramCommands(
   commands?: Array<{ command: string; description: string }>,
 ): Promise<TelegramConfigResult> {
-  const storedToken = getSecureKey("credential:telegram:bot_token");
+  const storedToken = getSecureKey(credentialKey("telegram", "bot_token"));
   if (!storedToken) {
     return {
       success: false,
@@ -302,8 +309,10 @@ export async function setTelegramCommands(
       return {
         success: false,
         hasBotToken: true,
-        connected: !!getSecureKey("credential:telegram:webhook_secret"),
-        hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+        connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
+        hasWebhookSecret: !!getSecureKey(
+          credentialKey("telegram", "webhook_secret"),
+        ),
         error: `Failed to set bot commands: ${body}`,
       };
     }
@@ -312,14 +321,18 @@ export async function setTelegramCommands(
     return {
       success: false,
       hasBotToken: true,
-      connected: !!getSecureKey("credential:telegram:webhook_secret"),
-      hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+      connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
+      hasWebhookSecret: !!getSecureKey(
+        credentialKey("telegram", "webhook_secret"),
+      ),
       error: `Failed to set bot commands: ${message}`,
     };
   }
 
-  const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
-  const hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   return {
     success: true,
     hasBotToken,

--- a/assistant/src/email/providers/index.ts
+++ b/assistant/src/email/providers/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { getNestedValue, loadRawConfig } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { ConfigError } from "../../util/errors.js";
 import type { EmailProvider } from "../provider.js";
@@ -13,7 +14,7 @@ export const SUPPORTED_PROVIDERS = ["agentmail"] as const;
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
 
 const PROVIDER_KEY_MAP: Record<SupportedProvider, string[]> = {
-  agentmail: ["agentmail", "credential:agentmail:api_key"],
+  agentmail: ["agentmail", credentialKey("agentmail", "api_key")],
 };
 
 /**

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -10,11 +10,15 @@
  */
 
 import { getPlatformBaseUrl } from "../../config/env.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { MANAGED_PROVIDER_META } from "./constants.js";
 
 /** Storage key for the assistant API key credential. */
-const ASSISTANT_API_KEY_STORAGE_KEY = "credential:vellum:assistant_api_key";
+const ASSISTANT_API_KEY_STORAGE_KEY = credentialKey(
+  "vellum",
+  "assistant_api_key",
+);
 
 export interface ManagedProxyContext {
   /** Whether managed proxy prerequisites are satisfied. */

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -16,6 +16,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import { getLogger } from "../../util/logger.js";
@@ -40,7 +41,7 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     return; // Username already cached in config
   }
 
-  const token = getSecureKey("credential:telegram:bot_token");
+  const token = getSecureKey(credentialKey("telegram", "bot_token"));
   if (!token) return;
 
   try {

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -12,6 +12,7 @@ import {
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { credentialKey } from "../../../../security/credential-key.js";
 import { getSecureKey } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import { httpError } from "../../../http-errors.js";
@@ -29,8 +30,8 @@ const log = getLogger("slack-share");
  */
 function resolveSlackToken(): string | undefined {
   return (
-    getSecureKey("credential:integration:slack:access_token") ??
-    getSecureKey("credential:slack_channel:bot_token")
+    getSecureKey(credentialKey("integration:slack", "access_token")) ??
+    getSecureKey(credentialKey("slack_channel", "bot_token"))
   );
 }
 

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -21,6 +21,7 @@ import {
 import { loadRawConfig, saveRawConfig } from "../../../config/loader.js";
 import { syncTwilioWebhooks } from "../../../daemon/handlers/config-ingress.js";
 import type { IngressConfig } from "../../../inbound/public-ingress-urls.js";
+import { credentialKey } from "../../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
@@ -136,7 +137,7 @@ export async function handleSetTwilioCredentials(
   // validation (gateway/src/credential-reader.ts), while the assistant reads
   // from config via resolveAccountSid(). Both stores must stay in sync.
   const sidStored = await setSecureKeyAsync(
-    "credential:twilio:account_sid",
+    credentialKey("twilio", "account_sid"),
     body.accountSid,
   );
   if (!sidStored) {
@@ -148,11 +149,11 @@ export async function handleSetTwilioCredentials(
   }
 
   const tokenStored = await setSecureKeyAsync(
-    "credential:twilio:auth_token",
+    credentialKey("twilio", "auth_token"),
     body.authToken,
   );
   if (!tokenStored) {
-    await deleteSecureKeyAsync("credential:twilio:account_sid");
+    await deleteSecureKeyAsync(credentialKey("twilio", "account_sid"));
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -202,8 +203,8 @@ export async function handleSetTwilioCredentials(
  * DELETE /v1/integrations/twilio/credentials
  */
 export async function handleClearTwilioCredentials(): Promise<Response> {
-  const r1 = await deleteSecureKeyAsync("credential:twilio:account_sid");
-  const r2 = await deleteSecureKeyAsync("credential:twilio:auth_token");
+  const r1 = await deleteSecureKeyAsync(credentialKey("twilio", "account_sid"));
+  const r2 = await deleteSecureKeyAsync(credentialKey("twilio", "auth_token"));
 
   if (r1 === "error" || r2 === "error") {
     return Response.json(

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,4 +1,5 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 
 interface IntegrationProbe {
@@ -13,13 +14,13 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
     name: "Gmail",
     category: "email",
     isConnected: () =>
-      !!getSecureKey("credential:integration:gmail:access_token"),
+      !!getSecureKey(credentialKey("integration:gmail", "access_token")),
   },
   {
     name: "Slack",
     category: "messaging",
     isConnected: () =>
-      !!getSecureKey("credential:integration:slack:access_token"),
+      !!getSecureKey(credentialKey("integration:slack", "access_token")),
   },
   {
     name: "Twilio",
@@ -30,8 +31,8 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
     name: "Telegram",
     category: "messaging",
     isConnected: () =>
-      !!getSecureKey("credential:telegram:bot_token") &&
-      !!getSecureKey("credential:telegram:webhook_secret"),
+      !!getSecureKey(credentialKey("telegram", "bot_token")) &&
+      !!getSecureKey(credentialKey("telegram", "webhook_secret")),
   },
 ];
 


### PR DESCRIPTION
## Summary
Converts all remaining assistant source files from old colon-delimited credential key format (`credential:service:field`) to the new `credentialKey()` helper that produces slash-delimited keys (`credential/service/field`).

Files converted:
- config-telegram.ts (~20 instances)
- config-slack-channel.ts (~18 instances)
- integrations/twilio.ts (~6 instances)
- integrations/slack/share.ts (2 instances)
- schedule/integration-status.ts (4 instances)
- calls/twilio-provider.ts (1 instance)
- channel-invite-transports/telegram.ts (1 instance)
- email/providers/index.ts (1 instance)
- providers/managed-proxy/context.ts (1 instance)

Fixes gap identified during plan review for credential-storage-hygiene.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
