### PR TITLE
fix: complete credential key delimiter migration and add migrateKeys() to daemon startup

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -142,7 +142,7 @@ describe("executeBrowserFillCredential", () => {
       '[data-vellum-eid="e1"]',
       "super-secret-password",
     );
-    expect(mockGetSecureKey).toHaveBeenCalledWith("credential:gmail:password");
+    expect(mockGetSecureKey).toHaveBeenCalledWith("credential/gmail/password");
   });
 
   test("fills credential by CSS selector", async () => {
@@ -297,7 +297,7 @@ describe("executeBrowserFillCredential", () => {
         "password",
       );
       expect(mockGetSecureKey).toHaveBeenCalledWith(
-        "credential:gmail:password",
+        "credential/gmail/password",
       );
     });
 

--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -90,7 +90,7 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/',
       "security find-generic-password",
-      "secret-tool lookup service vellum-assistant account credential:ngrok:authtoken",
+      "secret-tool lookup service vellum-assistant account credential/ngrok/authtoken",
     ],
   },
   {
@@ -119,6 +119,7 @@ const KEYCHAIN_ALLOWLIST = new Set<string>([
 const KEYCHAIN_PATTERNS = [
   "security find-generic-password",
   "secret-tool lookup service vellum-assistant account credential:",
+  "secret-tool lookup service vellum-assistant account credential/",
 ];
 
 const HOST_BASH_RETRIEVAL_ALLOWLIST = new Set<string>([

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -197,10 +197,10 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("reports ready when all Meta credentials and display number are configured", async () => {
       mockSecureKeys = {
-        "credential:whatsapp:phone_number_id": "123456789",
-        "credential:whatsapp:access_token": "EAAxxxxxx",
-        "credential:whatsapp:app_secret": "abc123",
-        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+        "credential/whatsapp/phone_number_id": "123456789",
+        "credential/whatsapp/access_token": "EAAxxxxxx",
+        "credential/whatsapp/app_secret": "abc123",
+        "credential/whatsapp/webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
         whatsapp: { phoneNumber: "+15551234567" },
@@ -215,10 +215,10 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("reports not ready when display phone number is missing", async () => {
       mockSecureKeys = {
-        "credential:whatsapp:phone_number_id": "123456789",
-        "credential:whatsapp:access_token": "EAAxxxxxx",
-        "credential:whatsapp:app_secret": "abc123",
-        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+        "credential/whatsapp/phone_number_id": "123456789",
+        "credential/whatsapp/access_token": "EAAxxxxxx",
+        "credential/whatsapp/app_secret": "abc123",
+        "credential/whatsapp/webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
@@ -236,10 +236,10 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("checks each Meta credential individually", async () => {
       mockSecureKeys = {
-        "credential:whatsapp:phone_number_id": "123456789",
+        "credential/whatsapp/phone_number_id": "123456789",
         // access_token missing
-        "credential:whatsapp:app_secret": "abc123",
-        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+        "credential/whatsapp/app_secret": "abc123",
+        "credential/whatsapp/webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
@@ -272,10 +272,10 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("checks invite policy", async () => {
       mockSecureKeys = {
-        "credential:whatsapp:phone_number_id": "123456789",
-        "credential:whatsapp:access_token": "EAAxxxxxx",
-        "credential:whatsapp:app_secret": "abc123",
-        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+        "credential/whatsapp/phone_number_id": "123456789",
+        "credential/whatsapp/access_token": "EAAxxxxxx",
+        "credential/whatsapp/app_secret": "abc123",
+        "credential/whatsapp/webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
         whatsapp: { phoneNumber: "+15551234567" },
@@ -293,10 +293,10 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("checks ingress configuration", async () => {
       mockSecureKeys = {
-        "credential:whatsapp:phone_number_id": "123456789",
-        "credential:whatsapp:access_token": "EAAxxxxxx",
-        "credential:whatsapp:app_secret": "abc123",
-        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+        "credential/whatsapp/phone_number_id": "123456789",
+        "credential/whatsapp/access_token": "EAAxxxxxx",
+        "credential/whatsapp/app_secret": "abc123",
+        "credential/whatsapp/webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
         whatsapp: { phoneNumber: "+15551234567" },

--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -92,7 +92,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     let filledValue: string | undefined;
     const result = await broker.browserFill({
@@ -114,7 +114,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -167,7 +167,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -193,8 +193,8 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "password", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:username", "octocat");
-    setSecureKey("credential:github:password", "hunter2");
+    setSecureKey("credential/github/username", "octocat");
+    setSecureKey("credential/github/password", "hunter2");
 
     const filled: Record<string, string> = {};
 
@@ -227,7 +227,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -245,7 +245,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -263,7 +263,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -286,7 +286,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -305,7 +305,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     // No domain provided and no allowedDomains policy — should succeed
     const result = await broker.browserFill({
@@ -322,7 +322,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["other_tool"],
     });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     let fillCalled = false;
     const result = await broker.browserFill({
@@ -343,7 +343,7 @@ describe("CredentialBroker.browserFill", () => {
 
   test("denies fill when allowedTools is empty (fail-closed)", async () => {
     upsertCredentialMetadata("github", "token", { allowedTools: [] });
-    setSecureKey("credential:github:token", "ghp_secret123");
+    setSecureKey("credential/github/token", "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -362,7 +362,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey("credential:github:token", "ghp_supersecret");
+    setSecureKey("credential/github/token", "ghp_supersecret");
 
     const result = await broker.browserFill({
       service: "github",
@@ -388,7 +388,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["s3_upload", "cloudfront_invalidate"],
         allowedDomains: [],
       });
-      setSecureKey("credential:aws:access_key", "AKIA_test");
+      setSecureKey("credential/aws/access_key", "AKIA_test");
 
       let fillCalled = false;
       const result = await broker.browserFill({
@@ -413,7 +413,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["browser_fill_credential"],
         allowedDomains: ["github.com"],
       });
-      setSecureKey("credential:github:pat", "ghp_fill_test");
+      setSecureKey("credential/github/pat", "ghp_fill_test");
 
       let fillCalled = false;
       const result = await broker.browserFill({
@@ -437,7 +437,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["slack_post"],
         allowedDomains: ["slack.com"],
       });
-      setSecureKey("credential:slack:bot_token", "xoxb-test");
+      setSecureKey("credential/slack/bot_token", "xoxb-test");
 
       const result = await broker.browserFill({
         service: "slack",
@@ -460,7 +460,7 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("custom", "key", {
         allowedTools: [],
       });
-      setSecureKey("credential:custom:key", "secret");
+      setSecureKey("credential/custom/key", "secret");
 
       const result = await broker.browserFill({
         service: "custom",
@@ -490,7 +490,7 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("github", "token", {
         allowedTools: ["browser_fill_credential"],
       });
-      setSecureKey("credential:github:token", "ghp_updated");
+      setSecureKey("credential/github/token", "ghp_updated");
 
       let filledValue: string | undefined;
       const result = await broker.browserFill({
@@ -514,8 +514,8 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("github", "password", {
         allowedTools: ["other_tool"],
       });
-      setSecureKey("credential:github:username", "octocat");
-      setSecureKey("credential:github:password", "hunter2");
+      setSecureKey("credential/github/username", "octocat");
+      setSecureKey("credential/github/password", "hunter2");
 
       // username allows browser_fill_credential
       const r1 = await broker.browserFill({
@@ -548,8 +548,8 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["browser_fill_credential"],
         allowedDomains: ["gitlab.com"],
       });
-      setSecureKey("credential:github:token", "gh_tok");
-      setSecureKey("credential:gitlab:token", "gl_tok");
+      setSecureKey("credential/github/token", "gh_tok");
+      setSecureKey("credential/gitlab/token", "gl_tok");
 
       // github credential on github.com succeeds
       let filled1 = "";

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -85,7 +85,7 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -109,7 +109,7 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -161,7 +161,7 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -182,7 +182,7 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -201,7 +201,7 @@ describe("CredentialBroker.serverUse", () => {
       allowedTools: ["publish_page"],
       allowedDomains: ["vercel.com"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -222,7 +222,7 @@ describe("CredentialBroker.serverUse", () => {
       allowedTools: ["publish_page"],
       allowedDomains: [],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -247,7 +247,7 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("aws", "access_key", {
         allowedTools: ["deploy_lambda", "s3_upload"],
       });
-      setSecureKey("credential:aws:access_key", "AKIA_test");
+      setSecureKey("credential/aws/access_key", "AKIA_test");
 
       const result = await broker.serverUse({
         service: "aws",
@@ -270,7 +270,7 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("stripe", "secret_key", {
         allowedTools: [],
       });
-      setSecureKey("credential:stripe:secret_key", "sk_test_xyz");
+      setSecureKey("credential/stripe/secret_key", "sk_test_xyz");
 
       const result = await broker.serverUse({
         service: "stripe",
@@ -291,7 +291,7 @@ describe("CredentialBroker.serverUse", () => {
         allowedTools: ["git_push"],
         allowedDomains: ["github.com"],
       });
-      setSecureKey("credential:github:oauth_token", "gho_test");
+      setSecureKey("credential/github/oauth_token", "gho_test");
 
       const result = await broker.serverUse({
         service: "github",
@@ -322,7 +322,7 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("vercel", "api_token", {
         allowedTools: ["publish_page", "unpublish_page"],
       });
-      setSecureKey("credential:vercel:api_token", "tok_updated");
+      setSecureKey("credential/vercel/api_token", "tok_updated");
 
       const result = await broker.serverUse({
         service: "vercel",
@@ -342,8 +342,8 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("vercel", "deploy_hook", {
         allowedTools: ["trigger_deploy"],
       });
-      setSecureKey("credential:vercel:api_token", "tok_api");
-      setSecureKey("credential:vercel:deploy_hook", "hook_secret");
+      setSecureKey("credential/vercel/api_token", "tok_api");
+      setSecureKey("credential/vercel/deploy_hook", "hook_secret");
 
       // api_token should deny trigger_deploy
       const r1 = await broker.serverUse({
@@ -377,8 +377,8 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("gitlab", "api_token", {
         allowedTools: ["gitlab_api"],
       });
-      setSecureKey("credential:github:api_token", "gh_tok");
-      setSecureKey("credential:gitlab:api_token", "gl_tok");
+      setSecureKey("credential/github/api_token", "gh_tok");
+      setSecureKey("credential/gitlab/api_token", "gl_tok");
 
       // github credential should not serve gitlab tool
       const r1 = broker.serverUseById({
@@ -395,8 +395,8 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("gitlab", "api_token", {
         allowedTools: ["gitlab_api"],
       });
-      setSecureKey("credential:github:api_token", "gh_tok");
-      setSecureKey("credential:gitlab:api_token", "gl_tok");
+      setSecureKey("credential/github/api_token", "gh_tok");
+      setSecureKey("credential/gitlab/api_token", "gl_tok");
 
       // github credential should not serve gitlab tool
       const r1 = await broker.serverUse({
@@ -458,7 +458,7 @@ describe("CredentialBroker.serverUseById", () => {
         },
       ],
     });
-    setSecureKey("credential:fal:api_key", "fal-secret-key");
+    setSecureKey("credential/fal/api_key", "fal-secret-key");
 
     const result = broker.serverUseById({
       credentialId: meta.credentialId,
@@ -483,7 +483,7 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["media_proxy"],
     });
-    setSecureKey("credential:fal:api_key", "fal-secret-key");
+    setSecureKey("credential/fal/api_key", "fal-secret-key");
 
     const result = broker.serverUseById({
       credentialId: meta.credentialId,
@@ -514,7 +514,7 @@ describe("CredentialBroker.serverUseById", () => {
       allowedTools: ["media_proxy"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey("credential:github:oauth_token", "gho_test");
+    setSecureKey("credential/github/oauth_token", "gho_test");
 
     const result = broker.serverUseById({
       credentialId: meta.credentialId,
@@ -531,7 +531,7 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["media_proxy"],
     });
-    setSecureKey("credential:vercel:api_token", "test-vercel-token");
+    setSecureKey("credential/vercel/api_token", "test-vercel-token");
 
     const result = broker.serverUseById({
       credentialId: meta.credentialId,
@@ -547,7 +547,7 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("stripe", "secret_key", {
       allowedTools: [],
     });
-    setSecureKey("credential:stripe:secret_key", "sk_test_xyz");
+    setSecureKey("credential/stripe/secret_key", "sk_test_xyz");
 
     const result = broker.serverUseById({
       credentialId: meta.credentialId,

--- a/assistant/src/__tests__/credential-broker.test.ts
+++ b/assistant/src/__tests__/credential-broker.test.ts
@@ -125,7 +125,7 @@ describe("CredentialBroker", () => {
 
       const result = broker.consume(auth.token.tokenId);
       expect(result.success).toBe(true);
-      expect(result.storageKey).toBe("credential:github:token");
+      expect(result.storageKey).toBe("credential/github/token");
     });
 
     test("rejects double consumption", () => {

--- a/assistant/src/__tests__/credential-resolve.test.ts
+++ b/assistant/src/__tests__/credential-resolve.test.ts
@@ -56,7 +56,7 @@ describe("credential resolver", () => {
       expect(result!.credentialId).toBe(created.credentialId);
       expect(result!.service).toBe("github");
       expect(result!.field).toBe("token");
-      expect(result!.storageKey).toBe("credential:github:token");
+      expect(result!.storageKey).toBe("credential/github/token");
       expect(result!.metadata.allowedTools).toEqual([
         "browser_fill_credential",
       ]);
@@ -111,7 +111,7 @@ describe("credential resolver", () => {
       expect(result!.credentialId).toBe(created.credentialId);
       expect(result!.service).toBe("gmail");
       expect(result!.field).toBe("password");
-      expect(result!.storageKey).toBe("credential:gmail:password");
+      expect(result!.storageKey).toBe("credential/gmail/password");
     });
 
     test("returns undefined for non-existent ID", () => {
@@ -190,10 +190,10 @@ describe("credential resolver", () => {
   });
 
   describe("storage key format", () => {
-    test("storage key follows credential:{service}:{field} format", () => {
+    test("storage key follows credential/{service}/{field} format", () => {
       upsertCredentialMetadata("my-service", "api-key");
       const result = resolveByServiceField("my-service", "api-key");
-      expect(result!.storageKey).toBe("credential:my-service:api-key");
+      expect(result!.storageKey).toBe("credential/my-service/api-key");
     });
   });
 

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -113,8 +113,8 @@ mock.module("../calls/twilio-provider.js", () => ({
 }));
 
 const secureKeyStore: Record<string, string | undefined> = {
-  "credential:twilio:account_sid": "AC_test",
-  "credential:twilio:auth_token": "test_token",
+  "credential/twilio/account_sid": "AC_test",
+  "credential/twilio/auth_token": "test_token",
 };
 
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -36,12 +36,12 @@ describe("integration-status", () => {
     });
 
     test("returns all connected when all keys are set", () => {
-      secureKeyValues.set("credential:integration:gmail:access_token", "tok");
-      secureKeyValues.set("credential:integration:slack:access_token", "tok");
+      secureKeyValues.set("credential/integration:gmail/access_token", "tok");
+      secureKeyValues.set("credential/integration:slack/access_token", "tok");
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
-      secureKeyValues.set("credential:telegram:webhook_secret", "secret");
+      secureKeyValues.set("credential/twilio/auth_token", "auth");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
+      secureKeyValues.set("credential/telegram/webhook_secret", "secret");
 
       const summary = getIntegrationSummary();
       expect(summary.every((s: { connected: boolean }) => s.connected)).toBe(
@@ -51,9 +51,9 @@ describe("integration-status", () => {
 
     test("returns mixed status", () => {
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
-      secureKeyValues.set("credential:telegram:webhook_secret", "secret");
+      secureKeyValues.set("credential/twilio/auth_token", "auth");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
+      secureKeyValues.set("credential/telegram/webhook_secret", "secret");
 
       const summary = getIntegrationSummary();
       const connected = summary.filter(
@@ -82,7 +82,7 @@ describe("integration-status", () => {
     });
 
     test("Telegram disconnected when only bot_token is set (missing webhook_secret)", () => {
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
 
       const summary = getIntegrationSummary();
       const telegram = summary.find(
@@ -95,9 +95,9 @@ describe("integration-status", () => {
   describe("formatIntegrationSummary", () => {
     test("shows checkmarks and crosses", () => {
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
-      secureKeyValues.set("credential:telegram:webhook_secret", "secret");
+      secureKeyValues.set("credential/twilio/auth_token", "auth");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
+      secureKeyValues.set("credential/telegram/webhook_secret", "secret");
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
@@ -113,12 +113,12 @@ describe("integration-status", () => {
     });
 
     test("all connected", () => {
-      secureKeyValues.set("credential:integration:gmail:access_token", "tok");
-      secureKeyValues.set("credential:integration:slack:access_token", "tok");
+      secureKeyValues.set("credential/integration:gmail/access_token", "tok");
+      secureKeyValues.set("credential/integration:slack/access_token", "tok");
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
-      secureKeyValues.set("credential:telegram:webhook_secret", "secret");
+      secureKeyValues.set("credential/twilio/auth_token", "auth");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
+      secureKeyValues.set("credential/telegram/webhook_secret", "secret");
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
@@ -134,13 +134,13 @@ describe("integration-status", () => {
     });
 
     test("returns true when any integration in category is connected", () => {
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
-      secureKeyValues.set("credential:telegram:webhook_secret", "secret");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
+      secureKeyValues.set("credential/telegram/webhook_secret", "secret");
       expect(hasCapability("messaging")).toBe(true);
     });
 
     test("returns false when only partial credentials exist for category integrations", () => {
-      secureKeyValues.set("credential:telegram:bot_token", "tok");
+      secureKeyValues.set("credential/telegram/bot_token", "tok");
       // Missing webhook_secret — Telegram should not count as connected
       expect(hasCapability("messaging")).toBe(false);
     });
@@ -150,7 +150,7 @@ describe("integration-status", () => {
     });
 
     test("email category checks Gmail", () => {
-      secureKeyValues.set("credential:integration:gmail:access_token", "tok");
+      secureKeyValues.set("credential/integration:gmail/access_token", "tok");
       expect(hasCapability("email")).toBe(true);
     });
   });

--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -18,7 +18,7 @@ mock.module("../config/env.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => {
-    if (key === "credential:vellum:assistant_api_key") {
+    if (key === "credential/vellum/assistant_api_key") {
       return mockAssistantApiKey;
     }
     return null;

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -19,7 +19,7 @@ const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
   ...actualSecureKeys,
   getSecureKey: (key: string) => {
-    if (key === "credential:vellum:assistant_api_key") {
+    if (key === "credential/vellum/assistant_api_key") {
       return mockAssistantApiKey || null;
     }
     return null;

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -16,7 +16,7 @@ mock.module("../config/env.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => {
-    if (key === "credential:vellum:assistant_api_key") {
+    if (key === "credential/vellum/assistant_api_key") {
       return mockAssistantApiKey;
     }
     return null;

--- a/assistant/src/__tests__/script-proxy-policy-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-policy-runtime.test.ts
@@ -64,7 +64,7 @@ function makeResolved(
     credentialId,
     service: "test-service",
     field: "api-key",
-    storageKey: `credential:test-service:api-key`,
+    storageKey: `credential/test-service/api-key`,
     injectionTemplates: templates,
     metadata: {
       credentialId,

--- a/assistant/src/__tests__/script-proxy-session-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-session-manager.test.ts
@@ -56,7 +56,7 @@ function makeResolved(
     credentialId,
     service: "test-service",
     field: "api-key",
-    storageKey: `credential:test-service:api-key`,
+    storageKey: `credential/test-service/api-key`,
     injectionTemplates: templates,
     metadata: {
       credentialId,

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -96,7 +96,7 @@ describe("one-time send override", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not enabled");
     // Value must NOT be stored in keychain
-    expect(storedKeys.has("credential:svc:key")).toBe(false);
+    expect(storedKeys.has("credential/svc/key")).toBe(false);
   });
 
   test("transient_send succeeds when allowOneTimeSend is enabled", async () => {
@@ -119,7 +119,7 @@ describe("one-time send override", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("NOT saved");
     // Value must NOT be stored in keychain
-    expect(storedKeys.has("credential:svc:key")).toBe(false);
+    expect(storedKeys.has("credential/svc/key")).toBe(false);
   });
 
   test("store delivery always persists to keychain regardless of allowOneTimeSend", async () => {
@@ -138,7 +138,7 @@ describe("one-time send override", () => {
     );
     expect(result.isError).toBe(false);
     expect(result.content).toContain("stored");
-    expect(storedKeys.has("credential:svc:key")).toBe(true);
+    expect(storedKeys.has("credential/svc/key")).toBe(true);
   });
 
   test("transient_send response content never contains the secret value", async () => {

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -108,7 +108,7 @@ describe("session-messaging secret redirect", () => {
       label: "Telegram Bot Token",
     });
     expect(setSecureKeyMock).toHaveBeenCalledWith(
-      "credential:telegram:bot_token",
+      "credential/telegram/bot_token",
       "123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678",
     );
     expect(upsertCredentialMetadataMock).toHaveBeenCalledWith(
@@ -158,7 +158,7 @@ describe("session-messaging secret redirect", () => {
       label: "Telegram Bot Token",
     });
     expect(setSecureKeyMock).toHaveBeenCalledWith(
-      "credential:telegram:bot_token",
+      "credential/telegram/bot_token",
       "123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678",
     );
   });
@@ -197,7 +197,7 @@ describe("session-messaging secret redirect", () => {
       label: "Telegram Bot Token",
     });
     expect(setSecureKeyMock).toHaveBeenCalledWith(
-      "credential:telegram:bot_token",
+      "credential/telegram/bot_token",
       "123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678",
     );
   });
@@ -231,7 +231,7 @@ describe("session-messaging secret redirect", () => {
       label: "Secure Credential Entry",
     });
     expect(setSecureKeyMock).toHaveBeenCalledWith(
-      "credential:detected:Some Unknown Secret",
+      "credential/detected/Some Unknown Secret",
       "opaque-secret",
     );
     expect(upsertCredentialMetadataMock).toHaveBeenCalledWith(

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -199,8 +199,8 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns connected: true when both tokens are set", () => {
-    secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
-    secureKeyStore["credential:slack_channel:app_token"] = "xapp-test";
+    secureKeyStore["credential/slack_channel/bot_token"] = "xoxb-test";
+    secureKeyStore["credential/slack_channel/app_token"] = "xapp-test";
 
     const result = getSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -210,7 +210,7 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns metadata from config when available", () => {
-    secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
+    secureKeyStore["credential/slack_channel/bot_token"] = "xoxb-test";
     configStore = {
       slack: {
         teamId: "T123",
@@ -240,7 +240,7 @@ describe("Slack channel config handler", () => {
     );
     expect(result.success).toBe(true);
     expect(result.hasAppToken).toBe(true);
-    expect(secureKeyStore["credential:slack_channel:app_token"]).toBe(
+    expect(secureKeyStore["credential/slack_channel/app_token"]).toBe(
       "xapp-valid-token-123",
     );
   });
@@ -296,8 +296,8 @@ describe("Slack channel config handler", () => {
   });
 
   test("DELETE clears credentials and config", async () => {
-    secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
-    secureKeyStore["credential:slack_channel:app_token"] = "xapp-test";
+    secureKeyStore["credential/slack_channel/bot_token"] = "xoxb-test";
+    secureKeyStore["credential/slack_channel/app_token"] = "xapp-test";
     credentialMetadataStore.push({
       service: "slack_channel",
       field: "bot_token",
@@ -322,10 +322,10 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(false);
 
     expect(
-      secureKeyStore["credential:slack_channel:bot_token"],
+      secureKeyStore["credential/slack_channel/bot_token"],
     ).toBeUndefined();
     expect(
-      secureKeyStore["credential:slack_channel:app_token"],
+      secureKeyStore["credential/slack_channel/app_token"],
     ).toBeUndefined();
     expect(credentialMetadataStore).toHaveLength(0);
 

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -105,7 +105,7 @@ describe("handleListSlackChannels", () => {
 
   test("returns channels sorted by type then name", async () => {
     secureKeyValues.set(
-      "credential:integration:slack:access_token",
+      "credential/integration:slack/access_token",
       "xoxb-test",
     );
 
@@ -176,7 +176,7 @@ describe("handleListSlackChannels", () => {
   });
 
   test("falls back to legacy bot token", async () => {
-    secureKeyValues.set("credential:slack_channel:bot_token", "xoxb-legacy");
+    secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-legacy");
 
     listConversationsResult = { ok: true, channels: [] };
 
@@ -194,7 +194,7 @@ describe("handleShareToSlackChannel", () => {
 
   test("returns 400 for malformed JSON", async () => {
     secureKeyValues.set(
-      "credential:integration:slack:access_token",
+      "credential/integration:slack/access_token",
       "xoxb-test",
     );
     const req = new Request("http://localhost/v1/slack/share", {
@@ -208,7 +208,7 @@ describe("handleShareToSlackChannel", () => {
 
   test("returns 400 when missing required fields", async () => {
     secureKeyValues.set(
-      "credential:integration:slack:access_token",
+      "credential/integration:slack/access_token",
       "xoxb-test",
     );
     const req = makeRequest({ appId: "app1" });
@@ -220,7 +220,7 @@ describe("handleShareToSlackChannel", () => {
 
   test("returns 404 when app not found", async () => {
     secureKeyValues.set(
-      "credential:integration:slack:access_token",
+      "credential/integration:slack/access_token",
       "xoxb-test",
     );
     appStoreResult = null;
@@ -231,7 +231,7 @@ describe("handleShareToSlackChannel", () => {
 
   test("posts message and returns success", async () => {
     secureKeyValues.set(
-      "credential:integration:slack:access_token",
+      "credential/integration:slack/access_token",
       "xoxb-test",
     );
     appStoreResult = {

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -30,7 +30,7 @@ import { getTwilioConfig } from "../calls/twilio-config.js";
 describe("twilio-config", () => {
   beforeEach(() => {
     mockSecureKeys = {
-      "credential:twilio:auth_token": "test_auth_token",
+      "credential/twilio/auth_token": "test_auth_token",
     };
     mockLoadConfigResult = {
       twilio: {

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -40,8 +40,8 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => {
-    if (key === "credential:twilio:auth_token") return mockAuthToken;
-    if (key === "credential:twilio:account_sid") return mockAccountSid;
+    if (key === "credential/twilio/auth_token") return mockAuthToken;
+    if (key === "credential/twilio/account_sid") return mockAccountSid;
     return undefined;
   },
 }));

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -47,12 +47,12 @@ function readMockTwilioAccountSid(): string | undefined {
   const twilio = (mockRawConfigStore.twilio ?? {}) as Record<string, unknown>;
   return (
     (twilio.accountSid as string | undefined) ??
-    mockSecureKeyStore["credential:twilio:account_sid"]
+    mockSecureKeyStore["credential/twilio/account_sid"]
   );
 }
 
 function readMockTwilioAuthToken(): string | undefined {
-  return mockSecureKeyStore["credential:twilio:auth_token"];
+  return mockSecureKeyStore["credential/twilio/auth_token"];
 }
 
 function readMockTwilioPhoneNumber(): string | undefined {
@@ -429,8 +429,8 @@ describe("twilio webhook routes", () => {
       twilio: { accountSid: "AC_existing", phoneNumber: "+15550001111" },
     };
     mockSecureKeyStore = {
-      "credential:twilio:account_sid": "AC_existing",
-      "credential:twilio:auth_token": "test-auth-token",
+      "credential/twilio/account_sid": "AC_existing",
+      "credential/twilio/auth_token": "test-auth-token",
     };
     mockAvailableNumbers = [{ phoneNumber: "+15556667777" }];
     mockProvisionedNumber = { phoneNumber: "+15556667777" };

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -136,7 +136,7 @@ export type CallerIdentityResult =
  * For `assistant_number`: uses the Twilio phone number from
  *   `getTwilioConfig()`. No eligibility check is performed — this is a fast path.
  * For `user_number`: uses `config.calls.callerIdentity.userNumber` or the
- *   secure key `credential:twilio:user_phone_number`, then validates that the
+ *   secure key `credential/twilio/user_phone_number`, then validates that the
  *   number is usable as an outbound caller ID via the Twilio API.
  */
 export async function resolveCallerIdentity(
@@ -215,7 +215,7 @@ export async function resolveCallerIdentity(
     return {
       ok: false,
       error:
-        "user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential:twilio:user_phone_number via the credential_store tool.",
+        "user_number mode requires a user phone number. Set calls.callerIdentity.userNumber in config or store credential/twilio/user_phone_number via the credential_store tool.",
     };
   }
 
@@ -226,7 +226,7 @@ export async function resolveCallerIdentity(
     );
     return {
       ok: false,
-      error: `User phone number "${userNumber}" is not in E.164 format (must start with + followed by digits, e.g. +14155551234). Check calls.callerIdentity.userNumber in config or credential:twilio:user_phone_number.`,
+      error: `User phone number "${userNumber}" is not in E.164 format (must start with + followed by digits, e.g. +14155551234). Check calls.callerIdentity.userNumber in config or credential/twilio/user_phone_number.`,
     };
   }
 

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
@@ -280,7 +281,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
    * middleware) can check availability independently.
    */
   static getAuthToken(): string | null {
-    return getSecureKey("credential:twilio:auth_token") || null;
+    return getSecureKey(credentialKey("twilio", "auth_token")) || null;
   }
 
   /**

--- a/assistant/src/cli/commands/oauth.ts
+++ b/assistant/src/cli/commands/oauth.ts
@@ -17,7 +17,7 @@ guaranteed-valid access token, refreshing transparently if the stored token
 is expired or near-expiry. Callers never need to handle refresh themselves.
 
 The <service> argument is the short integration name (e.g. "twitter", "gmail",
-"slack"). Internally this maps to credential:integration:<service>:access_token.
+"slack"). Internally this maps to credential/integration:<service>/access_token.
 
 Examples:
   $ assistant oauth token twitter

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -5,6 +5,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -34,8 +35,12 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
-  const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-  const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
@@ -79,10 +84,10 @@ export async function setSlackChannelConfig(
       };
       if (!data.ok) {
         const storedBotToken = !!getSecureKey(
-          "credential:slack_channel:bot_token",
+          credentialKey("slack_channel", "bot_token"),
         );
         const storedAppToken = !!getSecureKey(
-          "credential:slack_channel:app_token",
+          credentialKey("slack_channel", "app_token"),
         );
         return {
           success: false,
@@ -103,10 +108,10 @@ export async function setSlackChannelConfig(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -118,15 +123,15 @@ export async function setSlackChannelConfig(
     }
 
     const stored = await setSecureKeyAsync(
-      "credential:slack_channel:bot_token",
+      credentialKey("slack_channel", "bot_token"),
       botToken,
     );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -161,10 +166,10 @@ export async function setSlackChannelConfig(
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -176,15 +181,15 @@ export async function setSlackChannelConfig(
     }
 
     const stored = await setSecureKeyAsync(
-      "credential:slack_channel:app_token",
+      credentialKey("slack_channel", "app_token"),
       appToken,
     );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
-        "credential:slack_channel:bot_token",
+        credentialKey("slack_channel", "bot_token"),
       );
       const storedAppToken = !!getSecureKey(
-        "credential:slack_channel:app_token",
+        credentialKey("slack_channel", "app_token"),
       );
       return {
         success: false,
@@ -198,8 +203,12 @@ export async function setSlackChannelConfig(
     upsertCredentialMetadata("slack_channel", "app_token", {});
   }
 
-  const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-  const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
 
   if (hasBotToken && !hasAppToken) {
     warning =
@@ -220,12 +229,20 @@ export async function setSlackChannelConfig(
 }
 
 export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
-  const r1 = await deleteSecureKeyAsync("credential:slack_channel:bot_token");
-  const r2 = await deleteSecureKeyAsync("credential:slack_channel:app_token");
+  const r1 = await deleteSecureKeyAsync(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const r2 = await deleteSecureKeyAsync(
+    credentialKey("slack_channel", "app_token"),
+  );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
-    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+    const hasBotToken = !!getSecureKey(
+      credentialKey("slack_channel", "bot_token"),
+    );
+    const hasAppToken = !!getSecureKey(
+      credentialKey("slack_channel", "app_token"),
+    );
     return {
       success: false,
       hasBotToken,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -8,6 +8,7 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
+import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -60,8 +61,10 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
-  const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
-  const hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
@@ -79,7 +82,7 @@ export async function setTelegramConfig(
   // Track provenance so we only rollback tokens that were freshly provided.
   const isNewToken = !!botToken;
   const resolvedToken =
-    botToken || getSecureKey("credential:telegram:bot_token");
+    botToken || getSecureKey(credentialKey("telegram", "bot_token"));
   if (!resolvedToken) {
     return {
       success: false,
@@ -133,7 +136,7 @@ export async function setTelegramConfig(
 
   // Store bot token securely (async — writes broker + encrypted store)
   const stored = await setSecureKeyAsync(
-    "credential:telegram:bot_token",
+    credentialKey("telegram", "bot_token"),
     resolvedToken,
   );
   if (!stored) {
@@ -156,12 +159,14 @@ export async function setTelegramConfig(
   invalidateConfigCache();
 
   // Ensure webhook secret exists (generate if missing)
-  let hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  let hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
     const secretStored = await setSecureKeyAsync(
-      "credential:telegram:webhook_secret",
+      credentialKey("telegram", "webhook_secret"),
       webhookSecret,
     );
     if (secretStored) {
@@ -172,7 +177,7 @@ export async function setTelegramConfig(
       // When the token came from secure storage it was already valid
       // configuration; deleting it would destroy working state.
       if (isNewToken) {
-        await deleteSecureKeyAsync("credential:telegram:bot_token");
+        await deleteSecureKeyAsync(credentialKey("telegram", "bot_token"));
         deleteCredentialMetadata("telegram", "bot_token");
       }
       // Always revert the config write — the botUsername was written
@@ -222,7 +227,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   // The gateway reconcile short-circuits when credentials are absent,
   // so we must call the Telegram API directly while the token is still
   // available.
-  const botToken = getSecureKey("credential:telegram:bot_token");
+  const botToken = getSecureKey(credentialKey("telegram", "bot_token"));
   if (botToken) {
     try {
       await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`);
@@ -234,13 +239,15 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
     }
   }
 
-  const r1 = await deleteSecureKeyAsync("credential:telegram:bot_token");
-  const r2 = await deleteSecureKeyAsync("credential:telegram:webhook_secret");
+  const r1 = await deleteSecureKeyAsync(credentialKey("telegram", "bot_token"));
+  const r2 = await deleteSecureKeyAsync(
+    credentialKey("telegram", "webhook_secret"),
+  );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
+    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
     const hasWebhookSecret = !!getSecureKey(
-      "credential:telegram:webhook_secret",
+      credentialKey("telegram", "webhook_secret"),
     );
     return {
       success: false,
@@ -272,7 +279,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 export async function setTelegramCommands(
   commands?: Array<{ command: string; description: string }>,
 ): Promise<TelegramConfigResult> {
-  const storedToken = getSecureKey("credential:telegram:bot_token");
+  const storedToken = getSecureKey(credentialKey("telegram", "bot_token"));
   if (!storedToken) {
     return {
       success: false,
@@ -302,8 +309,10 @@ export async function setTelegramCommands(
       return {
         success: false,
         hasBotToken: true,
-        connected: !!getSecureKey("credential:telegram:webhook_secret"),
-        hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+        connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
+        hasWebhookSecret: !!getSecureKey(
+          credentialKey("telegram", "webhook_secret"),
+        ),
         error: `Failed to set bot commands: ${body}`,
       };
     }
@@ -312,14 +321,18 @@ export async function setTelegramCommands(
     return {
       success: false,
       hasBotToken: true,
-      connected: !!getSecureKey("credential:telegram:webhook_secret"),
-      hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+      connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
+      hasWebhookSecret: !!getSecureKey(
+        credentialKey("telegram", "webhook_secret"),
+      ),
       error: `Failed to set bot commands: ${message}`,
     };
   }
 
-  const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
-  const hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   return {
     success: true,
     hasBotToken,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -54,6 +54,7 @@ import {
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { migrateKeys } from "../security/credential-key.js";
 import { watchSessions } from "../tools/watch/watch-state.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
@@ -136,6 +137,11 @@ export async function runDaemon(): Promise<void> {
 
     ensureDataDir();
 
+    // Migrate legacy colon-delimited credential keys to the new
+    // slash-delimited format. Must run after ensureDataDir() so the
+    // secure key store is available, and before any credential reads.
+    migrateKeys();
+
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the
     // protected directory.
@@ -193,7 +199,9 @@ export async function runDaemon(): Promise<void> {
       const httpTokenPath = join(getRootDir(), "http-token");
       writeFileSync(httpTokenPath, credentials.accessToken, { mode: 0o600 });
       chmodSync(httpTokenPath, 0o600);
-      log.info("Daemon startup: CLI edge token written to credential store and http-token");
+      log.info(
+        "Daemon startup: CLI edge token written to credential store and http-token",
+      );
     } else {
       log.warn("No guardian principal available — CLI edge token not written");
     }

--- a/assistant/src/email/providers/index.ts
+++ b/assistant/src/email/providers/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { getNestedValue, loadRawConfig } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { ConfigError } from "../../util/errors.js";
 import type { EmailProvider } from "../provider.js";
@@ -13,7 +14,7 @@ export const SUPPORTED_PROVIDERS = ["agentmail"] as const;
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
 
 const PROVIDER_KEY_MAP: Record<SupportedProvider, string[]> = {
-  agentmail: ["agentmail", "credential:agentmail:api_key"],
+  agentmail: ["agentmail", credentialKey("agentmail", "api_key")],
 };
 
 /**

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -54,8 +54,8 @@ export const telegramBotMessagingProvider: MessagingProvider = {
 
   /**
    * Custom connectivity check. The standard registry check looks for
-   * credential:telegram:access_token, but the Telegram bot token is
-   * stored as credential:telegram:bot_token. This method lets the
+   * credential/telegram/access_token, but the Telegram bot token is
+   * stored as credential/telegram/bot_token. This method lets the
    * registry detect that Telegram credentials exist.
    *
    * Both bot_token and webhook_secret are required — the gateway's

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -10,11 +10,15 @@
  */
 
 import { getPlatformBaseUrl } from "../../config/env.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { MANAGED_PROVIDER_META } from "./constants.js";
 
 /** Storage key for the assistant API key credential. */
-const ASSISTANT_API_KEY_STORAGE_KEY = "credential:vellum:assistant_api_key";
+const ASSISTANT_API_KEY_STORAGE_KEY = credentialKey(
+  "vellum",
+  "assistant_api_key",
+);
 
 export interface ManagedProxyContext {
   /** Whether managed proxy prerequisites are satisfied. */

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -16,6 +16,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import { getLogger } from "../../util/logger.js";
@@ -40,7 +41,7 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     return; // Username already cached in config
   }
 
-  const token = getSecureKey("credential:telegram:bot_token");
+  const token = getSecureKey(credentialKey("telegram", "bot_token"));
   if (!token) return;
 
   try {

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -12,6 +12,7 @@ import {
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { credentialKey } from "../../../../security/credential-key.js";
 import { getSecureKey } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import { httpError } from "../../../http-errors.js";
@@ -29,8 +30,8 @@ const log = getLogger("slack-share");
  */
 function resolveSlackToken(): string | undefined {
   return (
-    getSecureKey("credential:integration:slack:access_token") ??
-    getSecureKey("credential:slack_channel:bot_token")
+    getSecureKey(credentialKey("integration:slack", "access_token")) ??
+    getSecureKey(credentialKey("slack_channel", "bot_token"))
   );
 }
 

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -21,6 +21,7 @@ import {
 import { loadRawConfig, saveRawConfig } from "../../../config/loader.js";
 import { syncTwilioWebhooks } from "../../../daemon/handlers/config-ingress.js";
 import type { IngressConfig } from "../../../inbound/public-ingress-urls.js";
+import { credentialKey } from "../../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
@@ -136,7 +137,7 @@ export async function handleSetTwilioCredentials(
   // validation (gateway/src/credential-reader.ts), while the assistant reads
   // from config via resolveAccountSid(). Both stores must stay in sync.
   const sidStored = await setSecureKeyAsync(
-    "credential:twilio:account_sid",
+    credentialKey("twilio", "account_sid"),
     body.accountSid,
   );
   if (!sidStored) {
@@ -148,11 +149,11 @@ export async function handleSetTwilioCredentials(
   }
 
   const tokenStored = await setSecureKeyAsync(
-    "credential:twilio:auth_token",
+    credentialKey("twilio", "auth_token"),
     body.authToken,
   );
   if (!tokenStored) {
-    await deleteSecureKeyAsync("credential:twilio:account_sid");
+    await deleteSecureKeyAsync(credentialKey("twilio", "account_sid"));
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -202,8 +203,8 @@ export async function handleSetTwilioCredentials(
  * DELETE /v1/integrations/twilio/credentials
  */
 export async function handleClearTwilioCredentials(): Promise<Response> {
-  const r1 = await deleteSecureKeyAsync("credential:twilio:account_sid");
-  const r2 = await deleteSecureKeyAsync("credential:twilio:auth_token");
+  const r1 = await deleteSecureKeyAsync(credentialKey("twilio", "account_sid"));
+  const r2 = await deleteSecureKeyAsync(credentialKey("twilio", "auth_token"));
 
   if (r1 === "error" || r2 === "error") {
     return Response.json(

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,4 +1,5 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
+import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 
 interface IntegrationProbe {
@@ -13,13 +14,13 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
     name: "Gmail",
     category: "email",
     isConnected: () =>
-      !!getSecureKey("credential:integration:gmail:access_token"),
+      !!getSecureKey(credentialKey("integration:gmail", "access_token")),
   },
   {
     name: "Slack",
     category: "messaging",
     isConnected: () =>
-      !!getSecureKey("credential:integration:slack:access_token"),
+      !!getSecureKey(credentialKey("integration:slack", "access_token")),
   },
   {
     name: "Twilio",
@@ -30,8 +31,8 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
     name: "Telegram",
     category: "messaging",
     isConnected: () =>
-      !!getSecureKey("credential:telegram:bot_token") &&
-      !!getSecureKey("credential:telegram:webhook_secret"),
+      !!getSecureKey(credentialKey("telegram", "bot_token")) &&
+      !!getSecureKey(credentialKey("telegram", "webhook_secret")),
   },
 ];
 


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for credential-storage-hygiene.

**Gap 1 — Incomplete key-delimiter migration:** Migrated all remaining production and test files from the legacy colon-delimited `credential:service:field` format to use `credentialKey()` helper (producing `credential/service/field`). Updated 25 files total: production code in email providers, channel-invite transports, call-domain error messages, telegram adapter comments, oauth CLI docs, and all corresponding test files with mock key stores.

**Gap 2 — `migrateKeys()` not called at daemon startup:** Added `migrateKeys()` call in `daemon/lifecycle.ts` immediately after `ensureDataDir()`, ensuring legacy colon-delimited keys are migrated before any credential reads during the daemon boot sequence.

Fixes gap identified during plan review for credential-storage-hygiene.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
