### PR TITLE
fix: improve migrateKeys() parsing to handle field names with colons

### DIFF
--- a/assistant/src/security/credential-key.ts
+++ b/assistant/src/security/credential-key.ts
@@ -8,6 +8,7 @@
  * "integration:gmail"). The slash-delimited format avoids this.
  */
 
+import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   deleteSecureKey,
@@ -42,9 +43,17 @@ let migrated = false;
  * Legacy key format: `credential:<service>:<field>`
  * New key format:    `credential/<service>/<field>`
  *
- * Service names may contain colons (e.g. "integration:gmail"), so the
- * parsing splits on the first colon after "credential" and the last
- * colon to extract service and field.
+ * The old colon-delimited format is ambiguous when either the service
+ * or field name contains colons — for `credential:A:B:C:D`, you can't
+ * tell where the service ends and the field begins without external
+ * context.
+ *
+ * To resolve this, the function first consults the credential metadata
+ * store to find which (service, field) pair matches a valid split.
+ * If no metadata match is found, it falls back to splitting on the
+ * **first** colon after the prefix — this handles the common case
+ * where service names are simple (e.g. "doordash.com") and field
+ * names may contain colons (e.g. "session:cookies").
  */
 export function migrateKeys(): void {
   if (migrated) return;
@@ -68,20 +77,29 @@ export function migrateKeys(): void {
     "Migrating colon-delimited credential keys to slash-delimited format",
   );
 
+  // Build a set of known (service, field) pairs from credential metadata
+  // to disambiguate colon-delimited keys.
+  const knownPairs = new Set<string>();
+  try {
+    for (const meta of listCredentialMetadata()) {
+      knownPairs.add(`${meta.service}\0${meta.field}`);
+    }
+  } catch {
+    // If metadata is unavailable, we'll rely on the first-colon fallback.
+  }
+
   for (const oldKey of colonKeys) {
-    // Strip the "credential:" prefix
+    // Strip the "credential:" prefix — `rest` is "service:field" with
+    // potential colons in either part.
     const rest = oldKey.slice("credential:".length);
 
-    // Split on the last colon to get field; everything before is the service.
-    // This handles service names with colons (e.g. "integration:gmail").
-    const lastColon = rest.lastIndexOf(":");
-    if (lastColon <= 0) {
+    const parsed = parseServiceField(rest, knownPairs);
+    if (parsed === undefined) {
       log.warn({ key: oldKey }, "Skipping malformed credential key");
       continue;
     }
 
-    const service = rest.slice(0, lastColon);
-    const field = rest.slice(lastColon + 1);
+    const { service, field } = parsed;
     const newKey = credentialKey(service, field);
 
     // Skip if the new key already exists (idempotent)
@@ -106,6 +124,44 @@ export function migrateKeys(): void {
       );
     }
   }
+}
+
+/**
+ * Parse a "service:field" string, using known metadata pairs to
+ * disambiguate when colons appear in either part.
+ *
+ * Strategy:
+ * 1. Try every possible split position and check against metadata.
+ * 2. If no metadata match, fall back to splitting on the first colon
+ *    (field names with colons are more common than service names with colons).
+ *
+ * Returns undefined for malformed keys that have no colon.
+ */
+function parseServiceField(
+  rest: string,
+  knownPairs: Set<string>,
+): { service: string; field: string } | undefined {
+  const firstColon = rest.indexOf(":");
+  if (firstColon <= 0) return undefined;
+
+  // Try each possible split position against metadata
+  if (knownPairs.size > 0) {
+    for (let i = firstColon; i < rest.length; i++) {
+      if (rest[i] !== ":") continue;
+      const service = rest.slice(0, i);
+      const field = rest.slice(i + 1);
+      if (field.length > 0 && knownPairs.has(`${service}\0${field}`)) {
+        return { service, field };
+      }
+    }
+  }
+
+  // Fallback: split on first colon — handles simple services with
+  // compound field names (e.g. "doordash.com:session:cookies").
+  return {
+    service: rest.slice(0, firstColon),
+    field: rest.slice(firstColon + 1),
+  };
 }
 
 /** @internal Test-only: reset the migration guard so migrateKeys() runs again. */


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for credential-storage-hygiene.md.

**Gap:** migrateKeys() misparsing field names with colons (e.g., session:cookies)
**What was expected:** Correct migration of keys like credential:doordash.com:session:cookies
**What was found:** lastIndexOf(':') split produces wrong service/field split for fields containing colons

Uses credential metadata store to disambiguate service/field boundaries, with first-colon fallback for keys without metadata records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
