### PR TITLE
Add setupStatus field to Swift ChannelReadinessInfo model

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2099,6 +2099,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Rich channel readiness information returned by `fetchChannelReadiness()`.
     public struct ChannelReadinessInfo {
         public let ready: Bool
+        public let setupStatus: String?
         public let channelHandle: String?
         public let checks: [ReadinessCheck]
 
@@ -2131,6 +2132,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             struct Snapshot: Decodable {
                 let channel: String
                 let ready: Bool
+                let setupStatus: String?
                 let channelHandle: String?
                 let localChecks: [CheckResult]?
                 let remoteChecks: [CheckResult]?
@@ -2148,6 +2150,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 .map { ReadinessCheck(name: $0.name, passed: $0.passed, message: $0.message) }
             result[snapshot.channel] = ChannelReadinessInfo(
                 ready: snapshot.ready,
+                setupStatus: snapshot.setupStatus,
                 channelHandle: snapshot.channelHandle,
                 checks: checks
             )

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2328,6 +2328,7 @@ public final class HTTPTransport {
         struct ChannelReadinessSnapshot: Decodable {
             let channel: String
             let ready: Bool
+            let setupStatus: String?
             let channelHandle: String?
             let localChecks: [CheckResult]?
             let remoteChecks: [CheckResult]?
@@ -2491,6 +2492,7 @@ public final class HTTPTransport {
                 .map { DaemonClient.ReadinessCheck(name: $0.name, passed: $0.passed, message: $0.message) }
             result[snapshot.channel] = DaemonClient.ChannelReadinessInfo(
                 ready: snapshot.ready,
+                setupStatus: snapshot.setupStatus,
                 channelHandle: snapshot.channelHandle,
                 checks: checks
             )


### PR DESCRIPTION
## Summary
- Add `setupStatus: String?` field to `ChannelReadinessInfo` struct for parsing the new readiness API field
- Update `Snapshot` decodable to include `setupStatus` from the readiness response
- Update `HTTPDaemonClient` readiness snapshot and construction to match
- Backward compatible — field is optional and defaults to nil for older daemon versions

Part of plan: channel-setup-status.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
