### PR TITLE
fix: resolve sync I/O and blank pane issues in Contacts UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -60,6 +60,16 @@ struct ContactsContainerView: View {
                     if let store {
                         AssistantChannelsDetailView(store: store, daemonClient: daemonClient)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    } else {
+                        VStack(spacing: VSpacing.md) {
+                            ProgressView()
+                                .controlSize(.regular)
+                            Text("Loading assistant channels...")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(VColor.background)
                     }
                 case .contact(let contactId):
                     if let contact = viewModel.contacts.first(where: { $0.id == contactId }) {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -11,6 +11,7 @@ struct ContactsListView: View {
 
     @State private var hoveredContactId: String?
     @State private var isAssistantHovered = false
+    @State private var cachedAssistantDisplayName: String = AssistantDisplayName.placeholder
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -25,6 +26,9 @@ struct ContactsListView: View {
         }
         .onAppear {
             viewModel.loadContacts()
+        }
+        .task {
+            cachedAssistantDisplayName = AssistantDisplayName.firstUserFacing(from: [IdentityInfo.load()?.name]) ?? AssistantDisplayName.placeholder
         }
     }
 
@@ -89,7 +93,7 @@ struct ContactsListView: View {
                 HStack(spacing: VSpacing.md) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         HStack(spacing: VSpacing.sm) {
-                            Text(assistantDisplayName)
+                            Text(cachedAssistantDisplayName)
                                 .font(VFont.bodyBold)
                                 .foregroundColor(VColor.textPrimary)
                                 .lineLimit(1)
@@ -122,12 +126,6 @@ struct ContactsListView: View {
             }
             .vCard(background: VColor.surfaceSubtle)
         }
-    }
-
-    /// The assistant's display name, loaded from the identity file or falling
-    /// back to "Assistant".
-    private var assistantDisplayName: String {
-        AssistantDisplayName.firstUserFacing(from: [IdentityInfo.load()?.name]) ?? AssistantDisplayName.placeholder
     }
 
     /// Summarizes which assistant channels are configured.


### PR DESCRIPTION
Fix two issues from PR #15374 review:

1. **Sync file I/O in computed property** — Replaced synchronous `IdentityInfo.load()` call in `assistantDisplayName` computed property (which was invoked on every view body evaluation) with a `@State` variable (`cachedAssistantDisplayName`) loaded once in a `.task` modifier.

2. **Blank right pane when store is nil** — Added a `ProgressView` placeholder for the `selection == .assistant` case when `SettingsStore` is nil, preventing a completely blank right pane.

3. **`performUninstall()` public access** — Confirmed this is intentional: the method is called cross-module from `VellumAssistantApp.swift` (in the `vellum-assistant-app` target) which imports `VellumAssistantLib`, so `public` access is required. No change needed.

**Files changed:**
- `clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift`
- `clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
