### PR TITLE
fix: remove dead recordingPath and preserve recordingId in DoorDash session

### DIFF
--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -72,7 +72,11 @@ async function runChromeCommand(
     ({ stdout } = await execFileAsync("assistant", args));
   } catch (err: unknown) {
     // Node's ExecFileException includes stdout/stderr from the child process
-    const execErr = err as { stdout?: string; stderr?: string; message?: string };
+    const execErr = err as {
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
     if (typeof execErr.stdout === "string" && execErr.stdout.trim()) {
       try {
         const result = JSON.parse(execErr.stdout);
@@ -99,7 +103,11 @@ async function ensureChromeWithCdp(opts?: {
   if (opts?.startUrl) args.push("--start-url", opts.startUrl);
   if (opts?.port) args.push("--port", String(opts.port));
   const result = await runChromeCommand(args, "Chrome launch failed");
-  return result as { baseUrl: string; launchedByUs: boolean; userDataDir: string };
+  return result as {
+    baseUrl: string;
+    launchedByUs: boolean;
+    userDataDir: string;
+  };
 }
 
 async function minimizeChromeWindow(cdpBase?: string): Promise<void> {

--- a/skills/doordash/scripts/doordash-cli.ts
+++ b/skills/doordash/scripts/doordash-cli.ts
@@ -211,7 +211,9 @@ export function registerDoordashCommand(program: Command): void {
 
         const result = await startLearnSession(duration);
         if (result.recordingId) {
-          const session = await importFromCredentialStore("doordash.com");
+          const session = await importFromCredentialStore("doordash.com", {
+            recordingId: result.recordingId,
+          });
 
           // Also extract and save captured queries for self-healing
           let queriesCaptured = 0;
@@ -1009,7 +1011,6 @@ export function registerDoordashCommand(program: Command): void {
 
 interface LearnResult {
   recordingId?: string;
-  recordingPath?: string;
 }
 
 async function startLearnSession(
@@ -1109,7 +1110,6 @@ async function startLearnSession(
             if (status.savedRecordingPath && status.recordingId) {
               resolve({
                 recordingId: status.recordingId,
-                recordingPath: status.savedRecordingPath,
               });
               return;
             }
@@ -1126,7 +1126,6 @@ async function startLearnSession(
                 statSync(expectedPath);
                 resolve({
                   recordingId: status.recordingId,
-                  recordingPath: expectedPath,
                 });
                 return;
               } catch {

--- a/skills/doordash/scripts/lib/session.ts
+++ b/skills/doordash/scripts/lib/session.ts
@@ -59,9 +59,15 @@ export function clearSession(): void {
 /**
  * Import cookies that the daemon saved to the credential store under the
  * target domain key. Copies them into the local DoorDash session file.
+ *
+ * NOTE: This depends on the daemon having already written cookies to the
+ * credential store before this function is called. The daemon writes cookies
+ * asynchronously during the learn session, so callers should only invoke this
+ * after the learn session has completed (status === "completed").
  */
 export async function importFromCredentialStore(
   targetDomain: string,
+  opts?: { recordingId?: string },
 ): Promise<DoorDashSession> {
   const { stdout } = await execFileAsync("assistant", [
     "credentials",
@@ -76,6 +82,7 @@ export async function importFromCredentialStore(
   const session: DoorDashSession = {
     cookies,
     importedAt: new Date().toISOString(),
+    recordingId: opts?.recordingId,
   };
   saveSession(session);
   return session;


### PR DESCRIPTION
Address feedback from PR #14587 review:\n1. Remove dead recordingPath property from LearnResult and its computation\n2. Preserve recordingId when creating session from credential store\n3. Document timing dependency on daemon credential store write
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
