### PR TITLE
fix: remove dead message_back disposition from LLM tool schema

### DIFF
--- a/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
+++ b/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
@@ -181,25 +181,6 @@ describe("guardian-action-conversation-turn", () => {
     expect(result.replyText).toBe("Sure, I'll call them back right away.");
   });
 
-  test('classifies "send a text message" as message_back', async () => {
-    const generator = createMockGenerator({
-      disposition: "message_back",
-      replyText: "Got it, I'll send them a text message.",
-    });
-
-    const result = await processGuardianFollowUpTurn(
-      {
-        questionText: "What is the gate code?",
-        lateAnswerText: "The gate code is 1234",
-        guardianReply: "Just send them a text",
-      },
-      generator,
-    );
-
-    expect(result.disposition).toBe("message_back");
-    expect(result.replyText).toBe("Got it, I'll send them a text message.");
-  });
-
   test('classifies "never mind" as decline', async () => {
     const generator = createMockGenerator({
       disposition: "decline",
@@ -448,19 +429,6 @@ describe("guardian-action-conversation-turn", () => {
     expect(updated!.followupAction).toBe("call_back");
   });
 
-  test("message_back disposition transitions to dispatching with message_back action", () => {
-    const { request } = createAwaitingChoiceRequest("conv-turn-7");
-
-    const updated = progressFollowupState(
-      request.id,
-      "dispatching",
-      "message_back",
-    );
-    expect(updated).not.toBeNull();
-    expect(updated!.followupState).toBe("dispatching");
-    expect(updated!.followupAction).toBe("message_back");
-  });
-
   test("decline disposition finalizes to declined", () => {
     const { request } = createAwaitingChoiceRequest("conv-turn-8");
 
@@ -488,7 +456,7 @@ describe("guardian-action-conversation-turn", () => {
     const second = progressFollowupState(
       request.id,
       "dispatching",
-      "message_back",
+      "call_back",
     );
     expect(second).toBeNull();
 

--- a/assistant/src/__tests__/guardian-action-copy-generator.test.ts
+++ b/assistant/src/__tests__/guardian-action-copy-generator.test.ts
@@ -33,8 +33,6 @@ const ALL_SCENARIOS: GuardianActionMessageScenario[] = [
   "guardian_superseded_remap",
   "guardian_unknown_code",
   "guardian_auto_matched",
-  "outbound_message_copy",
-  "followup_message_sent",
   "followup_call_started",
   "followup_action_failed",
   "guardian_answer_delivery_failed",
@@ -109,24 +107,6 @@ describe("guardian-action-copy-generator", () => {
         requestCodes: ["QFOO12"],
       });
       expect(msg).toContain("QFOO12");
-    });
-
-    test("outbound_message_copy includes lateAnswerText and questionText", () => {
-      const msg = getGuardianActionFallbackMessage({
-        scenario: "outbound_message_copy",
-        questionText: "When is the appointment?",
-        lateAnswerText: "It is at 3pm tomorrow.",
-      });
-      expect(msg).toContain("When is the appointment?");
-      expect(msg).toContain("It is at 3pm tomorrow.");
-    });
-
-    test("outbound_message_copy without lateAnswerText still includes questionText", () => {
-      const msg = getGuardianActionFallbackMessage({
-        scenario: "outbound_message_copy",
-        questionText: "Is the office open?",
-      });
-      expect(msg).toContain("Is the office open?");
     });
   });
 

--- a/assistant/src/__tests__/guardian-action-followup-executor.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-executor.test.ts
@@ -127,10 +127,7 @@ function resetTables(): void {
  * Create a request in `dispatching` state ready for the executor.
  * The call session has fromNumber='+15550001111' (the counterparty).
  */
-function createDispatchingRequest(
-  convId: string,
-  action: "call_back" | "message_back",
-) {
+function createDispatchingRequest(convId: string, action: "call_back") {
   ensureConversation(convId);
   const session = createCallSession({
     conversationId: convId,
@@ -278,30 +275,6 @@ describe("guardian-action-followup-executor", () => {
       expect(result.guardianReplyText.length).toBeGreaterThan(0);
 
       // Verify follow-up state is failed
-      const updated = getGuardianActionRequest(request.id);
-      expect(updated!.followupState).toBe("failed");
-      expect(updated!.followupCompletedAt).toBeGreaterThan(0);
-    });
-  });
-
-  // ── message_back (unsupported) error path ─────────────────────────────
-
-  describe("message_back", () => {
-    test("returns failure and finalizes as failed when message_back is dispatched", async () => {
-      const { request } = createDispatchingRequest(
-        "exec-msg-1",
-        "message_back",
-      );
-
-      const result = await executeFollowupAction(request.id, "message_back");
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error).toContain("Unsupported action");
-        expect(result.error).toContain("message_back");
-      }
-      expect(result.guardianReplyText.length).toBeGreaterThan(0);
-
       const updated = getGuardianActionRequest(request.id);
       expect(updated!.followupState).toBe("failed");
       expect(updated!.followupCompletedAt).toBeGreaterThan(0);

--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -314,7 +314,7 @@ describe("guardian-action-followup-store", () => {
     const request = createTestRequest("conv-followup-15");
     markTimedOutWithReason(request.id, "call_timeout");
     startFollowupFromExpiredRequest(request.id, "Late answer");
-    progressFollowupState(request.id, "dispatching", "message_back");
+    progressFollowupState(request.id, "dispatching", "call_back");
 
     const result = finalizeFollowup(request.id, "failed");
     expect(result).not.toBeNull();

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -83,8 +83,8 @@ const FOLLOWUP_CONVERSATION_MAX_TOKENS = 300;
 const FOLLOWUP_CONVERSATION_SYSTEM_PROMPT =
   "You are an assistant helping route a guardian's reply to a post-timeout follow-up message. " +
   "A voice caller asked a question, but the call timed out before the guardian could answer. " +
-  "The guardian has now replied late, and was asked whether they want to call the caller back, " +
-  "send them a text message, or skip it. " +
+  "The guardian has now replied late, and was asked whether they want to call the caller back " +
+  "or skip it. " +
   "Analyze the guardian's latest reply to determine their intent. " +
   "When uncertain, default to keep_pending and ask a clarifying question. " +
   "Always provide a natural, helpful reply along with your decision.";
@@ -101,10 +101,10 @@ const FOLLOWUP_CONVERSATION_TOOL_SCHEMA = {
     properties: {
       disposition: {
         type: "string",
-        enum: ["call_back", "message_back", "decline", "keep_pending"],
+        enum: ["call_back", "decline", "keep_pending"],
         description:
           "The guardian's intent: call_back to call the original caller, " +
-          "message_back to send a text message, decline to skip the follow-up, " +
+          "decline to skip the follow-up, " +
           "keep_pending if the intent is unclear (ask for clarification).",
       },
       replyText: {
@@ -118,7 +118,6 @@ const FOLLOWUP_CONVERSATION_TOOL_SCHEMA = {
 
 const VALID_FOLLOWUP_DISPOSITIONS: ReadonlySet<string> = new Set([
   "call_back",
-  "message_back",
   "decline",
   "keep_pending",
 ]);

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -44,7 +44,7 @@ export type FollowupState =
   | "completed"
   | "declined"
   | "failed";
-export type FollowupAction = "call_back" | "message_back" | "decline";
+export type FollowupAction = "call_back" | "decline";
 
 export interface GuardianActionRequest {
   id: string;

--- a/assistant/src/memory/schema/guardian.ts
+++ b/assistant/src/memory/schema/guardian.ts
@@ -27,7 +27,7 @@ export const guardianActionRequests = sqliteTable(
     followupState: text("followup_state").notNull().default("none"), // none | awaiting_guardian_choice | dispatching | completed | declined | failed
     lateAnswerText: text("late_answer_text"),
     lateAnsweredAt: integer("late_answered_at"),
-    followupAction: text("followup_action"), // call_back | message_back | decline
+    followupAction: text("followup_action"), // call_back | decline
     followupCompletedAt: integer("followup_completed_at"),
     toolName: text("tool_name"), // tool identity for tool-approval requests
     inputDigest: text("input_digest"), // canonical SHA-256 digest of tool input

--- a/assistant/src/runtime/guardian-action-conversation-turn.ts
+++ b/assistant/src/runtime/guardian-action-conversation-turn.ts
@@ -2,12 +2,11 @@
  * Guardian follow-up conversation engine.
  *
  * When a guardian replies to a post-timeout follow-up prompt (e.g. "would you
- * like to call them back or send a message?"), this engine classifies the
+ * like to call them back?"), this engine classifies the
  * guardian's intent into a structured disposition and produces a natural reply.
  *
  * Dispositions:
  *   - call_back:     Guardian wants to call the original caller back
- *   - message_back:  Guardian wants to send a text/message to the caller
  *   - decline:       Guardian declines to follow up ("never mind", "no thanks")
  *   - keep_pending:  Intent is ambiguous — ask for clarification
  *
@@ -37,7 +36,6 @@ const FALLBACK_RETRY_TEXT = getGuardianActionFallbackMessage({
 
 const VALID_DISPOSITIONS: ReadonlySet<string> = new Set([
   "call_back",
-  "message_back",
   "decline",
   "keep_pending",
 ]);

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -173,7 +173,7 @@ async function executeCallBack(
 
 /**
  * Execute a follow-up action after the conversation engine has classified
- * the guardian's intent as call_back or message_back and the follow-up
+ * the guardian's intent as call_back and the follow-up
  * state has been transitioned to `dispatching`.
  *
  * On success: finalizes the follow-up to `completed` and returns

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -36,8 +36,6 @@ export type GuardianActionMessageScenario =
   | "guardian_superseded_remap"
   | "guardian_unknown_code"
   | "guardian_auto_matched"
-  | "outbound_message_copy"
-  | "followup_message_sent"
   | "followup_call_started"
   | "followup_action_failed"
   | "guardian_answer_delivery_failed";
@@ -183,8 +181,8 @@ export function getGuardianActionFallbackMessage(
 
     case "guardian_late_answer_followup":
       return context.callerIdentifier
-        ? `${context.callerIdentifier} called earlier with a question, but I wasn't able to connect them. Would you like to call them back or send them a message?`
-        : "Someone called earlier with a question, but I wasn't able to connect them. Would you like to call them back or send them a message?";
+        ? `${context.callerIdentifier} called earlier with a question, but I wasn't able to connect them. Would you like to call them back?`
+        : "Someone called earlier with a question, but I wasn't able to connect them. Would you like to call them back?";
 
     case "guardian_followup_dispatching":
       return context.followupAction
@@ -205,7 +203,7 @@ export function getGuardianActionFallbackMessage(
       return "No problem. Let me know if you change your mind or need anything else.";
 
     case "guardian_followup_clarification":
-      return "Sorry, I didn't quite catch that. Would you like to call them back, send them a message, or skip it for now?";
+      return "Sorry, I didn't quite catch that. Would you like to call them back or skip it for now?";
 
     case "guardian_pending_disambiguation":
       return listedCodes
@@ -246,24 +244,6 @@ export function getGuardianActionFallbackMessage(
       return context.questionText
         ? `Got it! Your answer has been applied to the current active request: "${context.questionText}"`
         : "Got it! Your answer has been applied to the current active request on the call.";
-
-    case "outbound_message_copy":
-      // This message is sent TO the original caller relaying the guardian's answer.
-      // When lateAnswerText is available, include it — that's the whole point of message_back.
-      if (context.lateAnswerText && context.questionText) {
-        return `Hi! You asked "${context.questionText}" earlier. Here's the answer: ${context.lateAnswerText}`;
-      }
-      if (context.lateAnswerText) {
-        return `Hi! Regarding your earlier question — here's the answer: ${context.lateAnswerText}`;
-      }
-      return context.questionText
-        ? `Hi! You asked "${context.questionText}" earlier. We'll get back to you with an answer soon.`
-        : "Hi! Thanks for calling earlier. We'll get back to you soon.";
-
-    case "followup_message_sent":
-      return context.counterpartyPhone
-        ? `Done! I've sent a text message to ${context.counterpartyPhone} with your answer.`
-        : "Done! I've sent them a text message with your answer.";
 
     case "followup_call_started":
       return context.counterpartyPhone

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -83,7 +83,6 @@ export type GuardianActionCopyGenerator = (
 /** The disposition returned by the guardian follow-up conversation engine. */
 export type GuardianFollowUpDisposition =
   | "call_back"
-  | "message_back"
   | "decline"
   | "keep_pending";
 


### PR DESCRIPTION
Remove message_back from the LLM tool schema and valid disposition sets. SMS was removed but message_back was left in the enum, causing the LLM to occasionally produce a disposition that fails at execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
