### PR TITLE
Add OAuthConnection interface types and provider base URL registry

### DIFF
--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -1,0 +1,38 @@
+export interface OAuthConnectionRequest {
+  method: string;
+  path: string; // relative, e.g. "/2/tweets"
+  query?: Record<string, string>;
+  headers?: Record<string, string>;
+  body?: unknown; // JSON-serializable
+  /**
+   * Override the connection's default base URL for this request.
+   * Required for providers that span multiple API hosts sharing
+   * one OAuth token (e.g. Google: Gmail, Calendar, People all
+   * use the same credential but different base URLs).
+   */
+  baseUrl?: string;
+}
+
+export interface OAuthConnectionResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+export interface OAuthConnection {
+  /** Make an authenticated HTTP request through this connection. */
+  request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse>;
+
+  /**
+   * Execute a callback with a valid raw access token. This is an escape hatch
+   * for provider-specific endpoints that don't fit the relative-path model
+   * (e.g. Gmail batch API on a different host). Throws for platform connections
+   * where raw tokens are not available locally.
+   */
+  withToken<T>(fn: (token: string) => Promise<T>): Promise<T>;
+
+  readonly id: string;
+  readonly providerKey: string;
+  readonly accountInfo: string | null;
+  readonly grantedScopes: string[];
+}

--- a/assistant/src/oauth/provider-base-urls.ts
+++ b/assistant/src/oauth/provider-base-urls.ts
@@ -1,0 +1,22 @@
+/** Default base URL per credential service. Used by the connection when no per-request override is provided. */
+export const PROVIDER_BASE_URLS: Record<string, string> = {
+  "integration:gmail": "https://gmail.googleapis.com/gmail/v1/users/me",
+  "integration:slack": "https://slack.com/api",
+  "integration:twitter": "https://api.x.com",
+  "integration:notion": "https://api.notion.com",
+  "integration:linear": "https://api.linear.app",
+  "integration:github": "https://api.github.com",
+};
+
+/**
+ * Alternative base URLs for providers that span multiple API hosts
+ * sharing one OAuth token. Callers pass these via `request({ baseUrl })`.
+ */
+export const GOOGLE_CALENDAR_BASE_URL =
+  "https://www.googleapis.com/calendar/v3";
+export const GOOGLE_PEOPLE_BASE_URL = "https://people.googleapis.com/v1";
+export const GMAIL_BATCH_BASE_URL = "https://www.googleapis.com/batch/gmail/v1";
+
+export function getProviderBaseUrl(providerKey: string): string | undefined {
+  return PROVIDER_BASE_URLS[providerKey];
+}


### PR DESCRIPTION
## Summary
- Introduce OAuthConnection, OAuthConnectionRequest, and OAuthConnectionResponse interfaces for abstracting BYO vs Platform OAuth connections
- Add provider base URL registry covering all current integration providers (Gmail, Slack, Twitter, Notion, Linear, GitHub) plus alternative Google API hosts (Calendar, People, Gmail Batch)
- Support per-request baseUrl override for providers spanning multiple API hosts sharing one OAuth token

Part of plan: oauth-conn-request.md (PR 1 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
