### PR TITLE
feat: add environment and device ID tags to Sentry events

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -282,6 +282,7 @@ extension AppDelegate {
 
         // 3. Persist the new assistant selection
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        SentryDeviceInfo.updateAssistantTag(assistant.assistantId)
         // Clear stale org ID so the next bootstrap re-resolves it for the new assistant
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         assistant.writeToWorkspaceConfig()
@@ -438,6 +439,7 @@ extension AppDelegate {
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")
         UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        SentryDeviceInfo.updateAssistantTag(nil)
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -59,6 +59,7 @@ extension AppDelegate {
         }
 
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        SentryDeviceInfo.updateAssistantTag(assistant.assistantId)
         assistant.writeToWorkspaceConfig()
         return assistant
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -208,6 +208,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
             options.releaseName = "vellum-macos@\(appVersion)"
             options.dist = buildNumber
+            options.environment = SentryDeviceInfo.sentryEnvironment
             options.debug = false
             options.tracesSampleRate = 0.1
             options.configureProfiling = { profilingOptions in
@@ -215,6 +216,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             }
             options.sendDefaultPii = false
         }
+        SentryDeviceInfo.configureSentryScope()
 
         // Surface any crash log from the previous session so the user can send
         // it. Also records this launch timestamp for the next session's check.

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -262,6 +262,7 @@ struct OnboardingFlowView: View {
             }
 
             UserDefaults.standard.set(assistant.id, forKey: "connectedAssistantId")
+            SentryDeviceInfo.updateAssistantTag(assistant.id)
 
             isBootstrappingManaged = false
             log.info("Managed bootstrap completed for assistant \(assistant.id, privacy: .public); proceeding to app")

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -68,12 +68,14 @@ import os
                     options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
                     options.releaseName = "vellum-macos@\(version)"
                     options.dist = build
+                    options.environment = SentryDeviceInfo.sentryEnvironment
                     options.sendDefaultPii = false
                     // Disable crash capture and session tracking so the temporary
                     // restart only sends the explicit event, not incidental crashes.
                     options.enableCrashHandler = false
                     options.enableAutoSessionTracking = false
                 }
+                SentryDeviceInfo.configureSentryScope()
             }
 
             // Attach files to the scope before capturing the event.
@@ -142,6 +144,7 @@ import os
                 options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
                 options.releaseName = "vellum-macos@\(version)"
                 options.dist = build
+                options.environment = SentryDeviceInfo.sentryEnvironment
                 options.debug = false
                 options.tracesSampleRate = 0.1
                 options.configureProfiling = { profilingOptions in
@@ -149,6 +152,7 @@ import os
                 }
                 options.sendDefaultPii = false
             }
+            SentryDeviceInfo.configureSentryScope()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -31,11 +31,24 @@ enum SentryDeviceInfo {
     static func configureSentryScope() {
         SentrySDK.configureScope { scope in
             scope.setTag(value: deviceId, key: "device_id")
-            scope.setTag(value: ProcessInfo.processInfo.hostName, key: "hostname")
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
                 scope.setTag(value: assistantId, key: "assistant_id")
+            } else {
+                scope.removeTag(key: "assistant_id")
             }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
+        }
+    }
+
+    /// Updates the `assistant_id` Sentry tag when the connected assistant changes.
+    /// Call from assistant switch, sign-in, and sign-out flows.
+    static func updateAssistantTag(_ assistantId: String?) {
+        SentrySDK.configureScope { scope in
+            if let id = assistantId {
+                scope.setTag(value: id, key: "assistant_id")
+            } else {
+                scope.removeTag(key: "assistant_id")
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -31,8 +31,9 @@ enum SentryDeviceInfo {
     static func configureSentryScope() {
         SentrySDK.configureScope { scope in
             scope.setTag(value: deviceId, key: "device_id")
-            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
-                scope.setTag(value: assistantId, key: "assistant_id")
+            if let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+               LockfileAssistant.loadAll().contains(where: { $0.assistantId == storedId }) {
+                scope.setTag(value: storedId, key: "assistant_id")
             } else {
                 scope.removeTag(key: "assistant_id")
             }

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -1,0 +1,57 @@
+import CryptoKit
+import Foundation
+import IOKit
+@preconcurrency import Sentry
+
+/// Privacy-safe device identification and Sentry scope configuration.
+/// Uses the same SHA-256(IOPlatformUUID + salt) approach as PairingQRCodeSheet.computeHostId().
+enum SentryDeviceInfo {
+    /// A stable, hashed device identifier derived from the hardware UUID.
+    /// Computed once and cached for the process lifetime.
+    static let deviceId: String = {
+        let platformUUID = getPlatformUUID() ?? UUID().uuidString
+        let salt = "vellum-assistant-host-id"
+        let input = Data((platformUUID + salt).utf8)
+        let hash = SHA256.hash(data: input)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }()
+
+    /// Sentry environment string matching the daemon convention in instrument.ts.
+    static let sentryEnvironment: String = {
+        #if DEBUG
+        return "development"
+        #else
+        return "production"
+        #endif
+    }()
+
+    /// Configures the Sentry scope with device and assistant tags.
+    /// Call after every `SentrySDK.start` (AppDelegate init, MetricKitManager restart,
+    /// manual report temporary start) so all events carry filtering context.
+    static func configureSentryScope() {
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: deviceId, key: "device_id")
+            scope.setTag(value: ProcessInfo.processInfo.hostName, key: "hostname")
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+                scope.setTag(value: assistantId, key: "assistant_id")
+            }
+            scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
+        }
+    }
+
+    private static func getPlatformUUID() -> String? {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching("IOPlatformExpertDevice")
+        )
+        guard service != 0 else { return nil }
+        defer { IOObjectRelease(service) }
+
+        let key = kIOPlatformUUIDKey as CFString
+        guard let uuid = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? String else {
+            return nil
+        }
+        return uuid
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `environment` (`development`/`production`) to all Sentry SDK init calls, matching the daemon convention in `instrument.ts`.
- Adds persistent scope tags to every Sentry event: `device_id` (SHA-256 of hardware UUID), `hostname`, `assistant_id`, and `os_version`.
- Centralizes the tagging logic in a new `SentryDeviceInfo` utility (`Telemetry/SentryDeviceInfo.swift`) so all three SDK init paths (AppDelegate, MetricKitManager.startSentry, MetricKitManager.sendManualReport) share the same configuration.

## Test plan
- [ ] Build succeeds
- [ ] Send a test Sentry event from Settings > Developer > "Send Test Error" and verify `environment`, `device_id`, `hostname`, and `os_version` tags appear in Sentry dashboard
- [ ] Verify debug builds show `environment: development` and release builds show `environment: production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
