### PR TITLE
feat: add feature flag to disable automatic memory recall

### DIFF
--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -40,6 +40,11 @@ mock.module("../providers/registry.js", () => ({
   initializeProviders: () => {},
 }));
 
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+  loadDefaultsRegistry: () => ({}),
+}));
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -128,6 +128,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
+    },
+    {
+      "id": "automatic-memory-recall",
+      "scope": "assistant",
+      "key": "feature_flags.automatic-memory-recall.enabled",
+      "label": "Automatic Memory Recall",
+      "description": "Automatically retrieve and inject relevant memories before every LLM call. Disabling eliminates the latency of embedding generation, semantic search, and reranking on each message while preserving on-demand memory_recall tool access.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -1,3 +1,4 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { estimatePromptTokens } from "../context/token-estimator.js";
 import { getMemoryConflictAndCleanupStats } from "../memory/admin.js";
@@ -157,45 +158,83 @@ export async function prepareMemoryContext(
       })
     : { text: "" };
 
+  // Feature flag: when automatic memory recall is disabled, skip the entire
+  // buildMemoryRecall() pipeline (embedding generation, semantic search,
+  // reranking) to eliminate its latency. The on-demand memory_recall tool
+  // remains available for explicit lookups.
+  const automaticRecallEnabled = isAssistantFeatureFlagEnabled(
+    "feature_flags.automatic-memory-recall.enabled",
+    runtimeConfig,
+  );
+
+  const noopRecall = {
+    enabled: false,
+    degraded: false,
+    injectedText: "",
+    lexicalHits: 0,
+    semanticHits: 0,
+    recencyHits: 0,
+    entityHits: 0,
+    relationSeedEntityCount: 0,
+    relationTraversedEdgeCount: 0,
+    relationNeighborEntityCount: 0,
+    relationExpandedItemCount: 0,
+    earlyTerminated: false,
+    mergedCount: 0,
+    selectedCount: 0,
+    rerankApplied: false,
+    injectedTokens: 0,
+    latencyMs: 0,
+    topCandidates: [],
+  } as Awaited<ReturnType<typeof buildMemoryRecall>>;
+
   // Memory recall
-  const recallQuery = buildMemoryQuery(content, ctx.messages);
   const recallInjectionStrategy: RecallInjectionStrategy =
     (runtimeConfig.memory?.retrieval?.injectionStrategy as
       | RecallInjectionStrategy
       | undefined) ?? "prepend_user_block";
-  const dynamicBudgetConfig = runtimeConfig.memory?.retrieval?.dynamicBudget;
-  const recallBudget = dynamicBudgetConfig?.enabled
-    ? computeRecallBudget({
-        estimatedPromptTokens: estimatePromptTokens(
-          ctx.messages,
-          ctx.systemPrompt,
-          { providerName: ctx.provider.name },
-        ),
-        maxInputTokens: runtimeConfig.contextWindow.maxInputTokens,
-        targetHeadroomTokens: dynamicBudgetConfig.targetHeadroomTokens,
-        minInjectTokens: dynamicBudgetConfig.minInjectTokens,
-        maxInjectTokens: dynamicBudgetConfig.maxInjectTokens,
-      })
-    : undefined;
-  // Build scope policy override for non-default scopes so retrieval
-  // honours the session's memory policy regardless of the global config.
-  const scopePolicyOverride: ScopePolicyOverride | undefined =
-    ctx.scopeId !== "default"
-      ? { scopeId: ctx.scopeId, fallbackToDefault: ctx.includeDefaultFallback }
-      : undefined;
 
-  const recall = await buildMemoryRecall(
-    recallQuery,
-    ctx.conversationId,
-    runtimeConfig,
-    {
-      excludeMessageIds: [userMessageId],
-      signal: abortSignal,
-      maxInjectTokensOverride: recallBudget,
-      scopeId: ctx.scopeId,
-      scopePolicyOverride,
-    },
-  );
+  let recall: Awaited<ReturnType<typeof buildMemoryRecall>>;
+
+  if (automaticRecallEnabled) {
+    const recallQuery = buildMemoryQuery(content, ctx.messages);
+    const dynamicBudgetConfig = runtimeConfig.memory?.retrieval?.dynamicBudget;
+    const recallBudget = dynamicBudgetConfig?.enabled
+      ? computeRecallBudget({
+          estimatedPromptTokens: estimatePromptTokens(
+            ctx.messages,
+            ctx.systemPrompt,
+            { providerName: ctx.provider.name },
+          ),
+          maxInputTokens: runtimeConfig.contextWindow.maxInputTokens,
+          targetHeadroomTokens: dynamicBudgetConfig.targetHeadroomTokens,
+          minInjectTokens: dynamicBudgetConfig.minInjectTokens,
+          maxInjectTokens: dynamicBudgetConfig.maxInjectTokens,
+        })
+      : undefined;
+    // Build scope policy override for non-default scopes so retrieval
+    // honours the session's memory policy regardless of the global config.
+    const scopePolicyOverride: ScopePolicyOverride | undefined =
+      ctx.scopeId !== "default"
+        ? { scopeId: ctx.scopeId, fallbackToDefault: ctx.includeDefaultFallback }
+        : undefined;
+
+    recall = await buildMemoryRecall(
+      recallQuery,
+      ctx.conversationId,
+      runtimeConfig,
+      {
+        excludeMessageIds: [userMessageId],
+        signal: abortSignal,
+        maxInjectTokensOverride: recallBudget,
+        scopeId: ctx.scopeId,
+        scopePolicyOverride,
+      },
+    );
+  } else {
+    recall = noopRecall;
+  }
+
   const memoryStatus = getMemoryConflictAndCleanupStats();
 
   onEvent({

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -128,6 +128,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": false
+    },
+    {
+      "id": "automatic-memory-recall",
+      "scope": "assistant",
+      "key": "feature_flags.automatic-memory-recall.enabled",
+      "label": "Automatic Memory Recall",
+      "description": "Automatically retrieve and inject relevant memories before every LLM call. Disabling eliminates the latency of embedding generation, semantic search, and reranking on each message while preserving on-demand memory_recall tool access.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -128,6 +128,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
+    },
+    {
+      "id": "automatic-memory-recall",
+      "scope": "assistant",
+      "key": "feature_flags.automatic-memory-recall.enabled",
+      "label": "Automatic Memory Recall",
+      "description": "Automatically retrieve and inject relevant memories before every LLM call. Disabling eliminates the latency of embedding generation, semantic search, and reranking on each message while preserving on-demand memory_recall tool access.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `feature_flags.automatic-memory-recall.enabled` feature flag (default: **disabled**) to skip the automatic `buildMemoryRecall()` pipeline that runs before every LLM call
- When disabled, eliminates the latency of embedding generation (5-15s), semantic search, and LLM reranking (20-60s) on each message
- Conflict gate evaluation and dynamic profile compilation are preserved as independent operations
- The on-demand `memory_recall` tool (`assistant/src/tools/memory/register.ts`) already exists and remains fully functional for explicit lookups

## Details

The automatic memory recall pipeline in `prepareMemoryContext()` performs embedding generation, Qdrant semantic search, and LLM reranking on every user message. For simple messages like "hi", this adds significant unnecessary latency.

This PR gates that pipeline behind a feature flag. When disabled (the default), the function returns a noop recall result but still runs:
1. **Conflict gate evaluation** - for background conflict resolution/dismissal
2. **Dynamic profile compilation** - for user context injection
3. **Memory status event emission** - so the UI still receives status updates

The existing `memory_recall` tool (defined in `assistant/src/tools/memory/definitions.ts`, handled by `assistant/src/tools/memory/handlers.ts`) provides on-demand memory search with the same retrieval pipeline, so users can still explicitly ask the assistant to recall information.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Feature flag guard tests pass (`assistant-feature-flag-guard.test.ts`, `assistant-feature-flag-guardrails.test.ts`, `assistant-feature-flags-integration.test.ts`)
- [x] Session profile injection tests pass (added feature flag mock)
- [x] Session conflict gate tests pass (conflict evaluation preserved)
- [x] Session agent loop tests pass
- [x] Memory lifecycle e2e tests pass
- [x] Skill feature flags tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
