### PR TITLE
Refactor Slack client to accept OAuthConnection

### DIFF
--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -1,10 +1,12 @@
 /**
  * Low-level Slack Web API wrapper.
  *
- * All methods take a user OAuth token and throw SlackApiError on failures.
- * Throws with status: 401 on auth errors for withValidToken compatibility.
+ * All methods accept either an OAuthConnection or a raw token string.
+ * Throws SlackApiError on failures, with status: 401 on auth errors
+ * for withValidToken compatibility.
  */
 
+import type { OAuthConnection } from "../../../oauth/connection.js";
 import type {
   SlackApiResponse,
   SlackAuthTestResponse,
@@ -46,7 +48,100 @@ function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function request<T extends SlackApiResponse>(
+/**
+ * Check a Slack API response envelope for errors and map to SlackApiError.
+ * Returns the data if ok, throws otherwise.
+ */
+function checkSlackEnvelope<T extends SlackApiResponse>(data: T): T {
+  if (!data.ok) {
+    const slackError = data.error ?? "unknown_error";
+    const status = [
+      "invalid_auth",
+      "token_expired",
+      "token_revoked",
+      "not_authed",
+    ].includes(slackError)
+      ? 401
+      : 400;
+    throw new SlackApiError(
+      status,
+      slackError,
+      `Slack API error: ${slackError}`,
+    );
+  }
+  return data;
+}
+
+/**
+ * Execute a Slack API request via OAuthConnection with rate-limit retry.
+ */
+async function requestViaConnection<T extends SlackApiResponse>(
+  connection: OAuthConnection,
+  method: string,
+  params?: Record<string, string | undefined>,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  const query: Record<string, string> | undefined = params
+    ? Object.fromEntries(
+        Object.entries(params).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      )
+    : undefined;
+
+  for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+    const resp = await connection.request({
+      method: body ? "POST" : "GET",
+      path: `/${method}`,
+      query: query && Object.keys(query).length > 0 ? query : undefined,
+      body,
+    });
+
+    // Handle 429 rate limits with Retry-After backoff
+    if (resp.status === 429) {
+      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
+      }
+      const retryAfter =
+        parseInt(
+          resp.headers["retry-after"] ?? resp.headers["Retry-After"] ?? "",
+          10,
+        ) || DEFAULT_RETRY_AFTER_S;
+      await sleepMs(retryAfter * 1000);
+      continue;
+    }
+
+    if (resp.status >= 400) {
+      throw new SlackApiError(
+        resp.status,
+        `http_${resp.status}`,
+        `Slack API HTTP ${resp.status}`,
+      );
+    }
+
+    const data = resp.body as T;
+
+    // Handle rate_limited error in response body (some Slack APIs return 200 with error)
+    if (
+      !data.ok &&
+      data.error === "rate_limited" &&
+      attempt < MAX_RATE_LIMIT_RETRIES
+    ) {
+      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
+      continue;
+    }
+
+    return checkSlackEnvelope(data);
+  }
+
+  // Unreachable, but TypeScript needs this
+  throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
+}
+
+/**
+ * Execute a Slack API request via raw token with rate-limit retry.
+ */
+async function requestViaToken<T extends SlackApiResponse>(
   token: string,
   method: string,
   params?: Record<string, string | undefined>,
@@ -96,68 +191,76 @@ async function request<T extends SlackApiResponse>(
     }
 
     const data = (await resp.json()) as T;
-    if (!data.ok) {
-      const slackError = data.error ?? "unknown_error";
 
-      // Handle rate_limited error in response body (some Slack APIs return 200 with error)
-      if (slackError === "rate_limited" && attempt < MAX_RATE_LIMIT_RETRIES) {
-        await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
-        continue;
-      }
-
-      // Map auth errors to 401 for token-manager retry
-      const status = [
-        "invalid_auth",
-        "token_expired",
-        "token_revoked",
-        "not_authed",
-      ].includes(slackError)
-        ? 401
-        : 400;
-      throw new SlackApiError(
-        status,
-        slackError,
-        `Slack API error: ${slackError}`,
-      );
+    // Handle rate_limited error in response body (some Slack APIs return 200 with error)
+    if (
+      !data.ok &&
+      data.error === "rate_limited" &&
+      attempt < MAX_RATE_LIMIT_RETRIES
+    ) {
+      await sleepMs(DEFAULT_RETRY_AFTER_S * 1000);
+      continue;
     }
 
-    return data;
+    return checkSlackEnvelope(data);
   }
 
   // Unreachable, but TypeScript needs this
   throw new SlackApiError(429, "rate_limited", "Slack API rate limited");
 }
 
-export async function authTest(token: string): Promise<SlackAuthTestResponse> {
-  return request<SlackAuthTestResponse>(token, "auth.test");
+async function request<T extends SlackApiResponse>(
+  connectionOrToken: OAuthConnection | string,
+  method: string,
+  params?: Record<string, string | undefined>,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  if (typeof connectionOrToken === "string") {
+    return requestViaToken<T>(connectionOrToken, method, params, body);
+  }
+  return requestViaConnection<T>(connectionOrToken, method, params, body);
+}
+
+export async function authTest(
+  connectionOrToken: OAuthConnection | string,
+): Promise<SlackAuthTestResponse> {
+  return request<SlackAuthTestResponse>(connectionOrToken, "auth.test");
 }
 
 export async function listConversations(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   types = "public_channel,private_channel,mpim,im",
   excludeArchived = true,
   limit = 200,
   cursor?: string,
 ): Promise<SlackConversationsListResponse> {
-  return request<SlackConversationsListResponse>(token, "conversations.list", {
-    types,
-    exclude_archived: String(excludeArchived),
-    limit: String(limit),
-    cursor,
-  });
+  return request<SlackConversationsListResponse>(
+    connectionOrToken,
+    "conversations.list",
+    {
+      types,
+      exclude_archived: String(excludeArchived),
+      limit: String(limit),
+      cursor,
+    },
+  );
 }
 
 export async function conversationInfo(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
 ): Promise<SlackConversationInfoResponse> {
-  return request<SlackConversationInfoResponse>(token, "conversations.info", {
-    channel,
-  });
+  return request<SlackConversationInfoResponse>(
+    connectionOrToken,
+    "conversations.info",
+    {
+      channel,
+    },
+  );
 }
 
 export async function conversationHistory(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   limit = 50,
   latest?: string,
@@ -165,7 +268,7 @@ export async function conversationHistory(
   cursor?: string,
 ): Promise<SlackConversationHistoryResponse> {
   return request<SlackConversationHistoryResponse>(
-    token,
+    connectionOrToken,
     "conversations.history",
     {
       channel,
@@ -178,13 +281,13 @@ export async function conversationHistory(
 }
 
 export async function conversationReplies(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   ts: string,
   limit = 50,
 ): Promise<SlackConversationRepliesResponse> {
   return request<SlackConversationRepliesResponse>(
-    token,
+    connectionOrToken,
     "conversations.replies",
     {
       channel,
@@ -195,12 +298,12 @@ export async function conversationReplies(
 }
 
 export async function conversationMark(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   ts: string,
 ): Promise<SlackConversationMarkResponse> {
   return request<SlackConversationMarkResponse>(
-    token,
+    connectionOrToken,
     "conversations.mark",
     undefined,
     {
@@ -211,11 +314,11 @@ export async function conversationMark(
 }
 
 export async function conversationsOpen(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   userId: string,
 ): Promise<SlackConversationsOpenResponse> {
   return request<SlackConversationsOpenResponse>(
-    token,
+    connectionOrToken,
     "conversations.open",
     undefined,
     {
@@ -225,10 +328,12 @@ export async function conversationsOpen(
 }
 
 export async function userInfo(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   userId: string,
 ): Promise<SlackUserInfoResponse> {
-  return request<SlackUserInfoResponse>(token, "users.info", { user: userId });
+  return request<SlackUserInfoResponse>(connectionOrToken, "users.info", {
+    user: userId,
+  });
 }
 
 export interface PostMessageOptions {
@@ -237,7 +342,7 @@ export interface PostMessageOptions {
 }
 
 export async function postMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   text: string,
   optionsOrThreadTs?: PostMessageOptions | string,
@@ -250,7 +355,7 @@ export async function postMessage(
   if (opts.threadTs) body.thread_ts = opts.threadTs;
   if (opts.blocks) body.blocks = opts.blocks;
   return request<SlackPostMessageResponse>(
-    token,
+    connectionOrToken,
     "chat.postMessage",
     undefined,
     body,
@@ -264,7 +369,7 @@ export async function postMessage(
  * after posting, and they disappear when the user reloads the Slack client.
  */
 export async function postEphemeral(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   user: string,
   text: string,
@@ -273,7 +378,7 @@ export async function postEphemeral(
   const body: Record<string, unknown> = { channel, user, text };
   if (threadTs) body.thread_ts = threadTs;
   return request<SlackPostEphemeralResponse>(
-    token,
+    connectionOrToken,
     "chat.postEphemeral",
     undefined,
     body,
@@ -281,61 +386,80 @@ export async function postEphemeral(
 }
 
 export async function searchMessages(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   query: string,
   count = 20,
   page = 1,
 ): Promise<SlackSearchMessagesResponse> {
-  return request<SlackSearchMessagesResponse>(token, "search.messages", {
-    query,
-    count: String(count),
-    page: String(page),
-  });
+  return request<SlackSearchMessagesResponse>(
+    connectionOrToken,
+    "search.messages",
+    {
+      query,
+      count: String(count),
+      page: String(page),
+    },
+  );
 }
 
 export async function addReaction(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   timestamp: string,
   name: string,
 ): Promise<SlackReactionAddResponse> {
-  return request<SlackReactionAddResponse>(token, "reactions.add", undefined, {
-    channel,
-    timestamp,
-    name,
-  });
+  return request<SlackReactionAddResponse>(
+    connectionOrToken,
+    "reactions.add",
+    undefined,
+    {
+      channel,
+      timestamp,
+      name,
+    },
+  );
 }
 
 export async function updateMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   ts: string,
   text: string,
 ): Promise<SlackChatUpdateResponse> {
-  return request<SlackChatUpdateResponse>(token, "chat.update", undefined, {
-    channel,
-    ts,
-    text,
-  });
+  return request<SlackChatUpdateResponse>(
+    connectionOrToken,
+    "chat.update",
+    undefined,
+    {
+      channel,
+      ts,
+      text,
+    },
+  );
 }
 
 export async function deleteMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
   ts: string,
 ): Promise<SlackChatDeleteResponse> {
-  return request<SlackChatDeleteResponse>(token, "chat.delete", undefined, {
-    channel,
-    ts,
-  });
+  return request<SlackChatDeleteResponse>(
+    connectionOrToken,
+    "chat.delete",
+    undefined,
+    {
+      channel,
+      ts,
+    },
+  );
 }
 
 export async function leaveConversation(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   channel: string,
 ): Promise<SlackConversationLeaveResponse> {
   return request<SlackConversationLeaveResponse>(
-    token,
+    connectionOrToken,
     "conversations.leave",
     undefined,
     {


### PR DESCRIPTION
## Summary
- Add OAuthConnection | string overloads to all Slack client functions for incremental migration
- Preserve rate limit retry (429 + Retry-After) and Slack auth error mapping for connection path
- String overloads permanently retained for non-OAuth bot token callers (slack/share.ts)

Part of plan: oauth-conn-request.md (PR 5 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
