### PR TITLE
Implement PlatformOAuthConnection for server-side proxy

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -62,7 +62,7 @@ describe("PlatformOAuthConnection", () => {
           { status: 200 },
         );
       },
-    ) as typeof globalThis.fetch;
+    ) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
     const result = await conn.request({
@@ -89,7 +89,7 @@ describe("PlatformOAuthConnection", () => {
           { status: 200 },
         );
       },
-    ) as typeof globalThis.fetch;
+    ) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
     await conn.request({
@@ -110,7 +110,7 @@ describe("PlatformOAuthConnection", () => {
           { status: 200 },
         );
       },
-    ) as typeof globalThis.fetch;
+    ) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
     await conn.request({ method: "GET", path: "/some/path" });
@@ -119,7 +119,7 @@ describe("PlatformOAuthConnection", () => {
   test("424 response throws CredentialRequiredError", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("", { status: 424 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
     await expect(
@@ -130,7 +130,7 @@ describe("PlatformOAuthConnection", () => {
   test("502 response throws ProviderUnreachableError", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("", { status: 502 });
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
     await expect(
@@ -152,7 +152,7 @@ describe("PlatformOAuthConnection", () => {
         JSON.stringify({ status: 200, headers: {}, body: null }),
         { status: 200 },
       );
-    }) as typeof globalThis.fetch;
+    }) as unknown as typeof globalThis.fetch;
 
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  CredentialRequiredError,
+  PlatformOAuthConnection,
+  ProviderUnreachableError,
+} from "./platform-connection.js";
+
+const DEFAULT_OPTIONS = {
+  id: "conn-1",
+  providerKey: "integration:gmail",
+  externalId: "ext-123",
+  accountInfo: "user@example.com",
+  grantedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+  assistantId: "asst-abc",
+  platformBaseUrl: "https://platform.example.com",
+  apiKey: "test-api-key",
+};
+
+describe("PlatformOAuthConnection", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("successful proxied request", async () => {
+    const upstreamBody = { messages: [{ id: "msg-1", snippet: "Hello" }] };
+
+    globalThis.fetch = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        expect(url).toBe(
+          "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/gmail/",
+        );
+        expect(init?.method).toBe("POST");
+        expect(init?.headers).toEqual({
+          Authorization: "Api-Key test-api-key",
+          "Content-Type": "application/json",
+        });
+
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed).toEqual({
+          request: {
+            method: "GET",
+            path: "/gmail/v1/users/me/messages",
+            query: { maxResults: "10" },
+            headers: {},
+            body: null,
+          },
+        });
+
+        return new Response(
+          JSON.stringify({
+            status: 200,
+            headers: { "content-type": "application/json" },
+            body: upstreamBody,
+          }),
+          { status: 200 },
+        );
+      },
+    ) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    const result = await conn.request({
+      method: "GET",
+      path: "/gmail/v1/users/me/messages",
+      query: { maxResults: "10" },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers).toEqual({ "content-type": "application/json" });
+    expect(result.body).toEqual(upstreamBody);
+  });
+
+  test("forwards baseUrl when provided", async () => {
+    globalThis.fetch = mock(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed.request.baseUrl).toBe(
+          "https://www.googleapis.com/calendar/v3",
+        );
+
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: {} }),
+          { status: 200 },
+        );
+      },
+    ) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    await conn.request({
+      method: "GET",
+      path: "/calendars/primary/events",
+      baseUrl: "https://www.googleapis.com/calendar/v3",
+    });
+  });
+
+  test("omits baseUrl from envelope when not provided", async () => {
+    globalThis.fetch = mock(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect("baseUrl" in parsed.request).toBe(false);
+
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: null }),
+          { status: 200 },
+        );
+      },
+    ) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    await conn.request({ method: "GET", path: "/some/path" });
+  });
+
+  test("424 response throws CredentialRequiredError", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("", { status: 424 });
+    }) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(CredentialRequiredError);
+  });
+
+  test("502 response throws ProviderUnreachableError", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response("", { status: 502 });
+    }) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    await expect(
+      conn.request({ method: "GET", path: "/test" }),
+    ).rejects.toThrow(ProviderUnreachableError);
+  });
+
+  test("withToken throws clear error", async () => {
+    const conn = new PlatformOAuthConnection(DEFAULT_OPTIONS);
+    await expect(conn.withToken(async (token) => token)).rejects.toThrow(
+      "Raw token access is not supported for platform-managed connections. Use connection.request() instead.",
+    );
+  });
+
+  test("strips integration: prefix from providerKey for slug", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      expect(String(url)).toContain("/external-provider-proxy/slack/");
+      return new Response(
+        JSON.stringify({ status: 200, headers: {}, body: null }),
+        { status: 200 },
+      );
+    }) as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      providerKey: "integration:slack",
+    });
+    await conn.request({ method: "GET", path: "/test" });
+  });
+});

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,0 +1,110 @@
+import type {
+  OAuthConnection,
+  OAuthConnectionRequest,
+  OAuthConnectionResponse,
+} from "./connection.js";
+
+export class CredentialRequiredError extends Error {
+  constructor(message = "Connection not set up on platform") {
+    super(message);
+    this.name = "CredentialRequiredError";
+  }
+}
+
+export class ProviderUnreachableError extends Error {
+  constructor(message = "Provider is unreachable") {
+    super(message);
+    this.name = "ProviderUnreachableError";
+  }
+}
+
+export interface PlatformOAuthConnectionOptions {
+  id: string;
+  providerKey: string;
+  externalId: string;
+  accountInfo: string | null;
+  grantedScopes: string[];
+  assistantId: string;
+  platformBaseUrl: string;
+  apiKey: string;
+}
+
+export class PlatformOAuthConnection implements OAuthConnection {
+  readonly id: string;
+  readonly providerKey: string;
+  readonly externalId: string;
+  readonly accountInfo: string | null;
+  readonly grantedScopes: string[];
+
+  private readonly assistantId: string;
+  private readonly platformBaseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(options: PlatformOAuthConnectionOptions) {
+    this.id = options.id;
+    this.providerKey = options.providerKey;
+    this.externalId = options.externalId;
+    this.accountInfo = options.accountInfo;
+    this.grantedScopes = options.grantedScopes;
+    this.assistantId = options.assistantId;
+    this.platformBaseUrl = options.platformBaseUrl;
+    this.apiKey = options.apiKey;
+  }
+
+  async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
+    const providerSlug = this.providerKey.replace(/^integration:/, "");
+    const proxyUrl = `${this.platformBaseUrl}/v1/assistants/${this.assistantId}/external-provider-proxy/${providerSlug}/`;
+
+    const body: Record<string, unknown> = {
+      request: {
+        method: req.method,
+        path: req.path,
+        query: req.query ?? {},
+        headers: req.headers ?? {},
+        body: req.body ?? null,
+        ...(req.baseUrl ? { baseUrl: req.baseUrl } : {}),
+      },
+    };
+
+    const response = await fetch(proxyUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Api-Key ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (response.status === 424) {
+      throw new CredentialRequiredError();
+    }
+
+    if (response.status === 502) {
+      throw new ProviderUnreachableError();
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Platform proxy returned unexpected status ${response.status}`,
+      );
+    }
+
+    const json = (await response.json()) as {
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+    };
+
+    return {
+      status: json.status,
+      headers: json.headers,
+      body: json.body,
+    };
+  }
+
+  async withToken<T>(_fn: (token: string) => Promise<T>): Promise<T> {
+    throw new Error(
+      "Raw token access is not supported for platform-managed connections. Use connection.request() instead.",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Implement PlatformOAuthConnection that proxies all requests through the Vellum platform server
- Handle platform proxy error codes (424 → CredentialRequiredError, 502 → ProviderUnreachableError)
- Forward per-request baseUrl override to the platform proxy for multi-host providers (e.g. Google)

Part of plan: oauth-conn-request.md (PR 3 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
