### PR TITLE
fix: handle post-tool text delivery and approval buttons in no-messageId telegram streaming edge case

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.test.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { ApprovalUIMetadata } from "./channel-approval-types.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 
 // ---------------------------------------------------------------------------
@@ -491,6 +492,137 @@ describe("TelegramStreamingDelivery", () => {
     expect(callPayload(0).text).toBe("Hello, world!! Great!");
 
     await delivery.finish();
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
+  // ── Test 5j: no-messageId + tool_use_start + finish delivers post-tool text ─
+  test("no-messageId + tool_use_start + finish delivers post-tool text", async () => {
+    // Scenario from Devin review: initial send succeeds without messageId,
+    // more deltas arrive, tool_use_start fires, finish() must deliver post-tool text.
+    mockDeliverChannelReply.mockReset();
+    let localCallCount = 0;
+    mockDeliverChannelReply.mockImplementation(
+      async (): Promise<ChannelDeliveryResult> => {
+        localCallCount++;
+        if (localCallCount === 1) return { ok: true }; // no messageId
+        return { ok: true, messageId: 400 };
+      },
+    );
+
+    const delivery = createDelivery();
+
+    // Step 1: initial send (>= 20 chars), succeeds without messageId
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "a".repeat(25),
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+
+    // Step 2: more deltas arrive — stuck in buffer (onTextDelta skips both branches)
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "post-tool text",
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1); // no new call
+
+    // Step 3: tool_use_start — buffer should NOT be moved to currentMessageText
+    delivery.onEvent({
+      type: "tool_use_start",
+      toolName: "some_tool",
+      input: {},
+    });
+
+    // Step 4: finish() — should deliver the post-tool text as a new message
+    await delivery.finish();
+
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(2);
+    const secondPayload = callPayload(1);
+    expect(secondPayload.text).toBe("post-tool text");
+    expect(secondPayload.messageId).toBeUndefined(); // new message, not edit
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
+  // ── Test 5k: no-messageId + finish with approval sends approval as new message ─
+  test("no-messageId + finish with approval sends approval as new message", async () => {
+    // Scenario from Codex review: initial send succeeds without messageId,
+    // no additional buffer, but finish(approval) must still deliver approval buttons.
+    mockDeliverChannelReply.mockReset();
+    mockDeliverChannelReply.mockImplementation(
+      async (): Promise<ChannelDeliveryResult> => {
+        return { ok: true }; // no messageId
+      },
+    );
+
+    const delivery = createDelivery();
+
+    // Initial send succeeds without messageId
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "a".repeat(25),
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+
+    // finish() with approval — approval must not be silently dropped
+    const approval: ApprovalUIMetadata = {
+      requestId: "test-req",
+      actions: [{ id: "approve_once", label: "Approve" }],
+      plainTextFallback: "Reply APPROVE or REJECT",
+    };
+    await delivery.finish(approval);
+
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(2);
+    const secondPayload = callPayload(1);
+    // Approval buttons sent as a new message
+    expect(secondPayload.approval).toEqual(approval);
+    expect(secondPayload.messageId).toBeUndefined();
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
+  // ── Test 5l: no-messageId + buffer + finish with approval delivers both ─
+  test("no-messageId + buffer + finish with approval delivers both text and approval", async () => {
+    // Combined scenario: no-messageId initial send, buffered text, and approval buttons.
+    mockDeliverChannelReply.mockReset();
+    let localCallCount = 0;
+    mockDeliverChannelReply.mockImplementation(
+      async (): Promise<ChannelDeliveryResult> => {
+        localCallCount++;
+        if (localCallCount === 1) return { ok: true }; // no messageId
+        return { ok: true, messageId: 500 };
+      },
+    );
+
+    const delivery = createDelivery();
+
+    // Initial send succeeds without messageId
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "a".repeat(25),
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+
+    // More deltas arrive
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "remainder",
+    });
+
+    // finish() with approval — should deliver buffer text + approval together
+    const approval: ApprovalUIMetadata = {
+      requestId: "test-req",
+      actions: [{ id: "approve_once", label: "Approve" }],
+      plainTextFallback: "Reply APPROVE or REJECT",
+    };
+    await delivery.finish(approval);
+
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(2);
+    const secondPayload = callPayload(1);
+    expect(secondPayload.text).toBe("remainder");
+    expect(secondPayload.approval).toEqual(approval);
+    expect(secondPayload.messageId).toBeUndefined();
     expect(delivery.finishSucceeded).toBe(true);
   });
 

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -51,11 +51,13 @@ export class TelegramStreamingDelivery {
         // Flush buffer and send an edit so the message is up-to-date before the tool runs
         if (this.buffer.length > 0 && this.currentMessageId) {
           this.flushEdit();
-        } else if (this.buffer.length > 0) {
+        } else if (this.buffer.length > 0 && !this.textDelivered) {
           // No message sent yet — just move buffer to currentMessageText
           this.currentMessageText += this.buffer;
           this.buffer = "";
         }
+        // When textDelivered is true but currentMessageId is null (no-messageId
+        // response), leave buffer as-is so finish() sends it as a new message.
         break;
       case "message_complete":
         // Don't finalize here — let finish() handle it
@@ -117,6 +119,14 @@ export class TelegramStreamingDelivery {
       this.buffer.length === 0
     ) {
       await this.sendNewMessage(this.currentMessageText, approval);
+      this.finishOk = true;
+      return;
+    }
+
+    // Text was delivered but no messageId was returned, and there are approval
+    // buttons to attach. Send them as a new message so they aren't silently dropped.
+    if (!this.currentMessageId && this.textDelivered && approval) {
+      await this.sendNewMessage("", approval);
       this.finishOk = true;
       return;
     }


### PR DESCRIPTION
Address feedback from PR #14352 about text loss when tool_use_start fires after a successful no-messageId initial send, and approval buttons being silently dropped when gateway omits messageId.

## Changes

1. **tool_use_start handler**: Added `!this.textDelivered` guard to the else-if branch that moves buffer to currentMessageText. When text was already delivered but no messageId was returned, the buffer now stays in place so finish() can correctly send it as a new message.

2. **finish() approval fallback**: Added a new branch to handle the case where textDelivered is true, currentMessageId is null, buffer is empty, but approval buttons need to be sent. Previously this fell through to finishOk=true without delivering the approval.

3. **Tests**: Added three new tests covering:
   - No-messageId + tool_use_start + finish delivers post-tool text (Devin BUG)
   - No-messageId + finish with approval sends approval as new message (Codex P1)
   - No-messageId + buffer + finish with approval delivers both text and approval
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
