### PR TITLE
Refactor Gmail, People, and Calendar clients to accept OAuthConnection

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
@@ -1,3 +1,5 @@
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import { GOOGLE_CALENDAR_BASE_URL } from "../../../oauth/provider-base-urls.js";
 import type {
   CalendarEvent,
   CalendarEventsListResponse,
@@ -6,6 +8,7 @@ import type {
   FreeBusyResponse,
 } from "./types.js";
 
+/** Used by the legacy string-token path. */
 const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
 
 export class CalendarApiError extends Error {
@@ -20,39 +23,111 @@ export class CalendarApiError extends Error {
 }
 
 async function request<T>(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   path: string,
   options?: RequestInit,
 ): Promise<T> {
-  const url = `${CALENDAR_API_BASE}${path}`;
-  const resp = await fetch(url, {
-    ...options,
+  if (typeof connectionOrToken === "string") {
+    // Legacy path: use raw token directly
+    const token = connectionOrToken;
+    const url = `${CALENDAR_API_BASE}${path}`;
+    const resp = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new CalendarApiError(
+        resp.status,
+        resp.statusText,
+        `Calendar API ${resp.status}: ${body}`,
+      );
+    }
+    const contentLength = resp.headers.get("content-length");
+    if (resp.status === 204 || contentLength === "0") {
+      return undefined as T;
+    }
+    const text = await resp.text();
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
+  }
+
+  // OAuthConnection path: use connection.request() with baseUrl override
+  const connection = connectionOrToken;
+  const method = (options?.method ?? "GET").toUpperCase();
+
+  // Extract non-auth headers
+  let extraHeaders: Record<string, string> | undefined;
+  if (options?.headers) {
+    const raw = options.headers;
+    const result: Record<string, string> = {};
+    if (raw instanceof Headers) {
+      raw.forEach((v, k) => {
+        if (k.toLowerCase() !== "authorization") result[k] = v;
+      });
+    } else if (Array.isArray(raw)) {
+      for (const [k, v] of raw) {
+        if (k.toLowerCase() !== "authorization") result[k] = v;
+      }
+    } else {
+      for (const [k, v] of Object.entries(raw)) {
+        if (k.toLowerCase() !== "authorization" && v !== undefined)
+          result[k] = v;
+      }
+    }
+    if (Object.keys(result).length > 0) extraHeaders = result;
+  }
+
+  // Extract body
+  let reqBody: unknown | undefined;
+  if (options?.body) {
+    if (typeof options.body === "string") {
+      try {
+        reqBody = JSON.parse(options.body);
+      } catch {
+        reqBody = options.body;
+      }
+    } else {
+      reqBody = options.body;
+    }
+  }
+
+  const resp = await connection.request({
+    method,
+    path,
+    baseUrl: GOOGLE_CALENDAR_BASE_URL,
     headers: {
-      Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
-      ...options?.headers,
+      ...extraHeaders,
     },
+    body: reqBody,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => "");
+
+  if (resp.status < 200 || resp.status >= 300) {
+    const bodyStr =
+      typeof resp.body === "string"
+        ? resp.body
+        : JSON.stringify(resp.body ?? "");
     throw new CalendarApiError(
       resp.status,
-      resp.statusText,
-      `Calendar API ${resp.status}: ${body}`,
+      "",
+      `Calendar API ${resp.status}: ${bodyStr}`,
     );
   }
-  const contentLength = resp.headers.get("content-length");
-  if (resp.status === 204 || contentLength === "0") {
+
+  if (resp.status === 204 || resp.body === undefined) {
     return undefined as T;
   }
-  const text = await resp.text();
-  if (!text) return undefined as T;
-  return JSON.parse(text) as T;
+  return resp.body as T;
 }
 
 /** List events from a calendar. */
 export async function listEvents(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   calendarId = "primary",
   options?: {
     timeMin?: string;
@@ -86,19 +161,19 @@ export async function listEvents(
   if (options?.syncToken) params.set("syncToken", options.syncToken);
 
   return request<CalendarEventsListResponse>(
-    token,
+    connectionOrToken,
     `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
   );
 }
 
 /** Get a single event by ID. */
 export async function getEvent(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   eventId: string,
   calendarId = "primary",
 ): Promise<CalendarEvent> {
   return request<CalendarEvent>(
-    token,
+    connectionOrToken,
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(
       eventId,
     )}`,
@@ -107,7 +182,7 @@ export async function getEvent(
 
 /** Create a new event. */
 export async function createEvent(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   event: {
     summary: string;
     start: { dateTime?: string; date?: string; timeZone?: string };
@@ -121,7 +196,7 @@ export async function createEvent(
 ): Promise<CalendarEvent> {
   const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
-    token,
+    connectionOrToken,
     `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
     {
       method: "POST",
@@ -132,7 +207,7 @@ export async function createEvent(
 
 /** Update an event (patch). */
 export async function patchEvent(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   eventId: string,
   updates: Partial<{
     summary: string;
@@ -147,7 +222,7 @@ export async function patchEvent(
 ): Promise<CalendarEvent> {
   const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
-    token,
+    connectionOrToken,
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(
       eventId,
     )}?${params}`,
@@ -160,10 +235,10 @@ export async function patchEvent(
 
 /** Query free/busy information. */
 export async function freeBusy(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   query: FreeBusyRequest,
 ): Promise<FreeBusyResponse> {
-  return request<FreeBusyResponse>(token, "/freeBusy", {
+  return request<FreeBusyResponse>(connectionOrToken, "/freeBusy", {
     method: "POST",
     body: JSON.stringify(query),
   });
@@ -171,7 +246,10 @@ export async function freeBusy(
 
 /** List calendars the user has access to. */
 export async function listCalendars(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
 ): Promise<CalendarListResponse> {
-  return request<CalendarListResponse>(token, "/users/me/calendarList");
+  return request<CalendarListResponse>(
+    connectionOrToken,
+    "/users/me/calendarList",
+  );
 }

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -1,4 +1,8 @@
 import type {
+  OAuthConnection,
+  OAuthConnectionResponse,
+} from "../../../oauth/connection.js";
+import type {
   GmailAttachment,
   GmailDraft,
   GmailFilter,
@@ -54,53 +58,151 @@ interface GmailRequestOptions extends RequestInit {
   retryable?: boolean;
 }
 
+/**
+ * Extract non-Authorization headers from request options for use with OAuthConnection.
+ */
+function extractNonAuthHeaders(
+  options?: GmailRequestOptions,
+): Record<string, string> | undefined {
+  if (!options?.headers) return undefined;
+  const raw = options.headers;
+  const result: Record<string, string> = {};
+  if (raw instanceof Headers) {
+    raw.forEach((v, k) => {
+      if (k.toLowerCase() !== "authorization") result[k] = v;
+    });
+  } else if (Array.isArray(raw)) {
+    for (const [k, v] of raw) {
+      if (k.toLowerCase() !== "authorization") result[k] = v;
+    }
+  } else {
+    for (const [k, v] of Object.entries(raw)) {
+      if (k.toLowerCase() !== "authorization" && v !== undefined) result[k] = v;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Extract the JSON body from request options for use with OAuthConnection.
+ */
+function extractBody(options?: GmailRequestOptions): unknown | undefined {
+  if (!options?.body) return undefined;
+  if (typeof options.body === "string") {
+    try {
+      return JSON.parse(options.body);
+    } catch {
+      return options.body;
+    }
+  }
+  return options.body;
+}
+
 async function request<T>(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   path: string,
   options?: GmailRequestOptions,
 ): Promise<T> {
-  const url = `${GMAIL_API_BASE}${path}`;
   const canRetry = options?.retryable ?? isIdempotent(options);
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const resp = await fetch(url, {
-      ...options,
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        ...options?.headers,
-      },
-    });
+  if (typeof connectionOrToken === "string") {
+    // Legacy path: use raw token directly
+    const token = connectionOrToken;
+    const url = `${GMAIL_API_BASE}${path}`;
 
-    if (!resp.ok) {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const resp = await fetch(url, {
+        ...options,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          ...options?.headers,
+        },
+      });
+
+      if (!resp.ok) {
+        if (canRetry && isRetryable(resp.status) && attempt < MAX_RETRIES) {
+          const retryAfter = resp.headers.get("retry-after");
+          const delayMs = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          continue;
+        }
+        const body = await resp.text().catch(() => "");
+        throw new GmailApiError(
+          resp.status,
+          resp.statusText,
+          `Gmail API ${resp.status}: ${body}`,
+        );
+      }
+
+      // Some endpoints (e.g. batchModify) return empty success responses
+      const contentLength = resp.headers.get("content-length");
+      if (resp.status === 204 || contentLength === "0") {
+        return undefined as T;
+      }
+      const text = await resp.text();
+      if (!text) return undefined as T;
+      return JSON.parse(text) as T;
+    }
+
+    // Unreachable -- the loop always returns or throws -- but TypeScript needs this
+    throw new Error(
+      "Unreachable: retry loop exited without returning or throwing",
+    );
+  }
+
+  // OAuthConnection path
+  const connection = connectionOrToken;
+  const method = (options?.method ?? "GET").toUpperCase();
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let resp: OAuthConnectionResponse;
+    try {
+      resp = await connection.request({
+        method,
+        path,
+        headers: {
+          "Content-Type": "application/json",
+          ...extractNonAuthHeaders(options),
+        },
+        body: extractBody(options),
+      });
+    } catch (err) {
+      // Network-level errors from connection.request() are not retryable
+      throw err;
+    }
+
+    if (resp.status < 200 || resp.status >= 300) {
       if (canRetry && isRetryable(resp.status) && attempt < MAX_RETRIES) {
-        const retryAfter = resp.headers.get("retry-after");
+        const retryAfter =
+          resp.headers["retry-after"] ?? resp.headers["Retry-After"];
         const delayMs = retryAfter
           ? parseInt(retryAfter, 10) * 1000
           : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         continue;
       }
-      const body = await resp.text().catch(() => "");
+      const bodyStr =
+        typeof resp.body === "string"
+          ? resp.body
+          : JSON.stringify(resp.body ?? "");
       throw new GmailApiError(
         resp.status,
-        resp.statusText,
-        `Gmail API ${resp.status}: ${body}`,
+        "",
+        `Gmail API ${resp.status}: ${bodyStr}`,
       );
     }
 
-    // Some endpoints (e.g. batchModify) return empty success responses
-    const contentLength = resp.headers.get("content-length");
-    if (resp.status === 204 || contentLength === "0") {
+    // Success — body is already parsed by connection.request()
+    if (resp.status === 204 || resp.body === undefined) {
       return undefined as T;
     }
-    const text = await resp.text();
-    if (!text) return undefined as T;
-    return JSON.parse(text) as T;
+    return resp.body as T;
   }
 
-  // Unreachable — the loop always returns or throws — but TypeScript needs this
   throw new Error(
     "Unreachable: retry loop exited without returning or throwing",
   );
@@ -108,7 +210,7 @@ async function request<T>(
 
 /** List messages matching a query. */
 export async function listMessages(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   query?: string,
   maxResults = 20,
   pageToken?: string,
@@ -121,12 +223,15 @@ export async function listMessages(
   if (labelIds) {
     for (const id of labelIds) params.append("labelIds", id);
   }
-  return request<GmailMessageListResponse>(token, `/messages?${params}`);
+  return request<GmailMessageListResponse>(
+    connectionOrToken,
+    `/messages?${params}`,
+  );
 }
 
 /** Get a single message by ID. */
 export async function getMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageId: string,
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
@@ -137,7 +242,10 @@ export async function getMessage(
     for (const h of metadataHeaders) params.append("metadataHeaders", h);
   }
   if (fields) params.set("fields", fields);
-  return request<GmailMessage>(token, `/messages/${messageId}?${params}`);
+  return request<GmailMessage>(
+    connectionOrToken,
+    `/messages/${messageId}?${params}`,
+  );
 }
 
 /**
@@ -175,7 +283,7 @@ function parseSubResponse(
  * Returns successfully parsed messages and a list of IDs that failed (for individual retry).
  */
 async function executeBatchCall(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageIds: string[],
   format: GmailMessageFormat,
   metadataHeaders: string[] | undefined,
@@ -203,70 +311,87 @@ async function executeBatchCall(
   );
   const body = parts.join("") + `--${boundary}--\r\n`;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const resp = await fetch(GMAIL_BATCH_URL, {
-      method: "POST",
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS * 2),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": `multipart/mixed; boundary=${boundary}`,
-      },
-      body,
-    });
+  const doBatchFetch = async (token: string) => {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const resp = await fetch(GMAIL_BATCH_URL, {
+        method: "POST",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS * 2),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": `multipart/mixed; boundary=${boundary}`,
+        },
+        body,
+      });
 
-    if (!resp.ok) {
-      if (isRetryable(resp.status) && attempt < MAX_RETRIES) {
-        const retryAfter = resp.headers.get("retry-after");
-        const delayMs = retryAfter
-          ? parseInt(retryAfter, 10) * 1000
-          : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
-        await new Promise((r) => setTimeout(r, delayMs));
-        continue;
-      }
-      const errBody = await resp.text().catch(() => "");
-      throw new GmailApiError(
-        resp.status,
-        resp.statusText,
-        `Gmail batch API ${resp.status}: ${errBody}`,
-      );
-    }
-
-    const contentType = resp.headers.get("content-type") ?? "";
-    const responseText = await resp.text();
-
-    const boundaryMatch = contentType.match(/boundary=(?:"([^"]+)"|([^\s;]+))/);
-    const respBoundary = boundaryMatch?.[1] ?? boundaryMatch?.[2];
-    if (!respBoundary)
-      throw new Error("Missing boundary in Gmail batch response");
-
-    const respParts = responseText.split(`--${respBoundary}`);
-    const messages: Array<{ index: number; msg: GmailMessage }> = [];
-    const failedIds: Array<{ index: number; id: string }> = [];
-
-    for (const rp of respParts) {
-      const parsed = parseSubResponse(rp);
-      if (!parsed) continue;
-
-      if (parsed.status >= 200 && parsed.status < 300 && parsed.json) {
-        try {
-          messages.push({
-            index: parsed.index,
-            msg: JSON.parse(parsed.json) as GmailMessage,
-          });
-        } catch {
-          failedIds.push({ index: parsed.index, id: messageIds[parsed.index] });
+      if (!resp.ok) {
+        if (isRetryable(resp.status) && attempt < MAX_RETRIES) {
+          const retryAfter = resp.headers.get("retry-after");
+          const delayMs = retryAfter
+            ? parseInt(retryAfter, 10) * 1000
+            : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+          await new Promise((r) => setTimeout(r, delayMs));
+          continue;
         }
-      } else {
-        failedIds.push({ index: parsed.index, id: messageIds[parsed.index] });
+        const errBody = await resp.text().catch(() => "");
+        throw new GmailApiError(
+          resp.status,
+          resp.statusText,
+          `Gmail batch API ${resp.status}: ${errBody}`,
+        );
       }
+
+      const contentType = resp.headers.get("content-type") ?? "";
+      const responseText = await resp.text();
+
+      const boundaryMatch = contentType.match(
+        /boundary=(?:"([^"]+)"|([^\s;]+))/,
+      );
+      const respBoundary = boundaryMatch?.[1] ?? boundaryMatch?.[2];
+      if (!respBoundary)
+        throw new Error("Missing boundary in Gmail batch response");
+
+      const respParts = responseText.split(`--${respBoundary}`);
+      const messages: Array<{ index: number; msg: GmailMessage }> = [];
+      const failedIds: Array<{ index: number; id: string }> = [];
+
+      for (const rp of respParts) {
+        const parsed = parseSubResponse(rp);
+        if (!parsed) continue;
+
+        if (parsed.status >= 200 && parsed.status < 300 && parsed.json) {
+          try {
+            messages.push({
+              index: parsed.index,
+              msg: JSON.parse(parsed.json) as GmailMessage,
+            });
+          } catch {
+            failedIds.push({
+              index: parsed.index,
+              id: messageIds[parsed.index],
+            });
+          }
+        } else {
+          failedIds.push({
+            index: parsed.index,
+            id: messageIds[parsed.index],
+          });
+        }
+      }
+
+      return { messages, failedIds };
     }
 
-    return { messages, failedIds };
+    throw new Error(
+      "Unreachable: batch retry loop exited without returning or throwing",
+    );
+  };
+
+  if (typeof connectionOrToken === "string") {
+    return doBatchFetch(connectionOrToken);
   }
 
-  throw new Error(
-    "Unreachable: batch retry loop exited without returning or throwing",
-  );
+  // OAuthConnection path: use withToken to get raw token for batch endpoint
+  return connectionOrToken.withToken(doBatchFetch);
 }
 
 /**
@@ -275,7 +400,7 @@ async function executeBatchCall(
  * Falls back to individual getMessage for any sub-requests that fail within a batch.
  */
 export async function batchGetMessages(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageIds: string[],
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
@@ -283,10 +408,16 @@ export async function batchGetMessages(
 ): Promise<GmailMessage[]> {
   if (messageIds.length === 0) return [];
 
-  // Single message — just use getMessage directly
+  // Single message -- just use getMessage directly
   if (messageIds.length === 1) {
     return [
-      await getMessage(token, messageIds[0], format, metadataHeaders, fields),
+      await getMessage(
+        connectionOrToken,
+        messageIds[0],
+        format,
+        metadataHeaders,
+        fields,
+      ),
     ];
   }
 
@@ -307,7 +438,13 @@ export async function batchGetMessages(
     const wave = chunks.slice(i, i + BATCH_CONCURRENCY);
     const waveResults = await Promise.all(
       wave.map((chunk) =>
-        executeBatchCall(token, chunk.ids, format, metadataHeaders, fields),
+        executeBatchCall(
+          connectionOrToken,
+          chunk.ids,
+          format,
+          metadataHeaders,
+          fields,
+        ),
       ),
     );
 
@@ -324,7 +461,7 @@ export async function batchGetMessages(
       if (failedIds.length > 0) {
         const retried = await Promise.all(
           failedIds.map(({ id }) =>
-            getMessage(token, id, format, metadataHeaders, fields),
+            getMessage(connectionOrToken, id, format, metadataHeaders, fields),
           ),
         );
         for (let r = 0; r < failedIds.length; r++) {
@@ -339,24 +476,28 @@ export async function batchGetMessages(
 
 /** Modify labels on a single message. */
 export async function modifyMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageId: string,
   modifications: GmailModifyRequest,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(token, `/messages/${messageId}/modify`, {
-    method: "POST",
-    body: JSON.stringify(modifications),
-    retryable: true,
-  });
+  return request<GmailMessage>(
+    connectionOrToken,
+    `/messages/${messageId}/modify`,
+    {
+      method: "POST",
+      body: JSON.stringify(modifications),
+      retryable: true,
+    },
+  );
 }
 
 /** Batch modify labels on multiple messages. */
 export async function batchModifyMessages(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageIds: string[],
   modifications: GmailModifyRequest,
 ): Promise<void> {
-  await request<void>(token, "/messages/batchModify", {
+  await request<void>(connectionOrToken, "/messages/batchModify", {
     method: "POST",
     body: JSON.stringify({ ids: messageIds, ...modifications }),
     retryable: true,
@@ -365,24 +506,33 @@ export async function batchModifyMessages(
 
 /** Move a message to trash. */
 export async function trashMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageId: string,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(token, `/messages/${messageId}/trash`, {
-    method: "POST",
-    retryable: true,
-  });
+  return request<GmailMessage>(
+    connectionOrToken,
+    `/messages/${messageId}/trash`,
+    {
+      method: "POST",
+      retryable: true,
+    },
+  );
 }
 
 /** List all labels. */
-export async function listLabels(token: string): Promise<GmailLabel[]> {
-  const resp = await request<GmailLabelsListResponse>(token, "/labels");
+export async function listLabels(
+  connectionOrToken: OAuthConnection | string,
+): Promise<GmailLabel[]> {
+  const resp = await request<GmailLabelsListResponse>(
+    connectionOrToken,
+    "/labels",
+  );
   return resp.labels ?? [];
 }
 
 /** Create a draft. */
 export async function createDraft(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   to: string,
   subject: string,
   body: string,
@@ -409,7 +559,7 @@ export async function createDraft(
     .replace(/=+$/, "");
   const message: Record<string, unknown> = { raw };
   if (threadId) message.threadId = threadId;
-  return request<GmailDraft>(token, "/drafts", {
+  return request<GmailDraft>(connectionOrToken, "/drafts", {
     method: "POST",
     body: JSON.stringify({ message }),
   });
@@ -417,13 +567,13 @@ export async function createDraft(
 
 /** Create a draft from a pre-built base64url MIME payload. */
 export async function createDraftRaw(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   raw: string,
   threadId?: string,
 ): Promise<GmailDraft> {
   const message: Record<string, unknown> = { raw };
   if (threadId) message.threadId = threadId;
-  return request<GmailDraft>(token, "/drafts", {
+  return request<GmailDraft>(connectionOrToken, "/drafts", {
     method: "POST",
     body: JSON.stringify({ message }),
   });
@@ -431,10 +581,10 @@ export async function createDraftRaw(
 
 /** Send an existing draft by ID. */
 export async function sendDraft(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   draftId: string,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(token, "/drafts/send", {
+  return request<GmailMessage>(connectionOrToken, "/drafts/send", {
     method: "POST",
     body: JSON.stringify({ id: draftId }),
   });
@@ -442,7 +592,7 @@ export async function sendDraft(
 
 /** Send an email. */
 export async function sendMessage(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   to: string,
   subject: string,
   body: string,
@@ -465,38 +615,40 @@ export async function sendMessage(
     .replace(/=+$/, "");
   const payload: Record<string, unknown> = { raw };
   if (threadId) payload.threadId = threadId;
-  return request<GmailMessage>(token, "/messages/send", {
+  return request<GmailMessage>(connectionOrToken, "/messages/send", {
     method: "POST",
     body: JSON.stringify(payload),
   });
 }
 
 /** Get the authenticated user's profile (email address). */
-export async function getProfile(token: string): Promise<GmailProfile> {
-  return request<GmailProfile>(token, "/profile");
+export async function getProfile(
+  connectionOrToken: OAuthConnection | string,
+): Promise<GmailProfile> {
+  return request<GmailProfile>(connectionOrToken, "/profile");
 }
 
 /** Get attachment data for a message. */
 export async function getAttachment(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   messageId: string,
   attachmentId: string,
 ): Promise<GmailAttachment> {
   return request<GmailAttachment>(
-    token,
+    connectionOrToken,
     `/messages/${messageId}/attachments/${attachmentId}`,
   );
 }
 
 /** Send an email with a pre-built raw MIME payload (for multipart/attachments). */
 export async function sendMessageRaw(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   raw: string,
   threadId?: string,
 ): Promise<GmailMessage> {
   const payload: Record<string, unknown> = { raw };
   if (threadId) payload.threadId = threadId;
-  return request<GmailMessage>(token, "/messages/send", {
+  return request<GmailMessage>(connectionOrToken, "/messages/send", {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -504,23 +656,25 @@ export async function sendMessageRaw(
 
 /** Create a user label. */
 export async function createLabel(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   name: string,
   opts?: {
     messageListVisibility?: "show" | "hide";
     labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
   },
 ): Promise<GmailLabel> {
-  return request<GmailLabel>(token, "/labels", {
+  return request<GmailLabel>(connectionOrToken, "/labels", {
     method: "POST",
     body: JSON.stringify({ name, ...opts }),
   });
 }
 
 /** List all Gmail filters. */
-export async function listFilters(token: string): Promise<GmailFilter[]> {
+export async function listFilters(
+  connectionOrToken: OAuthConnection | string,
+): Promise<GmailFilter[]> {
   const resp = await request<GmailFiltersListResponse>(
-    token,
+    connectionOrToken,
     "/settings/filters",
   );
   return resp.filter ?? [];
@@ -528,11 +682,11 @@ export async function listFilters(token: string): Promise<GmailFilter[]> {
 
 /** Create a Gmail filter. */
 export async function createFilter(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   criteria: GmailFilterCriteria,
   action: GmailFilterAction,
 ): Promise<GmailFilter> {
-  return request<GmailFilter>(token, "/settings/filters", {
+  return request<GmailFilter>(connectionOrToken, "/settings/filters", {
     method: "POST",
     body: JSON.stringify({ criteria, action }),
   });
@@ -540,28 +694,35 @@ export async function createFilter(
 
 /** Delete a Gmail filter. */
 export async function deleteFilter(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   filterId: string,
 ): Promise<void> {
-  await request<void>(token, `/settings/filters/${filterId}`, {
+  await request<void>(connectionOrToken, `/settings/filters/${filterId}`, {
     method: "DELETE",
   });
 }
 
 /** Get vacation auto-reply settings. */
 export async function getVacation(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
 ): Promise<GmailVacationSettings> {
-  return request<GmailVacationSettings>(token, "/settings/vacation");
+  return request<GmailVacationSettings>(
+    connectionOrToken,
+    "/settings/vacation",
+  );
 }
 
 /** Update vacation auto-reply settings. */
 export async function updateVacation(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   settings: GmailVacationSettings,
 ): Promise<GmailVacationSettings> {
-  return request<GmailVacationSettings>(token, "/settings/vacation", {
-    method: "PUT",
-    body: JSON.stringify(settings),
-  });
+  return request<GmailVacationSettings>(
+    connectionOrToken,
+    "/settings/vacation",
+    {
+      method: "PUT",
+      body: JSON.stringify(settings),
+    },
+  );
 }

--- a/assistant/src/messaging/providers/gmail/people-client.ts
+++ b/assistant/src/messaging/providers/gmail/people-client.ts
@@ -3,36 +3,69 @@
  * Separate from the Gmail client due to a different base URL.
  */
 
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import { GOOGLE_PEOPLE_BASE_URL } from "../../../oauth/provider-base-urls.js";
 import { GmailApiError } from "./client.js";
 import type {
   PeopleConnectionsResponse,
   PeopleSearchResponse,
 } from "./people-types.js";
 
+/** Used by the legacy string-token path. */
 const PEOPLE_API_BASE = "https://people.googleapis.com/v1";
 
 const PERSON_FIELDS = "names,emailAddresses,phoneNumbers,organizations";
 
-async function request<T>(token: string, url: string): Promise<T> {
-  const resp = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+async function request<T>(
+  connectionOrToken: OAuthConnection | string,
+  path: string,
+): Promise<T> {
+  if (typeof connectionOrToken === "string") {
+    // Legacy path: use raw token with full URL
+    const token = connectionOrToken;
+    const url = `${PEOPLE_API_BASE}${path}`;
+    const resp = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new GmailApiError(
+        resp.status,
+        resp.statusText,
+        `People API ${resp.status}: ${body}`,
+      );
+    }
+    return resp.json() as Promise<T>;
+  }
+
+  // OAuthConnection path: use connection.request() with baseUrl override
+  const connection = connectionOrToken;
+  const resp = await connection.request({
+    method: "GET",
+    path,
+    baseUrl: GOOGLE_PEOPLE_BASE_URL,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => "");
+
+  if (resp.status < 200 || resp.status >= 300) {
+    const bodyStr =
+      typeof resp.body === "string"
+        ? resp.body
+        : JSON.stringify(resp.body ?? "");
     throw new GmailApiError(
       resp.status,
-      resp.statusText,
-      `People API ${resp.status}: ${body}`,
+      "",
+      `People API ${resp.status}: ${bodyStr}`,
     );
   }
-  return resp.json() as Promise<T>;
+
+  return resp.body as T;
 }
 
 /** List the user's contacts with pagination. */
 export async function listContacts(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   pageSize = 50,
   pageToken?: string,
 ): Promise<PeopleConnectionsResponse> {
@@ -42,14 +75,14 @@ export async function listContacts(
   });
   if (pageToken) params.set("pageToken", pageToken);
   return request<PeopleConnectionsResponse>(
-    token,
-    `${PEOPLE_API_BASE}/people/me/connections?${params}`,
+    connectionOrToken,
+    `/people/me/connections?${params}`,
   );
 }
 
 /** Search contacts by name or email. */
 export async function searchContacts(
-  token: string,
+  connectionOrToken: OAuthConnection | string,
   query: string,
 ): Promise<PeopleSearchResponse> {
   const params = new URLSearchParams({
@@ -57,7 +90,7 @@ export async function searchContacts(
     readMask: PERSON_FIELDS,
   });
   return request<PeopleSearchResponse>(
-    token,
-    `${PEOPLE_API_BASE}/people:searchContacts?${params}`,
+    connectionOrToken,
+    `/people:searchContacts?${params}`,
   );
 }


### PR DESCRIPTION
## Summary
- Add OAuthConnection | string overloads to all Gmail client functions (20 functions) for incremental migration
- Add overloads to People client with per-request baseUrl override for Google People API host
- Add overloads to Calendar client with per-request baseUrl override for Google Calendar API host
- All existing callers passing string tokens continue to work unchanged

Part of plan: oauth-conn-request.md (PR 4 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
