### PR TITLE
fix: update tests for metadata v4 and complete secure-keys mock

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -560,7 +560,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       readFileSync(join(TEST_DIR, "metadata.json"), "utf-8"),
     );
     expect(raw.credentials[0]).not.toHaveProperty("oauth2ClientSecret");
-    expect(raw.version).toBe(3);
+    expect(raw.version).toBe(4);
   });
 });
 

--- a/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
+++ b/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
@@ -38,6 +38,9 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (_keyId: string) => mockSecureKey,
+  setSecureKey: (_account: string, _value: string) => true,
+  deleteSecureKey: (_account: string) => "deleted" as const,
+  listSecureKeys: () => [] as string[],
 }));
 
 // Suppress logger output during tests


### PR DESCRIPTION
## Summary
- Update `credential-security-invariants.test.ts` to expect metadata version 4 (was 3) after the `hasRefreshToken` migration was added
- Complete the `secure-keys.js` mock in `telegram-bot-username-resolution.test.ts` to include `setSecureKey`, `deleteSecureKey`, and `listSecureKeys` — the transitive import via `credential-key.ts` requires these exports

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22971022420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
