### PR TITLE
fix: remove duplicate import and add legacy config path fallback for accountInfo

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -635,10 +635,14 @@ function buildIntegrationSection(): string {
   const raw = loadRawConfig();
   const lines = ["## Connected Services", ""];
   for (const cred of oauthCreds) {
-    const acctInfo = getNestedValue(
+    const acctInfo = (getNestedValue(
       raw,
       `integrations.${cred.service}.accountInfo`,
-    ) as string | undefined;
+    ) ??
+      // Fallback: legacy config path used before the namespace migration
+      getNestedValue(raw, `integrations.accountInfo.${cred.service}`)) as
+      | string
+      | undefined;
     const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
     lines.push(`- **${cred.service}**: ${state}`);
   }

--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { credentialKey } from "../credential-key.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";


### PR DESCRIPTION
## Summary
- Remove duplicate `credentialKey` import in `gateway/src/__tests__/telegram-api-redaction.test.ts` that broke type-checking
- Add fallback read of legacy `integrations.accountInfo.{service}` config path in system prompt builder so users who connected OAuth between Mar 7-11 still see their account info (e.g., "Connected (user@example.com)") instead of just "Connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
