### PR TITLE
Migrate Calendar tools and watcher to OAuthConnection

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { ok, withCalendarToken } from "./shared.js";
+import { getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -14,14 +14,13 @@ export async function run(
   const calendarIds = (input.calendar_ids as string[]) ?? ["primary"];
   const timezone = input.timezone as string | undefined;
 
-  return withCalendarToken(async (token) => {
-    const result = await calendar.freeBusy(token, {
-      timeMin,
-      timeMax,
-      timeZone: timezone,
-      items: calendarIds.map((id) => ({ id })),
-    });
-
-    return ok(JSON.stringify(result, null, 2));
+  const connection = getCalendarConnection();
+  const result = await calendar.freeBusy(connection, {
+    timeMin,
+    timeMax,
+    timeZone: timezone,
+    items: calendarIds.map((id) => ({ id })),
   });
+
+  return ok(JSON.stringify(result, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { ok, withCalendarToken } from "./shared.js";
+import { getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -40,9 +40,8 @@ export async function run(
     eventBody.attendees = attendees.map((email) => ({ email }));
   }
 
-  return withCalendarToken(async (token) => {
-    const event = await calendar.createEvent(token, eventBody, calendarId);
-    const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
-    return ok(`Event created (ID: ${event.id}).${link}`);
-  });
+  const connection = getCalendarConnection();
+  const event = await calendar.createEvent(connection, eventBody, calendarId);
+  const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
+  return ok(`Event created (ID: ${event.id}).${link}`);
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { ok, withCalendarToken } from "./shared.js";
+import { getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -12,8 +12,7 @@ export async function run(
   const eventId = input.event_id as string;
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  return withCalendarToken(async (token) => {
-    const event = await calendar.getEvent(token, eventId, calendarId);
-    return ok(JSON.stringify(event, null, 2));
-  });
+  const connection = getCalendarConnection();
+  const event = await calendar.getEvent(connection, eventId, calendarId);
+  return ok(JSON.stringify(event, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { ok, withCalendarToken } from "./shared.js";
+import { getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -17,20 +17,19 @@ export async function run(
   const singleEvents = (input.single_events as boolean) ?? true;
   const orderBy = input.order_by as "startTime" | "updated" | undefined;
 
-  return withCalendarToken(async (token) => {
-    const result = await calendar.listEvents(token, calendarId, {
-      timeMin,
-      timeMax,
-      maxResults,
-      query,
-      singleEvents,
-      orderBy,
-    });
-
-    if (!result.items?.length) {
-      return ok("No events found in the specified time range.");
-    }
-
-    return ok(JSON.stringify(result, null, 2));
+  const connection = getCalendarConnection();
+  const result = await calendar.listEvents(connection, calendarId, {
+    timeMin,
+    timeMax,
+    maxResults,
+    query,
+    singleEvents,
+    orderBy,
   });
+
+  if (!result.items?.length) {
+    return ok("No events found in the specified time range.");
+  }
+
+  return ok(JSON.stringify(result, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { ok, withCalendarToken } from "./shared.js";
+import { getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -13,45 +13,45 @@ export async function run(
   const response = input.response as "accepted" | "declined" | "tentative";
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  return withCalendarToken(async (token) => {
-    // First get the event to find the user's attendee entry
-    const event = await calendar.getEvent(token, eventId, calendarId);
-    const selfAttendee = event.attendees?.find((a) => a.self);
+  const connection = getCalendarConnection();
 
-    if (!selfAttendee) {
-      // If the user is the organizer and not in the attendees list,
-      // they don't need to RSVP
-      if (event.organizer?.self) {
-        return ok("You are the organizer of this event. No RSVP needed.");
-      }
-      return ok(
-        "Could not find your attendee entry for this event. You may not be invited.",
-      );
+  // First get the event to find the user's attendee entry
+  const event = await calendar.getEvent(connection, eventId, calendarId);
+  const selfAttendee = event.attendees?.find((a) => a.self);
+
+  if (!selfAttendee) {
+    // If the user is the organizer and not in the attendees list,
+    // they don't need to RSVP
+    if (event.organizer?.self) {
+      return ok("You are the organizer of this event. No RSVP needed.");
     }
-
-    // Update the attendee's response status
-    const updatedAttendees = event.attendees!.map((a) =>
-      a.self ? { ...a, responseStatus: response } : a,
+    return ok(
+      "Could not find your attendee entry for this event. You may not be invited.",
     );
+  }
 
-    await calendar.patchEvent(
-      token,
-      eventId,
-      {
-        attendees: updatedAttendees as Array<{
-          email: string;
-          responseStatus?: string;
-        }>,
-      },
-      calendarId,
-    );
+  // Update the attendee's response status
+  const updatedAttendees = event.attendees!.map((a) =>
+    a.self ? { ...a, responseStatus: response } : a,
+  );
 
-    const responseLabel =
-      response === "accepted"
-        ? "Accepted"
-        : response === "declined"
-          ? "Declined"
-          : "Tentatively accepted";
-    return ok(`${responseLabel} the event "${event.summary ?? eventId}".`);
-  });
+  await calendar.patchEvent(
+    connection,
+    eventId,
+    {
+      attendees: updatedAttendees as Array<{
+        email: string;
+        responseStatus?: string;
+      }>,
+    },
+    calendarId,
+  );
+
+  const responseLabel =
+    response === "accepted"
+      ? "Accepted"
+      : response === "declined"
+        ? "Declined"
+        : "Tentatively accepted";
+  return ok(`${responseLabel} the event "${event.summary ?? eventId}".`);
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -1,4 +1,5 @@
-import { withValidToken } from "../../../../security/token-manager.js";
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type { ToolExecutionResult } from "../../../../tools/types.js";
 
 export function ok(content: string): ToolExecutionResult {
@@ -13,8 +14,6 @@ export function err(message: string): ToolExecutionResult {
  * Calendar uses the same OAuth credential service as Gmail since both
  * scopes are granted in a single OAuth consent flow.
  */
-export async function withCalendarToken<T>(
-  fn: (token: string) => Promise<T>,
-): Promise<T> {
-  return withValidToken("integration:gmail", fn);
+export function getCalendarConnection(): OAuthConnection {
+  return resolveOAuthConnection("integration:gmail");
 }

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -11,7 +11,9 @@ import {
   listEvents,
 } from "../../config/bundled-skills/google-calendar/calendar-client.js";
 import type { CalendarEvent } from "../../config/bundled-skills/google-calendar/types.js";
-import { withValidToken } from "../../security/token-manager.js";
+import type { OAuthConnection } from "../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
+import { GOOGLE_CALENDAR_BASE_URL } from "../../oauth/provider-base-urls.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   FetchResult,
@@ -20,8 +22,6 @@ import type {
 } from "../provider-types.js";
 
 const log = getLogger("watcher:google-calendar");
-
-const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
 
 /** The credential service — calendar shares OAuth tokens with Gmail. */
 const CREDENTIAL_SERVICE = "integration:gmail";
@@ -69,7 +69,7 @@ interface SyncResponse {
  * Returns all accumulated events and the final nextSyncToken.
  */
 async function incrementalSync(
-  token: string,
+  connection: OAuthConnection,
   syncToken: string,
 ): Promise<SyncResponse> {
   let allItems: CalendarEvent[] = [];
@@ -77,27 +77,32 @@ async function incrementalSync(
   let nextSyncToken: string | undefined;
 
   do {
-    const params = new URLSearchParams({ syncToken });
-    if (pageToken) params.set("pageToken", pageToken);
-    const url = `${CALENDAR_API_BASE}/calendars/primary/events?${params}`;
-    const resp = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
+    const query: Record<string, string> = { syncToken };
+    if (pageToken) query.pageToken = pageToken;
+
+    const resp = await connection.request({
+      method: "GET",
+      path: "/calendars/primary/events",
+      query,
+      baseUrl: GOOGLE_CALENDAR_BASE_URL,
     });
 
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
+    if (resp.status < 200 || resp.status >= 300) {
+      const bodyStr =
+        typeof resp.body === "string"
+          ? resp.body
+          : JSON.stringify(resp.body ?? "");
       if (resp.status === 410) {
-        throw new SyncTokenExpiredError(body);
+        throw new SyncTokenExpiredError(bodyStr);
       }
-      // Throw CalendarApiError so withValidToken can detect 401s via the status property
       throw new CalendarApiError(
         resp.status,
-        resp.statusText,
-        `Calendar Sync API ${resp.status}: ${body}`,
+        "",
+        `Calendar Sync API ${resp.status}: ${bodyStr}`,
       );
     }
 
-    const page = (await resp.json()) as SyncResponse;
+    const page = resp.body as SyncResponse;
     if (page.items) allItems = allItems.concat(page.items);
     pageToken = page.nextPageToken;
     nextSyncToken = page.nextSyncToken;
@@ -119,16 +124,48 @@ export const googleCalendarProvider: WatcherProvider = {
   requiredCredentialService: CREDENTIAL_SERVICE,
 
   async getInitialWatermark(credentialService: string): Promise<string> {
-    return withValidToken(credentialService, async (token) => {
-      // Do a full sync with a narrow window to get the initial syncToken.
-      // The API may paginate even for small result sets, so follow nextPageToken
-      // until we reach the final page that carries the nextSyncToken.
+    const connection = resolveOAuthConnection(credentialService);
+
+    // Do a full sync with a narrow window to get the initial syncToken.
+    // The API may paginate even for small result sets, so follow nextPageToken
+    // until we reach the final page that carries the nextSyncToken.
+    const now = new Date().toISOString();
+    let pageToken: string | undefined;
+    let syncToken: string | undefined;
+
+    do {
+      const result = await listEvents(connection, "primary", {
+        timeMin: now,
+        maxResults: 250,
+        singleEvents: true,
+        pageToken,
+      });
+      syncToken = result.nextSyncToken;
+      pageToken = result.nextPageToken;
+    } while (pageToken && !syncToken);
+
+    if (!syncToken) {
+      throw new Error("Calendar API did not return a syncToken");
+    }
+    return syncToken;
+  },
+
+  async fetchNew(
+    credentialService: string,
+    watermark: string | null,
+    _config: Record<string, unknown>,
+    _watcherKey: string,
+  ): Promise<FetchResult> {
+    const connection = resolveOAuthConnection(credentialService);
+
+    if (!watermark) {
+      // No watermark — paginate through to get the initial syncToken, return no items
       const now = new Date().toISOString();
       let pageToken: string | undefined;
       let syncToken: string | undefined;
 
       do {
-        const result = await listEvents(token, "primary", {
+        const result = await listEvents(connection, "primary", {
           timeMin: now,
           maxResults: 250,
           singleEvents: true,
@@ -138,82 +175,52 @@ export const googleCalendarProvider: WatcherProvider = {
         pageToken = result.nextPageToken;
       } while (pageToken && !syncToken);
 
-      if (!syncToken) {
-        throw new Error("Calendar API did not return a syncToken");
-      }
-      return syncToken;
-    });
-  },
+      return { items: [], watermark: syncToken ?? "" };
+    }
 
-  async fetchNew(
-    credentialService: string,
-    watermark: string | null,
-    _config: Record<string, unknown>,
-    _watcherKey: string,
-  ): Promise<FetchResult> {
-    return withValidToken(credentialService, async (token) => {
-      if (!watermark) {
-        // No watermark — paginate through to get the initial syncToken, return no items
-        const now = new Date().toISOString();
-        let pageToken: string | undefined;
-        let syncToken: string | undefined;
+    try {
+      const syncResp = await incrementalSync(connection, watermark);
+      const newWatermark = syncResp.nextSyncToken ?? watermark;
 
-        do {
-          const result = await listEvents(token, "primary", {
-            timeMin: now,
-            maxResults: 250,
-            singleEvents: true,
-            pageToken,
-          });
-          syncToken = result.nextSyncToken;
-          pageToken = result.nextPageToken;
-        } while (pageToken && !syncToken);
-
-        return { items: [], watermark: syncToken ?? "" };
+      if (!syncResp.items || syncResp.items.length === 0) {
+        return { items: [], watermark: newWatermark };
       }
 
-      try {
-        const syncResp = await incrementalSync(token, watermark);
-        const newWatermark = syncResp.nextSyncToken ?? watermark;
+      // Convert events to watcher items, distinguishing new vs updated
+      const items: WatcherItem[] = [];
+      for (const event of syncResp.items) {
+        if (event.status === "cancelled") continue;
 
-        if (!syncResp.items || syncResp.items.length === 0) {
-          return { items: [], watermark: newWatermark };
-        }
-
-        // Convert events to watcher items, distinguishing new vs updated
-        const items: WatcherItem[] = [];
-        for (const event of syncResp.items) {
-          if (event.status === "cancelled") continue;
-
-          const eventType =
-            event.created === event.updated
-              ? "new_calendar_event"
-              : "updated_calendar_event";
-          items.push(eventToItem(event, eventType));
-        }
-
-        log.info(
-          { count: items.length, watermark: newWatermark },
-          "Calendar: fetched event changes",
-        );
-        return { items, watermark: newWatermark };
-      } catch (err) {
-        if (err instanceof SyncTokenExpiredError) {
-          log.warn("Calendar syncToken expired, falling back to recent events");
-          return fallbackFetch(token);
-        }
-        throw err;
+        const eventType =
+          event.created === event.updated
+            ? "new_calendar_event"
+            : "updated_calendar_event";
+        items.push(eventToItem(event, eventType));
       }
-    });
+
+      log.info(
+        { count: items.length, watermark: newWatermark },
+        "Calendar: fetched event changes",
+      );
+      return { items, watermark: newWatermark };
+    } catch (err) {
+      if (err instanceof SyncTokenExpiredError) {
+        log.warn("Calendar syncToken expired, falling back to recent events");
+        return fallbackFetch(connection);
+      }
+      throw err;
+    }
   },
 };
 
 /**
  * Fallback when syncToken expires: list upcoming events from today.
  */
-async function fallbackFetch(token: string): Promise<FetchResult> {
+async function fallbackFetch(
+  connection: OAuthConnection,
+): Promise<FetchResult> {
   const now = new Date().toISOString();
-  const result = await listEvents(token, "primary", {
+  const result = await listEvents(connection, "primary", {
     timeMin: now,
     maxResults: 25,
     singleEvents: true,
@@ -229,7 +236,7 @@ async function fallbackFetch(token: string): Promise<FetchResult> {
   let syncToken: string | undefined;
 
   do {
-    const syncResult = await listEvents(token, "primary", {
+    const syncResult = await listEvents(connection, "primary", {
       timeMin: now,
       maxResults: 250,
       singleEvents: true,


### PR DESCRIPTION
## Summary
- Replace withCalendarToken with getCalendarConnection() in shared.ts and all 5 calendar tool files
- Refactor calendar watcher to use OAuthConnection with per-request GOOGLE_CALENDAR_BASE_URL override
- Delete withCalendarToken function and remove local CALENDAR_API_BASE redeclaration from watcher

Part of plan: oauth-conn-request.md (PR 7 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
