### PR TITLE
fix: re-fetch channel setup status after disconnect

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1155,6 +1155,7 @@ public final class SettingsStore: ObservableObject {
                     self.slackChannelBotUsername = nil
                     self.slackChannelTeamName = nil
                     self.slackChannelError = nil
+                    self.fetchChannelSetupStatus()
                 }
             } catch {
                 log.error("Failed to clear Slack channel config: \(error)")
@@ -1311,6 +1312,7 @@ public final class SettingsStore: ObservableObject {
                 path: "/v1/integrations/twilio/credentials"
             )
             twilioSaveInProgress = false
+            self.fetchChannelSetupStatus()
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for channel-setup-status.md.

**Gap 1:** clearTwilioCredentials does not re-fetch setupStatus after server-side DELETE
**Gap 2:** clearSlackChannelConfig does not re-fetch setupStatus after server-side DELETE

Adds `self.fetchChannelSetupStatus()` calls after successful credential clears, matching the pattern already used by the save methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
