### PR TITLE
Migrate Gmail tools, contacts, and Gmail watcher to OAuthConnection

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -3,8 +3,7 @@ import {
   searchContacts,
 } from "../../../../messaging/providers/gmail/people-client.js";
 import type { Person } from "../../../../messaging/providers/gmail/people-types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -44,43 +43,41 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      switch (action) {
-        case "list": {
-          const pageSize = (input.page_size as number) ?? 50;
-          const pageToken = input.page_token as string | undefined;
+    const connection = resolveOAuthConnection("integration:gmail");
+    switch (action) {
+      case "list": {
+        const pageSize = (input.page_size as number) ?? 50;
+        const pageToken = input.page_token as string | undefined;
 
-          const resp = await listContacts(token, pageSize, pageToken);
-          const contacts = (resp.connections ?? []).map(formatContact);
+        const resp = await listContacts(connection, pageSize, pageToken);
+        const contacts = (resp.connections ?? []).map(formatContact);
 
-          const result: Record<string, unknown> = {
-            contacts,
-            total: resp.totalPeople ?? contacts.length,
-          };
-          if (resp.nextPageToken) result.nextPageToken = resp.nextPageToken;
+        const result: Record<string, unknown> = {
+          contacts,
+          total: resp.totalPeople ?? contacts.length,
+        };
+        if (resp.nextPageToken) result.nextPageToken = resp.nextPageToken;
 
-          return ok(JSON.stringify(result, null, 2));
-        }
-
-        case "search": {
-          const query = input.query as string;
-          if (!query) return err("query is required for search action.");
-
-          const resp = await searchContacts(token, query);
-          const contacts = (resp.results ?? []).map((r) =>
-            formatContact(r.person),
-          );
-
-          return ok(
-            JSON.stringify({ contacts, total: contacts.length }, null, 2),
-          );
-        }
-
-        default:
-          return err(`Unknown action "${action}". Use list or search.`);
+        return ok(JSON.stringify(result, null, 2));
       }
-    });
+
+      case "search": {
+        const query = input.query as string;
+        if (!query) return err("query is required for search action.");
+
+        const resp = await searchContacts(connection, query);
+        const contacts = (resp.results ?? []).map((r) =>
+          formatContact(r.person),
+        );
+
+        return ok(
+          JSON.stringify({ contacts, total: contacts.length }, null, 2),
+        );
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use list or search.`);
+    }
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -3,8 +3,7 @@ import {
   listMessages,
   modifyMessage,
 } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -35,49 +34,47 @@ export async function run(
     }
 
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        const allMessageIds: string[] = [];
-        let pageToken: string | undefined;
-        let truncated = false;
+      const connection = resolveOAuthConnection("integration:gmail");
+      const allMessageIds: string[] = [];
+      let pageToken: string | undefined;
+      let truncated = false;
 
-        while (allMessageIds.length < MAX_MESSAGES) {
-          const listResp = await listMessages(
-            token,
-            query,
-            Math.min(500, MAX_MESSAGES - allMessageIds.length),
-            pageToken,
-          );
-          const ids = (listResp.messages ?? []).map((m) => m.id);
-          if (ids.length === 0) break;
-          allMessageIds.push(...ids);
-          pageToken = listResp.nextPageToken ?? undefined;
-          if (!pageToken) break;
-        }
+      while (allMessageIds.length < MAX_MESSAGES) {
+        const listResp = await listMessages(
+          connection,
+          query,
+          Math.min(500, MAX_MESSAGES - allMessageIds.length),
+          pageToken,
+        );
+        const ids = (listResp.messages ?? []).map((m) => m.id);
+        if (ids.length === 0) break;
+        allMessageIds.push(...ids);
+        pageToken = listResp.nextPageToken ?? undefined;
+        if (!pageToken) break;
+      }
 
-        if (allMessageIds.length >= MAX_MESSAGES && pageToken) {
-          truncated = true;
-        }
+      if (allMessageIds.length >= MAX_MESSAGES && pageToken) {
+        truncated = true;
+      }
 
-        if (allMessageIds.length === 0) {
-          return ok("No messages matched the query. Nothing archived.");
-        }
+      if (allMessageIds.length === 0) {
+        return ok("No messages matched the query. Nothing archived.");
+      }
 
-        for (let i = 0; i < allMessageIds.length; i += BATCH_MODIFY_LIMIT) {
-          const chunk = allMessageIds.slice(i, i + BATCH_MODIFY_LIMIT);
-          await batchModifyMessages(token, chunk, {
-            removeLabelIds: ["INBOX"],
-          });
-        }
+      for (let i = 0; i < allMessageIds.length; i += BATCH_MODIFY_LIMIT) {
+        const chunk = allMessageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+        await batchModifyMessages(connection, chunk, {
+          removeLabelIds: ["INBOX"],
+        });
+      }
 
-        const summary = `Archived ${allMessageIds.length} message(s) matching query: ${query}`;
-        if (truncated) {
-          return ok(
-            `${summary}\n\nNote: this operation was capped at ${MAX_MESSAGES} messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,
-          );
-        }
-        return ok(summary);
-      });
+      const summary = `Archived ${allMessageIds.length} message(s) matching query: ${query}`;
+      if (truncated) {
+        return ok(
+          `${summary}\n\nNote: this operation was capped at ${MAX_MESSAGES} messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,
+        );
+      }
+      return ok(summary);
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }
@@ -106,11 +103,9 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        await modifyMessage(token, messageId, { removeLabelIds: ["INBOX"] });
-        return ok("Message archived.");
-      });
+      const connection = resolveOAuthConnection("integration:gmail");
+      await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
+      return ok("Message archived.");
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }
@@ -126,23 +121,21 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      if (messageIds.length === 1) {
-        await modifyMessage(token, messageIds[0], {
-          removeLabelIds: ["INBOX"],
-        });
-        return ok("Message archived.");
-      }
+    const connection = resolveOAuthConnection("integration:gmail");
+    if (messageIds.length === 1) {
+      await modifyMessage(connection, messageIds[0], {
+        removeLabelIds: ["INBOX"],
+      });
+      return ok("Message archived.");
+    }
 
-      for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
-        const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
-        await batchModifyMessages(token, chunk, {
-          removeLabelIds: ["INBOX"],
-        });
-      }
-      return ok(`Archived ${messageIds.length} message(s).`);
-    });
+    for (let i = 0; i < messageIds.length; i += BATCH_MODIFY_LIMIT) {
+      const chunk = messageIds.slice(i, i + BATCH_MODIFY_LIMIT);
+      await batchModifyMessages(connection, chunk, {
+        removeLabelIds: ["INBOX"],
+      });
+    }
+    return ok(`Archived ${messageIds.length} message(s).`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -6,8 +6,7 @@ import {
   getMessage,
 } from "../../../../messaging/providers/gmail/client.js";
 import type { GmailMessagePart } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -57,17 +56,15 @@ export async function run(
 
   if (action === "list") {
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        const message = await getMessage(token, messageId, "full");
-        const attachments = collectAttachments(message.payload?.parts);
+      const connection = resolveOAuthConnection("integration:gmail");
+      const message = await getMessage(connection, messageId, "full");
+      const attachments = collectAttachments(message.payload?.parts);
 
-        if (attachments.length === 0) {
-          return ok("No attachments found on this message.");
-        }
+      if (attachments.length === 0) {
+        return ok("No attachments found on this message.");
+      }
 
-        return ok(JSON.stringify(attachments, null, 2));
-      });
+      return ok(JSON.stringify(attachments, null, 2));
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }
@@ -81,26 +78,26 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        const attachment = await getAttachment(token, messageId, attachmentId);
+      const connection = resolveOAuthConnection("integration:gmail");
+      const attachment = await getAttachment(
+        connection,
+        messageId,
+        attachmentId,
+      );
 
-        // Gmail returns base64url; convert to standard base64 then to Buffer
-        const base64 = attachment.data.replace(/-/g, "+").replace(/_/g, "/");
-        const buffer = Buffer.from(base64, "base64");
+      // Gmail returns base64url; convert to standard base64 then to Buffer
+      const base64 = attachment.data.replace(/-/g, "+").replace(/_/g, "/");
+      const buffer = Buffer.from(base64, "base64");
 
-        const outputDir = context.workingDir ?? process.cwd();
-        // Sanitize filename: strip path separators to prevent traversal attacks from crafted MIME filenames
-        const safeName = basename(filename).replace(/\.\./g, "_");
-        const outputPath = resolve(outputDir, safeName);
-        if (!outputPath.startsWith(outputDir))
-          return err("Invalid filename: path traversal detected.");
-        await writeFile(outputPath, buffer);
+      const outputDir = context.workingDir ?? process.cwd();
+      // Sanitize filename: strip path separators to prevent traversal attacks from crafted MIME filenames
+      const safeName = basename(filename).replace(/\.\./g, "_");
+      const outputPath = resolve(outputDir, safeName);
+      if (!outputPath.startsWith(outputDir))
+        return err("Invalid filename: path traversal detected.");
+      await writeFile(outputPath, buffer);
 
-        return ok(
-          `Attachment saved to ${outputPath} (${buffer.length} bytes).`,
-        );
-      });
+      return ok(`Attachment saved to ${outputPath} (${buffer.length} bytes).`);
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -1,6 +1,5 @@
 import { createDraft } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -23,21 +22,19 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      const draft = await createDraft(
-        token,
-        to,
-        subject,
-        body,
-        inReplyTo,
-        cc,
-        bcc,
-      );
-      return ok(
-        `Draft created (ID: ${draft.id}). It will appear in your Gmail Drafts.`,
-      );
-    });
+    const connection = resolveOAuthConnection("integration:gmail");
+    const draft = await createDraft(
+      connection,
+      to,
+      subject,
+      body,
+      inReplyTo,
+      cc,
+      bcc,
+    );
+    return ok(
+      `Draft created (ID: ${draft.id}). It will appear in your Gmail Drafts.`,
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -7,8 +7,7 @@ import type {
   GmailFilterAction,
   GmailFilterCriteria,
 } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -26,57 +25,53 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      switch (action) {
-        case "list": {
-          const filters = await listFilters(token);
-          if (filters.length === 0) {
-            return ok("No filters configured.");
-          }
-          return ok(JSON.stringify(filters, null, 2));
+    const connection = resolveOAuthConnection("integration:gmail");
+    switch (action) {
+      case "list": {
+        const filters = await listFilters(connection);
+        if (filters.length === 0) {
+          return ok("No filters configured.");
         }
-
-        case "create": {
-          const criteria: GmailFilterCriteria = {};
-          if (input.from) criteria.from = input.from as string;
-          if (input.to) criteria.to = input.to as string;
-          if (input.subject) criteria.subject = input.subject as string;
-          if (input.query) criteria.query = input.query as string;
-          if (input.has_attachment !== undefined)
-            criteria.hasAttachment = input.has_attachment as boolean;
-
-          const filterAction: GmailFilterAction = {};
-          if (input.add_label_ids)
-            filterAction.addLabelIds = input.add_label_ids as string[];
-          if (input.remove_label_ids)
-            filterAction.removeLabelIds = input.remove_label_ids as string[];
-          if (input.forward) filterAction.forward = input.forward as string;
-
-          if (Object.keys(criteria).length === 0) {
-            return err(
-              "At least one filter criteria is required (from, to, subject, query, or has_attachment).",
-            );
-          }
-
-          const filter = await createFilter(token, criteria, filterAction);
-          return ok(`Filter created (ID: ${filter.id}).`);
-        }
-
-        case "delete": {
-          const filterId = input.filter_id as string;
-          if (!filterId) return err("filter_id is required for delete action.");
-
-          await deleteFilter(token, filterId);
-          return ok("Filter deleted.");
-        }
-
-        default:
-          return err(
-            `Unknown action "${action}". Use list, create, or delete.`,
-          );
+        return ok(JSON.stringify(filters, null, 2));
       }
-    });
+
+      case "create": {
+        const criteria: GmailFilterCriteria = {};
+        if (input.from) criteria.from = input.from as string;
+        if (input.to) criteria.to = input.to as string;
+        if (input.subject) criteria.subject = input.subject as string;
+        if (input.query) criteria.query = input.query as string;
+        if (input.has_attachment !== undefined)
+          criteria.hasAttachment = input.has_attachment as boolean;
+
+        const filterAction: GmailFilterAction = {};
+        if (input.add_label_ids)
+          filterAction.addLabelIds = input.add_label_ids as string[];
+        if (input.remove_label_ids)
+          filterAction.removeLabelIds = input.remove_label_ids as string[];
+        if (input.forward) filterAction.forward = input.forward as string;
+
+        if (Object.keys(criteria).length === 0) {
+          return err(
+            "At least one filter criteria is required (from, to, subject, query, or has_attachment).",
+          );
+        }
+
+        const filter = await createFilter(connection, criteria, filterAction);
+        return ok(`Filter created (ID: ${filter.id}).`);
+      }
+
+      case "delete": {
+        const filterId = input.filter_id as string;
+        if (!filterId) return err("filter_id is required for delete action.");
+
+        await deleteFilter(connection, filterId);
+        return ok("Filter deleted.");
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use list, create, or delete.`);
+    }
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -5,8 +5,8 @@ import {
   listMessages,
   modifyMessage,
 } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -15,12 +15,14 @@ import { err, ok } from "./shared.js";
 
 const FOLLOW_UP_LABEL_NAME = "Follow-up";
 
-async function getOrCreateFollowUpLabel(token: string): Promise<string> {
-  const labels = await listLabels(token);
+async function getOrCreateFollowUpLabel(
+  connection: OAuthConnection,
+): Promise<string> {
+  const labels = await listLabels(connection);
   const existing = labels.find((l) => l.name === FOLLOW_UP_LABEL_NAME);
   if (existing) return existing.id;
 
-  const created = await createLabel(token, FOLLOW_UP_LABEL_NAME);
+  const created = await createLabel(connection, FOLLOW_UP_LABEL_NAME);
   return created.id;
 }
 
@@ -35,67 +37,68 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      switch (action) {
-        case "track": {
-          const messageId = input.message_id as string;
-          if (!messageId)
-            return err("message_id is required for track action.");
+    const connection = resolveOAuthConnection("integration:gmail");
+    switch (action) {
+      case "track": {
+        const messageId = input.message_id as string;
+        if (!messageId) return err("message_id is required for track action.");
 
-          const labelId = await getOrCreateFollowUpLabel(token);
-          await modifyMessage(token, messageId, { addLabelIds: [labelId] });
-          return ok("Message marked for follow-up.");
-        }
-
-        case "list": {
-          const labelId = await getOrCreateFollowUpLabel(token);
-          const listResp = await listMessages(token, undefined, 50, undefined, [
-            labelId,
-          ]);
-          const messageIds = (listResp.messages ?? []).map((m) => m.id);
-
-          if (messageIds.length === 0) {
-            return ok("No messages are currently tracked for follow-up.");
-          }
-
-          const messages = await batchGetMessages(
-            token,
-            messageIds,
-            "metadata",
-            ["From", "Subject", "Date"],
-          );
-          const items = messages.map((m) => {
-            const headers = m.payload?.headers ?? [];
-            const from =
-              headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
-            const subject =
-              headers.find((h) => h.name.toLowerCase() === "subject")?.value ??
-              "";
-            const date =
-              headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
-            return { id: m.id, threadId: m.threadId, from, subject, date };
-          });
-
-          return ok(JSON.stringify(items, null, 2));
-        }
-
-        case "untrack": {
-          const messageId = input.message_id as string;
-          if (!messageId)
-            return err("message_id is required for untrack action.");
-
-          const labelId = await getOrCreateFollowUpLabel(token);
-          await modifyMessage(token, messageId, { removeLabelIds: [labelId] });
-          return ok("Follow-up tracking removed from message.");
-        }
-
-        default:
-          return err(
-            `Unknown action "${action}". Use track, list, or untrack.`,
-          );
+        const labelId = await getOrCreateFollowUpLabel(connection);
+        await modifyMessage(connection, messageId, { addLabelIds: [labelId] });
+        return ok("Message marked for follow-up.");
       }
-    });
+
+      case "list": {
+        const labelId = await getOrCreateFollowUpLabel(connection);
+        const listResp = await listMessages(
+          connection,
+          undefined,
+          50,
+          undefined,
+          [labelId],
+        );
+        const messageIds = (listResp.messages ?? []).map((m) => m.id);
+
+        if (messageIds.length === 0) {
+          return ok("No messages are currently tracked for follow-up.");
+        }
+
+        const messages = await batchGetMessages(
+          connection,
+          messageIds,
+          "metadata",
+          ["From", "Subject", "Date"],
+        );
+        const items = messages.map((m) => {
+          const headers = m.payload?.headers ?? [];
+          const from =
+            headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+          const subject =
+            headers.find((h) => h.name.toLowerCase() === "subject")?.value ??
+            "";
+          const date =
+            headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+          return { id: m.id, threadId: m.threadId, from, subject, date };
+        });
+
+        return ok(JSON.stringify(items, null, 2));
+      }
+
+      case "untrack": {
+        const messageId = input.message_id as string;
+        if (!messageId)
+          return err("message_id is required for untrack action.");
+
+        const labelId = await getOrCreateFollowUpLabel(connection);
+        await modifyMessage(connection, messageId, {
+          removeLabelIds: [labelId],
+        });
+        return ok("Follow-up tracking removed from message.");
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use track, list, or untrack.`);
+    }
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -5,8 +5,7 @@ import {
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
 import type { GmailMessagePart } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -76,66 +75,68 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      const message = await getMessage(token, messageId, "full");
-      const headers = message.payload?.headers ?? [];
-      const originalFrom = extractHeader(headers, "From");
-      const originalDate = extractHeader(headers, "Date");
-      const originalSubject = extractHeader(headers, "Subject");
-      const originalBody = extractPlainTextBody(message.payload);
+    const connection = resolveOAuthConnection("integration:gmail");
+    const message = await getMessage(connection, messageId, "full");
+    const headers = message.payload?.headers ?? [];
+    const originalFrom = extractHeader(headers, "From");
+    const originalDate = extractHeader(headers, "Date");
+    const originalSubject = extractHeader(headers, "Subject");
+    const originalBody = extractPlainTextBody(message.payload);
 
-      const forwardHeader = [
-        additionalText ? `${additionalText}\n\n` : "",
-        "---------- Forwarded message ----------",
-        `From: ${originalFrom}`,
-        `Date: ${originalDate}`,
-        `Subject: ${originalSubject}`,
-        "",
-        originalBody,
-      ].join("\n");
+    const forwardHeader = [
+      additionalText ? `${additionalText}\n\n` : "",
+      "---------- Forwarded message ----------",
+      `From: ${originalFrom}`,
+      `Date: ${originalDate}`,
+      `Subject: ${originalSubject}`,
+      "",
+      originalBody,
+    ].join("\n");
 
-      const subject = originalSubject.startsWith("Fwd:")
-        ? originalSubject
-        : `Fwd: ${originalSubject}`;
+    const subject = originalSubject.startsWith("Fwd:")
+      ? originalSubject
+      : `Fwd: ${originalSubject}`;
 
-      // Collect and download attachments from the original message
-      const attachmentRefs = collectAttachmentRefs(message.payload?.parts);
-      const attachments = await Promise.all(
-        attachmentRefs.map(async (ref) => {
-          const att = await getAttachment(token, messageId, ref.attachmentId);
-          const data = Buffer.from(
-            att.data.replace(/-/g, "+").replace(/_/g, "/"),
-            "base64",
-          );
-          return { filename: ref.filename, mimeType: ref.mimeType, data };
-        }),
-      );
-
-      if (attachments.length > 0) {
-        const raw = buildMultipartMime({
-          to: forwardTo,
-          subject,
-          body: forwardHeader,
-          attachments,
-        });
-        const draft = await createDraftRaw(token, raw);
-        return ok(
-          `Forward draft created to ${forwardTo} with ${attachments.length} attachment(s) (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+    // Collect and download attachments from the original message
+    const attachmentRefs = collectAttachmentRefs(message.payload?.parts);
+    const attachments = await Promise.all(
+      attachmentRefs.map(async (ref) => {
+        const att = await getAttachment(
+          connection,
+          messageId,
+          ref.attachmentId,
         );
-      }
+        const data = Buffer.from(
+          att.data.replace(/-/g, "+").replace(/_/g, "/"),
+          "base64",
+        );
+        return { filename: ref.filename, mimeType: ref.mimeType, data };
+      }),
+    );
 
+    if (attachments.length > 0) {
       const raw = buildMultipartMime({
         to: forwardTo,
         subject,
         body: forwardHeader,
-        attachments: [],
+        attachments,
       });
-      const draft = await createDraftRaw(token, raw);
+      const draft = await createDraftRaw(connection, raw);
       return ok(
-        `Forward draft created to ${forwardTo} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+        `Forward draft created to ${forwardTo} with ${attachments.length} attachment(s) (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
       );
+    }
+
+    const raw = buildMultipartMime({
+      to: forwardTo,
+      subject,
+      body: forwardHeader,
+      attachments: [],
     });
+    const draft = await createDraftRaw(connection, raw);
+    return ok(
+      `Forward draft created to ${forwardTo} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -2,8 +2,7 @@ import {
   batchModifyMessages,
   modifyMessage,
 } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -21,14 +20,12 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        await batchModifyMessages(token, messageIds, {
-          addLabelIds,
-          removeLabelIds,
-        });
-        return ok(`Labels updated on ${messageIds.length} message(s).`);
+      const connection = resolveOAuthConnection("integration:gmail");
+      await batchModifyMessages(connection, messageIds, {
+        addLabelIds,
+        removeLabelIds,
       });
+      return ok(`Labels updated on ${messageIds.length} message(s).`);
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }
@@ -36,11 +33,12 @@ export async function run(
 
   if (messageId) {
     try {
-      const provider = getMessagingProvider("gmail");
-      return await withValidToken(provider.credentialService, async (token) => {
-        await modifyMessage(token, messageId, { addLabelIds, removeLabelIds });
-        return ok("Labels updated.");
+      const connection = resolveOAuthConnection("integration:gmail");
+      await modifyMessage(connection, messageId, {
+        addLabelIds,
+        removeLabelIds,
       });
+      return ok("Labels updated.");
     } catch (e) {
       return err(e instanceof Error ? e.message : String(e));
     }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -3,8 +3,7 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import type { GmailMessage } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -56,159 +55,162 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      // Pipeline: fire metadata fetches for each page of IDs as they arrive
-      const allMessageIds: string[] = [];
-      const fetchPromises: Promise<GmailMessage[]>[] = [];
-      let pageToken: string | undefined = inputPageToken;
-      let truncated = false;
-      let timeBudgetExceeded = false;
-      const metadataHeaders = ["From", "Subject", "Date"];
-      const startTime = Date.now();
-      const TIME_BUDGET_MS = 90_000;
+    const connection = resolveOAuthConnection("integration:gmail");
+    // Pipeline: fire metadata fetches for each page of IDs as they arrive
+    const allMessageIds: string[] = [];
+    const fetchPromises: Promise<GmailMessage[]>[] = [];
+    let pageToken: string | undefined = inputPageToken;
+    let truncated = false;
+    let timeBudgetExceeded = false;
+    const metadataHeaders = ["From", "Subject", "Date"];
+    const startTime = Date.now();
+    const TIME_BUDGET_MS = 90_000;
 
-      while (allMessageIds.length < maxMessages) {
-        if (Date.now() - startTime > TIME_BUDGET_MS) {
-          timeBudgetExceeded = true;
-          truncated = true;
-          break;
-        }
-        const pageSize = Math.min(100, maxMessages - allMessageIds.length);
-        const listResp = await listMessages(token, query, pageSize, pageToken);
-        const ids = (listResp.messages ?? []).map((m) => m.id);
-        if (ids.length === 0) break;
-        allMessageIds.push(...ids);
-        fetchPromises.push(
-          batchGetMessages(
-            token,
-            ids,
-            "metadata",
-            metadataHeaders,
-            "id,internalDate,payload/headers",
-          ),
-        );
-        pageToken = listResp.nextPageToken ?? undefined;
-        if (!pageToken) break;
-      }
-
-      if (allMessageIds.length >= maxMessages && pageToken) {
+    while (allMessageIds.length < maxMessages) {
+      if (Date.now() - startTime > TIME_BUDGET_MS) {
+        timeBudgetExceeded = true;
         truncated = true;
+        break;
       }
-
-      if (allMessageIds.length === 0) {
-        return ok(
-          JSON.stringify({
-            senders: [],
-            total_scanned: 0,
-            note: "No emails found matching the query.",
-          }),
-        );
-      }
-
-      const messages = (await Promise.all(fetchPromises)).flat();
-
-      // Aggregate all fetched messages by sender
-      const senderMap = new Map<string, OutreachSenderAggregation>();
-
-      for (const msg of messages) {
-        const headers = msg.payload?.headers ?? [];
-        const fromHeader =
-          headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
-        const subject =
-          headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
-        const dateStr =
-          headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
-
-        const { displayName, email } = parseFrom(fromHeader);
-        if (!email) continue;
-
-        let agg = senderMap.get(email);
-        if (!agg) {
-          agg = {
-            displayName,
-            email,
-            messageCount: 0,
-            newestMessageId: msg.id,
-            oldestDate: dateStr,
-            newestDate: dateStr,
-            messageIds: [],
-            hasMore: false,
-            sampleSubjects: [],
-          };
-          senderMap.set(email, agg);
-        }
-
-        agg.messageCount++;
-
-        if (!agg.displayName && displayName) agg.displayName = displayName;
-
-        if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
-          agg.messageIds.push(msg.id);
-        } else {
-          agg.hasMore = true;
-        }
-
-        // Track date range
-        const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
-        const oldestEpoch = agg.oldestDate
-          ? new Date(agg.oldestDate).getTime()
-          : Infinity;
-        const newestEpoch = agg.newestDate
-          ? new Date(agg.newestDate).getTime()
-          : 0;
-
-        if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
-          agg.oldestDate = dateStr || agg.oldestDate;
-        }
-        if (msgEpoch > newestEpoch) {
-          agg.newestDate = dateStr || agg.newestDate;
-          agg.newestMessageId = msg.id;
-        }
-
-        if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
-          agg.sampleSubjects.push(subject);
-        }
-      }
-
-      // Sort by message count desc, take top N
-      const sorted = [...senderMap.values()]
-        .sort((a, b) => b.messageCount - a.messageCount)
-        .slice(0, maxSenders);
-
-      const senders = sorted.map((s) => ({
-        id: Buffer.from(s.email).toString("base64url"),
-        display_name: s.displayName || s.email.split("@")[0],
-        email: s.email,
-        message_count: s.messageCount,
-        newest_message_id: s.newestMessageId,
-        oldest_date: s.oldestDate,
-        newest_date: s.newestDate,
-        search_query: `from:${s.email}`,
-        sample_subjects: s.sampleSubjects,
-      }));
-
-      // Store message IDs server-side to keep them out of LLM context
-      const scanId = storeScanResult(
-        sorted.map((s) => ({
-          id: Buffer.from(s.email).toString("base64url"),
-          messageIds: s.messageIds,
-          newestMessageId: s.newestMessageId,
-          newestUnsubscribableMessageId: null,
-        })),
+      const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+      const listResp = await listMessages(
+        connection,
+        query,
+        pageSize,
+        pageToken,
       );
+      const ids = (listResp.messages ?? []).map((m) => m.id);
+      if (ids.length === 0) break;
+      allMessageIds.push(...ids);
+      fetchPromises.push(
+        batchGetMessages(
+          connection,
+          ids,
+          "metadata",
+          metadataHeaders,
+          "id,internalDate,payload/headers",
+        ),
+      );
+      pageToken = listResp.nextPageToken ?? undefined;
+      if (!pageToken) break;
+    }
 
+    if (allMessageIds.length >= maxMessages && pageToken) {
+      truncated = true;
+    }
+
+    if (allMessageIds.length === 0) {
       return ok(
         JSON.stringify({
-          scan_id: scanId,
-          senders,
-          total_scanned: allMessageIds.length,
-          ...(truncated ? { truncated: true } : {}),
-          ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
-          note: "Scanned inbox for senders without List-Unsubscribe headers (potential cold outreach). Use gmail_archive and gmail_filters for cleanup.",
+          senders: [],
+          total_scanned: 0,
+          note: "No emails found matching the query.",
         }),
       );
-    });
+    }
+
+    const messages = (await Promise.all(fetchPromises)).flat();
+
+    // Aggregate all fetched messages by sender
+    const senderMap = new Map<string, OutreachSenderAggregation>();
+
+    for (const msg of messages) {
+      const headers = msg.payload?.headers ?? [];
+      const fromHeader =
+        headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+      const subject =
+        headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+      const dateStr =
+        headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+
+      const { displayName, email } = parseFrom(fromHeader);
+      if (!email) continue;
+
+      let agg = senderMap.get(email);
+      if (!agg) {
+        agg = {
+          displayName,
+          email,
+          messageCount: 0,
+          newestMessageId: msg.id,
+          oldestDate: dateStr,
+          newestDate: dateStr,
+          messageIds: [],
+          hasMore: false,
+          sampleSubjects: [],
+        };
+        senderMap.set(email, agg);
+      }
+
+      agg.messageCount++;
+
+      if (!agg.displayName && displayName) agg.displayName = displayName;
+
+      if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+        agg.messageIds.push(msg.id);
+      } else {
+        agg.hasMore = true;
+      }
+
+      // Track date range
+      const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+      const oldestEpoch = agg.oldestDate
+        ? new Date(agg.oldestDate).getTime()
+        : Infinity;
+      const newestEpoch = agg.newestDate
+        ? new Date(agg.newestDate).getTime()
+        : 0;
+
+      if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+        agg.oldestDate = dateStr || agg.oldestDate;
+      }
+      if (msgEpoch > newestEpoch) {
+        agg.newestDate = dateStr || agg.newestDate;
+        agg.newestMessageId = msg.id;
+      }
+
+      if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+        agg.sampleSubjects.push(subject);
+      }
+    }
+
+    // Sort by message count desc, take top N
+    const sorted = [...senderMap.values()]
+      .sort((a, b) => b.messageCount - a.messageCount)
+      .slice(0, maxSenders);
+
+    const senders = sorted.map((s) => ({
+      id: Buffer.from(s.email).toString("base64url"),
+      display_name: s.displayName || s.email.split("@")[0],
+      email: s.email,
+      message_count: s.messageCount,
+      newest_message_id: s.newestMessageId,
+      oldest_date: s.oldestDate,
+      newest_date: s.newestDate,
+      search_query: `from:${s.email}`,
+      sample_subjects: s.sampleSubjects,
+    }));
+
+    // Store message IDs server-side to keep them out of LLM context
+    const scanId = storeScanResult(
+      sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: null,
+      })),
+    );
+
+    return ok(
+      JSON.stringify({
+        scan_id: scanId,
+        senders,
+        total_scanned: allMessageIds.length,
+        ...(truncated ? { truncated: true } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        note: "Scanned inbox for senders without List-Unsubscribe headers (potential cold outreach). Use gmail_archive and gmail_filters for cleanup.",
+      }),
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -1,6 +1,5 @@
 import { sendDraft } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -15,11 +14,9 @@ export async function run(
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      const msg = await sendDraft(token, draftId);
-      return ok(`Draft sent (Message ID: ${msg.id}).`);
-    });
+    const connection = resolveOAuthConnection("integration:gmail");
+    const msg = await sendDraft(connection, draftId);
+    return ok(`Draft sent (Message ID: ${msg.id}).`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -3,8 +3,7 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import type { GmailMessage } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -58,187 +57,190 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      // Pipeline: fire metadata fetches for each page of IDs as they arrive,
-      // overlapping fetch latency with pagination latency
-      const allMessageIds: string[] = [];
-      const fetchPromises: Promise<GmailMessage[]>[] = [];
-      let pageToken: string | undefined = inputPageToken;
-      let truncated = false;
-      let timeBudgetExceeded = false;
-      const metadataHeaders = ["From", "List-Unsubscribe", "Subject", "Date"];
-      const startTime = Date.now();
-      const TIME_BUDGET_MS = 90_000;
+    const connection = resolveOAuthConnection("integration:gmail");
+    // Pipeline: fire metadata fetches for each page of IDs as they arrive,
+    // overlapping fetch latency with pagination latency
+    const allMessageIds: string[] = [];
+    const fetchPromises: Promise<GmailMessage[]>[] = [];
+    let pageToken: string | undefined = inputPageToken;
+    let truncated = false;
+    let timeBudgetExceeded = false;
+    const metadataHeaders = ["From", "List-Unsubscribe", "Subject", "Date"];
+    const startTime = Date.now();
+    const TIME_BUDGET_MS = 90_000;
 
-      while (allMessageIds.length < maxMessages) {
-        if (Date.now() - startTime > TIME_BUDGET_MS) {
-          timeBudgetExceeded = true;
-          truncated = true;
-          break;
-        }
-        const pageSize = Math.min(100, maxMessages - allMessageIds.length);
-        const listResp = await listMessages(token, query, pageSize, pageToken);
-        const ids = (listResp.messages ?? []).map((m) => m.id);
-        if (ids.length === 0) break;
-        allMessageIds.push(...ids);
-        fetchPromises.push(
-          batchGetMessages(
-            token,
-            ids,
-            "metadata",
-            metadataHeaders,
-            "id,internalDate,payload/headers",
-          ),
-        );
-        pageToken = listResp.nextPageToken ?? undefined;
-        if (!pageToken) break;
-      }
-
-      // If we stopped because we hit the cap but there were still more pages, flag truncation
-      if (allMessageIds.length >= maxMessages && pageToken) {
+    while (allMessageIds.length < maxMessages) {
+      if (Date.now() - startTime > TIME_BUDGET_MS) {
+        timeBudgetExceeded = true;
         truncated = true;
+        break;
       }
-
-      if (allMessageIds.length === 0) {
-        return ok(
-          JSON.stringify({
-            senders: [],
-            total_scanned: 0,
-            message:
-              "No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).",
-          }),
-        );
-      }
-
-      const messages = (await Promise.all(fetchPromises)).flat();
-
-      // Group by sender email
-      const senderMap = new Map<string, SenderAggregation>();
-
-      for (const msg of messages) {
-        const headers = msg.payload?.headers ?? [];
-        const fromHeader =
-          headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
-        const subject =
-          headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
-        const dateStr =
-          headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
-        const listUnsub = headers.find(
-          (h) => h.name.toLowerCase() === "list-unsubscribe",
-        )?.value;
-
-        const { displayName, email } = parseFrom(fromHeader);
-        if (!email) continue;
-
-        let agg = senderMap.get(email);
-        if (!agg) {
-          agg = {
-            displayName,
-            email,
-            messageCount: 0,
-            hasUnsubscribe: false,
-            newestMessageId: msg.id,
-            newestUnsubscribableMessageId: null,
-            newestUnsubscribableEpoch: 0,
-            oldestDate: dateStr,
-            newestDate: dateStr,
-            messageIds: [],
-            hasMore: false,
-            sampleSubjects: [],
-          };
-          senderMap.set(email, agg);
-        }
-
-        agg.messageCount++;
-
-        if (listUnsub) agg.hasUnsubscribe = true;
-
-        // Use displayName from earliest message that has one
-        if (!agg.displayName && displayName) agg.displayName = displayName;
-
-        // Track message IDs (cap at MAX_IDS_PER_SENDER)
-        if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
-          agg.messageIds.push(msg.id);
-        } else {
-          agg.hasMore = true;
-        }
-
-        // Track date range — compare using internalDate (epoch ms) for reliability
-        const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
-        const oldestEpoch = agg.oldestDate
-          ? new Date(agg.oldestDate).getTime()
-          : Infinity;
-        const newestEpoch = agg.newestDate
-          ? new Date(agg.newestDate).getTime()
-          : 0;
-
-        if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
-          agg.oldestDate = dateStr || agg.oldestDate;
-        }
-        if (msgEpoch > newestEpoch) {
-          agg.newestDate = dateStr || agg.newestDate;
-          agg.newestMessageId = msg.id;
-        }
-
-        // Track the newest message that actually has List-Unsubscribe so
-        // gmail_unsubscribe() is called with a message that carries the header
-        if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
-          agg.newestUnsubscribableMessageId = msg.id;
-          agg.newestUnsubscribableEpoch = msgEpoch;
-        }
-
-        // Collect sample subjects
-        if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
-          agg.sampleSubjects.push(subject);
-        }
-      }
-
-      // Sort by message count descending, take top N
-      const sorted = [...senderMap.values()]
-        .sort((a, b) => b.messageCount - a.messageCount)
-        .slice(0, maxSenders);
-
-      const resultSenders = sorted.map((s) => ({
-        id: Buffer.from(s.email).toString("base64url"),
-        display_name: s.displayName || s.email.split("@")[0],
-        email: s.email,
-        message_count: s.messageCount,
-        has_unsubscribe: s.hasUnsubscribe,
-        // When unsubscribe is available, point to a message that carries the header
-        newest_message_id:
-          s.hasUnsubscribe && s.newestUnsubscribableMessageId
-            ? s.newestUnsubscribableMessageId
-            : s.newestMessageId,
-        oldest_date: s.oldestDate,
-        newest_date: s.newestDate,
-        // Preserve original query filters so follow-up searches stay scoped
-        search_query: `from:${s.email} ${query}`,
-        sample_subjects: s.sampleSubjects,
-      }));
-
-      // Store message IDs server-side to keep them out of LLM context
-      const scanId = storeScanResult(
-        sorted.map((s) => ({
-          id: Buffer.from(s.email).toString("base64url"),
-          messageIds: s.messageIds,
-          newestMessageId: s.newestMessageId,
-          newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
-        })),
+      const pageSize = Math.min(100, maxMessages - allMessageIds.length);
+      const listResp = await listMessages(
+        connection,
+        query,
+        pageSize,
+        pageToken,
       );
+      const ids = (listResp.messages ?? []).map((m) => m.id);
+      if (ids.length === 0) break;
+      allMessageIds.push(...ids);
+      fetchPromises.push(
+        batchGetMessages(
+          connection,
+          ids,
+          "metadata",
+          metadataHeaders,
+          "id,internalDate,payload/headers",
+        ),
+      );
+      pageToken = listResp.nextPageToken ?? undefined;
+      if (!pageToken) break;
+    }
 
+    // If we stopped because we hit the cap but there were still more pages, flag truncation
+    if (allMessageIds.length >= maxMessages && pageToken) {
+      truncated = true;
+    }
+
+    if (allMessageIds.length === 0) {
       return ok(
         JSON.stringify({
-          scan_id: scanId,
-          senders: resultSenders,
-          total_scanned: allMessageIds.length,
-          query_used: query,
-          ...(truncated ? { truncated: true } : {}),
-          ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
-          note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
+          senders: [],
+          total_scanned: 0,
+          message:
+            "No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).",
         }),
       );
-    });
+    }
+
+    const messages = (await Promise.all(fetchPromises)).flat();
+
+    // Group by sender email
+    const senderMap = new Map<string, SenderAggregation>();
+
+    for (const msg of messages) {
+      const headers = msg.payload?.headers ?? [];
+      const fromHeader =
+        headers.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+      const subject =
+        headers.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+      const dateStr =
+        headers.find((h) => h.name.toLowerCase() === "date")?.value ?? "";
+      const listUnsub = headers.find(
+        (h) => h.name.toLowerCase() === "list-unsubscribe",
+      )?.value;
+
+      const { displayName, email } = parseFrom(fromHeader);
+      if (!email) continue;
+
+      let agg = senderMap.get(email);
+      if (!agg) {
+        agg = {
+          displayName,
+          email,
+          messageCount: 0,
+          hasUnsubscribe: false,
+          newestMessageId: msg.id,
+          newestUnsubscribableMessageId: null,
+          newestUnsubscribableEpoch: 0,
+          oldestDate: dateStr,
+          newestDate: dateStr,
+          messageIds: [],
+          hasMore: false,
+          sampleSubjects: [],
+        };
+        senderMap.set(email, agg);
+      }
+
+      agg.messageCount++;
+
+      if (listUnsub) agg.hasUnsubscribe = true;
+
+      // Use displayName from earliest message that has one
+      if (!agg.displayName && displayName) agg.displayName = displayName;
+
+      // Track message IDs (cap at MAX_IDS_PER_SENDER)
+      if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+        agg.messageIds.push(msg.id);
+      } else {
+        agg.hasMore = true;
+      }
+
+      // Track date range — compare using internalDate (epoch ms) for reliability
+      const msgEpoch = msg.internalDate ? Number(msg.internalDate) : 0;
+      const oldestEpoch = agg.oldestDate
+        ? new Date(agg.oldestDate).getTime()
+        : Infinity;
+      const newestEpoch = agg.newestDate
+        ? new Date(agg.newestDate).getTime()
+        : 0;
+
+      if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+        agg.oldestDate = dateStr || agg.oldestDate;
+      }
+      if (msgEpoch > newestEpoch) {
+        agg.newestDate = dateStr || agg.newestDate;
+        agg.newestMessageId = msg.id;
+      }
+
+      // Track the newest message that actually has List-Unsubscribe so
+      // gmail_unsubscribe() is called with a message that carries the header
+      if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
+        agg.newestUnsubscribableMessageId = msg.id;
+        agg.newestUnsubscribableEpoch = msgEpoch;
+      }
+
+      // Collect sample subjects
+      if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+        agg.sampleSubjects.push(subject);
+      }
+    }
+
+    // Sort by message count descending, take top N
+    const sorted = [...senderMap.values()]
+      .sort((a, b) => b.messageCount - a.messageCount)
+      .slice(0, maxSenders);
+
+    const resultSenders = sorted.map((s) => ({
+      id: Buffer.from(s.email).toString("base64url"),
+      display_name: s.displayName || s.email.split("@")[0],
+      email: s.email,
+      message_count: s.messageCount,
+      has_unsubscribe: s.hasUnsubscribe,
+      // When unsubscribe is available, point to a message that carries the header
+      newest_message_id:
+        s.hasUnsubscribe && s.newestUnsubscribableMessageId
+          ? s.newestUnsubscribableMessageId
+          : s.newestMessageId,
+      oldest_date: s.oldestDate,
+      newest_date: s.newestDate,
+      // Preserve original query filters so follow-up searches stay scoped
+      search_query: `from:${s.email} ${query}`,
+      sample_subjects: s.sampleSubjects,
+    }));
+
+    // Store message IDs server-side to keep them out of LLM context
+    const scanId = storeScanResult(
+      sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+      })),
+    );
+
+    return ok(
+      JSON.stringify({
+        scan_id: scanId,
+        senders: resultSenders,
+        total_scanned: allMessageIds.length,
+        query_used: query,
+        ...(truncated ? { truncated: true } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with gmail_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
+      }),
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -1,6 +1,5 @@
 import { trashMessage } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -18,11 +17,9 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      await trashMessage(token, messageId);
-      return ok("Message moved to trash.");
-    });
+    const connection = resolveOAuthConnection("integration:gmail");
+    await trashMessage(connection, messageId);
+    return ok("Message moved to trash.");
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -2,8 +2,7 @@ import {
   getMessage,
   sendMessage,
 } from "../../../../messaging/providers/gmail/client.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import {
   isPrivateOrLocalHost,
   resolveHostAddresses,
@@ -32,92 +31,88 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      const message = await getMessage(token, messageId, "metadata", [
-        "List-Unsubscribe",
-        "List-Unsubscribe-Post",
-      ]);
-      const headers = message.payload?.headers ?? [];
-      const unsubHeader = headers.find(
-        (h) => h.name.toLowerCase() === "list-unsubscribe",
-      )?.value;
+    const connection = resolveOAuthConnection("integration:gmail");
+    const message = await getMessage(connection, messageId, "metadata", [
+      "List-Unsubscribe",
+      "List-Unsubscribe-Post",
+    ]);
+    const headers = message.payload?.headers ?? [];
+    const unsubHeader = headers.find(
+      (h) => h.name.toLowerCase() === "list-unsubscribe",
+    )?.value;
 
-      if (!unsubHeader) {
-        return err(
-          "No List-Unsubscribe header found. Manual unsubscribe may be required.",
-        );
-      }
-
-      const httpsMatch = unsubHeader.match(/<(https:\/\/[^>]+)>/);
-      const mailtoMatch = unsubHeader.match(/<mailto:([^>]+)>/);
-      const postHeader = headers.find(
-        (h) => h.name.toLowerCase() === "list-unsubscribe-post",
-      )?.value;
-
-      if (httpsMatch) {
-        const url = httpsMatch[1];
-        let parsed: URL;
-        let validatedAddresses: string[];
-        try {
-          parsed = new URL(url);
-          if (parsed.protocol !== "https:") {
-            return err("Unsubscribe URL must use HTTPS.");
-          }
-          if (isPrivateOrLocalHost(parsed.hostname)) {
-            return err("Unsubscribe URL points to a private or local address.");
-          }
-          const { addresses, blockedAddress } = await resolveRequestAddress(
-            parsed.hostname,
-            resolveHostAddresses,
-            false,
-          );
-          if (blockedAddress) {
-            return err(
-              "Unsubscribe URL resolves to a private or local address.",
-            );
-          }
-          if (addresses.length === 0) {
-            return err("Unable to resolve unsubscribe URL hostname.");
-          }
-          validatedAddresses = addresses;
-        } catch {
-          return err("Invalid unsubscribe URL.");
-        }
-
-        const method = postHeader ? "POST" : "GET";
-        const reqOpts = postHeader
-          ? {
-              method: "POST" as const,
-              headers: { "Content-Type": "application/x-www-form-urlencoded" },
-              body: postHeader,
-            }
-          : undefined;
-
-        let lastStatus = 0;
-        for (const address of validatedAddresses) {
-          try {
-            lastStatus = await pinnedHttpsRequest(parsed, address, reqOpts);
-            if (lastStatus >= 200 && lastStatus < 400) {
-              return ok(`Successfully unsubscribed via HTTPS ${method}.`);
-            }
-          } catch {
-            continue;
-          }
-        }
-        return err(`Unsubscribe request failed: ${lastStatus}`);
-      }
-
-      if (mailtoMatch) {
-        const mailtoAddr = mailtoMatch[1].split("?")[0];
-        await sendMessage(token, mailtoAddr, "Unsubscribe", "Unsubscribe");
-        return ok(`Unsubscribe email sent to ${mailtoAddr}.`);
-      }
-
+    if (!unsubHeader) {
       return err(
-        "No supported unsubscribe method found (requires https: or mailto: URL).",
+        "No List-Unsubscribe header found. Manual unsubscribe may be required.",
       );
-    });
+    }
+
+    const httpsMatch = unsubHeader.match(/<(https:\/\/[^>]+)>/);
+    const mailtoMatch = unsubHeader.match(/<mailto:([^>]+)>/);
+    const postHeader = headers.find(
+      (h) => h.name.toLowerCase() === "list-unsubscribe-post",
+    )?.value;
+
+    if (httpsMatch) {
+      const url = httpsMatch[1];
+      let parsed: URL;
+      let validatedAddresses: string[];
+      try {
+        parsed = new URL(url);
+        if (parsed.protocol !== "https:") {
+          return err("Unsubscribe URL must use HTTPS.");
+        }
+        if (isPrivateOrLocalHost(parsed.hostname)) {
+          return err("Unsubscribe URL points to a private or local address.");
+        }
+        const { addresses, blockedAddress } = await resolveRequestAddress(
+          parsed.hostname,
+          resolveHostAddresses,
+          false,
+        );
+        if (blockedAddress) {
+          return err("Unsubscribe URL resolves to a private or local address.");
+        }
+        if (addresses.length === 0) {
+          return err("Unable to resolve unsubscribe URL hostname.");
+        }
+        validatedAddresses = addresses;
+      } catch {
+        return err("Invalid unsubscribe URL.");
+      }
+
+      const method = postHeader ? "POST" : "GET";
+      const reqOpts = postHeader
+        ? {
+            method: "POST" as const,
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: postHeader,
+          }
+        : undefined;
+
+      let lastStatus = 0;
+      for (const address of validatedAddresses) {
+        try {
+          lastStatus = await pinnedHttpsRequest(parsed, address, reqOpts);
+          if (lastStatus >= 200 && lastStatus < 400) {
+            return ok(`Successfully unsubscribed via HTTPS ${method}.`);
+          }
+        } catch {
+          continue;
+        }
+      }
+      return err(`Unsubscribe request failed: ${lastStatus}`);
+    }
+
+    if (mailtoMatch) {
+      const mailtoAddr = mailtoMatch[1].split("?")[0];
+      await sendMessage(connection, mailtoAddr, "Unsubscribe", "Unsubscribe");
+      return ok(`Unsubscribe email sent to ${mailtoAddr}.`);
+    }
+
+    return err(
+      "No supported unsubscribe method found (requires https: or mailto: URL).",
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -3,8 +3,7 @@ import {
   updateVacation,
 } from "../../../../messaging/providers/gmail/client.js";
 import type { GmailVacationSettings } from "../../../../messaging/providers/gmail/types.js";
-import { getMessagingProvider } from "../../../../messaging/registry.js";
-import { withValidToken } from "../../../../security/token-manager.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -22,48 +21,43 @@ export async function run(
   }
 
   try {
-    const provider = getMessagingProvider("gmail");
-    return await withValidToken(provider.credentialService, async (token) => {
-      switch (action) {
-        case "get": {
-          const settings = await getVacation(token);
-          return ok(JSON.stringify(settings, null, 2));
-        }
-
-        case "enable": {
-          const message = input.message as string;
-          if (!message)
-            return err("message is required when enabling vacation responder.");
-
-          const settings: GmailVacationSettings = {
-            enableAutoReply: true,
-            responseSubject: (input.subject as string) ?? "Out of Office",
-            responseBodyPlainText: message,
-            restrictToContacts:
-              (input.restrict_to_contacts as boolean) ?? false,
-            restrictToDomain: (input.restrict_to_domain as boolean) ?? false,
-          };
-
-          if (input.start_time) settings.startTime = String(input.start_time);
-          if (input.end_time) settings.endTime = String(input.end_time);
-
-          const updated = await updateVacation(token, settings);
-          return ok(
-            `Vacation responder enabled.\n${JSON.stringify(updated, null, 2)}`,
-          );
-        }
-
-        case "disable": {
-          await updateVacation(token, { enableAutoReply: false });
-          return ok("Vacation responder disabled.");
-        }
-
-        default:
-          return err(
-            `Unknown action "${action}". Use get, enable, or disable.`,
-          );
+    const connection = resolveOAuthConnection("integration:gmail");
+    switch (action) {
+      case "get": {
+        const settings = await getVacation(connection);
+        return ok(JSON.stringify(settings, null, 2));
       }
-    });
+
+      case "enable": {
+        const message = input.message as string;
+        if (!message)
+          return err("message is required when enabling vacation responder.");
+
+        const settings: GmailVacationSettings = {
+          enableAutoReply: true,
+          responseSubject: (input.subject as string) ?? "Out of Office",
+          responseBodyPlainText: message,
+          restrictToContacts: (input.restrict_to_contacts as boolean) ?? false,
+          restrictToDomain: (input.restrict_to_domain as boolean) ?? false,
+        };
+
+        if (input.start_time) settings.startTime = String(input.start_time);
+        if (input.end_time) settings.endTime = String(input.end_time);
+
+        const updated = await updateVacation(connection, settings);
+        return ok(
+          `Vacation responder enabled.\n${JSON.stringify(updated, null, 2)}`,
+        );
+      }
+
+      case "disable": {
+        await updateVacation(connection, { enableAutoReply: false });
+        return ok("Vacation responder disabled.");
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use get, enable, or disable.`);
+    }
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -9,9 +9,11 @@
 import {
   batchGetMessages,
   getProfile,
+  listMessages,
 } from "../../messaging/providers/gmail/client.js";
 import type { GmailMessage } from "../../messaging/providers/gmail/types.js";
-import { withValidToken } from "../../security/token-manager.js";
+import type { OAuthConnection } from "../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   FetchResult,
@@ -20,8 +22,6 @@ import type {
 } from "../provider-types.js";
 
 const log = getLogger("watcher:gmail");
-
-const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 
 /** Gmail History API response types */
 interface HistoryMessage {
@@ -71,29 +71,38 @@ function messageToItem(msg: GmailMessage): WatcherItem {
 }
 
 async function fetchHistory(
-  token: string,
+  connection: OAuthConnection,
   startHistoryId: string,
 ): Promise<HistoryListResponse> {
-  const params = new URLSearchParams({
+  const query: Record<string, string> = {
     startHistoryId,
     historyTypes: "messageAdded",
     maxResults: "100",
-  });
-  const url = `${GMAIL_API_BASE}/history?${params}`;
-  const resp = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
+  };
+
+  const resp = await connection.request({
+    method: "GET",
+    path: "/history",
+    query,
   });
 
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => "");
-    if (resp.status === 404) {
-      // historyId expired — caller handles fallback
-      throw new HistoryExpiredError(body);
-    }
+  if (resp.status === 404) {
+    const body =
+      typeof resp.body === "string"
+        ? resp.body
+        : JSON.stringify(resp.body ?? "");
+    throw new HistoryExpiredError(body);
+  }
+
+  if (resp.status < 200 || resp.status >= 300) {
+    const body =
+      typeof resp.body === "string"
+        ? resp.body
+        : JSON.stringify(resp.body ?? "");
     throw new Error(`Gmail History API ${resp.status}: ${body}`);
   }
 
-  return resp.json() as Promise<HistoryListResponse>;
+  return resp.body as HistoryListResponse;
 }
 
 class HistoryExpiredError extends Error {
@@ -109,13 +118,12 @@ export const gmailProvider: WatcherProvider = {
   requiredCredentialService: "integration:gmail",
 
   async getInitialWatermark(credentialService: string): Promise<string> {
-    return withValidToken(credentialService, async (token) => {
-      const profile = await getProfile(token);
-      if (!profile.historyId) {
-        throw new Error("Gmail profile did not return a historyId");
-      }
-      return profile.historyId;
-    });
+    const connection = resolveOAuthConnection(credentialService);
+    const profile = await getProfile(connection);
+    if (!profile.historyId) {
+      throw new Error("Gmail profile did not return a historyId");
+    }
+    return profile.historyId;
   },
 
   async fetchNew(
@@ -124,76 +132,76 @@ export const gmailProvider: WatcherProvider = {
     _config: Record<string, unknown>,
     _watcherKey: string,
   ): Promise<FetchResult> {
-    return withValidToken(credentialService, async (token) => {
-      if (!watermark) {
-        // No watermark — get initial position, return no items
-        const profile = await getProfile(token);
-        return { items: [], watermark: profile.historyId ?? "0" };
+    const connection = resolveOAuthConnection(credentialService);
+
+    if (!watermark) {
+      // No watermark — get initial position, return no items
+      const profile = await getProfile(connection);
+      return { items: [], watermark: profile.historyId ?? "0" };
+    }
+
+    try {
+      const historyResp = await fetchHistory(connection, watermark);
+      const newWatermark = historyResp.historyId ?? watermark;
+
+      if (!historyResp.history || historyResp.history.length === 0) {
+        return { items: [], watermark: newWatermark };
       }
 
-      try {
-        const historyResp = await fetchHistory(token, watermark);
-        const newWatermark = historyResp.historyId ?? watermark;
-
-        if (!historyResp.history || historyResp.history.length === 0) {
-          return { items: [], watermark: newWatermark };
-        }
-
-        // Collect unique new message IDs
-        const messageIds = new Set<string>();
-        for (const record of historyResp.history) {
-          if (record.messagesAdded) {
-            for (const added of record.messagesAdded) {
-              messageIds.add(added.message.id);
-            }
+      // Collect unique new message IDs
+      const messageIds = new Set<string>();
+      for (const record of historyResp.history) {
+        if (record.messagesAdded) {
+          for (const added of record.messagesAdded) {
+            messageIds.add(added.message.id);
           }
         }
-
-        if (messageIds.size === 0) {
-          return { items: [], watermark: newWatermark };
-        }
-
-        // Fetch metadata for new messages
-        const messages = await batchGetMessages(
-          token,
-          Array.from(messageIds),
-          "metadata",
-          ["From", "Subject", "Date"],
-        );
-
-        // Only include INBOX messages (skip sent, drafts, etc.)
-        const inboxMessages = messages.filter((m) =>
-          m.labelIds?.includes("INBOX"),
-        );
-
-        const items = inboxMessages.map(messageToItem);
-        log.info(
-          { count: items.length, watermark: newWatermark },
-          "Gmail: fetched new messages",
-        );
-
-        return { items, watermark: newWatermark };
-      } catch (err) {
-        if (err instanceof HistoryExpiredError) {
-          log.warn(
-            "Gmail historyId expired, falling back to recent unread messages",
-          );
-          return fallbackFetch(token);
-        }
-        throw err;
       }
-    });
+
+      if (messageIds.size === 0) {
+        return { items: [], watermark: newWatermark };
+      }
+
+      // Fetch metadata for new messages
+      const messages = await batchGetMessages(
+        connection,
+        Array.from(messageIds),
+        "metadata",
+        ["From", "Subject", "Date"],
+      );
+
+      // Only include INBOX messages (skip sent, drafts, etc.)
+      const inboxMessages = messages.filter((m) =>
+        m.labelIds?.includes("INBOX"),
+      );
+
+      const items = inboxMessages.map(messageToItem);
+      log.info(
+        { count: items.length, watermark: newWatermark },
+        "Gmail: fetched new messages",
+      );
+
+      return { items, watermark: newWatermark };
+    } catch (err) {
+      if (err instanceof HistoryExpiredError) {
+        log.warn(
+          "Gmail historyId expired, falling back to recent unread messages",
+        );
+        return fallbackFetch(connection);
+      }
+      throw err;
+    }
   },
 };
 
 /**
  * Fallback when historyId expires: list recent unread inbox messages.
  */
-async function fallbackFetch(token: string): Promise<FetchResult> {
-  const { listMessages } =
-    await import("../../messaging/providers/gmail/client.js");
+async function fallbackFetch(
+  connection: OAuthConnection,
+): Promise<FetchResult> {
   const listResp = await listMessages(
-    token,
+    connection,
     "is:unread newer_than:1d",
     20,
     undefined,
@@ -201,12 +209,12 @@ async function fallbackFetch(token: string): Promise<FetchResult> {
   );
 
   if (!listResp.messages || listResp.messages.length === 0) {
-    const profile = await getProfile(token);
+    const profile = await getProfile(connection);
     return { items: [], watermark: profile.historyId ?? "0" };
   }
 
   const messages = await batchGetMessages(
-    token,
+    connection,
     listResp.messages.map((m) => m.id),
     "metadata",
     ["From", "Subject", "Date"],
@@ -215,6 +223,6 @@ async function fallbackFetch(token: string): Promise<FetchResult> {
   const items = messages.map(messageToItem);
 
   // Get fresh historyId for the new watermark
-  const profile = await getProfile(token);
+  const profile = await getProfile(connection);
   return { items, watermark: profile.historyId ?? "0" };
 }


### PR DESCRIPTION
## Summary
- Replace withValidToken + string token pattern with resolveOAuthConnection in all 13 Gmail tool files
- Migrate contacts tool to use OAuthConnection (People API uses per-request baseUrl override)
- Refactor Gmail watcher to use OAuthConnection including local fetchHistory function

Part of plan: oauth-conn-request.md (PR 6 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
