### PR TITLE
Refactor MessagingProvider adapters and tools to use OAuthConnection

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { MessagingProvider } from "../messaging/provider.js";
 import type { SendOptions } from "../messaging/provider-types.js";
+import type { OAuthConnection } from "../oauth/connection.js";
 
 const sendMessageMock = mock(async (..._args: unknown[]) => ({
   id: "msg-1",
@@ -23,19 +24,16 @@ const provider: MessagingProvider = {
   getHistory: async () => [],
   search: async () => ({ total: 0, messages: [], hasMore: false }),
   sendMessage: (
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     options?: SendOptions,
-  ) => sendMessageMock(token, conversationId, text, options),
+  ) => sendMessageMock(connectionOrToken, conversationId, text, options),
 };
 
 mock.module("../config/bundled-skills/messaging/tools/shared.js", () => ({
   resolveProvider: () => provider,
-  withProviderToken: async (
-    _provider: MessagingProvider,
-    fn: (token: string) => Promise<unknown>,
-  ) => fn("provider-token"),
+  getProviderConnection: () => "provider-token",
   ok: (content: string) => ({ content, isError: false }),
   err: (content: string) => ({ content, isError: true }),
   extractHeader: () => "",

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -12,7 +12,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import { truncate } from "../../../../util/truncate.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 function upsertMemoryItem(opts: {
   kind: string;
@@ -91,76 +91,75 @@ export async function run(
 
   try {
     const provider = resolveProvider(platform);
-    return withProviderToken(provider, async (token) => {
-      // Search for sent messages using the platform's search
-      const query =
-        queryFilter ?? (provider.id === "gmail" ? "in:sent" : "from:me");
-      const searchResult = await provider.search(token, query, {
-        count: maxMessages,
-      });
-
-      if (searchResult.messages.length === 0) {
-        return err(
-          "No sent messages found. Send some messages first, then try again.",
-        );
-      }
-
-      const result = await extractStylePatterns(searchResult.messages);
-
-      if (result.stylePatterns.length === 0) {
-        return err("No style patterns were extracted. Try with more messages.");
-      }
-
-      const scopeId = context.memoryScopeId ?? "default";
-      let savedCount = 0;
-
-      for (const pattern of result.stylePatterns) {
-        const subject = `${provider.id} writing style: ${pattern.aspect}`;
-        const importance = clampUnitInterval(
-          Math.min(0.85, Math.max(0.55, pattern.importance ?? 0.65)),
-        );
-        upsertMemoryItem({
-          kind: "style",
-          subject,
-          statement: pattern.summary,
-          importance,
-          scopeId,
-        });
-        savedCount++;
-      }
-
-      for (const contact of result.contactObservations) {
-        if (!contact.name || !contact.toneNote) continue;
-        const subject = `${provider.id} relationship: ${contact.name}`;
-        upsertMemoryItem({
-          kind: "relationship",
-          subject,
-          statement: truncate(
-            `${contact.name} (${contact.email}): ${contact.toneNote}`,
-            500,
-            "",
-          ),
-          importance: 0.6,
-          scopeId,
-        });
-        savedCount++;
-      }
-
-      const aspects = result.stylePatterns.map((p) => p.aspect).join(", ");
-      const contactCount = result.contactObservations.length;
-      const summary = [
-        `Analyzed ${searchResult.messages.length} messages on ${provider.displayName}.`,
-        `Extracted ${result.stylePatterns.length} style patterns (${aspects}).`,
-        contactCount > 0
-          ? `Noted ${contactCount} recurring contact relationship(s).`
-          : "",
-        `Saved ${savedCount} memory items. Future drafts will automatically reflect your writing style.`,
-      ]
-        .filter(Boolean)
-        .join(" ");
-
-      return ok(summary);
+    const conn = getProviderConnection(provider);
+    // Search for sent messages using the platform's search
+    const query =
+      queryFilter ?? (provider.id === "gmail" ? "in:sent" : "from:me");
+    const searchResult = await provider.search(conn, query, {
+      count: maxMessages,
     });
+
+    if (searchResult.messages.length === 0) {
+      return err(
+        "No sent messages found. Send some messages first, then try again.",
+      );
+    }
+
+    const result = await extractStylePatterns(searchResult.messages);
+
+    if (result.stylePatterns.length === 0) {
+      return err("No style patterns were extracted. Try with more messages.");
+    }
+
+    const scopeId = context.memoryScopeId ?? "default";
+    let savedCount = 0;
+
+    for (const pattern of result.stylePatterns) {
+      const subject = `${provider.id} writing style: ${pattern.aspect}`;
+      const importance = clampUnitInterval(
+        Math.min(0.85, Math.max(0.55, pattern.importance ?? 0.65)),
+      );
+      upsertMemoryItem({
+        kind: "style",
+        subject,
+        statement: pattern.summary,
+        importance,
+        scopeId,
+      });
+      savedCount++;
+    }
+
+    for (const contact of result.contactObservations) {
+      if (!contact.name || !contact.toneNote) continue;
+      const subject = `${provider.id} relationship: ${contact.name}`;
+      upsertMemoryItem({
+        kind: "relationship",
+        subject,
+        statement: truncate(
+          `${contact.name} (${contact.email}): ${contact.toneNote}`,
+          500,
+          "",
+        ),
+        importance: 0.6,
+        scopeId,
+      });
+      savedCount++;
+    }
+
+    const aspects = result.stylePatterns.map((p) => p.aspect).join(", ");
+    const contactCount = result.contactObservations.length;
+    const summary = [
+      `Analyzed ${searchResult.messages.length} messages on ${provider.displayName}.`,
+      `Extracted ${result.stylePatterns.length} style patterns (${aspects}).`,
+      contactCount > 0
+        ? `Noted ${contactCount} recurring contact relationship(s).`
+        : "",
+      `Saved ${savedCount} memory items. Future drafts will automatically reflect your writing style.`,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return ok(summary);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -30,21 +30,20 @@ export async function run(
       );
     }
 
-    return withProviderToken(provider, async (token) => {
-      const result = await provider.archiveByQuery!(token, query);
+    const conn = getProviderConnection(provider);
+    const result = await provider.archiveByQuery!(conn, query);
 
-      if (result.archived === 0) {
-        return ok("No messages matched the query. Nothing archived.");
-      }
+    if (result.archived === 0) {
+      return ok("No messages matched the query. Nothing archived.");
+    }
 
-      const summary = `Archived ${result.archived} message(s) matching query: ${query}`;
-      if (result.truncated) {
-        return ok(
-          `${summary}\n\nNote: this operation was capped at 5000 messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,
-        );
-      }
-      return ok(summary);
-    });
+    const summary = `Archived ${result.archived} message(s) matching query: ${query}`;
+    if (result.truncated) {
+      return ok(
+        `${summary}\n\nNote: this operation was capped at 5000 messages. Additional messages matching the query may remain in the inbox. Run the command again to archive more.`,
+      );
+    }
+    return ok(summary);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-auth-test.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-auth-test.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -12,10 +12,9 @@ export async function run(
 
   try {
     const provider = resolveProvider(platform);
-    return withProviderToken(provider, async (token) => {
-      const info = await provider.testConnection(token);
-      return ok(JSON.stringify(info, null, 2));
-    });
+    const conn = getProviderConnection(provider);
+    const info = await provider.testConnection(conn);
+    return ok(JSON.stringify(info, null, 2));
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-list-conversations.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-list-conversations.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -14,13 +14,12 @@ export async function run(
 
   try {
     const provider = resolveProvider(platform);
-    return withProviderToken(provider, async (token) => {
-      const conversations = await provider.listConversations(token, {
-        types: types as Array<"channel" | "dm" | "group" | "inbox"> | undefined,
-        limit,
-      });
-      return ok(JSON.stringify(conversations, null, 2));
+    const conn = getProviderConnection(provider);
+    const conversations = await provider.listConversations(conn, {
+      types: types as Array<"channel" | "dm" | "group" | "inbox"> | undefined,
+      limit,
     });
+    return ok(JSON.stringify(conversations, null, 2));
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -23,10 +23,9 @@ export async function run(
         `${provider.displayName} does not support marking messages as read.`,
       );
     }
-    return withProviderToken(provider, async (token) => {
-      await provider.markRead!(token, conversationId, messageId);
-      return ok("Marked as read.");
-    });
+    const conn = getProviderConnection(provider);
+    await provider.markRead(conn, conversationId, messageId);
+    return ok("Marked as read.");
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -19,20 +19,19 @@ export async function run(
 
   try {
     const provider = resolveProvider(platform);
-    return withProviderToken(provider, async (token) => {
-      let messages;
-      if (threadId && provider.getThreadReplies) {
-        messages = await provider.getThreadReplies(
-          token,
-          conversationId,
-          threadId,
-          { limit },
-        );
-      } else {
-        messages = await provider.getHistory(token, conversationId, { limit });
-      }
-      return ok(JSON.stringify(messages, null, 2));
-    });
+    const conn = getProviderConnection(provider);
+    let messages;
+    if (threadId && provider.getThreadReplies) {
+      messages = await provider.getThreadReplies(
+        conn,
+        conversationId,
+        threadId,
+        { limit },
+      );
+    } else {
+      messages = await provider.getHistory(conn, conversationId, { limit });
+    }
+    return ok(JSON.stringify(messages, null, 2));
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -18,10 +18,9 @@ export async function run(
 
   try {
     const provider = resolveProvider(platform);
-    return withProviderToken(provider, async (token) => {
-      const result = await provider.search(token, query, { count: maxResults });
-      return ok(JSON.stringify(result, null, 2));
-    });
+    const conn = getProviderConnection(provider);
+    const result = await provider.search(conn, query, { count: maxResults });
+    return ok(JSON.stringify(result, null, 2));
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -18,10 +18,10 @@ import {
   err,
   extractEmail,
   extractHeader,
+  getProviderConnection,
   ok,
   parseAddressList,
   resolveProvider,
-  withProviderToken,
 } from "./shared.js";
 
 export async function run(
@@ -51,115 +51,65 @@ export async function run(
       return err("Attachments are only supported on Gmail.");
     }
 
+    const conn = getProviderConnection(provider);
+
     // Gmail: create a draft instead of sending directly
     if (provider.id === "gmail") {
-      return withProviderToken(provider, async (token) => {
-        // Reply mode: thread_id provided — create a threaded draft with reply-all recipients
-        if (threadId) {
-          // Fetch thread messages to extract recipients and threading headers
-          const list = await listMessages(token, `thread:${threadId}`, 10);
-          if (!list.messages?.length) {
-            return err("No messages found in this thread.");
-          }
-
-          const messages = await batchGetMessages(
-            token,
-            list.messages.map((m) => m.id),
-            "metadata",
-            ["From", "To", "Cc", "Message-ID", "Subject"],
-          );
-
-          // Use the latest message for threading and recipient extraction
-          const latest = messages[messages.length - 1];
-          const latestHeaders = latest.payload?.headers ?? [];
-
-          const messageIdHeader = extractHeader(latestHeaders, "Message-ID");
-          let replySubject = extractHeader(latestHeaders, "Subject");
-          if (replySubject && !replySubject.startsWith("Re:")) {
-            replySubject = `Re: ${replySubject}`;
-          }
-
-          // Build reply-all recipient list, excluding the user's own email
-          const profile = await getProfile(token);
-          const userEmail = profile.emailAddress.toLowerCase();
-
-          const allRecipients = new Set<string>();
-          const allCc = new Set<string>();
-
-          // From the latest message: From goes to To, original To/Cc go to Cc
-          const fromAddr = extractHeader(latestHeaders, "From");
-          const toAddrs = extractHeader(latestHeaders, "To");
-          const ccAddrs = extractHeader(latestHeaders, "Cc");
-
-          if (fromAddr) allRecipients.add(fromAddr);
-          for (const addr of parseAddressList(toAddrs)) {
-            allRecipients.add(addr);
-          }
-          for (const addr of parseAddressList(ccAddrs)) {
-            allCc.add(addr);
-          }
-
-          // Remove user's own email from recipients using exact email comparison
-          const filterSelf = (addr: string) => extractEmail(addr) !== userEmail;
-          const toList = [...allRecipients].filter(filterSelf);
-          const ccList = [...allCc].filter(filterSelf);
-
-          if (toList.length === 0) {
-            return err("Could not determine reply recipients from thread.");
-          }
-
-          // With attachments: build multipart MIME for threaded reply
-          if (attachmentPaths?.length) {
-            const attachments = await Promise.all(
-              attachmentPaths.map(async (filePath) => {
-                const data = await readFile(filePath);
-                const filename = basename(filePath);
-                const mimeType = guessMimeType(filePath);
-                return { filename, mimeType, data };
-              }),
-            );
-
-            const raw = buildMultipartMime({
-              to: toList.join(", "),
-              subject: replySubject,
-              body: text,
-              inReplyTo: messageIdHeader || undefined,
-              cc: ccList.length > 0 ? ccList.join(", ") : undefined,
-              attachments,
-            });
-            const draft = await createDraftRaw(token, raw, threadId);
-
-            const filenames = attachments.map((a) => a.filename).join(", ");
-            const recipientSummary =
-              ccList.length > 0
-                ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
-                : `To: ${toList.join(", ")}`;
-            return ok(
-              `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
-            );
-          }
-
-          const draft = await createDraft(
-            token,
-            toList.join(", "),
-            replySubject,
-            text,
-            messageIdHeader || undefined,
-            ccList.length > 0 ? ccList.join(", ") : undefined,
-            undefined,
-            threadId,
-          );
-
-          const recipientSummary =
-            ccList.length > 0
-              ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
-              : `To: ${toList.join(", ")}`;
-          return ok(
-            `Gmail draft created (ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
-          );
+      // Reply mode: thread_id provided — create a threaded draft with reply-all recipients
+      if (threadId) {
+        // Fetch thread messages to extract recipients and threading headers
+        const list = await listMessages(conn, `thread:${threadId}`, 10);
+        if (!list.messages?.length) {
+          return err("No messages found in this thread.");
         }
 
-        // With attachments: build multipart MIME and use createDraftRaw
+        const messages = await batchGetMessages(
+          conn,
+          list.messages.map((m) => m.id),
+          "metadata",
+          ["From", "To", "Cc", "Message-ID", "Subject"],
+        );
+
+        // Use the latest message for threading and recipient extraction
+        const latest = messages[messages.length - 1];
+        const latestHeaders = latest.payload?.headers ?? [];
+
+        const messageIdHeader = extractHeader(latestHeaders, "Message-ID");
+        let replySubject = extractHeader(latestHeaders, "Subject");
+        if (replySubject && !replySubject.startsWith("Re:")) {
+          replySubject = `Re: ${replySubject}`;
+        }
+
+        // Build reply-all recipient list, excluding the user's own email
+        const profile = await getProfile(conn);
+        const userEmail = profile.emailAddress.toLowerCase();
+
+        const allRecipients = new Set<string>();
+        const allCc = new Set<string>();
+
+        // From the latest message: From goes to To, original To/Cc go to Cc
+        const fromAddr = extractHeader(latestHeaders, "From");
+        const toAddrs = extractHeader(latestHeaders, "To");
+        const ccAddrs = extractHeader(latestHeaders, "Cc");
+
+        if (fromAddr) allRecipients.add(fromAddr);
+        for (const addr of parseAddressList(toAddrs)) {
+          allRecipients.add(addr);
+        }
+        for (const addr of parseAddressList(ccAddrs)) {
+          allCc.add(addr);
+        }
+
+        // Remove user's own email from recipients using exact email comparison
+        const filterSelf = (addr: string) => extractEmail(addr) !== userEmail;
+        const toList = [...allRecipients].filter(filterSelf);
+        const ccList = [...allCc].filter(filterSelf);
+
+        if (toList.length === 0) {
+          return err("Could not determine reply recipients from thread.");
+        }
+
+        // With attachments: build multipart MIME for threaded reply
         if (attachmentPaths?.length) {
           const attachments = await Promise.all(
             attachmentPaths.map(async (filePath) => {
@@ -171,51 +121,99 @@ export async function run(
           );
 
           const raw = buildMultipartMime({
-            to: conversationId,
-            subject: subject ?? "",
+            to: toList.join(", "),
+            subject: replySubject,
             body: text,
-            inReplyTo,
+            inReplyTo: messageIdHeader || undefined,
+            cc: ccList.length > 0 ? ccList.join(", ") : undefined,
             attachments,
           });
-          const draft = await createDraftRaw(token, raw, threadId);
+          const draft = await createDraftRaw(conn, raw, threadId);
 
           const filenames = attachments.map((a) => a.filename).join(", ");
+          const recipientSummary =
+            ccList.length > 0
+              ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
+              : `To: ${toList.join(", ")}`;
           return ok(
-            `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+            `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
           );
         }
 
-        // Without attachments: use standard createDraft
         const draft = await createDraft(
-          token,
-          conversationId,
-          subject ?? "",
+          conn,
+          toList.join(", "),
+          replySubject,
           text,
-          inReplyTo,
-          undefined,
+          messageIdHeader || undefined,
+          ccList.length > 0 ? ccList.join(", ") : undefined,
           undefined,
           threadId,
         );
+
+        const recipientSummary =
+          ccList.length > 0
+            ? `To: ${toList.join(", ")}; Cc: ${ccList.join(", ")}`
+            : `To: ${toList.join(", ")}`;
         return ok(
-          `Gmail draft created (ID: ${draft.id}). Review it in your Gmail Drafts, then tell me to send it or send it yourself from Gmail.`,
+          `Gmail draft created (ID: ${draft.id}). ${recipientSummary}. Review in Gmail Drafts, then tell me to send it or send it yourself.`,
         );
-      });
+      }
+
+      // With attachments: build multipart MIME and use createDraftRaw
+      if (attachmentPaths?.length) {
+        const attachments = await Promise.all(
+          attachmentPaths.map(async (filePath) => {
+            const data = await readFile(filePath);
+            const filename = basename(filePath);
+            const mimeType = guessMimeType(filePath);
+            return { filename, mimeType, data };
+          }),
+        );
+
+        const raw = buildMultipartMime({
+          to: conversationId,
+          subject: subject ?? "",
+          body: text,
+          inReplyTo,
+          attachments,
+        });
+        const draft = await createDraftRaw(conn, raw, threadId);
+
+        const filenames = attachments.map((a) => a.filename).join(", ");
+        return ok(
+          `Gmail draft created with ${attachments.length} attachment(s): ${filenames} (Draft ID: ${draft.id}). Review in Gmail Drafts, then tell me to send it or send it yourself.`,
+        );
+      }
+
+      // Without attachments: use standard createDraft
+      const draft = await createDraft(
+        conn,
+        conversationId,
+        subject ?? "",
+        text,
+        inReplyTo,
+        undefined,
+        undefined,
+        threadId,
+      );
+      return ok(
+        `Gmail draft created (ID: ${draft.id}). Review it in your Gmail Drafts, then tell me to send it or send it yourself from Gmail.`,
+      );
     }
 
     // Non-Gmail platforms
-    return withProviderToken(provider, async (token) => {
-      const result = await provider.sendMessage(token, conversationId, text, {
-        subject,
-        inReplyTo,
-        threadId,
-        assistantId: context.assistantId,
-      });
-
-      const threadSuffix = result.threadId
-        ? `, "thread_id": "${result.threadId}"`
-        : "";
-      return ok(`Message sent (ID: ${result.id}${threadSuffix}).`);
+    const result = await provider.sendMessage(conn, conversationId, text, {
+      subject,
+      inReplyTo,
+      threadId,
+      assistantId: context.assistantId,
     });
+
+    const threadSuffix = result.threadId
+      ? `, "thread_id": "${result.threadId}"`
+      : "";
+    return ok(`Message sent (ID: ${result.id}${threadSuffix}).`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -2,7 +2,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { err, ok, resolveProvider, withProviderToken } from "./shared.js";
+import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -23,47 +23,46 @@ export async function run(
       );
     }
 
-    return withProviderToken(provider, async (token) => {
-      const result = await provider.senderDigest!(token, query, {
-        maxMessages,
-        maxSenders,
-        pageToken,
-      });
+    const conn = getProviderConnection(provider);
+    const result = await provider.senderDigest!(conn, query, {
+      maxMessages,
+      maxSenders,
+      pageToken,
+    });
 
-      if (result.senders.length === 0) {
-        return ok(
-          JSON.stringify({
-            senders: [],
-            total_scanned: result.totalScanned,
-            query_used: result.queryUsed,
-            ...(result.truncated ? { truncated: true } : {}),
-            message:
-              "No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).",
-          }),
-        );
-      }
-
-      // Map to snake_case output format for LLM consumption
-      const senders = result.senders.map((s) => ({
-        id: s.id,
-        display_name: s.displayName,
-        email: s.email,
-        message_count: s.messageCount,
-        has_unsubscribe: s.hasUnsubscribe,
-        newest_message_id: s.newestMessageId,
-        search_query: s.searchQuery,
-      }));
-
+    if (result.senders.length === 0) {
       return ok(
         JSON.stringify({
-          senders,
+          senders: [],
           total_scanned: result.totalScanned,
           query_used: result.queryUsed,
           ...(result.truncated ? { truncated: true } : {}),
-          note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use messaging_archive_by_sender with the sender's search_query to archive their messages.`,
+          message:
+            "No emails found matching the query. Try broadening the search (e.g. remove category filter or extend date range).",
         }),
       );
-    });
+    }
+
+    // Map to snake_case output format for LLM consumption
+    const senders = result.senders.map((s) => ({
+      id: s.id,
+      display_name: s.displayName,
+      email: s.email,
+      message_count: s.messageCount,
+      has_unsubscribe: s.hasUnsubscribe,
+      newest_message_id: s.newestMessageId,
+      search_query: s.searchQuery,
+    }));
+
+    return ok(
+      JSON.stringify({
+        senders,
+        total_scanned: result.totalScanned,
+        query_used: result.queryUsed,
+        ...(result.truncated ? { truncated: true } : {}),
+        note: `message_count reflects emails found per sender within the ${result.totalScanned} messages scanned. Use messaging_archive_by_sender with the sender's search_query to archive their messages.`,
+      }),
+    );
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -8,6 +8,8 @@ import {
   getMessagingProvider,
   isPlatformEnabled,
 } from "../../../../messaging/registry.js";
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
 import { withValidToken } from "../../../../security/token-manager.js";
 import type { ToolExecutionResult } from "../../../../tools/types.js";
 
@@ -126,9 +128,25 @@ export function resolveProvider(platformInput?: string): MessagingProvider {
 }
 
 /**
+ * Resolve an OAuthConnection (or empty string for non-OAuth providers)
+ * for the given messaging provider.
+ *
+ * Non-OAuth providers (e.g. Telegram) use isConnected() and don't need
+ * tokens — they receive an empty string which the string overload handles.
+ */
+export function getProviderConnection(
+  provider: MessagingProvider,
+): OAuthConnection | string {
+  if (provider.isConnected?.()) return "";
+  return resolveOAuthConnection(provider.credentialService);
+}
+
+/**
  * Execute a callback with a valid OAuth token for the given provider.
  * Providers that manage their own auth (e.g. Telegram with a bot token)
  * expose isConnected() and don't need an OAuth access_token lookup.
+ *
+ * @deprecated Prefer getProviderConnection() and passing the connection directly.
  */
 export async function withProviderToken<T>(
   provider: MessagingProvider,

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -5,6 +5,7 @@
  * implementing one adapter file + an OAuth setup skill.
  */
 
+import type { OAuthConnection } from "../oauth/connection.js";
 import type {
   ArchiveResult,
   ConnectionInfo,
@@ -29,23 +30,25 @@ export interface MessagingProvider {
 
   // ── Universal operations (every platform must implement) ──────────
 
-  testConnection(token: string): Promise<ConnectionInfo>;
+  testConnection(
+    connectionOrToken: OAuthConnection | string,
+  ): Promise<ConnectionInfo>;
   listConversations(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     options?: ListOptions,
   ): Promise<Conversation[]>;
   getHistory(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]>;
   search(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult>;
   sendMessage(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     options?: SendOptions,
@@ -54,25 +57,28 @@ export interface MessagingProvider {
   // ── Optional operations (platforms implement what they support) ───
 
   getThreadReplies?(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]>;
   markRead?(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     messageId?: string,
   ): Promise<void>;
 
   /** Scan messages and group by sender for bulk cleanup (e.g. newsletter decluttering). */
   senderDigest?(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     query: string,
     options?: { maxMessages?: number; maxSenders?: number; pageToken?: string },
   ): Promise<SenderDigestResult>;
   /** Archive messages matching a search query. */
-  archiveByQuery?(token: string, query: string): Promise<ArchiveResult>;
+  archiveByQuery?(
+    connectionOrToken: OAuthConnection | string,
+    query: string,
+  ): Promise<ArchiveResult>;
 
   /**
    * Override the default credential check used by getConnectedProviders().

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -5,6 +5,7 @@
  * and implements the MessagingProvider interface.
  */
 
+import type { OAuthConnection } from "../../../oauth/connection.js";
 import type { MessagingProvider } from "../../provider.js";
 import type {
   ArchiveResult,
@@ -94,8 +95,10 @@ export const gmailMessagingProvider: MessagingProvider = {
     "unsubscribe",
   ]),
 
-  async testConnection(token: string): Promise<ConnectionInfo> {
-    const profile = await gmail.getProfile(token);
+  async testConnection(
+    connectionOrToken: OAuthConnection | string,
+  ): Promise<ConnectionInfo> {
+    const profile = await gmail.getProfile(connectionOrToken);
     return {
       connected: true,
       user: profile.emailAddress,
@@ -108,11 +111,11 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async listConversations(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
     // Gmail "conversations" are modeled as labels with unread counts
-    const labels = await gmail.listLabels(token);
+    const labels = await gmail.listLabels(connectionOrToken);
     const conversations: Conversation[] = [];
 
     for (const label of labels) {
@@ -151,14 +154,14 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async getHistory(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
     // conversationId is a label ID — list messages in that label
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      token,
+      connectionOrToken,
       undefined,
       limit,
       undefined,
@@ -168,7 +171,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      token,
+      connectionOrToken,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -177,19 +180,23 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async search(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
     const count = options?.count ?? 20;
-    const listResult = await gmail.listMessages(token, query, count);
+    const listResult = await gmail.listMessages(
+      connectionOrToken,
+      query,
+      count,
+    );
 
     if (!listResult.messages?.length) {
       return { total: 0, messages: [], hasMore: false };
     }
 
     const messages = await gmail.batchGetMessages(
-      token,
+      connectionOrToken,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -203,7 +210,7 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     options?: SendOptions,
@@ -212,7 +219,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     const to = conversationId;
     const subject = options?.subject ?? "";
     const msg = await gmail.sendMessage(
-      token,
+      connectionOrToken,
       to,
       subject,
       text,
@@ -228,7 +235,7 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async getThreadReplies(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     _conversationId: string,
     threadId: string,
     options?: HistoryOptions,
@@ -236,7 +243,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     // Get all messages in a Gmail thread
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      token,
+      connectionOrToken,
       `thread:${threadId}`,
       limit,
     );
@@ -244,7 +251,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      token,
+      connectionOrToken,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -253,16 +260,18 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async markRead(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     _conversationId: string,
     messageId?: string,
   ): Promise<void> {
     if (!messageId) return;
-    await gmail.modifyMessage(token, messageId, { removeLabelIds: ["UNREAD"] });
+    await gmail.modifyMessage(connectionOrToken, messageId, {
+      removeLabelIds: ["UNREAD"],
+    });
   },
 
   async senderDigest(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     query: string,
     options?: { maxMessages?: number; maxSenders?: number; pageToken?: string },
   ): Promise<SenderDigestResult> {
@@ -285,7 +294,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
       const listResp = await gmail.listMessages(
-        token,
+        connectionOrToken,
         query,
         pageSize,
         pageToken,
@@ -295,7 +304,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       allMessageIds.push(...ids);
       fetchPromises.push(
         gmail.batchGetMessages(
-          token,
+          connectionOrToken,
           ids,
           "metadata",
           metadataHeaders,
@@ -409,7 +418,10 @@ export const gmailMessagingProvider: MessagingProvider = {
     };
   },
 
-  async archiveByQuery(token: string, query: string): Promise<ArchiveResult> {
+  async archiveByQuery(
+    connectionOrToken: OAuthConnection | string,
+    query: string,
+  ): Promise<ArchiveResult> {
     const maxMessages = 5000;
     const batchModifyLimit = 1000;
 
@@ -419,7 +431,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     while (allMessageIds.length < maxMessages) {
       const listResp = await gmail.listMessages(
-        token,
+        connectionOrToken,
         query,
         Math.min(500, maxMessages - allMessageIds.length),
         pageToken,
@@ -441,7 +453,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     for (let i = 0; i < allMessageIds.length; i += batchModifyLimit) {
       const chunk = allMessageIds.slice(i, i + batchModifyLimit);
-      await gmail.batchModifyMessages(token, chunk, {
+      await gmail.batchModifyMessages(connectionOrToken, chunk, {
         removeLabelIds: ["INBOX"],
       });
     }

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -5,6 +5,7 @@
  * and implements the MessagingProvider interface.
  */
 
+import type { OAuthConnection } from "../../../oauth/connection.js";
 import type { MessagingProvider } from "../../provider.js";
 import type {
   ConnectionInfo,
@@ -27,13 +28,16 @@ import type {
 // Cache user display names to avoid repeated API calls within a session
 const userNameCache = new Map<string, string>();
 
-async function resolveUserName(token: string, userId: string): Promise<string> {
+async function resolveUserName(
+  connectionOrToken: OAuthConnection | string,
+  userId: string,
+): Promise<string> {
   if (!userId) return "unknown";
   const cached = userNameCache.get(userId);
   if (cached) return cached;
 
   try {
-    const resp = await slack.userInfo(token, userId);
+    const resp = await slack.userInfo(connectionOrToken, userId);
     const name =
       resp.user.profile?.display_name ||
       resp.user.profile?.real_name ||
@@ -108,8 +112,10 @@ export const slackProvider: MessagingProvider = {
   credentialService: "integration:slack",
   capabilities: new Set(["reactions", "threads", "leave_channel"]),
 
-  async testConnection(token: string): Promise<ConnectionInfo> {
-    const resp = await slack.authTest(token);
+  async testConnection(
+    connectionOrToken: OAuthConnection | string,
+  ): Promise<ConnectionInfo> {
+    const resp = await slack.authTest(connectionOrToken);
     return {
       connected: true,
       user: resp.user,
@@ -119,7 +125,7 @@ export const slackProvider: MessagingProvider = {
   },
 
   async listConversations(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     options?: ListOptions,
   ): Promise<Conversation[]> {
     const typeMap: Record<string, string> = {
@@ -141,7 +147,7 @@ export const slackProvider: MessagingProvider = {
     // Paginate through all results
     do {
       const resp = await slack.listConversations(
-        token,
+        connectionOrToken,
         types,
         options?.excludeArchived ?? true,
         options?.limit ?? 200,
@@ -158,7 +164,7 @@ export const slackProvider: MessagingProvider = {
     for (const conv of conversations) {
       if (conv.type === "dm" && conv.metadata?.dmUserId) {
         conv.name = await resolveUserName(
-          token,
+          connectionOrToken,
           conv.metadata.dmUserId as string,
         );
       }
@@ -168,12 +174,12 @@ export const slackProvider: MessagingProvider = {
   },
 
   async getHistory(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
     const resp = await slack.conversationHistory(
-      token,
+      connectionOrToken,
       conversationId,
       options?.limit ?? 50,
       options?.before,
@@ -182,7 +188,7 @@ export const slackProvider: MessagingProvider = {
 
     const messages: Message[] = [];
     for (const msg of resp.messages) {
-      const name = await resolveUserName(token, msg.user ?? "");
+      const name = await resolveUserName(connectionOrToken, msg.user ?? "");
       messages.push(mapMessage(msg, conversationId, name));
     }
 
@@ -190,11 +196,15 @@ export const slackProvider: MessagingProvider = {
   },
 
   async search(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const resp = await slack.searchMessages(token, query, options?.count ?? 20);
+    const resp = await slack.searchMessages(
+      connectionOrToken,
+      query,
+      options?.count ?? 20,
+    );
     return {
       total: resp.messages.total,
       messages: resp.messages.matches.map(mapSearchMatch),
@@ -203,13 +213,13 @@ export const slackProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     options?: SendOptions,
   ): Promise<SendResult> {
     const resp = await slack.postMessage(
-      token,
+      connectionOrToken,
       conversationId,
       text,
       options?.threadId,
@@ -222,32 +232,32 @@ export const slackProvider: MessagingProvider = {
   },
 
   async getThreadReplies(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
     const resp = await slack.conversationReplies(
-      token,
+      connectionOrToken,
       conversationId,
       threadId,
       options?.limit ?? 50,
     );
     const messages: Message[] = [];
     for (const msg of resp.messages) {
-      const name = await resolveUserName(token, msg.user ?? "");
+      const name = await resolveUserName(connectionOrToken, msg.user ?? "");
       messages.push(mapMessage(msg, conversationId, name));
     }
     return messages;
   },
 
   async markRead(
-    token: string,
+    connectionOrToken: OAuthConnection | string,
     conversationId: string,
     messageId?: string,
   ): Promise<void> {
     // Slack's conversations.mark requires a timestamp — use the provided one or "now"
     const ts = messageId ?? String(Date.now() / 1000);
-    await slack.conversationMark(token, conversationId, ts);
+    await slack.conversationMark(connectionOrToken, conversationId, ts);
   },
 };


### PR DESCRIPTION
## Summary
- Change MessagingProvider interface to accept OAuthConnection | string in all token-bearing methods
- Update Gmail and Slack adapters to pass connections through to underlying clients
- Replace withProviderToken with getProviderConnection in messaging tools
- Telegram adapter continues working unchanged via string path

Part of plan: oauth-conn-request.md (PR 10 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
