### PR TITLE
fix: raise rate limit to 300 req/min and emit session error on regenerate failure

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -55,7 +55,7 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 
 All `/v1/*` endpoints share a per-client-IP sliding-window rate limiter (`middleware/rate-limiter.ts`):
 
-- **Authenticated**: 60 requests/minute
+- **Authenticated**: 300 requests/minute
 - **Unauthenticated**: 20 requests/minute
 
 When the limit is exceeded, the limiter returns 429 and logs a structured warning (module: `rate-limiter`) with the denied endpoint and a breakdown of which endpoints consumed the budget in the current window. This makes it easy to identify whether the cause is rapid thread switching, polling, or unexpected request volume.

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -8,7 +8,7 @@ import { isPrivateAddress } from "./auth.js";
 
 const log = getLogger("rate-limiter");
 
-const DEFAULT_MAX_REQUESTS = 60;
+const DEFAULT_MAX_REQUESTS = 300;
 const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
 const MAX_TRACKED_TOKENS = 10_000;
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1934,8 +1934,8 @@ public final class ChatViewModel: ObservableObject {
         // responded — e.g. because the send was rate-limited with 429), resend
         // the original message instead of regenerating. A /regenerate request
         // would fail with 404 because the daemon never received the message.
-        if let lastMsg = messages.last, lastMsg.role == .user, let text = lastMsg.text {
-            lastFailedMessageText = text
+        if let lastMsg = messages.last, lastMsg.role == .user {
+            lastFailedMessageText = lastMsg.text
             lastFailedMessageDisplayText = nil
             lastFailedMessageAttachments = nil
             retryLastMessage()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1937,7 +1937,22 @@ public final class ChatViewModel: ObservableObject {
         if let lastMsg = messages.last, lastMsg.role == .user {
             lastFailedMessageText = lastMsg.text
             lastFailedMessageDisplayText = nil
-            lastFailedMessageAttachments = nil
+            // Preserve attachments so they are resent with the retry.
+            // ChatAttachment.data may already be cleared for older messages,
+            // but for a just-sent 429'd message it is still populated.
+            lastFailedMessageAttachments = lastMsg.attachments.compactMap { att in
+                guard !att.data.isEmpty else { return nil }
+                return UserMessageAttachment(
+                    id: att.id,
+                    filename: att.filename,
+                    mimeType: att.mimeType,
+                    data: att.data,
+                    extractedText: nil,
+                    sizeBytes: nil,
+                    thumbnailData: nil,
+                    filePath: att.filePath
+                )
+            }
             retryLastMessage()
         } else {
             regenerateLastMessage()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1929,7 +1929,19 @@ public final class ChatViewModel: ObservableObject {
             }
         }
         dismissSessionError()
-        regenerateLastMessage()
+
+        // When the last message is from the user (i.e. the assistant never
+        // responded — e.g. because the send was rate-limited with 429), resend
+        // the original message instead of regenerating. A /regenerate request
+        // would fail with 404 because the daemon never received the message.
+        if let lastMsg = messages.last, lastMsg.role == .user, let text = lastMsg.text {
+            lastFailedMessageText = text
+            lastFailedMessageDisplayText = nil
+            lastFailedMessageAttachments = nil
+            retryLastMessage()
+        } else {
+            regenerateLastMessage()
+        }
     }
 
     /// Whether the current error has a failed user message that can be retried.

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -3462,9 +3462,21 @@ public final class HTTPTransport {
                 }
             } else {
                 log.error("Regenerate failed (HTTP \(http.statusCode))")
+                onMessage?(.sessionError(SessionErrorMessage(
+                    sessionId: sessionId,
+                    code: .regenerateFailed,
+                    userMessage: "Unable to regenerate response. Try sending your message again.",
+                    retryable: false
+                )))
             }
         } catch {
             log.error("Regenerate error: \(error.localizedDescription)")
+            onMessage?(.sessionError(SessionErrorMessage(
+                sessionId: sessionId,
+                code: .regenerateFailed,
+                userMessage: "Unable to regenerate response. Try sending your message again.",
+                retryable: false
+            )))
         }
     }
 

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -3466,7 +3466,7 @@ public final class HTTPTransport {
                     sessionId: sessionId,
                     code: .regenerateFailed,
                     userMessage: "Unable to regenerate response. Try sending your message again.",
-                    retryable: false
+                    retryable: true
                 )))
             }
         } catch {
@@ -3475,7 +3475,7 @@ public final class HTTPTransport {
                 sessionId: sessionId,
                 code: .regenerateFailed,
                 userMessage: "Unable to regenerate response. Try sending your message again.",
-                retryable: false
+                retryable: true
             )))
         }
     }


### PR DESCRIPTION
## Summary

Fixes two related bugs that cause the desktop app to get stuck indefinitely after rate limiting:

- **Rate limit too low (60 → 300 req/min)**: Normal desktop usage (thread switching, guardian polling, history loading, mark-read events) easily exceeds 60 req/min. Observed 75 requests in a single 60s window from routine usage, causing `POST /v1/messages` to get 429'd. Raised to 300 — this is a local daemon, not a public API, and the limit exists only to prevent abuse from external callers.
- **Regenerate 404 leaves UI stuck in "Thinking" forever**: When a message send gets 429'd and the user clicks "Retry", `regenerateLastResponse()` sends `POST /v1/conversations/:id/regenerate`. But since the original message was never delivered (429'd), no session exists, so the daemon returns 404. The client logged the error but never emitted a session error event, so the UI stayed stuck showing "Thinking" indefinitely with no way to recover. Now emits `.regenerateFailed` session error on any non-success/non-401 status code (and on network errors), so the UI displays the error and allows the user to send a new message.

### Root cause from logs

In a single 60-second window, the desktop app made 75 requests from normal usage:
- 19x `POST /v1/conversations/switch` (thread switching)
- 15x `POST /v1/conversations/seen` (mark read)
- 14x `GET /v1/messages` (history loading)
- 13x `GET /v1/guardian-actions/pending` (polling ~every 3-5s)
- 5x `POST /v1/suggestion`
- 5x `POST /v1/messages` (actual message sends)

## Test plan

- [ ] Verify `DEFAULT_MAX_REQUESTS` is 300 in `rate-limiter.ts`
- [ ] Verify docs in `AGENTS.md` / `CLAUDE.md` reflect 300 req/min
- [ ] Verify `regenerateLastResponse()` emits `.sessionError` with `.regenerateFailed` on non-success status codes
- [ ] Verify `regenerateLastResponse()` emits `.sessionError` on network errors (catch block)
- [ ] Manual: rapid thread switching + message sends no longer trigger 429
- [ ] Manual: if regenerate fails (e.g. 404), UI shows error banner instead of stuck "Thinking"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
