### PR TITLE
Remove string overloads from API clients and clean up legacy token code

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
@@ -8,9 +8,6 @@ import type {
   FreeBusyResponse,
 } from "./types.js";
 
-/** Used by the legacy string-token path. */
-const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
-
 export class CalendarApiError extends Error {
   constructor(
     public readonly status: number,
@@ -23,41 +20,10 @@ export class CalendarApiError extends Error {
 }
 
 async function request<T>(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   path: string,
   options?: RequestInit,
 ): Promise<T> {
-  if (typeof connectionOrToken === "string") {
-    // Legacy path: use raw token directly
-    const token = connectionOrToken;
-    const url = `${CALENDAR_API_BASE}${path}`;
-    const resp = await fetch(url, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        ...options?.headers,
-      },
-    });
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
-      throw new CalendarApiError(
-        resp.status,
-        resp.statusText,
-        `Calendar API ${resp.status}: ${body}`,
-      );
-    }
-    const contentLength = resp.headers.get("content-length");
-    if (resp.status === 204 || contentLength === "0") {
-      return undefined as T;
-    }
-    const text = await resp.text();
-    if (!text) return undefined as T;
-    return JSON.parse(text) as T;
-  }
-
-  // OAuthConnection path: use connection.request() with baseUrl override
-  const connection = connectionOrToken;
   const method = (options?.method ?? "GET").toUpperCase();
 
   // Extract non-auth headers
@@ -127,7 +93,7 @@ async function request<T>(
 
 /** List events from a calendar. */
 export async function listEvents(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   calendarId = "primary",
   options?: {
     timeMin?: string;
@@ -161,19 +127,19 @@ export async function listEvents(
   if (options?.syncToken) params.set("syncToken", options.syncToken);
 
   return request<CalendarEventsListResponse>(
-    connectionOrToken,
+    connection,
     `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
   );
 }
 
 /** Get a single event by ID. */
 export async function getEvent(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   eventId: string,
   calendarId = "primary",
 ): Promise<CalendarEvent> {
   return request<CalendarEvent>(
-    connectionOrToken,
+    connection,
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(
       eventId,
     )}`,
@@ -182,7 +148,7 @@ export async function getEvent(
 
 /** Create a new event. */
 export async function createEvent(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   event: {
     summary: string;
     start: { dateTime?: string; date?: string; timeZone?: string };
@@ -196,7 +162,7 @@ export async function createEvent(
 ): Promise<CalendarEvent> {
   const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
-    connectionOrToken,
+    connection,
     `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
     {
       method: "POST",
@@ -207,7 +173,7 @@ export async function createEvent(
 
 /** Update an event (patch). */
 export async function patchEvent(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   eventId: string,
   updates: Partial<{
     summary: string;
@@ -222,7 +188,7 @@ export async function patchEvent(
 ): Promise<CalendarEvent> {
   const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
-    connectionOrToken,
+    connection,
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(
       eventId,
     )}?${params}`,
@@ -235,10 +201,10 @@ export async function patchEvent(
 
 /** Query free/busy information. */
 export async function freeBusy(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   query: FreeBusyRequest,
 ): Promise<FreeBusyResponse> {
-  return request<FreeBusyResponse>(connectionOrToken, "/freeBusy", {
+  return request<FreeBusyResponse>(connection, "/freeBusy", {
     method: "POST",
     body: JSON.stringify(query),
   });
@@ -246,10 +212,7 @@ export async function freeBusy(
 
 /** List calendars the user has access to. */
 export async function listCalendars(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
 ): Promise<CalendarListResponse> {
-  return request<CalendarListResponse>(
-    connectionOrToken,
-    "/users/me/calendarList",
-  );
+  return request<CalendarListResponse>(connection, "/users/me/calendarList");
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -9,6 +9,7 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
+import type { OAuthConnection } from "../../../../oauth/connection.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -55,16 +56,17 @@ export async function run(
 
     // Gmail: create a draft instead of sending directly
     if (provider.id === "gmail") {
+      const gmailConn = conn as OAuthConnection;
       // Reply mode: thread_id provided — create a threaded draft with reply-all recipients
       if (threadId) {
         // Fetch thread messages to extract recipients and threading headers
-        const list = await listMessages(conn, `thread:${threadId}`, 10);
+        const list = await listMessages(gmailConn, `thread:${threadId}`, 10);
         if (!list.messages?.length) {
           return err("No messages found in this thread.");
         }
 
         const messages = await batchGetMessages(
-          conn,
+          gmailConn,
           list.messages.map((m) => m.id),
           "metadata",
           ["From", "To", "Cc", "Message-ID", "Subject"],
@@ -81,7 +83,7 @@ export async function run(
         }
 
         // Build reply-all recipient list, excluding the user's own email
-        const profile = await getProfile(conn);
+        const profile = await getProfile(gmailConn);
         const userEmail = profile.emailAddress.toLowerCase();
 
         const allRecipients = new Set<string>();
@@ -128,7 +130,7 @@ export async function run(
             cc: ccList.length > 0 ? ccList.join(", ") : undefined,
             attachments,
           });
-          const draft = await createDraftRaw(conn, raw, threadId);
+          const draft = await createDraftRaw(gmailConn, raw, threadId);
 
           const filenames = attachments.map((a) => a.filename).join(", ");
           const recipientSummary =
@@ -141,7 +143,7 @@ export async function run(
         }
 
         const draft = await createDraft(
-          conn,
+          gmailConn,
           toList.join(", "),
           replySubject,
           text,
@@ -178,7 +180,7 @@ export async function run(
           inReplyTo,
           attachments,
         });
-        const draft = await createDraftRaw(conn, raw, threadId);
+        const draft = await createDraftRaw(gmailConn, raw, threadId);
 
         const filenames = attachments.map((a) => a.filename).join(", ");
         return ok(
@@ -188,7 +190,7 @@ export async function run(
 
       // Without attachments: use standard createDraft
       const draft = await createDraft(
-        conn,
+        gmailConn,
         conversationId,
         subject ?? "",
         text,

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -10,7 +10,6 @@ import {
 } from "../../../../messaging/registry.js";
 import type { OAuthConnection } from "../../../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
-import { withValidToken } from "../../../../security/token-manager.js";
 import type { ToolExecutionResult } from "../../../../tools/types.js";
 
 export function ok(content: string): ToolExecutionResult {
@@ -139,21 +138,4 @@ export function getProviderConnection(
 ): OAuthConnection | string {
   if (provider.isConnected?.()) return "";
   return resolveOAuthConnection(provider.credentialService);
-}
-
-/**
- * Execute a callback with a valid OAuth token for the given provider.
- * Providers that manage their own auth (e.g. Telegram with a bot token)
- * expose isConnected() and don't need an OAuth access_token lookup.
- *
- * @deprecated Prefer getProviderConnection() and passing the connection directly.
- */
-export async function withProviderToken<T>(
-  provider: MessagingProvider,
-  fn: (token: string) => Promise<T>,
-): Promise<T> {
-  if (provider.isConnected?.()) {
-    return fn("");
-  }
-  return withValidToken(provider.credentialService, fn);
 }

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -98,7 +98,8 @@ export const gmailMessagingProvider: MessagingProvider = {
   async testConnection(
     connectionOrToken: OAuthConnection | string,
   ): Promise<ConnectionInfo> {
-    const profile = await gmail.getProfile(connectionOrToken);
+    const connection = connectionOrToken as OAuthConnection;
+    const profile = await gmail.getProfile(connection);
     return {
       connected: true,
       user: profile.emailAddress,
@@ -114,8 +115,9 @@ export const gmailMessagingProvider: MessagingProvider = {
     connectionOrToken: OAuthConnection | string,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
+    const connection = connectionOrToken as OAuthConnection;
     // Gmail "conversations" are modeled as labels with unread counts
-    const labels = await gmail.listLabels(connectionOrToken);
+    const labels = await gmail.listLabels(connection);
     const conversations: Conversation[] = [];
 
     for (const label of labels) {
@@ -158,10 +160,11 @@ export const gmailMessagingProvider: MessagingProvider = {
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
+    const connection = connectionOrToken as OAuthConnection;
     // conversationId is a label ID — list messages in that label
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      connectionOrToken,
+      connection,
       undefined,
       limit,
       undefined,
@@ -171,7 +174,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      connectionOrToken,
+      connection,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -184,19 +187,16 @@ export const gmailMessagingProvider: MessagingProvider = {
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
+    const connection = connectionOrToken as OAuthConnection;
     const count = options?.count ?? 20;
-    const listResult = await gmail.listMessages(
-      connectionOrToken,
-      query,
-      count,
-    );
+    const listResult = await gmail.listMessages(connection, query, count);
 
     if (!listResult.messages?.length) {
       return { total: 0, messages: [], hasMore: false };
     }
 
     const messages = await gmail.batchGetMessages(
-      connectionOrToken,
+      connection,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -215,11 +215,12 @@ export const gmailMessagingProvider: MessagingProvider = {
     text: string,
     options?: SendOptions,
   ): Promise<SendResult> {
+    const connection = connectionOrToken as OAuthConnection;
     // conversationId is the recipient email for Gmail
     const to = conversationId;
     const subject = options?.subject ?? "";
     const msg = await gmail.sendMessage(
-      connectionOrToken,
+      connection,
       to,
       subject,
       text,
@@ -240,10 +241,11 @@ export const gmailMessagingProvider: MessagingProvider = {
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
+    const connection = connectionOrToken as OAuthConnection;
     // Get all messages in a Gmail thread
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      connectionOrToken,
+      connection,
       `thread:${threadId}`,
       limit,
     );
@@ -251,7 +253,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      connectionOrToken,
+      connection,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -264,8 +266,9 @@ export const gmailMessagingProvider: MessagingProvider = {
     _conversationId: string,
     messageId?: string,
   ): Promise<void> {
+    const connection = connectionOrToken as OAuthConnection;
     if (!messageId) return;
-    await gmail.modifyMessage(connectionOrToken, messageId, {
+    await gmail.modifyMessage(connection, messageId, {
       removeLabelIds: ["UNREAD"],
     });
   },
@@ -275,6 +278,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     query: string,
     options?: { maxMessages?: number; maxSenders?: number; pageToken?: string },
   ): Promise<SenderDigestResult> {
+    const connection = connectionOrToken as OAuthConnection;
     const maxMessages = Math.min(options?.maxMessages ?? 5000, 5000);
     const maxSenders = options?.maxSenders ?? 30;
     const maxIdsPerSender = 5000;
@@ -294,7 +298,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
       const listResp = await gmail.listMessages(
-        connectionOrToken,
+        connection,
         query,
         pageSize,
         pageToken,
@@ -304,7 +308,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       allMessageIds.push(...ids);
       fetchPromises.push(
         gmail.batchGetMessages(
-          connectionOrToken,
+          connection,
           ids,
           "metadata",
           metadataHeaders,
@@ -422,6 +426,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     connectionOrToken: OAuthConnection | string,
     query: string,
   ): Promise<ArchiveResult> {
+    const connection = connectionOrToken as OAuthConnection;
     const maxMessages = 5000;
     const batchModifyLimit = 1000;
 
@@ -431,7 +436,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     while (allMessageIds.length < maxMessages) {
       const listResp = await gmail.listMessages(
-        connectionOrToken,
+        connection,
         query,
         Math.min(500, maxMessages - allMessageIds.length),
         pageToken,
@@ -453,7 +458,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     for (let i = 0; i < allMessageIds.length; i += batchModifyLimit) {
       const chunk = allMessageIds.slice(i, i + batchModifyLimit);
-      await gmail.batchModifyMessages(connectionOrToken, chunk, {
+      await gmail.batchModifyMessages(connection, chunk, {
         removeLabelIds: ["INBOX"],
       });
     }

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -19,7 +19,6 @@ import type {
   GmailVacationSettings,
 } from "./types.js";
 
-const GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
 const GMAIL_BATCH_URL = "https://www.googleapis.com/batch/gmail/v1";
 
 /** Max sub-requests per batch HTTP call (Gmail API limit) */
@@ -99,63 +98,11 @@ function extractBody(options?: GmailRequestOptions): unknown | undefined {
 }
 
 async function request<T>(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   path: string,
   options?: GmailRequestOptions,
 ): Promise<T> {
   const canRetry = options?.retryable ?? isIdempotent(options);
-
-  if (typeof connectionOrToken === "string") {
-    // Legacy path: use raw token directly
-    const token = connectionOrToken;
-    const url = `${GMAIL_API_BASE}${path}`;
-
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      const resp = await fetch(url, {
-        ...options,
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          ...options?.headers,
-        },
-      });
-
-      if (!resp.ok) {
-        if (canRetry && isRetryable(resp.status) && attempt < MAX_RETRIES) {
-          const retryAfter = resp.headers.get("retry-after");
-          const delayMs = retryAfter
-            ? parseInt(retryAfter, 10) * 1000
-            : INITIAL_BACKOFF_MS * Math.pow(2, attempt);
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-          continue;
-        }
-        const body = await resp.text().catch(() => "");
-        throw new GmailApiError(
-          resp.status,
-          resp.statusText,
-          `Gmail API ${resp.status}: ${body}`,
-        );
-      }
-
-      // Some endpoints (e.g. batchModify) return empty success responses
-      const contentLength = resp.headers.get("content-length");
-      if (resp.status === 204 || contentLength === "0") {
-        return undefined as T;
-      }
-      const text = await resp.text();
-      if (!text) return undefined as T;
-      return JSON.parse(text) as T;
-    }
-
-    // Unreachable -- the loop always returns or throws -- but TypeScript needs this
-    throw new Error(
-      "Unreachable: retry loop exited without returning or throwing",
-    );
-  }
-
-  // OAuthConnection path
-  const connection = connectionOrToken;
   const method = (options?.method ?? "GET").toUpperCase();
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -210,7 +157,7 @@ async function request<T>(
 
 /** List messages matching a query. */
 export async function listMessages(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   query?: string,
   maxResults = 20,
   pageToken?: string,
@@ -223,15 +170,12 @@ export async function listMessages(
   if (labelIds) {
     for (const id of labelIds) params.append("labelIds", id);
   }
-  return request<GmailMessageListResponse>(
-    connectionOrToken,
-    `/messages?${params}`,
-  );
+  return request<GmailMessageListResponse>(connection, `/messages?${params}`);
 }
 
 /** Get a single message by ID. */
 export async function getMessage(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageId: string,
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
@@ -242,10 +186,7 @@ export async function getMessage(
     for (const h of metadataHeaders) params.append("metadataHeaders", h);
   }
   if (fields) params.set("fields", fields);
-  return request<GmailMessage>(
-    connectionOrToken,
-    `/messages/${messageId}?${params}`,
-  );
+  return request<GmailMessage>(connection, `/messages/${messageId}?${params}`);
 }
 
 /**
@@ -283,7 +224,7 @@ function parseSubResponse(
  * Returns successfully parsed messages and a list of IDs that failed (for individual retry).
  */
 async function executeBatchCall(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageIds: string[],
   format: GmailMessageFormat,
   metadataHeaders: string[] | undefined,
@@ -386,12 +327,8 @@ async function executeBatchCall(
     );
   };
 
-  if (typeof connectionOrToken === "string") {
-    return doBatchFetch(connectionOrToken);
-  }
-
-  // OAuthConnection path: use withToken to get raw token for batch endpoint
-  return connectionOrToken.withToken(doBatchFetch);
+  // Use withToken to get raw token for batch endpoint
+  return connection.withToken(doBatchFetch);
 }
 
 /**
@@ -400,7 +337,7 @@ async function executeBatchCall(
  * Falls back to individual getMessage for any sub-requests that fail within a batch.
  */
 export async function batchGetMessages(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageIds: string[],
   format: GmailMessageFormat = "full",
   metadataHeaders?: string[],
@@ -412,7 +349,7 @@ export async function batchGetMessages(
   if (messageIds.length === 1) {
     return [
       await getMessage(
-        connectionOrToken,
+        connection,
         messageIds[0],
         format,
         metadataHeaders,
@@ -439,7 +376,7 @@ export async function batchGetMessages(
     const waveResults = await Promise.all(
       wave.map((chunk) =>
         executeBatchCall(
-          connectionOrToken,
+          connection,
           chunk.ids,
           format,
           metadataHeaders,
@@ -461,7 +398,7 @@ export async function batchGetMessages(
       if (failedIds.length > 0) {
         const retried = await Promise.all(
           failedIds.map(({ id }) =>
-            getMessage(connectionOrToken, id, format, metadataHeaders, fields),
+            getMessage(connection, id, format, metadataHeaders, fields),
           ),
         );
         for (let r = 0; r < failedIds.length; r++) {
@@ -476,28 +413,24 @@ export async function batchGetMessages(
 
 /** Modify labels on a single message. */
 export async function modifyMessage(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageId: string,
   modifications: GmailModifyRequest,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(
-    connectionOrToken,
-    `/messages/${messageId}/modify`,
-    {
-      method: "POST",
-      body: JSON.stringify(modifications),
-      retryable: true,
-    },
-  );
+  return request<GmailMessage>(connection, `/messages/${messageId}/modify`, {
+    method: "POST",
+    body: JSON.stringify(modifications),
+    retryable: true,
+  });
 }
 
 /** Batch modify labels on multiple messages. */
 export async function batchModifyMessages(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageIds: string[],
   modifications: GmailModifyRequest,
 ): Promise<void> {
-  await request<void>(connectionOrToken, "/messages/batchModify", {
+  await request<void>(connection, "/messages/batchModify", {
     method: "POST",
     body: JSON.stringify({ ids: messageIds, ...modifications }),
     retryable: true,
@@ -506,33 +439,26 @@ export async function batchModifyMessages(
 
 /** Move a message to trash. */
 export async function trashMessage(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageId: string,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(
-    connectionOrToken,
-    `/messages/${messageId}/trash`,
-    {
-      method: "POST",
-      retryable: true,
-    },
-  );
+  return request<GmailMessage>(connection, `/messages/${messageId}/trash`, {
+    method: "POST",
+    retryable: true,
+  });
 }
 
 /** List all labels. */
 export async function listLabels(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
 ): Promise<GmailLabel[]> {
-  const resp = await request<GmailLabelsListResponse>(
-    connectionOrToken,
-    "/labels",
-  );
+  const resp = await request<GmailLabelsListResponse>(connection, "/labels");
   return resp.labels ?? [];
 }
 
 /** Create a draft. */
 export async function createDraft(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   to: string,
   subject: string,
   body: string,
@@ -559,7 +485,7 @@ export async function createDraft(
     .replace(/=+$/, "");
   const message: Record<string, unknown> = { raw };
   if (threadId) message.threadId = threadId;
-  return request<GmailDraft>(connectionOrToken, "/drafts", {
+  return request<GmailDraft>(connection, "/drafts", {
     method: "POST",
     body: JSON.stringify({ message }),
   });
@@ -567,13 +493,13 @@ export async function createDraft(
 
 /** Create a draft from a pre-built base64url MIME payload. */
 export async function createDraftRaw(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   raw: string,
   threadId?: string,
 ): Promise<GmailDraft> {
   const message: Record<string, unknown> = { raw };
   if (threadId) message.threadId = threadId;
-  return request<GmailDraft>(connectionOrToken, "/drafts", {
+  return request<GmailDraft>(connection, "/drafts", {
     method: "POST",
     body: JSON.stringify({ message }),
   });
@@ -581,10 +507,10 @@ export async function createDraftRaw(
 
 /** Send an existing draft by ID. */
 export async function sendDraft(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   draftId: string,
 ): Promise<GmailMessage> {
-  return request<GmailMessage>(connectionOrToken, "/drafts/send", {
+  return request<GmailMessage>(connection, "/drafts/send", {
     method: "POST",
     body: JSON.stringify({ id: draftId }),
   });
@@ -592,7 +518,7 @@ export async function sendDraft(
 
 /** Send an email. */
 export async function sendMessage(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   to: string,
   subject: string,
   body: string,
@@ -615,7 +541,7 @@ export async function sendMessage(
     .replace(/=+$/, "");
   const payload: Record<string, unknown> = { raw };
   if (threadId) payload.threadId = threadId;
-  return request<GmailMessage>(connectionOrToken, "/messages/send", {
+  return request<GmailMessage>(connection, "/messages/send", {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -623,32 +549,32 @@ export async function sendMessage(
 
 /** Get the authenticated user's profile (email address). */
 export async function getProfile(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
 ): Promise<GmailProfile> {
-  return request<GmailProfile>(connectionOrToken, "/profile");
+  return request<GmailProfile>(connection, "/profile");
 }
 
 /** Get attachment data for a message. */
 export async function getAttachment(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   messageId: string,
   attachmentId: string,
 ): Promise<GmailAttachment> {
   return request<GmailAttachment>(
-    connectionOrToken,
+    connection,
     `/messages/${messageId}/attachments/${attachmentId}`,
   );
 }
 
 /** Send an email with a pre-built raw MIME payload (for multipart/attachments). */
 export async function sendMessageRaw(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   raw: string,
   threadId?: string,
 ): Promise<GmailMessage> {
   const payload: Record<string, unknown> = { raw };
   if (threadId) payload.threadId = threadId;
-  return request<GmailMessage>(connectionOrToken, "/messages/send", {
+  return request<GmailMessage>(connection, "/messages/send", {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -656,14 +582,14 @@ export async function sendMessageRaw(
 
 /** Create a user label. */
 export async function createLabel(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   name: string,
   opts?: {
     messageListVisibility?: "show" | "hide";
     labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
   },
 ): Promise<GmailLabel> {
-  return request<GmailLabel>(connectionOrToken, "/labels", {
+  return request<GmailLabel>(connection, "/labels", {
     method: "POST",
     body: JSON.stringify({ name, ...opts }),
   });
@@ -671,10 +597,10 @@ export async function createLabel(
 
 /** List all Gmail filters. */
 export async function listFilters(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
 ): Promise<GmailFilter[]> {
   const resp = await request<GmailFiltersListResponse>(
-    connectionOrToken,
+    connection,
     "/settings/filters",
   );
   return resp.filter ?? [];
@@ -682,11 +608,11 @@ export async function listFilters(
 
 /** Create a Gmail filter. */
 export async function createFilter(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   criteria: GmailFilterCriteria,
   action: GmailFilterAction,
 ): Promise<GmailFilter> {
-  return request<GmailFilter>(connectionOrToken, "/settings/filters", {
+  return request<GmailFilter>(connection, "/settings/filters", {
     method: "POST",
     body: JSON.stringify({ criteria, action }),
   });
@@ -694,35 +620,28 @@ export async function createFilter(
 
 /** Delete a Gmail filter. */
 export async function deleteFilter(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   filterId: string,
 ): Promise<void> {
-  await request<void>(connectionOrToken, `/settings/filters/${filterId}`, {
+  await request<void>(connection, `/settings/filters/${filterId}`, {
     method: "DELETE",
   });
 }
 
 /** Get vacation auto-reply settings. */
 export async function getVacation(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
 ): Promise<GmailVacationSettings> {
-  return request<GmailVacationSettings>(
-    connectionOrToken,
-    "/settings/vacation",
-  );
+  return request<GmailVacationSettings>(connection, "/settings/vacation");
 }
 
 /** Update vacation auto-reply settings. */
 export async function updateVacation(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   settings: GmailVacationSettings,
 ): Promise<GmailVacationSettings> {
-  return request<GmailVacationSettings>(
-    connectionOrToken,
-    "/settings/vacation",
-    {
-      method: "PUT",
-      body: JSON.stringify(settings),
-    },
-  );
+  return request<GmailVacationSettings>(connection, "/settings/vacation", {
+    method: "PUT",
+    body: JSON.stringify(settings),
+  });
 }

--- a/assistant/src/messaging/providers/gmail/people-client.ts
+++ b/assistant/src/messaging/providers/gmail/people-client.ts
@@ -11,37 +11,12 @@ import type {
   PeopleSearchResponse,
 } from "./people-types.js";
 
-/** Used by the legacy string-token path. */
-const PEOPLE_API_BASE = "https://people.googleapis.com/v1";
-
 const PERSON_FIELDS = "names,emailAddresses,phoneNumbers,organizations";
 
 async function request<T>(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   path: string,
 ): Promise<T> {
-  if (typeof connectionOrToken === "string") {
-    // Legacy path: use raw token with full URL
-    const token = connectionOrToken;
-    const url = `${PEOPLE_API_BASE}${path}`;
-    const resp = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    if (!resp.ok) {
-      const body = await resp.text().catch(() => "");
-      throw new GmailApiError(
-        resp.status,
-        resp.statusText,
-        `People API ${resp.status}: ${body}`,
-      );
-    }
-    return resp.json() as Promise<T>;
-  }
-
-  // OAuthConnection path: use connection.request() with baseUrl override
-  const connection = connectionOrToken;
   const resp = await connection.request({
     method: "GET",
     path,
@@ -65,7 +40,7 @@ async function request<T>(
 
 /** List the user's contacts with pagination. */
 export async function listContacts(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   pageSize = 50,
   pageToken?: string,
 ): Promise<PeopleConnectionsResponse> {
@@ -75,14 +50,14 @@ export async function listContacts(
   });
   if (pageToken) params.set("pageToken", pageToken);
   return request<PeopleConnectionsResponse>(
-    connectionOrToken,
+    connection,
     `/people/me/connections?${params}`,
   );
 }
 
 /** Search contacts by name or email. */
 export async function searchContacts(
-  connectionOrToken: OAuthConnection | string,
+  connection: OAuthConnection,
   query: string,
 ): Promise<PeopleSearchResponse> {
   const params = new URLSearchParams({
@@ -90,7 +65,7 @@ export async function searchContacts(
     readMask: PERSON_FIELDS,
   });
   return request<PeopleSearchResponse>(
-    connectionOrToken,
+    connection,
     `/people:searchContacts?${params}`,
   );
 }

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -4,6 +4,10 @@
  * All methods accept either an OAuthConnection or a raw token string.
  * Throws SlackApiError on failures, with status: 401 on auth errors
  * for withValidToken compatibility.
+ *
+ * String overloads are retained for non-OAuth callers (e.g. slack/share.ts)
+ * that pass raw bot tokens via resolveSlackToken(). These bypass the
+ * OAuthConnection model by design.
  */
 
 import type { OAuthConnection } from "../../../oauth/connection.js";

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -289,6 +289,9 @@ async function doRefresh(service: string): Promise<string> {
  * 1. Retrieves the stored access token (throws if none exists).
  * 2. If the token is expired or near-expiry, refreshes it before calling the callback.
  * 3. If the callback throws with a 401 status, attempts one refresh-and-retry cycle.
+ *
+ * @deprecated Use `resolveOAuthConnection(service).request()` instead.
+ * Retained only for BYO connection internals.
  */
 export async function withValidToken<T>(
   service: string,


### PR DESCRIPTION
## Summary
- Remove string token overloads from Gmail, People, and Calendar clients (all callers now use OAuthConnection)
- Retain Slack string overloads for non-OAuth bot token callers (slack/share.ts)
- Remove withProviderToken from messaging tools shared
- Deprecate withValidToken (retained only for BYO connection internals)
- Clean up dead constants (GMAIL_API_BASE, PEOPLE_API_BASE, CALENDAR_API_BASE) and unused imports

Part of plan: oauth-conn-request.md (PR 11 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
