### PR TITLE
fix: exclude .test.ts files from secure-keys import scan

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -248,7 +248,11 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
         const s = statSync(full);
         if (s.isDirectory()) {
           collectTsFiles(full, files);
-        } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+        } else if (
+          entry.endsWith(".ts") &&
+          !entry.endsWith(".d.ts") &&
+          !entry.endsWith(".test.ts")
+        ) {
           files.push(full);
         }
       }


### PR DESCRIPTION
## Summary
- The `secure-keys` import allowlist test in `credential-security-invariants.test.ts` only excluded files in the `__tests__/` directory, but `oauth/byo-connection.test.ts` is a colocated test file outside that directory
- Fix: also exclude `.test.ts` files from the scan, since test files legitimately mock/import `secure-keys` for testing

## Original prompt
fix the failing ci job from this run https://github.com/vellum-ai/vellum-assistant/actions/runs/22972206138 might be in a different repo. i deleted the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
