### PR TITLE
fix: make Content-Type a default rather than override in BYOOAuthConnection

### DIFF
--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -62,9 +62,9 @@ export class BYOOAuthConnection implements OAuthConnection {
       const resp = await fetch(fullUrl, {
         method: req.method,
         headers: {
+          "Content-Type": "application/json",
           ...req.headers,
           Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
         },
         body: req.body ? JSON.stringify(req.body) : undefined,
       });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-conn-request.md.

**Gap:** Content-Type header unconditionally overwritten in BYOOAuthConnection
**What was expected:** Caller-provided Content-Type headers should be respected
**What was found:** Content-Type: application/json was set after the spread of req.headers, always overwriting caller values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
