### PR TITLE
fix: remove dead err function from google-calendar shared.ts

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -6,10 +6,6 @@ export function ok(content: string): ToolExecutionResult {
   return { content, isError: false };
 }
 
-export function err(message: string): ToolExecutionResult {
-  return { content: message, isError: true };
-}
-
 /**
  * Calendar uses the same OAuth credential service as Gmail since both
  * scopes are granted in a single OAuth consent flow.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-conn-request.md.

**Gap:** Dead err function in google-calendar shared.ts
**What was expected:** No dead code per AGENTS.md rules
**What was found:** The err function is exported but never imported by any file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
