### PR TITLE
Use shared humanDescription for confirmation system notifications

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -108,58 +108,11 @@ public final class ToolConfirmationNotificationService {
     }
 
     private func formatBody(_ message: ConfirmationRequestMessage) -> String {
-        // For shell commands, show both the human-readable reason and the raw command
-        if message.toolName == "bash" || message.toolName == "host_bash" {
-            let command = commandPreview(toolName: message.toolName, input: message.input)
-            if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
-                let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
-                // Don't append a dangling "$ " when command is empty
-                guard !command.isEmpty else {
-                    return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : capitalizedReason
-                }
-                let commandLine = "$ \(command)"
-                let body = "\(capitalizedReason)\n\(commandLine)"
-                if body.count <= 200 { return body }
-                // Truncate reason first to preserve the command
-                let commandBudget = min(commandLine.count, 200)
-                let reasonBudget = 200 - commandBudget - 1 // 1 for newline
-                if reasonBudget >= 4 {
-                    let truncatedReason = String(capitalizedReason.prefix(reasonBudget - 3)) + "..."
-                    let truncatedBody = "\(truncatedReason)\n\(commandLine)"
-                    if truncatedBody.count <= 200 { return truncatedBody }
-                }
-                // Command alone exceeds the limit — truncate it
-                return commandLine.count > 200 ? String(commandLine.prefix(197)) + "..." : commandLine
-            }
-            return command.count > 200 ? String(command.prefix(197)) + "..." : command
-        }
-        // For all other tools, prefer the human-readable reason
-        if let reason = message.input["reason"]?.value as? String, !reason.isEmpty {
-            let capitalizedReason = reason.prefix(1).uppercased() + reason.dropFirst()
-            // Filter out `reason` key so commandPreview doesn't duplicate it
-            let nonReasonInput = message.input.filter { $0.key != "reason" && $0.key != "reasoning" }
-            let preview = commandPreview(toolName: message.toolName, input: nonReasonInput)
-            if !preview.isEmpty {
-                let body = "\(capitalizedReason)\n\(preview)"
-                if body.count <= 200 { return body }
-                // Truncate reason first to preserve the target preview
-                let previewBudget = min(preview.count, 200)
-                let reasonBudget = 200 - previewBudget - 1 // 1 for newline
-                if reasonBudget >= 4 {
-                    let truncatedReason = String(capitalizedReason.prefix(reasonBudget - 3)) + "..."
-                    let truncatedBody = "\(truncatedReason)\n\(preview)"
-                    if truncatedBody.count <= 200 { return truncatedBody }
-                }
-                // Preview alone exceeds the limit — truncate it
-                return preview.count > 200 ? String(preview.prefix(197)) + "..." : preview
-            }
-            return capitalizedReason.count > 200 ? String(capitalizedReason.prefix(197)) + "..." : String(capitalizedReason)
-        }
-        let preview = commandPreview(toolName: message.toolName, input: message.input)
-        if preview.count > 200 {
-            return String(preview.prefix(197)) + "..."
-        }
-        return preview
+        let description = confirmationHumanDescription(
+            toolName: message.toolName,
+            input: message.input
+        )
+        return description.count > 200 ? String(description.prefix(197)) + "..." : description
     }
 
     private func toolDisplayName(_ toolName: String) -> String {
@@ -173,53 +126,6 @@ public final class ToolConfirmationNotificationService {
         case "schedule_delete": return "Delete Schedule"
         case "schedule_list":   return "List Schedules"
         default: return toolName.replacingOccurrences(of: "_", with: " ").capitalized
-        }
-    }
-
-    private func commandPreview(toolName: String, input: [String: AnyCodable]) -> String {
-        switch toolName {
-        case "bash", "host_bash":
-            return (input["command"]?.value as? String) ?? ""
-        case "file_read":
-            return "read \((input["path"]?.value as? String) ?? "")"
-        case "file_write":
-            return "write \((input["path"]?.value as? String) ?? "")"
-        case "file_edit":
-            return "edit \((input["path"]?.value as? String) ?? "")"
-        case "web_fetch":
-            return "fetch \((input["url"]?.value as? String) ?? "")"
-        case "browser_navigate":
-            return "navigate \((input["url"]?.value as? String) ?? "")"
-        case "schedule_create", "schedule_update":
-            let verb = toolName == "schedule_create" ? "Create" : "Update"
-            let name = (input["name"]?.value as? String) ?? ""
-            let jobId = (input["job_id"]?.value as? String) ?? ""
-            let expr = (input["expression"]?.value as? String)
-                ?? (input["cron_expression"]?.value as? String) ?? ""
-            let message = (input["message"]?.value as? String) ?? ""
-            var parts: [String] = []
-            if !name.isEmpty { parts.append("\"\(name)\"") }
-            if !jobId.isEmpty && name.isEmpty { parts.append(jobId) }
-            if !expr.isEmpty { parts.append(expr) }
-            if parts.isEmpty && !message.isEmpty {
-                let truncated = message.count > 60 ? String(message.prefix(57)) + "..." : message
-                parts.append("\"\(truncated)\"")
-            }
-            return parts.isEmpty ? "\(verb) schedule" : "\(verb): \(parts.joined(separator: " — "))"
-        case "schedule_delete":
-            return (input["job_id"]?.value as? String) ?? "schedule"
-        default:
-            // Prefer semantically meaningful keys over arbitrary dictionary order
-            let preferredKeys = ["name", "query", "message", "description", "title", "url", "path", "command", "id"]
-            for key in preferredKeys {
-                if let val = input[key]?.value as? String, !val.isEmpty {
-                    return val.count > 80 ? String(val.prefix(77)) + "..." : val
-                }
-            }
-            if let firstString = input.values.compactMap({ $0.value as? String }).first {
-                return firstString.count > 80 ? String(firstString.prefix(77)) + "..." : firstString
-            }
-            return ""
         }
     }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -585,10 +585,52 @@ public func confirmationHumanDescription(
     let reason = (input["reason"]?.value as? String) ?? ""
     let r = reason.isEmpty ? "" : reason.prefix(1).lowercased() + reason.dropFirst()
 
+    // Derive permissionFriendlyName from input when not provided
+    let perm: String = permissionFriendlyName ?? {
+        guard let type = input["permission_type"]?.value as? String else { return "Permission" }
+        switch type {
+        case "full_disk_access": return "Full Disk Access"
+        case "accessibility": return "Accessibility"
+        case "screen_recording": return "Screen Recording"
+        case "calendar": return "Calendar"
+        case "contacts": return "Contacts"
+        case "photos": return "Photos"
+        case "location": return "Location Services"
+        case "microphone": return "Microphone"
+        case "camera": return "Camera"
+        default: return type.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }()
+
+    // Derive toolCategory from toolName when not provided
+    let tc: String = toolCategory ?? {
+        switch toolName {
+        case "bash", "host_bash":                    return "Run Command"
+        case "file_write", "host_file_write":        return "Write File"
+        case "file_edit", "host_file_edit":           return "Edit File"
+        case "file_read", "host_file_read":           return "Read File"
+        case "web_fetch":                             return "Fetch URL"
+        case "web_search":                            return "Web Search"
+        case "credential_store":                      return "Secure Storage"
+        case _ where toolName.hasPrefix("browser_"):  return "Browser"
+        case _ where toolName.hasPrefix("schedule_"): return "Scheduling"
+        case _ where toolName.hasPrefix("watcher_"):  return "Watcher"
+        case _ where toolName.hasPrefix("memory_"):   return "Memory"
+        case "skill_load":                            return "Skill"
+        case "evaluate_typescript_code":              return "Code Sandbox"
+        case "document_create", "document_update":    return "Document"
+        default:
+            return toolName
+                .replacingOccurrences(of: "_", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }()
+
     switch toolName {
     case "request_system_permission":
         if reason.isEmpty {
-            let perm = permissionFriendlyName ?? "Permission"
             return "I need \(perm) access to continue."
         }
         return reason
@@ -657,9 +699,8 @@ public func confirmationHumanDescription(
     case "schedule_delete":
         return "Allow deleting a schedule?"
     default:
-        let tc = (toolCategory ?? toolName.replacingOccurrences(of: "_", with: " ").capitalized).lowercased()
-        if !r.isEmpty { return "Allow using \(tc) \(r)?" }
-        return "Allow using \(tc)?"
+        if !r.isEmpty { return "Allow using \(tc.lowercased()) \(r)?" }
+        return "Allow using \(tc.lowercased())?"
     }
 }
 

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -582,7 +582,14 @@ public func confirmationHumanDescription(
     toolCategory: String? = nil,
     permissionFriendlyName: String? = nil
 ) -> String {
-    let reason = (input["reason"]?.value as? String) ?? ""
+    // Use reason, falling back to description/message for tools that provide
+    // context via other fields (e.g. context_overflow_compression uses description)
+    let rawReason = (input["reason"]?.value as? String) ?? ""
+    let reason: String = rawReason.isEmpty
+        ? (input["description"]?.value as? String)
+            ?? (input["message"]?.value as? String)
+            ?? ""
+        : rawReason
     let r = reason.isEmpty ? "" : reason.prefix(1).lowercased() + reason.dropFirst()
 
     // Derive permissionFriendlyName from input when not provided

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -517,85 +517,12 @@ public struct ToolConfirmationData: Equatable {
 
     /// Short question asking the user to approve the action.
     public var humanDescription: String {
-        let reason = (input["reason"]?.value as? String) ?? ""
-        // Lowercase the first letter so reason flows naturally mid-sentence (e.g. "to determine..." not "To determine...")
-        let r = reason.isEmpty ? "" : reason.prefix(1).lowercased() + reason.dropFirst()
-
-        switch toolName {
-        case "request_system_permission":
-            if reason.isEmpty {
-                return "I need \(permissionFriendlyName) access to continue."
-            }
-            return reason
-        case "bash", "host_bash":
-            if !r.isEmpty { return "Allow running a command on your computer \(r)?" }
-            return "Allow running a command on your computer?"
-        case "file_write", "host_file_write":
-            if !r.isEmpty { return "Allow writing a file \(r)?" }
-            let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "Allow writing a file?" }
-            return "Allow writing to \(URL(fileURLWithPath: path).lastPathComponent)?"
-        case "file_edit", "host_file_edit":
-            if !r.isEmpty { return "Allow editing a file \(r)?" }
-            let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "Allow editing a file?" }
-            return "Allow editing \(URL(fileURLWithPath: path).lastPathComponent)?"
-        case "file_read", "host_file_read":
-            if !r.isEmpty { return "Allow reading a file \(r)?" }
-            let path = (input["path"]?.value as? String) ?? ""
-            if path.isEmpty { return "Allow reading a file?" }
-            return "Allow reading \(URL(fileURLWithPath: path).lastPathComponent)?"
-        case "web_fetch":
-            if !r.isEmpty { return "Allow fetching a URL \(r)?" }
-            let url = (input["url"]?.value as? String) ?? ""
-            if let host = URL(string: url)?.host {
-                return "Allow fetching data from \(host)?"
-            }
-            return "Allow fetching a URL?"
-        case "browser_navigate":
-            if !r.isEmpty { return "Allow opening a page \(r)?" }
-            let url = (input["url"]?.value as? String) ?? ""
-            if let host = URL(string: url)?.host {
-                return "Allow opening \(host)?"
-            }
-            return "Allow opening a page?"
-        case "credential_store":
-            let action = (input["action"]?.value as? String) ?? ""
-            let service = (input["service"]?.value as? String) ?? ""
-            switch action {
-            case "oauth2_connect":
-                return service.isEmpty
-                    ? "Allow connecting an account?"
-                    : "Allow connecting your \(service.capitalized) account?"
-            case "store":
-                return service.isEmpty
-                    ? "Allow saving a credential securely?"
-                    : "Allow saving a \(service) credential securely?"
-            case "delete":
-                return service.isEmpty
-                    ? "Allow removing a stored credential?"
-                    : "Allow removing a \(service) credential?"
-            case "prompt":
-                return service.isEmpty
-                    ? "Allow asking for a credential?"
-                    : "Allow asking for a \(service) credential?"
-            default:
-                return "Allow accessing secure storage?"
-            }
-        case "schedule_create":
-            let name = (input["name"]?.value as? String) ?? ""
-            return name.isEmpty
-                ? "Allow creating a schedule?"
-                : "Allow creating schedule \"\(name)\"?"
-        case "schedule_update":
-            return "Allow updating a schedule?"
-        case "schedule_delete":
-            return "Allow deleting a schedule?"
-        default:
-            let tc = toolCategory.lowercased()
-            if !r.isEmpty { return "Allow using \(tc) \(r)?" }
-            return "Allow using \(tc)?"
-        }
+        confirmationHumanDescription(
+            toolName: toolName,
+            input: input,
+            toolCategory: toolCategory,
+            permissionFriendlyName: permissionFriendlyName
+        )
     }
 
     public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
@@ -642,6 +569,97 @@ public struct ToolConfirmationData: Equatable {
             executionTarget: executionTarget,
             persistentDecisionsAllowed: promptPayload.persistentDecisionsAllowed
         )
+    }
+}
+
+/// Shared helper that builds a human-friendly confirmation description from tool
+/// metadata. Used by both the inline `ToolConfirmationBubble` (via
+/// `ToolConfirmationData.humanDescription`) and system notifications (via
+/// `ToolConfirmationNotificationService`).
+public func confirmationHumanDescription(
+    toolName: String,
+    input: [String: AnyCodable],
+    toolCategory: String? = nil,
+    permissionFriendlyName: String? = nil
+) -> String {
+    let reason = (input["reason"]?.value as? String) ?? ""
+    let r = reason.isEmpty ? "" : reason.prefix(1).lowercased() + reason.dropFirst()
+
+    switch toolName {
+    case "request_system_permission":
+        if reason.isEmpty {
+            let perm = permissionFriendlyName ?? "Permission"
+            return "I need \(perm) access to continue."
+        }
+        return reason
+    case "bash", "host_bash":
+        if !r.isEmpty { return "Allow running a command on your computer \(r)?" }
+        return "Allow running a command on your computer?"
+    case "file_write", "host_file_write":
+        if !r.isEmpty { return "Allow writing a file \(r)?" }
+        let path = (input["path"]?.value as? String) ?? ""
+        if path.isEmpty { return "Allow writing a file?" }
+        return "Allow writing to \(URL(fileURLWithPath: path).lastPathComponent)?"
+    case "file_edit", "host_file_edit":
+        if !r.isEmpty { return "Allow editing a file \(r)?" }
+        let path = (input["path"]?.value as? String) ?? ""
+        if path.isEmpty { return "Allow editing a file?" }
+        return "Allow editing \(URL(fileURLWithPath: path).lastPathComponent)?"
+    case "file_read", "host_file_read":
+        if !r.isEmpty { return "Allow reading a file \(r)?" }
+        let path = (input["path"]?.value as? String) ?? ""
+        if path.isEmpty { return "Allow reading a file?" }
+        return "Allow reading \(URL(fileURLWithPath: path).lastPathComponent)?"
+    case "web_fetch":
+        if !r.isEmpty { return "Allow fetching a URL \(r)?" }
+        let url = (input["url"]?.value as? String) ?? ""
+        if let host = URL(string: url)?.host {
+            return "Allow fetching data from \(host)?"
+        }
+        return "Allow fetching a URL?"
+    case "browser_navigate":
+        if !r.isEmpty { return "Allow opening a page \(r)?" }
+        let url = (input["url"]?.value as? String) ?? ""
+        if let host = URL(string: url)?.host {
+            return "Allow opening \(host)?"
+        }
+        return "Allow opening a page?"
+    case "credential_store":
+        let action = (input["action"]?.value as? String) ?? ""
+        let service = (input["service"]?.value as? String) ?? ""
+        switch action {
+        case "oauth2_connect":
+            return service.isEmpty
+                ? "Allow connecting an account?"
+                : "Allow connecting your \(service.capitalized) account?"
+        case "store":
+            return service.isEmpty
+                ? "Allow saving a credential securely?"
+                : "Allow saving a \(service) credential securely?"
+        case "delete":
+            return service.isEmpty
+                ? "Allow removing a stored credential?"
+                : "Allow removing a \(service) credential?"
+        case "prompt":
+            return service.isEmpty
+                ? "Allow asking for a credential?"
+                : "Allow asking for a \(service) credential?"
+        default:
+            return "Allow accessing secure storage?"
+        }
+    case "schedule_create":
+        let name = (input["name"]?.value as? String) ?? ""
+        return name.isEmpty
+            ? "Allow creating a schedule?"
+            : "Allow creating schedule \"\(name)\"?"
+    case "schedule_update":
+        return "Allow updating a schedule?"
+    case "schedule_delete":
+        return "Allow deleting a schedule?"
+    default:
+        let tc = (toolCategory ?? toolName.replacingOccurrences(of: "_", with: " ").capitalized).lowercased()
+        if !r.isEmpty { return "Allow using \(tc) \(r)?" }
+        return "Allow using \(tc)?"
     }
 }
 


### PR DESCRIPTION
## Summary
Confirmation system notifications now show the same human-friendly text as the inline confirmation bubble, instead of raw shell commands or technical data.

Before: `$ PUBLIC_URL=$(assistant config get ingress.publicBaseUrl); echo "Public URL:...`
After: `Allow running a command on your computer checking if the public ingress URL is still working for Twilio webhooks?`

## Changes
- **ChatMessage.swift**: Extract `humanDescription` logic into a shared free function `confirmationHumanDescription(toolName:input:toolCategory:permissionFriendlyName:)`. The existing `ToolConfirmationData.humanDescription` property now delegates to it.
- **ToolConfirmationNotificationService.swift**: Replace custom `formatBody` truncation logic (which dropped the reason for long bash commands) with a call to the shared `confirmationHumanDescription`. Remove now-unused `commandPreview` method.

## Root cause
The notification service had its own truncation logic that gave all 200 chars of budget to the raw shell command when it was long, dropping the human-friendly reason text entirely. The inline confirmation bubble never had this issue because it used `humanDescription` which always prioritizes the reason.

## Test plan
- [ ] Trigger a bash confirmation while app is backgrounded — notification body should show "Allow running a command on your computer <reason>?"
- [ ] Trigger a file_write confirmation while backgrounded — should show "Allow writing a file <reason>?"
- [ ] Verify inline confirmation bubble still works identically (delegates to same function)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
