### PR TITLE
feat: per-message send failure UI with inline retry buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -19,6 +19,8 @@ struct ChatBubble: View {
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
     var resolveHttpPort: (() -> Int?) = { nil }
+    /// Called when the user taps "Retry" on a failed message.
+    var onRetryFailedMessage: ((UUID) -> Void)?
     var showAvatar: Bool = true
     var isLatestAssistantMessage: Bool = false
     /// When true, the assistant is still processing after tool calls completed.
@@ -80,7 +82,7 @@ struct ChatBubble: View {
 
     @ViewBuilder
     private var bubbleBorderOverlay: some View {
-        if message.isError {
+        if message.isError || (isUser && message.status == .sendFailed) {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .strokeBorder(VColor.error.opacity(0.3), lineWidth: 1)
         }
@@ -193,6 +195,11 @@ struct ChatBubble: View {
                         }
                     }
 
+                    // Per-message send failure indicator with inline retry button
+                    if isUser && message.status == .sendFailed {
+                        sendFailedIndicator
+                    }
+
                     // Single unified status area at the bottom of the message:
                     // - In-progress: shows "Running a terminal command ..."
                     // - Complete: shows compact chips ("Ran a terminal command" + "Permission granted")
@@ -247,6 +254,27 @@ struct ChatBubble: View {
             let resolved = await MediaEmbedResolver.resolve(message: message, settings: settings)
             guard !Task.isCancelled else { return }
             mediaEmbedIntents = resolved
+        }
+    }
+
+    // MARK: - Send Failed Indicator
+
+    private var sendFailedIndicator: some View {
+        HStack(spacing: VSpacing.xs) {
+            VIconView(.triangleAlert, size: 12)
+                .foregroundColor(VColor.error)
+            Text("Failed to send")
+                .font(VFont.caption)
+                .foregroundColor(VColor.error)
+            Button {
+                onRetryFailedMessage?(message.id)
+            } label: {
+                Text("Retry")
+                    .font(VFont.caption.weight(.medium))
+                    .foregroundColor(VColor.accent)
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -64,6 +64,8 @@ struct ChatView: View {
     var onRehydrateMessage: ((UUID) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
     var onSurfaceRefetch: ((String, String) -> Void)?
+    /// Called when the user taps "Retry" on a per-message send failure.
+    var onRetryFailedMessage: ((UUID) -> Void)?
     var subagentDetailStore: SubagentDetailStore
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
@@ -208,6 +210,7 @@ struct ChatView: View {
                             onSubagentTap: onSubagentTap,
                             onRehydrateMessage: onRehydrateMessage,
                             onSurfaceRefetch: onSurfaceRefetch,
+                            onRetryFailedMessage: onRetryFailedMessage,
                             subagentDetailStore: subagentDetailStore,
                             displayedMessageCount: displayedMessageCount,
                             hasMoreMessages: hasMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -74,6 +74,8 @@ struct MessageListView: View {
     var onRehydrateMessage: ((UUID) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
     var onSurfaceRefetch: ((String, String) -> Void)?
+    /// Called when the user taps "Retry" on a per-message send failure.
+    var onRetryFailedMessage: ((UUID) -> Void)?
     var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Pagination
@@ -439,6 +441,7 @@ struct MessageListView: View {
                             onReportMessage: onReportMessage,
                             onRehydrateMessage: onRehydrateMessage,
                             onSurfaceRefetch: onSurfaceRefetch,
+                            onRetryFailedMessage: onRetryFailedMessage,
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             onModelPickerSelect: onModelPickerSelect,
@@ -917,6 +920,8 @@ private struct MessageCellView: View {
     var onRehydrateMessage: ((UUID) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
     var onSurfaceRefetch: ((String, String) -> Void)?
+    /// Called when the user taps "Retry" on a per-message send failure.
+    var onRetryFailedMessage: ((UUID) -> Void)?
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
     var onModelPickerSelect: ((UUID, String) -> Void)?
@@ -1038,6 +1043,7 @@ private struct MessageCellView: View {
                 onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
                 mediaEmbedSettings: mediaEmbedSettings,
                 resolveHttpPort: resolveHttpPort,
+                onRetryFailedMessage: onRetryFailedMessage,
                 showAvatar: !previousIsAssistant,
                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -694,6 +694,9 @@ struct ActiveChatViewWrapper: View {
             onSurfaceRefetch: { surfaceId, sessionId in
                 viewModel.refetchStrippedSurface(surfaceId: surfaceId, sessionId: sessionId)
             },
+            onRetryFailedMessage: { messageId in
+                viewModel.retryFailedMessage(id: messageId)
+            },
             subagentDetailStore: viewModel.subagentDetailStore,
             resolveHttpPort: daemonClient.httpPortResolver,
             isHistoryLoaded: viewModel.isHistoryLoaded,

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -18,6 +18,8 @@ public enum ChatMessageStatus: Equatable {
     case processing
     /// Message is buffered in the local offline queue pending daemon reconnect.
     case pendingOffline
+    /// HTTP send failed — the message was never delivered to the daemon.
+    case sendFailed
 }
 
 /// Tracks the state of an inline tool confirmation request.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1603,6 +1603,23 @@ extension ChatViewModel {
             // Empty sessionId is treated as a broadcast (e.g. transport-level 401)
             guard sessionId != nil, msg.sessionId.isEmpty || belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
+
+            // Per-message send failure: mark the specific user message instead
+            // of showing a session-level error banner.
+            if let failedContent = msg.failedMessageContent {
+                if let idx = messages.lastIndex(where: { $0.role == .user && $0.text == failedContent && $0.status != .sendFailed }) {
+                    messages[idx].status = .sendFailed
+                }
+                // Only reset sending state if no other messages are in-flight.
+                // Check if any non-failed user messages are still pending.
+                let hasActiveSend = messages.contains(where: { $0.role == .user && ($0.status == .processing || $0.status == .sent) }) && isSending
+                if !hasActiveSend {
+                    isThinking = false
+                    isSending = false
+                }
+                return
+            }
+
             isWorkspaceRefinementInFlight = false
             refinementFlushTask?.cancel()
             refinementFlushTask = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2066,6 +2066,46 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Retry sending a specific failed message. Moves it to the end of the
+    /// conversation and resends it so it appears as the most recent message.
+    public func retryFailedMessage(id: UUID) {
+        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
+        let message = messages[idx]
+        guard message.role == .user, message.status == .sendFailed else { return }
+
+        // Remove the failed message from its current position
+        messages.remove(at: idx)
+
+        // Re-append it at the end with .sent status
+        var retryMessage = ChatMessage(
+            role: .user,
+            text: message.text,
+            status: .sent,
+            skillInvocation: message.skillInvocation,
+            attachments: message.attachments
+        )
+        retryMessage.isHidden = message.isHidden
+        messages.append(retryMessage)
+
+        // Convert ChatAttachments back to UserMessageAttachments for the send call
+        let userAttachments: [UserMessageAttachment]? = message.attachments.isEmpty ? nil : message.attachments.compactMap { att in
+            guard !att.data.isEmpty else { return nil }
+            return UserMessageAttachment(
+                id: att.id,
+                filename: att.filename,
+                mimeType: att.mimeType,
+                data: att.data,
+                extractedText: nil,
+                sizeBytes: nil,
+                thumbnailData: nil,
+                filePath: att.filePath
+            )
+        }
+
+        // Resend via the normal path
+        sendUserMessage(message.text, attachments: userAttachments)
+    }
+
     /// Respond to a tool confirmation request displayed inline in the chat.
     public func respondToConfirmation(requestId: String, decision: String) {
         // DaemonClient.send silently returns when connection is nil (it does

--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -18,6 +18,8 @@ public struct MessageBubbleView: View {
     public let onGuardianAction: ((String, String) -> Void)?
     /// Called when a stripped surface scrolls into view and needs its data re-fetched.
     public let onSurfaceRefetch: ((String, String) -> Void)?
+    /// Called when the user taps "Retry" on a per-message send failure.
+    public let onRetryFailedMessage: ((UUID) -> Void)?
 
     public init(
         message: ChatMessage,
@@ -26,7 +28,8 @@ public struct MessageBubbleView: View {
         onRegenerate: (() -> Void)?,
         onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
         onGuardianAction: ((String, String) -> Void)? = nil,
-        onSurfaceRefetch: ((String, String) -> Void)? = nil
+        onSurfaceRefetch: ((String, String) -> Void)? = nil,
+        onRetryFailedMessage: ((UUID) -> Void)? = nil
     ) {
         self.message = message
         self.onConfirmationResponse = onConfirmationResponse
@@ -35,6 +38,7 @@ public struct MessageBubbleView: View {
         self.onAlwaysAllow = onAlwaysAllow
         self.onGuardianAction = onGuardianAction
         self.onSurfaceRefetch = onSurfaceRefetch
+        self.onRetryFailedMessage = onRetryFailedMessage
     }
 
     public var body: some View {
@@ -116,6 +120,26 @@ public struct MessageBubbleView: View {
                         Text("Pending")
                             .font(VFont.small)
                             .foregroundColor(VColor.textMuted)
+                    }
+                    .padding(.horizontal, VSpacing.sm)
+                }
+
+                // Per-message send failure indicator with inline retry button
+                if message.role == .user && message.status == .sendFailed {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.triangleAlert, size: 11)
+                            .foregroundColor(VColor.error)
+                        Text("Failed to send")
+                            .font(VFont.small)
+                            .foregroundColor(VColor.error)
+                        Button {
+                            onRetryFailedMessage?(message.id)
+                        } label: {
+                            Text("Retry")
+                                .font(VFont.small.weight(.medium))
+                                .foregroundColor(VColor.accent)
+                        }
+                        .buttonStyle(.plain)
                     }
                     .padding(.horizontal, VSpacing.sm)
                 }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1581,7 +1581,8 @@ public final class HTTPTransport {
                         sessionId: sessionId,
                         code: .providerApi,
                         userMessage: "Failed to upload \(failedCount) attachment\(failedCount == 1 ? "" : "s"). Please try again.",
-                        retryable: true
+                        retryable: true,
+                        failedMessageContent: content
                     )))
                     return
                 }
@@ -1629,7 +1630,8 @@ public final class HTTPTransport {
                         sessionId: sessionId,
                         code: .providerApi,
                         userMessage: "Failed to send message — authentication error. Please try again.",
-                        retryable: true
+                        retryable: true,
+                        failedMessageContent: content
                     )))
                 }
             } else {
@@ -1639,7 +1641,8 @@ public final class HTTPTransport {
                     sessionId: sessionId,
                     code: .providerApi,
                     userMessage: "Failed to send message (HTTP \(http.statusCode))",
-                    retryable: true
+                    retryable: true,
+                    failedMessageContent: content
                 )))
             }
         } catch {
@@ -1648,7 +1651,8 @@ public final class HTTPTransport {
                 sessionId: sessionId,
                 code: .providerApi,
                 userMessage: error.localizedDescription,
-                retryable: true
+                retryable: true,
+                failedMessageContent: content
             )))
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1410,13 +1410,18 @@ public struct SessionErrorMessage: Decodable, Sendable {
     public let userMessage: String
     public let retryable: Bool
     public let debugDetails: String?
+    /// Non-nil when the error is a client-side HTTP send failure.
+    /// Contains the message content that failed to send, used to mark
+    /// the specific user message as `.sendFailed` in the chat.
+    public let failedMessageContent: String?
 
-    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil) {
+    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil, failedMessageContent: String? = nil) {
         self.sessionId = sessionId
         self.code = code
         self.userMessage = userMessage
         self.retryable = retryable
         self.debugDetails = debugDetails
+        self.failedMessageContent = failedMessageContent
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces session-level error banner with per-message error indicators when HTTP message sends fail (e.g. 429, network errors)
- Each failed user message shows a red "Failed to send" label with a "Retry" button directly on the message bubble
- On retry, the message moves to the end of the conversation and is resent, appearing as the most recent message

## Original prompt
ah this isn't great if the user sends multiple messages back to back. it's unclear that the 2nd to last message was never actually sent. could we update this UI to instead put the error UI directly on each message that wasnt sent, with a "try" button below each individual message? then, once the message is sent, we can move it to be the most recently sent message. do this in a new worktree / feature branch based off of latest main since i just merged your last PR into main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
