### PR TITLE
fix: per-message send failure UI — clear sending state and handle nil session

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1611,8 +1611,15 @@ extension ChatViewModel {
                     messages[idx].status = .sendFailed
                 }
                 // Only reset sending state if no other messages are in-flight.
-                // Check if any non-failed user messages are still pending.
-                let hasActiveSend = messages.contains(where: { $0.role == .user && ($0.status == .processing || $0.status == .sent) }) && isSending
+                // Check for genuinely in-flight statuses (.processing, .queued)
+                // — NOT .sent, which is the default/terminal status for all
+                // previously delivered messages.
+                let hasActiveSend = isSending && messages.contains(where: { msg in
+                    guard msg.role == .user else { return false }
+                    if msg.status == .processing { return true }
+                    if case .queued = msg.status { return true }
+                    return false
+                })
                 if !hasActiveSend {
                     isThinking = false
                     isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2102,8 +2102,12 @@ public final class ChatViewModel: ObservableObject {
             )
         }
 
-        // Resend via the normal path
-        sendUserMessage(message.text, attachments: userAttachments)
+        // Resend — bootstrap a new session if needed (mirrors retryLastMessage)
+        if sessionId == nil {
+            bootstrapSession(userMessage: message.text, attachments: userAttachments)
+        } else {
+            sendUserMessage(message.text, attachments: userAttachments)
+        }
     }
 
     /// Respond to a tool confirmation request displayed inline in the chat.


### PR DESCRIPTION
## Summary
- Fix bug where `isSending`/`isThinking` were never cleared after per-message failure because `hasActiveSend` included `.sent` status (always true for conversations with prior messages)
- Add `sessionId == nil` guard to `retryFailedMessage` so it bootstraps a new session if needed, matching `retryLastMessage` behavior

## Original prompt
please address the coding agent feedback on that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
