### PR TITLE
fix: only set Content-Type header when request has body

### DIFF
--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -62,7 +62,7 @@ export class BYOOAuthConnection implements OAuthConnection {
       const resp = await fetch(fullUrl, {
         method: req.method,
         headers: {
-          "Content-Type": "application/json",
+          ...(req.body ? { "Content-Type": "application/json" } : {}),
           ...req.headers,
           Authorization: `Bearer ${token}`,
         },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-conn-request.md.

**Gap:** Content-Type header set unconditionally on all requests
**What was expected:** GET requests should not include Content-Type header
**What was found:** BYOOAuthConnection.request() always sets Content-Type: application/json

Makes the Content-Type: application/json header conditional on req.body being present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
