### PR TITLE
fix: remove unused GMAIL_BATCH_BASE_URL export

### DIFF
--- a/assistant/src/oauth/provider-base-urls.ts
+++ b/assistant/src/oauth/provider-base-urls.ts
@@ -15,7 +15,6 @@ export const PROVIDER_BASE_URLS: Record<string, string> = {
 export const GOOGLE_CALENDAR_BASE_URL =
   "https://www.googleapis.com/calendar/v3";
 export const GOOGLE_PEOPLE_BASE_URL = "https://people.googleapis.com/v1";
-export const GMAIL_BATCH_BASE_URL = "https://www.googleapis.com/batch/gmail/v1";
 
 export function getProviderBaseUrl(providerKey: string): string | undefined {
   return PROVIDER_BASE_URLS[providerKey];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-conn-request.md.

**Gap:** GMAIL_BATCH_BASE_URL export is unused
**What was expected:** Provider base URL exports should be used or removed
**What was found:** GMAIL_BATCH_BASE_URL is never imported; Gmail client uses its own local constant

Removes the dead export from provider-base-urls.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
