### PR TITLE
fix: add 30s request timeout to BYOOAuthConnection

### DIFF
--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -39,6 +39,7 @@ export class GmailApiError extends Error {
 
 const MAX_RETRIES = 3;
 const INITIAL_BACKOFF_MS = 1000;
+/** Timeout for batch API calls that bypass OAuthConnection.request() (which has its own 30s timeout). */
 const REQUEST_TIMEOUT_MS = 30_000;
 
 function isRetryable(status: number): boolean {

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -17,6 +17,9 @@ import type {
 
 const log = getLogger("byo-oauth-connection");
 
+/** Default per-request timeout to prevent hung requests from blocking indefinitely. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export interface BYOOAuthConnectionOptions {
   id: string;
   providerKey: string;
@@ -67,6 +70,7 @@ export class BYOOAuthConnection implements OAuthConnection {
           Authorization: `Bearer ${token}`,
         },
         body: req.body ? JSON.stringify(req.body) : undefined,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
 
       if (resp.status === 401) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-conn-request.md.

**Gap:** Gmail API per-request timeout dropped during migration
**What was expected:** The old Gmail client had a 30-second timeout on every API request
**What was found:** BYOOAuthConnection.request() calls fetch() with no timeout

Adds a 30-second default timeout to BYOOAuthConnection.request() fetch calls. Also cleans up the partially-dead REQUEST_TIMEOUT_MS constant in gmail/client.ts with a comment clarifying it is only used by the batch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
