### PR TITLE
Fix: flush partialOutput buffer before pagination prepend

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2460,6 +2460,9 @@ public final class ChatViewModel: ObservableObject {
             // Older page fetched on demand — prepend before existing messages
             // and expand the display window so the newly loaded messages are
             // visible. The loading indicator is cleared here.
+            // Flush any buffered partial output before prepending — the prepend
+            // shifts positional indices so stale buffer entries would corrupt.
+            flushPartialOutputBuffer()
             self.messages = chatMessages + self.messages
             // Expand the display window by the number of messages prepended so
             // the user sees them immediately. Use Int.max if no more pages exist.


### PR DESCRIPTION
Flush buffered partial output before prepending pagination messages in `populateFromHistory`. The prepend shifts positional indices, so stale buffer entries would write to the wrong tool call.

Addresses Codex review feedback on #15444.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
