### PR TITLE
fix: prevent blocked members from bypassing ingress ACL verification paths

### DIFF
--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -400,4 +400,68 @@ describe("Verification control messages are deterministic (guard)", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("handleChannelInbound does not allow blocked members to bootstrap with /start gv_<token>", async () => {
+    const { createHash, randomBytes } = await import("node:crypto");
+    const { handleChannelInbound } =
+      await import("../runtime/routes/inbound-message-handler.js");
+    const { createOutboundSession } =
+      await import("../runtime/channel-verification-service.js");
+    const { upsertContactChannel } = await import("../contacts/contacts-write.js");
+
+    const blockedIdentity = {
+      sourceChannel: "telegram",
+      externalUserId: "user-blocked-bootstrap",
+      externalChatId: "chat-blocked-bootstrap",
+      displayName: "Blocked Bootstrap User",
+      status: "blocked",
+      policy: "deny",
+    } as const;
+    upsertContactChannel(blockedIdentity);
+
+    const bootstrapToken = randomBytes(16).toString("hex");
+    const bootstrapTokenHash = createHash("sha256")
+      .update(bootstrapToken)
+      .digest("hex");
+
+    createOutboundSession({
+      channel: "telegram",
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: blockedIdentity.externalUserId,
+      bootstrapTokenHash,
+    });
+
+    let processMessageCalled = false;
+    const processMessage = async () => {
+      processMessageCalled = true;
+      return { messageId: "msg-1" };
+    };
+
+    const req = new Request("http://localhost/channels/inbound", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChannel: "telegram",
+        interface: "telegram",
+        conversationExternalId: blockedIdentity.externalChatId,
+        externalMessageId: `msg-blocked-bootstrap-${Date.now()}`,
+        content: `/start gv_${bootstrapToken}`,
+        actorExternalId: blockedIdentity.externalUserId,
+        actorDisplayName: blockedIdentity.displayName,
+        sourceMetadata: {
+          commandIntent: { type: "start", payload: `gv_${bootstrapToken}` },
+        },
+      }),
+    });
+
+    const response = await handleChannelInbound(req, processMessage);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(body.accepted).toBe(true);
+    expect(body.denied).toBe(true);
+    expect(body.reason).toBe("member_blocked");
+    expect(body.verificationOutcome).toBeUndefined();
+    expect(processMessageCalled).toBe(false);
+  });
+
 });

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -452,9 +452,11 @@ export async function enforceIngressAcl(
         }
 
         // ── Invite token intercept (inactive member) ──
-        // Same as the non-member branch: invite tokens can reactivate
-        // revoked/pending members without requiring guardian approval.
-        if (inviteToken && denyInactiveMember) {
+        // Invite tokens can reactivate revoked/pending members without
+        // requiring guardian approval, but blocked members are excluded so
+        // they are short-circuited at the ACL layer rather than entering the
+        // redemption path.
+        if (!isBlockedMember && inviteToken && denyInactiveMember) {
           const inviteResult = await handleInviteTokenIntercept({
             rawToken: inviteToken,
             sourceChannel,
@@ -477,9 +479,15 @@ export async function enforceIngressAcl(
         }
 
         // ── 6-digit invite code intercept (inactive member) ──
-        // Same as the non-member branch: codes can reactivate revoked/pending
-        // members. Non-matching codes fall through to normal processing.
-        if (denyInactiveMember && /^\d{6}$/.test(trimmedContent)) {
+        // Codes can reactivate revoked/pending members; non-matching codes
+        // fall through. Blocked members are excluded here for consistency —
+        // the redemption service would reject them anyway, but early exit
+        // avoids unnecessary work.
+        if (
+          !isBlockedMember &&
+          denyInactiveMember &&
+          /^\d{6}$/.test(trimmedContent)
+        ) {
           const codeInterceptResult = await handleInviteCodeIntercept({
             code: trimmedContent,
             sourceChannel,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -403,11 +403,12 @@ export async function enforceIngressAcl(
 
     if (resolvedMember) {
       if (resolvedMember.channel.status !== "active") {
+        const isBlockedMember = resolvedMember.channel.status === "blocked";
         // Same bypass logic as the no-member branch: verification codes and
-        // bootstrap commands must pass through even when the member record is
-        // revoked/blocked — otherwise the user can never re-verify.
+        // bootstrap commands must pass through for re-verifiable states
+        // (pending/revoked), but never for blocked members.
         let denyInactiveMember = true;
-        if (isGuardianVerifyCode) {
+        if (!isBlockedMember && isGuardianVerifyCode) {
           const hasPendingChallenge = !!getPendingSession(sourceChannel);
           const hasActiveOutboundSession = !!findActiveSession(sourceChannel);
           if (hasPendingChallenge || hasActiveOutboundSession) {
@@ -424,7 +425,7 @@ export async function enforceIngressAcl(
             );
           }
         }
-        if (isBootstrapCommand) {
+        if (!isBlockedMember && isBootstrapCommand) {
           const bootstrapPayload = (
             rawCommandIntentForAcl as Record<string, unknown>
           ).payload as string;


### PR DESCRIPTION
### Motivation

- A recent change allowed guardian verification codes and bootstrap `/start gv_` commands to bypass the ingress ACL for any non-`active` member, which unintentionally included `blocked` members and allowed them to regain access if they still held a valid token.
- The goal is to preserve the intended convenience for re-verifiable states (e.g. `pending`/`revoked`) while preventing `blocked` members from reaching deterministic verification/bootstrap intercepts and getting reactivated without guardian awareness.

### Description

- Restrict the inactive-member verification/bootstrap bypass in `enforceIngressAcl` so it does not apply when a member's channel `status` is `blocked` by checking `resolvedMember.channel.status === 'blocked'` before allowing the bypass in `assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts`.
- Update comments to clarify that bypasses are allowed for re-verifiable states (pending/revoked) but deliberately disallowed for blocked members.
- Add a regression test `handleChannelInbound does not allow blocked members to bootstrap with /start gv_<token>` to `assistant/src/__tests__/deterministic-verification-control-plane.test.ts` that creates a blocked member with a pending bootstrap session and asserts the inbound `/start gv_` request is denied with `member_blocked` and does not invoke normal message processing.

### Testing

- Added a unit test `assistant/src/__tests__/deterministic-verification-control-plane.test.ts` (regression) but it could not be executed in this environment because `bun` is not available; attempting to run `cd assistant && bun test src/__tests__/deterministic-verification-control-plane.test.ts` failed due to missing Bun and download/network restrictions.
- In this environment linting/type-check steps that would normally run via Bun were skipped for the same reason, so no automated test run succeeded here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae958b0bd0832393325115f677e561)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
