### PR TITLE
feat: enable Vertex AI wire format in GeminiProvider when using managed proxy

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -739,14 +739,17 @@ describe("GeminiProvider", () => {
     expect(lastConstructorOpts).toEqual({ apiKey: "test-key" });
   });
 
-  test("sets httpOptions.baseUrl when managedBaseUrl is provided", () => {
+  test("sets vertexai mode with httpOptions.baseUrl when managedBaseUrl is provided", () => {
     new GeminiProvider("managed-key", "gemini-3-flash", {
-      managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
+      managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
     });
     expect(lastConstructorOpts).toEqual({
       apiKey: "managed-key",
+      vertexai: true,
+      project: "proxy",
+      location: "us-central1",
       httpOptions: {
-        baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
       },
     });
   });
@@ -756,7 +759,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
       },
     );
 
@@ -781,7 +784,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
       },
     );
 

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -16,6 +16,10 @@ export interface GeminiProviderOptions {
   streamTimeoutMs?: number;
   /** When set, routes requests through the managed proxy at this base URL. */
   managedBaseUrl?: string;
+  /** Vertex AI project placeholder (used with managed proxy). */
+  vertexProject?: string;
+  /** Vertex AI location placeholder (used with managed proxy). */
+  vertexLocation?: string;
 }
 
 export class GeminiProvider implements Provider {
@@ -29,12 +33,15 @@ export class GeminiProvider implements Provider {
     model: string,
     options: GeminiProviderOptions = {},
   ) {
-    this.client = new GoogleGenAI({
-      apiKey,
-      ...(options.managedBaseUrl
-        ? { httpOptions: { baseUrl: options.managedBaseUrl } }
-        : {}),
-    });
+    this.client = options.managedBaseUrl
+      ? new GoogleGenAI({
+          apiKey,
+          vertexai: true,
+          project: options.vertexProject ?? "proxy",
+          location: options.vertexLocation ?? "us-central1",
+          httpOptions: { baseUrl: options.managedBaseUrl },
+        })
+      : new GoogleGenAI({ apiKey });
     this.model = model;
     this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
   }


### PR DESCRIPTION
## Summary
- Extend GeminiProviderOptions with vertexProject and vertexLocation fields
- When managedBaseUrl is set, initialize GoogleGenAI with vertexai: true and placeholder project/location so the SDK emits Vertex-format request paths
- Update managed proxy tests to assert the new vertexai constructor shape

Part of plan: vertex-gemini-proxy.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
