### PR TITLE
feat: route managed Gemini fallback through /v1/runtime-proxy/vertex

### DIFF
--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -173,6 +173,31 @@ describe("managed proxy integration — credential precedence", () => {
       expect(baseURL).toContain("/v1/runtime-proxy/vertex");
       expect(baseURL).not.toContain("/v1/runtime-proxy/anthropic");
     });
+
+    test("managed gemini uses vertex proxy path instead of gemini proxy path", () => {
+      enableManagedProxy();
+      initializeProviders({
+        apiKeys: {},
+        provider: "anthropic",
+        model: "test-model",
+      });
+
+      const provider = getProvider("gemini");
+
+      // Unwrap RetryProvider → LogfireProvider → GeminiProvider to inspect
+      // the GoogleGenAI client's configured base URL.
+      const retryInner = (provider as any).inner;
+      const logfireInner = (retryInner as any).inner ?? retryInner;
+      const geminiClient = (logfireInner as any).client;
+
+      expect(geminiClient).toBeDefined();
+      // GoogleGenAI exposes a protected `apiClient` with getBaseUrl()
+      const apiClient = (geminiClient as any).apiClient;
+      const baseUrl: string =
+        apiClient?.getCustomBaseUrl?.() ?? apiClient?.getBaseUrl?.() ?? "";
+      expect(baseUrl).toContain("/v1/runtime-proxy/vertex");
+      expect(baseUrl).not.toContain("/v1/runtime-proxy/gemini");
+    });
   });
 
   describe("neither user keys nor managed context → providers not initialized", () => {

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -289,8 +289,8 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("gemini", "user-key");
   } else {
-    // No user Gemini key — try managed proxy fallback
-    const managedBaseUrl = buildManagedBaseUrl("gemini");
+    // No user Gemini key — route through Vertex managed proxy
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "gemini");


### PR DESCRIPTION
## Summary
- Change managed Gemini proxy path from `/v1/runtime-proxy/gemini` to `/v1/runtime-proxy/vertex` in registry.ts
- Add integration test verifying managed Gemini routes through the vertex proxy path
- No changes to managed-proxy-context.test.ts (tests the function itself, not how it's called)

Part of plan: vertex-gemini-proxy.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
