### PR TITLE
refactor: remove unused per-provider proxy paths from managed proxy constants

### DIFF
--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -107,19 +107,19 @@ describe("buildManagedBaseUrl", () => {
 
   test("builds correct URL for managed providers", () => {
     expect(buildManagedBaseUrl("openai")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/openai",
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
     expect(buildManagedBaseUrl("anthropic")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/anthropic",
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
     expect(buildManagedBaseUrl("gemini")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/gemini",
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
     expect(buildManagedBaseUrl("fireworks")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/fireworks",
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
     expect(buildManagedBaseUrl("openrouter")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/openrouter",
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
   });
 

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -311,10 +311,11 @@ describe("managed proxy integration — constants integrity", () => {
     }
   });
 
-  test("managed proxy paths are unique across providers", () => {
-    const paths = Object.values(MANAGED_PROVIDER_META)
-      .filter((m) => m.managed && m.proxyPath)
-      .map((m) => m.proxyPath);
-    expect(new Set(paths).size).toBe(paths.length);
+  test("all managed providers route through the vertex proxy path", () => {
+    for (const meta of Object.values(MANAGED_PROVIDER_META)) {
+      if (meta.managed && meta.proxyPath) {
+        expect(meta.proxyPath).toBe("/v1/runtime-proxy/vertex");
+      }
+    }
   });
 });

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -24,27 +24,27 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   openai: {
     name: "openai",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/openai",
+    proxyPath: "/v1/runtime-proxy/vertex",
   },
   anthropic: {
     name: "anthropic",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/anthropic",
+    proxyPath: "/v1/runtime-proxy/vertex",
   },
   gemini: {
     name: "gemini",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/gemini",
+    proxyPath: "/v1/runtime-proxy/vertex",
   },
   fireworks: {
     name: "fireworks",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/fireworks",
+    proxyPath: "/v1/runtime-proxy/vertex",
   },
   openrouter: {
     name: "openrouter",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/openrouter",
+    proxyPath: "/v1/runtime-proxy/vertex",
   },
   vertex: {
     name: "vertex",


### PR DESCRIPTION
## Summary
- Set all managed providers' proxyPath to "/v1/runtime-proxy/vertex" in constants.ts
- Update managed-proxy-context tests to expect vertex path for all providers
- Remove stale "unique paths" test since uniform vertex routing is the intended design

Part of plan: vertex-gemini-proxy.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
