### PR TITLE
fix: resolve GoogleGenAI apiKey/project mutual exclusion in managed proxy

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -744,12 +744,10 @@ describe("GeminiProvider", () => {
       managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
     });
     expect(lastConstructorOpts).toEqual({
-      apiKey: "managed-key",
       vertexai: true,
-      project: "proxy",
-      location: "us-central1",
       httpOptions: {
         baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+        headers: { "x-goog-api-key": "managed-key" },
       },
     });
   });

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -16,10 +16,6 @@ export interface GeminiProviderOptions {
   streamTimeoutMs?: number;
   /** When set, routes requests through the managed proxy at this base URL. */
   managedBaseUrl?: string;
-  /** Vertex AI project placeholder (used with managed proxy). */
-  vertexProject?: string;
-  /** Vertex AI location placeholder (used with managed proxy). */
-  vertexLocation?: string;
 }
 
 export class GeminiProvider implements Provider {
@@ -35,11 +31,11 @@ export class GeminiProvider implements Provider {
   ) {
     this.client = options.managedBaseUrl
       ? new GoogleGenAI({
-          apiKey,
           vertexai: true,
-          project: options.vertexProject ?? "proxy",
-          location: options.vertexLocation ?? "us-central1",
-          httpOptions: { baseUrl: options.managedBaseUrl },
+          httpOptions: {
+            baseUrl: options.managedBaseUrl,
+            headers: { "x-goog-api-key": apiKey },
+          },
         })
       : new GoogleGenAI({ apiKey });
     this.model = model;


### PR DESCRIPTION
## Summary
- Fixed `GeminiProvider` constructor to avoid passing both `apiKey` and `project`/`location` to `GoogleGenAI`, which the SDK now rejects as mutually exclusive
- When using managed proxy mode, the API key is now passed via `httpOptions.headers` (`x-goog-api-key`) instead, and `project`/`location` are omitted since the proxy handles Vertex AI routing
- Removed unused `vertexProject`/`vertexLocation` options from `GeminiProviderOptions`

## Original prompt
fix these tests: provider-managed-proxy-integration.test.ts (17 fail) and provider-fail-open-selection.test.ts (4 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
