### PR TITLE
feat: fetch and upload logs from managed assistants via platform API

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -105,9 +105,19 @@ enum LogExporter {
             }
         }
 
-        // 3. Daemon logs and audit data via daemon HTTP APIs
+        // 3. Assistant logs — platform API for managed, local gateway for self-hosted
         let home = NSHomeDirectory()
-        await fetchDaemonExports(into: tempDir)
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let isManagedAssistant: Bool = {
+            guard let id = connectedId else { return false }
+            return LockfileAssistant.loadByName(id)?.isManaged == true
+        }()
+
+        if isManagedAssistant {
+            await fetchPlatformLogs(into: tempDir)
+        } else {
+            await fetchDaemonExports(into: tempDir)
+        }
 
         // 4. XDG CLI logs — ~/.config/vellum/logs/ (hatch.log, retire.log, etc.)
         let xdgConfigHome = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
@@ -267,6 +277,98 @@ enum LogExporter {
             }
         } catch {
             log.warning("Export API request failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Platform Log Helpers
+
+    /// Fetches logs from the platform API for managed assistants, downloads
+    /// the tar.gz response, extracts it into `directory/platform-logs/`.
+    /// Silently skips on any failure (non-fatal, mirrors `fetchDaemonExports`).
+    private nonisolated static func fetchPlatformLogs(into directory: URL) async {
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") else {
+            return
+        }
+
+        guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            return
+        }
+
+        guard LockfileAssistant.loadByName(assistantId)?.isManaged == true else {
+            return
+        }
+
+        guard let token = SessionTokenManager.getToken() else {
+            log.warning("No session token available — skipping platform log export")
+            return
+        }
+
+        let baseURL = AuthService.shared.baseURL
+
+        guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistantId)/logs/export/") else {
+            log.warning("Failed to construct platform log export URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 60
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse,
+                  (200...299).contains(http.statusCode) else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                log.warning("Platform log export API failed with status \(status)")
+                return
+            }
+
+            let fileManager = FileManager.default
+            let tarPath = fileManager.temporaryDirectory
+                .appendingPathComponent("platform-logs-\(UUID().uuidString).tar.gz")
+            try data.write(to: tarPath)
+
+            defer {
+                try? fileManager.removeItem(at: tarPath)
+            }
+
+            let extractDir = directory.appendingPathComponent("platform-logs", isDirectory: true)
+            try fileManager.createDirectory(at: extractDir, withIntermediateDirectories: true)
+
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+                process.arguments = [
+                    "xzf",
+                    tarPath.path,
+                    "-C", extractDir.path,
+                ]
+
+                let pipe = Pipe()
+                process.standardError = pipe
+
+                process.terminationHandler = { proc in
+                    if proc.terminationStatus == 0 {
+                        continuation.resume()
+                    } else {
+                        let stderr = String(
+                            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                            encoding: .utf8
+                        ) ?? ""
+                        continuation.resume(throwing: ExportError.tarFailed(stderr))
+                    }
+                }
+
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        } catch {
+            log.warning("Platform log export request failed: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add fetchPlatformLogs method to LogExporter that downloads logs from the platform API for managed assistants
- Branch buildArchive to use platform fetch for managed assistants vs local gateway for self-hosted
- Extract platform tar.gz response into archive staging directory alongside other local log sources

Part of plan: managed-log-export.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
