### PR TITLE
fix: use consistent buildManagedBaseUrl("vertex") across all providers

### DIFF
--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -259,7 +259,8 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openai", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("openai");
+    // No user OpenAI key — route through Vertex managed proxy
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "openai");
@@ -337,7 +338,8 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("fireworks", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("fireworks");
+    // No user Fireworks key — route through Vertex managed proxy
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "fireworks");
@@ -369,7 +371,8 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openrouter", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("openrouter");
+    // No user OpenRouter key — route through Vertex managed proxy
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "openrouter");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for vertex-gemini-proxy.md.

**Gap:** Inconsistent buildManagedBaseUrl key usage in registry
**What was expected:** All managed providers should use a consistent pattern
**What was found:** Anthropic/Gemini used "vertex" while OpenAI/Fireworks/OpenRouter used their own names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
