### PR TITLE
revert: restore per-provider proxy paths for openai, fireworks, openrouter

### DIFF
--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -107,7 +107,7 @@ describe("buildManagedBaseUrl", () => {
 
   test("builds correct URL for managed providers", () => {
     expect(buildManagedBaseUrl("openai")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
+      "https://platform.example.com/v1/runtime-proxy/openai",
     );
     expect(buildManagedBaseUrl("anthropic")).toBe(
       "https://platform.example.com/v1/runtime-proxy/vertex",
@@ -116,10 +116,10 @@ describe("buildManagedBaseUrl", () => {
       "https://platform.example.com/v1/runtime-proxy/vertex",
     );
     expect(buildManagedBaseUrl("fireworks")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
+      "https://platform.example.com/v1/runtime-proxy/fireworks",
     );
     expect(buildManagedBaseUrl("openrouter")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
+      "https://platform.example.com/v1/runtime-proxy/openrouter",
     );
   });
 

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -335,11 +335,24 @@ describe("managed proxy integration — constants integrity", () => {
     }
   });
 
-  test("all managed providers route through the vertex proxy path", () => {
-    for (const meta of Object.values(MANAGED_PROVIDER_META)) {
-      if (meta.managed && meta.proxyPath) {
-        expect(meta.proxyPath).toBe("/v1/runtime-proxy/vertex");
-      }
-    }
+  test("anthropic and gemini route through vertex proxy path", () => {
+    expect(MANAGED_PROVIDER_META.anthropic.proxyPath).toBe(
+      "/v1/runtime-proxy/vertex",
+    );
+    expect(MANAGED_PROVIDER_META.gemini.proxyPath).toBe(
+      "/v1/runtime-proxy/vertex",
+    );
+  });
+
+  test("other providers use their own proxy paths", () => {
+    expect(MANAGED_PROVIDER_META.openai.proxyPath).toBe(
+      "/v1/runtime-proxy/openai",
+    );
+    expect(MANAGED_PROVIDER_META.fireworks.proxyPath).toBe(
+      "/v1/runtime-proxy/fireworks",
+    );
+    expect(MANAGED_PROVIDER_META.openrouter.proxyPath).toBe(
+      "/v1/runtime-proxy/openrouter",
+    );
   });
 });

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -24,7 +24,7 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   openai: {
     name: "openai",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
+    proxyPath: "/v1/runtime-proxy/openai",
   },
   anthropic: {
     name: "anthropic",
@@ -39,12 +39,12 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   fireworks: {
     name: "fireworks",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
+    proxyPath: "/v1/runtime-proxy/fireworks",
   },
   openrouter: {
     name: "openrouter",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
+    proxyPath: "/v1/runtime-proxy/openrouter",
   },
   vertex: {
     name: "vertex",

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -259,8 +259,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openai", "user-key");
   } else {
-    // No user OpenAI key — route through Vertex managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = buildManagedBaseUrl("openai");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "openai");
@@ -338,8 +337,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("fireworks", "user-key");
   } else {
-    // No user Fireworks key — route through Vertex managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = buildManagedBaseUrl("fireworks");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "fireworks");
@@ -371,8 +369,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openrouter", "user-key");
   } else {
-    // No user OpenRouter key — route through Vertex managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = buildManagedBaseUrl("openrouter");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "openrouter");


### PR DESCRIPTION
## Summary
- Restore original provider-specific proxy paths for openai (`/v1/runtime-proxy/openai`), fireworks (`/v1/runtime-proxy/fireworks`), and openrouter (`/v1/runtime-proxy/openrouter`)
- Only anthropic and gemini should route through `/v1/runtime-proxy/vertex` — this was an intentional design choice
- Update tests to assert the correct per-provider paths and add explicit coverage for which providers use vertex vs their own path

## Test plan
- [x] `bun test managed-proxy-context.test.ts` passes
- [x] `bun test provider-managed-proxy-integration.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
