### PR TITLE
fix: update gemini-provider test to match managed proxy constructor args

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -744,12 +744,12 @@ describe("GeminiProvider", () => {
       managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
     });
     expect(lastConstructorOpts).toEqual({
-      apiKey: "managed-key",
       vertexai: true,
       project: "proxy",
       location: "us-central1",
       httpOptions: {
         baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+        headers: { Authorization: "Bearer managed-key" },
       },
     });
   });


### PR DESCRIPTION
## Summary
- Updated the "sets vertexai mode with httpOptions.baseUrl when managedBaseUrl is provided" test to match the actual constructor behavior: managed proxy path does not pass `apiKey` directly, instead it sends `Authorization: Bearer <key>` in `httpOptions.headers`

## Original prompt
fix this test: GeminiProvider > sets vertexai mode with httpOptions.baseUrl when managedBaseUrl is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
