### PR TITLE
fix: match empty state max-width to regular chat bubble width

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -195,6 +195,7 @@ struct ChatTemporaryChatEmptyStateView: View {
                 placeholderText: "Ask anything...",
                 threadId: threadId
             )
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
 
             Spacer()
             Spacer()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -72,7 +72,7 @@ struct ChatEmptyStateView: View {
                     .foregroundColor(VColor.textSecondary)
                     .multilineTextAlignment(.leading)
             }
-            .frame(maxWidth: 500)
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
             .opacity(visible ? 1 : 0)
             .scaleEffect(visible ? 1 : 0.8)
             .padding(.horizontal, VSpacing.xl)
@@ -102,7 +102,7 @@ struct ChatEmptyStateView: View {
                 placeholderText: placeholder,
                 threadId: threadId
             )
-            .frame(maxWidth: 500)
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
             .opacity(visible ? 1 : 0)
             .offset(y: visible ? 0 : 10)
 


### PR DESCRIPTION
## Summary
- Changed the hardcoded `maxWidth: 500` in `ChatEmptyStateView` to use `VSpacing.chatBubbleMaxWidth` (680pt), matching the width of regular chat message bubbles
- Applies to both the greeting text and the composer in the empty state

## Original prompt
https://linear.app/vellum/issue/LUM-150/first-message-max-width-too-tight-should-match-regular-chat-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
