### PR TITLE
M1: Log report form UI with reason categories, message, and email

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -157,17 +157,14 @@ private struct ReasonRow: View {
 // MARK: - Preview
 
 #if DEBUG
-struct LogReportFormView_Preview: PreviewProvider {
-    static var previews: some View {
-        ZStack {
-            VColor.background.ignoresSafeArea()
-            LogReportFormView(
-                onSend: { _ in },
-                onCancel: {}
-            )
-        }
-        .frame(width: 440, height: 520)
-        .previewDisplayName("LogReportFormView")
+#Preview("LogReportFormView") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        LogReportFormView(
+            onSend: { _ in },
+            onCancel: {}
+        )
     }
+    .frame(width: 440, height: 520)
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A sheet displayed before sending logs, letting the user pick a reason
+/// category, describe the issue, and optionally provide an email for follow-up.
+@MainActor
+struct LogReportFormView: View {
+    let onSend: (LogReportFormData) -> Void
+    let onCancel: () -> Void
+
+    @State private var selectedReason: LogReportReason?
+    @State private var message: String = ""
+    @AppStorage("logReportEmail") private var email: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            header
+            reasonPicker
+            messageField
+            emailField
+            privacyNote
+            Spacer(minLength: 0)
+            actionRow
+        }
+        .padding(VSpacing.xl)
+        .background(VColor.background)
+        .frame(width: 440, height: 520)
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text("Send Logs")
+                .font(VFont.headline)
+                .foregroundColor(VColor.textPrimary)
+            Text("Select a reason for your report so we can triage it faster.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var reasonPicker: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            ForEach(LogReportReason.allCases) { reason in
+                ReasonRow(
+                    reason: reason,
+                    isSelected: selectedReason == reason,
+                    action: { selectedReason = reason }
+                )
+            }
+        }
+    }
+
+    private var messageField: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("What happened?")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            VTextEditor(
+                placeholder: "Describe what happened...",
+                text: $message,
+                minHeight: 60,
+                maxHeight: 80
+            )
+        }
+    }
+
+    private var emailField: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Email (optional)")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+            VTextField(
+                placeholder: "you@example.com",
+                text: $email,
+                leadingIcon: VIcon.mail.rawValue
+            )
+        }
+    }
+
+    private var privacyNote: some View {
+        Text("Your email is included only in the log archive for follow-up. It is not sent to any analytics service.")
+            .font(VFont.caption)
+            .foregroundColor(VColor.textMuted)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var actionRow: some View {
+        HStack {
+            Spacer()
+            VButton(label: "Cancel", style: .secondary, size: .medium) {
+                onCancel()
+            }
+            VButton(
+                label: "Send Logs",
+                leftIcon: VIcon.send.rawValue,
+                style: .primary,
+                size: .medium,
+                isDisabled: selectedReason == nil
+            ) {
+                guard let reason = selectedReason else { return }
+                onSend(LogReportFormData(
+                    reason: reason,
+                    message: message,
+                    email: email
+                ))
+            }
+        }
+    }
+}
+
+// MARK: - Reason Row
+
+private struct ReasonRow: View {
+    let reason: LogReportReason
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                VIconView(.resolve(reason.icon), size: 14)
+                    .foregroundColor(isSelected ? VColor.accent : VColor.textSecondary)
+                Text(reason.displayName)
+                    .font(VFont.body)
+                    .foregroundColor(isSelected ? VColor.textPrimary : VColor.textSecondary)
+                Spacer()
+                if isSelected {
+                    VIconView(.circleCheck, size: 14)
+                        .foregroundColor(VColor.accent)
+                }
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isSelected ? VColor.surface : (isHovered ? VColor.surface.opacity(0.5) : Color.clear))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(isSelected ? VColor.accent.opacity(0.5) : Color.clear, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in isHovered = hovering }
+        .pointerCursor()
+        .accessibilityLabel(reason.displayName)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct LogReportFormView_Preview: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            LogReportFormView(
+                onSend: { _ in },
+                onCancel: {}
+            )
+        }
+        .frame(width: 440, height: 520)
+        .previewDisplayName("LogReportFormView")
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -1,0 +1,44 @@
+import Foundation
+import VellumAssistantShared
+
+/// Pre-defined categories a user can pick when sending a log report.
+enum LogReportReason: String, CaseIterable, Identifiable {
+    case bugReport
+    case performanceIssue
+    case connectionIssue
+    case assistantBehavior
+    case appCrash
+    case other
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .bugReport: return "Bug Report"
+        case .performanceIssue: return "Performance Issue"
+        case .connectionIssue: return "Connection Issue"
+        case .assistantBehavior: return "Assistant Behavior"
+        case .appCrash: return "App Crash"
+        case .other: return "Other"
+        }
+    }
+
+    /// Lucide icon raw value suitable for `VIcon.resolve(_:)`.
+    var icon: String {
+        switch self {
+        case .bugReport: return VIcon.bug.rawValue
+        case .performanceIssue: return VIcon.zap.rawValue
+        case .connectionIssue: return VIcon.wifiOff.rawValue
+        case .assistantBehavior: return VIcon.brain.rawValue
+        case .appCrash: return VIcon.triangleAlert.rawValue
+        case .other: return VIcon.messageCircle.rawValue
+        }
+    }
+}
+
+/// Aggregated form data collected from the log report sheet.
+struct LogReportFormData {
+    var reason: LogReportReason
+    var message: String
+    var email: String
+}


### PR DESCRIPTION
## Summary
- Add LogReportReason enum with 6 pre-defined categories (Bug Report, Performance Issue, Connection Issue, Assistant Behavior, App Crash, Other)
- Add LogReportFormData struct for form state
- Add LogReportFormView with reason picker, message editor, optional email field
- Email persisted via @AppStorage for cross-session convenience
- Privacy note explains email is only included in log archive

Part of #15515
Closes #15516
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
