### PR TITLE
feat: add managed proxy fallback for image generation

### DIFF
--- a/assistant/src/__tests__/gemini-image-service.test.ts
+++ b/assistant/src/__tests__/gemini-image-service.test.ts
@@ -100,10 +100,13 @@ describe("generateImage", () => {
   test("generate mode returns images from response parts", async () => {
     fakeResponse = imageResponse("image/png", "abc123");
 
-    const result = await generateImage("test-key", {
-      prompt: "a cat",
-      mode: "generate",
-    });
+    const result = await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "a cat",
+        mode: "generate",
+      },
+    );
 
     expect(result.images).toHaveLength(1);
     expect(result.images[0].mimeType).toBe("image/png");
@@ -114,10 +117,13 @@ describe("generateImage", () => {
   test("generate mode collects text commentary from response", async () => {
     fakeResponse = imageWithTextResponse("Here is your image");
 
-    const result = await generateImage("test-key", {
-      prompt: "a dog",
-      mode: "generate",
-    });
+    const result = await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "a dog",
+        mode: "generate",
+      },
+    );
 
     expect(result.text).toBe("Here is your image");
     expect(result.images).toHaveLength(1);
@@ -126,11 +132,14 @@ describe("generateImage", () => {
   test("edit mode passes source images as inline data", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "remove background",
-      mode: "edit",
-      sourceImages: [{ mimeType: "image/jpeg", dataBase64: "srcdata" }],
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "remove background",
+        mode: "edit",
+        sourceImages: [{ mimeType: "image/jpeg", dataBase64: "srcdata" }],
+      },
+    );
 
     expect(lastGenerateParams).not.toBeNull();
     const contents = (lastGenerateParams as Record<string, unknown>)
@@ -148,11 +157,14 @@ describe("generateImage", () => {
   test("model validation rejects unknown models and defaults", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-      model: "invalid-model",
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+        model: "invalid-model",
+      },
+    );
 
     expect(lastGenerateParams).not.toBeNull();
     expect((lastGenerateParams as Record<string, unknown>).model).toBe(
@@ -163,11 +175,14 @@ describe("generateImage", () => {
   test("model validation accepts allowed models", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-      model: "gemini-3-pro-image",
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+        model: "gemini-3-pro-image",
+      },
+    );
 
     expect((lastGenerateParams as Record<string, unknown>).model).toBe(
       "gemini-3-pro-image",
@@ -177,11 +192,14 @@ describe("generateImage", () => {
   test("variants makes parallel calls", async () => {
     fakeResponse = imageResponse();
 
-    const result = await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-      variants: 3,
-    });
+    const result = await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+        variants: 3,
+      },
+    );
 
     expect(generateCallCount).toBe(3);
     expect(result.images).toHaveLength(3);
@@ -190,11 +208,14 @@ describe("generateImage", () => {
   test("variants are clamped to 1-4", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-      variants: 10,
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+        variants: 10,
+      },
+    );
 
     expect(generateCallCount).toBe(4);
   });
@@ -202,10 +223,13 @@ describe("generateImage", () => {
   test("variants defaults to 1", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+      },
+    );
 
     expect(generateCallCount).toBe(1);
   });
@@ -213,10 +237,13 @@ describe("generateImage", () => {
   test("handles empty candidates gracefully", async () => {
     fakeResponse = { candidates: [] };
 
-    const result = await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-    });
+    const result = await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+      },
+    );
 
     expect(result.images).toHaveLength(0);
     expect(result.text).toBeUndefined();
@@ -225,10 +252,13 @@ describe("generateImage", () => {
   test("response config includes TEXT and IMAGE modalities", async () => {
     fakeResponse = imageResponse();
 
-    await generateImage("test-key", {
-      prompt: "test",
-      mode: "generate",
-    });
+    await generateImage(
+      { type: "direct", apiKey: "test-key" },
+      {
+        prompt: "test",
+        mode: "generate",
+      },
+    );
 
     const config = (lastGenerateParams as Record<string, unknown>)
       .config as Record<string, unknown>;

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -17,6 +17,7 @@ let mockGenerateResult = {
   resolvedModel: "gemini-2.5-flash-image",
 };
 let mockGenerateError: Error | null = null;
+let lastGenerateCredentials: unknown = null;
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
@@ -27,7 +28,11 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../media/gemini-image-service.js", () => ({
-  generateImage: async (_apiKey: string, _request: Record<string, unknown>) => {
+  generateImage: async (
+    credentials: unknown,
+    _request: Record<string, unknown>,
+  ) => {
+    lastGenerateCredentials = credentials;
     if (mockGenerateError) throw mockGenerateError;
     return mockGenerateResult;
   },
@@ -35,6 +40,18 @@ mock.module("../media/gemini-image-service.js", () => ({
     if (error instanceof Error) return `Mock error: ${error.message}`;
     return "Mock unknown error";
   },
+}));
+
+let mockManagedBaseUrl: string | undefined;
+let mockManagedProxyContext = {
+  enabled: false,
+  platformBaseUrl: "",
+  assistantApiKey: "",
+};
+
+mock.module("../providers/managed-proxy/context.js", () => ({
+  buildManagedBaseUrl: () => mockManagedBaseUrl,
+  resolveManagedProxyContext: () => mockManagedProxyContext,
 }));
 
 let mockAttachments: Array<{
@@ -138,6 +155,13 @@ beforeEach(() => {
   };
   mockGenerateError = null;
   mockAttachments = [];
+  lastGenerateCredentials = null;
+  mockManagedBaseUrl = undefined;
+  mockManagedProxyContext = {
+    enabled: false,
+    platformBaseUrl: "",
+    assistantApiKey: "",
+  };
 });
 
 const fakeContext = {
@@ -153,13 +177,50 @@ describe("image-studio skill script wrapper", () => {
     expect(getTool("media_generate_image")).toBeUndefined();
   });
 
-  test("returns error when no API key is configured", async () => {
+  test("returns error when no API key and no managed proxy", async () => {
     mockApiKey = undefined;
 
     const result = await run({ prompt: "a cat" }, fakeContext);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No Gemini API key");
+  });
+
+  test("falls back to managed proxy when no API key is configured", async () => {
+    mockApiKey = undefined;
+    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-key-123",
+    };
+
+    const result = await run({ prompt: "a hippo" }, fakeContext);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Generated 1 image");
+    expect(lastGenerateCredentials).toEqual({
+      type: "managed-proxy",
+      assistantApiKey: "managed-key-123",
+      baseUrl: "https://platform.example.com/v1/runtime-proxy/vertex",
+    });
+  });
+
+  test("prefers direct API key over managed proxy", async () => {
+    mockApiKey = "direct-key";
+    mockManagedBaseUrl = "https://platform.example.com/v1/runtime-proxy/vertex";
+    mockManagedProxyContext = {
+      enabled: true,
+      platformBaseUrl: "https://platform.example.com",
+      assistantApiKey: "managed-key-123",
+    };
+
+    await run({ prompt: "a cat" }, fakeContext);
+
+    expect(lastGenerateCredentials).toEqual({
+      type: "direct",
+      apiKey: "direct-key",
+    });
   });
 
   test("returns generated image with contentBlocks", async () => {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -51,7 +51,7 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const apiKey = config.apiKeys.gemini;
+  const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
 
   // Resolve credentials: prefer direct API key, fall back to managed proxy
   let credentials: ImageGenCredentials | undefined;

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -5,10 +5,15 @@ import {
 } from "../../../../daemon/media-visibility-policy.js";
 import {
   generateImage,
+  type ImageGenCredentials,
   mapGeminiError,
 } from "../../../../media/gemini-image-service.js";
 import { getAttachmentsByIds } from "../../../../memory/attachments-store.js";
 import { getConversationThreadType } from "../../../../memory/conversation-crud.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
 import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
 import type {
@@ -48,7 +53,23 @@ export async function run(
   const config = getConfig();
   const apiKey = config.apiKeys.gemini;
 
-  if (!apiKey) {
+  // Resolve credentials: prefer direct API key, fall back to managed proxy
+  let credentials: ImageGenCredentials | undefined;
+  if (apiKey) {
+    credentials = { type: "direct", apiKey };
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      credentials = {
+        type: "managed-proxy",
+        assistantApiKey: ctx.assistantApiKey,
+        baseUrl: managedBaseUrl,
+      };
+    }
+  }
+
+  if (!credentials) {
     return {
       content:
         "No Gemini API key configured. Please set your Gemini API key to use image generation.",
@@ -95,7 +116,7 @@ export async function run(
   }
 
   try {
-    const result = await generateImage(apiKey, {
+    const result = await generateImage(credentials, {
       prompt,
       mode,
       sourceImages,

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -11,8 +11,16 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import { getAppsDir } from "../memory/app-store.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../providers/managed-proxy/context.js";
 import { getLogger } from "../util/logger.js";
-import { generateImage, mapGeminiError } from "./gemini-image-service.js";
+import {
+  generateImage,
+  type ImageGenCredentials,
+  mapGeminiError,
+} from "./gemini-image-service.js";
 
 const log = getLogger("app-icon-generator");
 
@@ -29,8 +37,26 @@ export async function generateAppIcon(
 ): Promise<void> {
   const config = getConfig();
   const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
-  if (!apiKey) {
-    log.debug("No Gemini API key — skipping app icon generation");
+
+  let credentials: ImageGenCredentials | undefined;
+  if (apiKey) {
+    credentials = { type: "direct", apiKey };
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      credentials = {
+        type: "managed-proxy",
+        assistantApiKey: ctx.assistantApiKey,
+        baseUrl: managedBaseUrl,
+      };
+    }
+  }
+
+  if (!credentials) {
+    log.debug(
+      "No Gemini API key or managed proxy — skipping app icon generation",
+    );
     return;
   }
 
@@ -58,7 +84,7 @@ export async function generateAppIcon(
   try {
     log.info({ appId, appName }, "Generating app icon via Gemini");
 
-    const result = await generateImage(apiKey, {
+    const result = await generateImage(credentials, {
       prompt,
       mode: "generate",
       model: config.imageGenModel,

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,19 +1,42 @@
 import { getConfig } from "../config/loader.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "../providers/managed-proxy/context.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
-import { generateImage } from "./gemini-image-service.js";
+import {
+  generateImage,
+  type ImageGenCredentials,
+} from "./gemini-image-service.js";
 
 export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
   const geminiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
-  if (!geminiKey) {
+
+  let credentials: ImageGenCredentials | undefined;
+  if (geminiKey) {
+    credentials = { type: "direct", apiKey: geminiKey };
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      credentials = {
+        type: "managed-proxy",
+        assistantApiKey: ctx.assistantApiKey,
+        baseUrl: managedBaseUrl,
+      };
+    }
+  }
+
+  if (!credentials) {
     throw new ConfigError(
       "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
     );
   }
 
-  const result = await generateImage(geminiKey, {
+  const result = await generateImage(credentials, {
     prompt,
     mode: "generate",
     model: config.imageGenModel,

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -13,6 +13,21 @@ export interface ImageGenerationRequest {
   variants?: number;
 }
 
+/** Credentials for direct Gemini API access. */
+export interface DirectCredentials {
+  type: "direct";
+  apiKey: string;
+}
+
+/** Credentials for managed proxy access via Vertex AI. */
+export interface ManagedProxyCredentials {
+  type: "managed-proxy";
+  assistantApiKey: string;
+  baseUrl: string;
+}
+
+export type ImageGenCredentials = DirectCredentials | ManagedProxyCredentials;
+
 export interface GeneratedImage {
   mimeType: string;
   dataBase64: string;
@@ -64,7 +79,7 @@ export function mapGeminiError(error: unknown): string {
 // --- Core function ---
 
 export async function generateImage(
-  apiKey: string,
+  credentials: ImageGenCredentials,
   request: ImageGenerationRequest,
 ): Promise<ImageGenerationResult> {
   const model =
@@ -74,7 +89,18 @@ export async function generateImage(
 
   const variants = Math.max(1, Math.min(request.variants ?? 1, MAX_VARIANTS));
 
-  const client = new GoogleGenAI({ apiKey });
+  const client =
+    credentials.type === "managed-proxy"
+      ? new GoogleGenAI({
+          vertexai: true,
+          project: "proxy",
+          location: "us-central1",
+          httpOptions: {
+            baseUrl: credentials.baseUrl,
+            headers: { Authorization: `Bearer ${credentials.assistantApiKey}` },
+          },
+        })
+      : new GoogleGenAI({ apiKey: credentials.apiKey });
 
   // Build contents array — append a title request so the model's text
   // response contains a short filename-safe title for the generated image.


### PR DESCRIPTION
## Summary
- When no Gemini API key is configured, image generation (tool, app icons, avatars) now falls back to routing through the Vertex managed proxy using the assistant API key
- The `generateImage` function accepts a credentials discriminated union (`DirectCredentials | ManagedProxyCredentials`) instead of a raw API key string
- All three callers updated: `media-generate-image` tool, `app-icon-generator`, and `avatar-router`

## Original prompt
the image generation tool needs a fallback path: when config.apiKeys.gemini is missing, it should check if managed proxy is available via resolveManagedProxyContext(), and if so, configure the GoogleGenAI client to route through the Vertex proxy URL instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
