### PR TITLE
fix: polish composer line height and vertical spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -61,7 +61,7 @@ struct ComposerView: View {
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
     var placeholderText: String = "What would you like to do?"
-    var composerCompactHeight: CGFloat = 34
+    var composerCompactHeight: CGFloat = 38
     var threadId: UUID?
 
     @Environment(\.conversationZoomScale) private var zoomScale
@@ -149,6 +149,7 @@ struct ComposerView: View {
         // visible text coloring.
         if hasSlashHighlight {
             Text(slashHighlightedText(font: font))
+                .lineSpacing(4)
                 .lineLimit(1...)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
@@ -162,6 +163,7 @@ struct ComposerView: View {
             + Text(ghostSuffix)
                 .font(font)
                 .foregroundColor(VColor.textSecondary.opacity(0.55)))
+                .lineSpacing(4)
                 .lineLimit(1...)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
@@ -180,6 +182,7 @@ struct ComposerView: View {
         .lineLimit(1...)
         .textFieldStyle(.plain)
         .font(font)
+        .lineSpacing(4)
         .foregroundColor(hasSlashHighlight ? .clear : VColor.textPrimary)
         .tint(VColor.accent)
         .focused($composerFocus)
@@ -387,8 +390,8 @@ struct ComposerView: View {
             }
             content()
         }
-        .padding(.top, VSpacing.sm)
-        .padding(.bottom, VSpacing.sm)
+        .padding(.top, VSpacing.md)
+        .padding(.bottom, VSpacing.md)
         .padding(.leading, VSpacing.lg)
         .padding(.trailing, VSpacing.lg)
         .background(


### PR DESCRIPTION
## Summary
- Added `lineSpacing(4)` to the composer text field and its overlays (slash highlight, ghost text) for better multi-line readability, matching chat bubble line spacing
- Increased composer compact height from 34pt to 38pt for more breathing room
- Increased vertical padding from `VSpacing.sm` (8pt) to `VSpacing.md` (12pt) for a less cramped feel

## Original prompt
https://linear.app/vellum/issue/LUM-149/chatbar-polish-line-height-and-vertical-spacing-feel-too-small

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
