### PR TITLE
Per-thread conversation keys for desktop client

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -33,6 +33,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 // Switching to a real thread discards any draft
                 draftViewModel = nil
 
+                // Switch the daemon's conversation key to this thread's key BEFORE
+                // loading history or sending the session switch request, so SSE events
+                // and history fetches target the correct conversation.
+                daemonClient.switchConversationKey("vellum:\(activeThreadId.uuidString)")
+
                 let activeViewModel = getOrCreateViewModel(for: activeThreadId)
                 activeViewModel?.ensureMessageLoopStarted()
                 sessionRestorer.loadHistoryIfNeeded(threadId: activeThreadId)
@@ -204,6 +209,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         self.isRestoringThreads = !isFirstLaunch
         // Enter draft mode so the window shows an empty chat without a sidebar entry
         enterDraftMode()
+        // Register callback to learn the daemon's real session ID and update the
+        // ChatViewModel/ThreadModel so belongsToSession() passes.
+        daemonClient.onSessionIdLearned = { [weak self] temporaryId, realId in
+            self?.handleSessionIdLearned(temporaryId: temporaryId, realId: realId)
+        }
         sessionRestorer.delegate = self
         sessionRestorer.startObserving(skipInitialFetch: isFirstLaunch)
     }
@@ -339,6 +349,27 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         activeThreadId = thread.id
         updateLastInteracted(threadId: thread.id)
         log.info("Promoted draft to thread \(thread.id)")
+    }
+
+    /// Called when the daemon's real session ID is learned from the first SSE event.
+    /// Updates the ChatViewModel and ThreadModel so events are routed correctly.
+    private func handleSessionIdLearned(temporaryId: String, realId: String) {
+        // Find the ChatViewModel that has the temporary session ID
+        for (threadId, viewModel) in chatViewModels {
+            if viewModel.sessionId == temporaryId {
+                log.info("Updating sessionId for thread \(threadId): \(temporaryId) → \(realId)")
+                viewModel.sessionId = realId
+                if let threadIndex = threads.firstIndex(where: { $0.id == threadId }) {
+                    threads[threadIndex].sessionId = realId
+                }
+                return
+            }
+        }
+        // Also check the draft view model
+        if draftViewModel?.sessionId == temporaryId {
+            log.info("Updating draft sessionId: \(temporaryId) → \(realId)")
+            draftViewModel?.sessionId = realId
+        }
     }
 
     func createPrivateThread() {

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -98,6 +98,8 @@ public protocol DaemonClientProtocol {
     func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
     func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error>
+    func switchConversationKey(_ newKey: String)
+    var onSessionIdLearned: ((String, String) -> Void)? { get set }
 }
 
 extension DaemonClientProtocol {
@@ -115,6 +117,9 @@ extension DaemonClientProtocol {
     public func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+
+    /// Default no-op for clients that don't support per-thread conversation keys.
+    public func switchConversationKey(_ newKey: String) {}
 }
 
 // MARK: - Usage Response Models
@@ -619,6 +624,20 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// HTTP transport for communicating with the assistant.
     public var httpTransport: HTTPTransport?
+
+    /// Delegate conversation key switching to the HTTP transport.
+    public func switchConversationKey(_ newKey: String) {
+        httpTransport?.switchConversationKey(newKey)
+    }
+
+    /// Callback invoked when the daemon's real session ID is learned.
+    /// Stored on DaemonClient (not HTTPTransport) so it survives transport
+    /// creation/recreation during connect(). Forwarded to httpTransport when set.
+    public var onSessionIdLearned: ((String, String) -> Void)? {
+        didSet {
+            httpTransport?.onSessionIdLearned = onSessionIdLearned
+        }
+    }
 
     public private(set) var config: DaemonConfig
 
@@ -1348,8 +1367,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Subagent Management
 
     /// Abort a running subagent.
-    public func sendSubagentAbort(subagentId: String) throws {
-        try send(SubagentAbortMessage(subagentId: subagentId))
+    public func sendSubagentAbort(subagentId: String, sessionId: String? = nil) throws {
+        try send(SubagentAbortMessage(subagentId: subagentId, sessionId: sessionId))
     }
 
     /// Request subagent detail events (lazy-loaded when the user opens the detail panel).

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -64,6 +64,8 @@ extension DaemonClient {
         }
 
         self.httpTransport = transport
+        // Forward stored callbacks to the new transport instance
+        transport.onSessionIdLearned = self.onSessionIdLearned
 
         do {
             try await transport.connect()

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4272,11 +4272,13 @@ public struct SubagentMessageRequest: Codable, Sendable {
     public let type: String
     public let subagentId: String
     public let content: String
+    public let sessionId: String?
 
-    public init(type: String, subagentId: String, content: String) {
+    public init(type: String, subagentId: String, content: String, sessionId: String? = nil) {
         self.type = type
         self.subagentId = subagentId
         self.content = content
+        self.sessionId = sessionId
     }
 }
 

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -30,8 +30,7 @@ extension HTTPTransport {
                 // acts as the session. Emit a synthetic session_info so ChatViewModel
                 // records the session ID.
                 let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
-                self.activeLocalSessionId = sessionId
-                self.remoteSessionId = nil  // Reset — will be learned from the first SSE event
+                self.pendingLocalSessionId = sessionId
                 let info = ServerMessage.sessionInfo(
                     SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
                 )

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -15,10 +15,10 @@ extension HTTPTransport {
                 Task { await self.fetchSubagentDetail(subagentId: msg.subagentId, conversationId: msg.conversationId) }
                 return true
             } else if let msg = message as? SubagentAbortMessage {
-                Task { await self.handleSubagentAbort(subagentId: msg.subagentId) }
+                Task { await self.handleSubagentAbort(subagentId: msg.subagentId, sessionId: msg.sessionId) }
                 return true
             } else if let msg = message as? SubagentMessageRequest {
-                Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content) }
+                Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content, sessionId: msg.sessionId) }
                 return true
             }
 
@@ -62,7 +62,7 @@ extension HTTPTransport {
         }
     }
 
-    private func handleSubagentAbort(subagentId: String, isRetry: Bool = false) async {
+    private func handleSubagentAbort(subagentId: String, sessionId: String?, isRetry: Bool = false) async {
         guard let url = buildURL(for: .subagentAbort(id: subagentId)) else { return }
 
         var request = URLRequest(url: url)
@@ -72,7 +72,7 @@ extension HTTPTransport {
 
         // The abort endpoint requires a sessionId in the body
         var body: [String: Any] = [:]
-        if let sessionId = activeLocalSessionId {
+        if let sessionId = sessionId {
             body["sessionId"] = sessionId
         }
 
@@ -83,7 +83,7 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await handleSubagentAbort(subagentId: subagentId, isRetry: true) }
+                    if case .success = result { await handleSubagentAbort(subagentId: subagentId, sessionId: sessionId, isRetry: true) }
                     return
                 }
                 guard (200..<300).contains(http.statusCode) else {
@@ -98,7 +98,7 @@ extension HTTPTransport {
         }
     }
 
-    private func handleSubagentMessage(subagentId: String, content: String, isRetry: Bool = false) async {
+    private func handleSubagentMessage(subagentId: String, content: String, sessionId: String?, isRetry: Bool = false) async {
         guard let url = buildURL(for: .subagentMessage(id: subagentId)) else { return }
 
         var request = URLRequest(url: url)
@@ -107,7 +107,7 @@ extension HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = ["content": content]
-        if let sessionId = activeLocalSessionId {
+        if let sessionId = sessionId {
             body["sessionId"] = sessionId
         }
 
@@ -118,7 +118,7 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await handleSubagentMessage(subagentId: subagentId, content: content, isRetry: true) }
+                    if case .success = result { await handleSubagentMessage(subagentId: subagentId, content: content, sessionId: sessionId, isRetry: true) }
                     return
                 }
                 guard (200..<300).contains(http.statusCode) else {

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -104,7 +104,7 @@ public final class HTTPTransport {
 
     public let baseURL: String
     public private(set) var bearerToken: String?
-    private let conversationKey: String
+    private(set) var conversationKey: String
     private let sourceChannel: String
     let transportMetadata: TransportMetadata
 
@@ -172,14 +172,10 @@ public final class HTTPTransport {
     /// Clients should persist the new token (e.g. to Keychain).
     var onTokenRefreshed: ((String) -> Void)?
 
-    /// The local session ID used by the client (set from the synthetic session_info).
-    /// Used to remap the daemon's internal conversation ID to the client's session ID
-    /// so that ChatViewModel's belongsToSession() filter passes.
-    var activeLocalSessionId: String?
-
-    /// The daemon's internal conversation ID, learned from the first SSE event.
-    /// All occurrences are remapped to `activeLocalSessionId` in incoming events.
-    var remoteSessionId: String?
+    /// The local session ID set from the synthetic session_info, used to detect
+    /// when the daemon's real conversation ID differs from what the client expects.
+    /// Cleared after the first SSE event fires `onSessionIdLearned`.
+    var pendingLocalSessionId: String?
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -1343,6 +1339,25 @@ public final class HTTPTransport {
         setSSEConnected(false)
     }
 
+    /// Switch to a new conversation key and restart the SSE stream so events
+    /// are received for the new conversation.
+    func switchConversationKey(_ newKey: String) {
+        guard newKey != conversationKey else { return }
+        log.info("Switching conversationKey from \(self.conversationKey, privacy: .public) to \(newKey, privacy: .public)")
+        conversationKey = newKey
+        pendingLocalSessionId = nil
+        // Restart SSE to subscribe to the new conversation key's event stream
+        if sseTask != nil {
+            stopSSE()
+            startSSE()
+        }
+    }
+
+    /// Callback invoked when the daemon's real session ID is learned from the
+    /// first SSE event. Parameters: (temporaryId, realId). Called BEFORE the
+    /// event is dispatched so ChatViewModel.sessionId can be updated.
+    var onSessionIdLearned: ((String, String) -> Void)?
+
     private func startSSEStream() {
         sseTask?.cancel()
 
@@ -1422,46 +1437,20 @@ public final class HTTPTransport {
     }
 
     private func parseSSEData(_ data: String) {
-        // Remap the daemon's internal session/conversation ID to the client's
-        // local session ID so that ChatViewModel.belongsToSession() passes.
-        // The daemon assigns its own UUID via getOrCreateConversation(), which
-        // differs from the correlationId the client uses as sessionId.
-        var jsonString = data
-        if let localId = activeLocalSessionId {
-            if remoteSessionId == nil {
-                // Learn the daemon's session ID from the first event envelope.
-                if let eventData = data.data(using: .utf8),
-                   let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
-                   let eventSessionId = envelope.sessionId,
-                   eventSessionId != localId {
-                    remoteSessionId = eventSessionId
-                    log.info("Learned remote sessionId \(eventSessionId, privacy: .public) → local \(localId, privacy: .public)")
-                }
-            }
-            if let remoteId = remoteSessionId {
-                // Replace only the sessionId JSON value — not arbitrary occurrences
-                // of the UUID elsewhere in the payload. Handle both compact
-                // ("sessionId":"…") and pretty-printed ("sessionId": "…") JSON.
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\":\"\(remoteId)\"",
-                    with: "\"sessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\": \"\(remoteId)\"",
-                    with: "\"sessionId\": \"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\":\"\(remoteId)\"",
-                    with: "\"parentSessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\": \"\(remoteId)\"",
-                    with: "\"parentSessionId\": \"\(localId)\""
-                )
-            }
+        // When the first SSE event arrives with a sessionId that differs from the
+        // client's pending local ID, notify via callback so the ChatViewModel's
+        // sessionId can be updated before the event is dispatched.
+        if let localId = pendingLocalSessionId,
+           let eventData = data.data(using: .utf8),
+           let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
+           let eventSessionId = envelope.sessionId,
+           eventSessionId != localId {
+            log.info("Learned real sessionId \(eventSessionId, privacy: .public) for pending \(localId, privacy: .public)")
+            onSessionIdLearned?(localId, eventSessionId)
+            pendingLocalSessionId = nil  // Only fire once per session creation
         }
 
-        guard let jsonData = jsonString.data(using: .utf8) else { return }
+        guard let jsonData = data.data(using: .utf8) else { return }
 
         do {
             let event = try decoder.decode(AssistantEvent.self, from: jsonData)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2099,9 +2099,11 @@ public struct SubagentDetailRequestMessage: Encodable, Sendable {
 public struct SubagentAbortMessage: Encodable, Sendable {
     public let type: String = "subagent_abort"
     public let subagentId: String
+    public let sessionId: String?
 
-    public init(subagentId: String) {
+    public init(subagentId: String, sessionId: String? = nil) {
         self.subagentId = subagentId
+        self.sessionId = sessionId
     }
 }
 

--- a/clients/shared/Network/MockDaemonClient.swift
+++ b/clients/shared/Network/MockDaemonClient.swift
@@ -34,6 +34,8 @@ public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
 
     public func startSSE() {}
     public func stopSSE() {}
+    public func switchConversationKey(_ newKey: String) {}
+    public var onSessionIdLearned: ((String, String) -> Void)?
 
     /// Inject a server message into all active subscribers.
     public func emit(_ message: ServerMessage) {


### PR DESCRIPTION
## Summary
- Replace the static single `conversationKey` (assistantId) with per-thread keys (`vellum:<threadId>`) so each desktop thread gets its own daemon conversation
- Replace fragile JSON string remapping of sessionIds (`activeLocalSessionId`/`remoteSessionId`) with an `onSessionIdLearned` callback that updates `ChatViewModel.sessionId` to the daemon's real conversationId before events are dispatched
- Thread `sessionId` through subagent message types to fix broken references to the removed `activeLocalSessionId`

## Test plan
- [ ] Send a message in a new thread — response should appear
- [ ] Create a second thread, send a message — should get its own title (not reuse first thread's)
- [ ] Switch between threads — messages should still flow correctly
- [ ] Send follow-up messages in an existing thread — responses should appear
- [ ] Verify subagent abort still works from the detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
