### PR TITLE
M2: Wire log report form into send flow with metadata propagation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -517,7 +517,78 @@ extension AppDelegate {
     }
 
     @objc public func sendLogsToSentry() {
-        LogExporter.sendLogsToSentry()
+        // If the window is already showing, just bring it forward.
+        if let existing = logReportWindow, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let dismiss: () -> Void = { [weak self] in
+            self?.dismissLogReportWindow()
+        }
+
+        let view = LogReportFormView(
+            onSend: { [weak self] formData in
+                self?.dismissLogReportWindow()
+                LogExporter.sendLogsToSentry(formData: formData)
+            },
+            onCancel: dismiss
+        )
+
+        let hostingController = NSHostingController(rootView: view)
+        hostingController.sizingOptions = []
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 520),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = hostingController
+        window.title = "Send Logs"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        logReportWindowObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.handleLogReportWindowWillClose()
+            }
+        }
+
+        NSApp.activateAsDockAppIfNeeded()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        logReportWindow = window
+    }
+
+    private func dismissLogReportWindow() {
+        if let observer = logReportWindowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            logReportWindowObserver = nil
+        }
+        let closingWindow = logReportWindow
+        logReportWindow?.close()
+        logReportWindow = nil
+        revertActivationPolicyIfNoWindows(excluding: closingWindow)
+    }
+
+    private func handleLogReportWindowWillClose() {
+        if let observer = logReportWindowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            logReportWindowObserver = nil
+        }
+        let closingWindow = logReportWindow
+        logReportWindow = nil
+        revertActivationPolicyIfNoWindows(excluding: closingWindow)
     }
 
     func refreshSkillsCache() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -78,6 +78,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var bootstrapInterstitialWindow: NSWindow?
     var crashReportWindow: NSWindow?
     var crashReportWindowObserver: NSObjectProtocol?
+    var logReportWindow: NSWindow?
+    var logReportWindowObserver: NSObjectProtocol?
     /// Active task for the bootstrap retry coordinator. Cancelled on dismiss.
     var bootstrapRetryTask: Task<Void, Never>?
     /// Tracks the most recent failure kind during bootstrap retries so that

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -158,15 +158,16 @@ enum LogExporter {
             to: tempDir.appendingPathComponent("port-diagnostics.json")
         )
 
-        // 9. Report metadata — reason, message, and email from the log report form
+        // 9. Report metadata — reason and message from the log report form.
+        // Email is intentionally excluded from the archive to avoid sending PII to Sentry.
+        // It is persisted locally via @AppStorage("logReportEmail") and can be correlated
+        // with the device_id Sentry tag when follow-up is needed.
         if let formData {
-            var metadata: [String: String] = [
+            let metadata: [String: String] = [
                 "reason": formData.reason.rawValue,
                 "message": formData.message,
+                "device_id": SentryDeviceInfo.deviceId,
             ]
-            if !formData.email.isEmpty {
-                metadata["email"] = formData.email
-            }
             if let data = try? JSONSerialization.data(
                 withJSONObject: metadata,
                 options: [.prettyPrinted, .sortedKeys]

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -25,14 +25,15 @@ private let log = Logger(
 enum LogExporter {
 
     /// Collects logs, archives them, and sends to Sentry as an attachment for developer debugging.
-    static func sendLogsToSentry() {
+    /// Includes report metadata (reason, message, email) from the log report form.
+    static func sendLogsToSentry(formData: LogReportFormData) {
         Task {
             let fileManager = FileManager.default
             let archiveURL = fileManager.temporaryDirectory
                 .appendingPathComponent("vellum-assistant-logs-\(UUID().uuidString).tar.gz")
 
             do {
-                try await buildArchive(destination: archiveURL)
+                try await buildArchive(destination: archiveURL, formData: formData)
             } catch {
                 log.error("Failed to build log archive for Sentry: \(error.localizedDescription)")
                 let alert = NSAlert()
@@ -47,7 +48,13 @@ enum LogExporter {
             let attachment = Attachment(path: archiveURL.path, filename: archiveName)
             let event = Event(level: .info)
             event.message = SentryMessage(formatted: "Manual log export")
-            event.tags = ["source": "manual_log_export"]
+            event.tags = [
+                "source": "manual_log_export",
+                "report_reason": formData.reason.rawValue,
+            ]
+            if !formData.message.isEmpty {
+                event.extra = ["report_message": formData.message]
+            }
 
             await withCheckedContinuation { continuation in
                 MetricKitManager.sendManualReport(event, attachments: [attachment]) {
@@ -76,7 +83,7 @@ enum LogExporter {
 
     /// Builds a tar.gz archive containing all discoverable log files.
     /// Runs file I/O and the tar process off the main actor to avoid blocking the UI.
-    private nonisolated static func buildArchive(destination: URL) async throws {
+    private nonisolated static func buildArchive(destination: URL, formData: LogReportFormData? = nil) async throws {
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory
             .appendingPathComponent("vellum-log-export-\(UUID().uuidString)", isDirectory: true)
@@ -150,6 +157,23 @@ enum LogExporter {
         PortDiagnostics.write(
             to: tempDir.appendingPathComponent("port-diagnostics.json")
         )
+
+        // 9. Report metadata — reason, message, and email from the log report form
+        if let formData {
+            var metadata: [String: String] = [
+                "reason": formData.reason.rawValue,
+                "message": formData.message,
+            ]
+            if !formData.email.isEmpty {
+                metadata["email"] = formData.email
+            }
+            if let data = try? JSONSerialization.data(
+                withJSONObject: metadata,
+                options: [.prettyPrinted, .sortedKeys]
+            ) {
+                try? data.write(to: tempDir.appendingPathComponent("report-metadata.json"))
+            }
+        }
 
         // Verify we have at least one file to export
         let collected = try fileManager.contentsOfDirectory(

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -2,7 +2,7 @@ import Foundation
 import VellumAssistantShared
 
 /// Pre-defined categories a user can pick when sending a log report.
-enum LogReportReason: String, CaseIterable, Identifiable {
+enum LogReportReason: String, CaseIterable, Identifiable, Sendable {
     case bugReport
     case performanceIssue
     case connectionIssue
@@ -37,7 +37,7 @@ enum LogReportReason: String, CaseIterable, Identifiable {
 }
 
 /// Aggregated form data collected from the log report sheet.
-struct LogReportFormData {
+struct LogReportFormData: Sendable {
     var reason: LogReportReason
     var message: String
     var email: String


### PR DESCRIPTION
## Summary
- Show LogReportFormView in a dedicated window when user clicks Send Logs to Vellum
- Add report_reason tag and report_message extra to Sentry events for filtering
- Include report-metadata.json in log archive with reason, message, and email
- Email is only included in the archive, never sent to Sentry

Part of #15515
Closes #15517
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
