### PR TITLE
fix: restrict diagnostics range widening to fallback-selected anchors

### DIFF
--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -186,6 +186,7 @@ async function handleDiagnosticsExport(body: {
     // been persisted — the user message and in-flight tool/usage data are
     // still captured.
     let anchorMessage;
+    let anchorIsFallback = false;
     if (anchorMessageId) {
       anchorMessage = db
         .select()
@@ -220,6 +221,7 @@ async function handleDiagnosticsExport(body: {
         .orderBy(desc(messages.createdAt))
         .limit(1)
         .get();
+      anchorIsFallback = true;
     }
 
     // 2. Compute the export time range.
@@ -250,15 +252,15 @@ async function handleDiagnosticsExport(body: {
       rangeStart =
         precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
 
-      // When the anchor is not an assistant message (e.g. the fallback "any
-      // message" path hit because the assistant reply hasn't been persisted
-      // yet), extend the range to the current time so in-flight tool
-      // invocations and usage recorded after the user message are captured.
-      const anchorIsAssistant = anchorMessage.role === "assistant";
-      rangeEnd = anchorIsAssistant ? anchorMessage.createdAt : now;
-      usageRangeEnd = anchorIsAssistant
-        ? anchorMessage.createdAt + 5000
-        : now + 5000;
+      // When the anchor was selected via the fallback "any message" path
+      // (because the assistant reply hasn't been persisted yet), extend the
+      // range to the current time so in-flight tool invocations and usage
+      // recorded after the user message are captured. An explicit anchor to a
+      // non-assistant message uses the message's own timestamp.
+      rangeEnd = anchorIsFallback ? now : anchorMessage.createdAt;
+      usageRangeEnd = anchorIsFallback
+        ? now + 5000
+        : anchorMessage.createdAt + 5000;
     } else {
       // No messages at all — use the current time so we capture any
       // in-flight LLM usage or tool invocations.


### PR DESCRIPTION
Addresses Codex feedback on #15331:

The now-based range widening was applied to all non-assistant anchors, but should only apply when the anchor was a fallback selection (the requested assistant message wasn't found). An explicit anchor to a non-assistant message now uses the message's timestamp instead of extending to now.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
