### PR TITLE
Defer new thread creation to first message send

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -219,6 +219,10 @@ extension MainWindowView {
                     threadManager.createThread()
                     if let id = threadManager.activeThreadId {
                         windowState.selection = .thread(id)
+                    } else {
+                        // Draft mode — clear selection so no sidebar thread is highlighted
+                        windowState.selection = nil
+                        windowState.persistentThreadId = nil
                     }
                 }
             )
@@ -484,6 +488,9 @@ extension MainWindowView {
                 threadManager.createThread()
                 if let id = threadManager.activeThreadId {
                     windowState.selection = .thread(id)
+                } else {
+                    windowState.selection = nil
+                    windowState.persistentThreadId = nil
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -16,6 +16,17 @@ extension MainWindowView {
         }
     }
 
+    func startNewThread() {
+        threadManager.createThread()
+        if let id = threadManager.activeThreadId {
+            windowState.selection = .thread(id)
+        } else {
+            // Draft mode — clear selection so no sidebar thread is highlighted
+            windowState.selection = nil
+            windowState.persistentThreadId = nil
+        }
+    }
+
     /// Maps a thread's interaction state to a dot color for VThreadIcon.
     func interactionDotColor(for thread: ThreadModel) -> Color? {
         switch threadManager.interactionState(for: thread.id) {
@@ -215,16 +226,7 @@ extension MainWindowView {
                         windowState.dismissToast(id: toastId)
                     }
                 },
-                onNewThread: {
-                    threadManager.createThread()
-                    if let id = threadManager.activeThreadId {
-                        windowState.selection = .thread(id)
-                    } else {
-                        // Draft mode — clear selection so no sidebar thread is highlighted
-                        windowState.selection = nil
-                        windowState.persistentThreadId = nil
-                    }
-                }
+                onNewThread: { startNewThread() }
             )
 
             ScrollView {
@@ -485,13 +487,7 @@ extension MainWindowView {
             sidebarSectionDivider(isExpanded: false)
 
             SidebarNavRow(icon: VIcon.squarePen.rawValue, label: "New Chat", isActive: false, isExpanded: false) {
-                threadManager.createThread()
-                if let id = threadManager.activeThreadId {
-                    windowState.selection = .thread(id)
-                } else {
-                    windowState.selection = nil
-                    windowState.persistentThreadId = nil
-                }
+                startNewThread()
             }
 
             // MARK: Thread Section (collapsed)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -209,10 +209,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     func createThread() {
-        // If we're in draft mode, promote the draft to a real thread so callers
-        // get a guaranteed activeThreadId.
+        // If already in draft mode with an empty draft, no-op
         if draftViewModel != nil, activeThreadId == nil {
-            promoteDraft(fromUserSend: false)
             return
         }
 
@@ -228,29 +226,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             }
         }
 
-        removeAbandonedEmptyThread()
-
-        let thread = ThreadModel()
-        let viewModel = makeViewModel()
-        viewModel.isHistoryLoaded = true  // No session yet — nothing to load
-        let threadId = thread.id
-        viewModel.onFirstUserMessage = { [weak self] _ in
-            self?.completedConversationCount += 1
-            // Only set "Untitled" if the user hasn't already renamed this thread.
-            if self?.pendingRenames[threadId] == nil {
-                self?.updateThreadTitle(id: threadId, title: "Untitled")
-            }
-            self?.updateLastInteracted(threadId: threadId)
-        }
-        threads.insert(thread, at: 0)
-        chatViewModels[thread.id] = viewModel
-        subscribeToBusyState(for: thread.id, viewModel: viewModel)
-        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
-        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
-        touchVMAccessOrder(thread.id)
-        evictStaleCachedViewModels()
-        activeThreadId = thread.id
-        log.info("Created thread \(thread.id) with title \"\(thread.title)\"")
+        // Enter draft mode — thread only appears in sidebar when the user sends
+        // their first message (via promoteDraft triggered by onUserMessageSent).
+        enterDraftMode()
     }
 
     /// Ensures an active thread exists, selecting or creating one if needed.


### PR DESCRIPTION
## Summary
- `createThread()` now enters draft mode instead of immediately adding a thread to the sidebar
- Thread only appears in sidebar when the user sends their first message (via `promoteDraft`)
- Sidebar selection is cleared when entering draft mode so no stale thread appears highlighted

## Test plan
- [ ] Click "New Chat" — no new thread should appear in the sidebar
- [ ] Type and send a message — thread should appear in sidebar
- [ ] Click "New Chat" multiple times without sending — should not create multiple empty threads
- [ ] Previous thread should deselect in sidebar when clicking "New Chat"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
