### PR TITLE
fix: sync gateway feature flag registry with canonical copy

### DIFF
--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -127,7 +127,7 @@
       "key": "feature_flags.settings-developer-nav.enabled",
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
-      "defaultEnabled": false
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The bundled `gateway/src/feature-flag-registry.json` had `settings-developer-nav.defaultEnabled` set to `false`, while the canonical `meta/feature-flags/feature-flag-registry.json` had it set to `true`
- Synced the gateway copy to match, fixing the `feature-flag-defaults-sync` test

## Original prompt
fix these tests FAIL: src/__tests__/feature-flag-defaults-sync.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
