### PR TITLE
fix: prevent workspace-mode bypass for medium-risk file mutations

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -680,14 +680,14 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("allow");
     });
 
-    test("file_write within workspace with no rule → auto-allowed in workspace mode", async () => {
+    test("file_write within workspace with no rule → prompt (Medium risk) in workspace mode", async () => {
       const result = await check(
         "file_write",
         { path: "/tmp/file.txt" },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("workspace-scoped");
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("Medium risk");
     });
 
     test("file_write outside workspace with no rule → prompt", async () => {
@@ -4595,24 +4595,24 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.reason).toContain("Workspace mode");
   });
 
-  test("file_write within workspace → allow (workspace-scoped)", async () => {
+  test("file_write within workspace → prompt (Medium risk)", async () => {
     const result = await check(
       "file_write",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Workspace mode");
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Medium risk");
   });
 
-  test("file_edit within workspace → allow (workspace-scoped)", async () => {
+  test("file_edit within workspace → prompt (Medium risk)", async () => {
     const result = await check(
       "file_edit",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Workspace mode");
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("Medium risk");
   });
 
   // ── file operations outside workspace follow risk-based fallback ──

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -794,7 +794,7 @@ export async function check(
   if (
     permissionsMode === "workspace" &&
     !matchedRule &&
-    risk !== RiskLevel.High
+    risk === RiskLevel.Low
   ) {
     // When sandbox is disabled, bash runs on the host — don't auto-allow
     const sandboxEnabled = getConfig().sandbox.enabled;


### PR DESCRIPTION
### Motivation
- Workspace mode previously auto-allowed workspace-scoped operations without considering risk level, which allowed `file_write`/`file_edit` inside the workspace (including `~/.vellum/workspace/hooks`) to bypass approval and enabled a path to execute arbitrary hook scripts.
- The intent is to preserve workspace-mode convenience for clearly low-risk actions while restoring prompts for medium-risk mutations that can persist executable payloads.

### Description
- Narrow the workspace-mode shortcut in `assistant/src/permissions/checker.ts` to only auto-allow when `risk === RiskLevel.Low` instead of allowing any non-High risk, preventing Medium-risk `file_write`/`file_edit` from being implicitly allowed. (`assistant/src/permissions/checker.ts`)
- Update permission tests to reflect the secure behavior by expecting prompts for workspace `file_write` and `file_edit` (Medium risk) while keeping `file_read` behavior unchanged. (`assistant/src/__tests__/checker.test.ts`)
- Kept existing bundled-skill low-risk auto-allow behavior and strict-mode semantics unchanged.

### Testing
- Updated unit tests in `assistant/src/__tests__/checker.test.ts` to assert the new behavior; the test files were modified accordingly and committed.
- Attempted to run the scoped test suite with `cd assistant && bun test src/__tests__/checker.test.ts`, but `bun` was unavailable in the environment so tests could not be executed here. Static checks/TypeScript/linting were also skipped due to the same toolchain limitation.
- Verified changes were committed (`git show --stat --oneline -1`) and the diff includes modifications to `assistant/src/permissions/checker.ts` and `assistant/src/__tests__/checker.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af39f51b3083238bc078edd049aeb1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
