### PR TITLE
fix: prevent workspace-mode bypass for medium-risk file mutations

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -673,14 +673,14 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("allow");
     });
 
-    test("file_write within workspace with no rule → auto-allowed in workspace mode", async () => {
+    test("file_write within workspace with no rule → prompt (medium risk bypasses workspace auto-allow)", async () => {
       const result = await check(
         "file_write",
         { path: "/tmp/file.txt" },
         "/tmp",
       );
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("workspace-scoped");
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("medium risk");
     });
 
     test("file_write outside workspace with no rule → prompt", async () => {
@@ -4588,24 +4588,24 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     expect(result.reason).toContain("Workspace mode");
   });
 
-  test("file_write within workspace → allow (workspace-scoped)", async () => {
+  test("file_write within workspace → prompt (Medium risk bypasses workspace auto-allow)", async () => {
     const result = await check(
       "file_write",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Workspace mode");
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("medium risk");
   });
 
-  test("file_edit within workspace → allow (workspace-scoped)", async () => {
+  test("file_edit within workspace → prompt (Medium risk bypasses workspace auto-allow)", async () => {
     const result = await check(
       "file_edit",
       { file_path: "/home/user/my-project/src/index.ts" },
       workspaceDir,
     );
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Workspace mode");
+    expect(result.decision).toBe("prompt");
+    expect(result.reason).toContain("medium risk");
   });
 
   // ── file operations outside workspace follow risk-based fallback ──

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -328,11 +328,11 @@ describe("ephemeral-permissions", () => {
       testConfig.permissions.mode = "workspace";
     });
 
-    test("workspace mode auto-allows workspace-scoped file_write (medium risk)", async () => {
+    test("workspace mode prompts for workspace-scoped file_write (medium risk)", async () => {
       const filePath = join(testDir, "workspace-test-file.txt");
       const result = await check("file_write", { path: filePath }, testDir);
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Workspace mode");
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("medium risk");
     });
 
     test("workspace mode still prompts for file_write outside workspace", async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -805,12 +805,12 @@ export async function check(
   }
 
   // Workspace mode: auto-allow workspace-scoped operations that don't have
-  // an explicit rule. Non-workspace operations fall through to risk-based policy.
-  // High-risk operations always require approval regardless of scope.
+  // an explicit rule, but only when risk is Low. Medium and High risk operations
+  // fall through to risk-based policy and always require approval.
   if (
     permissionsMode === "workspace" &&
     !matchedRule &&
-    risk !== RiskLevel.High
+    risk === RiskLevel.Low
   ) {
     // When sandbox is disabled, bash runs on the host — don't auto-allow
     const sandboxEnabled = getConfig().sandbox.enabled;

--- a/playwright/agent-xcode/.build
+++ b/playwright/agent-xcode/.build
@@ -1,0 +1,1 @@
+/Users/maddieabboud/projects/vellum-assistant/playwright/agent-xcode/.build

--- a/playwright/agent-xcode/.build
+++ b/playwright/agent-xcode/.build
@@ -1,1 +1,0 @@
-/Users/maddieabboud/projects/vellum-assistant/playwright/agent-xcode/.build


### PR DESCRIPTION
## Summary
- Narrow the workspace-mode shortcut in `checker.ts` to only auto-allow when `risk === RiskLevel.Low` instead of `risk !== RiskLevel.High`, preventing medium-risk tools like `file_write`/`file_edit` from being silently allowed inside the workspace (which enabled a hook injection vector)
- Update three test files to assert the new behavior: `checker.test.ts`, `ephemeral-permissions.test.ts`; fix `"Medium risk"` → `"medium risk"` in assertions to match the lowercase enum value format

## Original prompt
respond to feedback and take this pr over the line https://github.com/vellum-ai/vellum-assistant/pull/15535

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
