### PR TITLE
feat: per-thread conversation keys for desktop multi-thread isolation

### DIFF
--- a/assistant/src/__tests__/per-thread-conversation-keys.test.ts
+++ b/assistant/src/__tests__/per-thread-conversation-keys.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for per-thread conversation keys (desktop multi-thread support).
+ *
+ * Covers:
+ *   - Unscoped SSE subscription (no conversationKey) receives all events.
+ *   - Scoped SSE subscription (with conversationKey) still works.
+ *   - POST /v1/conversations/create returns a conversationId.
+ *   - POST /v1/messages returns conversationId in 202 responses.
+ *   - POST /v1/messages accepts conversationId instead of conversationKey.
+ */
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(mkdtempSync(join(tmpdir(), "per-thread-keys-")));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+    secretDetection: { enabled: false },
+    contextWindow: { maxInputTokens: 200000 },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+mock.module("../daemon/session-slash.js", () => ({
+  resolveSlash: (_content: string) => ({
+    kind: "passthrough",
+    content: _content,
+  }),
+}));
+
+mock.module("../daemon/session-process.js", () => ({
+  buildModelInfoEvent: () => ({ type: "model_info" }),
+  isModelSlashCommand: () => false,
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  getAttachmentsByIds: () => [],
+}));
+
+mock.module("../runtime/guardian-reply-router.js", () => ({
+  routeGuardianReply: async () => ({
+    consumed: false,
+    decisionApplied: false,
+    type: "not_consumed",
+  }),
+}));
+
+mock.module("../memory/canonical-guardian-store.js", () => ({
+  createCanonicalGuardianRequest: () => ({ id: "id", requestCode: "ABC" }),
+  generateCanonicalRequestCode: () => "ABC",
+  listPendingRequestsByConversationScope: () => [],
+}));
+
+mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
+  bridgeConfirmationRequestToGuardian: async () => undefined,
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: async (_conversationId: string, role: string) => ({
+    id: role === "user" ? "user-msg-id" : "assistant-msg-id",
+  }),
+  getMessages: () => [],
+  provenanceFromTrustContext: () => ({ provenanceTrustClass: "unknown" }),
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+}));
+
+mock.module("../runtime/trust-context-resolver.js", () => ({
+  resolveTrustContext: () => ({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  }),
+  withSourceChannel: (sourceChannel: unknown, ctx: unknown) => ({
+    ...(ctx as Record<string, unknown>),
+    sourceChannel,
+  }),
+}));
+
+mock.module("../security/secret-ingress.js", () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+import { getOrCreateConversation } from "../memory/conversation-key-store.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import type { AuthContext } from "../runtime/auth/types.js";
+import {
+  handleCreateConversation,
+  handleSendMessage,
+} from "../runtime/routes/conversation-routes.js";
+import { handleSubscribeAssistantEvents } from "../runtime/routes/events-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function clearTables() {
+  const db = getDb();
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM conversations");
+}
+
+const testAuthContext: AuthContext = {
+  subject: "actor:self:test",
+  principalType: "actor",
+  assistantId: "self",
+  actorPrincipalId: "test",
+  scopeProfile: "actor_client_v1",
+  scopes: new Set([
+    "chat.read",
+    "chat.write",
+    "approval.read",
+    "approval.write",
+    "settings.read",
+    "settings.write",
+  ]),
+  policyEpoch: 1,
+};
+
+function makeSession() {
+  const events: unknown[] = [];
+  const messages: unknown[] = [];
+  return {
+    session: {
+      setTrustContext: () => {},
+      updateClient: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      ensureActorScopedHistory: async () => {},
+      isProcessing: () => false,
+      processing: false,
+      hasAnyPendingConfirmation: () => false,
+      hasPendingConfirmation: () => false,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "q-id" }),
+      persistUserMessage: async () => "user-msg-id",
+      runAgentLoop: async () => {},
+      setPreactivatedSkillIds: () => {},
+      drainQueue: async () => {},
+      getMessages: () => messages,
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+      setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
+      hostBashProxy: undefined,
+      hostFileProxy: undefined,
+      trustContext: undefined,
+    },
+    events,
+  };
+}
+
+// ── SSE: Unscoped subscription ──────────────────────────────────────────────
+
+describe("SSE — unscoped subscription (no conversationKey)", () => {
+  beforeEach(clearTables);
+
+  test("returns 200 without conversationKey", () => {
+    const hub = new AssistantEventHub({ maxSubscribers: 10 });
+    const ac = new AbortController();
+    const req = new Request("http://localhost/v1/events", {
+      signal: ac.signal,
+    });
+    const res = handleSubscribeAssistantEvents(req, new URL(req.url), {
+      hub,
+      heartbeatIntervalMs: 60_000,
+      skipActorVerification: true as const,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    ac.abort();
+  });
+
+  test("unscoped subscriber receives events from multiple sessions", async () => {
+    const hub = new AssistantEventHub({ maxSubscribers: 10 });
+    const received: string[] = [];
+
+    // Subscribe directly to the hub (bypassing SSE stream complexity)
+    // to verify that an unscoped filter (no sessionId) receives all events.
+    const sub = hub.subscribe({ assistantId: "ast_daemon" }, (event) => {
+      if (event.sessionId) received.push(event.sessionId);
+    });
+
+    const event1 = buildAssistantEvent(
+      "ast_daemon",
+      { type: "assistant_text_delta", text: "hello from session1" },
+      "session-1",
+    );
+    const event2 = buildAssistantEvent(
+      "ast_daemon",
+      { type: "assistant_text_delta", text: "hello from session2" },
+      "session-2",
+    );
+
+    await hub.publish(event1);
+    await hub.publish(event2);
+
+    expect(received).toContain("session-1");
+    expect(received).toContain("session-2");
+    expect(received.length).toBe(2);
+
+    sub.dispose();
+  });
+});
+
+describe("SSE — scoped subscription (with conversationKey)", () => {
+  beforeEach(clearTables);
+
+  test("scoped subscriber only receives matching session events", async () => {
+    const hub = new AssistantEventHub({ maxSubscribers: 10 });
+
+    // Create a conversation for the key
+    const mapping = getOrCreateConversation("scoped-key-1");
+    const received: string[] = [];
+
+    // Subscribe with a sessionId filter (same as what the SSE route does
+    // when conversationKey is provided)
+    const sub = hub.subscribe(
+      { assistantId: "ast_daemon", sessionId: mapping.conversationId },
+      (event) => {
+        const msg = event.message as { text?: string };
+        if (msg.text) received.push(msg.text);
+      },
+    );
+
+    // Publish event for the scoped session
+    const matchingEvent = buildAssistantEvent(
+      "ast_daemon",
+      { type: "assistant_text_delta", text: "scoped event" },
+      mapping.conversationId,
+    );
+    // Publish event for a different session (should NOT be received)
+    const otherEvent = buildAssistantEvent(
+      "ast_daemon",
+      { type: "assistant_text_delta", text: "other session" },
+      "other-session-id",
+    );
+
+    await hub.publish(otherEvent);
+    await hub.publish(matchingEvent);
+
+    // Should only receive the matching event
+    expect(received).toEqual(["scoped event"]);
+
+    sub.dispose();
+  });
+});
+
+// ── POST /v1/conversations/create ───────────────────────────────────────────
+
+describe("POST /v1/conversations/create", () => {
+  beforeEach(clearTables);
+
+  test("creates a conversation and returns conversationId", async () => {
+    const req = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationKey: "vellum:test-create-1" }),
+    });
+    const res = await handleCreateConversation(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      conversationId: string;
+      created: boolean;
+    };
+    expect(body.conversationId).toBeDefined();
+    expect(typeof body.conversationId).toBe("string");
+    expect(body.created).toBe(true);
+  });
+
+  test("returns existing conversation on duplicate key", async () => {
+    const req1 = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationKey: "vellum:test-create-dup" }),
+    });
+    const res1 = await handleCreateConversation(req1);
+    const body1 = (await res1.json()) as {
+      conversationId: string;
+      created: boolean;
+    };
+    expect(body1.created).toBe(true);
+
+    const req2 = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationKey: "vellum:test-create-dup" }),
+    });
+    const res2 = await handleCreateConversation(req2);
+    const body2 = (await res2.json()) as {
+      conversationId: string;
+      created: boolean;
+    };
+    expect(body2.created).toBe(false);
+    expect(body2.conversationId).toBe(body1.conversationId);
+  });
+
+  test("different keys create different conversations", async () => {
+    const req1 = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationKey: "vellum:thread-a" }),
+    });
+    const req2 = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationKey: "vellum:thread-b" }),
+    });
+
+    const [res1, res2] = await Promise.all([
+      handleCreateConversation(req1),
+      handleCreateConversation(req2),
+    ]);
+    const body1 = (await res1.json()) as { conversationId: string };
+    const body2 = (await res2.json()) as { conversationId: string };
+
+    expect(body1.conversationId).not.toBe(body2.conversationId);
+  });
+
+  test("returns 400 without conversationKey", async () => {
+    const req = new Request("http://localhost/v1/conversations/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await handleCreateConversation(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /v1/messages — conversationId in response ──────────────────────────
+
+describe("POST /v1/messages — conversationId in response", () => {
+  beforeEach(clearTables);
+
+  test("202 response includes conversationId", async () => {
+    const { session } = makeSession();
+    const hub = new AssistantEventHub({ maxSubscribers: 10 });
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "vellum:msg-test-1",
+        content: "hello",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session as any,
+          resolveAttachments: () => [],
+          assistantEventHub: hub,
+        },
+      },
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      accepted: boolean;
+      conversationId: string;
+    };
+    expect(body.accepted).toBe(true);
+    expect(body.conversationId).toBeDefined();
+    expect(typeof body.conversationId).toBe("string");
+  });
+
+  test("accepts conversationId instead of conversationKey", async () => {
+    // Pre-create a conversation
+    const mapping = getOrCreateConversation("vellum:restored-thread");
+
+    const { session } = makeSession();
+    const hub = new AssistantEventHub({ maxSubscribers: 10 });
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationId: mapping.conversationId,
+        content: "follow-up message",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session as any,
+          resolveAttachments: () => [],
+          assistantEventHub: hub,
+        },
+      },
+      testAuthContext,
+    );
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      accepted: boolean;
+      conversationId: string;
+    };
+    expect(body.accepted).toBe(true);
+    expect(body.conversationId).toBe(mapping.conversationId);
+  });
+
+  test("returns 400 without conversationKey or conversationId", async () => {
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "hello",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    const res = await handleSendMessage(req, {}, testAuthContext);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("conversationKey or conversationId");
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -129,6 +129,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "btw", scopes: ["chat.write"] },
   { endpoint: "conversations", scopes: ["chat.read"] },
   { endpoint: "conversations:DELETE", scopes: ["chat.write"] },
+  { endpoint: "conversations/create", scopes: ["chat.write"] },
   { endpoint: "conversations/switch", scopes: ["chat.write"] },
   { endpoint: "conversations/name", scopes: ["chat.write"] },
   { endpoint: "conversations/cancel", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -532,6 +532,10 @@ export async function handleSendMessage(
     );
   }
 
+  if (body.conversationId && typeof body.conversationId !== "string") {
+    return httpError("BAD_REQUEST", "conversationId must be a string", 400);
+  }
+
   // Reject non-string content values (numbers, objects, etc.)
   if (content != null && typeof content !== "string") {
     return httpError("BAD_REQUEST", "content must be a string", 400);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -487,6 +487,7 @@ export async function handleSendMessage(
 ): Promise<Response> {
   const body = (await req.json()) as {
     conversationKey?: string;
+    conversationId?: string;
     content?: string;
     attachmentIds?: string[];
     sourceChannel?: string;
@@ -523,8 +524,12 @@ export async function handleSendMessage(
     );
   }
 
-  if (!conversationKey) {
-    return httpError("BAD_REQUEST", "conversationKey is required", 400);
+  if (!conversationKey && !body.conversationId) {
+    return httpError(
+      "BAD_REQUEST",
+      "conversationKey or conversationId is required",
+      400,
+    );
   }
 
   // Reject non-string content values (numbers, objects, etc.)
@@ -589,7 +594,11 @@ export async function handleSendMessage(
     );
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
+  // Resolve the conversation: prefer conversationId (direct lookup for restored
+  // threads) over conversationKey (key-based lookup/create for new threads).
+  const mapping = body.conversationId
+    ? { conversationId: body.conversationId, created: false }
+    : getOrCreateConversation(conversationKey!);
   const smDeps = deps.sendMessageDeps;
   const session = await smDeps.getOrCreateSession(mapping.conversationId);
 
@@ -687,6 +696,7 @@ export async function handleSendMessage(
       return Response.json(
         {
           accepted: true,
+          conversationId: mapping.conversationId,
           ...(inlineReplyResult.messageId
             ? { messageId: inlineReplyResult.messageId }
             : {}),
@@ -751,7 +761,10 @@ export async function handleSendMessage(
       pendingInteractions.removeBySession(session);
     }
 
-    return Response.json({ accepted: true, queued: true }, { status: 202 });
+    return Response.json(
+      { accepted: true, queued: true, conversationId: mapping.conversationId },
+      { status: 202 },
+    );
   }
 
   // Session is idle — persist and fire agent loop immediately
@@ -832,7 +845,11 @@ export async function handleSendMessage(
       });
 
       return Response.json(
-        { accepted: true, messageId: persisted.id },
+        {
+          accepted: true,
+          messageId: persisted.id,
+          conversationId: mapping.conversationId,
+        },
         { status: 202 },
       );
     } finally {
@@ -874,7 +891,10 @@ export async function handleSendMessage(
       );
     });
 
-  return Response.json({ accepted: true, messageId }, { status: 202 });
+  return Response.json(
+    { accepted: true, messageId, conversationId: mapping.conversationId },
+    { status: 202 },
+  );
 }
 
 async function generateLlmSuggestion(
@@ -1077,6 +1097,30 @@ export function handleSearchConversations(url: URL): Response {
   return Response.json({ query, results });
 }
 
+/**
+ * POST /v1/conversations/create
+ *
+ * Create (or look up) a conversation by conversationKey upfront, without
+ * sending a message. Returns the daemon's internal conversationId so clients
+ * can use it as a real session ID from the start.
+ */
+export async function handleCreateConversation(
+  req: Request,
+): Promise<Response> {
+  const body = (await req.json()) as { conversationKey?: string };
+  const { conversationKey } = body;
+
+  if (!conversationKey || typeof conversationKey !== "string") {
+    return httpError("BAD_REQUEST", "conversationKey is required", 400);
+  }
+
+  const mapping = getOrCreateConversation(conversationKey);
+  return Response.json({
+    conversationId: mapping.conversationId,
+    created: mapping.created,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -1106,6 +1150,11 @@ export function conversationRouteDefinitions(deps: {
           },
           authContext,
         ),
+    },
+    {
+      endpoint: "conversations/create",
+      method: "POST",
+      handler: async ({ req }) => handleCreateConversation(req),
     },
     {
       endpoint: "search",

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -26,10 +26,14 @@ import type { RouteDefinition } from "../http-router.js";
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 
 /**
- * Stream assistant events as Server-Sent Events for a specific conversation.
+ * Stream assistant events as Server-Sent Events.
  *
  * Query params:
- *   conversationKey -- required; scopes the stream to one conversation.
+ *   conversationKey -- optional; when present, scopes the stream to one
+ *                      conversation.  When absent, subscribes to ALL events
+ *                      for the daemon's internal assistant (used by desktop
+ *                      clients that multiplex threads over a single SSE
+ *                      connection).
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
@@ -56,15 +60,22 @@ export function handleSubscribeAssistantEvents(
   // scope and principal type requirements.
 
   const conversationKey = url.searchParams.get("conversationKey");
-  if (!conversationKey) {
-    return httpError("BAD_REQUEST", "conversationKey is required", 400);
-  }
 
   const hub = options?.hub ?? assistantEventHub;
   const heartbeatIntervalMs =
     options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
 
-  const mapping = getOrCreateConversation(conversationKey);
+  // When conversationKey is provided, scope events to that conversation
+  // (backwards-compatible for non-desktop channels). When absent, subscribe
+  // to ALL events for the assistant (desktop multiplexed SSE).
+  const subscriptionFilter: { assistantId: string; sessionId?: string } = {
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+  };
+  if (conversationKey) {
+    const mapping = getOrCreateConversation(conversationKey);
+    subscriptionFilter.sessionId = mapping.conversationId;
+  }
+
   const encoder = new TextEncoder();
 
   // -- Eager subscribe --------------------------------------------------------
@@ -90,10 +101,7 @@ export function handleSubscribeAssistantEvents(
 
   try {
     sub = hub.subscribe(
-      {
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-        sessionId: mapping.conversationId,
-      },
+      subscriptionFilter,
       (event) => {
         const controller = controllerRef;
         if (!controller) return;

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -51,6 +51,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     } catch {
                         log.error("Failed to send session switch request: \(error)")
                     }
+                    // Update the conversation key for the active thread so that
+                    // fallback operations route to the correct conversation.
+                    daemonClient.switchConversationKey(sessionId)
                 }
             } else {
                 // Only clear the persisted thread ID outside of restoration.

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1603,8 +1603,26 @@ extension ChatViewModel {
             }
 
         case .sessionError(let msg):
+            // During bootstrap (sessionId is nil), accept errors with empty
+            // sessionId so createConversation failures reset the UI state.
+            if sessionId == nil {
+                guard bootstrapCorrelationId != nil, msg.sessionId.isEmpty else { return }
+                log.error("Bootstrap failed: \(msg.userMessage, privacy: .private)")
+                bootstrapCorrelationId = nil
+                isThinking = false
+                isSending = false
+                lastFailedMessageText = pendingUserMessage
+                lastFailedMessageDisplayText = pendingUserMessageDisplayText
+                lastFailedMessageAttachments = pendingUserAttachments
+                lastFailedSendError = msg.userMessage
+                pendingUserMessage = nil
+                pendingUserMessageDisplayText = nil
+                pendingUserAttachments = nil
+                errorText = msg.userMessage
+                return
+            }
             // Empty sessionId is treated as a broadcast (e.g. transport-level 401)
-            guard sessionId != nil, msg.sessionId.isEmpty || belongsToSession(msg.sessionId) else { return }
+            guard msg.sessionId.isEmpty || belongsToSession(msg.sessionId) else { return }
             log.error("Session error [\(msg.code.rawValue, privacy: .public)]: \(msg.userMessage, privacy: .private)")
 
             // Per-message send failure: mark the specific user message instead

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -21,8 +21,11 @@ extension ChatViewModel {
     func belongsToSession(_ messageSessionId: String?) -> Bool {
         guard let messageSessionId else { return true }
         guard let sessionId else {
-            // No session established yet — accept all messages
-            return true
+            // No session established yet — reject until bootstrapped.
+            // With per-thread conversation keys, session_info (with real ID)
+            // arrives before any events are sent, so this prevents cross-thread
+            // event leakage during bootstrap.
+            return false
         }
         return messageSessionId == sessionId
     }

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -98,6 +98,7 @@ public protocol DaemonClientProtocol {
     func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
     func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error>
+    func switchConversationKey(_ newKey: String)
 }
 
 extension DaemonClientProtocol {
@@ -115,6 +116,9 @@ extension DaemonClientProtocol {
     public func sendBtwMessage(content: String, conversationKey: String) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { $0.finish() }
     }
+
+    /// Default no-op implementation for switching conversation keys.
+    public func switchConversationKey(_ newKey: String) {}
 }
 
 // MARK: - Usage Response Models

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -90,6 +90,13 @@ extension DaemonClient {
         httpTransport?.stopSSE()
     }
 
+    // MARK: - Per-Thread Conversation Management
+
+    /// Switch the active conversation key (no SSE restart needed since SSE is unscoped).
+    public func switchConversationKey(_ newKey: String) {
+        httpTransport?.switchConversationKey(newKey)
+    }
+
     // MARK: - Token Update
 
     /// Push a new bearer token to the active HTTP transport. If SSE is currently

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -31,10 +31,28 @@ extension HTTPTransport {
                 // session ID from the start — no remapping needed.
                 Task {
                     let conversationKey = "vellum:\(UUID().uuidString)"
-                    let realSessionId = await self.createConversation(conversationKey: conversationKey)
-                    let sessionId = realSessionId ?? UUID().uuidString
+                    // Retry createConversation up to 3 times on transient failures.
+                    // A fabricated UUID would permanently desync with the daemon's
+                    // real conversationId, making the thread stuck (belongsToSession
+                    // rejects all events for the mismatched ID).
+                    var realSessionId: String?
+                    for attempt in 1...3 {
+                        realSessionId = await self.createConversation(conversationKey: conversationKey)
+                        if realSessionId != nil { break }
+                        if attempt < 3 {
+                            try? await Task.sleep(nanoseconds: UInt64(attempt) * 500_000_000)
+                        }
+                    }
+                    guard let sessionId = realSessionId else {
+                        log.error("createConversation failed after 3 attempts — cannot create session")
+                        return
+                    }
                     // Track the conversationKey for this session so sendMessage can route correctly
                     self.conversationKeysBySessionId[sessionId] = conversationKey
+                    // Update the active conversationKey so subagent operations
+                    // (abort, message) use the correct sessionId immediately,
+                    // rather than waiting for a thread switch to trigger it.
+                    self.switchConversationKey(sessionId)
                     let info = ServerMessage.sessionInfo(
                         SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
                     )

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -26,16 +26,20 @@ extension HTTPTransport {
                 Task { await self.sendSecret(requestId: msg.requestId, value: msg.value, delivery: msg.delivery) }
                 return true
             } else if let msg = message as? SessionCreateMessage {
-                // For HTTP transport, session creation is implicit — the conversationKey
-                // acts as the session. Emit a synthetic session_info so ChatViewModel
-                // records the session ID.
-                let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
-                self.activeLocalSessionId = sessionId
-                self.remoteSessionId = nil  // Reset — will be learned from the first SSE event
-                let info = ServerMessage.sessionInfo(
-                    SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
-                )
-                self.onMessage?(info)
+                // Create a real conversation on the daemon and use its conversationId
+                // as the session ID. This ensures the client and daemon agree on the
+                // session ID from the start — no remapping needed.
+                Task {
+                    let conversationKey = "vellum:\(UUID().uuidString)"
+                    let realSessionId = await self.createConversation(conversationKey: conversationKey)
+                    let sessionId = realSessionId ?? UUID().uuidString
+                    // Track the conversationKey for this session so sendMessage can route correctly
+                    self.conversationKeysBySessionId[sessionId] = conversationKey
+                    let info = ServerMessage.sessionInfo(
+                        SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
+                    )
+                    self.onMessage?(info)
+                }
                 return true
             } else if let msg = message as? SessionListRequestMessage {
                 Task { await self.fetchSessionList(offset: Int(msg.offset ?? 0), limit: Int(msg.limit ?? 50)) }

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -33,6 +33,12 @@ extension HTTPTransport {
                     let conversationKey = "vellum:\(UUID().uuidString)"
                     guard let sessionId = await self.createConversation(conversationKey: conversationKey) else {
                         log.error("createConversation failed — cannot create session")
+                        self.onMessage?(.sessionError(SessionErrorMessage(
+                            sessionId: "",
+                            code: .providerApi,
+                            userMessage: "Failed to create conversation. Please try again.",
+                            retryable: true
+                        )))
                         return
                     }
                     // Track the conversationKey for this session so sendMessage can route correctly

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -31,20 +31,8 @@ extension HTTPTransport {
                 // session ID from the start — no remapping needed.
                 Task {
                     let conversationKey = "vellum:\(UUID().uuidString)"
-                    // Retry createConversation up to 3 times on transient failures.
-                    // A fabricated UUID would permanently desync with the daemon's
-                    // real conversationId, making the thread stuck (belongsToSession
-                    // rejects all events for the mismatched ID).
-                    var realSessionId: String?
-                    for attempt in 1...3 {
-                        realSessionId = await self.createConversation(conversationKey: conversationKey)
-                        if realSessionId != nil { break }
-                        if attempt < 3 {
-                            try? await Task.sleep(nanoseconds: UInt64(attempt) * 500_000_000)
-                        }
-                    }
-                    guard let sessionId = realSessionId else {
-                        log.error("createConversation failed after 3 attempts — cannot create session")
+                    guard let sessionId = await self.createConversation(conversationKey: conversationKey) else {
+                        log.error("createConversation failed — cannot create session")
                         return
                     }
                     // Track the conversationKey for this session so sendMessage can route correctly

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -70,11 +70,9 @@ extension HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        // The abort endpoint requires a sessionId in the body
-        var body: [String: Any] = [:]
-        if let sessionId = activeLocalSessionId {
-            body["sessionId"] = sessionId
-        }
+        // The abort endpoint requires a sessionId in the body.
+        // conversationKey holds the active thread's sessionId after switchConversationKey().
+        let body: [String: Any] = ["sessionId": conversationKey]
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -106,10 +104,7 @@ extension HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        var body: [String: Any] = ["content": content]
-        if let sessionId = activeLocalSessionId {
-            body["sessionId"] = sessionId
-        }
+        let body: [String: Any] = ["content": content, "sessionId": conversationKey]
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -104,7 +104,7 @@ public final class HTTPTransport {
 
     public let baseURL: String
     public private(set) var bearerToken: String?
-    private let conversationKey: String
+    private(set) var conversationKey: String
     private let sourceChannel: String
     let transportMetadata: TransportMetadata
 
@@ -172,14 +172,10 @@ public final class HTTPTransport {
     /// Clients should persist the new token (e.g. to Keychain).
     var onTokenRefreshed: ((String) -> Void)?
 
-    /// The local session ID used by the client (set from the synthetic session_info).
-    /// Used to remap the daemon's internal conversation ID to the client's session ID
-    /// so that ChatViewModel's belongsToSession() filter passes.
-    var activeLocalSessionId: String?
-
-    /// The daemon's internal conversation ID, learned from the first SSE event.
-    /// All occurrences are remapped to `activeLocalSessionId` in incoming events.
-    var remoteSessionId: String?
+    /// Maps sessionId (daemon conversationId) → conversationKey for per-thread routing.
+    /// Populated when a new conversation is created; used by sendMessage to route
+    /// messages to the correct daemon conversation.
+    var conversationKeysBySessionId: [String: String] = [:]
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -246,9 +242,10 @@ public final class HTTPTransport {
     /// identity are modelled as associated values.
     enum Endpoint {
         case healthz
-        case events(conversationKey: String)
+        case events
         case sendMessage
         case getMessages(conversationId: String?)
+        case conversationsCreate
         case conversations(limit: Int, offset: Int)
         case confirm
         case secret
@@ -457,9 +454,8 @@ public final class HTTPTransport {
         switch endpoint {
         case .healthz:
             return ("/healthz", nil)
-        case .events(let conversationKey):
-            let encoded = conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey
-            return ("/v1/events", "conversationKey=\(encoded)")
+        case .events:
+            return ("/v1/events", nil)
         case .sendMessage:
             return ("/v1/messages", nil)
         case .getMessages(let conversationId):
@@ -468,6 +464,8 @@ public final class HTTPTransport {
                 return ("/v1/messages", "conversationId=\(encoded)")
             }
             return ("/v1/messages", nil)
+        case .conversationsCreate:
+            return ("/v1/conversations/create", nil)
         case .conversations(let limit, let offset):
             return ("/v1/conversations", "limit=\(limit)&offset=\(offset)")
         case .confirm:
@@ -843,9 +841,8 @@ public final class HTTPTransport {
         switch endpoint {
         case .healthz:
             return ("\(prefix)/healthz/", nil)
-        case .events(let conversationKey):
-            let encoded = conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey
-            return ("\(prefix)/events/", "conversationKey=\(encoded)")
+        case .events:
+            return ("\(prefix)/events/", nil)
         case .sendMessage:
             return ("\(prefix)/messages/", nil)
         case .getMessages(let conversationId):
@@ -854,6 +851,8 @@ public final class HTTPTransport {
                 return ("\(prefix)/messages/", "conversationId=\(encoded)")
             }
             return ("\(prefix)/messages/", nil)
+        case .conversationsCreate:
+            return ("\(prefix)/conversations/create/", nil)
         case .conversations(let limit, let offset):
             return ("\(prefix)/conversations/", "limit=\(limit)&offset=\(offset)")
         case .confirm:
@@ -1302,6 +1301,42 @@ public final class HTTPTransport {
         }
     }
 
+    // MARK: - Per-Thread Conversation Management
+
+    /// Set the active conversation key (used as fallback for thread switching).
+    func switchConversationKey(_ newKey: String) {
+        self.conversationKey = newKey
+    }
+
+    /// Create a conversation on the daemon for the given conversationKey, returning
+    /// the daemon's internal conversationId. Used during session creation to get the
+    /// real session ID before emitting session_info.
+    func createConversation(conversationKey: String) async -> String? {
+        guard let url = buildURL(for: .conversationsCreate) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["conversationKey": conversationKey]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                log.error("createConversation failed: HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+                return nil
+            }
+            if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let conversationId = json["conversationId"] as? String {
+                return conversationId
+            }
+        } catch {
+            log.error("createConversation error: \(error.localizedDescription)")
+        }
+        return nil
+    }
+
     // MARK: - SSE Stream (on demand)
 
     /// Start the SSE event stream. Call when a chat window opens.
@@ -1346,8 +1381,8 @@ public final class HTTPTransport {
     private func startSSEStream() {
         sseTask?.cancel()
 
-        guard let url = buildURL(for: .events(conversationKey: self.conversationKey)) else {
-            log.error("Invalid SSE URL for conversationKey: \(self.conversationKey)")
+        guard let url = buildURL(for: .events) else {
+            log.error("Invalid SSE URL")
             return
         }
 
@@ -1422,46 +1457,7 @@ public final class HTTPTransport {
     }
 
     private func parseSSEData(_ data: String) {
-        // Remap the daemon's internal session/conversation ID to the client's
-        // local session ID so that ChatViewModel.belongsToSession() passes.
-        // The daemon assigns its own UUID via getOrCreateConversation(), which
-        // differs from the correlationId the client uses as sessionId.
-        var jsonString = data
-        if let localId = activeLocalSessionId {
-            if remoteSessionId == nil {
-                // Learn the daemon's session ID from the first event envelope.
-                if let eventData = data.data(using: .utf8),
-                   let envelope = try? decoder.decode(AssistantEvent.self, from: eventData),
-                   let eventSessionId = envelope.sessionId,
-                   eventSessionId != localId {
-                    remoteSessionId = eventSessionId
-                    log.info("Learned remote sessionId \(eventSessionId, privacy: .public) → local \(localId, privacy: .public)")
-                }
-            }
-            if let remoteId = remoteSessionId {
-                // Replace only the sessionId JSON value — not arbitrary occurrences
-                // of the UUID elsewhere in the payload. Handle both compact
-                // ("sessionId":"…") and pretty-printed ("sessionId": "…") JSON.
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\":\"\(remoteId)\"",
-                    with: "\"sessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"sessionId\": \"\(remoteId)\"",
-                    with: "\"sessionId\": \"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\":\"\(remoteId)\"",
-                    with: "\"parentSessionId\":\"\(localId)\""
-                )
-                jsonString = jsonString.replacingOccurrences(
-                    of: "\"parentSessionId\": \"\(remoteId)\"",
-                    with: "\"parentSessionId\": \"\(localId)\""
-                )
-            }
-        }
-
-        guard let jsonData = jsonString.data(using: .utf8) else { return }
+        guard let jsonData = data.data(using: .utf8) else { return }
 
         do {
             let event = try decoder.decode(AssistantEvent.self, from: jsonData)
@@ -1596,11 +1592,19 @@ public final class HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
+        // Look up the per-thread conversationKey. For restored threads (no mapping),
+        // send conversationId directly so the daemon uses the existing conversation.
+        let threadKey = conversationKeysBySessionId[sessionId]
         var body: [String: Any] = [
-            "conversationKey": conversationKey,
             "sourceChannel": sourceChannel,
             "interface": Self.defaultInterface
         ]
+        if let threadKey {
+            body["conversationKey"] = threadKey
+        } else {
+            // Restored thread: use conversationId (sessionId IS the daemon's conversationId)
+            body["conversationId"] = sessionId
+        }
         if let content, !content.isEmpty {
             body["content"] = content
         }

--- a/clients/shared/Network/MockDaemonClient.swift
+++ b/clients/shared/Network/MockDaemonClient.swift
@@ -34,6 +34,7 @@ public final class MockDaemonClient: DaemonClientProtocol, ObservableObject {
 
     public func startSSE() {}
     public func stopSSE() {}
+    public func switchConversationKey(_ newKey: String) {}
 
     /// Inject a server message into all active subscribers.
     public func emit(_ message: ServerMessage) {


### PR DESCRIPTION
## Summary
- **Daemon**: Make SSE `conversationKey` optional — when absent, subscribes to ALL events for the assistant (desktop multiplexed SSE). Other channels unchanged.
- **Daemon**: Add `POST /v1/conversations/create` endpoint so clients can get a real `conversationId` before sending messages.
- **Daemon**: Return `conversationId` in all 202 responses from `POST /v1/messages`. Accept `conversationId` as alternative to `conversationKey` for restored threads.
- **Client**: Each new thread generates a unique `conversationKey` (`vellum:<UUID>`), calls `POST /v1/conversations/create` to get the real daemon `conversationId`, and uses it as the session ID from the start.
- **Client**: Per-thread `conversationKeysBySessionId` mapping routes messages to the correct daemon conversation. Restored threads fall back to sending `conversationId` directly.
- **Client**: Delete all session ID remapping code (`activeLocalSessionId`, `remoteSessionId`, `parseSSEData` string replacement). Unscoped SSE URL.
- **Client**: Tighten `belongsToSession()` to reject events when no session is established (prevents cross-thread leakage during bootstrap).
- **Tests**: 10 new tests covering unscoped/scoped SSE, conversation creation, conversationId in responses, and conversationId-based message routing.

## Test plan
- [ ] Thread A "hello" → title generated. Thread B "weather?" → different title. Both work independently.
- [ ] Send in thread A, switch to B, send there. Switch back to A — response is there.
- [ ] Send in A, immediately send in B. Each response appears only in its own thread.
- [ ] Click New Chat 10x without sending. Restart. No "Generating title..." entries.
- [ ] Restart, select old thread, send follow-up — works correctly.
- [ ] `bun test per-thread-conversation-keys` passes (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
