### PR TITLE
fix: propagate toolUseId on tool_output_chunk

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -88,6 +88,7 @@ export interface ToolOutputChunk {
   type: "tool_output_chunk";
   chunk: string;
   sessionId?: string;
+  toolUseId?: string;
   subType?: "tool_start" | "tool_complete" | "status";
   subToolName?: string;
   subToolInput?: string;

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -384,6 +384,7 @@ export function handleToolOutputChunk(
       type: "tool_output_chunk",
       chunk: event.chunk,
       sessionId: deps.ctx.conversationId,
+      toolUseId: event.toolUseId,
       subType: structured.subType,
       subToolName: structured.subToolName,
       subToolInput: structured.subToolInput,
@@ -395,6 +396,7 @@ export function handleToolOutputChunk(
       type: "tool_output_chunk",
       chunk: event.chunk,
       sessionId: deps.ctx.conversationId,
+      toolUseId: event.toolUseId,
     });
   }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1368,10 +1368,26 @@ extension ChatViewModel {
             guard belongsToSession(msg.sessionId) else { return }
             guard !isLoadingHistory else { return }
             // Handle structured progress events from claude_code sub-tools
+            // Resolve the target tool call: prefer matching by toolUseId, fall back to positional heuristic.
+            let resolvedStructuredTarget: (msgIndex: Int, tcIndex: Int)? = {
+                if let toolUseId = msg.toolUseId {
+                    for i in stride(from: messages.count - 1, through: 0, by: -1) {
+                        if let tcIdx = messages[i].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                            return (i, tcIdx)
+                        }
+                    }
+                }
+                if let existingId = currentAssistantMessageId,
+                   let mIdx = messages.firstIndex(where: { $0.id == existingId }),
+                   let tcIdx = messages[mIdx].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+                    return (mIdx, tcIdx)
+                }
+                return nil
+            }()
             if let subType = msg.subType, !subType.isEmpty,
-               let existingId = currentAssistantMessageId,
-               let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
-               let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete && $0.toolName == "claude_code" }) {
+               let target = resolvedStructuredTarget {
+                let msgIndex = target.msgIndex
+                let tcIndex = target.tcIndex
                 switch subType {
                 case "tool_start":
                     if let toolName = msg.subToolName {
@@ -1408,10 +1424,26 @@ extension ChatViewModel {
                     break
                 }
             } else if msg.subType == nil || msg.subType?.isEmpty == true,
-                      !msg.chunk.isEmpty,
-                      let existingId = currentAssistantMessageId,
-                      let msgIndex = messages.firstIndex(where: { $0.id == existingId }),
-                      let tcIndex = messages[msgIndex].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                      !msg.chunk.isEmpty {
+                // Resolve target tool call: prefer toolUseId, fall back to positional heuristic.
+                let resolvedPlainTarget: (msgIndex: Int, tcIndex: Int)? = {
+                    if let toolUseId = msg.toolUseId {
+                        for i in stride(from: messages.count - 1, through: 0, by: -1) {
+                            if let tcIdx = messages[i].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                                return (i, tcIdx)
+                            }
+                        }
+                    }
+                    if let existingId = currentAssistantMessageId,
+                       let mIdx = messages.firstIndex(where: { $0.id == existingId }),
+                       let tcIdx = messages[mIdx].toolCalls.lastIndex(where: { !$0.isComplete }) {
+                        return (mIdx, tcIdx)
+                    }
+                    return nil
+                }()
+                guard let target = resolvedPlainTarget else { return }
+                let msgIndex = target.msgIndex
+                let tcIndex = target.tcIndex
                 // Append plain-text output chunks to the coalescing buffer.
                 // Structured JSON sub-events (with a valid subType) are handled above;
                 // the subType guard prevents them from leaking raw JSON here.

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4532,16 +4532,18 @@ public struct ToolOutputChunk: Codable, Sendable {
     public let type: String
     public let chunk: String
     public let sessionId: String?
+    public let toolUseId: String?
     public let subType: String?
     public let subToolName: String?
     public let subToolInput: String?
     public let subToolIsError: Bool?
     public let subToolId: String?
 
-    public init(type: String, chunk: String, sessionId: String? = nil, subType: String? = nil, subToolName: String? = nil, subToolInput: String? = nil, subToolIsError: Bool? = nil, subToolId: String? = nil) {
+    public init(type: String, chunk: String, sessionId: String? = nil, toolUseId: String? = nil, subType: String? = nil, subToolName: String? = nil, subToolInput: String? = nil, subToolIsError: Bool? = nil, subToolId: String? = nil) {
         self.type = type
         self.chunk = chunk
         self.sessionId = sessionId
+        self.toolUseId = toolUseId
         self.subType = subType
         self.subToolName = subToolName
         self.subToolInput = subToolInput


### PR DESCRIPTION
## Summary
- Add `toolUseId` field to `ToolOutputChunk` interface (TS) and struct (Swift)
- Pass `event.toolUseId` through in `handleToolOutputChunk` (both structured and plain branches)
- Use ID-based matching in the Swift client for routing chunks to the correct tool call, with fallback to existing positional heuristics

## Test plan
- [ ] Existing `tool_output_chunk` tests pass (additive field, no breaking changes)
- [ ] Verify streaming output routes to correct tool call when multiple tools run concurrently

https://claude.ai/code/session_01WcUCHDK8zZnWqbAKawfF1X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
