### PR TITLE
fix: strip partialOutput in stripHeavyContent()

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1655,6 +1655,8 @@ public struct ChatMessage: Identifiable, Equatable {
             toolCalls[i].inputFull = ""
             toolCalls[i].inputFullLength = 0
             toolCalls[i].inputRawDict = nil
+            toolCalls[i].partialOutput = ""
+            toolCalls[i].partialOutputRevision = 0
         }
         for i in attachments.indices {
             attachments[i].data = ""


### PR DESCRIPTION
## Summary
- Strip `partialOutput` in `stripHeavyContent()` to prevent memory retention of streaming output buffers

## Test plan
- [ ] Verify partialOutput is cleared after context compaction

https://claude.ai/code/session_01WcUCHDK8zZnWqbAKawfF1X
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
