### PR TITLE
fix: align ContextWindowManager system prompt with no-client sessions

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -83,19 +83,25 @@ export interface ContextWindowCompactOptions {
 
 export interface ContextWindowManagerOptions {
   provider: Provider;
-  systemPrompt: string;
+  systemPrompt: string | (() => string);
   config: ContextWindowConfig;
 }
 
 export class ContextWindowManager {
   private readonly provider: Provider;
-  private readonly systemPrompt: string;
+  private readonly _systemPrompt: string | (() => string);
   private readonly config: ContextWindowConfig;
 
   constructor(options: ContextWindowManagerOptions) {
     this.provider = options.provider;
-    this.systemPrompt = options.systemPrompt;
+    this._systemPrompt = options.systemPrompt;
     this.config = options.config;
+  }
+
+  private get systemPrompt(): string {
+    return typeof this._systemPrompt === "function"
+      ? this._systemPrompt()
+      : this._systemPrompt;
   }
 
   /**

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -346,7 +346,7 @@ export class Session {
     );
     this.contextWindowManager = new ContextWindowManager({
       provider,
-      systemPrompt,
+      systemPrompt: () => resolveSystemPromptCallback([]).systemPrompt,
       config: config.contextWindow,
     });
 


### PR DESCRIPTION
Aligns the ContextWindowManager's system prompt with the actual prompt sent to the provider in no-client sessions. Previously, the compaction logic used a longer prompt (without hasNoClient), causing premature compaction and unnecessary history loss in headless sessions. Addresses review feedback from PR #15528.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
