### PR TITLE
M1: Add toolUseId to ConfirmationRequest wire format

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -156,6 +156,8 @@ export interface ConfirmationRequest {
   persistentDecisionsAllowed?: boolean;
   /** Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread"). */
   temporaryOptionsAvailable?: Array<"allow_10m" | "allow_thread">;
+  /** The tool_use block ID for client-side correlation with specific tool calls. */
+  toolUseId?: string;
 }
 
 export interface SecretRequest {

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -121,6 +121,7 @@ export class PermissionPrompter {
         executionTarget,
         persistentDecisionsAllowed: persistentDecisionsAllowed ?? true,
         temporaryOptionsAvailable,
+        toolUseId,
       });
 
       this.onStateChanged?.(requestId, "pending", "system", toolUseId);

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -44,6 +44,8 @@ public struct ToolConfirmationData: Equatable {
     public let persistentDecisionsAllowed: Bool
     /// Which temporary approval options the daemon supports for this request (e.g. "allow_10m", "allow_thread").
     public let temporaryOptionsAvailable: [String]
+    /// The tool_use block ID for client-side correlation with specific tool calls.
+    public let toolUseId: String?
     public var state: ToolConfirmationState = .pending
     /// The decision string that was used to approve (e.g. "allow", "allow_10m", "allow_thread", "always_allow").
     /// Set when the state transitions to `.approved`.
@@ -527,7 +529,7 @@ public struct ToolConfirmationData: Equatable {
         )
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input
@@ -538,6 +540,7 @@ public struct ToolConfirmationData: Equatable {
         self.executionTarget = executionTarget
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
         self.temporaryOptionsAvailable = temporaryOptionsAvailable
+        self.toolUseId = toolUseId
         self.state = state
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1191,7 +1191,8 @@ extension ChatViewModel {
                 scopeOptions: msg.scopeOptions,
                 executionTarget: msg.executionTarget,
                 persistentDecisionsAllowed: msg.persistentDecisionsAllowed ?? true,
-                temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? []
+                temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? [],
+                toolUseId: msg.toolUseId
             )
             let confirmMsg = ChatMessage(
                 role: .assistant,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -778,8 +778,10 @@ public struct ConfirmationRequest: Codable, Sendable {
     public let persistentDecisionsAllowed: Bool?
     /// Which temporary approval options the client should render (e.g. "Allow for 10 minutes", "Allow for this thread").
     public let temporaryOptionsAvailable: [String]?
+    /// The tool_use block ID for client-side correlation with specific tool calls.
+    public let toolUseId: String?
 
-    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil) {
+    public init(type: String, requestId: String, toolName: String, input: [String: AnyCodable], riskLevel: String, executionTarget: String? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption], scopeOptions: [ConfirmationRequestScopeOption], diff: ConfirmationRequestDiff? = nil, sandboxed: Bool? = nil, sessionId: String? = nil, persistentDecisionsAllowed: Bool? = nil, temporaryOptionsAvailable: [String]? = nil, toolUseId: String? = nil) {
         self.type = type
         self.requestId = requestId
         self.toolName = toolName
@@ -793,6 +795,7 @@ public struct ConfirmationRequest: Codable, Sendable {
         self.sessionId = sessionId
         self.persistentDecisionsAllowed = persistentDecisionsAllowed
         self.temporaryOptionsAvailable = temporaryOptionsAvailable
+        self.toolUseId = toolUseId
     }
 }
 


### PR DESCRIPTION
Thread toolUseId through the confirmation_request message from daemon to client, enabling the client to link confirmation requests to specific tool calls. Part of #15541.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
