### PR TITLE
M2: Attach pending confirmations to ToolCallData

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -825,6 +825,9 @@ public struct ToolCallData: Identifiable, Equatable {
     /// changes without expensive full-string comparison. Incremented on
     /// every write, even when `partialOutput` is at the character cap.
     public var partialOutputRevision: Int = 0
+    /// Live pending confirmation attached to this tool call for inline rendering.
+    /// Set when a `confirmation_request` arrives, cleared when approved/denied.
+    public var pendingConfirmation: ToolConfirmationData?
     /// Sub-tool steps for claude_code tool calls (live progress tracking).
     public var claudeCodeSteps: [ClaudeCodeSubStep] = []
     /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
@@ -858,6 +861,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.completedAt == rhs.completedAt
             && lhs.confirmationDecision == rhs.confirmationDecision
             && lhs.confirmationLabel == rhs.confirmationLabel
+            && lhs.pendingConfirmation == rhs.pendingConfirmation
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1864,9 +1864,23 @@ extension ChatViewModel {
             }
             // Stamp confirmation data on the corresponding ToolCallData in the
             // preceding assistant message so it survives thread switches.
+            let decision = mapConfirmationState(msg.state)
             if let toolName = confirmationToolName,
-               let state = mapConfirmationState(msg.state) {
+               let state = decision {
                 stampConfirmationOnToolCall(toolName: toolName, decision: state, toolUseId: msg.toolUseId, targetMessageId: precedingAssistantId)
+            }
+            // Clear pendingConfirmation even for states that don't stamp a decision
+            // (e.g. resolved_stale) so the confirmation UI doesn't remain visible.
+            if decision == nil {
+                for i in messages.indices.reversed() {
+                    guard messages[i].role == .assistant, messages[i].confirmation == nil else { continue }
+                    if let tcIdx = messages[i].toolCalls.firstIndex(where: {
+                        $0.pendingConfirmation?.requestId == msg.requestId
+                    }) {
+                        messages[i].toolCalls[tcIdx].pendingConfirmation = nil
+                        break
+                    }
+                }
             }
 
         case .assistantActivityState(let msg):

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -58,6 +58,8 @@ extension ChatViewModel {
         }
         if let tcIdx = tcIdx {
             messages[msgIdx].toolCalls[tcIdx].confirmationDecision = decision
+            // Clear live pending confirmation now that a decision has been made
+            messages[msgIdx].toolCalls[tcIdx].pendingConfirmation = nil
             // Use the tool category from the confirmation data as the label
             let label = ToolConfirmationData(requestId: "", toolName: toolName, riskLevel: "").toolCategory
             messages[msgIdx].toolCalls[tcIdx].confirmationLabel = label
@@ -1194,6 +1196,13 @@ extension ChatViewModel {
                 temporaryOptionsAvailable: msg.temporaryOptionsAvailable ?? [],
                 toolUseId: msg.toolUseId
             )
+            // Attach confirmation to matching tool call if toolUseId is available
+            if let toolUseId = msg.toolUseId,
+               let assistantId = currentAssistantMessageId,
+               let msgIdx = messages.firstIndex(where: { $0.id == assistantId }),
+               let tcIdx = messages[msgIdx].toolCalls.firstIndex(where: { $0.toolUseId == toolUseId }) {
+                messages[msgIdx].toolCalls[tcIdx].pendingConfirmation = confirmation
+            }
             let confirmMsg = ChatMessage(
                 role: .assistant,
                 text: "",


### PR DESCRIPTION
## Summary
- Add `pendingConfirmation: ToolConfirmationData?` field to `ToolCallData` for inline confirmation rendering
- Populate `pendingConfirmation` on the matching tool call when a `confirmation_request` arrives (using `toolUseId` correlation)
- Clear `pendingConfirmation` in `stampConfirmationOnToolCall` when a decision is made

Part of #15541.

## Test plan
- [ ] Verify confirmation requests still create standalone confirmation messages (fallback preserved)
- [ ] Verify `pendingConfirmation` is set on the correct `ToolCallData` when `toolUseId` matches
- [ ] Verify `pendingConfirmation` is cleared when confirmation is approved/denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
