### PR TITLE
perf: cache resolved system prompt during compaction pass

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -91,6 +91,8 @@ export class ContextWindowManager {
   private readonly provider: Provider;
   private readonly _systemPrompt: string | (() => string);
   private readonly config: ContextWindowConfig;
+  /** Cached resolved system prompt, set for the duration of a compaction pass. */
+  private _resolvedSystemPrompt: string | undefined;
 
   constructor(options: ContextWindowManagerOptions) {
     this.provider = options.provider;
@@ -99,9 +101,24 @@ export class ContextWindowManager {
   }
 
   private get systemPrompt(): string {
+    if (this._resolvedSystemPrompt !== undefined) {
+      return this._resolvedSystemPrompt;
+    }
     return typeof this._systemPrompt === "function"
       ? this._systemPrompt()
       : this._systemPrompt;
+  }
+
+  /** Resolve and cache the system prompt for the duration of a compaction pass. */
+  private cacheSystemPrompt(): void {
+    this._resolvedSystemPrompt =
+      typeof this._systemPrompt === "function"
+        ? this._systemPrompt()
+        : this._systemPrompt;
+  }
+
+  private clearSystemPromptCache(): void {
+    this._resolvedSystemPrompt = undefined;
   }
 
   /**
@@ -112,16 +129,34 @@ export class ContextWindowManager {
    */
   shouldCompact(messages: Message[]): ShouldCompactResult {
     if (!this.config.enabled) return { needed: false, estimatedTokens: 0 };
-    const estimated = estimatePromptTokens(messages, this.systemPrompt, {
-      providerName: this.provider.name,
-    });
-    const threshold = Math.floor(
-      this.config.maxInputTokens * this.config.compactThreshold,
-    );
-    return { needed: estimated >= threshold, estimatedTokens: estimated };
+    this.cacheSystemPrompt();
+    try {
+      const estimated = estimatePromptTokens(messages, this.systemPrompt, {
+        providerName: this.provider.name,
+      });
+      const threshold = Math.floor(
+        this.config.maxInputTokens * this.config.compactThreshold,
+      );
+      return { needed: estimated >= threshold, estimatedTokens: estimated };
+    } finally {
+      this.clearSystemPromptCache();
+    }
   }
 
   async maybeCompact(
+    messages: Message[],
+    signal?: AbortSignal,
+    options?: ContextWindowCompactOptions,
+  ): Promise<ContextWindowResult> {
+    this.cacheSystemPrompt();
+    try {
+      return await this._maybeCompact(messages, signal, options);
+    } finally {
+      this.clearSystemPromptCache();
+    }
+  }
+
+  private async _maybeCompact(
     messages: Message[],
     signal?: AbortSignal,
     options?: ContextWindowCompactOptions,


### PR DESCRIPTION
Both Codex and Devin flagged that the dynamic systemPrompt getter causes redundant filesystem reads during compaction. Resolves the system prompt once at the start of maybeCompact() and shouldCompact(), and uses the cached value throughout, avoiding repeated callback invocations during binary search in pickKeepBoundary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
