### PR TITLE
M4: Update MessageListView to skip standalone confirmation messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -947,6 +947,28 @@ private struct MessageCellView: View {
         .id("thinking-indicator")
     }
 
+    /// Returns true when the given pending confirmation is already rendered inline
+    /// under a preceding assistant message's tool step (via AssistantProgressView),
+    /// so the standalone ToolConfirmationBubble row should be suppressed.
+    ///
+    /// Falls back to `false` when `pendingConfirmation` is not populated on any
+    /// tool call (e.g. history restore, missing `toolUseId`), which correctly
+    /// causes the standalone bubble to render as a fallback.
+    private func isConfirmationRenderedInline(
+        confirmation: ToolConfirmationData,
+        messages: [ChatMessage],
+        at index: Int
+    ) -> Bool {
+        for i in (0..<index).reversed() {
+            let msg = messages[i]
+            guard msg.role == .assistant, msg.confirmation == nil else { continue }
+            return msg.toolCalls.contains { tc in
+                tc.pendingConfirmation?.requestId == confirmation.requestId
+            }
+        }
+        return false
+    }
+
     var body: some View {
         if showTimestamp.contains(index) {
             TimestampDivider(date: message.timestamp)
@@ -954,15 +976,26 @@ private struct MessageCellView: View {
 
         if let confirmation = message.confirmation {
             if confirmation.state == .pending {
-                ToolConfirmationBubble(
+                // Check if this confirmation is already rendered inline under the
+                // preceding assistant message's tool step (via AssistantProgressView).
+                // If so, skip the standalone bubble to avoid duplication.
+                let isRenderedInline = isConfirmationRenderedInline(
                     confirmation: confirmation,
-                    isKeyboardActive: confirmation.requestId == activePendingRequestId,
-                    onAllow: { onConfirmationAllow(confirmation.requestId) },
-                    onDeny: { onConfirmationDeny(confirmation.requestId) },
-                    onAlwaysAllow: onAlwaysAllow,
-                    onTemporaryAllow: onTemporaryAllow
+                    messages: displayMessages,
+                    at: index
                 )
-                .id(message.id)
+
+                if !isRenderedInline {
+                    ToolConfirmationBubble(
+                        confirmation: confirmation,
+                        isKeyboardActive: confirmation.requestId == activePendingRequestId,
+                        onAllow: { onConfirmationAllow(confirmation.requestId) },
+                        onDeny: { onConfirmationDeny(confirmation.requestId) },
+                        onAlwaysAllow: onAlwaysAllow,
+                        onTemporaryAllow: onTemporaryAllow
+                    )
+                    .id(message.id)
+                }
             } else {
                 let hasPrecedingAssistant: Bool = {
                     guard index > 0 else { return false }


### PR DESCRIPTION
## Summary
- Suppress the standalone `ToolConfirmationBubble` message row when the confirmation is already rendered inline under the tool step in `AssistantProgressView`
- Add `isConfirmationRenderedInline` helper that walks backwards from the confirmation message to find the preceding assistant message and checks if any of its tool calls have the matching `pendingConfirmation`
- Preserves fallback rendering for history restore (when `pendingConfirmation` isn't populated) and missing `toolUseId`

## Test plan
- [ ] Trigger a tool confirmation during a live session — verify only the inline bubble appears (no duplicate standalone row)
- [ ] Load a session from history where confirmations were pending — verify standalone bubble renders as fallback
- [ ] Verify decided confirmations (approved/denied) still render correctly via permission chips
- [ ] Verify `PendingConfirmationFocusSelector` keyboard focus still works correctly

Part of #15541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
