### PR TITLE
Remove Messaging: Telegram feature flag

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-telegram",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.telegram.enabled",
-      "label": "Messaging: Telegram",
-      "description": "Allow messaging tools to operate on the Telegram platform",
-      "defaultEnabled": false
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",

--- a/assistant/src/messaging/registry.ts
+++ b/assistant/src/messaging/registry.ts
@@ -14,7 +14,6 @@ import type { MessagingProvider } from "./provider.js";
  */
 const PLATFORM_FLAG_KEYS: Record<string, string> = {
   gmail: "feature_flags.messaging.gmail.enabled",
-  telegram: "feature_flags.messaging.telegram.enabled",
 };
 
 const providers = new Map<string, MessagingProvider>();

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-telegram",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.telegram.enabled",
-      "label": "Messaging: Telegram",
-      "description": "Allow messaging tools to operate on the Telegram platform",
-      "defaultEnabled": false
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-telegram",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.telegram.enabled",
-      "label": "Messaging: Telegram",
-      "description": "Allow messaging tools to operate on the Telegram platform",
-      "defaultEnabled": false
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",


### PR DESCRIPTION
## Summary
- Removed the `messaging-telegram` feature flag entry from all three `feature-flag-registry.json` files (assistant, gateway, meta)
- Removed the `telegram` key from `PLATFORM_FLAG_KEYS` in `assistant/src/messaging/registry.ts`
- Telegram messaging is now unconditionally enabled — `isPlatformEnabled("telegram")` returns `true` by default since undeclared keys resolve to `true`

## Original prompt
Lets remove the "Messaging: Telegram" feature flag and keep all code as if it were enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
