### PR TITLE
Remove isPlatformEnabled and per-platform messaging flags

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -6,7 +6,6 @@ import type { MessagingProvider } from "../../../../messaging/provider.js";
 import {
   getConnectedProviders,
   getMessagingProvider,
-  isPlatformEnabled,
 } from "../../../../messaging/registry.js";
 import type { OAuthConnection } from "../../../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
@@ -110,9 +109,7 @@ export function extractEmail(address: string): string {
 export function resolveProvider(platformInput?: string): MessagingProvider {
   if (platformInput) return getMessagingProvider(platformInput);
 
-  const connected = getConnectedProviders().filter((p) =>
-    isPlatformEnabled(p.id),
-  );
+  const connected = getConnectedProviders();
   if (connected.length === 1) return connected[0];
   if (connected.length === 0) {
     throw new Error(

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-gmail",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.gmail.enabled",
-      "label": "Messaging: Gmail",
-      "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": true
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",

--- a/assistant/src/messaging/registry.ts
+++ b/assistant/src/messaging/registry.ts
@@ -2,19 +2,9 @@
  * Messaging provider registry — register/lookup providers by platform ID.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { getConfig } from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import type { MessagingProvider } from "./provider.js";
-
-/**
- * Per-platform feature flag keys. Platforms not listed here are allowed
- * by default (undeclared keys resolve to `true`).
- */
-const PLATFORM_FLAG_KEYS: Record<string, string> = {
-  gmail: "feature_flags.messaging.gmail.enabled",
-};
 
 const providers = new Map<string, MessagingProvider>();
 
@@ -30,22 +20,7 @@ export function getMessagingProvider(id: string): MessagingProvider {
       `Messaging provider "${id}" not found. Available: ${available}`,
     );
   }
-  assertPlatformEnabled(id);
   return provider;
-}
-
-export function isPlatformEnabled(platformId: string): boolean {
-  const flagKey = PLATFORM_FLAG_KEYS[platformId];
-  if (!flagKey) return true;
-  return isAssistantFeatureFlagEnabled(flagKey, getConfig());
-}
-
-function assertPlatformEnabled(platformId: string): void {
-  if (!isPlatformEnabled(platformId)) {
-    throw new Error(
-      `The ${platformId} platform is not enabled. Enable it in Settings > Features.`,
-    );
-  }
 }
 
 /** Return all registered providers that have stored credentials. */

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-gmail",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.gmail.enabled",
-      "label": "Messaging: Gmail",
-      "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": true
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging-gmail",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.gmail.enabled",
-      "label": "Messaging: Gmail",
-      "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": true
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",


### PR DESCRIPTION
## Summary
- Removed `isPlatformEnabled`, `assertPlatformEnabled`, and `PLATFORM_FLAG_KEYS` from `assistant/src/messaging/registry.ts`
- Removed the `isPlatformEnabled` filter from `resolveProvider()` in `shared.ts`
- Removed the now-dead `messaging-gmail` flag from all three `feature-flag-registry.json` files
- Messaging platforms are now always available once connected — no per-platform feature flag gating

## Original prompt
Can we just remove isPlatformEnabled?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
