### PR TITLE
feat: add "email-channel" feature flag to unified registry (default disabled)

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -74,6 +74,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "email-channel",
+      "scope": "assistant",
+      "key": "feature_flags.email-channel.enabled",
+      "label": "Email Channel",
+      "description": "Show the Email channel card on the Contacts page and enable the email-setup skill",
+      "defaultEnabled": false
+    },
+    {
       "id": "outbound-proxy-sidecar",
       "scope": "assistant",
       "key": "feature_flags.outbound-proxy-sidecar.enabled",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -74,6 +74,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "email-channel",
+      "scope": "assistant",
+      "key": "feature_flags.email-channel.enabled",
+      "label": "Email Channel",
+      "description": "Show the Email channel card on the Contacts page and enable the email-setup skill",
+      "defaultEnabled": false
+    },
+    {
       "id": "outbound-proxy-sidecar",
       "scope": "assistant",
       "key": "feature_flags.outbound-proxy-sidecar.enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -74,6 +74,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "email-channel",
+      "scope": "assistant",
+      "key": "feature_flags.email-channel.enabled",
+      "label": "Email Channel",
+      "description": "Show the Email channel card on the Contacts page and enable the email-setup skill",
+      "defaultEnabled": false
+    },
+    {
       "id": "outbound-proxy-sidecar",
       "scope": "assistant",
       "key": "feature_flags.outbound-proxy-sidecar.enabled",


### PR DESCRIPTION
## Summary
- Adds a new `email-channel` feature flag entry to the unified feature flag registry with `defaultEnabled: false`
- Syncs the registry to all three locations: `meta/feature-flags/`, `assistant/src/config/`, and `gateway/src/`

Part of plan: email-feature-flag.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
