### PR TITLE
chore: remove TELEGRAM_BOT_USERNAME env var fallback

### DIFF
--- a/assistant/src/telegram/bot-username.ts
+++ b/assistant/src/telegram/bot-username.ts
@@ -1,13 +1,12 @@
 import { getConfig } from "../config/loader.js";
 
 /**
- * Read the Telegram bot username from config, falling back to the
- * TELEGRAM_BOT_USERNAME env var.
+ * Read the Telegram bot username from config.
  */
 export function getTelegramBotUsername(): string | undefined {
   const value = getConfig().telegram.botUsername;
   if (value.trim().length > 0) {
     return value.trim();
   }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Remove process.env.TELEGRAM_BOT_USERNAME fallback from getTelegramBotUsername()
- Function now reads exclusively from config

Part of plan: rm-legacy-env-vars.md (PR 4 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
