### PR TITLE
chore: remove RUNTIME_URL, ASSISTANT_ID, RUNTIME_PROXY_BEARER_TOKEN, DOCTOR_URL env overrides

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -60,9 +60,7 @@ function parseArgs(): ParsedArgs {
     }
   } else {
     const hasExplicitUrl =
-      process.env.RUNTIME_URL ||
-      flagArgs.includes("--url") ||
-      flagArgs.includes("-u");
+      flagArgs.includes("--url") || flagArgs.includes("-u");
     const active = getActiveAssistant();
     if (active) {
       entry = findAssistantByName(active);
@@ -84,15 +82,9 @@ function parseArgs(): ParsedArgs {
     }
   }
 
-  let runtimeUrl =
-    process.env.RUNTIME_URL ||
-    entry?.localUrl ||
-    entry?.runtimeUrl ||
-    FALLBACK_RUNTIME_URL;
-  let assistantId =
-    process.env.ASSISTANT_ID || entry?.assistantId || FALLBACK_ASSISTANT_ID;
-  const bearerToken =
-    process.env.RUNTIME_PROXY_BEARER_TOKEN || entry?.bearerToken || undefined;
+  let runtimeUrl = entry?.localUrl || entry?.runtimeUrl || FALLBACK_RUNTIME_URL;
+  let assistantId = entry?.assistantId || FALLBACK_ASSISTANT_ID;
+  const bearerToken = entry?.bearerToken || undefined;
   const species: Species = (entry?.species as Species) ?? "vellum";
 
   for (let i = 0; i < flagArgs.length; i++) {
@@ -177,7 +169,7 @@ ${ANSI.bold}OPTIONS:${ANSI.reset}
 
 ${ANSI.bold}DEFAULTS:${ANSI.reset}
     Reads from ~/.vellum.lock.json (created by vellum hatch).
-    Override with flags above or env vars RUNTIME_URL / ASSISTANT_ID.
+    Override with flags above.
 
 ${ANSI.bold}EXAMPLES:${ANSI.reset}
     vellum client

--- a/cli/src/lib/doctor-client.ts
+++ b/cli/src/lib/doctor-client.ts
@@ -1,4 +1,4 @@
-const DOCTOR_URL = process.env.DOCTOR_URL || "https://doctor.vellum.ai";
+const DOCTOR_URL = "https://doctor.vellum.ai";
 
 export type ProgressPhase =
   | "invoking_prompt"


### PR DESCRIPTION
## Summary
- Remove env var overrides from CLI client URL/ID resolution (RUNTIME_URL, ASSISTANT_ID, RUNTIME_PROXY_BEARER_TOKEN)
- Remove DOCTOR_URL env var from doctor-client.ts
- CLI client now resolves from lockfile + CLI flags only

Part of plan: rm-legacy-env-vars.md (PR 5 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
