### PR TITLE
chore: remove VELLUM_CONFIG_SANDBOX_ENABLED env var override

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -333,12 +333,6 @@ export function loadConfig(): AssistantConfig {
     }
 
     // Environment variables override everything
-    if (process.env.VELLUM_CONFIG_SANDBOX_ENABLED === "false") {
-      config.sandbox.enabled = false;
-    } else if (process.env.VELLUM_CONFIG_SANDBOX_ENABLED === "true") {
-      config.sandbox.enabled = true;
-    }
-
     if (process.env.ANTHROPIC_API_KEY) {
       config.apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
     }


### PR DESCRIPTION
## Summary
- Remove VELLUM_CONFIG_SANDBOX_ENABLED env var override from config loader
- Sandbox setting now controlled exclusively via config file

Part of plan: rm-legacy-env-vars.md (PR 9 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
