### PR TITLE
Remove Telegram streaming delivery from background dispatch

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -31,12 +31,8 @@ import type {
   ApprovalCopyGenerator,
   MessageProcessor,
 } from "../../http-types.js";
-import { TelegramStreamingDelivery } from "../../telegram-streaming-delivery.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
-import {
-  deliverAttachmentsOnly,
-  deliverReplyViaCallback,
-} from "../channel-delivery-routes.js";
+import { deliverReplyViaCallback } from "../channel-delivery-routes.js";
 import { deliverGeneratedApprovalPrompt } from "../guardian-approval-prompt.js";
 
 const log = getLogger("runtime-http");
@@ -112,12 +108,6 @@ export function processChannelMessageInBackground(
   } = params;
 
   (async () => {
-    const boundGuardianActor = isBoundGuardianActor({
-      trustClass: trustCtx.trustClass,
-      guardianExternalUserId: trustCtx.guardianExternalUserId,
-      requesterExternalUserId: trustCtx.requesterExternalUserId,
-    });
-
     const typingCallbackUrl = shouldEmitTelegramTyping(
       sourceChannel,
       replyCallbackUrl,
@@ -181,16 +171,6 @@ export function processChannelMessageInBackground(
       }
     }
 
-    const telegramStreaming =
-      sourceChannel === "telegram" && replyCallbackUrl
-        ? new TelegramStreamingDelivery({
-            callbackUrl: replyCallbackUrl,
-            chatId: externalChatId,
-            mintBearerToken,
-            assistantId,
-          })
-        : undefined;
-
     try {
       const cmdIntent =
         commandIntent && typeof commandIntent.type === "string"
@@ -218,9 +198,6 @@ export function processChannelMessageInBackground(
           trustContext: trustCtx,
           isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
-          ...(telegramStreaming
-            ? { onEvent: (msg) => telegramStreaming.onEvent(msg) }
-            : {}),
         },
         sourceChannel,
         sourceInterface,
@@ -228,94 +205,18 @@ export function processChannelMessageInBackground(
       deliveryCrud.linkMessage(eventId, userMessageId);
       deliveryStatus.markProcessed(eventId);
 
-      if (telegramStreaming) {
-        // Retrieve approval metadata from pending interactions (if any)
-        // so approval buttons can be attached to the final streamed message.
-        // Approval prompts are guardian-only and must never be attached for
-        // non-guardian or unverified actors.
-        const prompt = boundGuardianActor
-          ? getChannelApprovalPrompt(conversationId)
-          : undefined;
-        const pending = boundGuardianActor
-          ? getApprovalInfoByConversation(conversationId)
-          : [];
-        const approvalMeta =
-          prompt && pending.length > 0
-            ? buildApprovalUIMetadata(prompt, pending[0])
-            : undefined;
-        try {
-          await telegramStreaming.finish(approvalMeta);
-          deliveryChannels.updateDeliveredSegmentCount(eventId, 1);
-        } catch (err) {
-          log.error(
-            { err, conversationId },
-            "Telegram streaming finalization failed",
-          );
-          // Fallback: deliver approval as a standalone message so buttons
-          // are not permanently lost when finish() fails.
-          if (approvalMeta && replyCallbackUrl) {
-            try {
-              await deliverChannelReply(
-                replyCallbackUrl,
-                {
-                  chatId: externalChatId,
-                  text: approvalMeta.plainTextFallback ?? "Action needed:",
-                  approval: approvalMeta,
-                  assistantId,
-                },
-                mintBearerToken(),
-              );
-            } catch (fallbackErr) {
-              log.error(
-                { err: fallbackErr, conversationId },
-                "Fallback approval delivery also failed",
-              );
-            }
-          }
-        }
-      }
-
       if (replyCallbackUrl) {
-        // Streaming fully succeeded — only send attachments since text
-        // was already delivered via streaming edits.
-        const streamingFullyDelivered =
-          telegramStreaming?.hasDeliveredText &&
-          telegramStreaming.finishSucceeded;
-
-        if (streamingFullyDelivered) {
-          await deliverAttachmentsOnly(
-            conversationId,
-            externalChatId,
-            replyCallbackUrl,
-            mintBearerToken(),
-            assistantId,
-          );
-        } else {
-          // Non-streaming path, or streaming partially failed (some text
-          // was delivered but finish/finalization threw). In the partial
-          // failure case the user has a truncated message, so we deliver
-          // the full response to ensure nothing is lost.
-          if (
-            telegramStreaming?.hasDeliveredText &&
-            !telegramStreaming.finishSucceeded
-          ) {
-            log.warn(
-              { conversationId },
-              "Telegram streaming partially failed — falling back to full text delivery",
-            );
-          }
-          await deliverReplyViaCallback(
-            conversationId,
-            externalChatId,
-            replyCallbackUrl,
-            mintBearerToken(),
-            assistantId,
-            {
-              onSegmentDelivered: (count) =>
-                deliveryChannels.updateDeliveredSegmentCount(eventId, count),
-            },
-          );
-        }
+        await deliverReplyViaCallback(
+          conversationId,
+          externalChatId,
+          replyCallbackUrl,
+          mintBearerToken(),
+          assistantId,
+          {
+            onSegmentDelivered: (count) =>
+              deliveryChannels.updateDeliveredSegmentCount(eventId, count),
+          },
+        );
       }
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary
- Remove TelegramStreamingDelivery integration from background dispatch, making Telegram use the same send-once deliverReplyViaCallback path as all other channels
- Remove streaming-specific code paths (onEvent wiring, finish() finalization, streamingFullyDelivered conditional, partial-failure fallback)
- Approval buttons continue to be delivered via the pending approval prompt watcher

Part of plan: rm-telegram-streaming.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
