### PR TITLE
chore: remove FEATURE_FLAG_DEFAULTS_PATH env var override

### DIFF
--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -42,10 +42,7 @@ function loadDefaultsRegistry(): FeatureFlagDefaultsRegistry {
   if (cachedDefaults) return cachedDefaults;
 
   const thisDir = import.meta.dirname ?? __dirname;
-  const envPath = process.env.FEATURE_FLAG_DEFAULTS_PATH?.trim();
   const candidates = [
-    // Explicit override (primarily for tests / controlled environments)
-    ...(envPath ? [envPath] : []),
     // Bundled: co-located copy in the same directory as this source file.
     // Works in Docker / packaged builds where the repo-root `meta/` dir
     // is not available.

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -18,7 +18,11 @@ const testDir = join(
 const vellumRoot = join(testDir, ".vellum");
 const workspaceDir = join(vellumRoot, "workspace");
 const configPath = join(workspaceDir, "config.json");
-const defaultsPath = join(testDir, "feature-flag-registry.json");
+
+// Place the test registry file adjacent to the gateway source so
+// getRegistryCandidates() finds it via the bundled-copy candidate.
+const gatewaySrcDir = join(import.meta.dirname, "..");
+const defaultsPath = join(gatewaySrcDir, "feature-flag-registry.json");
 
 const TEST_REGISTRY = {
   version: 1,
@@ -59,11 +63,9 @@ const TEST_REGISTRY = {
 };
 
 const savedBaseDataDir = process.env.BASE_DATA_DIR;
-const savedFeatureFlagDefaultsPath = process.env.FEATURE_FLAG_DEFAULTS_PATH;
 
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
-  process.env.FEATURE_FLAG_DEFAULTS_PATH = defaultsPath;
   mkdirSync(workspaceDir, { recursive: true });
   writeFileSync(defaultsPath, JSON.stringify(TEST_REGISTRY, null, 2));
   resetFeatureFlagDefaultsCache();
@@ -75,13 +77,14 @@ afterEach(() => {
   } else {
     process.env.BASE_DATA_DIR = savedBaseDataDir;
   }
-  if (savedFeatureFlagDefaultsPath === undefined) {
-    delete process.env.FEATURE_FLAG_DEFAULTS_PATH;
-  } else {
-    process.env.FEATURE_FLAG_DEFAULTS_PATH = savedFeatureFlagDefaultsPath;
-  }
   try {
     rmSync(testDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+  // Clean up the test registry file placed next to gateway source
+  try {
+    rmSync(defaultsPath, { force: true });
   } catch {
     // best effort cleanup
   }

--- a/gateway/src/feature-flag-defaults.ts
+++ b/gateway/src/feature-flag-defaults.ts
@@ -27,42 +27,35 @@ const REGISTRY_RELATIVE = join("meta", "feature-flags", REGISTRY_FILENAME);
  * `meta/` tree.
  *
  * Candidate order:
- *   1. `FEATURE_FLAG_DEFAULTS_PATH` env var (explicit override)
- *   2. Bundled copy adjacent to gateway source (`gateway/src/<file>`)
- *   3. macOS app bundle resources (`Contents/Resources/<file>`)
- *   4. Monorepo layout: walk up two levels from gateway/src/
- *   5. Docker / gateway-only layout: adjacent to gateway src (`<root>/meta/...`)
- *   6. cwd-based fallback
+ *   1. Bundled copy adjacent to gateway source (`gateway/src/<file>`)
+ *   2. macOS app bundle resources (`Contents/Resources/<file>`)
+ *   3. Monorepo layout: walk up two levels from gateway/src/
+ *   4. Docker / gateway-only layout: adjacent to gateway src (`<root>/meta/...`)
+ *   5. cwd-based fallback
  */
 function getRegistryCandidates(): string[] {
   const candidates: string[] = [];
 
   const srcDir = import.meta.dirname ?? new URL(".", import.meta.url).pathname;
 
-  // 1. Explicit env override
-  const envPath = process.env.FEATURE_FLAG_DEFAULTS_PATH?.trim();
-  if (envPath) {
-    candidates.push(envPath);
-  }
-
-  // 2. Bundled gateway-local copy
+  // 1. Bundled gateway-local copy
   candidates.push(join(srcDir, REGISTRY_FILENAME));
 
-  // 3. Packaged macOS app layout: <App>.app/Contents/MacOS/vellum-gateway
+  // 2. Packaged macOS app layout: <App>.app/Contents/MacOS/vellum-gateway
   //    defaults live under <App>.app/Contents/Resources/<file>.
   const execDir = dirname(process.execPath);
   candidates.push(join(execDir, "..", "Resources", REGISTRY_FILENAME));
 
-  // 4. Monorepo layout: gateway/src -> repo root is ../../
+  // 3. Monorepo layout: gateway/src -> repo root is ../../
   const repoRoot = join(srcDir, "..", "..");
   candidates.push(join(repoRoot, REGISTRY_RELATIVE));
 
-  // 5. Docker layout: the gateway Dockerfile copies the gateway dir to /app,
+  // 4. Docker layout: the gateway Dockerfile copies the gateway dir to /app,
   //    so the meta dir (if mounted or copied) may be under /app/../meta or a
   //    sibling directory. Also check one level up from srcDir (gateway root).
   candidates.push(join(srcDir, "..", REGISTRY_RELATIVE));
 
-  // 6. cwd-based fallback
+  // 5. cwd-based fallback
   candidates.push(join(process.cwd(), REGISTRY_RELATIVE));
 
   return candidates;


### PR DESCRIPTION
## Summary
- Remove FEATURE_FLAG_DEFAULTS_PATH env var override from gateway/feature-flag-defaults.ts and assistant/assistant-feature-flags.ts
- Feature flag defaults now discovered via filesystem candidate paths only
- Update tests to work without env var setup

Part of plan: rm-legacy-env-vars.md (PR 6 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
