### PR TITLE
chore: remove VELLUM_CLOUD env var and cloud metadata IP discovery

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -136,14 +136,12 @@ ANTHROPIC_API_KEY=${anthropicApiKey}
 GATEWAY_RUNTIME_PROXY_ENABLED=true
 RUNTIME_PROXY_BEARER_TOKEN=${bearerToken}
 VELLUM_ASSISTANT_NAME=${instanceName}
-VELLUM_CLOUD=${cloud}
 mkdir -p "\$HOME/.vellum"
 cat > "\$HOME/.vellum/.env" << DOTENV_EOF
 ANTHROPIC_API_KEY=\$ANTHROPIC_API_KEY
 GATEWAY_RUNTIME_PROXY_ENABLED=\$GATEWAY_RUNTIME_PROXY_ENABLED
 RUNTIME_PROXY_BEARER_TOKEN=\$RUNTIME_PROXY_BEARER_TOKEN
 RUNTIME_HTTP_PORT=7821
-VELLUM_CLOUD=\$VELLUM_CLOUD
 DOTENV_EOF
 
 mkdir -p "\$HOME/.vellum/workspace"
@@ -743,7 +741,10 @@ async function hatchLocal(
         `🧹 Found ${orphans.length} orphaned process${orphans.length === 1 ? "" : "es"} — cleaning up...`,
       );
       for (const orphan of orphans) {
-        await stopProcess(parseInt(orphan.pid, 10), `${orphan.name} (PID ${orphan.pid})`);
+        await stopProcess(
+          parseInt(orphan.pid, 10),
+          `${orphan.name} (PID ${orphan.pid})`,
+        );
       }
     }
   }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -472,48 +472,8 @@ export async function discoverPublicUrl(
   port?: number,
 ): Promise<string | undefined> {
   const effectivePort = port ?? GATEWAY_PORT;
-  const cloud = process.env.VELLUM_CLOUD;
 
-  let externalIp: string | undefined;
-
-  // Try cloud-specific metadata services for GCP and AWS.
-  if (cloud === "gcp" || cloud === "aws") {
-    try {
-      if (cloud === "gcp") {
-        const resp = await fetch(
-          "http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip",
-          { headers: { "Metadata-Flavor": "Google" } },
-        );
-        if (resp.ok) externalIp = (await resp.text()).trim();
-      } else if (cloud === "aws") {
-        // Use IMDSv2 (token-based) for compatibility with HttpTokens=required
-        const tokenResp = await fetch(
-          "http://169.254.169.254/latest/api/token",
-          {
-            method: "PUT",
-            headers: { "X-aws-ec2-metadata-token-ttl-seconds": "30" },
-          },
-        );
-        if (tokenResp.ok) {
-          const token = await tokenResp.text();
-          const ipResp = await fetch(
-            "http://169.254.169.254/latest/meta-data/public-ipv4",
-            { headers: { "X-aws-ec2-metadata-token": token } },
-          );
-          if (ipResp.ok) externalIp = (await ipResp.text()).trim();
-        }
-      }
-    } catch {
-      // metadata service not reachable
-    }
-
-    if (externalIp) {
-      console.log(`   Discovered external IP: ${externalIp}`);
-      return `http://${externalIp}:${effectivePort}`;
-    }
-  }
-
-  // For local and custom environments, use the local LAN address.
+  // Use the local LAN address.
   // On macOS, prefer the .local hostname (Bonjour/mDNS) so other devices on
   // the same network can reach the gateway by name.
   if (platform() === "darwin") {


### PR DESCRIPTION
## Summary
- Remove VELLUM_CLOUD env var reading from cli/local.ts
- Remove GCP/AWS metadata service IP discovery from discoverPublicUrl()
- Keep local LAN and macOS hostname discovery

Part of plan: rm-legacy-env-vars.md (PR 8 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
