### PR TITLE
feat: gate email-setup skill behind "email-channel" feature flag

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -117,7 +117,8 @@
         "emoji": "📧",
         "vellum": {
           "display-name": "Email Setup",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "feature-flag": "email-channel"
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/email-setup/SKILL.md
+++ b/skills/email-setup/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   vellum:
     display-name: "Email Setup"
     user-invocable: true
+    feature-flag: "email-channel"
 ---
 
 You are setting up your own personal email address. This is a one-time operation — once you have an email, you do not need to run this again.


### PR DESCRIPTION
## Summary
- Adds `feature-flag: "email-channel"` to the `email-setup` skill's YAML frontmatter
- When the flag is disabled (default), the skill is filtered out during skill resolution
- No code changes needed — the existing skill infrastructure handles feature flag gating

Part of plan: email-feature-flag.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
