### PR TITLE
chore: remove TCP, iOS, debug, and monitoring env vars from env-registry

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -41,7 +41,6 @@ mock.module("../config/env.js", () => ({
   getGatewayBaseUrl: () => "http://localhost:7822",
   getRuntimeGatewayOriginSecret: () => undefined,
   isHttpAuthDisabledWithoutSafetyGate: () => false,
-  getEnableMonitoring: () => false,
   checkUnrecognizedEnvVars: () => {},
   getBaseDataDir: () => testDir,
 }));

--- a/assistant/src/cli/commands/dev.ts
+++ b/assistant/src/cli/commands/dev.ts
@@ -22,8 +22,6 @@ existing assistant is running, it is stopped first (waits up to 5 seconds
 for an unresponsive assistant before force-killing it).
 
 Behavioral notes:
-  - Sets VELLUM_DEBUG=1 for DEBUG-level logging
-  - Sets VELLUM_LOG_STDERR=1 so logs stream to stderr (visible in terminal)
   - Sets BASE_DATA_DIR to the repository root
   - The assistant runs in the foreground; press Ctrl+C to stop
 
@@ -111,8 +109,6 @@ Examples:
         env: {
           ...process.env,
           BASE_DATA_DIR: repoRoot,
-          VELLUM_LOG_STDERR: "1",
-          VELLUM_DEBUG: "1",
         },
       });
 

--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -24,13 +24,6 @@ function flag(name: string): boolean {
   return raw === "true" || raw === "1";
 }
 
-function flagTriState(name: string): boolean | undefined {
-  const raw = str(name);
-  if (raw === "true" || raw === "1") return true;
-  if (raw === "false" || raw === "0") return false;
-  return undefined;
-}
-
 // ── Registry ─────────────────────────────────────────────────────────────────
 // Each entry documents the env var name, type, default, and purpose.
 
@@ -44,75 +37,11 @@ export function getBaseDataDir(): string | undefined {
 }
 
 /**
- * VELLUM_DAEMON_TCP_PORT — number, default: 8765
- * TCP port for the daemon's TCP listener (used by iOS clients).
- */
-export function getDaemonTcpPort(): number {
-  const raw = str("VELLUM_DAEMON_TCP_PORT");
-  if (raw) {
-    const port = parseInt(raw, 10);
-    if (!isNaN(port) && port > 0 && port <= 65535) return port;
-  }
-  return 8765;
-}
-
-/**
- * VELLUM_DAEMON_TCP_ENABLED — boolean tri-state, default: undefined (falls back to flag file)
- * Whether the daemon TCP listener should be active.
- * 'true'/'1' → on, 'false'/'0' → off, unset → check flag file.
- */
-export function getDaemonTcpEnabled(): boolean | undefined {
-  return flagTriState("VELLUM_DAEMON_TCP_ENABLED");
-}
-
-/**
- * VELLUM_DAEMON_TCP_HOST — string, default: context-dependent (127.0.0.1 or 0.0.0.0)
- * Hostname/address for the TCP listener. When unset, platform.ts resolves
- * based on whether iOS pairing is enabled.
- */
-export function getDaemonTcpHost(): string | undefined {
-  return str("VELLUM_DAEMON_TCP_HOST");
-}
-
-/**
- * VELLUM_DAEMON_IOS_PAIRING — boolean tri-state, default: undefined (falls back to flag file)
- * Whether iOS pairing mode is enabled. When on, TCP binds to 0.0.0.0.
- * 'true'/'1' → on, 'false'/'0' → off, unset → check flag file.
- */
-export function getDaemonIosPairing(): boolean | undefined {
-  return flagTriState("VELLUM_DAEMON_IOS_PAIRING");
-}
-
-/**
- * VELLUM_DEBUG — boolean, default: false
- * Enables debug-level logging and verbose output.
- */
-export function getDebugMode(): boolean {
-  return flag("VELLUM_DEBUG");
-}
-
-/**
- * VELLUM_LOG_STDERR — boolean, default: false
- * Forces logger output to stderr instead of log files.
- */
-export function getLogStderr(): boolean {
-  return flag("VELLUM_LOG_STDERR");
-}
-
-/**
  * DEBUG_STDOUT_LOGS — boolean, default: false
  * Enables additional log output to stdout (alongside file logging).
  */
 export function getDebugStdoutLogs(): boolean {
   return flag("DEBUG_STDOUT_LOGS");
-}
-
-/**
- * VELLUM_ENABLE_MONITORING — boolean, default: false
- * Enables monitoring/telemetry (Logfire, etc.).
- */
-export function getEnableMonitoring(): boolean {
-  return flag("VELLUM_ENABLE_MONITORING");
 }
 
 /**
@@ -132,24 +61,14 @@ export function getIsContainerized(): boolean {
  * to warn about typos or unrecognized variables.
  */
 const KNOWN_VELLUM_VARS = new Set([
-  "VELLUM_DAEMON_TCP_PORT",
-  "VELLUM_DAEMON_TCP_ENABLED",
-  "VELLUM_DAEMON_TCP_HOST",
-  "VELLUM_DAEMON_IOS_PAIRING",
-  "VELLUM_DAEMON_NOAUTH",
   "VELLUM_DAEMON_AUTOSTART",
-  "VELLUM_DEBUG",
-  "VELLUM_LOG_STDERR",
-  "VELLUM_ENABLE_MONITORING",
   "VELLUM_HOOK_EVENT",
   "VELLUM_HOOK_NAME",
   "VELLUM_HOOK_SETTINGS",
   "VELLUM_ROOT_DIR",
   "VELLUM_WORKSPACE_DIR",
   "VELLUM_CLAUDE_CODE_DEPTH",
-  "VELLUM_ASSISTANT_PLATFORM_URL",
   "VELLUM_UNSAFE_AUTH_BYPASS",
-  "VELLUM_DATA_DIR",
 ]);
 
 /**

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -8,17 +8,13 @@
  * - Fail-fast validation via validateEnv() at startup
  * - Shared derived values (e.g. gateway base URL) instead of duplicated logic
  *
- * Bootstrap-level env vars (BASE_DATA_DIR, VELLUM_DAEMON_*, VELLUM_DEBUG,
- * VELLUM_LOG_STDERR, DEBUG_STDOUT_LOGS) are defined in config/env-registry.ts
- * which has no internal dependencies and can be imported from platform/logger
- * without circular imports.
+ * Bootstrap-level env vars (BASE_DATA_DIR, DEBUG_STDOUT_LOGS) are defined
+ * in config/env-registry.ts which has no internal dependencies and can be
+ * imported from platform/logger without circular imports.
  */
 
 import { getLogger } from "../util/logger.js";
-import {
-  checkUnrecognizedEnvVars,
-  getEnableMonitoring,
-} from "./env-registry.js";
+import { checkUnrecognizedEnvVars } from "./env-registry.js";
 
 const log = getLogger("env");
 
@@ -145,7 +141,7 @@ export function getLogfireToken(): string | undefined {
 }
 
 export function isMonitoringEnabled(): boolean {
-  return getEnableMonitoring();
+  return false;
 }
 
 const DEFAULT_SENTRY_DSN =

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -12,11 +12,7 @@ import pino from "pino";
 import type { PrettyOptions } from "pino-pretty";
 import pinoPretty from "pino-pretty";
 
-import {
-  getDebugMode,
-  getDebugStdoutLogs,
-  getLogStderr,
-} from "../config/env-registry.js";
+import { getDebugStdoutLogs } from "../config/env-registry.js";
 import { logSerializers } from "./log-redact.js";
 import { getLogPath } from "./platform.js";
 
@@ -110,31 +106,18 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   activeLogDate = today;
   activeLogFileConfig = config;
 
-  const level = getDebugMode() ? "debug" : "info";
-
-  if (getDebugMode()) {
-    const prettyStream = pinoPretty(prettyOpts({ destination: 2 }));
-    return pino(
-      { name: "assistant", level, serializers: logSerializers },
-      pino.multistream([
-        { stream: fileStream, level: "info" as const },
-        { stream: prettyStream, level: "debug" as const },
-      ]),
-    );
-  }
-
   // When stdout is not a TTY (e.g. desktop app redirects to a hatch log file),
   // write to the rotating file only — the hatch log already captured early
   // startup output and echoing pino output there is unnecessary duplication.
   if (!process.stdout.isTTY) {
     return pino(
-      { name: "assistant", level, serializers: logSerializers },
+      { name: "assistant", level: "info", serializers: logSerializers },
       fileStream,
     );
   }
 
   return pino(
-    { name: "assistant", level, serializers: logSerializers },
+    { name: "assistant", level: "info", serializers: logSerializers },
     pino.multistream([
       { stream: fileStream, level: "info" as const },
       {
@@ -173,13 +156,11 @@ function getRootLogger(): pino.Logger {
   }
   if (!rootLogger) {
     const forceStderr =
-      process.env.BUN_TEST === "1" ||
-      process.env.NODE_ENV === "test" ||
-      getLogStderr();
+      process.env.BUN_TEST === "1" || process.env.NODE_ENV === "test";
     if (forceStderr) {
       rootLogger = pino(
         {
-          level: getDebugMode() ? "debug" : "info",
+          level: "info",
           serializers: logSerializers,
         },
         pino.destination(2),
@@ -208,17 +189,7 @@ function getRootLogger(): pino.Logger {
         prettyOpts({ destination: fileDest, colorize: false }),
       );
 
-      if (getDebugMode()) {
-        const prettyStream = pinoPretty(prettyOpts({ destination: 2 }));
-        const multi = pino.multistream([
-          { stream: fileStream, level: "info" as const },
-          { stream: prettyStream, level: "debug" as const },
-        ]);
-        rootLogger = pino(
-          { level: "debug", serializers: logSerializers },
-          multi,
-        );
-      } else if (getDebugStdoutLogs()) {
+      if (getDebugStdoutLogs()) {
         rootLogger = pino(
           { level: "info", serializers: logSerializers },
           pino.multistream([
@@ -238,7 +209,7 @@ function getRootLogger(): pino.Logger {
     } catch {
       rootLogger = pino(
         {
-          level: getDebugMode() ? "debug" : "info",
+          level: "info",
           serializers: logSerializers,
         },
         pinoPretty(prettyOpts({ destination: 2 })),
@@ -248,9 +219,9 @@ function getRootLogger(): pino.Logger {
   return rootLogger;
 }
 
-/** Returns true when VELLUM_DEBUG=1 is set. */
+/** Returns whether debug mode is active. Currently always false. */
 export function isDebug(): boolean {
-  return getDebugMode();
+  return false;
 }
 
 /**

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -8,13 +8,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import {
-  getBaseDataDir,
-  getDaemonIosPairing,
-  getDaemonTcpEnabled,
-  getDaemonTcpHost,
-  getDaemonTcpPort,
-} from "../config/env-registry.js";
+import { getBaseDataDir } from "../config/env-registry.js";
 
 export function isMacOS(): boolean {
   return process.platform === "darwin";
@@ -245,39 +239,30 @@ export function getInterfacesDir(): string {
 
 /**
  * Returns the TCP port the daemon should listen on for iOS clients.
- * Reads VELLUM_DAEMON_TCP_PORT env var; defaults to 8765.
+ * Hardcoded default: 8765.
  */
 export function getTCPPort(): number {
-  return getDaemonTcpPort();
+  return 8765;
 }
 
 /**
  * Returns whether the daemon TCP listener should be enabled.
- * Resolution order (first match wins):
- *   1. VELLUM_DAEMON_TCP_ENABLED env var ('true'/'1' → on, 'false'/'0' → off)
- *   2. Presence of the flag file ~/.vellum/tcp-enabled (exists → on)
- *   3. Default: false
+ * Checks for the presence of the flag file ~/.vellum/tcp-enabled.
+ * Default: false.
  *
  * The flag-file check makes it easy to enable TCP in dev without restarting
  * the shell: `touch ~/.vellum/tcp-enabled && kill -USR1 <daemon-pid>`.
- * The macOS CLI (AssistantCli) also sets the env var for bundled-binary deployments.
  */
 export function isTCPEnabled(): boolean {
-  const envValue = getDaemonTcpEnabled();
-  if (envValue !== undefined) return envValue;
   return existsSync(join(getRootDir(), "tcp-enabled"));
 }
 
 /**
  * Returns the hostname/address for the TCP listener.
- * Resolution order (first match wins):
- *   1. VELLUM_DAEMON_TCP_HOST env var (explicit override)
- *   2. If iOS pairing is enabled: '0.0.0.0' (LAN-accessible)
- *   3. Default: '127.0.0.1' (localhost only)
+ * If iOS pairing is enabled (flag file): '0.0.0.0' (LAN-accessible).
+ * Default: '127.0.0.1' (localhost only).
  */
 export function getTCPHost(): string {
-  const override = getDaemonTcpHost();
-  if (override) return override;
   if (isIOSPairingEnabled()) return "0.0.0.0";
   return "127.0.0.1";
 }
@@ -288,17 +273,13 @@ export function getTCPHost(): string {
  * instead of 127.0.0.1 (localhost only), making the daemon reachable
  * from iOS devices on the same local network.
  *
- * Resolution order (first match wins):
- *   1. VELLUM_DAEMON_IOS_PAIRING env var ('true'/'1' → on, 'false'/'0' → off)
- *   2. Presence of the flag file ~/.vellum/ios-pairing-enabled (exists → on)
- *   3. Default: false
+ * Checks for the presence of the flag file ~/.vellum/ios-pairing-enabled.
+ * Default: false.
  *
  * This is separate from isTCPEnabled() — TCP can be enabled for localhost-only
  * access without exposing the daemon to the LAN.
  */
 export function isIOSPairingEnabled(): boolean {
-  const envValue = getDaemonIosPairing();
-  if (envValue !== undefined) return envValue;
   return existsSync(join(getRootDir(), "ios-pairing-enabled"));
 }
 


### PR DESCRIPTION
## Summary
- Remove getDaemonTcpPort/Enabled/Host, getDaemonIosPairing, getDebugMode, getLogStderr, getEnableMonitoring from env-registry.ts
- Remove corresponding entries from KNOWN_VELLUM_VARS
- Update platform.ts to use hardcoded TCP defaults instead of env var getters
- Update logger.ts to use hardcoded false for debug/stderr modes and clean up dead code branches
- Update env.ts to hardcode isMonitoringEnabled to false
- Update dev.ts to remove VELLUM_DEBUG/VELLUM_LOG_STDERR from spawn env
- Clean up stale mock in actor-token-service.test.ts

Part of plan: rm-legacy-env-vars.md (PR 2 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
