### PR TITLE
chore: derive keychain broker socket path from data dir instead of env var

### DIFF
--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -36,7 +36,7 @@ const TEST_DIR = join(
 );
 const TOKEN_DIR = join(TEST_DIR, ".vellum", "protected");
 const TOKEN_PATH = join(TOKEN_DIR, "keychain-broker.token");
-const SOCKET_PATH = join(TEST_DIR, "broker.sock");
+const SOCKET_PATH = join(TEST_DIR, ".vellum", "keychain-broker.sock");
 const TEST_TOKEN = "test-auth-token-abc123";
 
 // ---------------------------------------------------------------------------
@@ -106,27 +106,16 @@ function createMockBroker(): {
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
-let originalEnv: string | undefined;
-
 beforeAll(() => {
   mkdirSync(TOKEN_DIR, { recursive: true });
 });
 
 beforeEach(() => {
-  originalEnv = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   // Clean up socket file from prior test
   try {
     rmSync(SOCKET_PATH, { force: true });
   } catch {
     /* ignore */
-  }
-});
-
-afterEach(() => {
-  if (originalEnv === undefined) {
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-  } else {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = originalEnv;
   }
 });
 
@@ -157,15 +146,15 @@ describe("keychain-broker-client", () => {
   // isAvailable()
   // -----------------------------------------------------------------------
   describe("isAvailable", () => {
-    test("returns false when env var is unset", () => {
-      delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+    test("returns false when socket file does not exist", () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       expect(client.isAvailable()).toBe(false);
     });
 
     test("returns false when token file does not exist", () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+      // Create the socket file so that check passes
+      writeFileSync(SOCKET_PATH, "");
       try {
         rmSync(TOKEN_PATH, { force: true });
       } catch {
@@ -175,8 +164,8 @@ describe("keychain-broker-client", () => {
       expect(client.isAvailable()).toBe(false);
     });
 
-    test("returns true when both env var and token file exist", () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("returns true when both socket file and token file exist", () => {
+      writeFileSync(SOCKET_PATH, "");
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       expect(client.isAvailable()).toBe(true);
@@ -190,7 +179,6 @@ describe("keychain-broker-client", () => {
     let broker: ReturnType<typeof createMockBroker>;
 
     beforeEach(async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       broker = createMockBroker();
     });
@@ -343,7 +331,6 @@ describe("keychain-broker-client", () => {
     let broker: ReturnType<typeof createMockBroker>;
 
     beforeEach(async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       broker = createMockBroker();
     });
@@ -381,7 +368,6 @@ describe("keychain-broker-client", () => {
     let broker: ReturnType<typeof createMockBroker>;
 
     beforeEach(async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       writeFileSync(TOKEN_PATH, "old-token");
       broker = createMockBroker();
     });
@@ -441,59 +427,42 @@ describe("keychain-broker-client", () => {
   // Graceful degradation
   // -----------------------------------------------------------------------
   describe("graceful degradation", () => {
-    test("get returns null when broker is not running", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("get returns null when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.get("test-key");
       expect(result).toBeNull();
     });
 
-    test("set returns false when broker is not running", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("set returns false when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.set("test-key", "value");
       expect(result).toBe(false);
     });
 
-    test("del returns false when broker is not running", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("del returns false when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.del("test-key");
       expect(result).toBe(false);
     });
 
-    test("list returns empty array when broker is not running", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("list returns empty array when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.list();
       expect(result).toEqual([]);
     });
 
-    test("ping returns null when broker is not running", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    test("ping returns null when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.ping();
       expect(result).toBeNull();
     });
 
-    test("returns fallbacks when socket path env var is unset", async () => {
-      delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-      writeFileSync(TOKEN_PATH, TEST_TOKEN);
-      const client = createBrokerClient();
-      expect(await client.get("key")).toBeNull();
-      expect(await client.set("key", "val")).toBe(false);
-      expect(await client.del("key")).toBe(false);
-      expect(await client.list()).toEqual([]);
-      expect(await client.ping()).toBeNull();
-    });
-
     test("returns fallbacks when token file is missing", async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       try {
         rmSync(TOKEN_PATH, { force: true });
       } catch {
@@ -515,7 +484,6 @@ describe("keychain-broker-client", () => {
     let broker: ReturnType<typeof createMockBroker>;
 
     beforeEach(async () => {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       broker = createMockBroker();
     });

--- a/assistant/src/security/keychain-broker-client.ts
+++ b/assistant/src/security/keychain-broker-client.ts
@@ -6,7 +6,7 @@
  * provides a graceful-fallback interface: every public method returns a
  * safe default on failure and never throws.
  *
- * Socket path: read from VELLUM_KEYCHAIN_BROKER_SOCKET env var.
+ * Socket path: derived from getRootDir() as `~/.vellum/keychain-broker.sock`.
  * Auth token: read from ~/.vellum/protected/keychain-broker.token on first
  * connection, cached for process lifetime.
  */
@@ -70,8 +70,8 @@ function getTokenPath(): string {
   return join(getRootDir(), "protected", "keychain-broker.token");
 }
 
-function getSocketPath(): string | undefined {
-  return process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+function getSocketPath(): string {
+  return join(getRootDir(), "keychain-broker.sock");
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +172,7 @@ export function createBrokerClient(): KeychainBrokerClient {
   function connect(): Promise<Socket> {
     return new Promise((resolve, reject) => {
       const socketPath = getSocketPath();
-      if (!socketPath) {
+      if (!pathExists(socketPath)) {
         reject(new Error("No socket path"));
         return;
       }
@@ -328,8 +328,7 @@ export function createBrokerClient(): KeychainBrokerClient {
   return {
     isAvailable(): boolean {
       if (permanentlyUnavailable) return false;
-      const socketPath = getSocketPath();
-      if (!socketPath) return false;
+      if (!pathExists(getSocketPath())) return false;
       return pathExists(getTokenPath());
     },
 

--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -133,6 +133,7 @@ function writeBrokerToken(token: string): void {
 
 /**
  * Create a mock keychain broker UDS server that responds to key.get requests.
+ * Listens on the derived socket path (getRootDir() + keychain-broker.sock).
  * Returns the socket path and a handle to close the server.
  */
 function createMockBroker(credentials: Record<string, string>): {
@@ -140,10 +141,8 @@ function createMockBroker(credentials: Record<string, string>): {
   server: Server;
   close: () => void;
 } {
-  const socketPath = join(
-    tmpdir(),
-    `mock-broker-${randomBytes(4).toString("hex")}.sock`,
-  );
+  const socketPath = join(testDir, ".vellum", "keychain-broker.sock");
+  mkdirSync(join(testDir, ".vellum"), { recursive: true });
 
   const server = createServer((conn) => {
     let buf = "";
@@ -206,22 +205,13 @@ function createMockBroker(credentials: Record<string, string>): {
 // Setup / teardown
 // ---------------------------------------------------------------------------
 
-let savedBrokerSocket: string | undefined;
-
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
-  savedBrokerSocket = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-  delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   logCalls.length = 0;
 });
 
 afterEach(() => {
   delete process.env.BASE_DATA_DIR;
-  if (savedBrokerSocket === undefined) {
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-  } else {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = savedBrokerSocket;
-  }
   try {
     rmSync(testDir, { recursive: true, force: true });
   } catch {
@@ -279,28 +269,12 @@ describe("readTelegramCredentials", () => {
 // ---------------------------------------------------------------------------
 
 describe("readCredential broker integration", () => {
-  test("returns undefined when broker env var is unset", async () => {
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+  test("returns undefined when socket file does not exist", async () => {
     const result = await readCredential(credentialKey("test", "key"));
     expect(result).toBeUndefined();
   });
 
-  test("falls back to encrypted store when broker is unavailable", async () => {
-    // No broker socket configured — should fall through to encrypted store
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-
-    writeEncryptedStore({
-      [credentialKey("test", "key")]: "encrypted-value",
-    });
-
-    const result = await readCredential(credentialKey("test", "key"));
-    expect(result).toBe("encrypted-value");
-  });
-
-  test("falls back to encrypted store when broker socket path is set but no server", async () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = "/tmp/nonexistent-broker.sock";
-    writeBrokerToken(TEST_TOKEN);
-
+  test("falls back to encrypted store when socket file does not exist", async () => {
     writeEncryptedStore({
       [credentialKey("test", "key")]: "encrypted-value",
     });
@@ -310,8 +284,9 @@ describe("readCredential broker integration", () => {
   });
 
   test("falls back to encrypted store when broker token file is missing", async () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = "/tmp/nonexistent-broker.sock";
-    // Don't write a token file
+    // Create socket file but no token file
+    mkdirSync(join(testDir, ".vellum"), { recursive: true });
+    writeFileSync(join(testDir, ".vellum", "keychain-broker.sock"), "");
 
     writeEncryptedStore({
       [credentialKey("test", "key")]: "encrypted-value",
@@ -326,7 +301,6 @@ describe("readCredential broker integration", () => {
       [credentialKey("test", "key")]: "broker-secret-value",
     });
     try {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
       writeBrokerToken(TEST_TOKEN);
 
       const result = await readCredential(credentialKey("test", "key"));
@@ -341,7 +315,6 @@ describe("readCredential broker integration", () => {
       [credentialKey("test", "key")]: "broker-value",
     });
     try {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
       writeBrokerToken(TEST_TOKEN);
 
       writeEncryptedStore({
@@ -359,7 +332,6 @@ describe("readCredential broker integration", () => {
     // Broker has no entry for the test credential key
     const broker = createMockBroker({});
     try {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
       writeBrokerToken(TEST_TOKEN);
 
       writeEncryptedStore({
@@ -389,7 +361,6 @@ describe("secret leak prevention", () => {
       [credentialKey("leak-test", "key")]: secretValue,
     });
     try {
-      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
       writeBrokerToken(TEST_TOKEN);
 
       const result = await readCredential(credentialKey("leak-test", "key"));
@@ -406,7 +377,6 @@ describe("secret leak prevention", () => {
 
   test("encrypted store read does not leak secret values into logs", async () => {
     const secretValue = "super-secret-encrypted-credential-value";
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
 
     writeEncryptedStore({
       [credentialKey("leak-test", "key")]: secretValue,
@@ -421,7 +391,6 @@ describe("secret leak prevention", () => {
 
   test("failed encrypted store read does not leak secret values into logs", async () => {
     const secretValue = "super-secret-telegram-token";
-    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
 
     writeMetadata([
       { service: "telegram", field: "bot_token" },

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -156,14 +156,13 @@ function getBrokerTokenPath(): string {
 /**
  * Try to read a credential from the keychain broker over its Unix domain socket.
  * Uses a native UDS connection (no external process spawn).
- * Returns `undefined` if the broker is unavailable, the socket env var is unset,
+ * Returns `undefined` if the broker is unavailable, the socket file doesn't exist,
  * the token file is missing, or the broker doesn't have the requested key.
  */
 async function readBrokerCredential(
   account: string,
 ): Promise<string | undefined> {
-  const socketPath = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-  if (!socketPath) return undefined;
+  const socketPath = join(getRootDir(), "keychain-broker.sock");
 
   // Check socket file exists before attempting connection — createConnection
   // can throw synchronously in some runtimes (e.g. Bun) for ENOENT.


### PR DESCRIPTION
## Summary
- Derive keychain broker socket path from getRootDir() instead of VELLUM_KEYCHAIN_BROKER_SOCKET env var
- Update both assistant/keychain-broker-client.ts and gateway/credential-reader.ts
- macOS app env var setting becomes harmless no-op

Part of plan: rm-legacy-env-vars.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
