### PR TITLE
Remove editTelegramMessage and messageId support from gateway

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -18,7 +18,6 @@ mock.module("../../telegram/send.js", () => ({
     sendTelegramReplyCalls.push(args);
     return { messageId: 42 };
   },
-  editTelegramMessage: async () => {},
   sendTelegramAttachments: async () => {},
   sendTypingIndicator: async (...args: unknown[]) => {
     sendTypingIndicatorCalls.push(args);
@@ -210,7 +209,6 @@ describe("telegram-deliver endpoint basics", () => {
       sendTelegramReply: async () => {
         throw new Error("Telegram API failure");
       },
-      editTelegramMessage: async () => {},
       sendTelegramAttachments: async () => {},
       sendTypingIndicator: async () => true,
     }));
@@ -230,7 +228,6 @@ describe("telegram-deliver endpoint basics", () => {
         sendTelegramReplyCalls.push(args);
         return { messageId: 42 };
       },
-      editTelegramMessage: async () => {},
       sendTelegramAttachments: async () => {},
       sendTypingIndicator: async (...args: unknown[]) => {
         sendTypingIndicatorCalls.push(args);

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -5,7 +5,6 @@ import { getLogger } from "../../logger.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
 import {
-  editTelegramMessage,
   sendTelegramAttachments,
   sendTelegramReply,
   sendTypingIndicator,
@@ -50,7 +49,6 @@ export function createTelegramDeliverHandler(
       attachments?: RuntimeAttachmentMeta[];
       approval?: ApprovalPayload;
       chatAction?: "typing";
-      messageId?: number;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -65,23 +63,10 @@ export function createTelegramDeliverHandler(
       attachments,
       approval,
       chatAction,
-      messageId,
     } = body;
 
     if (!chatId || typeof chatId !== "string") {
       return Response.json({ error: "chatId is required" }, { status: 400 });
-    }
-
-    if (
-      messageId !== undefined &&
-      (typeof messageId !== "number" ||
-        !Number.isInteger(messageId) ||
-        messageId <= 0)
-    ) {
-      return Response.json(
-        { error: "messageId must be a positive integer" },
-        { status: 400 },
-      );
     }
 
     if (chatAction !== undefined && chatAction !== "typing") {
@@ -196,32 +181,13 @@ export function createTelegramDeliverHandler(
       ? { credentials: caches.credentials, configFile: caches.configFile }
       : undefined;
 
-    let sendMessageId: number | undefined;
     try {
       if (chatAction === "typing") {
         await sendTypingIndicator(config, chatId, credentialOpts);
       }
 
       if (text) {
-        if (messageId !== undefined) {
-          await editTelegramMessage(
-            config,
-            chatId,
-            messageId,
-            text,
-            approval,
-            credentialOpts,
-          );
-        } else {
-          const sendResult = await sendTelegramReply(
-            config,
-            chatId,
-            text,
-            approval,
-            credentialOpts,
-          );
-          sendMessageId = sendResult.messageId;
-        }
+        await sendTelegramReply(config, chatId, text, approval, credentialOpts);
       }
 
       if (attachments && attachments.length > 0) {
@@ -247,10 +213,6 @@ export function createTelegramDeliverHandler(
       "Reply sent",
     );
 
-    const responseBody: { ok: true; messageId?: number } = { ok: true };
-    if (sendMessageId !== undefined) {
-      responseBody.messageId = sendMessageId;
-    }
-    return Response.json(responseBody);
+    return Response.json({ ok: true });
   };
 }

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -82,46 +82,6 @@ export async function sendTelegramReply(
   return { messageId: lastResult!.message_id };
 }
 
-export async function editTelegramMessage(
-  config: GatewayConfig,
-  chatId: string,
-  messageId: number,
-  text: string,
-  approval?: ApprovalPayload,
-  opts?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
-): Promise<void> {
-  if (text.length > TELEGRAM_MAX_MESSAGE_LEN) {
-    throw new Error(
-      `Text length ${text.length} exceeds Telegram's ${TELEGRAM_MAX_MESSAGE_LEN}-character limit for message edits`,
-    );
-  }
-
-  const payload: Record<string, unknown> = {
-    chat_id: chatId,
-    message_id: messageId,
-    text,
-  };
-  if (approval) {
-    payload.reply_markup = buildInlineKeyboard(approval);
-  }
-
-  try {
-    await callTelegramApi("editMessageText", payload, opts);
-  } catch (err) {
-    // Telegram returns "message is not modified" when the new text is identical
-    // to what's already displayed. Treat this as a no-op success rather than
-    // propagating a hard failure.
-    if (
-      err instanceof Error &&
-      err.message.includes("message is not modified")
-    ) {
-      log.debug({ chatId, messageId }, "Edit skipped: message is not modified");
-      return;
-    }
-    throw err;
-  }
-}
-
 export async function sendTelegramAttachments(
   config: GatewayConfig,
   chatId: string,


### PR DESCRIPTION
## Summary
- Remove the editTelegramMessage function from gateway/src/telegram/send.ts
- Remove messageId request parameter and edit code path from the Telegram deliver handler
- Simplify response to always return { ok: true } without messageId
- Remove/update test cases that exercised the edit code path

Part of plan: rm-telegram-streaming.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
