### PR TITLE
fix: update telegram invite tests to mock config instead of env var

### DIFF
--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -24,8 +24,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Prevent ensureTelegramBotUsernameResolved() from reading real credentials
-// and calling the Telegram API, which would populate credential metadata
-// with the real bot username and shadow the env var override in tests.
+// and calling the Telegram API.
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: () => undefined,
   setSecureKey: () => {},
@@ -33,6 +32,13 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => undefined,
   setSecureKeyAsync: async () => {},
   deleteSecureKeyAsync: async () => {},
+}));
+
+// Mock getTelegramBotUsername — the env var fallback was removed so we
+// control the return value directly via a mutable variable.
+let mockTelegramBotUsername: string | undefined;
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => mockTelegramBotUsername,
 }));
 
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
@@ -94,8 +100,7 @@ describe("ingress invite HTTP routes", () => {
   });
 
   test("POST /v1/contacts/invites — includes canonical share URL when bot username is configured", async () => {
-    const prevBotUsername = process.env.TELEGRAM_BOT_USERNAME;
-    process.env.TELEGRAM_BOT_USERNAME = "test_invite_bot";
+    mockTelegramBotUsername = "test_invite_bot";
 
     try {
       const req = new Request("http://localhost/v1/contacts/invites", {
@@ -121,11 +126,7 @@ describe("ingress invite HTTP routes", () => {
       expect(share.url).toBe(`https://t.me/test_invite_bot?start=iv_${token}`);
       expect(typeof share.displayText).toBe("string");
     } finally {
-      if (prevBotUsername === undefined) {
-        delete process.env.TELEGRAM_BOT_USERNAME;
-      } else {
-        process.env.TELEGRAM_BOT_USERNAME = prevBotUsername;
-      }
+      mockTelegramBotUsername = undefined;
     }
   });
 

--- a/assistant/src/__tests__/telegram-invite-adapter.test.ts
+++ b/assistant/src/__tests__/telegram-invite-adapter.test.ts
@@ -7,12 +7,20 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ChannelId } from "../channels/types.js";
-import { telegramInviteAdapter } from "../runtime/channel-invite-transports/telegram.js";
 
 // Mock credential metadata so tests don't depend on local persisted state.
 mock.module("../tools/credentials/metadata-store.js", () => ({
   getCredentialMetadata: () => undefined,
 }));
+
+// Mock getTelegramBotUsername — the env var fallback was removed so we
+// control the return value directly via a mutable variable.
+let mockBotUsername: string | undefined;
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => mockBotUsername,
+}));
+
+import { telegramInviteAdapter } from "../runtime/channel-invite-transports/telegram.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -20,31 +28,21 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 const CHANNEL: ChannelId = "telegram" as ChannelId;
 
-function setEnv(key: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = value;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // buildShareLink
 // ---------------------------------------------------------------------------
 
 describe("telegramInviteAdapter.buildShareLink", () => {
-  let originalBotUsername: string | undefined;
-
   beforeEach(() => {
-    originalBotUsername = process.env.TELEGRAM_BOT_USERNAME;
+    mockBotUsername = undefined;
   });
 
   afterEach(() => {
-    setEnv("TELEGRAM_BOT_USERNAME", originalBotUsername);
+    mockBotUsername = undefined;
   });
 
   test("builds a deep link with iv_ prefix", () => {
-    setEnv("TELEGRAM_BOT_USERNAME", "TestBot");
+    mockBotUsername = "TestBot";
 
     const link = telegramInviteAdapter.buildShareLink!({
       rawToken: "abc123",
@@ -56,7 +54,7 @@ describe("telegramInviteAdapter.buildShareLink", () => {
   });
 
   test("throws when bot username is not configured", () => {
-    setEnv("TELEGRAM_BOT_USERNAME", undefined);
+    mockBotUsername = undefined;
 
     expect(() =>
       telegramInviteAdapter.buildShareLink!({
@@ -138,25 +136,23 @@ describe("telegramInviteAdapter.extractInboundToken", () => {
 // ---------------------------------------------------------------------------
 
 describe("telegramInviteAdapter.resolveChannelHandle", () => {
-  let originalBotUsername: string | undefined;
-
   beforeEach(() => {
-    originalBotUsername = process.env.TELEGRAM_BOT_USERNAME;
+    mockBotUsername = undefined;
   });
 
   afterEach(() => {
-    setEnv("TELEGRAM_BOT_USERNAME", originalBotUsername);
+    mockBotUsername = undefined;
   });
 
-  test("returns @-prefixed bot username from env", () => {
-    setEnv("TELEGRAM_BOT_USERNAME", "MyBot");
+  test("returns @-prefixed bot username from config", () => {
+    mockBotUsername = "MyBot";
 
     const handle = telegramInviteAdapter.resolveChannelHandle!();
     expect(handle).toBe("@MyBot");
   });
 
   test("returns undefined when bot username is not configured", () => {
-    setEnv("TELEGRAM_BOT_USERNAME", undefined);
+    mockBotUsername = undefined;
 
     const handle = telegramInviteAdapter.resolveChannelHandle!();
     expect(handle).toBeUndefined();


### PR DESCRIPTION
## Summary
- Updated `telegram-invite-adapter.test.ts` and `invite-routes-http.test.ts` to mock `getTelegramBotUsername` directly instead of setting `process.env.TELEGRAM_BOT_USERNAME`
- The env var fallback was removed in #15557 but these tests were not updated, causing CI failures
- Uses `mock.module("../telegram/bot-username.js", ...)` with a mutable variable pattern consistent with existing tests (e.g., whatsapp-invite-adapter.test.ts)

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22984359521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
