### PR TITLE
Add Drizzle schema definitions for oauth_providers, oauth_apps, oauth_connections

### DIFF
--- a/assistant/src/memory/schema/index.ts
+++ b/assistant/src/memory/schema/index.ts
@@ -5,4 +5,5 @@ export * from "./guardian.js";
 export * from "./infrastructure.js";
 export * from "./memory-core.js";
 export * from "./notifications.js";
+export * from "./oauth.js";
 export * from "./tasks.js";

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -1,0 +1,65 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+export const oauthProviders = sqliteTable("oauth_providers", {
+  providerKey: text("provider_key").primaryKey(),
+  authUrl: text("auth_url").notNull(),
+  tokenUrl: text("token_url").notNull(),
+  tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+  userinfoUrl: text("userinfo_url"),
+  baseUrl: text("base_url"),
+  defaultScopes: text("default_scopes").notNull().default("[]"),
+  scopePolicy: text("scope_policy").notNull().default("{}"),
+  extraParams: text("extra_params"),
+  callbackTransport: text("callback_transport"),
+  loopbackPort: integer("loopback_port"),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
+export const oauthApps = sqliteTable(
+  "oauth_apps",
+  {
+    id: text("id").primaryKey(),
+    providerKey: text("provider_key")
+      .notNull()
+      .references(() => oauthProviders.providerKey),
+    clientId: text("client_id").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("idx_oauth_apps_provider_key_client_id").on(
+      table.providerKey,
+      table.clientId,
+    ),
+  ],
+);
+
+export const oauthConnections = sqliteTable(
+  "oauth_connections",
+  {
+    id: text("id").primaryKey(),
+    oauthAppId: text("oauth_app_id")
+      .notNull()
+      .references(() => oauthApps.id),
+    providerKey: text("provider_key").notNull(),
+    accountInfo: text("account_info"),
+    grantedScopes: text("granted_scopes").notNull().default("[]"),
+    expiresAt: integer("expires_at"),
+    hasRefreshToken: integer("has_refresh_token").notNull().default(0),
+    status: text("status").notNull().default("active"),
+    label: text("label"),
+    metadata: text("metadata"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_oauth_connections_provider_key").on(table.providerKey),
+  ],
+);


### PR DESCRIPTION
## Summary
- Define three Drizzle SQLite tables: oauth_providers, oauth_apps, oauth_connections
- Add unique index on (provider_key, client_id) for oauth_apps
- Add index on provider_key for oauth_connections
- Re-export from schema barrel

Part of plan: oauth-sqlite-migration.md (PR 1 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
