### PR TITLE
feat: hide Email card on Contacts page when "email-channel" flag is disabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct AssistantChannelsDetailView: View {
     @ObservedObject var store: SettingsStore
     var daemonClient: DaemonClient?
+    var isEmailEnabled: Bool = false
 
     // Telegram credential entry
     @State private var telegramBotTokenText = ""
@@ -50,13 +51,17 @@ struct AssistantChannelsDetailView: View {
                 telegramCard
                 slackChannelCard
                 voiceCard
-                emailCard
+                if isEmailEnabled {
+                    emailCard
+                }
             }
             .padding(VSpacing.lg)
         }
         .onAppear {
             store.fetchChannelSetupStatus()
-            store.refreshAssistantEmail()
+            if isEmailEnabled {
+                store.refreshAssistantEmail()
+            }
             store.refreshChannelVerificationStatus(channel: "telegram")
             store.refreshChannelVerificationStatus(channel: "phone")
             store.refreshChannelVerificationStatus(channel: "slack")

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -15,13 +15,15 @@ enum ContactSelection: Hashable {
 struct ContactsContainerView: View {
     var daemonClient: DaemonClient?
     var store: SettingsStore?
+    var isEmailEnabled: Bool = false
 
     @StateObject private var viewModel: ContactsViewModel
     @State private var selection: ContactSelection? = .assistant
 
-    init(daemonClient: DaemonClient?, store: SettingsStore? = nil) {
+    init(daemonClient: DaemonClient?, store: SettingsStore? = nil, isEmailEnabled: Bool = false) {
         self.daemonClient = daemonClient
         self.store = store
+        self.isEmailEnabled = isEmailEnabled
         _viewModel = StateObject(wrappedValue: ContactsViewModel(daemonClient: daemonClient))
     }
 
@@ -58,7 +60,7 @@ struct ContactsContainerView: View {
                 switch selection {
                 case .assistant:
                     if let store {
-                        AssistantChannelsDetailView(store: store, daemonClient: daemonClient)
+                        AssistantChannelsDetailView(store: store, daemonClient: daemonClient, isEmailEnabled: isEmailEnabled)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     } else {
                         VStack(spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -62,11 +62,13 @@ struct SettingsPanel: View {
     @State private var selectedTab: SettingsTab = .general
     @State private var isContactsEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
+    @State private var isEmailEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     private static let contactsFeatureFlagKey = "feature_flags.contacts.enabled"
     private static let developerFeatureFlagKey = "feature_flags.settings-developer-nav.enabled"
+    private static let emailFeatureFlagKey = "feature_flags.email-channel.enabled"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -170,6 +172,8 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .developer {
                         selectedTab = .general
                     }
+                } else if key == Self.emailFeatureFlagKey {
+                    isEmailEnabled = enabled
                 }
             }
         }
@@ -287,7 +291,7 @@ struct SettingsPanel: View {
         case .permissionsAndPrivacy:
             permissionsAndPrivacyContent
         case .contacts:
-            ContactsContainerView(daemonClient: daemonClient, store: store)
+            ContactsContainerView(daemonClient: daemonClient, store: store, isEmailEnabled: isEmailEnabled)
         case .archivedThreads:
             SettingsArchivedThreadsTab(threadManager: threadManager)
         case .developer:
@@ -730,6 +734,9 @@ struct SettingsPanel: View {
                 if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
                     isDeveloperEnabled = developerFlag.enabled
                 }
+                if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
+                    isEmailEnabled = emailFlag.enabled
+                }
                 return
             } catch {
                 // Fall through to local config fallback.
@@ -749,6 +756,9 @@ struct SettingsPanel: View {
         }
         if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
             isDeveloperEnabled = developerEnabled
+        }
+        if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
+            isEmailEnabled = emailEnabled
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `isEmailEnabled` property to `AssistantChannelsDetailView`, conditionally rendering the Email card
- Threads the `feature_flags.email-channel.enabled` flag through `SettingsPanel` → `ContactsContainerView` → `AssistantChannelsDetailView`
- Skips `refreshAssistantEmail()` network call when the flag is disabled
- Supports real-time toggling via the `.assistantFeatureFlagDidChange` notification

Part of plan: email-feature-flag.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
