### PR TITLE
chore: simplify gateway URL helpers, remove env var overrides

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -51,16 +51,8 @@ export function getGatewayPort(): number {
   return int("GATEWAY_PORT", DEFAULT_GATEWAY_PORT);
 }
 
-/**
- * Resolve the gateway base URL for internal service-to-service calls.
- * Prefers GATEWAY_INTERNAL_BASE_URL if set, then INTERNAL_GATEWAY_BASE_URL
- * (used by skill subprocesses), otherwise derives from port.
- */
+/** Resolve the gateway base URL for internal service-to-service calls. */
 export function getGatewayInternalBaseUrl(): string {
-  const explicit = str("GATEWAY_INTERNAL_BASE_URL");
-  if (explicit) return explicit.replace(/\/+$/, "");
-  const skillInjected = str("INTERNAL_GATEWAY_BASE_URL");
-  if (skillInjected) return skillInjected.replace(/\/+$/, "");
   return `http://127.0.0.1:${getGatewayPort()}`;
 }
 
@@ -197,11 +189,6 @@ export function getPlatformInternalApiKey(): string {
  * deprecated vars.
  */
 export function validateEnv(): void {
-  const gatewayPort = getGatewayPort();
-  if (gatewayPort < 1 || gatewayPort > 65535) {
-    throw new Error(`Invalid GATEWAY_PORT: ${gatewayPort} (must be 1-65535)`);
-  }
-
   const httpPort = getRuntimeHttpPort();
   if (httpPort < 1 || httpPort > 65535) {
     throw new Error(`Invalid RUNTIME_HTTP_PORT: ${httpPort} (must be 1-65535)`);


### PR DESCRIPTION
## Summary
- Simplify getGatewayInternalBaseUrl() to derive from GATEWAY_PORT only
- Remove GATEWAY_INTERNAL_BASE_URL and INTERNAL_GATEWAY_BASE_URL env var reads
- Remove gateway port validation from validateEnv() (validated in gateway/config.ts)
- Keep subprocess injection of INTERNAL_GATEWAY_BASE_URL and VELLUM_DATA_DIR in safe-env.ts

Part of plan: rm-legacy-env-vars.md (PR 12 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
