### PR TITLE
Add migration 149 to create oauth_providers, oauth_apps, oauth_connections tables

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -28,6 +28,7 @@ import {
   createMediaAssetsTables,
   createMessagesFts,
   createNotificationTables,
+  createOAuthTables,
   createScopedApprovalGrantsTable,
   createSequenceTables,
   createTasksAndWorkItemsTables,
@@ -339,6 +340,9 @@ export function initializeDb(): void {
 
   // 52. Drop the legacy reminders table after data migration
   migrateDropRemindersTable(database);
+
+  // 53. OAuth provider/app/connection tables
+  createOAuthTables(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/149-oauth-tables.ts
+++ b/assistant/src/memory/migrations/149-oauth-tables.ts
@@ -1,0 +1,60 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * OAuth provider, app, and connection tables.
+ * Creates tables in FK-dependency order: providers → apps → connections.
+ */
+export function createOAuthTables(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS oauth_providers (
+      provider_key TEXT PRIMARY KEY,
+      auth_url TEXT NOT NULL,
+      token_url TEXT NOT NULL,
+      token_endpoint_auth_method TEXT,
+      userinfo_url TEXT,
+      base_url TEXT,
+      default_scopes TEXT NOT NULL DEFAULT '[]',
+      scope_policy TEXT NOT NULL DEFAULT '{}',
+      extra_params TEXT,
+      callback_transport TEXT,
+      loopback_port INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS oauth_apps (
+      id TEXT PRIMARY KEY,
+      provider_key TEXT NOT NULL REFERENCES oauth_providers(provider_key),
+      client_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS oauth_connections (
+      id TEXT PRIMARY KEY,
+      oauth_app_id TEXT NOT NULL REFERENCES oauth_apps(id),
+      provider_key TEXT NOT NULL,
+      account_info TEXT,
+      granted_scopes TEXT NOT NULL DEFAULT '[]',
+      expires_at INTEGER,
+      has_refresh_token INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active',
+      label TEXT,
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  database.run(
+    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_apps_provider_client ON oauth_apps(provider_key, client_id)`,
+  );
+
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_oauth_connections_provider_key ON oauth_connections(provider_key)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -90,6 +90,7 @@ export { migrateDropAccountsTable } from "./145-drop-accounts-table.js";
 export { migrateScheduleOneShotRouting } from "./146-schedule-oneshot-routing.js";
 export { migrateRemindersToSchedules } from "./147-migrate-reminders-to-schedules.js";
 export { migrateDropRemindersTable } from "./148-drop-reminders-table.js";
+export { createOAuthTables } from "./149-oauth-tables.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Add DDL migration 149 with CREATE TABLE IF NOT EXISTS for three OAuth tables
- Create indexes: unique on (provider_key, client_id) for oauth_apps, regular on provider_key for oauth_connections
- Wire migration into initializeDb() after existing migrations

Part of plan: oauth-sqlite-migration.md (PR 2 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
