### PR TITLE
chore: clean up cli/local.ts env var passthrough to child processes

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -10,10 +10,7 @@ import { createRequire } from "module";
 import { homedir, hostname, networkInterfaces, platform } from "os";
 import { dirname, join } from "path";
 
-import {
-  loadLatestAssistant,
-  type LocalInstanceResources,
-} from "./assistant-config.js";
+import { type LocalInstanceResources } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
 import { stopProcessByPidFile } from "./process.js";
@@ -244,11 +241,6 @@ async function startDaemonFromSource(
     ...process.env,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
   };
-  // Preserve TCP listener flag when falling back from bundled desktop daemon
-  if (process.env.VELLUM_DESKTOP_APP) {
-    env.VELLUM_DAEMON_TCP_ENABLED =
-      process.env.VELLUM_DAEMON_TCP_ENABLED || "1";
-  }
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
@@ -354,16 +346,6 @@ async function startDaemonWatchFromSource(
 }
 
 function resolveGatewayDir(): string {
-  const override = process.env.VELLUM_GATEWAY_DIR?.trim();
-  if (override) {
-    if (!isGatewaySourceDir(override)) {
-      throw new Error(
-        `VELLUM_GATEWAY_DIR is set to "${override}", but it is not a valid gateway source directory.`,
-      );
-    }
-    return override;
-  }
-
   // Source tree: cli/src/lib/ → ../../.. → repo root → gateway/
   const sourceDir = join(import.meta.dir, "..", "..", "..", "gateway");
   if (isGatewaySourceDir(sourceDir)) {
@@ -386,7 +368,7 @@ function resolveGatewayDir(): string {
     return dirname(pkgPath);
   } catch {
     throw new Error(
-      "Gateway not found. Ensure @vellumai/vellum-gateway is installed, run from the source tree, or set VELLUM_GATEWAY_DIR.",
+      "Gateway not found. Ensure @vellumai/vellum-gateway is installed or run from the source tree.",
     );
   }
 }
@@ -640,7 +622,6 @@ export async function startLocalDaemon(
       const daemonEnv: Record<string, string> = {
         HOME: process.env.HOME || homedir(),
         PATH: `${bunBinDir}:${basePath}`,
-        VELLUM_DAEMON_TCP_ENABLED: "1",
       };
       // Forward optional config env vars the daemon may need
       for (const key of [
@@ -649,10 +630,6 @@ export async function startLocalDaemon(
         "QDRANT_HTTP_PORT",
         "QDRANT_URL",
         "RUNTIME_HTTP_PORT",
-        "VELLUM_DAEMON_TCP_PORT",
-        "VELLUM_DAEMON_TCP_HOST",
-        "VELLUM_KEYCHAIN_BROKER_SOCKET",
-        "VELLUM_DEBUG",
         "SENTRY_DSN",
         "TMPDIR",
         "USER",
@@ -787,109 +764,18 @@ export async function startGateway(
 
   console.log("🌐 Starting gateway...");
 
-  // Resolve the default assistant ID for the gateway. Prefer the explicitly
-  // provided assistantId (from hatch), then env override, then lockfile.
-  const resolvedAssistantId =
-    assistantId ||
-    process.env.GATEWAY_DEFAULT_ASSISTANT_ID ||
-    loadLatestAssistant()?.assistantId;
-
-  // Read the bearer token so the gateway can authenticate proxied requests
-  // (e.g. from paired iOS devices). Respect VELLUM_HTTP_TOKEN_PATH and
-  // BASE_DATA_DIR for consistency with gateway/config.ts and the daemon.
-  // When resources are provided, the token lives under the instance directory.
-  const httpTokenPath =
-    process.env.VELLUM_HTTP_TOKEN_PATH ??
-    (resources
-      ? join(resources.instanceDir, ".vellum", "http-token")
-      : join(
-          process.env.BASE_DATA_DIR?.trim() || homedir(),
-          ".vellum",
-          "http-token",
-        ));
-  let runtimeProxyBearerToken: string | undefined;
-  try {
-    const tok = readFileSync(httpTokenPath, "utf-8").trim();
-    if (tok) runtimeProxyBearerToken = tok;
-  } catch {
-    // Token file doesn't exist yet — daemon hasn't written it.
-  }
-
-  // If no token is available (first startup — daemon hasn't written it yet),
-  // poll for the file to appear. On fresh installs the daemon may take 60s+
-  // for Qdrant download, migrations, and first-time init. Starting the
-  // gateway without auth is a security risk since the config is loaded once
-  // at startup and never reloads, so we fail rather than silently disabling auth.
-  if (!runtimeProxyBearerToken) {
-    console.log("   Waiting for bearer token file...");
-    const maxWait = 60000;
-    const pollInterval = 500;
-    const start = Date.now();
-    const pidFile =
-      resources?.pidFile ??
-      join(
-        process.env.BASE_DATA_DIR?.trim() || homedir(),
-        ".vellum",
-        "vellum.pid",
-      );
-    while (Date.now() - start < maxWait) {
-      await new Promise((r) => setTimeout(r, pollInterval));
-      try {
-        const tok = readFileSync(httpTokenPath, "utf-8").trim();
-        if (tok) {
-          runtimeProxyBearerToken = tok;
-          break;
-        }
-      } catch {
-        // File still doesn't exist, keep polling.
-      }
-      // Check if the daemon process is still alive — no point waiting if it crashed
-      try {
-        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-        if (pid) process.kill(pid, 0); // throws if process doesn't exist
-      } catch {
-        break; // daemon process is gone
-      }
-    }
-  }
-
-  if (!runtimeProxyBearerToken) {
-    throw new Error(
-      `Bearer token file not found at ${httpTokenPath} after 60s.\n` +
-        "  The gateway cannot start without authentication — this would leave the proxy permanently unauthenticated.\n" +
-        "  Ensure the daemon is running and has written the token file, or set VELLUM_HTTP_TOKEN_PATH to the correct path.",
-    );
-  }
   const effectiveDaemonPort =
     resources?.daemonPort ?? Number(process.env.RUNTIME_HTTP_PORT || "7821");
 
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
-    GATEWAY_RUNTIME_PROXY_ENABLED: "true",
-    GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
-    RUNTIME_PROXY_BEARER_TOKEN: runtimeProxyBearerToken,
     RUNTIME_HTTP_PORT: String(effectiveDaemonPort),
     GATEWAY_PORT: String(effectiveGatewayPort),
-    // Skip the drain window for locally-launched gateways — there is no load
-    // balancer draining connections, so waiting serves no purpose and causes
-    // `vellum sleep` to SIGKILL the gateway when the CLI timeout is shorter
-    // than the drain window.  Respect an explicit env override.
-    GATEWAY_SHUTDOWN_DRAIN_MS: process.env.GATEWAY_SHUTDOWN_DRAIN_MS || "0",
     ...(watch ? { VELLUM_DEV: "1" } : {}),
     // Set BASE_DATA_DIR so the gateway loads the correct signing key and
     // credentials for this instance (mirrors the daemon env setup).
     ...(resources ? { BASE_DATA_DIR: resources.instanceDir } : {}),
   };
-
-  if (process.env.GATEWAY_UNMAPPED_POLICY) {
-    gatewayEnv.GATEWAY_UNMAPPED_POLICY = process.env.GATEWAY_UNMAPPED_POLICY;
-  } else {
-    gatewayEnv.GATEWAY_UNMAPPED_POLICY = "default";
-  }
-
-  if (resolvedAssistantId) {
-    gatewayEnv.GATEWAY_DEFAULT_ASSISTANT_ID = resolvedAssistantId;
-  }
   const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl(
     resources?.instanceDir,
   );


### PR DESCRIPTION
## Summary
- Remove VELLUM_GATEWAY_DIR override from resolveGatewayDir()
- Remove VELLUM_HTTP_TOKEN_PATH from httpTokenPath resolution in startGateway()
- Remove forwarding of VELLUM_DAEMON_TCP_PORT, VELLUM_DAEMON_TCP_HOST, VELLUM_KEYCHAIN_BROKER_SOCKET, VELLUM_DEBUG to daemon child process
- Remove VELLUM_DAEMON_TCP_ENABLED passthrough from startDaemonFromSource()
- Remove GATEWAY_RUNTIME_PROXY_ENABLED, GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH, RUNTIME_PROXY_BEARER_TOKEN, GATEWAY_SHUTDOWN_DRAIN_MS, GATEWAY_UNMAPPED_POLICY, GATEWAY_DEFAULT_ASSISTANT_ID from gateway env
- Remove dead code: bearer token reading/polling (was only used for RUNTIME_PROXY_BEARER_TOKEN), resolvedAssistantId resolution, loadLatestAssistant import

Part of plan: rm-legacy-env-vars.md (PR 13 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
