### PR TITLE
chore: remove twilio, call greeting, and monitoring env vars from env.ts

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -11,7 +11,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — must be set up before importing the service
 // ---------------------------------------------------------------------------
 
-let mockTwilioPhoneNumberEnv: string | undefined;
 let mockRawConfig: Record<string, unknown> | undefined;
 let mockSecureKeys: Record<string, string>;
 let mockHasTwilioCredentials: boolean;
@@ -23,16 +22,27 @@ mock.module("../calls/twilio-rest.js", () => ({
   getTollFreeVerificationStatus: async () => null,
 }));
 
-mock.module("../config/env.js", () => ({
-  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
-}));
+mock.module("../config/env.js", () => ({}));
 
 mock.module("../config/loader.js", () => ({
   loadRawConfig: () => mockRawConfig,
+  loadConfig: () => {
+    const raw = mockRawConfig ?? {};
+    const wa = (raw.whatsapp ?? {}) as Record<string, unknown>;
+    const tw = (raw.twilio ?? {}) as Record<string, unknown>;
+    return {
+      twilio: { phoneNumber: (tw.phoneNumber as string) ?? "" },
+      whatsapp: { phoneNumber: (wa.phoneNumber as string) ?? "" },
+    };
+  },
   getConfig: () => {
     const raw = mockRawConfig ?? {};
     const wa = (raw.whatsapp ?? {}) as Record<string, unknown>;
-    return { whatsapp: { phoneNumber: (wa.phoneNumber as string) ?? "" } };
+    const tw = (raw.twilio ?? {}) as Record<string, unknown>;
+    return {
+      twilio: { phoneNumber: (tw.phoneNumber as string) ?? "" },
+      whatsapp: { phoneNumber: (wa.phoneNumber as string) ?? "" },
+    };
   },
   invalidateConfigCache: () => {},
 }));
@@ -60,7 +70,6 @@ import { credentialKey } from "../security/credential-key.js";
 
 describe("channel readiness routes — email and WhatsApp probes", () => {
   beforeEach(() => {
-    mockTwilioPhoneNumberEnv = undefined;
     mockRawConfig = undefined;
     mockSecureKeys = {};
     mockHasTwilioCredentials = false;

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
-let mockTwilioPhoneNumberEnv: string | undefined;
+let mockTwilioPhoneNumber: string | undefined;
 let mockRawConfig: Record<string, unknown> | undefined;
 let mockSecureKeys: Record<string, string>;
 let mockHasTwilioCredentials: boolean;
@@ -27,16 +27,17 @@ mock.module("../channels/config.js", () => ({
   }),
 }));
 
-mock.module("../config/env.js", () => ({
-  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
-}));
+mock.module("../config/env.js", () => ({}));
 
 mock.module("../config/loader.js", () => ({
   loadRawConfig: () => mockRawConfig,
+  loadConfig: () => ({
+    twilio: { phoneNumber: mockTwilioPhoneNumber ?? "" },
+    whatsapp: { phoneNumber: "" },
+  }),
   getConfig: () => ({
-    whatsapp: {
-      phoneNumber: "",
-    },
+    twilio: { phoneNumber: mockTwilioPhoneNumber ?? "" },
+    whatsapp: { phoneNumber: "" },
   }),
 }));
 
@@ -100,7 +101,7 @@ describe("ChannelReadinessService", () => {
 
   beforeEach(() => {
     service = new ChannelReadinessService();
-    mockTwilioPhoneNumberEnv = undefined;
+    mockTwilioPhoneNumber = undefined;
     mockRawConfig = undefined;
     mockSecureKeys = {};
     mockHasTwilioCredentials = false;
@@ -406,7 +407,7 @@ describe("ChannelReadinessService", () => {
 
   test("voice readiness includes gateway_health when ingress is configured", async () => {
     mockHasTwilioCredentials = true;
-    mockTwilioPhoneNumberEnv = "+15550001111";
+    mockTwilioPhoneNumber = "+15550001111";
     mockRawConfig = {
       ingress: {
         enabled: true,

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -57,7 +57,6 @@ mock.module("../security/secure-keys.js", () => ({
 
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
-  getTwilioUserPhoneNumber: () => null,
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -77,7 +77,6 @@ function resolveIngressBaseUrlFromConfig(ingressConfig: unknown): string {
 
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
-  getCallWelcomeGreeting: () => process.env.CALL_WELCOME_GREETING || undefined,
   getGatewayInternalBaseUrl: () => "http://gateway.internal:7830",
   getIngressPublicBaseUrl: () => mockIngressPublicBaseUrl,
   setIngressPublicBaseUrl: (value: string | undefined) => {
@@ -438,7 +437,6 @@ describe("twilio webhook routes", () => {
     updatePhoneNumberWebhookCalls = [];
     mockTwilioApiValidationStatus = 200;
     mockTwilioApiValidationBody = JSON.stringify({ sid: "AC_validated" });
-    delete process.env.CALL_WELCOME_GREETING;
 
     globalThis.fetch = (async (
       url: string | URL | Request,
@@ -818,18 +816,6 @@ describe("twilio webhook routes", () => {
       expect(res.status).toBe(200);
       const twiml = await res.text();
       expect(twiml).not.toContain("welcomeGreeting=");
-    });
-
-    test("TwiML includes explicit welcome greeting override when configured", async () => {
-      process.env.CALL_WELCOME_GREETING = "Custom transport greeting";
-      const session = createTestSession("conv-twiml-4", "CA_twiml_4");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_twiml_4" });
-
-      const res = await handleVoiceWebhook(req);
-
-      expect(res.status).toBe(200);
-      const twiml = await res.text();
-      expect(twiml).toContain('welcomeGreeting="Custom transport greeting"');
     });
   });
 

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -5,7 +5,6 @@
  * to these functions so business logic lives in one place.
  */
 
-import { getTwilioUserPhoneNumber } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import { VALID_CALLER_IDENTITY_MODES } from "../config/schema.js";
 import type { AssistantConfig } from "../config/types.js";
@@ -111,8 +110,7 @@ export type CallerIdentitySource =
   | "per_call_override"
   | "implicit_default"
   | "user_config"
-  | "secure_key"
-  | "env_var";
+  | "secure_key";
 
 export type CallerIdentityResult =
   | {
@@ -194,9 +192,6 @@ export async function resolveCallerIdentity(
   if (identityConfig.userNumber) {
     userNumber = identityConfig.userNumber;
     numberSource = "user_config";
-  } else if (getTwilioUserPhoneNumber()) {
-    userNumber = getTwilioUserPhoneNumber()!;
-    numberSource = "env_var";
   } else {
     const secureKeyValue = getSecureKey(
       credentialKey("twilio", "user_phone_number"),

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -744,24 +744,20 @@ export class RelayConnection {
   }
 
   /**
-   * Start normal call flow — fire the controller greeting unless a
-   * static welcome greeting is configured.
+   * Start normal call flow — fire the controller greeting.
    */
   private startNormalCallFlow(
     controller: CallController,
     isInbound: boolean,
   ): void {
-    const hasStaticGreeting = !!process.env.CALL_WELCOME_GREETING?.trim();
-    if (!hasStaticGreeting) {
-      controller
-        .startInitialGreeting()
-        .catch((err) =>
-          log.error(
-            { err, callSessionId: this.callSessionId },
-            `Failed to start initial ${isInbound ? "inbound" : "outbound"} greeting`,
-          ),
-        );
-    }
+    controller
+      .startInitialGreeting()
+      .catch((err) =>
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          `Failed to start initial ${isInbound ? "inbound" : "outbound"} greeting`,
+        ),
+      );
   }
 
   /**

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,4 +1,3 @@
-import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getPublicBaseUrl,
@@ -25,14 +24,10 @@ export interface TwilioConfig {
  * agree on the same number.
  *
  * Resolution order:
- *   1. TWILIO_PHONE_NUMBER env var
- *   2. config.twilio?.phoneNumber
- *   3. ""
+ *   1. config.twilio?.phoneNumber
+ *   2. ""
  */
 export function resolveTwilioPhoneNumber(): string {
-  const fromEnv = getTwilioPhoneNumberEnv();
-  if (fromEnv) return fromEnv;
-
   try {
     const config = loadConfig();
     if (config.twilio?.phoneNumber) return config.twilio.phoneNumber;

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -6,7 +6,6 @@
  * - handleConnectAction: called when the ConversationRelay connection ends
  */
 
-import { getCallWelcomeGreeting } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import { getTwilioRelayUrl } from "../inbound/public-ingress-urls.js";
 import { mintEdgeRelayToken } from "../runtime/auth/token-service.js";
@@ -236,7 +235,7 @@ function buildVoiceWebhookTwiml(
   );
 
   const relayUrl = getTwilioRelayUrl(loadConfig());
-  const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
+  const welcomeGreeting = buildWelcomeGreeting(task);
 
   const relayToken = mintEdgeRelayToken();
 

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -113,35 +113,10 @@ export function hasUngatedHttpAuthDisabled(): boolean {
   return str("VELLUM_UNSAFE_AUTH_BYPASS")?.trim() !== "1";
 }
 
-// ── Twilio ───────────────────────────────────────────────────────────────────
-
-export function getTwilioPhoneNumberEnv(): string | undefined {
-  return str("TWILIO_PHONE_NUMBER");
-}
-
-export function getTwilioUserPhoneNumber(): string | undefined {
-  return str("TWILIO_USER_PHONE_NUMBER");
-}
-
-export function isTwilioWebhookValidationDisabled(): boolean {
-  // Intentionally strict: only exact "true" disables validation (not "1").
-  // This is a security-sensitive bypass — we don't want environments that
-  // template booleans as "1" to silently skip webhook signature checks.
-  return process.env.TWILIO_WEBHOOK_VALIDATION_DISABLED === "true";
-}
-
-export function getCallWelcomeGreeting(): string | undefined {
-  return str("CALL_WELCOME_GREETING");
-}
-
 // ── Monitoring ───────────────────────────────────────────────────────────────
 
 export function getLogfireToken(): string | undefined {
   return str("LOGFIRE_TOKEN");
-}
-
-export function isMonitoringEnabled(): boolean {
-  return false;
 }
 
 const DEFAULT_SENTRY_DSN =

--- a/assistant/src/logfire.ts
+++ b/assistant/src/logfire.ts
@@ -1,4 +1,4 @@
-import { getLogfireToken, isMonitoringEnabled } from "./config/env.js";
+import { getLogfireToken } from "./config/env.js";
 import type {
   Message,
   Provider,
@@ -13,7 +13,7 @@ const log = getLogger("logfire");
 
 type LogfireModule = typeof import("@pydantic/logfire-node");
 
-const LOGFIRE_ENABLED: boolean = !!getLogfireToken() && isMonitoringEnabled();
+const LOGFIRE_ENABLED: boolean = !!getLogfireToken();
 
 let logfireInstance: LogfireModule | null = null;
 

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -3,7 +3,6 @@
  */
 
 import { TwilioConversationRelayProvider } from "../../calls/twilio-provider.js";
-import { isTwilioWebhookValidationDisabled } from "../../config/env.js";
 import { loadConfig } from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getLogger } from "../../util/logger.js";
@@ -51,21 +50,12 @@ export const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set([
  * Returns a 403 Response if signature validation fails.
  *
  * Fail-closed: if the auth token is not configured, the request is rejected
- * with 403 rather than silently skipping validation. An explicit local-dev
- * bypass is available via TWILIO_WEBHOOK_VALIDATION_DISABLED=true.
+ * with 403 rather than silently skipping validation.
  */
 export async function validateTwilioWebhook(
   req: Request,
 ): Promise<{ body: string } | Response> {
   const rawBody = await req.text();
-
-  // Allow explicit local-dev bypass -- must be exactly "true"
-  if (isTwilioWebhookValidationDisabled()) {
-    log.warn(
-      "Twilio webhook signature validation explicitly disabled via TWILIO_WEBHOOK_VALIDATION_DISABLED",
-    );
-    return { body: rawBody };
-  }
 
   const authToken = TwilioConversationRelayProvider.getAuthToken();
 


### PR DESCRIPTION
## Summary
- Remove getTwilioPhoneNumberEnv, getTwilioUserPhoneNumber, isTwilioWebhookValidationDisabled, getCallWelcomeGreeting, and isMonitoringEnabled from env.ts
- Remove env-based webhook validation bypass in twilio-validation.ts
- Remove env var fallback for call greeting in relay-server.ts
- Clean up test references to removed env vars

Part of plan: rm-legacy-env-vars.md (PR 3 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
