### PR TITLE
Read OAuth accountInfo from oauth-store instead of config.json

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -7,6 +7,7 @@ import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
+import { getConnectionByProvider } from "../oauth/oauth-store.js";
 import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
@@ -656,14 +657,28 @@ function buildIntegrationSection(): string {
   const raw = loadRawConfig();
   const lines = ["## Connected Services", ""];
   for (const cred of oauthCreds) {
-    const acctInfo = (getNestedValue(
-      raw,
-      `integrations.${cred.service}.accountInfo`,
-    ) ??
-      // Fallback: legacy config path used before the namespace migration
-      getNestedValue(raw, `integrations.accountInfo.${cred.service}`)) as
-      | string
-      | undefined;
+    // DB-first: try reading accountInfo from the oauth-store (new connections)
+    let acctInfo: string | undefined;
+    try {
+      const conn = getConnectionByProvider(cred.service);
+      if (conn?.accountInfo) {
+        acctInfo = conn.accountInfo;
+      }
+    } catch {
+      // DB not available yet — fall through to config.json
+    }
+
+    // Fallback: read from config.json (pre-migration connections)
+    if (!acctInfo) {
+      acctInfo = (getNestedValue(
+        raw,
+        `integrations.${cred.service}.accountInfo`,
+      ) ??
+        // Fallback: legacy config path used before the namespace migration
+        getNestedValue(raw, `integrations.accountInfo.${cred.service}`)) as
+        | string
+        | undefined;
+    }
     const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
     lines.push(`- **${cred.service}**: ${state}`);
   }


### PR DESCRIPTION
## Summary
- Add DB-first read path for accountInfo in system prompt builder
- Try getConnectionByProvider() first, fall back to config.json
- Read-only change, no behavioral impact for users

Part of plan: oauth-sqlite-migration.md (PR 10 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
