### PR TITLE
Seed oauth_providers table from PROVIDER_PROFILES at startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -40,6 +40,7 @@ import {
   emitNotificationSignal,
   registerBroadcastFn,
 } from "../notifications/emit-signal.js";
+import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
@@ -160,6 +161,8 @@ export async function runDaemon(): Promise<void> {
       );
     }
     initializeDb();
+    // Seed well-known OAuth provider configurations (insert-if-not-exists)
+    seedOAuthProviders();
     log.info("Daemon startup: DB initialized");
 
     // Ensure a vellum guardian binding exists and mint the CLI edge token

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -16,7 +16,7 @@ export function seedOAuthProviders(): void {
     userinfoUrl: profile.userinfoUrl,
     baseUrl: PROVIDER_BASE_URLS[profile.service],
     defaultScopes: profile.defaultScopes,
-    scopePolicy: profile.scopePolicy as Record<string, unknown>,
+    scopePolicy: { ...profile.scopePolicy },
     extraParams: profile.extraParams,
     callbackTransport: profile.callbackTransport,
     loopbackPort: profile.loopbackPort,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -1,0 +1,26 @@
+import { seedProviders } from "./oauth-store.js";
+import { PROVIDER_BASE_URLS } from "./provider-base-urls.js";
+import { PROVIDER_PROFILES } from "./provider-profiles.js";
+
+/**
+ * Seed the oauth_providers table with well-known provider configurations
+ * from PROVIDER_PROFILES. Uses INSERT OR IGNORE so existing rows are never
+ * overwritten — safe to call on every startup.
+ */
+export function seedOAuthProviders(): void {
+  const profiles = Object.values(PROVIDER_PROFILES).map((profile) => ({
+    providerKey: profile.service,
+    authUrl: profile.authUrl,
+    tokenUrl: profile.tokenUrl,
+    tokenEndpointAuthMethod: profile.tokenEndpointAuthMethod,
+    userinfoUrl: profile.userinfoUrl,
+    baseUrl: PROVIDER_BASE_URLS[profile.service],
+    defaultScopes: profile.defaultScopes,
+    scopePolicy: profile.scopePolicy,
+    extraParams: profile.extraParams,
+    callbackTransport: profile.callbackTransport,
+    loopbackPort: profile.loopbackPort,
+  }));
+
+  seedProviders(profiles);
+}

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -16,7 +16,7 @@ export function seedOAuthProviders(): void {
     userinfoUrl: profile.userinfoUrl,
     baseUrl: PROVIDER_BASE_URLS[profile.service],
     defaultScopes: profile.defaultScopes,
-    scopePolicy: profile.scopePolicy,
+    scopePolicy: profile.scopePolicy as Record<string, unknown>,
     extraParams: profile.extraParams,
     callbackTransport: profile.callbackTransport,
     loopbackPort: profile.loopbackPort,


### PR DESCRIPTION
## Summary
- Create seed-providers.ts that maps PROVIDER_PROFILES to oauth-store seedProviders format
- Wire seedOAuthProviders() into daemon lifecycle after initializeDb()
- Idempotent: uses INSERT OR IGNORE, safe for repeated startups

Part of plan: oauth-sqlite-migration.md (PR 5 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
