### PR TITLE
Refactor storeOAuth2Tokens to create/update oauth_app and oauth_connection rows

### DIFF
--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -4,6 +4,12 @@
  * Extracted from vault.ts so it can be reused by both the credential
  * vault tool (interactive and deferred paths) and the future OAuth
  * orchestrator without duplicating storage logic.
+ *
+ * Dual-writes to both legacy stores (metadata.json, config.json, secure
+ * keys under `credential/{service}/...`) AND the new SQLite tables
+ * (oauth_app, oauth_connection) + new-format secure keys
+ * (`oauth_app/{id}/...`, `oauth_connection/{id}/...`). The SQLite writes
+ * are best-effort — failures are logged but do not block the flow.
  */
 
 import { credentialKey, migrateKeys } from "../security/credential-key.js";
@@ -18,6 +24,15 @@ import {
 import { upsertCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
+import { getLogger } from "../util/logger.js";
+import {
+  createConnection,
+  getConnectionByProvider,
+  updateConnection,
+  upsertApp,
+} from "./oauth-store.js";
+
+const log = getLogger("token-persistence");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,6 +52,8 @@ export interface StoreOAuth2TokensParams {
   wellKnownInjectionTemplates?: CredentialInjectionTemplate[];
   /** Fallback account info from an identity verifier (e.g. @username, email). */
   identityAccountInfo?: string;
+  /** Pre-resolved oauth_app ID — skips the upsertApp() call if provided. */
+  oauthAppId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,8 +65,9 @@ export interface StoreOAuth2TokensParams {
  *
  * Persists the access token, optional refresh token, client credentials,
  * and metadata (scopes, expiry, account info) into the secure key store
- * and credential metadata file. Runs any registered post-connect hook
- * for the service.
+ * and credential metadata file. Dual-writes to the new SQLite oauth_app /
+ * oauth_connection tables with new-format secure keys. Runs any registered
+ * post-connect hook for the service.
  */
 export async function storeOAuth2Tokens(
   params: StoreOAuth2TokensParams,
@@ -70,6 +88,7 @@ export async function storeOAuth2Tokens(
     wellKnownInjectionTemplates,
   } = params;
 
+  // ----- Legacy: store access_token under credential/{service}/access_token -----
   const tokenStored = await setSecureKeyAsync(
     credentialKey(service, "access_token"),
     tokens.accessToken,
@@ -97,6 +116,7 @@ export async function storeOAuth2Tokens(
     }
   }
 
+  // ----- Legacy: store client_secret under credential/{service}/client_secret -----
   // client_id is stored in metadata only (oauth2ClientId field) — not the
   // secure store. token-manager.ts reads it from meta?.oauth2ClientId.
   if (clientSecret) {
@@ -109,6 +129,7 @@ export async function storeOAuth2Tokens(
     }
   }
 
+  // ----- Legacy: credential metadata -----
   upsertCredentialMetadata(service, "access_token", {
     allowedTools: allowedTools ?? [],
     expiresAt,
@@ -123,6 +144,7 @@ export async function storeOAuth2Tokens(
       : {}),
   });
 
+  // ----- Legacy: accountInfo in config.json -----
   // Write accountInfo to config using a namespaced key (dynamic import to
   // avoid circular dependencies — the config loader may transitively depend
   // on credential modules).
@@ -151,12 +173,15 @@ export async function storeOAuth2Tokens(
     }
   }
 
+  // ----- Legacy: refresh token -----
+  let hasRefreshToken = false;
   if (tokens.refreshToken) {
     const refreshStored = await setSecureKeyAsync(
       credentialKey(service, "refresh_token"),
       tokens.refreshToken,
     );
     if (refreshStored) {
+      hasRefreshToken = true;
       upsertCredentialMetadata(service, "access_token", {
         hasRefreshToken: true,
       });
@@ -171,8 +196,118 @@ export async function storeOAuth2Tokens(
     });
   }
 
+  // -------------------------------------------------------------------
+  // SQLite dual-write: oauth_app + oauth_connection + new-format keys
+  // -------------------------------------------------------------------
+  // Best-effort — failures are logged but do not block the flow. The
+  // legacy stores above are the source of truth until migration is complete.
+  await persistToOAuthStore({
+    service,
+    clientId,
+    clientSecret,
+    tokens,
+    grantedScopes,
+    rawTokenResponse,
+    expiresAt: expiresAt ?? undefined,
+    hasRefreshToken,
+    resolvedAccountInfo,
+    oauthAppId: params.oauthAppId,
+  });
+
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
   await runPostConnectHook({ service, rawTokenResponse });
 
-  return { accountInfo: accountInfo ?? params.identityAccountInfo };
+  return { accountInfo: resolvedAccountInfo };
+}
+
+// ---------------------------------------------------------------------------
+// SQLite dual-write helper
+// ---------------------------------------------------------------------------
+
+async function persistToOAuthStore(params: {
+  service: string;
+  clientId: string;
+  clientSecret?: string;
+  tokens: OAuth2FlowResult["tokens"];
+  grantedScopes: string[];
+  rawTokenResponse: Record<string, unknown>;
+  expiresAt?: number;
+  hasRefreshToken: boolean;
+  resolvedAccountInfo?: string;
+  oauthAppId?: string;
+}): Promise<void> {
+  try {
+    const {
+      service,
+      clientId,
+      clientSecret,
+      tokens,
+      grantedScopes,
+      rawTokenResponse,
+      expiresAt,
+      hasRefreshToken,
+      resolvedAccountInfo,
+    } = params;
+
+    // 1. Upsert the oauth_app row (or use the pre-resolved ID).
+    const app = params.oauthAppId
+      ? { id: params.oauthAppId }
+      : upsertApp(service, clientId);
+
+    // 2. Dual-write client_secret to new key format:
+    //    oauth_app/{app.id}/client_secret
+    if (clientSecret) {
+      await setSecureKeyAsync(
+        `oauth_app/${app.id}/client_secret`,
+        clientSecret,
+      );
+    }
+
+    // 3. Upsert oauth_connection — reuse existing active connection for this
+    //    provider, or create a new one.
+    const existingConn = getConnectionByProvider(service);
+    let connId: string;
+
+    if (existingConn) {
+      connId = existingConn.id;
+      updateConnection(connId, {
+        accountInfo: resolvedAccountInfo,
+        grantedScopes,
+        expiresAt,
+        hasRefreshToken,
+        metadata: rawTokenResponse,
+      });
+    } else {
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: service,
+        accountInfo: resolvedAccountInfo,
+        grantedScopes,
+        expiresAt,
+        hasRefreshToken,
+        metadata: rawTokenResponse,
+      });
+      connId = conn.id;
+    }
+
+    // 4. Dual-write access_token to new key format:
+    //    oauth_connection/{conn.id}/access_token
+    await setSecureKeyAsync(
+      `oauth_connection/${connId}/access_token`,
+      tokens.accessToken,
+    );
+
+    // 5. Dual-write refresh_token to new key format (if present):
+    //    oauth_connection/{conn.id}/refresh_token
+    if (tokens.refreshToken) {
+      await setSecureKeyAsync(
+        `oauth_connection/${connId}/refresh_token`,
+        tokens.refreshToken,
+      );
+    }
+  } catch (err) {
+    // Non-fatal — legacy stores are already populated above. Log and
+    // continue so the OAuth flow completes successfully.
+    log.warn({ err }, "Failed to dual-write to OAuth SQLite store");
+  }
 }


### PR DESCRIPTION
## Summary
- Dual-write OAuth tokens to both legacy stores and new SQLite tables
- Create/update oauth_app and oauth_connection rows during token storage
- Dual-write secure keys to both credential/{service}/... and oauth_connection/{id}/... formats
- Store raw token response as metadata on oauth_connection for provider-specific fields

Part of plan: oauth-sqlite-migration.md (PR 7 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
