### PR TITLE
fix: remove dead messageId field from ChannelDeliveryResult

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -45,8 +45,6 @@ export interface ChannelDeliveryResult {
   ok: boolean;
   /** The message timestamp returned by the delivery endpoint (e.g. Slack message ts). */
   ts?: string;
-  /** The Telegram message_id returned when a new message was sent. */
-  messageId?: number;
 }
 
 interface ManagedOutboundCallbackContext {
@@ -99,9 +97,6 @@ export async function deliverChannelReply(
     const responseBody = (await response.json()) as Record<string, unknown>;
     if (typeof responseBody.ts === "string") {
       result.ts = responseBody.ts;
-    }
-    if (typeof responseBody.messageId === "number") {
-      result.messageId = responseBody.messageId;
     }
   } catch {
     // Response may not be JSON for non-Slack channels; that's fine.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-telegram-streaming.md.

**Gap:** ChannelDeliveryResult.messageId is dead code
**What was expected:** After removing Telegram streaming and the gateway's messageId response field, the assistant-side messageId field should also be removed
**What was found:** gateway-client.ts still defined messageId on ChannelDeliveryResult and parsed it from responses, but no code reads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
