### PR TITLE
Update settings routes and daemon handlers to read/write oauth-store

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -5,6 +5,7 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -35,6 +36,26 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
+  // Prefer oauth-store for connection status, fall back to keychain/config.
+  try {
+    const conn = getConnectionByProvider("slack_channel");
+    if (conn && conn.status === "active") {
+      const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+      return {
+        success: true,
+        hasBotToken: true,
+        hasAppToken: true,
+        connected: true,
+        ...(teamId ? { teamId } : {}),
+        ...(teamName ? { teamName } : {}),
+        ...(botUserId ? { botUserId } : {}),
+        ...(botUsername ? { botUsername } : {}),
+      };
+    }
+  } catch {
+    // DB not ready — fall through to keychain check
+  }
+
   const hasBotToken = !!getSecureKey(
     credentialKey("slack_channel", "bot_token"),
   );

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -8,6 +8,7 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
+import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -61,6 +62,23 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
+  // Prefer oauth-store for connection status, fall back to keychain check.
+  try {
+    const conn = getConnectionByProvider("telegram");
+    if (conn && conn.status === "active") {
+      const botUsername = getTelegramBotUsername();
+      return {
+        success: true,
+        hasBotToken: true,
+        botUsername,
+        connected: true,
+        hasWebhookSecret: true,
+      };
+    }
+  } catch {
+    // DB not ready — fall through to keychain check
+  }
+
   const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
   const hasWebhookSecret = !!getSecureKey(
     credentialKey("telegram", "webhook_secret"),

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
+import { getApp, getConnectionByProvider } from "../../oauth/oauth-store.js";
 import {
   getProviderProfile,
   resolveService,
@@ -173,11 +174,24 @@ async function handleOAuthConnectStart(body: {
 
   const resolvedService = resolveService(body.service);
 
-  // client_id is stored in metadata (oauth2ClientId), not the secure store.
-  let clientId = getCredentialMetadata(
-    resolvedService,
-    "access_token",
-  )?.oauth2ClientId;
+  // Prefer oauth-store for client_id, fall back to metadata-store.
+  let clientId: string | undefined;
+  try {
+    const conn = getConnectionByProvider(resolvedService);
+    if (conn) {
+      const app = getApp(conn.oauthAppId);
+      if (app) clientId = app.clientId;
+    }
+  } catch {
+    // DB not ready — fall through to metadata-store
+  }
+
+  if (!clientId) {
+    clientId = getCredentialMetadata(
+      resolvedService,
+      "access_token",
+    )?.oauth2ClientId;
+  }
   if (!clientId && resolvedService !== body.service) {
     clientId = getCredentialMetadata(
       body.service,
@@ -222,6 +236,15 @@ async function handleOAuthConnectStart(body: {
         authUrl = url;
       },
       onDeferredComplete: (deferredResult) => {
+        // Prefer accountInfo from oauth-store when available.
+        let accountInfo = deferredResult.accountInfo;
+        try {
+          const conn = getConnectionByProvider(resolvedService);
+          if (conn?.accountInfo) accountInfo = conn.accountInfo;
+        } catch {
+          // DB not ready — use orchestrator value
+        }
+
         // Emit oauth_connect_result to all connected SSE clients so the
         // UI can update immediately when the deferred browser flow completes.
         assistantEventHub
@@ -230,7 +253,7 @@ async function handleOAuthConnectStart(body: {
               type: "oauth_connect_result",
               success: deferredResult.success,
               service: deferredResult.service,
-              accountInfo: deferredResult.accountInfo,
+              accountInfo,
               error: deferredResult.error,
             }),
           )
@@ -273,10 +296,19 @@ async function handleOAuthConnectStart(body: {
       });
     }
 
+    // Prefer accountInfo from oauth-store when available.
+    let responseAccountInfo = result.accountInfo;
+    try {
+      const conn = getConnectionByProvider(resolvedService);
+      if (conn?.accountInfo) responseAccountInfo = conn.accountInfo;
+    } catch {
+      // DB not ready — use orchestrator value
+    }
+
     return Response.json({
       ok: true,
       grantedScopes: result.grantedScopes,
-      accountInfo: result.accountInfo,
+      accountInfo: responseAccountInfo,
       ...(authUrl ? { authUrl } : {}),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Prefer oauth-store reads for integration connection status in settings routes
- Add parallel oauth-store checks in Slack and Telegram config handlers
- Fall back to metadata-store when no oauth-store data exists

Part of plan: oauth-sqlite-migration.md (PR 14 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
