### PR TITLE
Refactor resolveOAuthConnection to use oauth-store with fallback to metadata-store

### DIFF
--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,16 +1,58 @@
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
+import { getConnectionByProvider, getProvider } from "./oauth-store.js";
 import { getProviderBaseUrl } from "./provider-base-urls.js";
 
 /**
  * Resolve an OAuthConnection for a given credential service.
- * Currently always creates a BYO connection from existing credential store.
- * Will be extended to create Platform connections when storage model supports it.
+ *
+ * Tries the new SQLite oauth-store first (connections created after the
+ * migration). Falls back to the legacy credential metadata store for
+ * pre-migration connections.
  */
 export function resolveOAuthConnection(
   credentialService: string,
 ): OAuthConnection {
+  // ----- New path: SQLite oauth-store -----
+  const conn = getConnectionByProvider(credentialService);
+  if (conn) {
+    // Read access_token from new key format, falling back to legacy key.
+    const accessToken =
+      getSecureKey(`oauth_connection/${conn.id}/access_token`) ??
+      getSecureKey(credentialKey(credentialService, "access_token"));
+
+    if (!accessToken) {
+      throw new Error(
+        `No access token found for "${credentialService}". Authorization required.`,
+      );
+    }
+
+    // Resolve base URL: prefer provider row, fall back to static map.
+    const provider = getProvider(credentialService);
+    const baseUrl = provider?.baseUrl ?? getProviderBaseUrl(credentialService);
+
+    if (!baseUrl) {
+      throw new Error(`No base URL configured for "${credentialService}".`);
+    }
+
+    const grantedScopes: string[] = conn.grantedScopes
+      ? JSON.parse(conn.grantedScopes)
+      : [];
+
+    return new BYOOAuthConnection({
+      id: conn.id,
+      providerKey: conn.providerKey,
+      baseUrl,
+      accountInfo: conn.accountInfo,
+      grantedScopes,
+      credentialService,
+    });
+  }
+
+  // ----- Legacy path: credential metadata store -----
   const meta = getCredentialMetadata(credentialService, "access_token");
   if (!meta) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Add DB-first read path in resolveOAuthConnection via getConnectionByProvider
- Read access_token from new key format (oauth_connection/{id}/access_token) with legacy fallback
- Look up base URL from oauth-store provider row with fallback to provider-base-urls
- Populate accountInfo from oauth_connection.account_info
- Fall back to metadata-store for pre-migration connections

Part of plan: oauth-sqlite-migration.md (PR 8 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
