### PR TITLE
Refactor connect orchestrator and scope-policy to read provider config from DB

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -12,7 +12,7 @@
  * - Ensuring metadata is writable (assertMetadataWritable)
  *
  * The orchestrator handles:
- * - Provider profile resolution
+ * - Provider config resolution (from DB)
  * - Scope policy enforcement
  * - Building the OAuth2Config
  * - Running the interactive or deferred flow
@@ -23,12 +23,53 @@
 import type { TokenEndpointAuthMethod } from "../security/oauth2.js";
 import { prepareOAuth2Flow, startOAuth2Flow } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";
-import type { OAuthConnectResult } from "./connect-types.js";
+import type {
+  OAuthConnectResult,
+  OAuthProviderProfile,
+  OAuthScopePolicy,
+} from "./connect-types.js";
+import { getProvider } from "./oauth-store.js";
 import { getProviderProfile, resolveService } from "./provider-profiles.js";
 import { resolveScopes } from "./scope-policy.js";
 import { storeOAuth2Tokens } from "./token-persistence.js";
 
 const log = getLogger("oauth-connect-orchestrator");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract only the behavioral/code-side fields from PROVIDER_PROFILES.
+ * These fields contain functions or IDs that cannot be stored in the DB.
+ */
+function getProviderBehavior(providerKey: string): {
+  identityVerifier?: OAuthProviderProfile["identityVerifier"];
+  setup?: OAuthProviderProfile["setup"];
+  setupSkillId?: string;
+  postConnectHookId?: string;
+  injectionTemplates?: OAuthProviderProfile["injectionTemplates"];
+} {
+  const profile = getProviderProfile(providerKey);
+  if (!profile) return {};
+  return {
+    identityVerifier: profile.identityVerifier,
+    setup: profile.setup,
+    setupSkillId: profile.setupSkillId,
+    postConnectHookId: profile.postConnectHookId,
+    injectionTemplates: profile.injectionTemplates,
+  };
+}
+
+/** Safely parse a JSON string, returning a fallback on failure or null/undefined input. */
+function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (value == null) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Options
@@ -90,23 +131,69 @@ export async function orchestrateOAuthConnect(
   options: OAuthConnectOptions,
 ): Promise<OAuthConnectResult> {
   const resolvedService = resolveService(options.service);
-  const profile = getProviderProfile(resolvedService);
 
-  // Merge explicit overrides with profile defaults
-  const authUrl = options.authUrl ?? profile?.authUrl;
-  const tokenUrl = options.tokenUrl ?? profile?.tokenUrl;
-  const extraParams = options.extraParams ?? profile?.extraParams;
-  const userinfoUrl = options.userinfoUrl ?? profile?.userinfoUrl;
+  // Read provider config from the DB
+  const providerRow = getProvider(resolvedService);
+  if (!providerRow) {
+    return {
+      success: false,
+      error: `No OAuth provider registered for "${resolvedService}". Ensure the provider is seeded in the database.`,
+      safeError: true,
+    };
+  }
+
+  // Behavioral/code-side fields still come from PROVIDER_PROFILES
+  const behavior = getProviderBehavior(resolvedService);
+
+  // Deserialize JSON fields from the DB row
+  const dbDefaultScopes = safeJsonParse<string[]>(
+    providerRow.defaultScopes,
+    [],
+  );
+  const dbScopePolicy = safeJsonParse<OAuthScopePolicy>(
+    providerRow.scopePolicy,
+    {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+  );
+  const dbExtraParams = safeJsonParse<Record<string, string> | undefined>(
+    providerRow.extraParams,
+    undefined,
+  );
+
+  // Merge explicit overrides with DB values
+  const authUrl = options.authUrl ?? providerRow.authUrl;
+  const tokenUrl = options.tokenUrl ?? providerRow.tokenUrl;
+  const extraParams = options.extraParams ?? dbExtraParams;
+  const userinfoUrl =
+    options.userinfoUrl ?? providerRow.userinfoUrl ?? undefined;
   const tokenEndpointAuthMethod =
-    options.tokenEndpointAuthMethod ?? profile?.tokenEndpointAuthMethod;
+    options.tokenEndpointAuthMethod ??
+    (providerRow.tokenEndpointAuthMethod as
+      | TokenEndpointAuthMethod
+      | undefined);
+  const callbackTransport =
+    (providerRow.callbackTransport as "loopback" | "gateway" | null) ??
+    "gateway";
+  const loopbackPort = providerRow.loopbackPort;
 
-  // Scopes: use explicit override, then try scope policy resolution, then profile defaults
+  // Scopes: use explicit override, then try scope policy resolution, then DB defaults
   let finalScopes: string[];
   if (options.scopes) {
     // Explicit scopes override — bypass policy (caller takes responsibility)
     finalScopes = options.scopes;
-  } else if (profile) {
-    const scopeResult = resolveScopes(profile, options.requestedScopes);
+  } else {
+    // Build a profile-compatible object for resolveScopes from the DB row
+    const scopeProfile: OAuthProviderProfile = {
+      service: resolvedService,
+      authUrl: providerRow.authUrl,
+      tokenUrl: providerRow.tokenUrl,
+      defaultScopes: dbDefaultScopes,
+      scopePolicy: dbScopePolicy,
+    };
+    const scopeResult = resolveScopes(scopeProfile, options.requestedScopes);
     if (!scopeResult.ok) {
       const guidance = scopeResult.allowedScopes
         ? ` Allowed scopes: ${scopeResult.allowedScopes.join(", ")}`
@@ -118,13 +205,6 @@ export async function orchestrateOAuthConnect(
       };
     }
     finalScopes = scopeResult.scopes;
-  } else {
-    // No profile and no explicit scopes — cannot proceed
-    return {
-      success: false,
-      error: `No well-known OAuth config found for "${options.service}" and no scopes were provided`,
-      safeError: true,
-    };
   }
 
   if (!authUrl) {
@@ -161,7 +241,7 @@ export async function orchestrateOAuthConnect(
     tokenEndpointAuthMethod,
     userinfoUrl,
     allowedTools: options.allowedTools,
-    wellKnownInjectionTemplates: profile?.injectionTemplates,
+    wellKnownInjectionTemplates: behavior.injectionTemplates,
   };
 
   // -----------------------------------------------------------------------
@@ -169,8 +249,6 @@ export async function orchestrateOAuthConnect(
   // -----------------------------------------------------------------------
   if (!options.isInteractive) {
     try {
-      const callbackTransport = profile?.callbackTransport ?? "gateway";
-
       // Gateway transport needs a public ingress URL
       if (callbackTransport !== "loopback") {
         const { loadConfig } = await import("../config/loader.js");
@@ -191,7 +269,7 @@ export async function orchestrateOAuthConnect(
       const prepared = await prepareOAuth2Flow(
         oauthConfig,
         callbackTransport === "loopback"
-          ? { callbackTransport, loopbackPort: profile?.loopbackPort }
+          ? { callbackTransport, loopbackPort: loopbackPort ?? undefined }
           : undefined,
       );
 
@@ -201,10 +279,10 @@ export async function orchestrateOAuthConnect(
           try {
             let accountInfo: string | undefined;
 
-            // Run identity verifier if available
-            if (profile?.identityVerifier) {
+            // Run identity verifier if available (code-side behavior)
+            if (behavior.identityVerifier) {
               try {
-                accountInfo = await profile.identityVerifier(
+                accountInfo = await behavior.identityVerifier(
                   result.tokens.accessToken,
                 );
               } catch {
@@ -293,19 +371,19 @@ export async function orchestrateOAuthConnect(
           }
         },
       },
-      profile?.callbackTransport
+      callbackTransport !== "gateway"
         ? {
-            callbackTransport: profile.callbackTransport,
-            loopbackPort: profile.loopbackPort,
+            callbackTransport,
+            loopbackPort: loopbackPort ?? undefined,
           }
         : undefined,
     );
 
-    // Run identity verifier if available
+    // Run identity verifier if available (code-side behavior)
     let verifiedIdentity: string | undefined;
-    if (profile?.identityVerifier) {
+    if (behavior.identityVerifier) {
       try {
-        verifiedIdentity = await profile.identityVerifier(tokens.accessToken);
+        verifiedIdentity = await behavior.identityVerifier(tokens.accessToken);
       } catch {
         // Non-fatal
       }


### PR DESCRIPTION
## Summary
- Switch connect orchestrator from reading PROVIDER_PROFILES to reading provider config from oauth-store DB
- Add getProviderBehavior() helper for code-side behavioral fields (identityVerifier, setup, etc.)
- Deserialize JSON fields from DB rows (default_scopes, scope_policy, extra_params)
- No changes to scope-policy.ts (already accepts deserialized objects)

Part of plan: oauth-sqlite-migration.md (PR 6 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
