### PR TITLE
Remove config.json accountInfo writes, read exclusively from oauth-store

### DIFF
--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -5,11 +5,11 @@
  * vault tool (interactive and deferred paths) and the future OAuth
  * orchestrator without duplicating storage logic.
  *
- * Dual-writes to both legacy stores (metadata.json, config.json, secure
- * keys under `credential/{service}/...`) AND the new SQLite tables
- * (oauth_app, oauth_connection) + new-format secure keys
- * (`oauth_app/{id}/...`, `oauth_connection/{id}/...`). The SQLite writes
- * are best-effort — failures are logged but do not block the flow.
+ * Dual-writes to both legacy stores (metadata.json, secure keys under
+ * `credential/{service}/...`) AND the new SQLite tables (oauth_app,
+ * oauth_connection) + new-format secure keys (`oauth_app/{id}/...`,
+ * `oauth_connection/{id}/...`). The SQLite writes are best-effort —
+ * failures are logged but do not block the flow.
  */
 
 import { credentialKey, migrateKeys } from "../security/credential-key.js";
@@ -144,34 +144,7 @@ export async function storeOAuth2Tokens(
       : {}),
   });
 
-  // ----- Legacy: accountInfo in config.json -----
-  // Write accountInfo to config using a namespaced key (dynamic import to
-  // avoid circular dependencies — the config loader may transitively depend
-  // on credential modules).
   const resolvedAccountInfo = accountInfo ?? params.identityAccountInfo;
-  if (resolvedAccountInfo) {
-    try {
-      const {
-        invalidateConfigCache,
-        loadRawConfig,
-        saveRawConfig,
-        setNestedValue,
-      } = await import("../config/loader.js");
-      const raw = loadRawConfig();
-
-      // Write to the namespaced path
-      setNestedValue(
-        raw,
-        `integrations.${service}.accountInfo`,
-        resolvedAccountInfo,
-      );
-
-      saveRawConfig(raw);
-      invalidateConfigCache();
-    } catch {
-      // Non-fatal — tokens stored even if config write fails
-    }
-  }
 
   // ----- Legacy: refresh token -----
   let hasRefreshToken = false;

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { CLI_HELP_REFERENCE } from "../cli/reference.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
-import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
+import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
 import { getConnectionByProvider } from "../oauth/oauth-store.js";
@@ -654,10 +654,8 @@ function buildIntegrationSection(): string {
   );
   if (oauthCreds.length === 0) return "";
 
-  const raw = loadRawConfig();
   const lines = ["## Connected Services", ""];
   for (const cred of oauthCreds) {
-    // DB-first: try reading accountInfo from the oauth-store (new connections)
     let acctInfo: string | undefined;
     try {
       const conn = getConnectionByProvider(cred.service);
@@ -665,20 +663,9 @@ function buildIntegrationSection(): string {
         acctInfo = conn.accountInfo;
       }
     } catch {
-      // DB not available yet — fall through to config.json
+      // DB not available — accountInfo simply not shown
     }
 
-    // Fallback: read from config.json (pre-migration connections)
-    if (!acctInfo) {
-      acctInfo = (getNestedValue(
-        raw,
-        `integrations.${cred.service}.accountInfo`,
-      ) ??
-        // Fallback: legacy config path used before the namespace migration
-        getNestedValue(raw, `integrations.accountInfo.${cred.service}`)) as
-        | string
-        | undefined;
-    }
     const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
     lines.push(`- **${cred.service}**: ${state}`);
   }


### PR DESCRIPTION
## Summary
- Remove config.json accountInfo write block from token-persistence.ts
- Remove config.json fallback in system-prompt.ts, read exclusively from oauth-store
- oauth_connection.account_info is now the sole source of truth

Part of plan: oauth-sqlite-migration.md (PR 15 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
