### PR TITLE
chore: clean up .env.example files, Dockerfiles, and documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -416,7 +416,7 @@ subgraph "Text Q&A Session"
     GW_ATTACH -->|"download from runtime<br/>+ upload to Telegram"| GW_WEBHOOK
 
     %% Gateway flow — Telegram deliver (runtime → gateway → Telegram)
-    %% replyCallbackUrl is built from gatewayInternalBaseUrl (GATEWAY_INTERNAL_BASE_URL env var)
+    %% replyCallbackUrl is built from gatewayInternalBaseUrl (hardcoded default, overridable via workspace config)
     HTTP_RT -->|"POST /deliver/telegram<br/>(via gatewayInternalBaseUrl)"| GW_TG_DELIVER
     GW_TG_DELIVER --> GW_REPLY
     GW_TG_DELIVER --> GW_ATTACH

--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -66,7 +66,7 @@ graph LR
 ### Transport
 
 - Unix domain socket: `~/.vellum/keychain-broker.sock`
-- Socket path is passed to daemon/gateway via `VELLUM_KEYCHAIN_BROKER_SOCKET` environment variable
+- Socket path is derived from the data directory (e.g., `join(getRootDir(), "keychain-broker.sock")`)
 - Newline-delimited JSON (`\n` as message boundary)
 
 ### Request envelope
@@ -157,7 +157,7 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 
 ## Developer Experience
 
-- **Debug builds:** The `#if !DEBUG` guard compiles out the entire `KeychainBrokerServer`. The `VELLUM_KEYCHAIN_BROKER_SOCKET` env var is not set, so clients see the broker as unavailable and use the encrypted store. Developers never encounter keychain prompts during the edit-build-run cycle.
+- **Debug builds:** The `#if !DEBUG` guard compiles out the entire `KeychainBrokerServer`. The broker socket is not created, so clients see the broker as unavailable and use the encrypted store. Developers never encounter keychain prompts during the edit-build-run cycle.
 - **Release builds:** The broker starts automatically with the app. The daemon discovers it via the socket env var and token file. No configuration needed.
 - **CLI-only / headless:** No macOS app means no broker socket. All storage uses the encrypted file store. This is the expected path for CI, servers, and non-macOS platforms.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -62,20 +62,19 @@ vellum hatch [species] [options]
 
 #### Remote Targets
 
-- **`local`** -- Starts the local assistant and local gateway. Gateway source resolution order is: `VELLUM_GATEWAY_DIR` override, repo source tree, then installed `@vellumai/vellum-gateway` package.
+- **`local`** -- Starts the local assistant and local gateway. Gateway source resolution order is: repo source tree, then installed `@vellumai/vellum-gateway` package.
 - **`gcp`** -- Creates a GCP Compute Engine VM (`e2-standard-4`: 4 vCPUs, 16 GB) with a startup script that bootstraps the assistant. Requires `gcloud` authentication and `GCP_PROJECT` / `GCP_DEFAULT_ZONE` environment variables.
 - **`aws`** -- Provisions an AWS instance.
 - **`custom`** -- Provisions on an arbitrary SSH host. Set `VELLUM_CUSTOM_HOST` (e.g. `user@hostname`) to specify the target.
 
 #### Environment Variables
 
-| Variable                  | Required For | Description                                                                                        |
-| ------------------------- | ------------ | -------------------------------------------------------------------------------------------------- |
-| `ANTHROPIC_API_KEY`       | All          | Anthropic API key passed to the assistant runtime.                                                 |
-| `GCP_PROJECT`             | `gcp`        | GCP project ID. Falls back to the active `gcloud` project.                                         |
-| `GCP_DEFAULT_ZONE`        | `gcp`        | GCP zone for the compute instance.                                                                 |
-| `VELLUM_CUSTOM_HOST`      | `custom`     | SSH host in `user@hostname` format.                                                                |
-| `VELLUM_GATEWAY_DIR`      | `local`      | Optional absolute path to a local gateway source directory to run instead of the packaged gateway. |
+| Variable             | Required For | Description                                                |
+| -------------------- | ------------ | ---------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`  | All          | Anthropic API key passed to the assistant runtime.         |
+| `GCP_PROJECT`        | `gcp`        | GCP project ID. Falls back to the active `gcloud` project. |
+| `GCP_DEFAULT_ZONE`   | `gcp`        | GCP zone for the compute instance.                         |
+| `VELLUM_CUSTOM_HOST` | `custom`     | SSH host in `user@hostname` format.                        |
 
 #### Examples
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -246,15 +246,15 @@ The assistant runtime reads this URL via the centralized `public-ingress-urls.ts
 
 All public-facing URLs are constructed by `assistant/src/inbound/public-ingress-urls.ts`:
 
-| Function                       | URL Pattern                                                                                                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Function                       | URL Pattern                                                                                                                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `getPublicBaseUrl()`           | Resolves the canonical base URL from `ingress.publicBaseUrl` in workspace config or module-level state (assistant-side; the gateway reads via `ConfigFileCache`) |
-| `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`                                                                                                                               |
-| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`                                                                                                                                                |
-| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`                                                                                                                                        |
-| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`                                                                                                                                             |
-| `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                                                                                                               |
-| `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                                                                                                                     |
+| `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`                                                                                                                |
+| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`                                                                                                                                 |
+| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`                                                                                                                         |
+| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`                                                                                                                              |
+| `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                                                                                                |
+| `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                                                                                                      |
 
 ### Telegram Messaging Flow
 
@@ -273,7 +273,7 @@ Outbound proactive (assistant → user, initiated by messaging provider):
   Runtime messaging provider → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendChatAction
 ```
 
-The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which defaults to `http://127.0.0.1:${GATEWAY_PORT}` and can be overridden via the `GATEWAY_INTERNAL_BASE_URL` environment variable. This allows distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts).
+The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which defaults to `http://127.0.0.1:${GATEWAY_PORT}` and can be overridden via workspace config. This allows distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts).
 
 The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-closed). If no bearer token is configured and the dev-only bypass flag (`telegram.deliverAuthBypass` in `workspace/config.json`) is not set, the endpoint returns 503 rather than allowing unauthenticated access. The bypass requires `APP_VERSION=0.0.0-dev`.
 
@@ -616,12 +616,12 @@ This also runs when the credential watcher detects changes to Telegram credentia
 
 ### Routing Auto-Configuration
 
-In single-assistant mode (the default local deployment), routing is automatically configured by the CLI:
+In single-assistant mode (the default local deployment), routing is automatically configured by the CLI via workspace config:
 
-- `GATEWAY_UNMAPPED_POLICY=default` is set so all inbound messages are forwarded
-- `GATEWAY_DEFAULT_ASSISTANT_ID` is set to the current assistant's ID
+- The unmapped policy is set to `default` so all inbound messages are forwarded
+- The default assistant ID is set to the current assistant's ID
 
-In multi-assistant mode, the operator must configure `GATEWAY_ASSISTANT_ROUTING_JSON` to map specific chat/user IDs to assistant IDs.
+In multi-assistant mode, the operator must configure the assistant routing map in workspace config to map specific chat/user IDs to assistant IDs.
 
 ### Slack Channel (Socket Mode)
 
@@ -1056,7 +1056,7 @@ The resolution is performed by `resolveCallerIdentity()` in `call-domain.ts`:
 
 1. **Per-call override** — If `callerIdentityMode` is provided in the call input and `calls.callerIdentity.allowPerCallOverride` is enabled, the requested mode is used (source: `per_call_override`).
 2. **Implicit default** — Otherwise, `assistant_number` is always used (source: `implicit_default`). There is no configurable default mode — this is a strict policy.
-3. **User number lookup** — For `user_number` mode (explicit only), the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`), `TWILIO_USER_PHONE_NUMBER` environment variable (source: `env_var`), or the `credential/twilio/user_phone_number` secure key (source: `secure_key`).
+3. **User number lookup** — For `user_number` mode (explicit only), the number is resolved from (in priority order): `calls.callerIdentity.userNumber` config (source: `user_config`) or the `credential/twilio/user_phone_number` secure key (source: `secure_key`).
 4. **Eligibility check** — User numbers are verified against the Twilio API to confirm they can be used as an outbound caller ID.
 
 Both the resolved mode and source are logged at info level on success, and rejections are logged at warn level.

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -26,48 +26,23 @@ bun run dev
 
 ## Configuration
 
-| Variable                             | Required | Default                            | Description                                                                                                                                                                                                                                                                                                                                                                        |
-| ------------------------------------ | -------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TELEGRAM_BOT_TOKEN`                 | No       | —                                  | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store: keychain broker first (UDS to the assistant daemon), then the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (daemon not running or non-macOS), the encrypted store is used directly. |
-| `TELEGRAM_WEBHOOK_SECRET`            | No       | —                                  | Secret for verifying webhook requests (Telegram disabled when unset). Same credential reader fallback behavior as `TELEGRAM_BOT_TOKEN`.                                                                                                                                                                                                                                            |
-| `ASSISTANT_RUNTIME_BASE_URL`         | Yes      | —                                  | Base URL of the assistant runtime HTTP server                                                                                                                                                                                                                                                                                                                                      |
-| `GATEWAY_ASSISTANT_ROUTING_JSON`     | No       | `{}`                               | JSON mapping of Telegram identities to assistant IDs                                                                                                                                                                                                                                                                                                                               |
-| `GATEWAY_DEFAULT_ASSISTANT_ID`       | No       | —                                  | Default assistant ID for unmapped users                                                                                                                                                                                                                                                                                                                                            |
-| `GATEWAY_UNMAPPED_POLICY`            | No       | `reject`                           | Policy for unmapped users: `reject` or `default`                                                                                                                                                                                                                                                                                                                                   |
-| `GATEWAY_PORT`                       | No       | `7830`                             | Port for the gateway HTTP server                                                                                                                                                                                                                                                                                                                                                   |
-| `GATEWAY_INTERNAL_BASE_URL`          | No       | `http://127.0.0.1:${GATEWAY_PORT}` | Base URL for runtime→gateway callbacks (e.g., the `replyCallbackUrl` sent to the assistant runtime for Telegram reply delivery). Defaults to `http://127.0.0.1:${GATEWAY_PORT}`. Override when the gateway and runtime are not co-located (e.g., separate containers, hosts, or behind a service mesh).                                                                            |
-| ~~`INGRESS_PUBLIC_BASE_URL`~~        | No       | —                                  | **Removed.** The gateway now reads `ingress.publicBaseUrl` from the workspace config file via `ConfigFileCache`. Set it via Settings > Public Ingress or `config set ingress.publicBaseUrl <url>`.                                                                                                                                                                                 |
-| `GATEWAY_RUNTIME_PROXY_ENABLED`      | No       | `false`                            | Enable runtime proxy for non-Telegram requests                                                                                                                                                                                                                                                                                                                                     |
-| `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH` | No       | `true`                             | Require bearer auth for proxied requests                                                                                                                                                                                                                                                                                                                                           |
-| `RUNTIME_BEARER_TOKEN`               | No       | —                                  | Bearer token (JWT) used by gateway when forwarding requests to assistant runtime internal endpoints (Twilio/OAuth/proxy upstream).                                                                                                                                                                                                                                                 |
-| `GATEWAY_SHUTDOWN_DRAIN_MS`          | No       | `5000`                             | Graceful shutdown drain window in milliseconds                                                                                                                                                                                                                                                                                                                                     |
-| `GATEWAY_RUNTIME_TIMEOUT_MS`         | No       | `30000`                            | Timeout for runtime HTTP calls (ms)                                                                                                                                                                                                                                                                                                                                                |
-| `GATEWAY_RUNTIME_MAX_RETRIES`        | No       | `2`                                | Max retries for runtime forward on 5xx/network errors                                                                                                                                                                                                                                                                                                                              |
-| `GATEWAY_RUNTIME_INITIAL_BACKOFF_MS` | No       | `500`                              | Initial backoff between retries (doubles each attempt)                                                                                                                                                                                                                                                                                                                             |
-| `GATEWAY_MAX_WEBHOOK_PAYLOAD_BYTES`  | No       | `1048576`                          | Max inbound webhook payload size (rejects with 413)                                                                                                                                                                                                                                                                                                                                |
-| `GATEWAY_MAX_ATTACHMENT_BYTES`       | No       | `20971520`                         | Max single attachment size (oversized are skipped)                                                                                                                                                                                                                                                                                                                                 |
-| `GATEWAY_MAX_ATTACHMENT_CONCURRENCY` | No       | `3`                                | Max concurrent attachment download/upload operations                                                                                                                                                                                                                                                                                                                               |
-| `TWILIO_ACCOUNT_SID`                 | No       | —                                  | Twilio Account SID for voice integration                                                                                                                                                                                                                                                                                                                                           |
-| `TWILIO_AUTH_TOKEN`                  | No       | —                                  | Twilio Auth Token for HMAC-SHA1 webhook signature validation                                                                                                                                                                                                                                                                                                                       |
+| Variable                  | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TELEGRAM_BOT_TOKEN`      | No       | —       | Bot token from @BotFather (Telegram disabled when unset). When not set as an env var, the gateway reads from the assistant's secure credential store: keychain broker first (UDS to the assistant daemon), then the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (daemon not running or non-macOS), the encrypted store is used directly. |
+| `TELEGRAM_WEBHOOK_SECRET` | No       | —       | Secret for verifying webhook requests (Telegram disabled when unset). Same credential reader fallback behavior as `TELEGRAM_BOT_TOKEN`.                                                                                                                                                                                                                                            |
+| `GATEWAY_PORT`            | No       | `7830`  | Port for the gateway HTTP server                                                                                                                                                                                                                                                                                                                                                   |
 
-Channel operational settings (Telegram API base URL, timeouts, deliver auth bypass flags) are managed via `workspace/config.json` through `ConfigFileCache`. See the channel-specific sections in `ARCHITECTURE.md` for details.
+Most gateway behavior is now configured via hardcoded defaults or workspace config (`~/.vellum/workspace/config.json`) rather than environment variables. Channel operational settings (Telegram API base URL, timeouts, deliver auth bypass flags, runtime base URL, routing, proxy settings, attachment limits, shutdown drain) are managed via `workspace/config.json` through `ConfigFileCache`. See the channel-specific sections in `ARCHITECTURE.md` for details.
 
 ## Routing
 
 v1 uses deterministic settings-based routing (no database):
 
-1. **conversation_id match** — explicit `conversation:<conversation_id>` entry in routing JSON
-2. **actor_id match** — explicit `actor:<actor_id>` entry in routing JSON
-3. **Unmapped policy** — `reject` (drop with message) or `default` (forward to `GATEWAY_DEFAULT_ASSISTANT_ID`)
+1. **conversation_id match** — explicit `conversation:<conversation_id>` entry in routing config
+2. **actor_id match** — explicit `actor:<actor_id>` entry in routing config
+3. **Unmapped policy** — `reject` (drop with message) or `default` (forward to the configured default assistant)
 
-### Routing JSON format
-
-```json
-{
-  "conversation:12345": "assistant-id-a",
-  "actor:67890": "assistant-id-b"
-}
-```
+Routing is configured via workspace config. See `ARCHITECTURE.md` for details.
 
 ## Setting up the Telegram webhook
 
@@ -245,15 +220,15 @@ When the ingress public base URL is configured (via `ingress.publicBaseUrl` in w
 
 ## Default Mode: Dedicated Routes Only
 
-By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, explicit control-plane proxies such as `/v1/channel-verification-sessions/*`, `/v1/integrations/telegram/*`, `/v1/integrations/slack/*`, and `/v1/contacts/invites/*`, plus the authenticated runtime health route `/v1/health`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
+By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, explicit control-plane proxies such as `/v1/channel-verification-sessions/*`, `/v1/integrations/telegram/*`, `/v1/integrations/slack/*`, and `/v1/contacts/invites/*`, plus the authenticated runtime health route `/v1/health`) remain available, but arbitrary runtime passthrough routes return `404` unless the runtime proxy is enabled via workspace config.
 
 ## Runtime Proxy Mode
 
-When `GATEWAY_RUNTIME_PROXY_ENABLED=true`, the gateway forwards all non-Telegram HTTP requests to the assistant runtime at `ASSISTANT_RUNTIME_BASE_URL`. This allows the gateway to serve as a single ingress point for both Telegram and API traffic.
+When the runtime proxy is enabled (via workspace config), the gateway forwards all non-Telegram HTTP requests to the assistant runtime. This allows the gateway to serve as a single ingress point for both Telegram and API traffic.
 
 ### Auth behavior
 
-By default (`GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=true`), proxied requests must include a valid `Authorization: Bearer <jwt>` header with a JWT signed by the shared signing key. Set `GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false` to disable auth.
+By default, proxied requests must include a valid `Authorization: Bearer <jwt>` header with a JWT signed by the shared signing key. Auth requirement is configured via workspace config.
 
 `OPTIONS` requests are always allowed without auth (CORS preflight). Telegram webhook requests use their own secret-based verification and are not affected by proxy auth.
 
@@ -285,9 +260,9 @@ When the assistant includes attachments in a reply, the gateway downloads each a
 
 - **Images** (`image/*` MIME types) are sent via `sendPhoto` (multipart form upload).
 - **Other files** are sent via `sendDocument` (multipart form upload).
-- **Oversized** attachments (exceeding `GATEWAY_MAX_ATTACHMENT_BYTES`, default 20 MB) are skipped and included in the partial-failure notice.
+- **Oversized** attachments (exceeding the hardcoded max attachment size, default 20 MB) are skipped and included in the partial-failure notice.
 - **Partial failures** are handled gracefully: each attachment is attempted independently. If any fail, a single summary notice is sent to the chat listing the undelivered filenames.
-- **Concurrency** is controlled by `GATEWAY_MAX_ATTACHMENT_CONCURRENCY` (default 3).
+- **Concurrency** is controlled by a hardcoded max concurrency limit (default 3).
 
 Text and attachments are sent separately — the text reply goes first via `sendMessage`, then each attachment follows.
 
@@ -299,7 +274,7 @@ Text and attachments are sent separately — the text reply goes first via `send
 | `/healthz`   | GET    | Always returns `200` while the process is alive                             |
 | `/readyz`    | GET    | Returns `200` while accepting traffic; `503` during graceful shutdown drain |
 
-On `SIGTERM` the gateway enters drain mode: `/readyz` begins returning `503` so the load balancer stops sending new traffic. After `GATEWAY_SHUTDOWN_DRAIN_MS` (default 5 s) the process exits.
+On `SIGTERM` the gateway enters drain mode: `/readyz` begins returning `503` so the load balancer stops sending new traffic. After the hardcoded shutdown drain window (default 5 s) the process exits.
 
 ## Docker
 
@@ -311,13 +286,12 @@ docker build -t vellum-gateway:local gateway
 docker run --rm -p 7830:7830 \
   -e TELEGRAM_BOT_TOKEN=... \
   -e TELEGRAM_WEBHOOK_SECRET=... \
-  -e ASSISTANT_RUNTIME_BASE_URL=http://host.docker.internal:7821 \
   vellum-gateway:local
 ```
 
 The image runs as non-root user `gateway` (uid 1001) and exposes port `7830`.
 
-When the runtime and gateway run in separate containers or hosts, set `GATEWAY_INTERNAL_BASE_URL` so the runtime can reach the gateway for callbacks (e.g., Telegram reply delivery). By default it points to `http://127.0.0.1:${GATEWAY_PORT}`, which only works when both services share the same host.
+The runtime base URL and gateway internal base URL are resolved from hardcoded defaults. When the runtime and gateway run in separate containers or hosts, configure the gateway internal base URL via workspace config so the runtime can reach the gateway for callbacks (e.g., Telegram reply delivery).
 
 ## Development
 
@@ -356,17 +330,17 @@ See [`benchmarking/gateway/README.md`](../benchmarking/gateway/README.md) for lo
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Telegram messages not arriving | Is the webhook registered? `curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo`                                                                                           |
 | 401 on webhook                 | Does `TELEGRAM_WEBHOOK_SECRET` match the `secret_token` in setWebhook?                                                                                                         |
-| "No route configured" replies  | Add a routing entry or set `GATEWAY_UNMAPPED_POLICY=default` with a default assistant                                                                                          |
-| Runtime errors                 | Is `ASSISTANT_RUNTIME_BASE_URL` reachable? Check runtime logs.                                                                                                                 |
-| No reply from assistant        | Is the assistant runtime processing messages? Check for `RUNTIME_HTTP_PORT` env var.                                                                                           |
+| "No route configured" replies  | Add a routing entry or configure the unmapped policy to `default` with a default assistant via workspace config                                                                |
+| Runtime errors                 | Is the assistant runtime reachable? Check runtime logs.                                                                                                                        |
+| No reply from assistant        | Is the assistant runtime processing messages? Check that the runtime HTTP server is running.                                                                                   |
 | 403 on channel inbound         | The runtime rejected the request because JWT authentication failed. Ensure the gateway and runtime share the same signing key (`~/.vellum/protected/actor-token-signing-key`). |
 
 ### Guardian-Specific Troubleshooting
 
-| Symptom                                                        | Cause                                                                                                                                              | Resolution                                                                                                                                                                  |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Guardian verification code reply gets no response              | The verification message did not reach the runtime, or the challenge expired                                                                       | Ensure the gateway is running, the bot token is valid, and the Telegram webhook is registered. Challenges expire after 10 minutes -- generate a new one via the desktop UI. |
-| Non-guardian actions auto-denied with "no guardian configured" | No guardian binding exists for the channel. The runtime is fail-closed for unverified channels.                                                    | Set up a guardian by running the verification flow from the desktop UI.                                                                                                     |
-| Approval prompt not delivered to guardian                      | The `replyCallbackUrl` may be unreachable, or the guardian's chat ID is stale                                                                      | Verify `GATEWAY_INTERNAL_BASE_URL` is set correctly (especially in containerized deployments). Re-verify the guardian if the chat ID has changed.                           |
-| Guardian approval expired                                      | The 30-minute TTL elapsed without a decision. A proactive sweep (every 60s) auto-denied the approval and notified both the requester and guardian. | The non-guardian user must re-trigger the action.                                                                                                                           |
-| "Only the verified guardian can approve or deny"               | A non-guardian sender attempted to respond to a guardian approval prompt                                                                           | Only the guardian whose `actorExternalId` matches the approval request can approve or deny.                                                                                 |
+| Symptom                                                        | Cause                                                                                                                                              | Resolution                                                                                                                                                                     |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Guardian verification code reply gets no response              | The verification message did not reach the runtime, or the challenge expired                                                                       | Ensure the gateway is running, the bot token is valid, and the Telegram webhook is registered. Challenges expire after 10 minutes -- generate a new one via the desktop UI.    |
+| Non-guardian actions auto-denied with "no guardian configured" | No guardian binding exists for the channel. The runtime is fail-closed for unverified channels.                                                    | Set up a guardian by running the verification flow from the desktop UI.                                                                                                        |
+| Approval prompt not delivered to guardian                      | The `replyCallbackUrl` may be unreachable, or the guardian's chat ID is stale                                                                      | Verify the gateway internal base URL is configured correctly in workspace config (especially in containerized deployments). Re-verify the guardian if the chat ID has changed. |
+| Guardian approval expired                                      | The 30-minute TTL elapsed without a decision. A proactive sweep (every 60s) auto-denied the approval and notified both the requester and guardian. | The non-guardian user must re-trigger the action.                                                                                                                              |
+| "Only the verified guardian can approve or deny"               | A non-guardian sender attempted to respond to a guardian approval prompt                                                                           | Only the guardian whose `actorExternalId` matches the approval request can approve or deny.                                                                                    |

--- a/skills/public-ingress/SKILL.md
+++ b/skills/public-ingress/SKILL.md
@@ -30,7 +30,7 @@ assistant config get ingress.publicBaseUrl
 assistant config get ingress.enabled
 ```
 
-Note: The local gateway target is `$INTERNAL_GATEWAY_BASE_URL` (e.g. `http://127.0.0.1:7830`).
+Resolve the local gateway URL by running `assistant config get gateway.internalBaseUrl` (defaults to `http://127.0.0.1:7830`).
 
 The commands return:
 
@@ -118,10 +118,11 @@ pkill -f ngrok || true
 sleep 1
 ```
 
-Start ngrok in the background, tunneling to the local gateway target:
+Resolve the local gateway URL first using `assistant config get gateway.internalBaseUrl`, then start ngrok in the background tunneling to that URL:
 
 ```bash
-nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &
+GATEWAY_URL=$(assistant config get gateway.internalBaseUrl)
+nohup ngrok http "$GATEWAY_URL" --log=stdout > /tmp/ngrok.log 2>&1 &
 echo $! > /tmp/ngrok.pid
 ```
 
@@ -158,12 +159,12 @@ print(match.group(1))
 ```
 
 ```bash
-echo "$INTERNAL_GATEWAY_BASE_URL" | grep -oE '[0-9]+$'
+assistant config get gateway.internalBaseUrl | grep -oE '[0-9]+$'
 ```
 
 Compare the two port numbers. If they differ, warn the user:
 
-> **Port mismatch detected:** ngrok is forwarding to port **X** but the gateway is listening on port **Y** (from `$INTERNAL_GATEWAY_BASE_URL`). Webhooks will not reach the gateway. Stop ngrok (`pkill -f ngrok`), then re-run this skill to start ngrok on the correct port.
+> **Port mismatch detected:** ngrok is forwarding to port **X** but the gateway is listening on port **Y**. Webhooks will not reach the gateway. Stop ngrok (`pkill -f ngrok`), then re-run this skill to start ngrok on the correct port.
 
 If the ports match, proceed silently to Step 5.
 
@@ -214,14 +215,14 @@ assistant config get ingress.enabled
 Summarize the setup:
 
 - **Public URL:** `<the-url>` (this is your `ingress.publicBaseUrl`)
-- **Local gateway target:** `$INTERNAL_GATEWAY_BASE_URL`
+- **Local gateway target:** (the URL from `assistant config get gateway.internalBaseUrl`)
 - **ngrok dashboard:** http://127.0.0.1:4040
 
 Provide useful follow-up commands:
 
 - **Check tunnel status:** `curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "import sys,json; [print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]"`
 - **View ngrok logs:** `cat /tmp/ngrok.log`
-- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &`
+- **Restart tunnel:** `pkill -f ngrok; sleep 1; GATEWAY_URL=$(assistant config get gateway.internalBaseUrl); nohup ngrok http "$GATEWAY_URL" --log=stdout > /tmp/ngrok.log 2>&1 &`
 - **Stop tunnel:** `pkill -f ngrok`
 - **Rotate URL:** Stop and restart ngrok (free tier assigns a new URL each time; update `ingress.publicBaseUrl` afterward)
 
@@ -243,7 +244,7 @@ The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not r
 
 ### Gateway not reachable on local target
 
-Re-check the local gateway target with `echo "$INTERNAL_GATEWAY_BASE_URL"`. Run `curl -s "$INTERNAL_GATEWAY_BASE_URL/healthz"` to verify it is reachable. If the gateway is not running, start the assistant first.
+Re-check the local gateway target with `assistant config get gateway.internalBaseUrl`. Run `curl -s "$(assistant config get gateway.internalBaseUrl)/healthz"` to verify it is reachable. If the gateway is not running, start the assistant first.
 
 ### "Too many connections" or tunnel limit errors
 
@@ -255,7 +256,7 @@ ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels befo
 
 **Cause:** ngrok is forwarding to a different port than the gateway is listening on. This can happen if the gateway port was changed after ngrok was started, or if ngrok was started manually with a hardcoded port.
 
-**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway URL with `echo "$INTERNAL_GATEWAY_BASE_URL"`, then re-run this skill to start ngrok on the correct port.
+**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway URL with `assistant config get gateway.internalBaseUrl`, then re-run this skill to start ngrok on the correct port.
 
 ### ngrok automatically restarts with wrong port
 


### PR DESCRIPTION
## Summary
- Clean up .env.example files to only list kept env vars
- Remove references to removed env vars from Dockerfiles
- Update documentation (ARCHITECTURE.md, READMEs, keychain-broker.md)
- Update skill SKILL.md files to use config-based approaches

Part of plan: rm-legacy-env-vars.md (PR 14 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
