### PR TITLE
Refactor vault tool oauth2_connect to resolve client_id from oauth-store

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -195,6 +195,23 @@ export function getAppByProviderAndClientId(
     .get();
 }
 
+/**
+ * Get the most recently created app for a provider.
+ * Returns undefined if no app exists for this provider.
+ */
+export function getMostRecentAppByProvider(
+  providerKey: string,
+): OAuthAppRow | undefined {
+  const db = getDb();
+  return db
+    .select()
+    .from(oauthApps)
+    .where(eq(oauthApps.providerKey, providerKey))
+    .orderBy(desc(oauthApps.createdAt))
+    .limit(1)
+    .get();
+}
+
 /** Delete an app by ID. Returns true if a row was deleted. */
 export function deleteApp(id: string): boolean {
   const db = getDb();

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,5 +1,6 @@
 import { getConfig } from "../../config/loader.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
+import { getMostRecentAppByProvider } from "../../oauth/oauth-store.js";
 import {
   getProviderProfile,
   resolveService,
@@ -780,13 +781,39 @@ class CredentialStoreTool implements Tool {
         // Fill missing params from provider profile
         const profile = getProviderProfile(service);
 
-        // Look up client_id from metadata and client_secret from secure store
-        const clientId =
-          (input.client_id as string | undefined) ??
-          findStoredOAuthClientId(service);
-        const clientSecret =
-          (input.client_secret as string | undefined) ??
-          findStoredOAuthSecret(service, "client_secret");
+        // Resolve client_id and client_secret.
+        // Priority:
+        //   1. Explicit input from the caller
+        //   2. oauth-store DB (most recent app for this provider)
+        //   3. Legacy metadata-store / secure key store
+        let clientId = input.client_id as string | undefined;
+        let clientSecret = input.client_secret as string | undefined;
+
+        if (!clientId || !clientSecret) {
+          // Try the oauth-store DB first
+          try {
+            const dbApp = getMostRecentAppByProvider(service);
+            if (dbApp) {
+              if (!clientId) clientId = dbApp.clientId;
+              if (!clientSecret) {
+                clientSecret = getSecureKey(
+                  `oauth_app/${dbApp.id}/client_secret`,
+                );
+              }
+            }
+          } catch (err) {
+            // DB may not be initialized yet — fall through to legacy lookup
+            log.debug(
+              { err, service },
+              "oauth-store lookup failed, falling back to metadata store",
+            );
+          }
+
+          // Fall back to legacy metadata-store / secure key store
+          if (!clientId) clientId = findStoredOAuthClientId(service);
+          if (!clientSecret)
+            clientSecret = findStoredOAuthSecret(service, "client_secret");
+        }
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
         const inputScopes = input.scopes as string[] | undefined;


### PR DESCRIPTION
## Summary
- Add DB-first client_id resolution from oauth-store in vault oauth2_connect action
- Read client_secret from new key format (oauth_app/{id}/client_secret) with legacy fallback
- Keep assertMetadataWritable() check during dual-write period
- Fall back to metadata-store for pre-migration users

Part of plan: oauth-sqlite-migration.md (PR 11 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
