### PR TITLE
Remove metadata-store and legacy secure-key dual-writes for OAuth credentials

### DIFF
--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,6 +1,4 @@
-import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
-import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
 import { getConnectionByProvider, getProvider } from "./oauth-store.js";
@@ -9,68 +7,47 @@ import { getProviderBaseUrl } from "./provider-base-urls.js";
 /**
  * Resolve an OAuthConnection for a given credential service.
  *
- * Tries the new SQLite oauth-store first (connections created after the
- * migration). Falls back to the legacy credential metadata store for
- * pre-migration connections.
+ * Reads exclusively from the SQLite oauth-store. Throws if no connection
+ * exists (authorization required).
  */
 export function resolveOAuthConnection(
   credentialService: string,
 ): OAuthConnection {
-  // ----- New path: SQLite oauth-store -----
   const conn = getConnectionByProvider(credentialService);
-  if (conn) {
-    // Read access_token from new key format, falling back to legacy key.
-    const accessToken =
-      getSecureKey(`oauth_connection/${conn.id}/access_token`) ??
-      getSecureKey(credentialKey(credentialService, "access_token"));
-
-    if (!accessToken) {
-      throw new Error(
-        `No access token found for "${credentialService}". Authorization required.`,
-      );
-    }
-
-    // Resolve base URL: prefer provider row, fall back to static map.
-    const provider = getProvider(credentialService);
-    const baseUrl = provider?.baseUrl ?? getProviderBaseUrl(credentialService);
-
-    if (!baseUrl) {
-      throw new Error(`No base URL configured for "${credentialService}".`);
-    }
-
-    const grantedScopes: string[] = conn.grantedScopes
-      ? JSON.parse(conn.grantedScopes)
-      : [];
-
-    return new BYOOAuthConnection({
-      id: conn.id,
-      providerKey: conn.providerKey,
-      baseUrl,
-      accountInfo: conn.accountInfo,
-      grantedScopes,
-      credentialService,
-    });
-  }
-
-  // ----- Legacy path: credential metadata store -----
-  const meta = getCredentialMetadata(credentialService, "access_token");
-  if (!meta) {
+  if (!conn) {
     throw new Error(
       `No credential found for "${credentialService}". Authorization required.`,
     );
   }
 
-  const baseUrl = getProviderBaseUrl(credentialService);
+  const accessToken = getSecureKey(
+    `oauth_connection/${conn.id}/access_token`,
+  );
+
+  if (!accessToken) {
+    throw new Error(
+      `No access token found for "${credentialService}". Authorization required.`,
+    );
+  }
+
+  // Resolve base URL: prefer provider row, fall back to static map.
+  const provider = getProvider(credentialService);
+  const baseUrl = provider?.baseUrl ?? getProviderBaseUrl(credentialService);
+
   if (!baseUrl) {
     throw new Error(`No base URL configured for "${credentialService}".`);
   }
 
+  const grantedScopes: string[] = conn.grantedScopes
+    ? JSON.parse(conn.grantedScopes)
+    : [];
+
   return new BYOOAuthConnection({
-    id: meta.credentialId,
-    providerKey: credentialService,
+    id: conn.id,
+    providerKey: conn.providerKey,
     baseUrl,
-    accountInfo: null,
-    grantedScopes: meta.grantedScopes ?? [],
+    accountInfo: conn.accountInfo,
+    grantedScopes,
     credentialService,
   });
 }

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -2,17 +2,14 @@
  * OAuth2 token persistence helper.
  *
  * Extracted from vault.ts so it can be reused by both the credential
- * vault tool (interactive and deferred paths) and the future OAuth
+ * vault tool (interactive and deferred paths) and the OAuth
  * orchestrator without duplicating storage logic.
  *
- * Dual-writes to both legacy stores (metadata.json, secure keys under
- * `credential/{service}/...`) AND the new SQLite tables (oauth_app,
- * oauth_connection) + new-format secure keys (`oauth_app/{id}/...`,
- * `oauth_connection/{id}/...`). The SQLite writes are best-effort —
- * failures are logged but do not block the flow.
+ * Writes exclusively to the SQLite tables (oauth_app, oauth_connection)
+ * and new-format secure keys (`oauth_app/{id}/...`,
+ * `oauth_connection/{id}/...`).
  */
 
-import { credentialKey, migrateKeys } from "../security/credential-key.js";
 import type {
   OAuth2FlowResult,
   TokenEndpointAuthMethod,
@@ -21,18 +18,14 @@ import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
-import { upsertCredentialMetadata } from "../tools/credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
-import { getLogger } from "../util/logger.js";
 import {
   createConnection,
   getConnectionByProvider,
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
-
-const log = getLogger("token-persistence");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,16 +57,13 @@ export interface StoreOAuth2TokensParams {
  * Store OAuth2 tokens and associated metadata after a successful flow.
  *
  * Persists the access token, optional refresh token, client credentials,
- * and metadata (scopes, expiry, account info) into the secure key store
- * and credential metadata file. Dual-writes to the new SQLite oauth_app /
+ * and metadata (scopes, expiry, account info) into the SQLite oauth_app /
  * oauth_connection tables with new-format secure keys. Runs any registered
  * post-connect hook for the service.
  */
 export async function storeOAuth2Tokens(
   params: StoreOAuth2TokensParams,
 ): Promise<{ accountInfo?: string }> {
-  migrateKeys();
-
   const {
     service,
     tokens,
@@ -81,21 +71,8 @@ export async function storeOAuth2Tokens(
     rawTokenResponse,
     clientId,
     clientSecret,
-    tokenUrl,
-    tokenEndpointAuthMethod,
     userinfoUrl,
-    allowedTools,
-    wellKnownInjectionTemplates,
   } = params;
-
-  // ----- Legacy: store access_token under credential/{service}/access_token -----
-  const tokenStored = await setSecureKeyAsync(
-    credentialKey(service, "access_token"),
-    tokens.accessToken,
-  );
-  if (!tokenStored) {
-    throw new Error("Failed to store access token in secure storage");
-  }
 
   const expiresAt = tokens.expiresIn
     ? Date.now() + tokens.expiresIn * 1000
@@ -116,12 +93,21 @@ export async function storeOAuth2Tokens(
     }
   }
 
-  // ----- Legacy: store client_secret under credential/{service}/client_secret -----
-  // client_id is stored in metadata only (oauth2ClientId field) — not the
-  // secure store. token-manager.ts reads it from meta?.oauth2ClientId.
+  const resolvedAccountInfo = accountInfo ?? params.identityAccountInfo;
+
+  // -------------------------------------------------------------------
+  // SQLite oauth_app + oauth_connection + new-format secure keys
+  // -------------------------------------------------------------------
+
+  // 1. Upsert the oauth_app row (or use the pre-resolved ID).
+  const app = params.oauthAppId
+    ? { id: params.oauthAppId }
+    : upsertApp(service, clientId);
+
+  // 2. Write client_secret to new key format: oauth_app/{app.id}/client_secret
   if (clientSecret) {
     const clientSecretStored = await setSecureKeyAsync(
-      credentialKey(service, "client_secret"),
+      `oauth_app/${app.id}/client_secret`,
       clientSecret,
     );
     if (!clientSecretStored) {
@@ -129,158 +115,61 @@ export async function storeOAuth2Tokens(
     }
   }
 
-  // ----- Legacy: credential metadata -----
-  upsertCredentialMetadata(service, "access_token", {
-    allowedTools: allowedTools ?? [],
-    expiresAt,
-    grantedScopes,
-    oauth2TokenUrl: tokenUrl,
-    oauth2ClientId: clientId,
-    ...(tokenEndpointAuthMethod
-      ? { oauth2TokenEndpointAuthMethod: tokenEndpointAuthMethod }
-      : {}),
-    ...(wellKnownInjectionTemplates
-      ? { injectionTemplates: wellKnownInjectionTemplates }
-      : {}),
-  });
+  // 3. Upsert oauth_connection — reuse existing active connection for this
+  //    provider, or create a new one.
+  const existingConn = getConnectionByProvider(service);
+  let connId: string;
 
-  const resolvedAccountInfo = accountInfo ?? params.identityAccountInfo;
+  const hasRefreshToken = !!tokens.refreshToken;
 
-  // ----- Legacy: refresh token -----
-  let hasRefreshToken = false;
+  if (existingConn) {
+    connId = existingConn.id;
+    updateConnection(connId, {
+      accountInfo: resolvedAccountInfo,
+      grantedScopes,
+      expiresAt: expiresAt ?? undefined,
+      hasRefreshToken,
+      metadata: rawTokenResponse,
+    });
+  } else {
+    const conn = createConnection({
+      oauthAppId: app.id,
+      providerKey: service,
+      accountInfo: resolvedAccountInfo,
+      grantedScopes,
+      expiresAt: expiresAt ?? undefined,
+      hasRefreshToken,
+      metadata: rawTokenResponse,
+    });
+    connId = conn.id;
+  }
+
+  // 4. Write access_token: oauth_connection/{conn.id}/access_token
+  const tokenStored = await setSecureKeyAsync(
+    `oauth_connection/${connId}/access_token`,
+    tokens.accessToken,
+  );
+  if (!tokenStored) {
+    throw new Error("Failed to store access token in secure storage");
+  }
+
+  // 5. Write or clear refresh_token: oauth_connection/{conn.id}/refresh_token
   if (tokens.refreshToken) {
-    const refreshStored = await setSecureKeyAsync(
-      credentialKey(service, "refresh_token"),
+    await setSecureKeyAsync(
+      `oauth_connection/${connId}/refresh_token`,
       tokens.refreshToken,
     );
-    if (refreshStored) {
-      hasRefreshToken = true;
-      upsertCredentialMetadata(service, "access_token", {
-        hasRefreshToken: true,
-      });
-    }
   } else {
     // Re-auth grants that omit refresh_token must clear any stale stored
     // token — otherwise withValidToken() will attempt refresh with invalid
     // credentials.
-    await deleteSecureKeyAsync(credentialKey(service, "refresh_token"));
-    upsertCredentialMetadata(service, "access_token", {
-      hasRefreshToken: false,
-    });
+    await deleteSecureKeyAsync(
+      `oauth_connection/${connId}/refresh_token`,
+    );
   }
-
-  // -------------------------------------------------------------------
-  // SQLite dual-write: oauth_app + oauth_connection + new-format keys
-  // -------------------------------------------------------------------
-  // Best-effort — failures are logged but do not block the flow. The
-  // legacy stores above are the source of truth until migration is complete.
-  await persistToOAuthStore({
-    service,
-    clientId,
-    clientSecret,
-    tokens,
-    grantedScopes,
-    rawTokenResponse,
-    expiresAt: expiresAt ?? undefined,
-    hasRefreshToken,
-    resolvedAccountInfo,
-    oauthAppId: params.oauthAppId,
-  });
 
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
   await runPostConnectHook({ service, rawTokenResponse });
 
   return { accountInfo: resolvedAccountInfo };
-}
-
-// ---------------------------------------------------------------------------
-// SQLite dual-write helper
-// ---------------------------------------------------------------------------
-
-async function persistToOAuthStore(params: {
-  service: string;
-  clientId: string;
-  clientSecret?: string;
-  tokens: OAuth2FlowResult["tokens"];
-  grantedScopes: string[];
-  rawTokenResponse: Record<string, unknown>;
-  expiresAt?: number;
-  hasRefreshToken: boolean;
-  resolvedAccountInfo?: string;
-  oauthAppId?: string;
-}): Promise<void> {
-  try {
-    const {
-      service,
-      clientId,
-      clientSecret,
-      tokens,
-      grantedScopes,
-      rawTokenResponse,
-      expiresAt,
-      hasRefreshToken,
-      resolvedAccountInfo,
-    } = params;
-
-    // 1. Upsert the oauth_app row (or use the pre-resolved ID).
-    const app = params.oauthAppId
-      ? { id: params.oauthAppId }
-      : upsertApp(service, clientId);
-
-    // 2. Dual-write client_secret to new key format:
-    //    oauth_app/{app.id}/client_secret
-    if (clientSecret) {
-      await setSecureKeyAsync(
-        `oauth_app/${app.id}/client_secret`,
-        clientSecret,
-      );
-    }
-
-    // 3. Upsert oauth_connection — reuse existing active connection for this
-    //    provider, or create a new one.
-    const existingConn = getConnectionByProvider(service);
-    let connId: string;
-
-    if (existingConn) {
-      connId = existingConn.id;
-      updateConnection(connId, {
-        accountInfo: resolvedAccountInfo,
-        grantedScopes,
-        expiresAt,
-        hasRefreshToken,
-        metadata: rawTokenResponse,
-      });
-    } else {
-      const conn = createConnection({
-        oauthAppId: app.id,
-        providerKey: service,
-        accountInfo: resolvedAccountInfo,
-        grantedScopes,
-        expiresAt,
-        hasRefreshToken,
-        metadata: rawTokenResponse,
-      });
-      connId = conn.id;
-    }
-
-    // 4. Dual-write access_token to new key format:
-    //    oauth_connection/{conn.id}/access_token
-    await setSecureKeyAsync(
-      `oauth_connection/${connId}/access_token`,
-      tokens.accessToken,
-    );
-
-    // 5. Dual-write refresh_token to new key format (if present):
-    //    oauth_connection/{conn.id}/refresh_token
-    if (tokens.refreshToken) {
-      await setSecureKeyAsync(
-        `oauth_connection/${connId}/refresh_token`,
-        tokens.refreshToken,
-      );
-    }
-  } catch (err) {
-    // Non-fatal — legacy stores are already populated above. Log and
-    // continue so the OAuth flow completes successfully.
-    log.warn({ err }, "Failed to dual-write to OAuth SQLite store");
-  }
 }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -13,7 +13,11 @@ import { join } from "node:path";
 import { loadSkillCatalog } from "../../config/skills.js";
 import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
-import { getApp, getConnectionByProvider } from "../../oauth/oauth-store.js";
+import {
+  getApp,
+  getConnectionByProvider,
+  getMostRecentAppByProvider,
+} from "../../oauth/oauth-store.js";
 import {
   getProviderProfile,
   resolveService,
@@ -27,10 +31,6 @@ import {
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
-import {
-  assertMetadataWritable,
-  getCredentialMetadata,
-} from "../../tools/credentials/metadata-store.js";
 import {
   type ManifestOverride,
   resolveExecutionTarget,
@@ -158,45 +158,35 @@ async function handleOAuthConnectStart(body: {
   service?: string;
   requestedScopes?: string[];
 }): Promise<Response> {
-  try {
-    assertMetadataWritable();
-  } catch {
-    return httpError(
-      "UNPROCESSABLE_ENTITY",
-      "Credential metadata file has an unrecognized version. Cannot store OAuth credentials.",
-      422,
-    );
-  }
-
   if (!body.service) {
     return httpError("BAD_REQUEST", "Missing required field: service", 400);
   }
 
   const resolvedService = resolveService(body.service);
 
-  // Prefer oauth-store for client_id, fall back to metadata-store.
+  // Resolve client_id and client_secret from oauth-store.
   let clientId: string | undefined;
-  try {
-    const conn = getConnectionByProvider(resolvedService);
-    if (conn) {
-      const app = getApp(conn.oauthAppId);
-      if (app) clientId = app.clientId;
+  let clientSecret: string | undefined;
+
+  // Try existing connection first (re-auth flow)
+  const conn = getConnectionByProvider(resolvedService);
+  if (conn) {
+    const app = getApp(conn.oauthAppId);
+    if (app) {
+      clientId = app.clientId;
+      clientSecret = getSecureKey(`oauth_app/${app.id}/client_secret`);
     }
-  } catch {
-    // DB not ready — fall through to metadata-store
   }
 
+  // Fall back to most recent app for this provider (first-time connect with stored app)
   if (!clientId) {
-    clientId = getCredentialMetadata(
-      resolvedService,
-      "access_token",
-    )?.oauth2ClientId;
-  }
-  if (!clientId && resolvedService !== body.service) {
-    clientId = getCredentialMetadata(
-      body.service,
-      "access_token",
-    )?.oauth2ClientId;
+    const dbApp = getMostRecentAppByProvider(resolvedService);
+    if (dbApp) {
+      clientId = dbApp.clientId;
+      if (!clientSecret) {
+        clientSecret = getSecureKey(`oauth_app/${dbApp.id}/client_secret`);
+      }
+    }
   }
 
   if (!clientId) {
@@ -207,7 +197,9 @@ async function handleOAuthConnectStart(body: {
     );
   }
 
-  const clientSecret = getClientSecret(resolvedService, body.service);
+  if (!clientSecret) {
+    clientSecret = getClientSecret(resolvedService, body.service);
+  }
 
   const profile = getProviderProfile(resolvedService);
   const requiresSecret =

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -1,11 +1,10 @@
 /**
- * Metadata-driven token manager for OAuth2 credentials.
+ * Token manager for OAuth2 credentials.
  *
- * Reads refresh configuration (tokenUrl, clientId, authMethod) from the
- * new SQLite oauth-store (provider + app + connection rows) when available,
- * falling back to the legacy credential metadata store. After a successful
- * refresh, dual-writes tokens to both old and new key paths and updates
- * the oauth_connection row.
+ * Reads refresh configuration (tokenUrl, clientId, authMethod) exclusively
+ * from the SQLite oauth-store (provider + app + connection rows). After a
+ * successful refresh, writes tokens to new-format secure key paths and
+ * updates the oauth_connection row.
  */
 
 import {
@@ -14,10 +13,6 @@ import {
   getProvider,
   updateConnection,
 } from "../oauth/oauth-store.js";
-import {
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import { credentialKey, migrateKeys } from "./credential-key.js";
 import { refreshOAuth2Token, type TokenEndpointAuthMethod } from "./oauth2.js";
@@ -164,12 +159,17 @@ export class TokenExpiredError extends Error {
 
 /**
  * Check whether the access token for a service is expired or will expire
- * within the buffer window, based on the `expiresAt` field in credential metadata.
+ * within the buffer window, based on the `expiresAt` field in the
+ * oauth_connection row.
  */
 function isTokenExpired(service: string): boolean {
-  const meta = getCredentialMetadata(service, "access_token");
-  if (!meta?.expiresAt) return false;
-  return Date.now() >= meta.expiresAt - EXPIRY_BUFFER_MS;
+  try {
+    const conn = getConnectionByProvider(service);
+    if (!conn?.expiresAt) return false;
+    return Date.now() >= conn.expiresAt - EXPIRY_BUFFER_MS;
+  } catch {
+    return false;
+  }
 }
 
 // ── Refresh config resolution ─────────────────────────────────────────
@@ -182,45 +182,55 @@ interface RefreshConfig {
   secret?: string;
   refreshToken?: string;
   authMethod?: TokenEndpointAuthMethod;
+  connId: string;
 }
 
 /**
- * Resolve refresh configuration from the new SQLite oauth-store.
+ * Resolve refresh configuration from the SQLite oauth-store.
  *
  * Looks up connection -> app -> provider to read tokenUrl, clientId, and
- * authMethod. Returns undefined if the connection is not found in the
- * new store (caller falls back to metadata-store).
+ * authMethod. Throws `TokenExpiredError` if the connection is not found
+ * or incomplete.
  */
-function resolveRefreshConfigFromOAuthStore(
-  service: string,
-): (RefreshConfig & { connId: string }) | undefined {
-  let conn;
-  try {
-    conn = getConnectionByProvider(service);
-  } catch {
-    return undefined;
+function resolveRefreshConfig(service: string): RefreshConfig {
+  const conn = getConnectionByProvider(service);
+  if (!conn) {
+    throw new TokenExpiredError(
+      service,
+      `No OAuth connection found for "${service}". Re-authorization required.${recoveryHint(service)}`,
+    );
   }
-  if (!conn) return undefined;
 
   const app = getApp(conn.oauthAppId);
-  if (!app) return undefined;
+  if (!app) {
+    throw new TokenExpiredError(
+      service,
+      `No OAuth app found for "${service}". Re-authorization required.${recoveryHint(service)}`,
+    );
+  }
 
   const provider = getProvider(conn.providerKey);
-  if (!provider) return undefined;
+  if (!provider) {
+    throw new TokenExpiredError(
+      service,
+      `No OAuth provider found for "${service}". Re-authorization required.${recoveryHint(service)}`,
+    );
+  }
 
   const tokenUrl = provider.tokenUrl;
   const clientId = app.clientId;
-  if (!tokenUrl || !clientId) return undefined;
+  if (!tokenUrl || !clientId) {
+    throw new TokenExpiredError(
+      service,
+      `Missing OAuth2 refresh config for "${service}".${recoveryHint(service)}`,
+    );
+  }
 
-  // Read client secret from new key format, falling back to legacy key.
-  const secret =
-    getSecureKey(`oauth_app/${app.id}/client_secret`) ??
-    getSecureKey(credentialKey(service, "client_secret"));
+  const secret = getSecureKey(`oauth_app/${app.id}/client_secret`);
 
-  // Read refresh_token from new key format, falling back to legacy key.
-  const refreshToken =
-    getSecureKey(`oauth_connection/${conn.id}/refresh_token`) ??
-    getSecureKey(credentialKey(service, "refresh_token"));
+  const refreshToken = getSecureKey(
+    `oauth_connection/${conn.id}/refresh_token`,
+  );
 
   const authMethod = provider.tokenEndpointAuthMethod as
     | TokenEndpointAuthMethod
@@ -237,71 +247,18 @@ function resolveRefreshConfigFromOAuthStore(
 }
 
 /**
- * Resolve refresh configuration from the legacy credential metadata store.
- *
- * Throws `TokenExpiredError` when the metadata is incomplete (missing
- * tokenUrl or clientId), since there is no fallback beyond this.
- */
-function resolveRefreshConfigFromMetadataStore(service: string): RefreshConfig {
-  const refreshToken = getSecureKey(credentialKey(service, "refresh_token"));
-
-  const meta = getCredentialMetadata(service, "access_token");
-  const tokenUrl = meta?.oauth2TokenUrl ?? "";
-  const clientId = meta?.oauth2ClientId ?? "";
-
-  if (!tokenUrl || !clientId) {
-    if (!refreshToken) {
-      throw new TokenExpiredError(
-        service,
-        `No refresh token available for "${service}". Re-authorization required.${recoveryHint(service)}`,
-      );
-    }
-    // Legacy credentials created by the old integration flow don't store
-    // oauth2TokenUrl/oauth2ClientId in metadata. The client ID is user-specific
-    // (from their Google Cloud Console) and cannot be recovered, so the only
-    // path forward is re-authorization via the new oauth2_connect flow.
-    const isLegacy = service === "integration:gmail" && !tokenUrl && !clientId;
-    const hint = isLegacy
-      ? ` This is a one-time migration: your old Gmail connection needs to be re-authorized. Ask me to "reconnect Gmail" to set it up again.`
-      : "";
-    throw new TokenExpiredError(
-      service,
-      `Missing OAuth2 refresh config for "${service}".${hint}${recoveryHint(service)}`,
-    );
-  }
-
-  const secret = getSecureKey(credentialKey(service, "client_secret"));
-
-  return {
-    tokenUrl,
-    clientId,
-    secret,
-    refreshToken,
-    authMethod: meta?.oauth2TokenEndpointAuthMethod as
-      | TokenEndpointAuthMethod
-      | undefined,
-  };
-}
-
-/**
  * Attempt to refresh the OAuth2 access token for a service.
  *
- * Tries the new SQLite oauth-store first for refresh config (provider,
- * app, connection). Falls back to the legacy metadata-store when the
- * connection is not found in the new store.
+ * Reads refresh config exclusively from the SQLite oauth-store (provider,
+ * app, connection).
  *
  * Returns the new access token on success.
  * Throws `TokenExpiredError` if refresh is not possible.
  */
 async function doRefresh(service: string): Promise<string> {
-  // ----- Resolve refresh config: new store first, legacy fallback -----
-  const oauthStoreConfig = resolveRefreshConfigFromOAuthStore(service);
-  const refreshConfig =
-    oauthStoreConfig ?? resolveRefreshConfigFromMetadataStore(service);
-
-  const { tokenUrl, clientId, secret, authMethod } = refreshConfig;
-  const connId = oauthStoreConfig?.connId;
-  const refreshToken = refreshConfig.refreshToken;
+  const refreshConfig = resolveRefreshConfig(service);
+  const { tokenUrl, clientId, secret, authMethod, connId, refreshToken } =
+    refreshConfig;
 
   if (!refreshToken) {
     throw new TokenExpiredError(
@@ -320,10 +277,7 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  log.info(
-    { service, source: connId ? "oauth-store" : "metadata-store" },
-    "Refreshing OAuth2 access token",
-  );
+  log.info({ service }, "Refreshing OAuth2 access token");
 
   let result;
   try {
@@ -349,10 +303,10 @@ async function doRefresh(service: string): Promise<string> {
     throw err;
   }
 
-  // ----- Store refreshed access_token (legacy path) -----
+  // ----- Store refreshed access_token -----
   if (
     !(await setSecureKeyAsync(
-      credentialKey(service, "access_token"),
+      `oauth_connection/${connId}/access_token`,
       result.accessToken,
     ))
   ) {
@@ -362,19 +316,10 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  // ----- Dual-write access_token to new key format -----
-  if (connId) {
-    await setSecureKeyAsync(
-      `oauth_connection/${connId}/access_token`,
-      result.accessToken,
-    );
-  }
-
   if (result.refreshToken) {
-    // ----- Store refreshed refresh_token (legacy path) -----
     if (
       !(await setSecureKeyAsync(
-        credentialKey(service, "refresh_token"),
+        `oauth_connection/${connId}/refresh_token`,
         result.refreshToken,
       ))
     ) {
@@ -383,17 +328,9 @@ async function doRefresh(service: string): Promise<string> {
         `Failed to store refreshed refresh token for "${service}".`,
       );
     }
-
-    // ----- Dual-write refresh_token to new key format -----
-    if (connId) {
-      await setSecureKeyAsync(
-        `oauth_connection/${connId}/refresh_token`,
-        result.refreshToken,
-      );
-    }
   }
 
-  // Update metadata with new expiry.
+  // Update oauth_connection row with new expiry.
   // Use null to explicitly clear a stale expiresAt when the provider omits
   // expires_in (or returns 0), so isTokenExpired won't keep forcing refreshes.
   const expiresAt =
@@ -401,21 +338,16 @@ async function doRefresh(service: string): Promise<string> {
       ? Date.now() + result.expiresIn * 1000
       : null;
 
-  upsertCredentialMetadata(service, "access_token", { expiresAt });
-
-  // ----- Update oauth_connection row after successful refresh -----
-  if (connId) {
-    try {
-      updateConnection(connId, {
-        expiresAt: expiresAt ?? undefined,
-        hasRefreshToken: !!result.refreshToken,
-      });
-    } catch (err) {
-      log.warn(
-        { err, service },
-        "Failed to update oauth_connection after refresh",
-      );
-    }
+  try {
+    updateConnection(connId, {
+      expiresAt: expiresAt ?? undefined,
+      hasRefreshToken: !!result.refreshToken,
+    });
+  } catch (err) {
+    log.warn(
+      { err, service },
+      "Failed to update oauth_connection after refresh",
+    );
   }
 
   recordRefreshSuccess(service);

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -37,50 +37,6 @@ import { toPolicyFromInput, validatePolicyInput } from "./policy-validate.js";
 
 const log = getLogger("credential-vault");
 
-/**
- * Look up a stored OAuth secret (e.g. client_secret) for a service from the
- * secure store. Checks both the canonical and alias service names.
- */
-function findStoredOAuthSecret(
-  service: string,
-  field: string,
-): string | undefined {
-  const servicesToCheck = [service];
-  // Also check the alias if the input is the canonical name, or vice versa
-  for (const [alias, canonical] of Object.entries(SERVICE_ALIASES)) {
-    if (canonical === service) servicesToCheck.push(alias);
-    if (alias === service) servicesToCheck.push(canonical);
-  }
-  for (const svc of servicesToCheck) {
-    const value = getSecureKey(credentialKey(svc, field));
-    if (value) return value;
-  }
-  return undefined;
-}
-
-/**
- * Look up the stored OAuth client_id for a service from credential metadata.
- * Checks both the canonical and alias service names.
- */
-function findStoredOAuthClientId(service: string): string | undefined {
-  const servicesToCheck = [service];
-  for (const [alias, canonical] of Object.entries(SERVICE_ALIASES)) {
-    if (canonical === service) servicesToCheck.push(alias);
-    if (alias === service) servicesToCheck.push(canonical);
-  }
-  // Check metadata first (written by oauth2_connect after successful auth)
-  for (const svc of servicesToCheck) {
-    const meta = getCredentialMetadata(svc, "access_token");
-    if (meta?.oauth2ClientId) return meta.oauth2ClientId;
-  }
-  // Fall back to secure key store (written by credential_store prompt action)
-  for (const svc of servicesToCheck) {
-    const value = getSecureKey(credentialKey(svc, "client_id"));
-    if (value) return value;
-  }
-  return undefined;
-}
-
 class CredentialStoreTool implements Tool {
   name = "credential_store";
   description =
@@ -785,34 +741,19 @@ class CredentialStoreTool implements Tool {
         // Priority:
         //   1. Explicit input from the caller
         //   2. oauth-store DB (most recent app for this provider)
-        //   3. Legacy metadata-store / secure key store
         let clientId = input.client_id as string | undefined;
         let clientSecret = input.client_secret as string | undefined;
 
         if (!clientId || !clientSecret) {
-          // Try the oauth-store DB first
-          try {
-            const dbApp = getMostRecentAppByProvider(service);
-            if (dbApp) {
-              if (!clientId) clientId = dbApp.clientId;
-              if (!clientSecret) {
-                clientSecret = getSecureKey(
-                  `oauth_app/${dbApp.id}/client_secret`,
-                );
-              }
+          const dbApp = getMostRecentAppByProvider(service);
+          if (dbApp) {
+            if (!clientId) clientId = dbApp.clientId;
+            if (!clientSecret) {
+              clientSecret = getSecureKey(
+                `oauth_app/${dbApp.id}/client_secret`,
+              );
             }
-          } catch (err) {
-            // DB may not be initialized yet — fall through to legacy lookup
-            log.debug(
-              { err, service },
-              "oauth-store lookup failed, falling back to metadata store",
-            );
           }
-
-          // Fall back to legacy metadata-store / secure key store
-          if (!clientId) clientId = findStoredOAuthClientId(service);
-          if (!clientSecret)
-            clientSecret = findStoredOAuthSecret(service, "client_secret");
         }
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
@@ -869,16 +810,6 @@ class CredentialStoreTool implements Tool {
             : '\n\nUse credential_store with action "prompt" to securely collect the client_secret from the user before calling oauth2_connect again.';
           return {
             content: `Error: client_secret is required for ${rawService} but not found in the vault.${skillHint}`,
-            isError: true,
-          };
-        }
-
-        try {
-          assertMetadataWritable();
-        } catch {
-          return {
-            content:
-              "Error: credential metadata file has an unrecognized version; cannot store credentials",
             isError: true,
           };
         }


### PR DESCRIPTION
## Summary
- Remove upsertCredentialMetadata() calls for OAuth credentials in token-persistence
- Remove legacy secure key path dual-writes (credential/{service}/...)
- Remove metadata-store fallbacks in token-manager, connection-resolver, vault, and settings-routes
- OAuth credentials now exclusively use oauth-store + new secure key paths
- Non-OAuth credentials (API keys, manual secrets) still use metadata-store

Part of plan: oauth-sqlite-migration.md (PR 16 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
