### PR TITLE
fix: restore VELLUM_DAEMON_NOAUTH and VELLUM_DATA_DIR in KNOWN_VELLUM_VARS

### DIFF
--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -62,6 +62,8 @@ export function getIsContainerized(): boolean {
  */
 const KNOWN_VELLUM_VARS = new Set([
   "VELLUM_DAEMON_AUTOSTART",
+  "VELLUM_DAEMON_NOAUTH",
+  "VELLUM_DATA_DIR",
   "VELLUM_HOOK_EVENT",
   "VELLUM_HOOK_NAME",
   "VELLUM_HOOK_SETTINGS",


### PR DESCRIPTION
## Summary
Fixes gap: VELLUM_DAEMON_NOAUTH and VELLUM_DATA_DIR were removed from KNOWN_VELLUM_VARS but are still actively used, causing false unrecognized env var warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
