### PR TITLE
fix: update tests for GATEWAY_INTERNAL_BASE_URL env var removal

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -501,8 +501,8 @@ describe("host_bash — environment setup", () => {
   });
 
   test("injects INTERNAL_GATEWAY_BASE_URL for host_bash commands", async () => {
-    const originalGatewayBase = process.env.GATEWAY_INTERNAL_BASE_URL;
-    process.env.GATEWAY_INTERNAL_BASE_URL = "http://gateway.internal:9000/";
+    const originalGatewayPort = process.env.GATEWAY_PORT;
+    process.env.GATEWAY_PORT = "9000";
     try {
       const result = await hostShellTool.execute(
         {
@@ -511,12 +511,12 @@ describe("host_bash — environment setup", () => {
         makeContext(),
       );
       expect(result.isError).toBe(false);
-      expect(result.content.trim()).toBe("http://gateway.internal:9000");
+      expect(result.content.trim()).toBe("http://127.0.0.1:9000");
     } finally {
-      if (originalGatewayBase === undefined) {
-        delete process.env.GATEWAY_INTERNAL_BASE_URL;
+      if (originalGatewayPort === undefined) {
+        delete process.env.GATEWAY_PORT;
       } else {
-        process.env.GATEWAY_INTERNAL_BASE_URL = originalGatewayBase;
+        process.env.GATEWAY_PORT = originalGatewayPort;
       }
     }
   });
@@ -695,7 +695,11 @@ describe("host_bash — spawn error handling", () => {
 describe("host_bash — proxy delegation", () => {
   function makeMockProxy(result: ToolExecutionResult) {
     const calls: Array<{
-      input: { command: string; working_dir?: string; timeout_seconds?: number };
+      input: {
+        command: string;
+        working_dir?: string;
+        timeout_seconds?: number;
+      };
       sessionId: string;
     }> = [];
 
@@ -703,7 +707,11 @@ describe("host_bash — proxy delegation", () => {
       proxy: {
         isAvailable: () => true,
         request: async (
-          input: { command: string; working_dir?: string; timeout_seconds?: number },
+          input: {
+            command: string;
+            working_dir?: string;
+            timeout_seconds?: number;
+          },
           sessionId: string,
           _signal?: AbortSignal,
         ) => {
@@ -748,7 +756,10 @@ describe("host_bash — proxy delegation", () => {
   });
 
   test("still validates input before proxying (null bytes in command)", async () => {
-    const proxyResult: ToolExecutionResult = { content: "proxied", isError: false };
+    const proxyResult: ToolExecutionResult = {
+      content: "proxied",
+      isError: false,
+    };
     const { proxy, calls } = makeMockProxy(proxyResult);
 
     const ctx: ToolContext = {
@@ -756,10 +767,7 @@ describe("host_bash — proxy delegation", () => {
       hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
     };
 
-    const result = await hostShellTool.execute(
-      { command: "echo \0evil" },
-      ctx,
-    );
+    const result = await hostShellTool.execute({ command: "echo \0evil" }, ctx);
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("null bytes");
@@ -768,7 +776,10 @@ describe("host_bash — proxy delegation", () => {
   });
 
   test("still validates input before proxying (relative working_dir)", async () => {
-    const proxyResult: ToolExecutionResult = { content: "proxied", isError: false };
+    const proxyResult: ToolExecutionResult = {
+      content: "proxied",
+      isError: false,
+    };
     const { proxy, calls } = makeMockProxy(proxyResult);
 
     const ctx: ToolContext = {
@@ -803,7 +814,8 @@ describe("host_bash — proxy delegation", () => {
 
     const ctx: ToolContext = {
       ...makeContext(),
-      hostBashProxy: unavailableProxy as unknown as ToolContext["hostBashProxy"],
+      hostBashProxy:
+        unavailableProxy as unknown as ToolContext["hostBashProxy"],
     };
 
     spawnCalls.length = 0;

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -457,10 +457,10 @@ describe("buildSanitizedEnv", () => {
   });
 
   test("injects INTERNAL_GATEWAY_BASE_URL from gateway config", () => {
-    process.env.GATEWAY_INTERNAL_BASE_URL = "http://gateway.internal:9000/";
+    process.env.GATEWAY_PORT = "9000";
     const env = buildSanitizedEnv();
-    expect(env.INTERNAL_GATEWAY_BASE_URL).toBe("http://gateway.internal:9000");
-    delete process.env.GATEWAY_INTERNAL_BASE_URL;
+    expect(env.INTERNAL_GATEWAY_BASE_URL).toBe("http://127.0.0.1:9000");
+    delete process.env.GATEWAY_PORT;
   });
 
   test("result is a plain object with no prototype-inherited secrets", () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-legacy-env-vars.md.

**Gap:** Test assertions for GATEWAY_INTERNAL_BASE_URL will fail
**What was expected:** Tests should use GATEWAY_PORT to configure the gateway URL
**What was found:** Tests still set the removed GATEWAY_INTERNAL_BASE_URL env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
