### PR TITLE
fix: remove dead assistantId parameter from startGateway

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -777,7 +777,7 @@ async function hatchLocal(
 
   let runtimeUrl: string;
   try {
-    runtimeUrl = await startGateway(instanceName, watch, resources);
+    runtimeUrl = await startGateway(watch, resources);
   } catch (error) {
     // Gateway failed — stop the daemon we just started so we don't leave
     // orphaned processes with no lock file entry.

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -69,7 +69,7 @@ export async function recover(): Promise<void> {
   // 7. Start daemon + gateway (same as wake)
   await startLocalDaemon(false, entry.resources);
   if (!process.env.VELLUM_DESKTOP_APP) {
-    await startGateway(undefined, false, entry.resources);
+    await startGateway(false, entry.resources);
   }
 
   console.log(`✅ Recovered assistant '${name}'.`);

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -87,12 +87,12 @@ export async function wake(): Promise<void> {
           `Gateway running (pid ${pid}) — restarting in watch mode...`,
         );
         await stopProcessByPidFile(gatewayPidFile, "gateway");
-        await startGateway(undefined, watch, resources);
+        await startGateway(watch, resources);
       } else {
         console.log(`Gateway already running (pid ${pid}).`);
       }
     } else {
-      await startGateway(undefined, watch, resources);
+      await startGateway(watch, resources);
     }
   }
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -741,7 +741,6 @@ export async function startLocalDaemon(
 }
 
 export async function startGateway(
-  assistantId?: string,
   watch: boolean = false,
   resources?: LocalInstanceResources,
 ): Promise<string> {


### PR DESCRIPTION
## Summary
Fixes gap: assistantId parameter left in startGateway() after all consumers were removed. Removes the dead parameter and updates all callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
