### PR TITLE
fix: restore $INTERNAL_GATEWAY_BASE_URL in public-ingress SKILL.md

### DIFF
--- a/skills/public-ingress/SKILL.md
+++ b/skills/public-ingress/SKILL.md
@@ -30,7 +30,7 @@ assistant config get ingress.publicBaseUrl
 assistant config get ingress.enabled
 ```
 
-Resolve the local gateway URL by running `assistant config get gateway.internalBaseUrl` (defaults to `http://127.0.0.1:7830`).
+The local gateway URL is available as the `$INTERNAL_GATEWAY_BASE_URL` environment variable (defaults to `http://127.0.0.1:7830`).
 
 The commands return:
 
@@ -118,11 +118,10 @@ pkill -f ngrok || true
 sleep 1
 ```
 
-Resolve the local gateway URL first using `assistant config get gateway.internalBaseUrl`, then start ngrok in the background tunneling to that URL:
+Start ngrok in the background tunneling to the local gateway URL:
 
 ```bash
-GATEWAY_URL=$(assistant config get gateway.internalBaseUrl)
-nohup ngrok http "$GATEWAY_URL" --log=stdout > /tmp/ngrok.log 2>&1 &
+nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &
 echo $! > /tmp/ngrok.pid
 ```
 
@@ -159,7 +158,7 @@ print(match.group(1))
 ```
 
 ```bash
-assistant config get gateway.internalBaseUrl | grep -oE '[0-9]+$'
+echo "$INTERNAL_GATEWAY_BASE_URL" | grep -oE '[0-9]+$'
 ```
 
 Compare the two port numbers. If they differ, warn the user:
@@ -215,14 +214,14 @@ assistant config get ingress.enabled
 Summarize the setup:
 
 - **Public URL:** `<the-url>` (this is your `ingress.publicBaseUrl`)
-- **Local gateway target:** (the URL from `assistant config get gateway.internalBaseUrl`)
+- **Local gateway target:** `$INTERNAL_GATEWAY_BASE_URL`
 - **ngrok dashboard:** http://127.0.0.1:4040
 
 Provide useful follow-up commands:
 
 - **Check tunnel status:** `curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "import sys,json; [print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]"`
 - **View ngrok logs:** `cat /tmp/ngrok.log`
-- **Restart tunnel:** `pkill -f ngrok; sleep 1; GATEWAY_URL=$(assistant config get gateway.internalBaseUrl); nohup ngrok http "$GATEWAY_URL" --log=stdout > /tmp/ngrok.log 2>&1 &`
+- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "$INTERNAL_GATEWAY_BASE_URL" --log=stdout > /tmp/ngrok.log 2>&1 &`
 - **Stop tunnel:** `pkill -f ngrok`
 - **Rotate URL:** Stop and restart ngrok (free tier assigns a new URL each time; update `ingress.publicBaseUrl` afterward)
 
@@ -244,7 +243,7 @@ The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not r
 
 ### Gateway not reachable on local target
 
-Re-check the local gateway target with `assistant config get gateway.internalBaseUrl`. Run `curl -s "$(assistant config get gateway.internalBaseUrl)/healthz"` to verify it is reachable. If the gateway is not running, start the assistant first.
+Re-check the local gateway target with `echo $INTERNAL_GATEWAY_BASE_URL`. Run `curl -s "$INTERNAL_GATEWAY_BASE_URL/healthz"` to verify it is reachable. If the gateway is not running, start the assistant first.
 
 ### "Too many connections" or tunnel limit errors
 
@@ -256,7 +255,7 @@ ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels befo
 
 **Cause:** ngrok is forwarding to a different port than the gateway is listening on. This can happen if the gateway port was changed after ngrok was started, or if ngrok was started manually with a hardcoded port.
 
-**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway URL with `assistant config get gateway.internalBaseUrl`, then re-run this skill to start ngrok on the correct port.
+**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway URL with `echo $INTERNAL_GATEWAY_BASE_URL`, then re-run this skill to start ngrok on the correct port.
 
 ### ngrok automatically restarts with wrong port
 


### PR DESCRIPTION
## Summary
Fixes gap: SKILL.md replaced $INTERNAL_GATEWAY_BASE_URL with non-existent config key gateway.internalBaseUrl. The env var is still injected by safe-env.ts and is the correct pattern per gateway/CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
