### PR TITLE
fix: preserve committed feature-flag-registry.json in tests

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -64,9 +64,18 @@ const TEST_REGISTRY = {
 
 const savedBaseDataDir = process.env.BASE_DATA_DIR;
 
+// Save the original committed registry contents so we can restore after tests
+let originalRegistryContents: string | null = null;
+
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
   mkdirSync(workspaceDir, { recursive: true });
+  // Preserve the original committed file before overwriting with test data
+  try {
+    originalRegistryContents = readFileSync(defaultsPath, "utf-8");
+  } catch {
+    originalRegistryContents = null;
+  }
   writeFileSync(defaultsPath, JSON.stringify(TEST_REGISTRY, null, 2));
   resetFeatureFlagDefaultsCache();
 });
@@ -82,9 +91,11 @@ afterEach(() => {
   } catch {
     // best effort cleanup
   }
-  // Clean up the test registry file placed next to gateway source
+  // Restore the original committed registry file instead of deleting it
   try {
-    rmSync(defaultsPath, { force: true });
+    if (originalRegistryContents !== null) {
+      writeFileSync(defaultsPath, originalRegistryContents);
+    }
   } catch {
     // best effort cleanup
   }


### PR DESCRIPTION
## Summary
Fixes gap: feature-flags-route test was deleting committed feature-flag-registry.json file, risking flaky parallel test failures. Now saves and restores the original file contents instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
