### PR TITLE
fix: remove stale env var references from documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ GET /v1/assistants/:assistantId/attachments/:attachmentId
 
 ### Telegram
 
-The gateway downloads attachments from the runtime API and delivers them via Telegram's `sendPhoto` (images) or `sendDocument` (other files). Oversized attachments (exceeding `GATEWAY_MAX_ATTACHMENT_BYTES`, default 20 MB) are skipped. Partial failures send a user-visible notice listing undelivered files.
+The gateway downloads attachments from the runtime API and delivers them via Telegram's `sendPhoto` (images) or `sendDocument` (other files). Oversized attachments (exceeding 20 MB) are skipped. Partial failures send a user-visible notice listing undelivered files.
 
 ### Attachment Sources
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -468,7 +468,7 @@ A complementary access-granting flow where the guardian proactively creates a sh
 
 | Channel  | Status   | Prerequisites                                                                                                                                                 |
 | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Telegram | Shipped  | Bot username resolved from credential metadata or `TELEGRAM_BOT_USERNAME` env                                                                                 |
+| Telegram | Shipped  | Bot username resolved from credential metadata or config                                                                                                      |
 | Voice    | Shipped  | Identity-bound voice code redemption via DTMF/speech in the relay state machine. Always-on canonical behavior with personalized friend/guardian name prompts. |
 | Slack    | Deferred | Needs DM-safe ingress — Socket Mode handles channel messages but DM-initiated invite flows need routing                                                       |
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -241,12 +241,9 @@ The per-assistant mapping is propagated to the gateway via the config file watch
 
 ### Phone Number Resolution Order
 
-At runtime, `getTwilioConfig()` resolves the phone number using this priority chain:
+At runtime, `getTwilioConfig()` resolves the phone number from **`twilio.phoneNumber` in config** — the primary source of truth, written by `provision_number` and `assign_number`.
 
-1. **`TWILIO_PHONE_NUMBER` env var** — highest priority, explicit override for dev/CI.
-2. **`twilio.phoneNumber` in config** — the primary source of truth, written by `provision_number` and `assign_number`.
-
-If no number is found after both sources, an error is thrown.
+If no number is found, an error is thrown.
 
 ### Assistant-Scoped Guardian State
 

--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -3,9 +3,9 @@
 Operational procedures for inspecting, managing, and debugging the trusted contact access flow. HTTP commands use the assistant runtime API (default `http://localhost:7821`) with bearer authentication.
 
 > **Note:** The `/v1/contacts` endpoints are served by the assistant runtime, not
-> the gateway. If you prefer to route through the gateway (`localhost:7830`), set
-> `GATEWAY_RUNTIME_PROXY_ENABLED=true` in the gateway environment — the proxy is
-> disabled by default and these routes will 404 without it.
+> the gateway. If you prefer to route through the gateway (`localhost:7830`), enable
+> the runtime proxy in the gateway config — it is disabled by default and these
+> routes will 404 without it.
 
 ## Prerequisites
 

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -9,10 +9,7 @@ import {
   removeAssistantEntry,
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
-import {
-  getPlatformUrl,
-  readPlatformToken,
-} from "../lib/platform-client";
+import { getPlatformUrl, readPlatformToken } from "../lib/platform-client";
 import { retireInstance as retireAwsInstance } from "../lib/aws";
 import { retireDocker } from "../lib/docker";
 import { retireInstance as retireGcpInstance } from "../lib/gcp";
@@ -83,7 +80,7 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon");
 
   // Stop gateway via PID file — use a longer timeout because the gateway has a
-  // configurable drain window (GATEWAY_SHUTDOWN_DRAIN_MS, default 5s) before it exits.
+  // drain window (5s) before it exits.
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
 

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -120,7 +120,7 @@ export async function sleep(): Promise<void> {
   }
 
   // Stop gateway — use a longer timeout because the gateway has a configurable
-  // drain window (GATEWAY_SHUTDOWN_DRAIN_MS, default 5s) before it exits.
+  // drain window (5s) before it exits.
   const gatewayStopped = await stopProcessByPidFile(
     gatewayPidFile,
     "gateway",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1836,7 +1836,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Runtime proxy",
           description:
-            "Reverse-proxies requests to the assistant runtime when GATEWAY_RUNTIME_PROXY_ENABLED is true. Supports all HTTP methods. Returns 404 when the proxy is disabled.",
+            "Reverse-proxies requests to the assistant runtime when the runtime proxy is enabled. Supports all HTTP methods. Returns 404 when the proxy is disabled.",
           operationId: "runtimeProxyGet",
           security: [{ BearerAuth: [] }],
           parameters: [
@@ -1898,7 +1898,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Runtime proxy",
           description:
-            "Reverse-proxies requests to the assistant runtime when GATEWAY_RUNTIME_PROXY_ENABLED is true.",
+            "Reverse-proxies requests to the assistant runtime when the runtime proxy is enabled.",
           operationId: "runtimeProxyPost",
           security: [{ BearerAuth: [] }],
           parameters: [


### PR DESCRIPTION
## Summary
Fixes gap: Multiple documentation files and code comments still reference removed env vars (TELEGRAM_BOT_USERNAME, TWILIO_PHONE_NUMBER, GATEWAY_MAX_ATTACHMENT_BYTES, GATEWAY_RUNTIME_PROXY_ENABLED, GATEWAY_SHUTDOWN_DRAIN_MS, VELLUM_KEYCHAIN_BROKER_SOCKET).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
