### PR TITLE
fix: remove dead VELLUM_DEBUG references from macOS app and hook template

### DIFF
--- a/assistant/hook-templates/debug-prompt-logger/hook.json
+++ b/assistant/hook-templates/debug-prompt-logger/hook.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-prompt-logger",
-  "description": "Logs system prompt and conversation history to stderr when VELLUM_DEBUG=1",
+  "description": "Logs system prompt and conversation history to stderr before each LLM call",
   "version": "1.0.0",
   "events": ["pre-llm-call"],
   "script": "run.sh"

--- a/assistant/hook-templates/debug-prompt-logger/run.sh
+++ b/assistant/hook-templates/debug-prompt-logger/run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # Debug Prompt Logger — prints the system prompt and conversation
-# history before each LLM call. Only active when VELLUM_DEBUG=1.
-
-[ "$VELLUM_DEBUG" != "1" ] && exit 0
+# history before each LLM call. Runs whenever the hook is installed.
 
 data=$(cat)
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -181,7 +181,7 @@ final class AssistantCli {
                 "PATH": fullEnv["PATH"] ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
                 "VELLUM_DESKTOP_APP": "1",
             ]
-            for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
+            for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR",
                         "SENTRY_DSN", "TMPDIR", "USER", "LANG",
                         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
                         "GOOGLE_APPLICATION_CREDENTIALS", "GCP_ACCOUNT_EMAIL",
@@ -661,7 +661,7 @@ final class AssistantCli {
                 "VELLUM_DESKTOP_APP": "1",
             ]
             // Forward optional config vars the CLI or daemon may need
-            for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR", "VELLUM_DEBUG",
+            for key in ["ANTHROPIC_API_KEY", "BASE_DATA_DIR",
                         "VELLUM_PLATFORM_URL",
                         "SENTRY_DSN", "TMPDIR", "USER", "LANG"] {
                 if let val = fullEnv[key] {


### PR DESCRIPTION
## Summary
Fixes gap: VELLUM_DEBUG was removed from env-registry but still referenced in macOS app env forwarding and hook template gating.

- Remove VELLUM_DEBUG from two env-forwarding arrays in AssistantCli.swift
- Remove the VELLUM_DEBUG=1 guard in debug-prompt-logger/run.sh (hook now runs whenever installed)
- Update hook.json description to no longer mention VELLUM_DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
