### PR TITLE
Add migration to delete legacy secure key paths for OAuth credentials

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -40,7 +40,10 @@ import {
   emitNotificationSignal,
   registerBroadcastFn,
 } from "../notifications/emit-signal.js";
-import { migrateOAuthCredentialsToSqlite } from "../oauth/migrate-to-sqlite.js";
+import {
+  cleanupLegacyOAuthKeys,
+  migrateOAuthCredentialsToSqlite,
+} from "../oauth/migrate-to-sqlite.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
@@ -166,6 +169,8 @@ export async function runDaemon(): Promise<void> {
     seedOAuthProviders();
     // Migrate existing OAuth credentials from metadata-store to SQLite tables
     migrateOAuthCredentialsToSqlite();
+    // Clean up legacy secure keys that were dual-written during migration
+    cleanupLegacyOAuthKeys();
     log.info("Daemon startup: DB initialized");
 
     // Ensure a vellum guardian binding exists and mint the CLI edge token

--- a/assistant/src/oauth/migrate-to-sqlite.ts
+++ b/assistant/src/oauth/migrate-to-sqlite.ts
@@ -15,13 +15,22 @@ import {
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
-import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
+import {
+  deleteSecureKey,
+  getSecureKey,
+  setSecureKey,
+} from "../security/secure-keys.js";
+import {
+  deleteCredentialMetadata,
+  listCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   createConnection,
   getConnectionByProvider,
   getProvider,
+  listApps,
+  listConnections,
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
@@ -165,4 +174,89 @@ function migrateOneCredential(
   }
 
   log.info({ service, connectionId: conn.id }, "Migrated OAuth credential");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Clean up legacy secure keys that were dual-written during migration
+// ---------------------------------------------------------------------------
+
+const CLEANUP_CHECKPOINT_KEY = "migration_cleanup_legacy_oauth_keys_v1";
+
+/**
+ * Delete legacy secure key paths (`credential/{service}/...`) for OAuth
+ * credentials that have been migrated to the SQLite-backed tables. Also
+ * removes the corresponding `CredentialMetadata` records for OAuth services
+ * so the metadata store no longer tracks them.
+ *
+ * Idempotent: checkpoint-guarded, and individual key deletions gracefully
+ * skip keys that are already missing.
+ */
+export function cleanupLegacyOAuthKeys(): void {
+  const checkpoint = getMemoryCheckpoint(CLEANUP_CHECKPOINT_KEY);
+  if (checkpoint != null) {
+    return;
+  }
+
+  // (a) For each oauth_connection, delete legacy access_token and refresh_token keys.
+  const connections = listConnections();
+  for (const conn of connections) {
+    const { providerKey } = conn;
+    try {
+      const legacyAccessKey = credentialKey(providerKey, "access_token");
+      deleteSecureKey(legacyAccessKey);
+
+      const legacyRefreshKey = credentialKey(providerKey, "refresh_token");
+      deleteSecureKey(legacyRefreshKey);
+    } catch (err) {
+      log.warn(
+        { err, providerKey },
+        "Failed to delete legacy connection keys — skipping",
+      );
+    }
+  }
+
+  // (b) For each oauth_app, delete the legacy client_secret key.
+  const apps = listApps();
+  for (const app of apps) {
+    const { providerKey } = app;
+    try {
+      const legacyClientSecretKey = credentialKey(providerKey, "client_secret");
+      deleteSecureKey(legacyClientSecretKey);
+    } catch (err) {
+      log.warn(
+        { err, providerKey },
+        "Failed to delete legacy app key — skipping",
+      );
+    }
+  }
+
+  // (c) Delete CredentialMetadata records for OAuth services.
+  // Collect unique provider keys from connections (these are the OAuth services).
+  const oauthServices = new Set<string>();
+  for (const conn of connections) {
+    oauthServices.add(conn.providerKey);
+  }
+  for (const app of apps) {
+    oauthServices.add(app.providerKey);
+  }
+
+  for (const service of oauthServices) {
+    try {
+      deleteCredentialMetadata(service, "access_token");
+    } catch (err) {
+      log.warn(
+        { err, service },
+        "Failed to delete legacy access_token metadata — skipping",
+      );
+    }
+  }
+
+  if (connections.length > 0 || apps.length > 0) {
+    log.info(
+      { connections: connections.length, apps: apps.length },
+      "Cleaned up legacy OAuth secure keys and metadata",
+    );
+  }
+
+  setMemoryCheckpoint(CLEANUP_CHECKPOINT_KEY, "done");
 }

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -212,6 +212,12 @@ export function getMostRecentAppByProvider(
     .get();
 }
 
+/** Return all OAuth apps. */
+export function listApps(): OAuthAppRow[] {
+  const db = getDb();
+  return db.select().from(oauthApps).all();
+}
+
 /** Delete an app by ID. Returns true if a row was deleted. */
 export function deleteApp(id: string): boolean {
   const db = getDb();


### PR DESCRIPTION
## Summary
- Add cleanupLegacyOAuthKeys() migration to delete legacy credential/{service}/... secure keys
- Delete legacy CredentialMetadata records for OAuth services
- Checkpoint-guarded for idempotency, gracefully skips missing keys

Part of plan: oauth-sqlite-migration.md (PR 17 of 18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
