### PR TITLE
fix: restore gateway runtime proxy config via workspace config

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -4,7 +4,7 @@ Operational procedures for inspecting, managing, and debugging the trusted conta
 
 > **Note:** The `/v1/contacts` endpoints are served by the assistant runtime, not
 > the gateway. If you prefer to route through the gateway (`localhost:7830`), set
-> `GATEWAY_RUNTIME_PROXY_ENABLED=true` in the gateway environment — the proxy is
+> `"gateway": { "runtimeProxyEnabled": true }` in workspace config — the proxy is
 > disabled by default and these routes will 404 without it.
 
 ## Prerequisites

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -133,13 +133,11 @@ ${timestampRedirect}
 trap 'EXIT_CODE=\$?; if [ \$EXIT_CODE -ne 0 ]; then echo "Startup script failed with exit code \$EXIT_CODE at line \$LINENO" > ${errorPath}; echo "Last 20 log lines:" >> ${errorPath}; tail -20 ${logPath} >> ${errorPath} 2>/dev/null || true; fi' EXIT
 ${userSetup}
 ANTHROPIC_API_KEY=${anthropicApiKey}
-GATEWAY_RUNTIME_PROXY_ENABLED=true
 RUNTIME_PROXY_BEARER_TOKEN=${bearerToken}
 VELLUM_ASSISTANT_NAME=${instanceName}
 mkdir -p "\$HOME/.vellum"
 cat > "\$HOME/.vellum/.env" << DOTENV_EOF
 ANTHROPIC_API_KEY=\$ANTHROPIC_API_KEY
-GATEWAY_RUNTIME_PROXY_ENABLED=\$GATEWAY_RUNTIME_PROXY_ENABLED
 RUNTIME_PROXY_BEARER_TOKEN=\$RUNTIME_PROXY_BEARER_TOKEN
 RUNTIME_HTTP_PORT=7821
 DOTENV_EOF
@@ -149,6 +147,11 @@ cat > "\$HOME/.vellum/workspace/config.json" << CONFIG_EOF
 {
   "logFile": {
     "dir": "\$HOME/.vellum/workspace/data/logs"
+  },
+  "gateway": {
+    "runtimeProxyEnabled": true,
+    "unmappedPolicy": "default",
+    "defaultAssistantId": "self"
   }
 }
 CONFIG_EOF

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -251,12 +251,7 @@ export async function hatchDocker(
   ];
 
   // Pass through environment variables the assistant needs
-  for (const envVar of [
-    "ANTHROPIC_API_KEY",
-    "GATEWAY_RUNTIME_PROXY_ENABLED",
-    "RUNTIME_PROXY_BEARER_TOKEN",
-    "VELLUM_PLATFORM_URL",
-  ]) {
+  for (const envVar of ["ANTHROPIC_API_KEY", "VELLUM_PLATFORM_URL"]) {
     if (process.env[envVar]) {
       runArgs.push("-e", `${envVar}=${process.env[envVar]}`);
     }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -379,6 +379,79 @@ function normalizeIngressUrl(value: unknown): string | undefined {
   return normalized || undefined;
 }
 
+// ── Workspace config helpers ──
+
+function getWorkspaceConfigPath(instanceDir?: string): string {
+  const baseDataDir =
+    instanceDir ??
+    (process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir()));
+  return join(baseDataDir, ".vellum", "workspace", "config.json");
+}
+
+function loadWorkspaceConfig(instanceDir?: string): Record<string, unknown> {
+  const configPath = getWorkspaceConfigPath(instanceDir);
+  try {
+    if (!existsSync(configPath)) return {};
+    return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return {};
+  }
+}
+
+function saveWorkspaceConfig(
+  config: Record<string, unknown>,
+  instanceDir?: string,
+): void {
+  const configPath = getWorkspaceConfigPath(instanceDir);
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+/**
+ * Write gateway operational settings to the workspace config file so the
+ * gateway reads them at startup via its config.ts readWorkspaceConfig().
+ */
+function writeGatewayConfig(
+  instanceDir?: string,
+  opts?: {
+    runtimeProxyEnabled?: boolean;
+    runtimeProxyRequireAuth?: boolean;
+    unmappedPolicy?: "reject" | "default";
+    defaultAssistantId?: string;
+    routingEntries?: Array<{
+      type: "conversation_id" | "actor_id";
+      key: string;
+      assistantId: string;
+    }>;
+  },
+): void {
+  const config = loadWorkspaceConfig(instanceDir);
+  const gateway = (config.gateway ?? {}) as Record<string, unknown>;
+
+  if (opts?.runtimeProxyEnabled !== undefined) {
+    gateway.runtimeProxyEnabled = opts.runtimeProxyEnabled;
+  }
+  if (opts?.runtimeProxyRequireAuth !== undefined) {
+    gateway.runtimeProxyRequireAuth = opts.runtimeProxyRequireAuth;
+  }
+  if (opts?.unmappedPolicy !== undefined) {
+    gateway.unmappedPolicy = opts.unmappedPolicy;
+  }
+  if (opts?.defaultAssistantId !== undefined) {
+    gateway.defaultAssistantId = opts.defaultAssistantId;
+  }
+  if (opts?.routingEntries !== undefined) {
+    gateway.routingEntries = opts.routingEntries;
+  }
+
+  config.gateway = gateway;
+  saveWorkspaceConfig(config, instanceDir);
+}
+
 function readWorkspaceIngressPublicBaseUrl(
   instanceDir?: string,
 ): string | undefined {
@@ -766,6 +839,14 @@ export async function startGateway(
 
   const effectiveDaemonPort =
     resources?.daemonPort ?? Number(process.env.RUNTIME_HTTP_PORT || "7821");
+
+  // Write gateway operational settings to workspace config before starting
+  // the gateway process. The gateway reads these at startup from config.json.
+  writeGatewayConfig(resources?.instanceDir, {
+    runtimeProxyEnabled: true,
+    unmappedPolicy: "default",
+    defaultAssistantId: assistantId ?? "self",
+  });
 
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "bun run --watch src/index.ts",
-    "dev:proxy": "GATEWAY_RUNTIME_PROXY_ENABLED=true GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH=false bun run --watch src/index.ts",
+    "dev:proxy": "bun run src/cli/enable-proxy.ts && bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun",
     "schema": "bun run src/cli/schema.ts",
     "start": "bun run src/index.ts",

--- a/gateway/src/cli/enable-proxy.ts
+++ b/gateway/src/cli/enable-proxy.ts
@@ -1,0 +1,39 @@
+/**
+ * Write gateway proxy settings to workspace config for local development.
+ * Used by the `dev:proxy` npm script.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+const rootDir = join(
+  process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir()),
+  ".vellum",
+);
+const configPath = join(rootDir, "workspace", "config.json");
+
+let config: Record<string, unknown> = {};
+try {
+  if (existsSync(configPath)) {
+    config = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  }
+} catch {
+  // start fresh
+}
+
+const gateway = (config.gateway ?? {}) as Record<string, unknown>;
+gateway.runtimeProxyEnabled = true;
+gateway.runtimeProxyRequireAuth = false;
+gateway.unmappedPolicy = "default";
+gateway.defaultAssistantId = "self";
+config.gateway = gateway;
+
+const dir = dirname(configPath);
+if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+
+console.log("Gateway proxy settings written to workspace config");

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,4 +1,8 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { getLogger, type LogFileConfig } from "./logger.js";
+import { getRootDir } from "./credential-reader.js";
 
 const log = getLogger("config");
 
@@ -29,6 +33,44 @@ type RoutingEntry = {
   assistantId: string;
 };
 
+/**
+ * Read the workspace config file at startup to populate gateway operational
+ * settings. The CLI writes these values before starting the gateway.
+ */
+function readWorkspaceConfig(): Record<string, unknown> {
+  try {
+    const configPath = join(getRootDir(), "workspace", "config.json");
+    if (!existsSync(configPath)) return {};
+    const raw = readFileSync(configPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object" || Array.isArray(data)) return {};
+    return data as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function parseRoutingEntries(raw: unknown): RoutingEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const entries: RoutingEntry[] = [];
+  for (const item of raw) {
+    if (
+      item &&
+      typeof item === "object" &&
+      (item.type === "conversation_id" || item.type === "actor_id") &&
+      typeof item.key === "string" &&
+      typeof item.assistantId === "string"
+    ) {
+      entries.push({
+        type: item.type,
+        key: item.key,
+        assistantId: item.assistantId,
+      });
+    }
+  }
+  return entries;
+}
+
 export function loadConfig(): GatewayConfig {
   const portRaw = process.env.GATEWAY_PORT || "7830";
   const port = Number(portRaw);
@@ -45,6 +87,23 @@ export function loadConfig(): GatewayConfig {
 
   const gatewayInternalBaseUrl = `http://127.0.0.1:${port}`;
 
+  // Read operational settings from workspace config. The CLI writes these
+  // before spawning the gateway (see cli/src/lib/local.ts writeGatewayConfig).
+  const wsConfig = readWorkspaceConfig();
+  const gw = (wsConfig.gateway ?? {}) as Record<string, unknown>;
+
+  const runtimeProxyEnabled =
+    gw.runtimeProxyEnabled === true || gw.runtimeProxyEnabled === "true";
+  const runtimeProxyRequireAuth =
+    gw.runtimeProxyRequireAuth !== false &&
+    gw.runtimeProxyRequireAuth !== "false";
+  const unmappedPolicy = gw.unmappedPolicy === "default" ? "default" : "reject";
+  const defaultAssistantId =
+    typeof gw.defaultAssistantId === "string" && gw.defaultAssistantId
+      ? gw.defaultAssistantId
+      : undefined;
+  const routingEntries = parseRoutingEntries(gw.routingEntries);
+
   const logFile: LogFileConfig = {
     dir: undefined,
     retentionDays: 30,
@@ -54,12 +113,12 @@ export function loadConfig(): GatewayConfig {
     {
       assistantRuntimeBaseUrl,
       gatewayInternalBaseUrl,
-      routingEntryCount: 0,
-      unmappedPolicy: "reject",
-      hasDefaultAssistant: false,
+      routingEntryCount: routingEntries.length,
+      unmappedPolicy,
+      hasDefaultAssistant: !!defaultAssistantId,
       port,
-      runtimeProxyEnabled: false,
-      runtimeProxyRequireAuth: true,
+      runtimeProxyEnabled,
+      runtimeProxyRequireAuth,
       trustProxy: false,
     },
     "Configuration loaded",
@@ -67,21 +126,21 @@ export function loadConfig(): GatewayConfig {
 
   return {
     assistantRuntimeBaseUrl,
-    defaultAssistantId: undefined,
+    defaultAssistantId,
     gatewayInternalBaseUrl,
     logFile,
     maxAttachmentBytes: 20 * 1024 * 1024,
     maxAttachmentConcurrency: 3,
     maxWebhookPayloadBytes: 1024 * 1024,
     port,
-    routingEntries: [],
+    routingEntries,
     runtimeInitialBackoffMs: 500,
     runtimeMaxRetries: 2,
-    runtimeProxyEnabled: false,
-    runtimeProxyRequireAuth: true,
+    runtimeProxyEnabled,
+    runtimeProxyRequireAuth,
     runtimeTimeoutMs: 30000,
     shutdownDrainMs: 5000,
-    unmappedPolicy: "reject",
+    unmappedPolicy,
     trustProxy: false,
   };
 }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1836,7 +1836,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Runtime proxy",
           description:
-            "Reverse-proxies requests to the assistant runtime when GATEWAY_RUNTIME_PROXY_ENABLED is true. Supports all HTTP methods. Returns 404 when the proxy is disabled.",
+            "Reverse-proxies requests to the assistant runtime when gateway.runtimeProxyEnabled is true in workspace config. Supports all HTTP methods. Returns 404 when the proxy is disabled.",
           operationId: "runtimeProxyGet",
           security: [{ BearerAuth: [] }],
           parameters: [
@@ -1898,7 +1898,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Runtime proxy",
           description:
-            "Reverse-proxies requests to the assistant runtime when GATEWAY_RUNTIME_PROXY_ENABLED is true.",
+            "Reverse-proxies requests to the assistant runtime when gateway.runtimeProxyEnabled is true in workspace config.",
           operationId: "runtimeProxyPost",
           security: [{ BearerAuth: [] }],
           parameters: [


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-legacy-env-vars.md.

**Gap:** Gateway runtime proxy permanently disabled — breaks cloud deploys and iOS pairing
**What was expected:** Proxy, unmapped policy, default assistant ID, and routing should remain configurable
**What was found:** These were hardcoded off when env vars were removed

Migrates these settings from env vars to workspace config file (ConfigFileCache pattern):
- `gateway/src/config.ts` now reads `gateway.runtimeProxyEnabled`, `gateway.runtimeProxyRequireAuth`, `gateway.unmappedPolicy`, `gateway.defaultAssistantId`, and `gateway.routingEntries` from `workspace/config.json`
- `cli/src/lib/local.ts` writes these values to workspace config before spawning the gateway
- `cli/src/commands/hatch.ts` writes gateway config to workspace config in cloud startup script (removes dead GATEWAY_RUNTIME_PROXY_ENABLED env var)
- `cli/src/lib/docker.ts` removes dead env var passthrough (GATEWAY_RUNTIME_PROXY_ENABLED, RUNTIME_PROXY_BEARER_TOKEN)
- `gateway/package.json` dev:proxy script now uses enable-proxy.ts to write workspace config
- Updated schema.ts docs and runbook to reference workspace config instead of env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
