### PR TITLE
fix: resolve assistantId ReferenceError in startGateway

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -844,7 +844,7 @@ export async function startGateway(
   writeGatewayConfig(resources?.instanceDir, {
     runtimeProxyEnabled: true,
     unmappedPolicy: "default",
-    defaultAssistantId: assistantId ?? "self",
+    defaultAssistantId: "self",
   });
 
   const gatewayEnv: Record<string, string> = {


### PR DESCRIPTION
## Summary
Fixes critical build break: `assistantId` variable referenced in `writeGatewayConfig()` call but the parameter was removed by #15598. Replaces with hardcoded `"self"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
