### PR TITLE
fix: clean up minor stale env var references

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -69,16 +69,14 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
 
 8. Build the macOS app (foreground, so compilation errors are caught immediately):
    ```bash
-   REPO_ROOT="$(pwd)"
-   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh
+   cd clients/macos && ./build.sh
    ```
 
    If the build fails, stop and report the error. Do not proceed to launch.
 
    Then launch with file-watching in the background (the build is cached, so this just launches + watches):
    ```bash
-   REPO_ROOT="$(pwd)"
-   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
+   cd clients/macos && ./build.sh run &
    ```
 
 9. Verify fresh state — run `vellum ps` to confirm processes are running:

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -31,7 +31,7 @@ import type {
 } from "../../provider-types.js";
 import * as telegram from "./client.js";
 
-/** Resolve the gateway base URL, preferring GATEWAY_INTERNAL_BASE_URL if set. */
+/** Resolve the gateway base URL. */
 function getGatewayUrl(): string {
   return getGatewayInternalBaseUrl();
 }

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -133,12 +133,10 @@ ${timestampRedirect}
 trap 'EXIT_CODE=\$?; if [ \$EXIT_CODE -ne 0 ]; then echo "Startup script failed with exit code \$EXIT_CODE at line \$LINENO" > ${errorPath}; echo "Last 20 log lines:" >> ${errorPath}; tail -20 ${logPath} >> ${errorPath} 2>/dev/null || true; fi' EXIT
 ${userSetup}
 ANTHROPIC_API_KEY=${anthropicApiKey}
-RUNTIME_PROXY_BEARER_TOKEN=${bearerToken}
 VELLUM_ASSISTANT_NAME=${instanceName}
 mkdir -p "\$HOME/.vellum"
 cat > "\$HOME/.vellum/.env" << DOTENV_EOF
 ANTHROPIC_API_KEY=\$ANTHROPIC_API_KEY
-RUNTIME_PROXY_BEARER_TOKEN=\$RUNTIME_PROXY_BEARER_TOKEN
 RUNTIME_HTTP_PORT=7821
 DOTENV_EOF
 

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -51,17 +51,10 @@ public enum LockfilePaths {
     /// Resolve the full gateway URL for the given (or latest) assistant.
     ///
     /// Resolution order:
-    /// 1. `GATEWAY_INTERNAL_BASE_URL` env var
-    /// 2. `runtimeUrl` from the lockfile entry for `connectedAssistantId`
+    /// 1. `runtimeUrl` from the lockfile entry for `connectedAssistantId`
     ///    (falls back to the most-recently-hatched entry)
-    /// 3. `http://127.0.0.1:{resolveGatewayPort()}`
+    /// 2. `http://127.0.0.1:{resolveGatewayPort()}`
     public static func resolveGatewayUrl(connectedAssistantId: String? = nil) -> String {
-        if let envUrl = ProcessInfo.processInfo.environment["GATEWAY_INTERNAL_BASE_URL"],
-           !envUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return envUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-                .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
-        }
-
         if let json = read(),
            let assistants = json["assistants"] as? [[String: Any]] {
             let assistant: [String: Any]?


### PR DESCRIPTION
## Summary
Cleans up minor residual stale references to removed env vars:
- Remove dead RUNTIME_PROXY_BEARER_TOKEN from cloud startup script
- Remove stale GATEWAY_INTERNAL_BASE_URL read from Swift LockfilePaths
- Update stale comment in telegram adapter
- Remove dead VELLUM_GATEWAY_DIR from update SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
