### PR TITLE
fix: update withValidToken to read from oauth-store key paths

### DIFF
--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -106,7 +106,6 @@ mock.module("./oauth-store.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { credentialKey } from "../security/credential-key.js";
 import { setSecureKey } from "../security/secure-keys.js";
 import {
   _resetInflightRefreshes,
@@ -184,9 +183,10 @@ function setupCredential(
     key: service,
     tokenUrl: "https://oauth2.googleapis.com/token",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
-    baseUrl: service === "integration:gmail"
-      ? "https://gmail.googleapis.com/gmail/v1/users/me"
-      : undefined,
+    baseUrl:
+      service === "integration:gmail"
+        ? "https://gmail.googleapis.com/gmail/v1/users/me"
+        : undefined,
   });
   mockApps.set(appId, {
     id: appId,
@@ -201,8 +201,7 @@ function setupCredential(
     grantedScopes: JSON.stringify(opts?.grantedScopes ?? ["read", "write"]),
     accountInfo: null,
   });
-  // Store tokens in both old-format (for withValidToken) and new-format (for resolveOAuthConnection)
-  setSecureKey(credentialKey(service, "access_token"), "test-access-token");
+  // Store access token in oauth-store key format
   setSecureKey(`oauth_connection/${connId}/access_token`, "test-access-token");
   // Store refresh token and client_secret in secure keys (token-manager reads them)
   setSecureKey(

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -14,7 +14,6 @@ import {
   updateConnection,
 } from "../oauth/oauth-store.js";
 import { getLogger } from "../util/logger.js";
-import { credentialKey } from "./credential-key.js";
 import { refreshOAuth2Token, type TokenEndpointAuthMethod } from "./oauth2.js";
 import { getSecureKey, setSecureKeyAsync } from "./secure-keys.js";
 
@@ -316,13 +315,6 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  // Also write to legacy credential key path so the deprecated
-  // withValidToken() reads the refreshed token on subsequent calls.
-  await setSecureKeyAsync(
-    credentialKey(service, "access_token"),
-    result.accessToken,
-  );
-
   if (result.refreshToken) {
     if (
       !(await setSecureKeyAsync(
@@ -377,7 +369,10 @@ export async function withValidToken<T>(
   service: string,
   callback: (token: string) => Promise<T>,
 ): Promise<T> {
-  let token = getSecureKey(credentialKey(service, "access_token"));
+  const conn = getConnectionByProvider(service);
+  let token = conn
+    ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
+    : undefined;
   if (!token) {
     throw new TokenExpiredError(
       service,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-sqlite-migration.md.

**Gap:** withValidToken reads legacy key path that is no longer written to
**What was expected:** Token reads should use new key format oauth_connection/{connId}/access_token
**What was found:** withValidToken reads credential/{service}/access_token which is no longer written

- Updated withValidToken to look up the connection via getConnectionByProvider(service), then read from oauth_connection/{conn.id}/access_token
- Removed credentialKey import from token-manager.ts (no longer needed)
- Updated byo-connection.test.ts to only write tokens in the new oauth-store format (removed dual-write workaround)
- Removed unused credentialKey import from the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
