### PR TITLE
fix: correct Gmail base URL in OAuth provider seed data

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -33,7 +33,7 @@ const PROVIDER_SEED_DATA: Record<
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     tokenUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
-    baseUrl: "https://gmail.googleapis.com",
+    baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     defaultScopes: [
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/gmail.modify",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-sqlite-migration.md.

**Gap:** Gmail base URL truncated — all Gmail API calls will fail
**What was expected:** Full base URL https://gmail.googleapis.com/gmail/v1/users/me
**What was found:** Truncated to https://gmail.googleapis.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
