### PR TITLE
fix: only delete oauth_connection on access_token removal, fix list connection selection

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -255,15 +255,16 @@ Examples:
           });
         }
 
-        // Build a lookup of oauth connections keyed by providerKey for enrichment
+        // Build a lookup of oauth connections keyed by providerKey for enrichment.
+        // listConnections() returns rows in no guaranteed order, so we compare
+        // createdAt to keep the most recent active connection per provider —
+        // matching the behaviour of getConnectionByProvider() used by inspect.
         const allConnections = safeListConnections();
         const connectionsByProvider = new Map<string, OAuthConnectionRow>();
         for (const conn of allConnections) {
-          // Keep the most recent active connection per provider
-          if (
-            conn.status === "active" &&
-            !connectionsByProvider.has(conn.providerKey)
-          ) {
+          if (conn.status !== "active") continue;
+          const existing = connectionsByProvider.get(conn.providerKey);
+          if (!existing || conn.createdAt > existing.createdAt) {
             connectionsByProvider.set(conn.providerKey, conn);
           }
         }
@@ -444,10 +445,14 @@ Examples:
           return;
         }
 
-        // Clean up matching oauth_connection row if one exists
-        const connection = safeGetConnectionByProvider(service);
-        if (connection) {
-          safeDeleteConnection(connection.id);
+        // Only delete the oauth_connection when removing the primary credential
+        // (access_token). Deleting auxiliary fields like client_secret should not
+        // destroy the connection that access_token depends on.
+        if (field === "access_token") {
+          const connection = safeGetConnectionByProvider(service);
+          if (connection) {
+            safeDeleteConnection(connection.id);
+          }
         }
 
         writeOutput(cmd, { ok: true, service, field });


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for oauth-sqlite-migration.md.

**Gap A:** credentials delete unconditionally removes oauth_connection — now only removes when deleting access_token
**Gap B:** Inconsistent connection selection in list vs inspect — now picks most recent active connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
