### PR TITLE
fix: allow null expiresAt in updateConnection to clear stale values

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -307,7 +307,8 @@ export function updateConnection(
   updates: Partial<{
     accountInfo: string;
     grantedScopes: string[];
-    expiresAt: number;
+    /** Pass `null` to explicitly clear a stale expiresAt in the DB. */
+    expiresAt: number | null;
     hasRefreshToken: boolean;
     status: string;
     label: string;
@@ -318,6 +319,8 @@ export function updateConnection(
   const now = Date.now();
 
   // Build the set clause, serializing JSON fields and converting booleans.
+  // For expiresAt, null means "clear the column" so we check for undefined
+  // explicitly rather than truthiness.
   const set: Record<string, unknown> = { updatedAt: now };
   if (updates.accountInfo !== undefined) set.accountInfo = updates.accountInfo;
   if (updates.grantedScopes !== undefined)

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -127,7 +127,7 @@ export async function storeOAuth2Tokens(
     updateConnection(connId, {
       accountInfo: resolvedAccountInfo,
       grantedScopes,
-      expiresAt: expiresAt ?? undefined,
+      expiresAt,
       hasRefreshToken,
       metadata: rawTokenResponse,
     });
@@ -163,9 +163,7 @@ export async function storeOAuth2Tokens(
     // Re-auth grants that omit refresh_token must clear any stale stored
     // token — otherwise withValidToken() will attempt refresh with invalid
     // credentials.
-    await deleteSecureKeyAsync(
-      `oauth_connection/${connId}/refresh_token`,
-    );
+    await deleteSecureKeyAsync(`oauth_connection/${connId}/refresh_token`);
   }
 
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -340,7 +340,7 @@ async function doRefresh(service: string): Promise<string> {
 
   try {
     updateConnection(connId, {
-      expiresAt: expiresAt ?? undefined,
+      expiresAt,
       hasRefreshToken: !!result.refreshToken,
     });
   } catch (err) {
@@ -370,7 +370,6 @@ export async function withValidToken<T>(
   service: string,
   callback: (token: string) => Promise<T>,
 ): Promise<T> {
-
   let token = getSecureKey(credentialKey(service, "access_token"));
   if (!token) {
     throw new TokenExpiredError(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-sqlite-migration.md.

**Gap:** expiresAt null-clearing silently skipped
**What was expected:** expiresAt should be clearable when provider stops sending expires_in
**What was found:** updateConnection skips undefined values, and null was converted to undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
