### PR TITLE
fix: update integration-status and messaging registry to use oauth-store

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { OAuthConnectionRow } from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 
 const secureKeyValues = new Map<string, string>();
 let mockTwilioAccountSid: string | undefined;
+
+/** Simulated active OAuth connections keyed by provider. */
+const oauthConnections = new Map<string, OAuthConnectionRow>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
@@ -17,12 +21,36 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (providerKey: string) =>
+    oauthConnections.get(providerKey),
+}));
+
+/** Helper to insert a fake active connection for a provider. */
+function setOAuthConnected(providerKey: string): void {
+  oauthConnections.set(providerKey, {
+    id: "fake-id",
+    oauthAppId: "fake-app",
+    providerKey,
+    accountInfo: null,
+    grantedScopes: "[]",
+    expiresAt: null,
+    hasRefreshToken: 0,
+    status: "active",
+    label: null,
+    metadata: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+}
+
 const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =
   await import("../schedule/integration-status.js");
 
 describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
+    oauthConnections.clear();
     mockTwilioAccountSid = undefined;
   });
 
@@ -38,14 +66,8 @@ describe("integration-status", () => {
     });
 
     test("returns all connected when all keys are set", () => {
-      secureKeyValues.set(
-        credentialKey("integration:gmail", "access_token"),
-        "tok",
-      );
-      secureKeyValues.set(
-        credentialKey("integration:slack", "access_token"),
-        "tok",
-      );
+      setOAuthConnected("integration:gmail");
+      setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
@@ -130,14 +152,8 @@ describe("integration-status", () => {
     });
 
     test("all connected", () => {
-      secureKeyValues.set(
-        credentialKey("integration:gmail", "access_token"),
-        "tok",
-      );
-      secureKeyValues.set(
-        credentialKey("integration:slack", "access_token"),
-        "tok",
-      );
+      setOAuthConnected("integration:gmail");
+      setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
@@ -179,10 +195,7 @@ describe("integration-status", () => {
     });
 
     test("email category checks Gmail", () => {
-      secureKeyValues.set(
-        credentialKey("integration:gmail", "access_token"),
-        "tok",
-      );
+      setOAuthConnected("integration:gmail");
       expect(hasCapability("email")).toBe(true);
     });
   });

--- a/assistant/src/messaging/registry.ts
+++ b/assistant/src/messaging/registry.ts
@@ -2,8 +2,7 @@
  * Messaging provider registry — register/lookup providers by platform ID.
  */
 
-import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getConnectionByProvider } from "../oauth/oauth-store.js";
 import type { MessagingProvider } from "./provider.js";
 
 const providers = new Map<string, MessagingProvider>();
@@ -27,10 +26,7 @@ export function getMessagingProvider(id: string): MessagingProvider {
 export function getConnectedProviders(): MessagingProvider[] {
   return Array.from(providers.values()).filter((p) => {
     if (p.isConnected) return p.isConnected();
-    const token = getSecureKey(
-      credentialKey(p.credentialService, "access_token"),
-    );
-    return token !== undefined;
+    return getConnectionByProvider(p.credentialService)?.status === "active";
   });
 }
 

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,4 +1,5 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
+import { getConnectionByProvider } from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 
@@ -14,13 +15,13 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
     name: "Gmail",
     category: "email",
     isConnected: () =>
-      !!getSecureKey(credentialKey("integration:gmail", "access_token")),
+      getConnectionByProvider("integration:gmail")?.status === "active",
   },
   {
     name: "Slack",
     category: "messaging",
     isConnected: () =>
-      !!getSecureKey(credentialKey("integration:slack", "access_token")),
+      getConnectionByProvider("integration:slack")?.status === "active",
   },
   {
     name: "Twilio",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-sqlite-migration.md.

**Gap:** integration-status.ts and messaging/registry.ts read legacy key paths
**What was expected:** Connection status checks should use oauth-store
**What was found:** Both files check credential/{service}/access_token which is no longer written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
