### PR TITLE
fix: remove legacy key reads from settings routes and channel handlers

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -36,38 +36,14 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
-  // Prefer oauth-store for connection status, fall back to keychain/config.
-  try {
-    const conn = getConnectionByProvider("slack_channel");
-    if (conn && conn.status === "active") {
-      const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
-      return {
-        success: true,
-        hasBotToken: true,
-        hasAppToken: true,
-        connected: true,
-        ...(teamId ? { teamId } : {}),
-        ...(teamName ? { teamName } : {}),
-        ...(botUserId ? { botUserId } : {}),
-        ...(botUsername ? { botUsername } : {}),
-      };
-    }
-  } catch {
-    // DB not ready — fall through to keychain check
-  }
-
-  const hasBotToken = !!getSecureKey(
-    credentialKey("slack_channel", "bot_token"),
-  );
-  const hasAppToken = !!getSecureKey(
-    credentialKey("slack_channel", "app_token"),
-  );
+  const conn = getConnectionByProvider("slack_channel");
+  const connected = !!(conn && conn.status === "active");
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
-    hasBotToken,
-    hasAppToken,
-    connected: hasBotToken && hasAppToken,
+    hasBotToken: connected,
+    hasAppToken: connected,
+    connected,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
     ...(botUserId ? { botUserId } : {}),

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -62,34 +62,15 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
-  // Prefer oauth-store for connection status, fall back to keychain check.
-  try {
-    const conn = getConnectionByProvider("telegram");
-    if (conn && conn.status === "active") {
-      const botUsername = getTelegramBotUsername();
-      return {
-        success: true,
-        hasBotToken: true,
-        botUsername,
-        connected: true,
-        hasWebhookSecret: true,
-      };
-    }
-  } catch {
-    // DB not ready — fall through to keychain check
-  }
-
-  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-  const hasWebhookSecret = !!getSecureKey(
-    credentialKey("telegram", "webhook_secret"),
-  );
+  const conn = getConnectionByProvider("telegram");
+  const connected = !!(conn && conn.status === "active");
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
-    hasBotToken,
+    hasBotToken: connected,
     botUsername,
-    connected: hasBotToken && hasWebhookSecret,
-    hasWebhookSecret,
+    connected,
+    hasWebhookSecret: connected,
   };
 }
 

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -29,7 +29,6 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../../permissions/checker.js";
-import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKey } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
@@ -141,20 +140,6 @@ function sanitizeOAuthError(message: string): string {
   return "OAuth authentication failed. Please try again.";
 }
 
-/** Resolve client_secret from the keychain, checking canonical then alias service name. */
-function getClientSecret(
-  resolvedService: string,
-  rawService: string,
-): string | undefined {
-  return (
-    getSecureKey(credentialKey(resolvedService, "client_secret")) ??
-    (resolvedService !== rawService
-      ? getSecureKey(credentialKey(rawService, "client_secret"))
-      : undefined) ??
-    undefined
-  );
-}
-
 async function handleOAuthConnectStart(body: {
   service?: string;
   requestedScopes?: string[];
@@ -196,10 +181,6 @@ async function handleOAuthConnectStart(body: {
       `No client_id found for "${body.service}". Store it first via the credential vault.`,
       400,
     );
-  }
-
-  if (!clientSecret) {
-    clientSecret = getClientSecret(resolvedService, body.service);
   }
 
   const behavior = getProviderBehavior(resolvedService);


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for oauth-sqlite-migration.md.

**Gap A:** settings-routes.ts getClientSecret reads legacy key — now reads from oauth-store
**Gap B:** Slack/Telegram handlers have dead legacy fallback — removed, using oauth-store exclusively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
