### PR TITLE
fix: resolve CI failures in credential/OAuth test suites

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -229,6 +229,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/integrations/slack/share.ts", // Slack share routes credential lookup
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
+      "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
+      "oauth/migrate-to-sqlite.ts", // one-time data migration from credential metadata to oauth-store
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -45,9 +45,54 @@ mock.module("../tools/registry.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock OAuth2 flow to avoid starting real HTTP servers
+// ---------------------------------------------------------------------------
+
+mock.module("../security/oauth2.js", () => ({
+  prepareOAuth2Flow: () => ({
+    authUrl: "https://accounts.google.com/o/oauth2/auth?mock=true",
+    state: "test-state",
+    completion: new Promise(() => {}), // never resolves — fire-and-forget in deferred path
+  }),
+  startOAuth2Flow: () => {
+    throw new Error("startOAuth2Flow should not be called in these tests");
+  },
+  refreshOAuth2Token: () =>
+    Promise.resolve({ accessToken: "new-token", expiresIn: 3600 }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock platform to redirect SQLite DB to the temp dir
+// ---------------------------------------------------------------------------
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => TEST_DIR,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(TEST_DIR, "test.pid"),
+  getDbPath: () => join(TEST_DIR, "test.db"),
+  getLogPath: () => join(TEST_DIR, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Mock public ingress URL — not available in unit tests. The connect
+// orchestrator dynamically imports this for non-interactive flows.
+// ---------------------------------------------------------------------------
+
+mock.module("../inbound/public-ingress-urls.js", () => ({
+  getPublicBaseUrl: () => {
+    throw new Error("No public ingress URL configured");
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Imports under test
 // ---------------------------------------------------------------------------
 
+import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import { seedProviders } from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
@@ -65,7 +110,12 @@ const _ctx: ToolContext = {
   trustClass: "guardian",
 };
 
+// Initialize the DB once — tests that need a clean slate use resetTestTables.
+mkdirSync(TEST_DIR, { recursive: true });
+initializeDb();
+
 afterAll(() => {
+  resetDb();
   mock.restore();
   if (existsSync(TEST_DIR)) {
     rmSync(TEST_DIR, { recursive: true });
@@ -474,11 +524,36 @@ describe("credential_store tool — prompt action", () => {
 
 describe("credential_store tool — oauth2_connect error paths", () => {
   beforeEach(() => {
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
+    // Re-create TEST_DIR and DB — earlier describe blocks may have deleted
+    // the entire directory (including the SQLite file).
+    if (existsSync(STORE_PATH)) rmSync(STORE_PATH, { force: true });
     mkdirSync(TEST_DIR, { recursive: true });
+    resetDb();
+    initializeDb();
     _setStorePath(STORE_PATH);
     _resetBackend();
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
+    // Clear OAuth tables for test isolation, then seed well-known providers
+    // so the orchestrator can resolve them.
+    resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
+    seedProviders([
+      {
+        providerKey: "integration:gmail",
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        defaultScopes: ["https://mail.google.com/"],
+        scopePolicy: {},
+        callbackTransport: "loopback",
+        loopbackPort: 8756,
+      },
+      {
+        providerKey: "integration:slack",
+        authUrl: "https://slack.com/oauth/v2/authorize",
+        tokenUrl: "https://slack.com/api/oauth.v2.access",
+        defaultScopes: ["channels:read"],
+        scopePolicy: {},
+      },
+    ]);
   });
 
   afterEach(() => {

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -46,6 +46,21 @@ mock.module("../tools/registry.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock platform to redirect SQLite DB to the temp dir
+// ---------------------------------------------------------------------------
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => TEST_DIR,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(TEST_DIR, "test.pid"),
+  getDbPath: () => join(TEST_DIR, "test.db"),
+  getLogPath: () => join(TEST_DIR, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+// ---------------------------------------------------------------------------
 // Mock OAuth2 token refresh for token-manager deduplication tests
 // ---------------------------------------------------------------------------
 
@@ -71,6 +86,12 @@ mock.module("../security/oauth2.js", () => {
 
 // getCredentialValue is no longer exported (sealed in PR 17) — use getSecureKey directly
 
+import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import {
+  createConnection,
+  seedProviders,
+  upsertApp,
+} from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 import {
   deleteSecureKey,
@@ -1160,11 +1181,14 @@ describe("credential_store tool", () => {
 describe("withValidToken refresh deduplication", () => {
   beforeAll(() => {
     mkdirSync(TEST_DIR, { recursive: true });
+    initializeDb();
   });
 
   beforeEach(() => {
     _resetBackend();
+    // Clean up files but NOT the DB file (managed by resetDb/initializeDb)
     for (const entry of readdirSync(TEST_DIR)) {
+      if (entry.startsWith("test.db")) continue; // preserve DB files
       rmSync(join(TEST_DIR, entry), { recursive: true, force: true });
     }
     _setStorePath(STORE_PATH);
@@ -1172,6 +1196,8 @@ describe("withValidToken refresh deduplication", () => {
     _resetRefreshBreakers();
     _resetInflightRefreshes();
     mockRefreshOAuth2Token.mockClear();
+    // Clear OAuth tables for test isolation
+    resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
   });
 
   afterEach(() => {
@@ -1183,18 +1209,51 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   afterAll(() => {
+    resetDb();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
   /**
    * Helper: set up a service with an access token, refresh token, and OAuth2
    * metadata so that token refresh can proceed through doRefresh().
+   *
+   * Seeds the oauth-store (provider → app → connection) and stores secrets
+   * in the new-format paths so that resolveRefreshConfig() in token-manager
+   * can find everything it needs.
    */
   function setupService(
     service: string,
     opts?: { expired?: boolean; accessToken?: string },
   ) {
     const accessToken = opts?.accessToken ?? "old-access-token";
+
+    // Seed the oauth-store: provider → app → connection
+    seedProviders([
+      {
+        providerKey: service,
+        authUrl: "https://oauth.example.com/authorize",
+        tokenUrl: "https://oauth.example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      },
+    ]);
+    const app = upsertApp(service, "test-client-id");
+    const conn = createConnection({
+      oauthAppId: app.id,
+      providerKey: service,
+      grantedScopes: ["read"],
+      hasRefreshToken: true,
+    });
+
+    // Store secrets in new-format paths (used by token-manager)
+    setSecureKey(`oauth_app/${app.id}/client_secret`, "test-client-secret");
+    setSecureKey(`oauth_connection/${conn.id}/access_token`, accessToken);
+    setSecureKey(
+      `oauth_connection/${conn.id}/refresh_token`,
+      "valid-refresh-token",
+    );
+
+    // Also store in legacy paths (used by withValidToken for initial token read)
     setSecureKey(credentialKey(service, "access_token"), accessToken);
     setSecureKey(
       credentialKey(service, "refresh_token"),

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -23,7 +23,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, resetDb, resetTestTables } from "../memory/db.js";
 import {
   createConnection,
   deleteApp,
@@ -64,6 +64,9 @@ function createTestApp(providerKey = "github", clientId = "client-1") {
 beforeEach(() => {
   resetDb();
   initializeDb();
+  // Explicitly clear all OAuth tables to prevent cross-test state pollution.
+  // Delete in FK-dependency order: connections → apps → providers.
+  resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
 });
 
 afterAll(() => {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -5,7 +5,7 @@
  * extra_params, granted_scopes, metadata) are stored as serialized JSON strings.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb, rawChanges } from "../memory/db.js";
@@ -294,7 +294,7 @@ export function getConnectionByProvider(
         eq(oauthConnections.status, "active"),
       ),
     )
-    .orderBy(desc(oauthConnections.createdAt))
+    .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
     .limit(1)
     .get();
 }

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -316,6 +316,13 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
+  // Also write to legacy credential key path so the deprecated
+  // withValidToken() reads the refreshed token on subsequent calls.
+  await setSecureKeyAsync(
+    credentialKey(service, "access_token"),
+    result.accessToken,
+  );
+
   if (result.refreshToken) {
     if (
       !(await setSecureKeyAsync(

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,6 +1,10 @@
 import { getConfig } from "../../config/loader.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
-import { getMostRecentAppByProvider } from "../../oauth/oauth-store.js";
+import {
+  getMostRecentAppByProvider,
+  getProvider,
+  seedProviders,
+} from "../../oauth/oauth-store.js";
 import {
   getProviderProfile,
   resolveService,
@@ -741,6 +745,7 @@ class CredentialStoreTool implements Tool {
         // Priority:
         //   1. Explicit input from the caller
         //   2. oauth-store DB (most recent app for this provider)
+        //   3. Credential metadata fallback (pre-migration credentials)
         let clientId = input.client_id as string | undefined;
         let clientSecret = input.client_secret as string | undefined;
 
@@ -754,6 +759,22 @@ class CredentialStoreTool implements Tool {
               );
             }
           }
+        }
+
+        // Credential metadata fallback — pre-migration credentials store
+        // oauth2ClientId in metadata and client_secret in the secure store
+        // under the credential key path.
+        if (!clientId) {
+          const meta = getCredentialMetadata(service, "access_token");
+          if (meta?.oauth2ClientId) {
+            clientId = meta.oauth2ClientId as string;
+          }
+        }
+        if (!clientSecret) {
+          const storedSecret = getSecureKey(
+            credentialKey(service, "client_secret"),
+          );
+          if (storedSecret) clientSecret = storedSecret;
         }
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
@@ -818,6 +839,31 @@ class CredentialStoreTool implements Tool {
           (input.token_endpoint_auth_method as
             | TokenEndpointAuthMethod
             | undefined) ?? profile?.tokenEndpointAuthMethod;
+
+        // Ensure custom providers have a DB row so the orchestrator can
+        // resolve callback transport and scope policy. Uses INSERT OR IGNORE
+        // so existing rows are never overwritten.
+        if (!profile && authUrl && tokenUrl) {
+          const existingProvider = getProvider(service);
+          if (!existingProvider) {
+            try {
+              seedProviders([
+                {
+                  providerKey: service,
+                  authUrl,
+                  tokenUrl,
+                  defaultScopes: inputScopes ?? [],
+                  scopePolicy: {},
+                },
+              ]);
+            } catch (err) {
+              log.warn(
+                { err, service },
+                "Failed to register custom OAuth provider",
+              );
+            }
+          }
+        }
 
         // Delegate to the shared orchestrator.
         // For profile-based providers, pass user scopes as requestedScopes so the


### PR DESCRIPTION
## Summary
- Fix source code bugs introduced by recent OAuth refactoring: missing credential metadata fallback in vault.ts, missing legacy path write in token-manager.ts, and nondeterministic ordering in oauth-store.ts
- Fix 4 failing test files by adding proper DB initialization, oauth-store seeding, and deterministic mocks
- Add 2 new files to secure-keys allowlist (connection-resolver.ts, migrate-to-sqlite.ts)

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22985749755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
