### PR TITLE
fix: resolve remaining CI failures in credential/OAuth test suites

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -229,6 +229,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/integrations/slack/share.ts", // Slack share routes credential lookup
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
+      "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
+      "oauth/migrate-to-sqlite.ts", // one-time data migration from credential metadata to oauth-store
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -48,18 +48,37 @@ mock.module("../tools/registry.js", () => ({
 // Mock oauth-store to avoid SQLite dependency in unit tests
 // ---------------------------------------------------------------------------
 
-let mockGetMostRecentAppByProvider: ReturnType<typeof mock<() => unknown>>;
-let mockGetProvider: ReturnType<typeof mock<() => unknown>>;
+let mockGetMostRecentAppByProvider: ReturnType<
+  typeof mock<(key: string) => unknown>
+>;
+let mockGetAppByProviderAndClientId: ReturnType<
+  typeof mock<(key: string, clientId: string) => unknown>
+>;
+let mockGetProvider: ReturnType<typeof mock<(key: string) => unknown>>;
 
 mock.module("../oauth/oauth-store.js", () => {
   mockGetMostRecentAppByProvider = mock(() => undefined);
+  mockGetAppByProviderAndClientId = mock(() => undefined);
   mockGetProvider = mock(() => undefined);
   return {
     getMostRecentAppByProvider: mockGetMostRecentAppByProvider,
+    getAppByProviderAndClientId: mockGetAppByProviderAndClientId,
     getProvider: mockGetProvider,
     listConnections: mock(() => []),
+    seedProviders: mock(() => {}),
   };
 });
+
+// ---------------------------------------------------------------------------
+// Mock public ingress URL — not available in unit tests. The connect
+// orchestrator dynamically imports this for non-interactive flows.
+// ---------------------------------------------------------------------------
+
+mock.module("../inbound/public-ingress-urls.js", () => ({
+  getPublicBaseUrl: () => {
+    throw new Error("No public ingress URL configured");
+  },
+}));
 
 // ---------------------------------------------------------------------------
 // Imports under test
@@ -490,18 +509,48 @@ describe("credential_store tool — prompt action", () => {
 // ---------------------------------------------------------------------------
 
 describe("credential_store tool — oauth2_connect error paths", () => {
+  /** Well-known provider rows returned by the mocked getProvider */
+  const wellKnownProviders: Record<string, object> = {
+    "integration:gmail": {
+      key: "integration:gmail",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
+      scopePolicy: JSON.stringify({}),
+      callbackTransport: "loopback",
+      loopbackPort: 8756,
+    },
+    "integration:slack": {
+      key: "integration:slack",
+      authUrl: "https://slack.com/oauth/v2/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      defaultScopes: JSON.stringify(["channels:read"]),
+      scopePolicy: JSON.stringify({}),
+    },
+  };
+
   beforeEach(() => {
     if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
     mkdirSync(TEST_DIR, { recursive: true });
     _setStorePath(STORE_PATH);
     _resetBackend();
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
+    // Return well-known provider rows so vault.ts knows gmail/slack are
+    // registered, and custom providers return undefined.
+    mockGetProvider.mockImplementation(
+      (key: string) => wellKnownProviders[key] ?? undefined,
+    );
+    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
+    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     _setMetadataPath(null);
     _setStorePath(null);
     _resetBackend();
+    mockGetProvider.mockImplementation(() => undefined);
+    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
+    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
   });
 
   test("requires service parameter", async () => {
@@ -571,6 +620,21 @@ describe("credential_store tool — oauth2_connect error paths", () => {
   });
 
   test("requires interactive context", async () => {
+    // Register custom-svc as a provider so the orchestrator finds it
+    // and reaches the non-interactive check (gateway transport).
+    mockGetProvider.mockImplementation((key: string) => {
+      if (key === "custom-svc") {
+        return {
+          key: "custom-svc",
+          authUrl: "https://auth.example.com",
+          tokenUrl: "https://token.example.com",
+          defaultScopes: JSON.stringify(["read"]),
+          scopePolicy: JSON.stringify({}),
+        };
+      }
+      return wellKnownProviders[key] ?? undefined;
+    });
+
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
@@ -627,11 +691,11 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
+      scopePolicy: JSON.stringify({}),
+      callbackTransport: "loopback",
+      loopbackPort: 8756,
     }));
-    setSecureKey(
-      "oauth_app/test-app-id/client_secret",
-      "test-secret",
-    );
+    setSecureKey("oauth_app/test-app-id/client_secret", "test-secret");
 
     const result = await credentialStoreTool.execute(
       {

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -23,7 +23,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { getDb, initializeDb, resetDb, resetTestTables } from "../memory/db.js";
 import {
   createConnection,
   deleteApp,
@@ -64,6 +64,9 @@ function createTestApp(providerKey = "github", clientId = "client-1") {
 beforeEach(() => {
   resetDb();
   initializeDb();
+  // Explicitly clear all OAuth tables to prevent cross-test state pollution.
+  // Delete in FK-dependency order: connections → apps → providers.
+  resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
 });
 
 afterAll(() => {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -5,7 +5,7 @@
  * extra_params, granted_scopes, metadata) are stored as serialized JSON strings.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb, rawChanges } from "../memory/db.js";
@@ -294,7 +294,7 @@ export function getConnectionByProvider(
         eq(oauthConnections.status, "active"),
       ),
     )
-    .orderBy(desc(oauthConnections.createdAt))
+    .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
     .limit(1)
     .get();
 }

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -316,6 +316,13 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
+  // Also write to legacy credential key path so the deprecated
+  // withValidToken() reads the refreshed token on subsequent calls.
+  await setSecureKeyAsync(
+    credentialKey(service, "access_token"),
+    result.accessToken,
+  );
+
   if (result.refreshToken) {
     if (
       !(await setSecureKeyAsync(


### PR DESCRIPTION
## Summary
- Fix token-manager to write refreshed tokens to legacy credential key path (fixes sequential withValidToken calls)
- Add deterministic ordering tiebreaker in getConnectionByProvider when timestamps collide
- Fix test mocks and setup for credential-vault-unit, oauth-store, and security-invariants tests

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22985749755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
