### PR TITLE
fix: revert Telegram and Slack Channel handlers to keychain-based credential checks

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -5,7 +5,6 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
-import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -36,14 +35,18 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
-  const conn = getConnectionByProvider("slack_channel");
-  const connected = !!(conn && conn.status === "active");
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
-    hasBotToken: connected,
-    hasAppToken: connected,
-    connected,
+    hasBotToken,
+    hasAppToken,
+    connected: hasBotToken && hasAppToken,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
     ...(botUserId ? { botUserId } : {}),

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -8,7 +8,6 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
-import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -62,15 +61,17 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
-  const conn = getConnectionByProvider("telegram");
-  const connected = !!(conn && conn.status === "active");
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
-    hasBotToken: connected,
+    hasBotToken,
     botUsername,
-    connected,
-    hasWebhookSecret: connected,
+    connected: hasBotToken && hasWebhookSecret,
+    hasWebhookSecret,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes regression from PR #15619 for oauth-sqlite-migration.md.

**Gap:** getTelegramConfig() and getSlackChannelConfig() always report disconnected
**What was expected:** Non-OAuth services should check keychain for bot tokens
**What was found:** getConnectionByProvider() always returns undefined for non-OAuth services

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
