### PR TITLE
fix: align tests with oauth-store key path changes

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -1240,11 +1240,14 @@ describe("withValidToken refresh deduplication", () => {
     opts?: { expired?: boolean; accessToken?: string },
   ) {
     const accessToken = opts?.accessToken ?? "old-access-token";
-    setSecureKey(credentialKey(service, "access_token"), accessToken);
 
     // Seed mock oauth-store maps so token-manager can resolve refresh config
     const appId = `app-${service}`;
     const connId = `conn-${service}`;
+
+    // Store access token under the oauth_connection key path that
+    // withValidToken reads (not the legacy credentialKey path).
+    setSecureKey(`oauth_connection/${connId}/access_token`, accessToken);
     mockProviders.set(service, {
       key: service,
       tokenUrl: "https://oauth.example.com/token",
@@ -1396,22 +1399,23 @@ describe("withValidToken refresh deduplication", () => {
 
     const err401 = Object.assign(new Error("Unauthorized"), { status: 401 });
 
-    // First call triggers a refresh
+    // First call triggers a refresh (old token → 401 → refresh → token-1)
     const r1 = await withValidToken(
       "integration:gmail",
       async (token: string) => {
-        if (token === "old-access-token") throw err401;
+        if (token !== "token-1") throw err401;
         return token;
       },
     );
     expect(r1).toBe("token-1");
     expect(refreshCount).toBe(1);
 
-    // Set up so the next call will also get a 401 (legacy key still has "old-access-token")
+    // Second call also triggers a 401 to verify dedup state was cleaned up
+    // and a new refresh is allowed (not deduplicated with the first).
     const r2 = await withValidToken(
       "integration:gmail",
       async (token: string) => {
-        if (token === "old-access-token") throw err401;
+        if (token !== "token-2") throw err401;
         return token;
       },
     );

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -164,6 +164,14 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
   _setMetadataPath: () => {},
 }));
 
+// Mock oauth-store — getSlackChannelConfig reads connection status from the DB
+let mockOAuthConnection: { id: string; status: string } | undefined;
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: () => mockOAuthConnection,
+  listConnections: () => [],
+}));
+
 // Mock fetch for Slack API validation
 const originalFetch = globalThis.fetch;
 
@@ -188,6 +196,7 @@ describe("Slack channel config handler", () => {
     secureKeyStore = {};
     credentialMetadataStore = [];
     configStore = {};
+    mockOAuthConnection = undefined;
     globalThis.fetch = originalFetch;
   });
 
@@ -200,8 +209,7 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns connected: true when both tokens are set", () => {
-    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
-    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
+    mockOAuthConnection = { id: "conn-slack", status: "active" };
 
     const result = getSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -211,7 +219,7 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns metadata from config when available", () => {
-    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    mockOAuthConnection = { id: "conn-slack", status: "active" };
     configStore = {
       slack: {
         teamId: "T123",

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -117,6 +117,10 @@ function buildCredentialOutput(
     createdAt: new Date(metadata.createdAt).toISOString(),
     updatedAt: new Date(metadata.updatedAt).toISOString(),
     injectionTemplateCount: metadata.injectionTemplates?.length ?? 0,
+    grantedScopes: connection ? JSON.parse(connection.grantedScopes) : null,
+    expiresAt: connection?.expiresAt
+      ? new Date(connection.expiresAt).toISOString()
+      : null,
   };
 
   if (connection) {


### PR DESCRIPTION
## Summary
- Add missing `oauth-store.js` mock to `slack-channel-config.test.ts` — the handler now reads connection status from the DB via `getConnectionByProvider`
- Fix `credential-vault.test.ts` `setupService` to store access tokens under the `oauth_connection/{id}/access_token` key path that `withValidToken` now reads (instead of the legacy `credentialKey` path)
- Add `grantedScopes` and `expiresAt` fields to `buildCredentialOutput()` in the credentials CLI so `list` and `inspect` output includes them

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22986756435/job/66738688039

🤖 Generated with [Claude Code](https://claude.com/claude-code)