### PR TITLE
fix: update credential-vault test to use new key format, remove stale allowlist entry

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -230,7 +230,6 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
-      "oauth/migrate-to-sqlite.ts", // one-time data migration from credential metadata to oauth-store
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for oauth-sqlite-migration.md.

**Gap A:** setupService stores token at legacy key, withValidToken reads new key — test fails
**Gap B:** Stale migrate-to-sqlite.ts entry in security invariants allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
