### PR TITLE
fix: update resolveSlackToken to read from oauth-store key path

### DIFF
--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -12,6 +12,12 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: async () => {},
 }));
 
+let connectionByProvider: Record<string, unknown> = {};
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (key: string) =>
+    connectionByProvider[key] ?? undefined,
+}));
+
 let listConversationsResult: unknown = { ok: true, channels: [] };
 let postMessageResult: unknown = {
   ok: true,
@@ -86,6 +92,7 @@ function makeRequest(body: unknown): Request {
 
 beforeEach(() => {
   secureKeyValues.clear();
+  connectionByProvider = {};
   listConversationsResult = { ok: true, channels: [] };
   userInfoResults = new Map();
   appStoreResult = null;
@@ -106,8 +113,9 @@ describe("handleListSlackChannels", () => {
   });
 
   test("returns channels sorted by type then name", async () => {
+    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
-      credentialKey("integration:slack", "access_token"),
+      "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
     );
 
@@ -198,8 +206,9 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 for malformed JSON", async () => {
+    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
-      credentialKey("integration:slack", "access_token"),
+      "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
     );
     const req = new Request("http://localhost/v1/slack/share", {
@@ -212,8 +221,9 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 400 when missing required fields", async () => {
+    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
-      credentialKey("integration:slack", "access_token"),
+      "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
     );
     const req = makeRequest({ appId: "app1" });
@@ -224,8 +234,9 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("returns 404 when app not found", async () => {
+    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
-      credentialKey("integration:slack", "access_token"),
+      "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
     );
     appStoreResult = null;
@@ -235,8 +246,9 @@ describe("handleShareToSlackChannel", () => {
   });
 
   test("posts message and returns success", async () => {
+    connectionByProvider["integration:slack"] = { id: "conn-slack-1" };
     secureKeyValues.set(
-      credentialKey("integration:slack", "access_token"),
+      "oauth_connection/conn-slack-1/access_token",
       "xoxb-test",
     );
     appStoreResult = {

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -12,6 +12,7 @@ import {
   userInfo,
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
 import { credentialKey } from "../../../../security/credential-key.js";
 import { getSecureKey } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
@@ -29,9 +30,12 @@ const log = getLogger("slack-share");
  * Prefers the OAuth integration token, falls back to the legacy channel token.
  */
 function resolveSlackToken(): string | undefined {
+  const conn = getConnectionByProvider("integration:slack");
+  const oauthToken = conn
+    ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
+    : undefined;
   return (
-    getSecureKey(credentialKey("integration:slack", "access_token")) ??
-    getSecureKey(credentialKey("slack_channel", "bot_token"))
+    oauthToken ?? getSecureKey(credentialKey("slack_channel", "bot_token"))
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-sqlite-migration.md.

**Gap:** resolveSlackToken() reads legacy key format
**What was expected:** OAuth token reads should use oauth_connection/{id}/access_token
**What was found:** Reads credential/integration:slack/access_token which is no longer written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
