### PR TITLE
fix: align slack-channel-config test with reverted implementation

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -164,14 +164,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
   _setMetadataPath: () => {},
 }));
 
-// Mock oauth-store — getSlackChannelConfig reads connection status from the DB
-let mockOAuthConnection: { id: string; status: string } | undefined;
-
-mock.module("../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: () => mockOAuthConnection,
-  listConnections: () => [],
-}));
-
 // Mock fetch for Slack API validation
 const originalFetch = globalThis.fetch;
 
@@ -196,7 +188,6 @@ describe("Slack channel config handler", () => {
     secureKeyStore = {};
     credentialMetadataStore = [];
     configStore = {};
-    mockOAuthConnection = undefined;
     globalThis.fetch = originalFetch;
   });
 
@@ -209,7 +200,8 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns connected: true when both tokens are set", () => {
-    mockOAuthConnection = { id: "conn-slack", status: "active" };
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
 
     const result = getSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -219,7 +211,7 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns metadata from config when available", () => {
-    mockOAuthConnection = { id: "conn-slack", status: "active" };
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
     configStore = {
       slack: {
         teamId: "T123",


### PR DESCRIPTION
## Summary
- The implementation was reverted to keychain-based credential checks (5f1047f7) but the test was separately updated to mock `getConnectionByProvider` from `oauth-store` (32a41913), leaving them out of sync
- Restores the test to use `secureKeyStore` for token presence checks and removes the unnecessary `oauth-store` mock

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22987059054/job/66739662979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
