### PR TITLE
Remove maximum attachments limit

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -10,7 +10,6 @@ import {
   estimateBase64Bytes,
   inferMimeType,
   MAX_ASSISTANT_ATTACHMENT_BYTES,
-  MAX_ASSISTANT_ATTACHMENTS,
   validateDrafts,
 } from "../daemon/assistant-attachments.js";
 
@@ -163,33 +162,27 @@ describe("validateDrafts", () => {
     expect(result.warnings[0]).toContain("exceeds");
   });
 
-  test("truncates beyond max count", () => {
-    const drafts = Array.from(
-      { length: MAX_ASSISTANT_ATTACHMENTS + 2 },
-      (_, i) => makeDraft({ filename: `file-${i}.txt` }),
+  test("accepts many drafts without count limit", () => {
+    const drafts = Array.from({ length: 20 }, (_, i) =>
+      makeDraft({ filename: `file-${i}.txt` }),
     );
     const result = validateDrafts(drafts);
-    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
-    expect(result.warnings).toHaveLength(2);
-    expect(result.warnings[0]).toContain(
-      `file-${MAX_ASSISTANT_ATTACHMENTS}.txt`,
-    );
-    expect(result.warnings[0]).toContain("exceeded maximum");
+    expect(result.accepted).toHaveLength(20);
+    expect(result.warnings).toHaveLength(0);
   });
 
-  test("rejects oversized before applying count cap", () => {
+  test("rejects oversized while accepting all valid drafts", () => {
     const drafts = [
       makeDraft({
         filename: "big.bin",
         sizeBytes: MAX_ASSISTANT_ATTACHMENT_BYTES + 1,
       }),
-      ...Array.from({ length: MAX_ASSISTANT_ATTACHMENTS }, (_, i) =>
+      ...Array.from({ length: 10 }, (_, i) =>
         makeDraft({ filename: `ok-${i}.txt` }),
       ),
     ];
     const result = validateDrafts(drafts);
-    // big.bin rejected for size; all MAX_ASSISTANT_ATTACHMENTS ok files accepted
-    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
+    expect(result.accepted).toHaveLength(10);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("big.bin");
   });
@@ -431,11 +424,8 @@ describe("contentBlocksToDrafts", () => {
 // ---------------------------------------------------------------------------
 
 describe("validateDrafts with reversed tool drafts", () => {
-  test("most recent tool screenshots win the attachment cap when reversed before validation", () => {
-    // Simulate a browser session producing many screenshots chronologically.
-    // After reversing, the most recent (highest index) should appear first
-    // and win the MAX_ASSISTANT_ATTACHMENTS cap.
-    const totalScreenshots = MAX_ASSISTANT_ATTACHMENTS + 3;
+  test("all tool screenshots accepted after reversing", () => {
+    const totalScreenshots = 8;
     const toolDrafts = Array.from({ length: totalScreenshots }, (_, i) =>
       makeDraft({
         sourceType: "tool_block",
@@ -446,23 +436,11 @@ describe("validateDrafts with reversed tool drafts", () => {
       }),
     );
 
-    // Reverse to prioritize most recent
     toolDrafts.reverse();
 
     const result = validateDrafts(toolDrafts);
-    expect(result.accepted).toHaveLength(MAX_ASSISTANT_ATTACHMENTS);
-
-    // The accepted drafts should be the most recent screenshots (highest step numbers)
-    const acceptedFilenames = result.accepted.map((d) => d.filename);
-    for (let i = 0; i < MAX_ASSISTANT_ATTACHMENTS; i++) {
-      expect(acceptedFilenames[i]).toBe(
-        `screenshot-step-${totalScreenshots - 1 - i}.png`,
-      );
-    }
-
-    // The oldest screenshots should be dropped
-    expect(result.warnings).toHaveLength(3);
-    expect(result.warnings[0]).toContain("screenshot-step-2.png");
+    expect(result.accepted).toHaveLength(totalScreenshots);
+    expect(result.warnings).toHaveLength(0);
   });
 });
 

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -17,9 +17,6 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Maximum number of attachments the assistant may emit per turn. */
-export const MAX_ASSISTANT_ATTACHMENTS = 5;
-
 /** Maximum size in bytes for a single assistant attachment (20 MB). */
 export const MAX_ASSISTANT_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
@@ -122,10 +119,9 @@ export interface ValidatedDrafts {
 }
 
 /**
- * Enforce per-turn attachment caps.
+ * Enforce per-attachment size cap.
  *
  * - Rejects individual drafts that exceed `MAX_ASSISTANT_ATTACHMENT_BYTES`.
- * - Truncates the list at `MAX_ASSISTANT_ATTACHMENTS`.
  */
 export function validateDrafts(
   drafts: AssistantAttachmentDraft[],
@@ -140,14 +136,6 @@ export function validateDrafts(
           `size ${formatBytes(draft.sizeBytes)} exceeds ${formatBytes(
             MAX_ASSISTANT_ATTACHMENT_BYTES,
           )} limit.`,
-      );
-      continue;
-    }
-
-    if (accepted.length >= MAX_ASSISTANT_ATTACHMENTS) {
-      warnings.push(
-        `Skipped attachment "${draft.filename}": ` +
-          `exceeded maximum of ${MAX_ASSISTANT_ATTACHMENTS} attachments per turn.`,
       );
       continue;
     }

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -175,8 +175,7 @@ export async function resolveAssistantAttachments(
       accumulatedToolContentBlocks,
       toolContentBlockToolNames,
     );
-    // Most recent tool outputs (e.g., final browser screenshot) should win
-    // the MAX_ASSISTANT_ATTACHMENTS cap over older intermediate screenshots.
+    // Most recent tool outputs first so deduplication keeps the latest version.
     toolDrafts.reverse();
     const merged = deduplicateDrafts([
       ...directiveDrafts.drafts,

--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -31,10 +31,6 @@ final class AttachmentFlowIOSTests: XCTestCase {
 
     // MARK: - Attachment Constants
 
-    func testMaxAttachmentsConstant() {
-        XCTAssertEqual(ChatViewModel.maxAttachments, 5)
-    }
-
     func testMaxFileSizeConstant() {
         XCTAssertEqual(ChatViewModel.maxFileSize, 20 * 1024 * 1024, "Max file size should be 20 MB")
     }
@@ -183,22 +179,6 @@ final class AttachmentFlowIOSTests: XCTestCase {
         }
         XCTAssertEqual(first.filename, "Screenshot.png")
         XCTAssertEqual(first.mimeType, "image/png")
-    }
-
-    func testAddAttachmentFromImageDataRespectsMaxAttachments() {
-        // Fill up to max
-        for i in 0..<ChatViewModel.maxAttachments {
-            let att = makeDummyAttachment(id: "att-\(i)", filename: "file\(i).txt")
-            viewModel.pendingAttachments.append(att)
-        }
-
-        // Try to add one more
-        let pngData = makeMinimalPNGData()
-        viewModel.addAttachment(imageData: pngData, filename: "Overflow.png")
-
-        XCTAssertEqual(viewModel.pendingAttachments.count, ChatViewModel.maxAttachments,
-                       "Should not exceed max attachments")
-        XCTAssertNotNil(viewModel.errorText, "Should set error when exceeding max")
     }
 
     // MARK: - Thumbnail Generation

--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -147,7 +147,6 @@ struct InputBarView: View {
             .photosPicker(
                 isPresented: $showPhotosPicker,
                 selection: $selectedPhotoItems,
-                maxSelectionCount: ChatViewModel.maxAttachments,
                 matching: .images
             )
             .fileImporter(

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -36,8 +36,6 @@ public final class ChatAttachmentManager: ObservableObject {
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5 MB limit per image; base64 encoding adds ~33% overhead.
     nonisolated static let maxImageSize = 4 * 1024 * 1024
-    /// Maximum number of attachments per message.
-    nonisolated public static let maxAttachments = 5
 
     // MARK: - Error callback
 
@@ -57,11 +55,6 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Public API
 
     public func addAttachment(url: URL) {
-        guard pendingAttachments.count < Self.maxAttachments else {
-            onError?("Maximum \(Self.maxAttachments) attachments per message.")
-            return
-        }
-
         // Move file reading, compression, and thumbnail generation off the main
         // thread — Data(contentsOf:) is a blocking syscall that can stall the UI
         // for up to 20 MB worth of I/O before we even begin image processing.
@@ -73,13 +66,6 @@ public final class ChatAttachmentManager: ObservableObject {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
             case .success(let attachment):
-                // Re-check cap here: multiple concurrent adds may have all passed
-                // the guard above before any of them appended, so we must verify
-                // again inside the async task before committing.
-                guard self.pendingAttachments.count < Self.maxAttachments else {
-                    self.onError?("Maximum \(Self.maxAttachments) attachments per message.")
-                    return
-                }
                 self.pendingAttachments.append(attachment)
             }
         }
@@ -122,11 +108,6 @@ public final class ChatAttachmentManager: ObservableObject {
     /// Add an attachment from raw image data (e.g. drag-and-drop, pasteboard).
     /// Converts TIFF to PNG if needed.
     public func addAttachment(imageData: Data, filename: String = "Dropped Image.png") {
-        guard pendingAttachments.count < Self.maxAttachments else {
-            onError?("Maximum \(Self.maxAttachments) attachments per message.")
-            return
-        }
-
         // Move image conversion, compression, and thumbnail generation off the
         // main thread — these are CPU-bound and can take tens of milliseconds
         // for large images.
@@ -138,12 +119,6 @@ public final class ChatAttachmentManager: ObservableObject {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
             case .success(let attachment):
-                // Re-check cap: multiple concurrent adds may all pass the guard
-                // above before any appends occur.
-                guard self.pendingAttachments.count < Self.maxAttachments else {
-                    self.onError?("Maximum \(Self.maxAttachments) attachments per message.")
-                    return
-                }
                 self.pendingAttachments.append(attachment)
             }
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -287,8 +287,6 @@ public final class ChatViewModel: ObservableObject {
     /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
     /// Anthropic has a 5MB limit per image; base64 encoding adds ~33% overhead.
     static let maxImageSize = ChatAttachmentManager.maxImageSize
-    /// Maximum number of attachments per message.
-    public static let maxAttachments = ChatAttachmentManager.maxAttachments
 
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol


### PR DESCRIPTION
## Summary
- Remove the hard-coded limit of 5 attachments per message/turn across client (Swift) and server (TypeScript)
- Remove `maxAttachments` from `ChatAttachmentManager`, `ChatViewModel`, and `MAX_ASSISTANT_ATTACHMENTS` from `assistant-attachments.ts`
- Update tests to reflect unlimited attachment count (per-file size limit still enforced)

## Original prompt
remove the maximum attachments limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
