### PR TITLE
fix: always show copy debug button on error toasts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -36,7 +36,7 @@ struct ChatSessionErrorToast: View {
         self.accent = Self.accentColor(for: error.category)
         self.actionLabel = error.isRetryable ? Self.actionLabel(for: error.category) : nil
         self.onAction = error.isRetryable ? onRetry : nil
-        self.showCopyDebug = error.debugDetails != nil
+        self.showCopyDebug = true
         self.onCopyDebugInfo = onCopyDebugInfo
         self.onDismiss = onDismiss
     }


### PR DESCRIPTION
## Summary
- Always show the copy debug info button on `ChatSessionErrorToast`, not just when `debugDetails` is present
- The `copySessionErrorDebugDetails()` method already copies useful info (category, session ID, retryable status) even without `debugDetails`, so the button should always be available

## Original prompt
This header should also have a copy button on the right like the other error headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
