### PR TITLE
fix: include debugDetails in regenerateFailed error toasts

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -3456,11 +3456,13 @@ public final class HTTPTransport {
                 }
             } else {
                 log.error("Regenerate failed (HTTP \(http.statusCode))")
+                let body = String(data: data, encoding: .utf8) ?? "(non-UTF8 body)"
                 onMessage?(.sessionError(SessionErrorMessage(
                     sessionId: sessionId,
                     code: .regenerateFailed,
                     userMessage: "Unable to regenerate response. Try sending your message again.",
-                    retryable: true
+                    retryable: true,
+                    debugDetails: "HTTP \(http.statusCode): \(body)"
                 )))
             }
         } catch {
@@ -3469,7 +3471,8 @@ public final class HTTPTransport {
                 sessionId: sessionId,
                 code: .regenerateFailed,
                 userMessage: "Unable to regenerate response. Try sending your message again.",
-                retryable: true
+                retryable: true,
+                debugDetails: error.localizedDescription
             )))
         }
     }


### PR DESCRIPTION
## Summary
- Pass `debugDetails` through on both regenerate failure paths: HTTP error status (includes status code + response body) and caught exceptions (includes error description)
- Previously these errors omitted `debugDetails`, making it impossible to diagnose why regeneration failed

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
