### PR TITLE
fix: extend ensureToolPairing to handle server_tool_use/web_search_tool_result pairing

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -666,6 +666,162 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     ).toBe(true);
   });
 
+  // -----------------------------------------------------------------------
+  // ensureToolPairing — server_tool_use / web_search_tool_result pairing
+  // -----------------------------------------------------------------------
+
+  test("server_tool_use with missing web_search_tool_result gets synthetic result injected", async () => {
+    const messages: Message[] = [
+      userMsg("Search for something"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_abc123",
+            name: "web_search",
+            input: { query: "test" },
+          },
+        ],
+      },
+      userMsg("Thanks"), // user text but no web_search_tool_result
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        tool_use_id?: string;
+        content?: unknown;
+      }>;
+    }>;
+
+    // The user message after assistant should contain a synthetic web_search_tool_result
+    const userAfterAssistant = sent[2];
+    expect(userAfterAssistant.role).toBe("user");
+    expect(userAfterAssistant.content[0].type).toBe("web_search_tool_result");
+    expect(userAfterAssistant.content[0].tool_use_id).toBe("srvtoolu_abc123");
+  });
+
+  test("server_tool_use at end of messages gets synthetic web_search_tool_result appended", async () => {
+    const messages: Message[] = [
+      userMsg("Search something"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_end",
+            name: "web_search",
+            input: { query: "test" },
+          },
+        ],
+      },
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // A synthetic user message should have been appended
+    expect(sent).toHaveLength(3);
+    expect(sent[2].role).toBe("user");
+    expect(sent[2].content[0].type).toBe("web_search_tool_result");
+    expect(sent[2].content[0].tool_use_id).toBe("srvtoolu_end");
+  });
+
+  test("server_tool_use with matching web_search_tool_result passes through unchanged", async () => {
+    const messages: Message[] = [
+      userMsg("Search something"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_ok",
+            name: "web_search",
+            input: { query: "test" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_ok",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "Example",
+                encrypted_content: "enc_abc",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    // No synthetic messages or blocks added
+    expect(sent).toHaveLength(3);
+    const resultBlocks = sent[2].content.filter(
+      (b) => b.type === "web_search_tool_result",
+    );
+    expect(resultBlocks).toHaveLength(1);
+    expect(resultBlocks[0].tool_use_id).toBe("srvtoolu_ok");
+  });
+
+  test("mixed tool_use and server_tool_use with partial results gets missing ones filled", async () => {
+    const messages: Message[] = [
+      userMsg("Do things"),
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_a", name: "file_read", input: {} },
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_b",
+            name: "web_search",
+            input: { query: "test" },
+          },
+        ],
+      },
+      // Only tu_a has a result
+      toolResultMsg("tu_a", "result A"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        tool_use_id?: string;
+      }>;
+    }>;
+
+    const userAfterAssistant = sent[2];
+    // Should have tool_result for tu_a and synthetic web_search_tool_result for srvtoolu_b
+    expect(userAfterAssistant.content).toHaveLength(2);
+    expect(userAfterAssistant.content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tu_a",
+    });
+    expect(userAfterAssistant.content[1]).toMatchObject({
+      type: "web_search_tool_result",
+      tool_use_id: "srvtoolu_b",
+    });
+  });
+
   test("assistant message with only unknown blocks gets placeholder text", async () => {
     const messages: Message[] = [
       userMsg("Start"),

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -63,6 +63,20 @@ function isToolUseBlock(block: unknown): block is Anthropic.ToolUseBlockParam {
   );
 }
 
+/** Type-guard for server_tool_use blocks (e.g. native web search). */
+function isServerToolUseBlock(block: unknown): block is {
+  type: "server_tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+} {
+  return (
+    typeof block === "object" &&
+    block != null &&
+    (block as { type: string }).type === "server_tool_use"
+  );
+}
+
 /** Type-guard for tool_result blocks in Anthropic-formatted content. */
 function isToolResultBlock(
   block: unknown,
@@ -71,6 +85,19 @@ function isToolResultBlock(
     typeof block === "object" &&
     block != null &&
     (block as { type: string }).type === "tool_result"
+  );
+}
+
+/** Type-guard for web_search_tool_result blocks. */
+function isWebSearchToolResultBlock(block: unknown): block is {
+  type: "web_search_tool_result";
+  tool_use_id: string;
+  content: unknown;
+} {
+  return (
+    typeof block === "object" &&
+    block != null &&
+    (block as { type: string }).type === "web_search_tool_result"
   );
 }
 
@@ -84,8 +111,12 @@ function summarizeMessages(messages: Anthropic.MessageParam[]): string[] {
     const blockDescs = content.map((b) => {
       const bt = (b as { type: string }).type;
       if (bt === "tool_use") return `tool_use(${(b as { id: string }).id})`;
+      if (bt === "server_tool_use")
+        return `server_tool_use(${(b as { id: string }).id})`;
       if (bt === "tool_result")
         return `tool_result(${(b as { tool_use_id: string }).tool_use_id})`;
+      if (bt === "web_search_tool_result")
+        return `web_search_tool_result(${(b as { tool_use_id: string }).tool_use_id})`;
       return bt;
     });
     return `[${idx}] ${m.role}: ${blockDescs.join(", ") || "(empty)"}`;
@@ -103,29 +134,70 @@ function buildSyntheticToolResult(
   };
 }
 
-function getOrderedToolUseIds(
-  content: Anthropic.ContentBlockParam[],
-): string[] {
+function buildSyntheticWebSearchToolResult(
+  toolUseId: string,
+): Anthropic.ContentBlockParam {
+  return {
+    type: "web_search_tool_result",
+    tool_use_id: toolUseId,
+    content: {
+      type: "web_search_tool_result_error",
+      error_code: "unavailable",
+    },
+  } as unknown as Anthropic.ContentBlockParam;
+}
+
+/** Build the appropriate synthetic result block based on whether the ID is for a server tool or regular tool. */
+function buildSyntheticResult(
+  toolUseId: string,
+  serverToolIds: ReadonlySet<string>,
+): Anthropic.ContentBlockParam {
+  if (serverToolIds.has(toolUseId)) {
+    return buildSyntheticWebSearchToolResult(toolUseId);
+  }
+  return buildSyntheticToolResult(toolUseId);
+}
+
+function getOrderedToolUseIds(content: Anthropic.ContentBlockParam[]): {
+  ids: string[];
+  serverToolIds: Set<string>;
+} {
   const ids: string[] = [];
   const seen = new Set<string>();
+  const serverToolIds = new Set<string>();
   for (const block of content) {
-    if (!isToolUseBlock(block)) continue;
-    if (seen.has(block.id)) continue;
-    seen.add(block.id);
-    ids.push(block.id);
+    if (isToolUseBlock(block)) {
+      if (!seen.has(block.id)) {
+        seen.add(block.id);
+        ids.push(block.id);
+      }
+    } else if (isServerToolUseBlock(block)) {
+      if (!seen.has(block.id)) {
+        seen.add(block.id);
+        ids.push(block.id);
+        serverToolIds.add(block.id);
+      }
+    }
   }
-  return ids;
+  return { ids, serverToolIds };
 }
 
 function hasOrderedToolResultPrefix(
   content: Anthropic.ContentBlockParam[],
   orderedToolUseIds: string[],
+  serverToolIds: ReadonlySet<string>,
 ): boolean {
   if (content.length < orderedToolUseIds.length) return false;
   for (let idx = 0; idx < orderedToolUseIds.length; idx++) {
     const block = content[idx];
-    if (!isToolResultBlock(block)) return false;
-    if (block.tool_use_id !== orderedToolUseIds[idx]) return false;
+    const expectedId = orderedToolUseIds[idx];
+    if (serverToolIds.has(expectedId)) {
+      if (!isWebSearchToolResultBlock(block)) return false;
+      if (block.tool_use_id !== expectedId) return false;
+    } else {
+      if (!isToolResultBlock(block)) return false;
+      if (block.tool_use_id !== expectedId) return false;
+    }
   }
   return true;
 }
@@ -134,14 +206,15 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
   pairedContent: Anthropic.ContentBlockParam[];
   carryoverContent: Anthropic.ContentBlockParam[];
   toolUseIds: string[];
+  serverToolIds: Set<string>;
 } {
   const leading: Anthropic.ContentBlockParam[] = [];
-  const toolUseBlocks: Anthropic.ToolUseBlockParam[] = [];
+  const toolUseBlocks: Anthropic.ContentBlockParam[] = [];
   const carryover: Anthropic.ContentBlockParam[] = [];
   let seenToolUse = false;
 
   for (const block of content) {
-    if (isToolUseBlock(block)) {
+    if (isToolUseBlock(block) || isServerToolUseBlock(block)) {
       seenToolUse = true;
       toolUseBlocks.push(block);
       continue;
@@ -158,6 +231,7 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
       pairedContent: content,
       carryoverContent: [],
       toolUseIds: [],
+      serverToolIds: new Set(),
     };
   }
 
@@ -165,16 +239,19 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
     ...leading,
     ...toolUseBlocks,
   ];
+  const { ids, serverToolIds } = getOrderedToolUseIds(pairedContent);
   return {
     pairedContent,
     carryoverContent: carryover,
-    toolUseIds: getOrderedToolUseIds(pairedContent),
+    toolUseIds: ids,
+    serverToolIds,
   };
 }
 
 function normalizeFollowingUserContent(
   nextContent: Anthropic.ContentBlockParam[],
   orderedToolUseIds: string[],
+  serverToolIds: ReadonlySet<string>,
 ): {
   toolResultPrefix: Anthropic.ContentBlockParam[];
   remainingContent: Anthropic.ContentBlockParam[];
@@ -182,7 +259,7 @@ function normalizeFollowingUserContent(
   hadOrderedPrefix: boolean;
 } {
   const pendingIds = new Set(orderedToolUseIds);
-  const matchedById = new Map<string, Anthropic.ToolResultBlockParam>();
+  const matchedById = new Map<string, Anthropic.ContentBlockParam>();
   const remaining: Anthropic.ContentBlockParam[] = [];
 
   for (const block of nextContent) {
@@ -194,12 +271,23 @@ function normalizeFollowingUserContent(
       matchedById.set(block.tool_use_id, block);
       continue;
     }
+    if (
+      isWebSearchToolResultBlock(block) &&
+      pendingIds.has(block.tool_use_id) &&
+      !matchedById.has(block.tool_use_id)
+    ) {
+      matchedById.set(
+        block.tool_use_id,
+        block as unknown as Anthropic.ContentBlockParam,
+      );
+      continue;
+    }
     remaining.push(block);
   }
 
   const missingIds = orderedToolUseIds.filter((id) => !matchedById.has(id));
   const orderedResults = orderedToolUseIds.map(
-    (id) => matchedById.get(id) ?? buildSyntheticToolResult(id),
+    (id) => matchedById.get(id) ?? buildSyntheticResult(id, serverToolIds),
   );
 
   return {
@@ -209,6 +297,7 @@ function normalizeFollowingUserContent(
     hadOrderedPrefix: hasOrderedToolResultPrefix(
       nextContent,
       orderedToolUseIds,
+      serverToolIds,
     ),
   };
 }
@@ -237,7 +326,7 @@ function ensureToolPairing(
     }
 
     const content = Array.isArray(msg.content) ? msg.content : [];
-    const { pairedContent, carryoverContent, toolUseIds } =
+    const { pairedContent, carryoverContent, toolUseIds, serverToolIds } =
       splitAssistantForToolPairing(content);
 
     if (toolUseIds.length === 0) {
@@ -246,7 +335,7 @@ function ensureToolPairing(
       continue;
     }
 
-    // Assistant message — push the paired portion (pre-tool text + tool_use blocks)
+    // Assistant message — push the paired portion (pre-tool text + tool_use/server_tool_use blocks)
     result.push({
       role: "assistant" as const,
       content: pairedContent,
@@ -267,7 +356,11 @@ function ensureToolPairing(
     const next = messages[i + 1];
     if (next && next.role === "user") {
       const nextContent = Array.isArray(next.content) ? next.content : [];
-      const normalized = normalizeFollowingUserContent(nextContent, toolUseIds);
+      const normalized = normalizeFollowingUserContent(
+        nextContent,
+        toolUseIds,
+        serverToolIds,
+      );
       if (normalized.missingIds.length > 0) {
         log.warn(
           {
@@ -332,7 +425,9 @@ function ensureToolPairing(
       );
       result.push({
         role: "user" as const,
-        content: toolUseIds.map((id) => buildSyntheticToolResult(id)),
+        content: toolUseIds.map((id) =>
+          buildSyntheticResult(id, serverToolIds),
+        ),
       });
 
       // If the assistant contained collapsed post-tool text, preserve it as a
@@ -353,17 +448,29 @@ function ensureToolPairing(
     const m = result[j];
     if (m.role !== "assistant") continue;
     const c = Array.isArray(m.content) ? m.content : [];
-    const ids = getOrderedToolUseIds(c);
-    if (ids.length === 0) continue;
+    const { ids: validationIds, serverToolIds: validationServerToolIds } =
+      getOrderedToolUseIds(c);
+    if (validationIds.length === 0) continue;
 
     const nxt = result[j + 1];
     const nxtContent =
       nxt && nxt.role === "user" && Array.isArray(nxt.content)
         ? nxt.content
         : [];
-    if (!hasOrderedToolResultPrefix(nxtContent, ids)) {
-      const unmatchedIds = ids.filter((id, idx) => {
+    if (
+      !hasOrderedToolResultPrefix(
+        nxtContent,
+        validationIds,
+        validationServerToolIds,
+      )
+    ) {
+      const unmatchedIds = validationIds.filter((id, idx) => {
         const block = nxtContent[idx];
+        if (validationServerToolIds.has(id)) {
+          return !(
+            isWebSearchToolResultBlock(block) && block.tool_use_id === id
+          );
+        }
         return !(isToolResultBlock(block) && block.tool_use_id === id);
       });
       log.error(


### PR DESCRIPTION
## Summary
- Extended `ensureToolPairing()` in the Anthropic provider to handle `server_tool_use` → `web_search_tool_result` pairing, not just `tool_use` → `tool_result`
- When a `server_tool_use` block (native web search) loses its corresponding result during message history manipulation, the repair logic now injects a synthetic `web_search_tool_result` with error content instead of silently passing the malformed history to the API
- Added 4 tests covering: missing result injection, end-of-messages synthetic result, passthrough of valid pairs, and mixed tool_use + server_tool_use partial results

## Original prompt
I sometimes get errors like this, figure out why and fix: Error: The AI provider rejected the request.
Category: providerApi
Session: 68FDEF8D-8B5C-47DA-B3C4-7656B18B6F9F
Retryable: true

Debug Details:
ProviderError: Anthropic API error (400): 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.5: `web_search` tool use with id `srvtoolu_0159jE1s1yPJzucdN6S8WB4Z` was found without a corresponding `web_search_tool_result` block"},"request_id":"req_011CYxeWzh5Re6g9YzB1iy9F"}
    at sendMessage (/$bunfs/root/vellum-daemon:228261:32)
    at async sendMessage (/$bunfs/root/vellum-daemon:252762:52)
    at async run (/$bunfs/root/vellum-daemon:300008:57)
    at async runAgentLoopImpl (unknown)
    at processTicksAndRejections (native:7:39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
