### PR TITLE
feat: include session error debug details and sanitized config in log export

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -14,7 +14,11 @@ import { desc } from "drizzle-orm";
 import { getDb } from "../../memory/db.js";
 import { toolInvocations } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
-import { getDataDir, getRootDir } from "../../util/platform.js";
+import {
+  getDataDir,
+  getRootDir,
+  getWorkspaceConfigPath,
+} from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -31,6 +35,7 @@ interface ExportResponse {
   success: true;
   auditRows: Array<Record<string, unknown>>;
   logFiles: Record<string, string>;
+  configSnapshot?: Record<string, unknown>;
 }
 
 /**
@@ -83,21 +88,56 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       }
     }
 
+    // --- Sanitized config snapshot ---
+    const configSnapshot = readSanitizedConfig();
+
     log.info(
-      { auditCount: auditRows.length, logFileCount: Object.keys(logFiles).length, totalBytes },
+      {
+        auditCount: auditRows.length,
+        logFileCount: Object.keys(logFiles).length,
+        totalBytes,
+        hasConfig: configSnapshot !== undefined,
+      },
       "Export completed",
     );
 
-    const payload: ExportResponse = { success: true, auditRows, logFiles };
+    const payload: ExportResponse = {
+      success: true,
+      auditRows,
+      logFiles,
+      configSnapshot,
+    };
     return Response.json(payload);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to export");
-    return httpError(
-      "INTERNAL_ERROR",
-      `Failed to export: ${message}`,
-      500,
-    );
+    return httpError("INTERNAL_ERROR", `Failed to export: ${message}`, 500);
+  }
+}
+
+/**
+ * Reads the workspace config.json and strips sensitive fields (API keys).
+ * Returns undefined if the file is missing or unreadable.
+ */
+function readSanitizedConfig(): Record<string, unknown> | undefined {
+  const configPath = getWorkspaceConfigPath();
+  if (!existsSync(configPath)) return undefined;
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw) as Record<string, unknown>;
+
+    // Strip API key values — preserve which providers have keys configured
+    if (config.apiKeys && typeof config.apiKeys === "object") {
+      const keys = config.apiKeys as Record<string, unknown>;
+      config.apiKeys = Object.fromEntries(
+        Object.keys(keys).map((k) => [k, keys[k] ? "(set)" : "(empty)"]),
+      );
+    }
+
+    return config;
+  } catch {
+    return undefined;
   }
 }
 

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -101,6 +101,7 @@ final class DebugStateWriter {
                 isBootstrapping: vm.isBootstrapping,
                 errorText: vm.errorText,
                 sessionErrorCategory: vm.sessionError.map { "\($0.category)" },
+                sessionErrorDebugDetails: vm.sessionError?.debugDetails,
                 selectedModel: vm.selectedModel,
                 messageCount: vm.messages.count,
                 pendingQueuedCount: vm.pendingQueuedCount,
@@ -168,6 +169,7 @@ struct DebugSnapshot: Codable {
         let isBootstrapping: Bool
         let errorText: String?
         let sessionErrorCategory: String?
+        let sessionErrorDebugDetails: String?
         let selectedModel: String
         let messageCount: Int
         let pendingQueuedCount: Int

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -14,13 +14,14 @@ private let log = Logger(
 ///
 /// Log sources included:
 /// - `~/Library/Application Support/vellum-assistant/logs/`  — per-session JSON logs
-/// - `~/Library/Application Support/vellum-assistant/debug-state.json` — live debug snapshot
-/// - Daemon logs and audit data via `POST /v1/export` gateway HTTP API
+/// - `~/Library/Application Support/vellum-assistant/debug-state.json` — live debug snapshot (includes session error debug details)
+/// - Daemon logs, audit data, and sanitized config via `POST /v1/export` gateway HTTP API
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys
 /// - `auth-debug.json` — non-sensitive token expiry and refresh state for session debugging
 /// - `port-diagnostics.json` — processes listening on assistant-relevant TCP ports
+/// - `config-snapshot.json` — sanitized workspace config (API key values redacted, structure preserved)
 @MainActor
 enum LogExporter {
 
@@ -151,6 +152,12 @@ enum LogExporter {
             to: tempDir.appendingPathComponent("port-diagnostics.json")
         )
 
+        // 9. Sanitized workspace config — client-side fallback if daemon export didn't include it
+        let configSnapshotPath = tempDir.appendingPathComponent("config-snapshot.json")
+        if !fileManager.fileExists(atPath: configSnapshotPath.path) {
+            writeSanitizedWorkspaceConfig(to: configSnapshotPath)
+        }
+
         // Verify we have at least one file to export
         let collected = try fileManager.contentsOfDirectory(
             at: tempDir,
@@ -274,6 +281,16 @@ enum LogExporter {
                         atomically: true,
                         encoding: .utf8
                     )
+                }
+            }
+
+            // Write sanitized config snapshot from the daemon
+            if let configSnapshot = json["configSnapshot"] {
+                if let configData = try? JSONSerialization.data(
+                    withJSONObject: configSnapshot,
+                    options: [.prettyPrinted, .sortedKeys]
+                ) {
+                    try? configData.write(to: directory.appendingPathComponent("config-snapshot.json"))
                 }
             }
         } catch {
@@ -503,6 +520,27 @@ enum LogExporter {
 
         guard let data = try? JSONSerialization.data(
             withJSONObject: info,
+            options: [.prettyPrinted, .sortedKeys]
+        ) else { return }
+        try? data.write(to: url)
+    }
+
+    /// Reads the workspace config.json and writes a sanitized copy with API key
+    /// values replaced by presence flags. Falls back silently if unreadable.
+    private nonisolated static func writeSanitizedWorkspaceConfig(to url: URL) {
+        var config = WorkspaceConfigIO.read()
+        guard !config.isEmpty else { return }
+
+        // Strip API key values — preserve which providers have keys configured
+        if var apiKeys = config["apiKeys"] as? [String: Any] {
+            for key in apiKeys.keys {
+                apiKeys[key] = apiKeys[key] != nil ? "(set)" : "(empty)"
+            }
+            config["apiKeys"] = apiKeys
+        }
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: config,
             options: [.prettyPrinted, .sortedKeys]
         ) else { return }
         try? data.write(to: url)


### PR DESCRIPTION
## Summary
- Add `sessionErrorDebugDetails` to `debug-state.json` snapshot — surfaces the daemon's classified error stack trace (actual provider error body) without needing daemon logs
- Add `config-snapshot.json` to log export — sanitized workspace config with API key values replaced by `(set)`/`(empty)` presence flags, preserving provider, model, and all non-sensitive settings
- Daemon-side: `/v1/export` now returns a `configSnapshot` field; client-side: fallback reads `~/.vellum/workspace/config.json` directly when daemon export doesn't include it

## Original prompt
Can you add this information to the dump that gets created when a user sends logs to Vellum?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
