### PR TITLE
fix: disable NL approval classification for desktop sessions

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -559,4 +559,140 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
+
+  test("desktop sessions do not pass approvalConversationGenerator to routeGuardianReply", async () => {
+    listPendingByDestinationMock.mockReturnValue([
+      { id: "pending-1", kind: "access_request" },
+    ]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: false,
+      decisionApplied: false,
+      type: "not_consumed",
+    });
+
+    const mockGenerator = mock(async () => ({}));
+    const persistUserMessage = mock(async () => "persisted-user-id");
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setTrustContext: () => {},
+      updateClient: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      ensureActorScopedHistory: async () => {},
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => false,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      trustContext: undefined,
+      hasPendingConfirmation: () => false,
+      setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
+    } as unknown as import("../daemon/session.js").Session;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "guardian-thread-key",
+        content: "no sorry, beats 0 and 3 should be new threads",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+
+    await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session,
+          assistantEventHub: { publish: async () => {} } as any,
+          resolveAttachments: () => [],
+        },
+        approvalConversationGenerator: mockGenerator as any,
+      },
+      testAuthContext,
+    );
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routerCall = (routeGuardianReplyMock as any).mock
+      .calls[0][0] as Record<string, unknown>;
+    // Desktop (vellum) should suppress the NL engine
+    expect(routerCall.approvalConversationGenerator).toBeUndefined();
+  });
+
+  test("channel sessions pass approvalConversationGenerator to routeGuardianReply", async () => {
+    listPendingByDestinationMock.mockReturnValue([
+      { id: "pending-1", kind: "access_request" },
+    ]);
+    listCanonicalMock.mockReturnValue([]);
+    routeGuardianReplyMock.mockResolvedValue({
+      consumed: false,
+      decisionApplied: false,
+      type: "not_consumed",
+    });
+
+    const mockGenerator = mock(async () => ({}));
+    const persistUserMessage = mock(async () => "persisted-user-id");
+    const runAgentLoop = mock(async () => undefined);
+    const session = {
+      setTrustContext: () => {},
+      updateClient: () => {},
+      emitConfirmationStateChanged: () => {},
+      emitActivityState: () => {},
+      setTurnChannelContext: () => {},
+      setTurnInterfaceContext: () => {},
+      ensureActorScopedHistory: async () => {},
+      usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+      isProcessing: () => false,
+      hasAnyPendingConfirmation: () => false,
+      denyAllPendingConfirmations: () => {},
+      enqueueMessage: () => ({ queued: true, requestId: "queued-id" }),
+      persistUserMessage,
+      runAgentLoop,
+      getMessages: () => [] as unknown[],
+      assistantId: "self",
+      trustContext: undefined,
+      hasPendingConfirmation: () => false,
+      setHostBashProxy: () => {},
+      setHostFileProxy: () => {},
+    } as unknown as import("../daemon/session.js").Session;
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        conversationKey: "guardian-thread-key",
+        content: "no sorry, beats 0 and 3 should be new threads",
+        sourceChannel: "telegram",
+        interface: "telegram",
+      }),
+    });
+
+    await handleSendMessage(
+      req,
+      {
+        sendMessageDeps: {
+          getOrCreateSession: async () => session,
+          assistantEventHub: { publish: async () => {} } as any,
+          resolveAttachments: () => [],
+        },
+        approvalConversationGenerator: mockGenerator as any,
+      },
+      testAuthContext,
+    );
+
+    expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
+    const routerCall = (routeGuardianReplyMock as any).mock
+      .calls[0][0] as Record<string, unknown>;
+    // Channel sessions should receive the NL engine
+    expect(routerCall.approvalConversationGenerator).toBe(mockGenerator);
+  });
 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -679,7 +679,13 @@ export async function handleSendMessage(
       attachments,
       session,
       onEvent,
-      approvalConversationGenerator: deps.approvalConversationGenerator,
+      // Desktop path: disable NL classification to avoid consuming non-decision
+      // messages while a tool confirmation is pending. Deterministic code-prefix
+      // and callback parsing remain active. Mirrors session-process.ts behavior.
+      approvalConversationGenerator:
+        sourceChannel === "vellum"
+          ? undefined
+          : deps.approvalConversationGenerator,
       verifiedActorExternalUserId,
       verifiedActorPrincipalId,
     });


### PR DESCRIPTION
## Summary
- Disable the LLM-based NL approval classification engine for desktop sessions (`sourceChannel === "vellum"`) in the HTTP handler path (`conversation-routes.ts`), matching the existing behavior in `session-process.ts`
- This prevents conversational messages like "no sorry, beats 0 and 3 should be new threads" from being misclassified as approval rejections when a tool approval is pending
- Add two tests verifying desktop sessions suppress the NL engine and channel sessions still receive it

## Original prompt
Disable NL approval classification for desktop sessions in the HTTP handler path. When a desktop user sends a message while a tool approval is pending, the NL classification engine (an LLM call) can misclassify conversational messages as approval decisions. The `session-process.ts` path already disables NL classification for desktop — this aligns the HTTP handler to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
