### PR TITLE
fix: use non-desktop channel in NL approval classification test

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -485,8 +485,8 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     createCanonicalGuardianRequest({
       id: requestId,
       kind: "tool_approval",
-      sourceType: "desktop",
-      sourceChannel: "vellum",
+      sourceType: "voice",
+      sourceChannel: "slack",
       conversationId,
       toolName: "call_start",
       status: "pending",
@@ -511,8 +511,8 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       body: JSON.stringify({
         conversationKey,
         content: "sure let's do that",
-        sourceChannel: "vellum",
-        interface: "macos",
+        sourceChannel: "slack",
+        interface: "slack",
       }),
     });
     const body = (await res.json()) as {


### PR DESCRIPTION
## Summary
- The NL approval classification test was using `sourceChannel: "vellum"` (desktop), but commit b139a61 correctly disabled NL classification for desktop sessions
- Updated the test to use `sourceChannel: "slack"` so the NL classification path is still exercised on a channel where it's active

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22989454129/job/66747054954

🤖 Generated with [Claude Code](https://claude.com/claude-code)