### PR TITLE
fix: prevent avatar sheet overlay from blocking button clicks after dismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -109,12 +109,12 @@ struct IdentityPanel: View {
             }
             .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isFullscreen)
             .overlay {
-                if let path = viewingFilePath {
-                    // Dismiss backdrop
-                    Color.black.opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { viewingFilePath = nil }
+                Color.black.opacity(viewingFilePath != nil ? 0.4 : 0)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(viewingFilePath != nil)
+                    .onTapGesture { viewingFilePath = nil }
 
+                if let path = viewingFilePath {
                     WorkspaceFileSheet(filePath: path, onClose: { viewingFilePath = nil })
                         .frame(width: 600, height: 500)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
@@ -124,11 +124,12 @@ struct IdentityPanel: View {
             }
             .animation(VAnimation.standard, value: viewingFilePath != nil)
             .overlay {
-                if showAvatarSheet {
-                    Color.black.opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture { showAvatarSheet = false }
+                Color.black.opacity(showAvatarSheet ? 0.4 : 0)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(showAvatarSheet)
+                    .onTapGesture { showAvatarSheet = false }
 
+                if showAvatarSheet {
                     AvatarManagementSheet(
                         onClose: { showAvatarSheet = false },
                         onEditAvatar: {


### PR DESCRIPTION
## Summary
- Overlay backdrops (`Color.black.opacity(0.4).ignoresSafeArea()`) inside `if` blocks with `.animation()` can leave ghost hit-test areas after the removal transition — SwiftUI sometimes fails to clean up the invisible views, blocking all touch input in the window
- Fix: keep backdrops always-present, drive them via state-bound opacity + `.allowsHitTesting()` instead of insertion/removal transitions
- Applied to both the avatar management sheet and workspace file sheet overlays in IdentityPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
