### PR TITLE
fix: distinguish permission timeout from explicit denial

### DIFF
--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -84,7 +84,10 @@ export class PermissionPrompter {
           "Permission prompt timed out, defaulting to deny",
         );
         this.onStateChanged?.(requestId, "timed_out", "timeout", toolUseId);
-        resolve({ decision: "deny" });
+        resolve({
+          decision: "deny",
+          decisionContext: `The permission prompt for the "${toolName}" tool timed out. The user did not explicitly deny this request — they may have been away or busy. You may retry this tool call if it is still needed for the current task.`,
+        });
       }, timeoutMs);
 
       this.pending.set(requestId, { resolve, reject, timer, toolUseId });


### PR DESCRIPTION
## Summary
- When a permission prompt times out (user stepped away), the model previously received the same "Permission denied by user" message as an explicit denial, causing it to refuse to retry
- Added a `decisionContext` to the timeout path in `PermissionPrompter` so the model gets a timeout-specific message that allows retrying, following the same pattern already used by `denyAllPending()`

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)