### PR TITLE
feat: expose pending request IDs from PermissionPrompter for cascading

### DIFF
--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -134,6 +134,11 @@ export class PermissionPrompter {
     return this.pending.has(requestId);
   }
 
+  /** Returns all currently pending request IDs. */
+  getPendingRequestIds(): string[] {
+    return [...this.pending.keys()];
+  }
+
   /** Returns the toolUseId associated with a pending request, if any. */
   getToolUseId(requestId: string): string | undefined {
     return this.pending.get(requestId)?.toolUseId;


### PR DESCRIPTION
## Summary
- Add `getPendingRequestIds()` method to `PermissionPrompter` that returns a copy of all currently pending request IDs
- Enables the upcoming cascading approval logic to iterate over pending confirmations

Part of plan: cascade-approvals.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
