### PR TITLE
feat: estimate PDF token cost for Anthropic using file-size heuristic

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -104,7 +104,7 @@ describe("token estimator", () => {
     expect(largeFileTokens - smallFileTokens).toBeGreaterThan(1000);
   });
 
-  test("does not count file base64 payload for OpenAI/Anthropic-style file fallback", () => {
+  test("does not count file base64 payload for OpenAI-style file fallback", () => {
     const sharedSource = {
       type: "base64" as const,
       filename: "report.pdf",
@@ -128,6 +128,47 @@ describe("token estimator", () => {
     );
 
     expect(largeFileTokens).toBe(smallFileTokens);
+  });
+
+  test("estimates Anthropic PDF tokens from file size", () => {
+    // ~14.8 MB PDF => ~20M base64 chars
+    const base64Length = 20_000_000;
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          filename: "large-report.pdf",
+          media_type: "application/pdf",
+          data: "a".repeat(base64Length),
+        },
+        extracted_text: "",
+      },
+      { providerName: "anthropic" },
+    );
+
+    // Raw bytes = 20_000_000 * 3/4 = 15_000_000
+    // Estimated tokens = 15_000_000 * 0.016 = 240_000 (plus overhead)
+    expect(tokens).toBeGreaterThan(200_000);
+  });
+
+  test("Anthropic PDF minimum is one page", () => {
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "file",
+        source: {
+          type: "base64",
+          filename: "tiny.pdf",
+          media_type: "application/pdf",
+          data: "a".repeat(16),
+        },
+        extracted_text: "",
+      },
+      { providerName: "anthropic" },
+    );
+
+    // Should be at least ANTHROPIC_PDF_MIN_TOKENS (1600) plus overhead
+    expect(tokens).toBeGreaterThanOrEqual(1600);
   });
 
   test("does not count non-inline file base64 payload for Gemini", () => {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -12,6 +12,12 @@ const OTHER_BLOCK_TOKENS = 16;
 const SYSTEM_PROMPT_OVERHEAD_TOKENS = 8;
 const GEMINI_INLINE_FILE_MIME_TYPES = new Set(["application/pdf"]);
 
+// Anthropic renders each PDF page as an image (~1,568 tokens at standard
+// resolution) plus any extracted text. Typical PDF pages are 50-150 KB.
+// Using ~100 KB/page and ~1,600 tokens/page gives ~0.016 tokens/byte.
+const ANTHROPIC_PDF_TOKENS_PER_BYTE = 0.016;
+const ANTHROPIC_PDF_MIN_TOKENS = 1600; // At least one page
+
 export interface TokenEstimatorOptions {
   providerName?: string;
 }
@@ -21,14 +27,37 @@ export function estimateTextTokens(text: string): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
-function shouldCountFileSourceData(
+function estimateAnthropicPdfTokens(base64Data: string): number {
+  const rawBytes = Math.ceil((base64Data.length * 3) / 4);
+  return Math.max(
+    ANTHROPIC_PDF_MIN_TOKENS,
+    Math.ceil(rawBytes * ANTHROPIC_PDF_TOKENS_PER_BYTE),
+  );
+}
+
+function estimateFileDataTokens(
   block: Extract<ContentBlock, { type: "file" }>,
   options?: TokenEstimatorOptions,
-): boolean {
-  if (options?.providerName !== "gemini") {
-    return false;
+): number {
+  const providerName = options?.providerName;
+
+  // Anthropic sends PDFs as native document blocks and renders each page as an image
+  if (
+    providerName === "anthropic" &&
+    block.source.media_type === "application/pdf"
+  ) {
+    return estimateAnthropicPdfTokens(block.source.data);
   }
-  return GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type);
+
+  // Gemini sends certain file types inline as base64
+  if (
+    providerName === "gemini" &&
+    GEMINI_INLINE_FILE_MIME_TYPES.has(block.source.media_type)
+  ) {
+    return estimateTextTokens(block.source.data);
+  }
+
+  return 0;
 }
 
 function estimateImageSourceDataTokens(
@@ -76,9 +105,7 @@ export function estimateContentBlockTokens(
         FILE_BLOCK_OVERHEAD_TOKENS +
         estimateTextTokens(block.source.filename) +
         estimateTextTokens(block.source.media_type) +
-        (shouldCountFileSourceData(block, options)
-          ? estimateTextTokens(block.source.data)
-          : 0) +
+        estimateFileDataTokens(block, options) +
         estimateTextTokens(block.extracted_text ?? "")
       );
     case "thinking":


### PR DESCRIPTION
## Summary
- Add Anthropic-specific PDF token estimation using file-size heuristic (~0.016 tokens/byte)
- Ensures large PDFs (e.g. 14.8 MB) are correctly flagged as exceeding context window
- Refactor file data token estimation into `estimateFileDataTokens()` helper
- OpenAI and Gemini behavior unchanged

Part of plan: media-token-estimation.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
