### PR TITLE
feat: export patternMatchesCandidate from trust-store for approval cascading

### DIFF
--- a/assistant/src/__tests__/trust-store-pattern-matches.test.ts
+++ b/assistant/src/__tests__/trust-store-pattern-matches.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { patternMatchesCandidate } from "../permissions/trust-store.js";
+
+describe("patternMatchesCandidate", () => {
+  test("exact match", () => {
+    expect(patternMatchesCandidate("bash:git commit", "bash:git commit")).toBe(
+      true,
+    );
+  });
+
+  test("glob match", () => {
+    expect(patternMatchesCandidate("bash:git *", "bash:git commit")).toBe(true);
+  });
+
+  test("no match", () => {
+    expect(patternMatchesCandidate("bash:git *", "file_write:/foo")).toBe(
+      false,
+    );
+  });
+
+  test("globstar matches anything", () => {
+    expect(patternMatchesCandidate("**", "bash:anything")).toBe(true);
+  });
+
+  test("invalid pattern returns false", () => {
+    expect(patternMatchesCandidate("[", "bash:anything")).toBe(false);
+  });
+});

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -76,6 +76,19 @@ function getCompiledPattern(pattern: string): Minimatch | null {
   return compiled;
 }
 
+/**
+ * Check whether a minimatch pattern matches a candidate string.
+ * Reuses the compiled pattern cache from trust rule evaluation.
+ */
+export function patternMatchesCandidate(
+  pattern: string,
+  candidate: string,
+): boolean {
+  const compiled = getCompiledPattern(pattern);
+  if (!compiled) return false;
+  return compiled.match(candidate);
+}
+
 /** Rebuild the compiled pattern cache from the current rule set. */
 function rebuildPatternCache(rules: TrustRule[]): void {
   compiledPatterns.clear();


### PR DESCRIPTION
## Summary
- Add `patternMatchesCandidate(pattern, candidate)` exported function to trust-store that reuses the compiled Minimatch cache
- Add unit tests covering exact match, glob, globstar, no-match, and invalid pattern cases

Part of plan: cascade-approvals.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
