### PR TITLE
feat: return conversationId in POST /v1/messages response body

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -364,11 +364,17 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
         interface: "macos",
       }),
     });
-    const body = (await res.json()) as { accepted: boolean; messageId: string };
+    const body = (await res.json()) as {
+      accepted: boolean;
+      messageId: string;
+      conversationId: string;
+    };
 
     expect(res.status).toBe(202);
     expect(body.accepted).toBe(true);
     expect(body.messageId).toBeDefined();
+    expect(typeof body.conversationId).toBe("string");
+    expect(body.conversationId.length).toBeGreaterThan(0);
 
     await stopServer();
   });
@@ -808,11 +814,17 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
         interface: "macos",
       }),
     });
-    const body2 = (await res2.json()) as { accepted: boolean; queued: boolean };
+    const body2 = (await res2.json()) as {
+      accepted: boolean;
+      queued: boolean;
+      conversationId: string;
+    };
 
     expect(res2.status).toBe(202);
     expect(body2.accepted).toBe(true);
     expect(body2.queued).toBe(true);
+    expect(typeof body2.conversationId).toBe("string");
+    expect(body2.conversationId.length).toBeGreaterThan(0);
 
     await stopServer();
   });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -693,6 +693,7 @@ export async function handleSendMessage(
       return Response.json(
         {
           accepted: true,
+          conversationId: mapping.conversationId,
           ...(inlineReplyResult.messageId
             ? { messageId: inlineReplyResult.messageId }
             : {}),
@@ -757,7 +758,10 @@ export async function handleSendMessage(
       pendingInteractions.removeBySession(session);
     }
 
-    return Response.json({ accepted: true, queued: true }, { status: 202 });
+    return Response.json(
+      { accepted: true, queued: true, conversationId: mapping.conversationId },
+      { status: 202 },
+    );
   }
 
   // Session is idle — persist and fire agent loop immediately
@@ -838,7 +842,11 @@ export async function handleSendMessage(
       });
 
       return Response.json(
-        { accepted: true, messageId: persisted.id },
+        {
+          accepted: true,
+          messageId: persisted.id,
+          conversationId: mapping.conversationId,
+        },
         { status: 202 },
       );
     } finally {
@@ -880,7 +888,10 @@ export async function handleSendMessage(
       );
     });
 
-  return Response.json({ accepted: true, messageId }, { status: 202 });
+  return Response.json(
+    { accepted: true, messageId, conversationId: mapping.conversationId },
+    { status: 202 },
+  );
 }
 
 async function generateLlmSuggestion(


### PR DESCRIPTION
## Summary
- Add conversationId to all 202 responses from POST /v1/messages
- Enables clients to map local session IDs to server conversation IDs
- Error responses (400/422/429) are unchanged

Part of plan: thread-isolation-fix.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)