### PR TITLE
feat: allow SSE subscription without conversationKey for unfiltered event delivery

### DIFF
--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -3,8 +3,9 @@
  *
  * Tests:
  *   - 401 unauthorized (missing bearer token)
- *   - 400 when conversationKey is absent
+ *   - 200 when conversationKey is omitted (unfiltered subscription)
  *   - Happy path: stream receives a published AssistantEvent
+ *   - Unfiltered: streams events from multiple conversations
  */
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -125,15 +126,13 @@ describe("SSE assistant-events endpoint", () => {
 
   // ── Validation ────────────────────────────────────────────────────────────
 
-  test("400 when conversationKey is missing", async () => {
+  test("200 when conversationKey is omitted (unfiltered subscription)", async () => {
     await startServer();
 
     const res = await fetch(eventsUrl(), { headers: AUTH_HEADERS });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as {
-      error: { message: string; code?: string };
-    };
-    expect(body.error.message).toContain("conversationKey");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    await res.body?.cancel();
 
     await stopServer();
   });
@@ -183,5 +182,54 @@ describe("SSE assistant-events endpoint", () => {
     expect(frame).toContain(`"assistantId":"self"`);
     expect(frame).toContain(`"sessionId":"${conversationId}"`);
     expect(frame).toContain('"type":"pong"');
+  });
+
+  // ── Unfiltered subscription ──────────────────────────────────────────────
+
+  test("streams all events when conversationKey is omitted", async () => {
+    // Subscribe without a conversationKey — should receive events from any session.
+    const ac = new AbortController();
+    const req = new Request("http://localhost/v1/events", {
+      signal: ac.signal,
+    });
+
+    const { AssistantEventHub } =
+      await import("../runtime/assistant-event-hub.js");
+    const testHub = new AssistantEventHub();
+
+    const { handleSubscribeAssistantEvents } =
+      await import("../runtime/routes/events-routes.js");
+    const response = handleSubscribeAssistantEvents(req, new URL(req.url), {
+      hub: testHub,
+      skipActorVerification: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+
+    // Consume the initial heartbeat.
+    const heartbeat = await reader.read();
+    expect(heartbeat.done).toBe(false);
+    expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
+
+    // Publish events with two different sessionIds.
+    const eventA = buildAssistantEvent("self", { type: "pong" }, "session-aaa");
+    const eventB = buildAssistantEvent("self", { type: "pong" }, "session-bbb");
+    await testHub.publish(eventA);
+    await testHub.publish(eventB);
+
+    // Read both frames from the stream.
+    const frameA = await reader.read();
+    expect(frameA.done).toBe(false);
+    const textA = new TextDecoder().decode(frameA.value);
+    expect(textA).toContain("session-aaa");
+
+    const frameB = await reader.read();
+    expect(frameB.done).toBe(false);
+    const textB = new TextDecoder().decode(frameB.value);
+    expect(textB).toContain("session-bbb");
+
+    ac.abort();
   });
 });

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -7,12 +7,17 @@
  * is called. The AuthContext is threaded through from the HTTP server
  * layer, so no additional actor-token verification is needed here.
  *
- * Subscribers receive all assistant events scoped to the given conversation.
+ * When `conversationKey` is provided, subscribers receive events scoped to
+ * that conversation. When omitted, subscribers receive events from ALL
+ * conversations for this assistant (unfiltered).
  */
 
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { formatSseFrame, formatSseHeartbeat } from "../assistant-event.js";
-import type { AssistantEventSubscription } from "../assistant-event-hub.js";
+import type {
+  AssistantEventFilter,
+  AssistantEventSubscription,
+} from "../assistant-event-hub.js";
 import {
   AssistantEventHub,
   assistantEventHub,
@@ -26,10 +31,12 @@ import type { RouteDefinition } from "../http-router.js";
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 
 /**
- * Stream assistant events as Server-Sent Events for a specific conversation.
+ * Stream assistant events as Server-Sent Events.
  *
  * Query params:
- *   conversationKey -- required; scopes the stream to one conversation.
+ *   conversationKey -- optional; when provided, scopes the stream to one
+ *                      conversation. When omitted, the stream delivers events
+ *                      from ALL conversations for this assistant.
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
@@ -56,15 +63,18 @@ export function handleSubscribeAssistantEvents(
   // scope and principal type requirements.
 
   const conversationKey = url.searchParams.get("conversationKey");
-  if (!conversationKey) {
-    return httpError("BAD_REQUEST", "conversationKey is required", 400);
-  }
 
   const hub = options?.hub ?? assistantEventHub;
   const heartbeatIntervalMs =
     options?.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
 
-  const mapping = getOrCreateConversation(conversationKey);
+  const filter: AssistantEventFilter = {
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+  };
+  if (conversationKey) {
+    const mapping = getOrCreateConversation(conversationKey);
+    filter.sessionId = mapping.conversationId;
+  }
   const encoder = new TextEncoder();
 
   // -- Eager subscribe --------------------------------------------------------
@@ -90,10 +100,7 @@ export function handleSubscribeAssistantEvents(
 
   try {
     sub = hub.subscribe(
-      {
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-        sessionId: mapping.conversationId,
-      },
+      filter,
       (event) => {
         const controller = controllerRef;
         if (!controller) return;


### PR DESCRIPTION
## Summary
- Make conversationKey optional on GET /v1/events SSE endpoint
- When omitted, subscribe to ALL assistant events (no sessionId filter)
- When provided, behavior is unchanged (scoped to that conversation)

Part of plan: thread-isolation-fix.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
