### PR TITLE
fix: use per-thread conversation keys and unfiltered SSE for proper thread isolation

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -247,6 +247,7 @@ public final class HTTPTransport {
     enum Endpoint {
         case healthz
         case events(conversationKey: String)
+        case eventsAll  // SSE subscription without conversationKey filter
         case sendMessage
         case getMessages(conversationId: String?)
         case conversations(limit: Int, offset: Int)
@@ -458,6 +459,8 @@ public final class HTTPTransport {
         case .events(let conversationKey):
             let encoded = conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey
             return ("/v1/events", "conversationKey=\(encoded)")
+        case .eventsAll:
+            return ("/v1/events", nil)
         case .sendMessage:
             return ("/v1/messages", nil)
         case .getMessages(let conversationId):
@@ -840,6 +843,8 @@ public final class HTTPTransport {
         case .events(let conversationKey):
             let encoded = conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey
             return ("\(prefix)/events/", "conversationKey=\(encoded)")
+        case .eventsAll:
+            return ("\(prefix)/events/", nil)
         case .sendMessage:
             return ("\(prefix)/messages/", nil)
         case .getMessages(let conversationId):
@@ -1336,8 +1341,8 @@ public final class HTTPTransport {
     private func startSSEStream() {
         sseTask?.cancel()
 
-        guard let url = buildURL(for: .events(conversationKey: self.conversationKey)) else {
-            log.error("Invalid SSE URL for conversationKey: \(self.conversationKey)")
+        guard let url = buildURL(for: .eventsAll) else {
+            log.error("Invalid SSE URL for unfiltered events")
             return
         }
 
@@ -1569,7 +1574,7 @@ public final class HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = [
-            "conversationKey": conversationKey,
+            "conversationKey": sessionId,
             "sourceChannel": sourceChannel,
             "interface": Self.defaultInterface
         ]
@@ -1588,6 +1593,16 @@ public final class HTTPTransport {
 
             if http.statusCode == 202 || http.statusCode == 200 {
                 log.info("Message sent successfully")
+                // Learn the server's conversationId for this thread's conversationKey.
+                // For new threads, the sessionId (used as conversationKey) differs from
+                // the server's internal conversationId. Store the mapping so parseSSEData
+                // can remap incoming events to the client's local session ID.
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let serverConvId = json["conversationId"] as? String,
+                   serverConvId != sessionId {
+                    self.serverToLocalSessionMap[serverConvId] = sessionId
+                    log.info("Mapped server conversation \(serverConvId, privacy: .public) → local session \(sessionId, privacy: .public)")
+                }
             } else if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 switch refreshResult {


### PR DESCRIPTION
## Summary
- Switch SSE subscription to unfiltered mode (no conversationKey) so events from all conversations are received
- Use per-thread sessionId as conversationKey in POST /v1/messages, creating separate backend conversations per thread
- Parse conversationId from POST response to populate serverToLocalSessionMap for event routing
- Fixes thread isolation: messages in Thread A no longer leak into Thread B

Part of plan: thread-isolation-fix.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
