### PR TITLE
fix: use real minimatch in cascade test mock to prevent trust-store mock pollution

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -10,6 +10,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { Minimatch } from "minimatch";
+
 import type {
   AgentEvent,
   CheckpointDecision,
@@ -108,19 +110,19 @@ mock.module("../skills/slash-commands.js", () => ({
   parseSlashCandidate: () => ({ kind: "not_slash" }),
 }));
 
-// Trust store mock — includes patternMatchesCandidate for cascade logic
+// Trust store mock — uses real minimatch for patternMatchesCandidate so the
+// mock doesn't break trust-store-pattern-matches.test.ts when both files run
+// in the same Bun process (mock.module leaks across test files).
 mock.module("../permissions/trust-store.js", () => ({
   addRule: () => {},
   findHighestPriorityRule: () => null,
   clearCache: () => {},
   patternMatchesCandidate: (pattern: string, candidate: string): boolean => {
-    // Simple glob matching: "tool:**" matches "tool:anything"
-    if (pattern.endsWith(":**")) {
-      const prefix = pattern.slice(0, -3);
-      return candidate.startsWith(prefix + ":");
+    try {
+      return new Minimatch(pattern).match(candidate);
+    } catch {
+      return false;
     }
-    if (pattern === "**") return true;
-    return pattern === candidate;
   },
 }));
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cascade-approvals.md.

**Gap:** Test mock pollution — cascade test's mock.module for trust-store leaks into pattern-matches test
**What was expected:** Each test file's mocks should be isolated
**What was found:** approval-cascade.test.ts stub for patternMatchesCandidate leaked into trust-store-pattern-matches.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
