### PR TITLE
fix: handle SSE events arriving before session mapping is established

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1438,6 +1438,51 @@ public final class HTTPTransport {
             )
         }
 
+        // Fallback: eagerly learn server-to-local mapping from the first unmapped SSE event.
+        // When SSE events arrive before the POST /v1/messages response (e.g. slash commands),
+        // the serverToLocalSessionMap won't have the mapping yet. If we have a pendingLocalSessionId
+        // and the event contains a sessionId that isn't a known local ID, assume it's the server's
+        // conversationId for the pending thread and establish the mapping immediately.
+        if let pendingId = pendingLocalSessionId {
+            let knownLocalIds = Set(serverToLocalSessionMap.values)
+            // Extract sessionId value using simple pattern matching (handles both compact and spaced JSON)
+            let patterns = ["\"sessionId\":\"", "\"sessionId\": \""]
+            for pattern in patterns {
+                if let startRange = jsonString.range(of: pattern) {
+                    let afterPattern = jsonString[startRange.upperBound...]
+                    if let endQuote = afterPattern.firstIndex(of: "\"") {
+                        let eventSessionId = String(afterPattern[afterPattern.startIndex..<endQuote])
+                        if !eventSessionId.isEmpty,
+                           eventSessionId != pendingId,
+                           !knownLocalIds.contains(eventSessionId),
+                           serverToLocalSessionMap[eventSessionId] == nil {
+                            // This is the server's conversationId for the pending thread
+                            serverToLocalSessionMap[eventSessionId] = pendingId
+                            log.info("Eagerly mapped server conversation \(eventSessionId, privacy: .public) → pending local session \(pendingId, privacy: .public)")
+                            // Apply the remapping to the current event
+                            jsonString = jsonString.replacingOccurrences(
+                                of: "\"sessionId\":\"\(eventSessionId)\"",
+                                with: "\"sessionId\":\"\(pendingId)\""
+                            )
+                            jsonString = jsonString.replacingOccurrences(
+                                of: "\"sessionId\": \"\(eventSessionId)\"",
+                                with: "\"sessionId\": \"\(pendingId)\""
+                            )
+                            jsonString = jsonString.replacingOccurrences(
+                                of: "\"parentSessionId\":\"\(eventSessionId)\"",
+                                with: "\"parentSessionId\":\"\(pendingId)\""
+                            )
+                            jsonString = jsonString.replacingOccurrences(
+                                of: "\"parentSessionId\": \"\(eventSessionId)\"",
+                                with: "\"parentSessionId\": \"\(pendingId)\""
+                            )
+                        }
+                        break
+                    }
+                }
+            }
+        }
+
         guard let jsonData = jsonString.data(using: .utf8) else { return }
 
         do {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Race condition: SSE events arrive before mapping is established
**What was expected:** All SSE events for a new thread should be correctly remapped
**What was found:** Events arriving before POST /v1/messages response were dropped because the serverToLocalSessionMap wasn't populated yet

Adds a fallback in parseSSEData that eagerly learns the server-to-local mapping from the first unmapped SSE event when a pendingLocalSessionId is set, mirroring the old learn-from-first-event behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
