### PR TITLE
docs: update SSE endpoint documentation to reflect optional conversationKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ GET /v1/events?conversationKey=<key>
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `conversationKey` | Yes | Stable, client-chosen key that maps to a conversation. Same key used for `POST /v1/assistants/:id/runs`. |
+| `conversationKey` | No | Stable, client-chosen key that maps to a conversation. Same key used for `POST /v1/assistants/:id/runs`. When omitted, subscribes to events from all conversations. |
 
 **Response**: `200 OK` with `Content-Type: text/event-stream`. Each frame is a standard SSE event:
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1709,7 +1709,7 @@ graph TB
     end
 
     subgraph "SSE Transport"
-        SSE_ROUTE["SSE Route<br/>GET /v1/events?conversationKey=...<br/>(events-routes.ts)<br/>──────────────────────<br/>ReadableStream + CountQueuingStrategy(16)<br/>Heartbeat every 30 s<br/>Slow-consumer shed"]
+        SSE_ROUTE["SSE Route<br/>GET /v1/events[?conversationKey=...]<br/>(events-routes.ts)<br/>──────────────────────<br/>ReadableStream + CountQueuingStrategy(16)<br/>Heartbeat every 30 s<br/>Slow-consumer shed"]
     end
 
     subgraph "Clients"


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** README documents conversationKey as required for SSE endpoint
**What was expected:** Documentation should reflect optional conversationKey
**What was found:** README and ARCHITECTURE.md still show conversationKey as required

- Updated README.md: changed `conversationKey` from Required: Yes to Required: No, added note about unfiltered behavior when omitted
- Updated ARCHITECTURE.md: changed Mermaid diagram label from `?conversationKey=...` to `[?conversationKey=...]` to indicate optionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)