### PR TITLE
fix: use Dictionary-compatible eviction for serverToLocalSessionMap cap

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1645,7 +1645,9 @@ public final class HTTPTransport {
                     // Evict arbitrary entries when over cap to prevent unbounded growth.
                     // Lost mappings are benign — they'll be re-learned from future SSE events.
                     while self.serverToLocalSessionMap.count > self.serverToLocalSessionMapCap {
-                        self.serverToLocalSessionMap.removeFirst()
+                        if let key = self.serverToLocalSessionMap.keys.first {
+                            self.serverToLocalSessionMap.removeValue(forKey: key)
+                        }
                     }
                     log.info("Mapped server conversation \(serverConvId, privacy: .public) → local session \(sessionId, privacy: .public)")
                 }


### PR DESCRIPTION
## Summary
- Replace `Dictionary.removeFirst()` (only available when `Self == SubSequence`) with `keys.first` + `removeValue(forKey:)` to fix Swift compilation error on CI

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22991491530/job/66753336562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
