### PR TITLE
fix: clear pendingLocalSessionId after mapping is established

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1454,6 +1454,7 @@ public final class HTTPTransport {
                            serverToLocalSessionMap[eventSessionId] == nil {
                             // This is the server's conversationId for the pending thread
                             serverToLocalSessionMap[eventSessionId] = pendingId
+                            pendingLocalSessionId = nil
                             log.info("Eagerly mapped server conversation \(eventSessionId, privacy: .public) → pending local session \(pendingId, privacy: .public)")
                             // Apply the remapping to the current event
                             jsonString = jsonString.replacingOccurrences(
@@ -1642,6 +1643,7 @@ public final class HTTPTransport {
                    let serverConvId = json["conversationId"] as? String,
                    serverConvId != sessionId {
                     self.serverToLocalSessionMap[serverConvId] = sessionId
+                    self.pendingLocalSessionId = nil
                     // Evict arbitrary entries when over cap to prevent unbounded growth.
                     // Lost mappings are benign — they'll be re-learned from future SSE events.
                     while self.serverToLocalSessionMap.count > self.serverToLocalSessionMapCap {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** pendingLocalSessionId is never cleared, causing stale cross-thread mapping risk
**What was expected:** After the server's conversationId mapping is learned, pendingLocalSessionId should be cleared
**What was found:** pendingLocalSessionId persists indefinitely, causing the SSE fallback to incorrectly map unrelated conversations to the last-created thread

Clears `pendingLocalSessionId` in two places:
- In `sendMessage` after learning the mapping from the POST /v1/messages response
- In `parseSSEData` after establishing the eager mapping from the first unmapped SSE event

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
