### PR TITLE
fix: recognize existing conversation IDs as conversation keys

### DIFF
--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -117,6 +117,27 @@ export function getOrCreateConversation(conversationKey: string): {
       return { conversationId: existing.conversationId, created: false };
     }
 
+    // Check if the conversationKey itself is an existing conversation ID.
+    // This happens when the client loads a thread from the conversations list
+    // and uses the server's conversationId as its local sessionId / conversationKey.
+    const existingConversation = tx
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(eq(conversations.id, conversationKey))
+      .get();
+
+    if (existingConversation) {
+      tx.insert(conversationKeys)
+        .values({
+          id: uuid(),
+          conversationKey,
+          conversationId: existingConversation.id,
+          createdAt: Date.now(),
+        })
+        .run();
+      return { conversationId: existingConversation.id, created: false };
+    }
+
     const now = Date.now();
     const conversationId = uuid();
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Existing threads from conversations list create duplicate backend conversations
**What was expected:** Existing threads should continue their backend conversation when the client sends conversationKey=conversationId
**What was found:** getOrCreateConversation doesn't recognize a conversationId as a valid key, creating a duplicate conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
