### PR TITLE
fix: thread session ID through subagent abort/message instead of using global property

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -350,7 +350,7 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
-                        onAbort: { try? daemonClient.sendSubagentAbort(subagentId: subagentId) },
+                        onAbort: { try? daemonClient.sendSubagentAbort(subagentId: subagentId, sessionId: viewModel.sessionId) },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
                                 try? daemonClient.sendSubagentDetailRequest(subagentId: subagentId, conversationId: conversationId)
@@ -680,7 +680,7 @@ struct ActiveChatViewWrapper: View {
             isTemporaryChat: isTemporaryChat,
             activeSubagents: viewModel.activeSubagents,
             onAbortSubagent: { subagentId in
-                try? daemonClient.sendSubagentAbort(subagentId: subagentId)
+                try? daemonClient.sendSubagentAbort(subagentId: subagentId, sessionId: viewModel.sessionId)
             },
             onSubagentTap: { subagentId in
                 windowState.selectedSubagentId = subagentId

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1348,8 +1348,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     // MARK: - Subagent Management
 
     /// Abort a running subagent.
-    public func sendSubagentAbort(subagentId: String) throws {
-        try send(SubagentAbortMessage(subagentId: subagentId))
+    public func sendSubagentAbort(subagentId: String, sessionId: String? = nil) throws {
+        try send(SubagentAbortMessage(subagentId: subagentId, sessionId: sessionId))
     }
 
     /// Request subagent detail events (lazy-loaded when the user opens the detail panel).

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4188,11 +4188,13 @@ public struct SubagentMessageRequest: Codable, Sendable {
     public let type: String
     public let subagentId: String
     public let content: String
+    public let sessionId: String?
 
-    public init(type: String, subagentId: String, content: String) {
+    public init(type: String, subagentId: String, content: String, sessionId: String? = nil) {
         self.type = type
         self.subagentId = subagentId
         self.content = content
+        self.sessionId = sessionId
     }
 }
 

--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -15,10 +15,10 @@ extension HTTPTransport {
                 Task { await self.fetchSubagentDetail(subagentId: msg.subagentId, conversationId: msg.conversationId) }
                 return true
             } else if let msg = message as? SubagentAbortMessage {
-                Task { await self.handleSubagentAbort(subagentId: msg.subagentId) }
+                Task { await self.handleSubagentAbort(subagentId: msg.subagentId, sessionId: msg.sessionId) }
                 return true
             } else if let msg = message as? SubagentMessageRequest {
-                Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content) }
+                Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content, sessionId: msg.sessionId) }
                 return true
             }
 
@@ -62,7 +62,7 @@ extension HTTPTransport {
         }
     }
 
-    private func handleSubagentAbort(subagentId: String, isRetry: Bool = false) async {
+    private func handleSubagentAbort(subagentId: String, sessionId: String? = nil, isRetry: Bool = false) async {
         guard let url = buildURL(for: .subagentAbort(id: subagentId)) else { return }
 
         var request = URLRequest(url: url)
@@ -72,7 +72,7 @@ extension HTTPTransport {
 
         // The abort endpoint requires a sessionId in the body
         var body: [String: Any] = [:]
-        if let sessionId = pendingLocalSessionId {
+        if let sessionId = sessionId {
             body["sessionId"] = sessionId
         }
 
@@ -83,7 +83,7 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await handleSubagentAbort(subagentId: subagentId, isRetry: true) }
+                    if case .success = result { await handleSubagentAbort(subagentId: subagentId, sessionId: sessionId, isRetry: true) }
                     return
                 }
                 guard (200..<300).contains(http.statusCode) else {
@@ -98,7 +98,7 @@ extension HTTPTransport {
         }
     }
 
-    private func handleSubagentMessage(subagentId: String, content: String, isRetry: Bool = false) async {
+    private func handleSubagentMessage(subagentId: String, content: String, sessionId: String? = nil, isRetry: Bool = false) async {
         guard let url = buildURL(for: .subagentMessage(id: subagentId)) else { return }
 
         var request = URLRequest(url: url)
@@ -107,7 +107,7 @@ extension HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = ["content": content]
-        if let sessionId = pendingLocalSessionId {
+        if let sessionId = sessionId {
             body["sessionId"] = sessionId
         }
 
@@ -118,7 +118,7 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await handleSubagentMessage(subagentId: subagentId, content: content, isRetry: true) }
+                    if case .success = result { await handleSubagentMessage(subagentId: subagentId, content: content, sessionId: sessionId, isRetry: true) }
                     return
                 }
                 guard (200..<300).contains(http.statusCode) else {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2075,9 +2075,11 @@ public struct SubagentDetailRequestMessage: Encodable, Sendable {
 public struct SubagentAbortMessage: Encodable, Sendable {
     public let type: String = "subagent_abort"
     public let subagentId: String
+    public let sessionId: String?
 
-    public init(subagentId: String) {
+    public init(subagentId: String, sessionId: String? = nil) {
         self.subagentId = subagentId
+        self.sessionId = sessionId
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Subagent abort/message endpoints use global pendingLocalSessionId instead of thread's actual session ID
**What was expected:** Subagent operations should use the correct thread's session ID
**What was found:** handleSubagentAbort and handleSubagentMessage read pendingLocalSessionId which always refers to the most recently created thread

- Added `sessionId` field to `SubagentAbortMessage` and `SubagentMessageRequest` types
- Updated `DaemonClient.sendSubagentAbort` to accept `sessionId` parameter
- Updated `HTTPDaemonClient+Subagents.swift` dispatcher and HTTP handlers to thread `sessionId` through instead of reading the global `pendingLocalSessionId`
- Updated both call sites in `PanelCoordinator.swift` to pass `viewModel.sessionId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
