### PR TITLE
fix: remove eager SSE mapping fallback to prevent cross-thread event misattribution

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -30,7 +30,6 @@ extension HTTPTransport {
                 // acts as the session. Emit a synthetic session_info so ChatViewModel
                 // records the session ID.
                 let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
-                self.pendingLocalSessionId = sessionId
                 let info = ServerMessage.sessionInfo(
                     SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
                 )

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -178,10 +178,6 @@ public final class HTTPTransport {
     var serverToLocalSessionMap: [String: String] = [:]
     private let serverToLocalSessionMapCap = 500
 
-    /// The local session ID for the most recently created session, awaiting
-    /// the server's conversationId from the first POST /v1/messages response.
-    var pendingLocalSessionId: String?
-
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
@@ -1434,52 +1430,6 @@ public final class HTTPTransport {
             )
         }
 
-        // Fallback: eagerly learn server-to-local mapping from the first unmapped SSE event.
-        // When SSE events arrive before the POST /v1/messages response (e.g. slash commands),
-        // the serverToLocalSessionMap won't have the mapping yet. If we have a pendingLocalSessionId
-        // and the event contains a sessionId that isn't a known local ID, assume it's the server's
-        // conversationId for the pending thread and establish the mapping immediately.
-        if let pendingId = pendingLocalSessionId {
-            let knownLocalIds = Set(serverToLocalSessionMap.values)
-            // Extract sessionId value using simple pattern matching (handles both compact and spaced JSON)
-            let patterns = ["\"sessionId\":\"", "\"sessionId\": \""]
-            for pattern in patterns {
-                if let startRange = jsonString.range(of: pattern) {
-                    let afterPattern = jsonString[startRange.upperBound...]
-                    if let endQuote = afterPattern.firstIndex(of: "\"") {
-                        let eventSessionId = String(afterPattern[afterPattern.startIndex..<endQuote])
-                        if !eventSessionId.isEmpty,
-                           eventSessionId != pendingId,
-                           !knownLocalIds.contains(eventSessionId),
-                           serverToLocalSessionMap[eventSessionId] == nil {
-                            // This is the server's conversationId for the pending thread
-                            serverToLocalSessionMap[eventSessionId] = pendingId
-                            pendingLocalSessionId = nil
-                            log.info("Eagerly mapped server conversation \(eventSessionId, privacy: .public) → pending local session \(pendingId, privacy: .public)")
-                            // Apply the remapping to the current event
-                            jsonString = jsonString.replacingOccurrences(
-                                of: "\"sessionId\":\"\(eventSessionId)\"",
-                                with: "\"sessionId\":\"\(pendingId)\""
-                            )
-                            jsonString = jsonString.replacingOccurrences(
-                                of: "\"sessionId\": \"\(eventSessionId)\"",
-                                with: "\"sessionId\": \"\(pendingId)\""
-                            )
-                            jsonString = jsonString.replacingOccurrences(
-                                of: "\"parentSessionId\":\"\(eventSessionId)\"",
-                                with: "\"parentSessionId\":\"\(pendingId)\""
-                            )
-                            jsonString = jsonString.replacingOccurrences(
-                                of: "\"parentSessionId\": \"\(eventSessionId)\"",
-                                with: "\"parentSessionId\": \"\(pendingId)\""
-                            )
-                        }
-                        break
-                    }
-                }
-            }
-        }
-
         guard let jsonData = jsonString.data(using: .utf8) else { return }
 
         do {
@@ -1643,9 +1593,8 @@ public final class HTTPTransport {
                    let serverConvId = json["conversationId"] as? String,
                    serverConvId != sessionId {
                     self.serverToLocalSessionMap[serverConvId] = sessionId
-                    self.pendingLocalSessionId = nil
                     // Evict arbitrary entries when over cap to prevent unbounded growth.
-                    // Lost mappings are benign — they'll be re-learned from future SSE events.
+                    // Lost mappings are benign — unmapped events are filtered by belongsToSession.
                     while self.serverToLocalSessionMap.count > self.serverToLocalSessionMapCap {
                         if let key = self.serverToLocalSessionMap.keys.first {
                             self.serverToLocalSessionMap.removeValue(forKey: key)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Eager SSE mapping fallback misattributes events when background threads are active
**What was expected:** SSE events should only be mapped to the correct thread
**What was found:** With unfiltered SSE, the fallback could map a background thread's event to the wrong session

Removes the `pendingLocalSessionId` property and the eager SSE-to-session fallback entirely. Mappings are now established solely from the POST `/v1/messages` response, which is authoritative. Events arriving before the mapping is established are transient and the client catches up from history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
