### PR TITLE
fix: translate client-local session ID to server conversation ID for subagent operations

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Subagents.swift
@@ -26,6 +26,20 @@ extension HTTPTransport {
         }
     }
 
+    // MARK: - Session ID Translation
+
+    /// Given a client-local session ID, find the corresponding server conversation ID
+    /// by doing a reverse lookup in `serverToLocalSessionMap`. Returns the original ID
+    /// if no mapping exists (the ID is already a server conversation ID, e.g. restored threads).
+    func serverSessionId(forLocal localId: String) -> String {
+        for (serverId, mappedLocalId) in serverToLocalSessionMap {
+            if mappedLocalId == localId {
+                return serverId
+            }
+        }
+        return localId
+    }
+
     // MARK: - Subagents HTTP Endpoints
 
     private func fetchSubagentDetail(subagentId: String, conversationId: String, isRetry: Bool = false) async {
@@ -70,10 +84,12 @@ extension HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
-        // The abort endpoint requires a sessionId in the body
+        // The abort endpoint requires a sessionId in the body.
+        // Translate client-local session ID → server conversation ID so the
+        // server's ownership check (parentSessionId) passes.
         var body: [String: Any] = [:]
         if let sessionId = sessionId {
-            body["sessionId"] = sessionId
+            body["sessionId"] = serverSessionId(forLocal: sessionId)
         }
 
         do {
@@ -106,9 +122,11 @@ extension HTTPTransport {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
 
+        // Translate client-local session ID → server conversation ID so the
+        // server's ownership check (parentSessionId) passes.
         var body: [String: Any] = ["content": content]
         if let sessionId = sessionId {
-            body["sessionId"] = sessionId
+            body["sessionId"] = serverSessionId(forLocal: sessionId)
         }
 
         do {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Subagent abort/message sends client-local session ID but server expects server conversation ID
**What was expected:** Server receives the conversation ID it uses for ownership validation
**What was found:** Client sends the local session UUID which doesn't match the server's parentSessionId

Adds a reverse-lookup helper on serverToLocalSessionMap and uses it in both subagent handlers to translate client-local → server conversation IDs before sending requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
