### PR TITLE
perf: use O(1) dictionary lookup instead of O(N) scan for SSE session remapping

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1408,24 +1408,42 @@ public final class HTTPTransport {
         }
     }
 
+    /// Extract the value of a JSON string field using lightweight string search.
+    /// Handles both `"key":"value"` and `"key": "value"` (with optional space after colon).
+    private func extractJsonStringValue(from jsonString: String, key: String) -> String? {
+        for pattern in ["\"\(key)\":\"", "\"\(key)\": \""] {
+            if let range = jsonString.range(of: pattern) {
+                let valueStart = range.upperBound
+                if let valueEnd = jsonString[valueStart...].firstIndex(of: "\"") {
+                    return String(jsonString[valueStart..<valueEnd])
+                }
+            }
+        }
+        return nil
+    }
+
     private func parseSSEData(_ data: String) {
         var jsonString = data
-        // Remap server conversation IDs to client-local session IDs
-        for (serverId, localId) in serverToLocalSessionMap {
+        // Remap server conversation IDs to client-local session IDs via O(1) dictionary lookup
+        if let sessionId = extractJsonStringValue(from: jsonString, key: "sessionId"),
+           let localId = serverToLocalSessionMap[sessionId] {
             jsonString = jsonString.replacingOccurrences(
-                of: "\"sessionId\":\"\(serverId)\"",
+                of: "\"sessionId\":\"\(sessionId)\"",
                 with: "\"sessionId\":\"\(localId)\""
             )
             jsonString = jsonString.replacingOccurrences(
-                of: "\"sessionId\": \"\(serverId)\"",
+                of: "\"sessionId\": \"\(sessionId)\"",
                 with: "\"sessionId\": \"\(localId)\""
             )
+        }
+        if let parentSessionId = extractJsonStringValue(from: jsonString, key: "parentSessionId"),
+           let localId = serverToLocalSessionMap[parentSessionId] {
             jsonString = jsonString.replacingOccurrences(
-                of: "\"parentSessionId\":\"\(serverId)\"",
+                of: "\"parentSessionId\":\"\(parentSessionId)\"",
                 with: "\"parentSessionId\":\"\(localId)\""
             )
             jsonString = jsonString.replacingOccurrences(
-                of: "\"parentSessionId\": \"\(serverId)\"",
+                of: "\"parentSessionId\": \"\(parentSessionId)\"",
                 with: "\"parentSessionId\": \"\(localId)\""
             )
         }


### PR DESCRIPTION
## Summary
Fixes performance gap identified during plan review for thread-isolation-fix.md.

**Gap:** parseSSEData iterated entire serverToLocalSessionMap (up to 500 entries × 4 replacements = 2000 ops) for every SSE event
**Fix:** Extract sessionId/parentSessionId first, do O(1) dictionary lookup, apply targeted replacement only when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
