### PR TITLE
fix: defer slash command SSE events to prevent race with HTTP response mapping

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -831,17 +831,10 @@ export async function handleSendMessage(
       // Emit fresh model info before the text delta so the client has
       // up-to-date configuredProviders when rendering /model, /models,
       // and provider shortcut commands (/gpt4, /opus, etc.).
-      if (isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)) {
-        onEvent(buildModelInfoEvent());
-      }
+      const shouldEmitModelInfo =
+        isModelSlashCommand(rawContent) || isProviderShortcut(rawContent);
 
-      onEvent({ type: "assistant_text_delta", text: slashResult.message });
-      onEvent({
-        type: "message_complete",
-        sessionId: mapping.conversationId,
-      });
-
-      return Response.json(
+      const response = Response.json(
         {
           accepted: true,
           messageId: persisted.id,
@@ -849,6 +842,25 @@ export async function handleSendMessage(
         },
         { status: 202 },
       );
+
+      // Defer event publishing to next tick so the HTTP response reaches the
+      // client first. This ensures the client's serverToLocalSessionMap is
+      // populated before SSE events arrive, preventing dropped events in new
+      // desktop threads.
+      const conversationId = mapping.conversationId;
+      const message = slashResult.message;
+      setTimeout(() => {
+        if (shouldEmitModelInfo) {
+          onEvent(buildModelInfoEvent());
+        }
+        onEvent({ type: "assistant_text_delta", text: message });
+        onEvent({
+          type: "message_complete",
+          sessionId: conversationId,
+        });
+      }, 0);
+
+      return response;
     } finally {
       session.processing = false;
       session.drainQueue().catch(() => {});


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for thread-isolation-fix.md.

**Gap:** Slash command events published before HTTP response, dropped in new desktop threads
**What was expected:** Slash command responses should appear in new threads
**What was found:** onEvent() fires synchronously before Response.json(), so SSE events arrive before the client establishes the session mapping

Defers event publishing via setTimeout(fn, 0) so the HTTP 202 response (with conversationId) reaches the client first, allowing the session mapping to be established before SSE events arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
