### PR TITLE
fix: style timezone picker scrollbar and debounce search

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -17,7 +17,9 @@ struct SettingsAppearanceTab: View {
     @State private var shortcutConflictWarning: String?
     @State private var selectedTimezone: String = ""
     @State private var timezoneSearchText: String = ""
+    @State private var debouncedTimezoneSearchText: String = ""
     @State private var isTimezoneDropdownOpen: Bool = false
+    @State private var timezoneSearchDebounceTask: Task<Void, Never>?
     @FocusState private var isTimezoneSearchFocused: Bool
 
     var body: some View {
@@ -82,6 +84,12 @@ struct SettingsAppearanceTab: View {
                     }
                     .onChange(of: timezoneSearchText) { _, newValue in
                         isTimezoneDropdownOpen = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        timezoneSearchDebounceTask?.cancel()
+                        timezoneSearchDebounceTask = Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 200_000_000)
+                            guard !Task.isCancelled else { return }
+                            debouncedTimezoneSearchText = newValue
+                        }
                     }
                     .onChange(of: isTimezoneSearchFocused) { _, focused in
                         if focused && timezoneSearchText.isEmpty {
@@ -124,11 +132,10 @@ struct SettingsAppearanceTab: View {
                                         .pointerCursor()
                                     }
                                 }
+                                .background { OverlayScrollerStyle() }
                             }
+                            .scrollContentBackground(.hidden)
                             .frame(maxHeight: 200)
-                            .background {
-                                OverlayScrollerStyle()
-                            }
                             .background(VColor.inputBackground)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
                             .overlay(
@@ -407,7 +414,7 @@ struct SettingsAppearanceTab: View {
     private var filteredTimezones: [TimezoneEntry] {
         let now = Date()
         let formatter = Self.timeFormatter
-        let query = timezoneSearchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let query = debouncedTimezoneSearchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         return Self.timezoneMetadata.compactMap { meta in
             let offset = Self.utcOffsetString(for: meta.tz)

--- a/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TimezonePicker.swift
@@ -150,7 +150,9 @@ struct TimezonePicker: View {
                             .padding(.vertical, VSpacing.md)
                     }
                 }
+                .background { OverlayScrollerStyle() }
             }
+            .scrollContentBackground(.hidden)
             .frame(maxHeight: 300)
         }
         .frame(width: 320)


### PR DESCRIPTION
## Summary
- Apply `OverlayScrollerStyle` to the timezone picker dropdown so its scrollbar matches the rest of Settings (thin overlay instead of legacy track style)
- Add 200ms debounce to the timezone search input to avoid filtering on every keystroke

## Test plan
- [ ] Open Settings > General > Timezone, type a city name
- [ ] Verify the scrollbar in the dropdown matches the styled scrollbar elsewhere in Settings
- [ ] Verify search feels responsive with debounced filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
