### PR TITLE
fix: strip trailing slash from platform URL and use VellumError hierarchy in OAuth

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { BackendError, VellumError } from "../util/errors.js";
 import {
   CredentialRequiredError,
   PlatformOAuthConnection,
@@ -116,6 +117,16 @@ describe("PlatformOAuthConnection", () => {
     await conn.request({ method: "GET", path: "/some/path" });
   });
 
+  test("error classes extend VellumError hierarchy", () => {
+    const credErr = new CredentialRequiredError();
+    expect(credErr).toBeInstanceOf(BackendError);
+    expect(credErr).toBeInstanceOf(VellumError);
+
+    const provErr = new ProviderUnreachableError();
+    expect(provErr).toBeInstanceOf(BackendError);
+    expect(provErr).toBeInstanceOf(VellumError);
+  });
+
   test("424 response throws CredentialRequiredError", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("", { status: 424 });
@@ -143,6 +154,24 @@ describe("PlatformOAuthConnection", () => {
     await expect(conn.withToken(async (token) => token)).rejects.toThrow(
       "Raw token access is not supported for platform-managed connections. Use connection.request() instead.",
     );
+  });
+
+  test("strips trailing slash from platformBaseUrl to avoid double slashes", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      expect(String(url)).toBe(
+        "https://platform.example.com/v1/assistants/asst-abc/external-provider-proxy/gmail/",
+      );
+      return new Response(
+        JSON.stringify({ status: 200, headers: {}, body: null }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      platformBaseUrl: "https://platform.example.com/",
+    });
+    await conn.request({ method: "GET", path: "/test" });
   });
 
   test("strips integration: prefix from providerKey for slug", async () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -1,17 +1,18 @@
+import { BackendError } from "../util/errors.js";
 import type {
   OAuthConnection,
   OAuthConnectionRequest,
   OAuthConnectionResponse,
 } from "./connection.js";
 
-export class CredentialRequiredError extends Error {
+export class CredentialRequiredError extends BackendError {
   constructor(message = "Connection not set up on platform") {
     super(message);
     this.name = "CredentialRequiredError";
   }
 }
 
-export class ProviderUnreachableError extends Error {
+export class ProviderUnreachableError extends BackendError {
   constructor(message = "Provider is unreachable") {
     super(message);
     this.name = "ProviderUnreachableError";
@@ -47,7 +48,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
     this.accountInfo = options.accountInfo;
     this.grantedScopes = options.grantedScopes;
     this.assistantId = options.assistantId;
-    this.platformBaseUrl = options.platformBaseUrl;
+    this.platformBaseUrl = options.platformBaseUrl.replace(/\/+$/, "");
     this.apiKey = options.apiKey;
   }
 
@@ -84,7 +85,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
     }
 
     if (!response.ok) {
-      throw new Error(
+      throw new BackendError(
         `Platform proxy returned unexpected status ${response.status}`,
       );
     }
@@ -103,7 +104,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
   }
 
   async withToken<T>(_fn: (token: string) => Promise<T>): Promise<T> {
-    throw new Error(
+    throw new BackendError(
       "Raw token access is not supported for platform-managed connections. Use connection.request() instead.",
     );
   }


### PR DESCRIPTION
Fixes double-slash in platform OAuth URL concatenation and migrates CredentialRequiredError/ProviderUnreachableError to VellumError hierarchy per error-handling.md guidelines.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
