### PR TITLE
fix: address PR #15464 review feedback (chan-setup-status)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -149,10 +149,9 @@ struct AssistantChannelsDetailView: View {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
-                        store.channelSetupStatus["telegram"] = "not_configured"
                     }
                 }
-            } else if status == "incomplete" || telegramSetupExpanded {
+            } else if (status == "incomplete" && store.telegramHasBotToken) || telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .secondary, size: .medium) {
@@ -284,10 +283,9 @@ struct AssistantChannelsDetailView: View {
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
                         slackChannelSetupExpanded = false
-                        store.channelSetupStatus["slack"] = "not_configured"
                     }
                 }
-            } else if status == "incomplete" || slackChannelSetupExpanded {
+            } else if (status == "incomplete" && store.slackChannelHasBotToken) || slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .secondary, size: .medium) {
@@ -430,10 +428,9 @@ struct AssistantChannelsDetailView: View {
                     VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
                     VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
-                        store.channelSetupStatus["phone"] = "not_configured"
                     }
                 }
-            } else if status == "incomplete" || voiceSetupExpanded {
+            } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .secondary, size: .medium) {


### PR DESCRIPTION
## Summary
Address reviewer feedback from PR #15464.

- **Gate channel setup UI on credentials, not just incomplete status (P1)**: The `incomplete` status alone is insufficient to determine whether credentials exist, since readiness can be `incomplete` due to other checks (e.g. global ingress) even without channel-specific credentials. Now the `incomplete` branch additionally checks `telegramHasBotToken`, `slackChannelHasBotToken`, or `twilioHasCredentials` before showing the credential entry UI.
- **Remove optimistic channelSetupStatus updates on disconnect (P2)**: The optimistic `channelSetupStatus[channel] = "not_configured"` assignments in disconnect handlers ran before the backend confirmed the clear. If the clear failed, the UI would show stale state. Since all three clear paths already call `fetchChannelSetupStatus()` on success (Telegram via `onTelegramConfigResponse`, Slack/Twilio via their HTTP success callbacks), the optimistic assignment is both redundant and potentially incorrect. Removed it from all three channels.

## Test plan
- [ ] Verify that when only ingress is configured (no bot token), the Telegram card shows "Set Up" button instead of the credential entry form
- [ ] Verify that clicking "Disconnect" on a channel card keeps showing "Connected" until the backend confirms the clear
- [ ] Verify that after a successful disconnect, the card transitions to "Set Up" state via the refetched channel readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
