### PR TITLE
fix: refresh email when feature flag toggles on at runtime (email-flag)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -92,6 +92,11 @@ struct AssistantChannelsDetailView: View {
                 store.refreshTwilioNumbers()
             }
         }
+        .onChange(of: isEmailEnabled) { _, enabled in
+            if enabled {
+                store.refreshAssistantEmail()
+            }
+        }
     }
 
     // MARK: - Email Channel Card


### PR DESCRIPTION
## Summary
- Adds `.onChange(of: isEmailEnabled)` handler to `AssistantChannelsDetailView` so that `refreshAssistantEmail()` is called when the email feature flag transitions from disabled to enabled at runtime
- Previously, the email refresh only ran inside `.onAppear`, meaning a runtime flag toggle would show the Email card but leave it in a "Not configured" state until the user navigated away and back

Address reviewer feedback from PR #15573.

## Test plan
- [ ] Toggle the `email-channel` feature flag off, open Contacts, then toggle it on — verify the Email card immediately shows the correct email address (not stuck on "Not configured")
- [ ] Verify that disabling the flag still hides the Email card as before
- [ ] Verify that opening Contacts with the flag already enabled still fetches the email on appear

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
