### PR TITLE
fix: address PR #15570 review feedback (rm-tg-stream)

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -31,8 +31,6 @@ export interface ChannelReplyPayload {
   ephemeral?: boolean;
   /** Slack user ID — required when `ephemeral` is true. */
   user?: string;
-  /** Telegram message_id for editing an existing message instead of sending a new one. */
-  messageId?: number;
   /** When provided, instructs the delivery endpoint to update an existing message instead of posting a new one. */
   messageTs?: string;
   /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */

--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -16,7 +16,6 @@ let sendTypingIndicatorCalls: Array<unknown[]> = [];
 mock.module("../../telegram/send.js", () => ({
   sendTelegramReply: async (...args: unknown[]) => {
     sendTelegramReplyCalls.push(args);
-    return { messageId: 42 };
   },
   sendTelegramAttachments: async () => {},
   sendTypingIndicator: async (...args: unknown[]) => {
@@ -226,7 +225,6 @@ describe("telegram-deliver endpoint basics", () => {
     mock.module("../../telegram/send.js", () => ({
       sendTelegramReply: async (...args: unknown[]) => {
         sendTelegramReplyCalls.push(args);
-        return { messageId: 42 };
       },
       sendTelegramAttachments: async () => {},
       sendTypingIndicator: async (...args: unknown[]) => {

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -9,7 +9,7 @@ const callTelegramApiMock = mock(
   (_method: string, _body: Record<string, unknown>, _opts?: unknown) =>
     Promise.resolve({}),
 );
-const sendTelegramReplyMock = mock(() => Promise.resolve({ messageId: 0 }));
+const sendTelegramReplyMock = mock(() => Promise.resolve());
 const handleInboundMock = mock(
   (_config: GatewayConfig, _normalized: unknown, _options?: unknown) =>
     Promise.resolve({ forwarded: true, rejected: false }),

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -12,10 +12,6 @@ import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
 
 const log = getLogger("telegram-send");
 
-export interface TelegramSendResult {
-  messageId: number;
-}
-
 const TELEGRAM_MAX_MESSAGE_LEN = 4000;
 
 /** Telegram Bot API enforces a 1-64 byte limit on InlineKeyboardButton callback_data. */
@@ -55,10 +51,9 @@ export async function sendTelegramReply(
   text: string,
   approval?: ApprovalPayload,
   opts?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
-): Promise<TelegramSendResult> {
+): Promise<void> {
   const chunks = splitText(text, TELEGRAM_MAX_MESSAGE_LEN);
 
-  let lastResult: { message_id: number } | undefined;
   for (let i = 0; i < chunks.length; i++) {
     const payload: Record<string, unknown> = {
       chat_id: chatId,
@@ -71,15 +66,10 @@ export async function sendTelegramReply(
       payload.reply_markup = buildInlineKeyboard(approval);
     }
 
-    lastResult = await callTelegramApi<{ message_id: number }>(
-      "sendMessage",
-      payload,
-      opts,
-    );
+    await callTelegramApi("sendMessage", payload, opts);
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
-  return { messageId: lastResult!.message_id };
 }
 
 export async function sendTelegramAttachments(


### PR DESCRIPTION
Address reviewer feedback from PR #15570.

Remove dead messageId code left behind after the gateway stopped supporting Telegram message editing:

- Remove `messageId?: number` from `ChannelReplyPayload` in `gateway-client.ts` (was exclusively used for Telegram edit flow)
- Remove `TelegramSendResult` interface and simplify `sendTelegramReply` to return `void` (no callers used the return value)
- Update test mocks to match the new void return type
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
