### PR TITLE
fix: address PR #15551 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -22,5 +22,8 @@ public final class AmbientAgent: ObservableObject {
 
     func pause() {}
     func resume() {}
-    func teardown() {}
+    func teardown() {
+        activeWatchSession?.stop()
+        activeWatchSession = nil
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -50,9 +50,6 @@ struct ChatView: View {
     let onDismissSessionError: () -> Void
     let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
-    var isLearnMode: Bool = false
-    var networkEntryCount: Int = 0
-    var idleHint: Bool = false
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
     var mediaEmbedSettings: MediaEmbedResolverSettings?
@@ -259,9 +256,6 @@ struct ChatView: View {
                             onMicrophoneToggle: onMicrophoneToggle,
                             watchSession: watchSession,
                             onStopWatch: onStopWatch,
-                            isLearnMode: isLearnMode,
-                            networkEntryCount: networkEntryCount,
-                            idleHint: idleHint,
                             voiceModeManager: voiceModeManager,
                             voiceService: voiceService,
                             onEndVoiceMode: onEndVoiceMode,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -22,9 +22,6 @@ struct ComposerSection: View {
     let onMicrophoneToggle: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
-    var isLearnMode: Bool = false
-    var networkEntryCount: Int = 0
-    var idleHint: Bool = false
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
@@ -36,7 +33,7 @@ struct ComposerSection: View {
     var body: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
-                WatchProgressView(session: watchSession, onStop: onStopWatch, isLearnMode: isLearnMode, networkEntryCount: networkEntryCount, idleHint: idleHint)
+                WatchProgressView(session: watchSession, onStop: onStopWatch)
                     .padding(.horizontal, VSpacing.lg)
                     .padding(.bottom, VSpacing.sm)
                     .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/WatchProgressView.swift
@@ -4,18 +4,10 @@ import VellumAssistantShared
 struct WatchProgressView: View {
     @ObservedObject var session: WatchSession
     let onStop: () -> Void
-    var isLearnMode: Bool = false
-    var networkEntryCount: Int = 0
-    var idleHint: Bool = false
 
     @State private var isPulsing = false
 
     private var progress: Double {
-        if isLearnMode {
-            // In learn mode the capture loop is skipped, so use time-based progress
-            guard session.durationSeconds > 0 else { return 0 }
-            return min(session.elapsedSeconds / Double(session.durationSeconds), 1.0)
-        }
         guard session.totalExpected > 0 else { return 0 }
         return Double(session.captureCount) / Double(session.totalExpected)
     }
@@ -36,7 +28,7 @@ struct WatchProgressView: View {
         VStack(spacing: VSpacing.md) {
             // Pulsing icon + label
             HStack(spacing: VSpacing.sm) {
-                VIconView(isLearnMode ? .wifi : .eye, size: 14)
+                VIconView(.eye, size: 14)
                     .foregroundColor(VColor.accent)
                     .opacity(isPulsing ? 0.4 : 1.0)
                     .animation(
@@ -44,17 +36,16 @@ struct WatchProgressView: View {
                         value: isPulsing
                     )
 
-                Text(isLearnMode ? "Recording network traffic..." : "Watching your workflow...")
+                Text("Watching your workflow...")
                     .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .textSelection(.enabled)
 
                 Spacer()
 
-                // Stop button — highlighted when idle hint is active
                 Button(action: onStop) {
                     VIconView(.square, size: 12)
-                        .foregroundColor(idleHint ? VColor.accent : VColor.error)
+                        .foregroundColor(VColor.error)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Stop watching")
@@ -71,32 +62,11 @@ struct WatchProgressView: View {
                         .foregroundColor(VColor.textSecondary)
                         .textSelection(.enabled)
                     Spacer()
-                    if isLearnMode {
-                        Text("\(networkEntryCount) network entries")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                            .textSelection(.enabled)
-                    } else {
-                        Text("\(session.captureCount)/\(session.totalExpected) captures")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-
-            // Idle hint prompt
-            if idleHint {
-                HStack(spacing: VSpacing.xs) {
-                    VIconView(.circleCheck, size: 12)
-                        .foregroundColor(VColor.accent)
-                    Text("No new activity detected. Ready to stop?")
+                    Text("\(session.captureCount)/\(session.totalExpected) captures")
                         .font(VFont.caption)
-                        .foregroundColor(VColor.accent)
+                        .foregroundColor(VColor.textSecondary)
                         .textSelection(.enabled)
-                    Spacer()
                 }
-                .transition(.opacity)
             }
 
             // Current app badge


### PR DESCRIPTION
## Summary
- Remove dead `isLearnMode`, `networkEntryCount`, and `idleHint` properties from `ChatView`, `ComposerSection`, and `WatchProgressView` — these were always at their default values after PanelCoordinator stopped passing them, per AGENTS.md dead code rule
- Simplify `WatchProgressView`: hardcode eye icon, "Watching your workflow..." label, error-colored stop button, and capture count display (removing unreachable learn-mode and idle-hint branches)
- Implement `AmbientAgent.teardown()` to stop and clear the active watch session, preventing post-logout capture activity

Address reviewer feedback from PR #15551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
