### PR TITLE
fix: address PR #15475 review feedback (oauth-conn-req)

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/calendar-client.ts
@@ -24,6 +24,7 @@ async function request<T>(
   connection: OAuthConnection,
   path: string,
   options?: RequestInit,
+  query?: Record<string, string | string[]>,
 ): Promise<T> {
   const method = (options?.method ?? "GET").toUpperCase();
 
@@ -66,6 +67,7 @@ async function request<T>(
   const resp = await connection.request({
     method,
     path,
+    query,
     baseUrl: GOOGLE_CALENDAR_BASE_URL,
     headers: {
       "Content-Type": "application/json",
@@ -107,29 +109,31 @@ export async function listEvents(
     syncToken?: string;
   },
 ): Promise<CalendarEventsListResponse> {
-  const params = new URLSearchParams();
+  const query: Record<string, string> = {};
 
-  if (options?.timeMin) params.set("timeMin", options.timeMin);
-  if (options?.timeMax) params.set("timeMax", options.timeMax);
-  params.set("maxResults", String(options?.maxResults ?? 25));
-  if (options?.query) params.set("q", options.query);
+  if (options?.timeMin) query.timeMin = options.timeMin;
+  if (options?.timeMax) query.timeMax = options.timeMax;
+  query.maxResults = String(options?.maxResults ?? 25);
+  if (options?.query) query.q = options.query;
 
   // Default to expanding recurring events into instances
   const singleEvents = options?.singleEvents ?? true;
-  params.set("singleEvents", String(singleEvents));
+  query.singleEvents = String(singleEvents);
 
   if (singleEvents && options?.orderBy) {
-    params.set("orderBy", options.orderBy);
+    query.orderBy = options.orderBy;
   } else if (singleEvents) {
-    params.set("orderBy", "startTime");
+    query.orderBy = "startTime";
   }
 
-  if (options?.pageToken) params.set("pageToken", options.pageToken);
-  if (options?.syncToken) params.set("syncToken", options.syncToken);
+  if (options?.pageToken) query.pageToken = options.pageToken;
+  if (options?.syncToken) query.syncToken = options.syncToken;
 
   return request<CalendarEventsListResponse>(
     connection,
-    `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+    `/calendars/${encodeURIComponent(calendarId)}/events`,
+    undefined,
+    query,
   );
 }
 
@@ -161,14 +165,14 @@ export async function createEvent(
   calendarId = "primary",
   sendUpdates: "all" | "externalOnly" | "none" = "all",
 ): Promise<CalendarEvent> {
-  const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
     connection,
-    `/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+    `/calendars/${encodeURIComponent(calendarId)}/events`,
     {
       method: "POST",
       body: JSON.stringify(event),
     },
+    { sendUpdates },
   );
 }
 
@@ -187,16 +191,16 @@ export async function patchEvent(
   calendarId = "primary",
   sendUpdates: "all" | "externalOnly" | "none" = "all",
 ): Promise<CalendarEvent> {
-  const params = new URLSearchParams({ sendUpdates });
   return request<CalendarEvent>(
     connection,
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(
       eventId,
-    )}?${params}`,
+    )}`,
     {
       method: "PATCH",
       body: JSON.stringify(updates),
     },
+    { sendUpdates },
   );
 }
 

--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -84,6 +84,20 @@ function extractNonAuthHeaders(
 }
 
 /**
+ * Convert URLSearchParams to a query record, collapsing multi-valued keys into arrays.
+ */
+function paramsToQuery(
+  params: URLSearchParams,
+): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+  for (const key of new Set(params.keys())) {
+    const values = params.getAll(key);
+    result[key] = values.length === 1 ? values[0] : values;
+  }
+  return result;
+}
+
+/**
  * Extract the JSON body from request options for use with OAuthConnection.
  */
 function extractBody(options?: GmailRequestOptions): unknown | undefined {
@@ -102,6 +116,7 @@ async function request<T>(
   connection: OAuthConnection,
   path: string,
   options?: GmailRequestOptions,
+  query?: Record<string, string | string[]>,
 ): Promise<T> {
   const canRetry = options?.retryable ?? isIdempotent(options);
   const method = (options?.method ?? "GET").toUpperCase();
@@ -112,6 +127,7 @@ async function request<T>(
       resp = await connection.request({
         method,
         path,
+        query,
         headers: {
           "Content-Type": "application/json",
           ...extractNonAuthHeaders(options),
@@ -171,7 +187,12 @@ export async function listMessages(
   if (labelIds) {
     for (const id of labelIds) params.append("labelIds", id);
   }
-  return request<GmailMessageListResponse>(connection, `/messages?${params}`);
+  return request<GmailMessageListResponse>(
+    connection,
+    "/messages",
+    undefined,
+    paramsToQuery(params),
+  );
 }
 
 /** Get a single message by ID. */
@@ -187,7 +208,12 @@ export async function getMessage(
     for (const h of metadataHeaders) params.append("metadataHeaders", h);
   }
   if (fields) params.set("fields", fields);
-  return request<GmailMessage>(connection, `/messages/${messageId}?${params}`);
+  return request<GmailMessage>(
+    connection,
+    `/messages/${messageId}`,
+    undefined,
+    paramsToQuery(params),
+  );
 }
 
 /**
@@ -333,9 +359,31 @@ async function executeBatchCall(
 }
 
 /**
+ * Fetch all messages individually using getMessage (no batch endpoint).
+ * Used as a fallback when the batch API is unavailable (e.g. platform connections
+ * that cannot expose raw tokens for the multipart batch endpoint).
+ */
+async function fetchMessagesIndividually(
+  connection: OAuthConnection,
+  messageIds: string[],
+  format: GmailMessageFormat,
+  metadataHeaders?: string[],
+  fields?: string,
+): Promise<GmailMessage[]> {
+  return Promise.all(
+    messageIds.map((id) =>
+      getMessage(connection, id, format, metadataHeaders, fields),
+    ),
+  );
+}
+
+/**
  * Get multiple messages using Gmail's batch HTTP endpoint.
  * Packs up to 100 sub-requests per HTTP call and runs up to BATCH_CONCURRENCY calls in parallel.
  * Falls back to individual getMessage for any sub-requests that fail within a batch.
+ *
+ * For connections that do not support raw token access (e.g. platform-managed connections),
+ * falls back to fetching each message individually via connection.request().
  */
 export async function batchGetMessages(
   connection: OAuthConnection,
@@ -357,6 +405,26 @@ export async function batchGetMessages(
         fields,
       ),
     ];
+  }
+
+  // Try batch API first; fall back to individual fetches if withToken is unavailable
+  // (e.g. platform-managed connections where raw tokens cannot be exposed).
+  let useBatch = true;
+  try {
+    // Probe withToken availability with a no-op call
+    await connection.withToken(async (token) => token);
+  } catch {
+    useBatch = false;
+  }
+
+  if (!useBatch) {
+    return fetchMessagesIndividually(
+      connection,
+      messageIds,
+      format,
+      metadataHeaders,
+      fields,
+    );
   }
 
   const results = new Array<GmailMessage | undefined>(messageIds.length).fill(

--- a/assistant/src/messaging/providers/gmail/people-client.ts
+++ b/assistant/src/messaging/providers/gmail/people-client.ts
@@ -17,10 +17,12 @@ const PERSON_FIELDS = "names,emailAddresses,phoneNumbers,organizations";
 async function request<T>(
   connection: OAuthConnection,
   path: string,
+  query?: Record<string, string | string[]>,
 ): Promise<T> {
   const resp = await connection.request({
     method: "GET",
     path,
+    query,
     baseUrl: GOOGLE_PEOPLE_BASE_URL,
   });
 
@@ -45,14 +47,15 @@ export async function listContacts(
   pageSize = 50,
   pageToken?: string,
 ): Promise<PeopleConnectionsResponse> {
-  const params = new URLSearchParams({
+  const query: Record<string, string> = {
     personFields: PERSON_FIELDS,
     pageSize: String(pageSize),
-  });
-  if (pageToken) params.set("pageToken", pageToken);
+  };
+  if (pageToken) query.pageToken = pageToken;
   return request<PeopleConnectionsResponse>(
     connection,
-    `/people/me/connections?${params}`,
+    "/people/me/connections",
+    query,
   );
 }
 
@@ -61,12 +64,8 @@ export async function searchContacts(
   connection: OAuthConnection,
   query: string,
 ): Promise<PeopleSearchResponse> {
-  const params = new URLSearchParams({
+  return request<PeopleSearchResponse>(connection, "/people:searchContacts", {
     query,
     readMask: PERSON_FIELDS,
   });
-  return request<PeopleSearchResponse>(
-    connection,
-    `/people:searchContacts?${params}`,
-  );
 }

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -53,7 +53,14 @@ export class BYOOAuthConnection implements OAuthConnection {
       let fullUrl = `${effectiveBaseUrl}${req.path}`;
 
       if (req.query && Object.keys(req.query).length > 0) {
-        const params = new URLSearchParams(req.query);
+        const params = new URLSearchParams();
+        for (const [key, value] of Object.entries(req.query)) {
+          if (Array.isArray(value)) {
+            for (const v of value) params.append(key, v);
+          } else {
+            params.append(key, value);
+          }
+        }
         fullUrl += `?${params.toString()}`;
       }
 

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -1,7 +1,7 @@
 export interface OAuthConnectionRequest {
   method: string;
   path: string; // relative, e.g. "/2/tweets"
-  query?: Record<string, string>;
+  query?: Record<string, string | string[]>;
   headers?: Record<string, string>;
   body?: unknown; // JSON-serializable
   /**


### PR DESCRIPTION
Address reviewer feedback from PR #15475.

## Changes

1. **Use query field instead of path-embedded params** (Devin review): Widen `OAuthConnectionRequest.query` from `Record<string, string>` to `Record<string, string | string[]>` to support multi-valued params (e.g. Gmail's `labelIds`, `metadataHeaders`). Refactor Gmail, People, and Calendar clients to pass query parameters via the `query` field instead of embedding them in the `path`. Update `BYOOAuthConnection.request()` to expand array values into repeated params.

2. **Fix batchGetMessages withToken failure for platform connections** (Codex P1 review): `batchGetMessages()` now probes `connection.withToken()` availability upfront and falls back to individual `getMessage()` calls for platform-managed connections where raw tokens are unavailable. This prevents batch email fetches from failing on platform connections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
