### PR TITLE
fix: update oauth_app_id when reconnecting with a different OAuth client

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -458,6 +458,27 @@ describe("connection operations", () => {
       expect(fetched!.updatedAt).toBeGreaterThanOrEqual(conn.createdAt);
     });
 
+    test("updates oauthAppId to a different app", () => {
+      const app1 = createTestApp("github", "client-1");
+      const app2 = upsertApp("github", "client-2");
+
+      const conn = createConnection({
+        oauthAppId: app1.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      expect(getConnection(conn.id)!.oauthAppId).toBe(app1.id);
+
+      const updated = updateConnection(conn.id, { oauthAppId: app2.id });
+      expect(updated).toBe(true);
+
+      const fetched = getConnection(conn.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.oauthAppId).toBe(app2.id);
+    });
+
     test("returns false for nonexistent id", () => {
       expect(updateConnection("nonexistent-id", { status: "revoked" })).toBe(
         false,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -307,6 +307,7 @@ export function getConnectionByProvider(
 export function updateConnection(
   id: string,
   updates: Partial<{
+    oauthAppId: string;
     accountInfo: string;
     grantedScopes: string[];
     /** Pass `null` to explicitly clear a stale expiresAt in the DB. */
@@ -324,6 +325,7 @@ export function updateConnection(
   // For expiresAt, null means "clear the column" so we check for undefined
   // explicitly rather than truthiness.
   const set: Record<string, unknown> = { updatedAt: now };
+  if (updates.oauthAppId !== undefined) set.oauthAppId = updates.oauthAppId;
   if (updates.accountInfo !== undefined) set.accountInfo = updates.accountInfo;
   if (updates.grantedScopes !== undefined)
     set.grantedScopes = JSON.stringify(updates.grantedScopes);

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -125,6 +125,7 @@ export async function storeOAuth2Tokens(
   if (existingConn) {
     connId = existingConn.id;
     updateConnection(connId, {
+      oauthAppId: app.id,
       accountInfo: resolvedAccountInfo,
       grantedScopes,
       expiresAt,


### PR DESCRIPTION
## Summary
- Add `oauthAppId` to `updateConnection` parameters so the connection's app linkage can be updated
- Wire up `oauthAppId: app.id` in `storeOAuth2Tokens` when reusing an existing connection
- Add test verifying the app ID update

Part of plan: oauth-post-migration-cleanup.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
