### PR TITLE
fix: address PR #15480 review feedback (oauth-conn-req)

### DIFF
--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -19,9 +19,7 @@ export function resolveOAuthConnection(
     );
   }
 
-  const accessToken = getSecureKey(
-    `oauth_connection/${conn.id}/access_token`,
-  );
+  const accessToken = getSecureKey(`oauth_connection/${conn.id}/access_token`);
 
   if (!accessToken) {
     throw new Error(
@@ -29,7 +27,12 @@ export function resolveOAuthConnection(
     );
   }
 
-  const provider = getProvider(credentialService);
+  // Look up the provider by credentialService first; fall back to the
+  // connection's canonical providerKey so custom credential_service overrides
+  // (e.g. "integration:github-work") still resolve to the well-known provider's
+  // base URL.
+  const provider =
+    getProvider(credentialService) ?? getProvider(conn.providerKey);
   const baseUrl = provider?.baseUrl;
 
   if (!baseUrl) {


### PR DESCRIPTION
Address reviewer feedback from PR #15480.

The connection resolver now falls back to the connection's canonical providerKey when the credentialService doesn't directly match a known provider, so custom credential_service overrides (e.g. 'integration:github-work') still resolve the well-known provider's base URL.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
