### PR TITLE
docs: fix stale help text in `oauth token` CLI command

### DIFF
--- a/assistant/src/cli/commands/oauth.ts
+++ b/assistant/src/cli/commands/oauth.ts
@@ -45,7 +45,7 @@ Arguments:
 Returns a valid OAuth access token for the given service. If the stored token
 is expired or near-expiry, it is refreshed automatically before being returned.
 The refresh uses the stored refresh token and OAuth2 configuration from
-credential metadata — no additional input is required.
+the OAuth connection store — no additional input is required.
 
 In human mode, prints the bare token to stdout (suitable for shell substitution).
 In JSON mode (--json), prints {"ok": true, "token": "..."}.


### PR DESCRIPTION
## Summary
- Update help text to reference "OAuth connection store" instead of "credential metadata"
- Accurately reflects that refresh config comes from oauth_connections/oauth_apps/oauth_providers rows

Part of plan: oauth-post-migration-cleanup.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
