### PR TITLE
chore: remove legacy `slack_channel:bot_token` fallback from Slack share routes

### DIFF
--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -13,7 +13,6 @@ import {
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
 import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
-import { credentialKey } from "../../../../security/credential-key.js";
 import { getSecureKey } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import { httpError } from "../../../http-errors.js";
@@ -26,17 +25,13 @@ const log = getLogger("slack-share");
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the Slack bot token from secure storage.
- * Prefers the OAuth integration token, falls back to the legacy channel token.
+ * Resolve the Slack bot token from the OAuth connection store.
  */
 function resolveSlackToken(): string | undefined {
   const conn = getConnectionByProvider("integration:slack");
-  const oauthToken = conn
+  return conn
     ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
     : undefined;
-  return (
-    oauthToken ?? getSecureKey(credentialKey("slack_channel", "bot_token"))
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove legacy `slack_channel:bot_token` fallback from `resolveSlackToken()`
- Now only resolves Slack tokens from the OAuth connection store
- Remove unused `credentialKey` import

Part of plan: oauth-post-migration-cleanup.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
