### PR TITLE
feat: add centralized `disconnectOAuthProvider` helper for full OAuth cleanup

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -23,11 +23,19 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+const mockDeleteSecureKeyAsync = mock(() =>
+  Promise.resolve("deleted" as const),
+);
+mock.module("../security/secure-keys.js", () => ({
+  deleteSecureKeyAsync: mockDeleteSecureKeyAsync,
+}));
+
 import { getDb, initializeDb, resetDb, resetTestTables } from "../memory/db.js";
 import {
   createConnection,
   deleteApp,
   deleteConnection,
+  disconnectOAuthProvider,
   getApp,
   getAppByProviderAndClientId,
   getConnection,
@@ -67,6 +75,7 @@ beforeEach(() => {
   // Explicitly clear all OAuth tables to prevent cross-test state pollution.
   // Delete in FK-dependency order: connections → apps → providers.
   resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
+  mockDeleteSecureKeyAsync.mockClear();
 });
 
 afterAll(() => {
@@ -538,6 +547,43 @@ describe("connection operations", () => {
     test("returns false for nonexistent id", () => {
       expect(deleteConnection("nonexistent-id")).toBe(false);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disconnectOAuthProvider
+// ---------------------------------------------------------------------------
+
+describe("disconnectOAuthProvider", () => {
+  test("returns false when no connection exists for the provider", async () => {
+    const result = await disconnectOAuthProvider("github");
+    expect(result).toBe(false);
+    expect(mockDeleteSecureKeyAsync).not.toHaveBeenCalled();
+  });
+
+  test("returns true and deletes connection row and secure keys when connection exists", async () => {
+    const app = createTestApp("github", "client-1");
+    const conn = createConnection({
+      oauthAppId: app.id,
+      providerKey: "github",
+      grantedScopes: ["repo"],
+      hasRefreshToken: true,
+    });
+
+    const result = await disconnectOAuthProvider("github");
+    expect(result).toBe(true);
+
+    // Verify secure keys were deleted
+    expect(mockDeleteSecureKeyAsync).toHaveBeenCalledTimes(2);
+    expect(mockDeleteSecureKeyAsync).toHaveBeenCalledWith(
+      `oauth_connection/${conn.id}/access_token`,
+    );
+    expect(mockDeleteSecureKeyAsync).toHaveBeenCalledWith(
+      `oauth_connection/${conn.id}/refresh_token`,
+    );
+
+    // Verify connection row was deleted
+    expect(getConnection(conn.id)).toBeUndefined();
   });
 });
 

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -14,6 +14,7 @@ import {
   oauthConnections,
   oauthProviders,
 } from "../memory/schema/oauth.js";
+import { deleteSecureKeyAsync } from "../security/secure-keys.js";
 
 // ---------------------------------------------------------------------------
 // Row types
@@ -360,4 +361,29 @@ export function deleteConnection(id: string): boolean {
   const db = getDb();
   db.delete(oauthConnections).where(eq(oauthConnections.id, id)).run();
   return rawChanges() > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Disconnect (full cleanup)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fully disconnect an OAuth provider: delete the new-format secure keys
+ * (access_token and refresh_token) and remove the connection row from SQLite.
+ *
+ * Returns `true` if a connection was found and cleaned up, `false` if no
+ * active connection existed for the given provider.
+ */
+export async function disconnectOAuthProvider(
+  providerKey: string,
+): Promise<boolean> {
+  const conn = getConnectionByProvider(providerKey);
+  if (!conn) return false;
+
+  await deleteSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
+  await deleteSecureKeyAsync(`oauth_connection/${conn.id}/refresh_token`);
+
+  deleteConnection(conn.id);
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- Add `disconnectOAuthProvider(providerKey)` to `oauth-store.ts` that cleans up secure keys and the connection row
- Add tests covering found and not-found paths with mocked secure key deletion

Part of plan: oauth-post-migration-cleanup.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
