### PR TITLE
chore: remove dead custom/unknown provider OAuth scaffolding from vault

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -104,15 +104,6 @@ export interface OAuthConnectOptions {
     accountInfo?: string;
     error?: string;
   }) => void;
-
-  // Optional overrides — when provided, these take precedence over the
-  // provider profile. This lets callers connect custom / unknown providers.
-  authUrl?: string;
-  tokenUrl?: string;
-  scopes?: string[];
-  extraParams?: Record<string, string>;
-  userinfoUrl?: string;
-  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,47 +154,37 @@ export async function orchestrateOAuthConnect(
     undefined,
   );
 
-  // Merge explicit overrides with DB values
-  const authUrl = options.authUrl ?? providerRow.authUrl;
-  const tokenUrl = options.tokenUrl ?? providerRow.tokenUrl;
-  const extraParams = options.extraParams ?? dbExtraParams;
-  const userinfoUrl =
-    options.userinfoUrl ?? providerRow.userinfoUrl ?? undefined;
-  const tokenEndpointAuthMethod =
-    options.tokenEndpointAuthMethod ??
-    (providerRow.tokenEndpointAuthMethod as
-      | TokenEndpointAuthMethod
-      | undefined);
+  // Resolve all protocol-level config from the DB
+  const authUrl = providerRow.authUrl;
+  const tokenUrl = providerRow.tokenUrl;
+  const extraParams = dbExtraParams;
+  const userinfoUrl = providerRow.userinfoUrl ?? undefined;
+  const tokenEndpointAuthMethod = providerRow.tokenEndpointAuthMethod as
+    | TokenEndpointAuthMethod
+    | undefined;
   const callbackTransport =
     (providerRow.callbackTransport as "loopback" | "gateway" | null) ??
     "gateway";
   const loopbackPort = providerRow.loopbackPort;
 
-  // Scopes: use explicit override, then try scope policy resolution, then DB defaults
-  let finalScopes: string[];
-  if (options.scopes) {
-    // Explicit scopes override — bypass policy (caller takes responsibility)
-    finalScopes = options.scopes;
-  } else {
-    // Build a scope-resolver-compatible object from the DB row
-    const scopeProfile = {
-      service: resolvedService,
-      defaultScopes: dbDefaultScopes,
-      scopePolicy: dbScopePolicy,
+  // Resolve scopes via the scope policy engine
+  const scopeProfile = {
+    service: resolvedService,
+    defaultScopes: dbDefaultScopes,
+    scopePolicy: dbScopePolicy,
+  };
+  const scopeResult = resolveScopes(scopeProfile, options.requestedScopes);
+  if (!scopeResult.ok) {
+    const guidance = scopeResult.allowedScopes
+      ? ` Allowed scopes: ${scopeResult.allowedScopes.join(", ")}`
+      : "";
+    return {
+      success: false,
+      error: `${scopeResult.error}${guidance}`,
+      safeError: true,
     };
-    const scopeResult = resolveScopes(scopeProfile, options.requestedScopes);
-    if (!scopeResult.ok) {
-      const guidance = scopeResult.allowedScopes
-        ? ` Allowed scopes: ${scopeResult.allowedScopes.join(", ")}`
-        : "";
-      return {
-        success: false,
-        error: `${scopeResult.error}${guidance}`,
-        safeError: true,
-      };
-    }
-    finalScopes = scopeResult.scopes;
   }
+  const finalScopes = scopeResult.scopes;
 
   if (!authUrl) {
     return {

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -16,7 +16,6 @@ import { buildAssistantEvent } from "../../runtime/assistant-event.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { credentialKey } from "../../security/credential-key.js";
-import type { TokenEndpointAuthMethod } from "../../security/oauth2.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -112,16 +111,6 @@ class CredentialStoreTool implements Tool {
             description:
               'Human-readable description of intended usage (for store/prompt actions), e.g. "GitHub login for pushing changes"',
           },
-          auth_url: {
-            type: "string",
-            description:
-              "OAuth2 authorization endpoint (only for oauth2_connect action). Auto-filled for well-known services (gmail, slack).",
-          },
-          token_url: {
-            type: "string",
-            description:
-              "OAuth2 token endpoint (only for oauth2_connect action). Auto-filled for well-known services (gmail, slack).",
-          },
           scopes: {
             type: "array",
             items: { type: "string" },
@@ -133,26 +122,10 @@ class CredentialStoreTool implements Tool {
             description:
               "OAuth2 client ID (only for oauth2_connect action). If omitted, looked up from previously stored credentials.",
           },
-          extra_params: {
-            type: "object",
-            description:
-              "Extra query params for OAuth2 auth URL (only for oauth2_connect action)",
-          },
-          userinfo_url: {
-            type: "string",
-            description:
-              "Endpoint to fetch account info after OAuth2 auth (only for oauth2_connect action)",
-          },
           client_secret: {
             type: "string",
             description:
               "OAuth2 client secret for providers that require it (e.g. Google, Slack). If omitted, looked up from previously stored credentials; if still absent, PKCE-only is used (only for oauth2_connect action)",
-          },
-          token_endpoint_auth_method: {
-            type: "string",
-            enum: ["client_secret_basic", "client_secret_post"],
-            description:
-              'How to send client credentials at the token endpoint: "client_secret_post" (default, in POST body) or "client_secret_basic" (HTTP Basic Auth header). Only for oauth2_connect action.',
           },
           alias: {
             type: "string",
@@ -768,35 +741,13 @@ class CredentialStoreTool implements Tool {
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
         const inputScopes = input.scopes as string[] | undefined;
 
-        if (providerRow) {
-          // Well-known provider (gmail, slack, twitter): the orchestrator
-          // resolves authUrl/tokenUrl/scopes from the DB provider row.
-        } else {
-          // Custom/unknown provider: require authUrl, tokenUrl, scopes from input
-          if (!input.auth_url)
-            return {
-              content:
-                "Error: auth_url is required for oauth2_connect action (no well-known config for this service)",
-              isError: true,
-            };
-          if (!input.token_url)
-            return {
-              content:
-                "Error: token_url is required for oauth2_connect action (no well-known config for this service)",
-              isError: true,
-            };
-          if (!inputScopes)
-            return {
-              content:
-                "Error: scopes is required for oauth2_connect action (no well-known config for this service)",
-              isError: true,
-            };
+        if (!providerRow) {
+          return {
+            content: `Error: no OAuth provider registered for "${service}". Ensure the provider is seeded in the database.`,
+            isError: true,
+          };
         }
 
-        const authUrl =
-          (input.auth_url as string | undefined) ?? providerRow?.authUrl;
-        const tokenUrl =
-          (input.token_url as string | undefined) ?? providerRow?.tokenUrl;
         if (!clientId)
           return {
             content:
@@ -809,7 +760,7 @@ class CredentialStoreTool implements Tool {
         // browser-automation workarounds that inevitably fail.
         const requiresSecret =
           behavior?.setup?.requiresClientSecret ??
-          !!(providerRow?.tokenEndpointAuthMethod || providerRow?.extraParams);
+          !!(providerRow.tokenEndpointAuthMethod || providerRow.extraParams);
         if (requiresSecret && !clientSecret) {
           const skillId = behavior?.setupSkillId;
           const skillHint = skillId
@@ -821,18 +772,8 @@ class CredentialStoreTool implements Tool {
           };
         }
 
-        const tokenEndpointAuthMethod =
-          (input.token_endpoint_auth_method as
-            | TokenEndpointAuthMethod
-            | undefined) ??
-          (providerRow?.tokenEndpointAuthMethod as
-            | TokenEndpointAuthMethod
-            | undefined);
-
-        // Delegate to the shared orchestrator.
-        // For profile-based providers, pass user scopes as requestedScopes so the
-        // scope policy engine (resolveScopes) is invoked. For custom providers,
-        // pass scopes directly as an explicit override.
+        // Delegate to the shared orchestrator — it resolves authUrl, tokenUrl,
+        // extraParams, userinfoUrl, and tokenEndpointAuthMethod from the DB.
         const result = await orchestrateOAuthConnect({
           service: rawService,
           clientId,
@@ -840,21 +781,7 @@ class CredentialStoreTool implements Tool {
           isInteractive: !!context.isInteractive,
           sendToClient: context.sendToClient,
           allowedTools: input.allowed_tools as string[] | undefined,
-          authUrl,
-          tokenUrl,
-          ...(providerRow
-            ? {
-                // Well-known provider: let orchestrator resolve scopes via policy engine.
-                // Only pass requestedScopes if the user explicitly provided scopes.
-                ...(inputScopes ? { requestedScopes: inputScopes } : {}),
-              }
-            : {
-                // Custom provider: explicit scopes override (bypasses policy engine)
-                scopes: inputScopes,
-              }),
-          extraParams: input.extra_params as Record<string, string> | undefined,
-          userinfoUrl: input.userinfo_url as string | undefined,
-          tokenEndpointAuthMethod,
+          ...(inputScopes ? { requestedScopes: inputScopes } : {}),
           onDeferredComplete: (deferredResult) => {
             // Emit oauth_connect_result to all connected SSE clients so the
             // UI can update immediately when the deferred browser flow completes.


### PR DESCRIPTION
## Summary
- Remove unreachable custom/unknown provider handling from vault's oauth2_connect action
- Remove dead input schema properties: auth_url, token_url, userinfo_url, token_endpoint_auth_method, extra_params
- Simplify orchestrateOAuthConnect call to let orchestrator resolve everything from DB

Part of plan: oauth-post-migration-cleanup.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
