### PR TITLE
fix: address PR #15611 review feedback (oauth-sqlite)

### DIFF
--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -82,10 +82,10 @@ export interface MessagingProvider {
 
   /**
    * Override the default credential check used by getConnectedProviders().
-   * When present, the registry calls this instead of looking for
-   * credential/{credentialService}/access_token. Useful for providers
-   * that don't use OAuth (e.g. Telegram bot tokens stored under a
-   * non-standard key).
+   * When present, the registry calls this instead of checking for an
+   * active oauth-store connection via getConnectionByProvider(). Useful
+   * for providers that don't use OAuth (e.g. Telegram bot tokens stored
+   * under a non-standard key).
    */
   isConnected?(): boolean;
 


### PR DESCRIPTION
Address reviewer feedback from PR #15611.

## Summary
- Update stale JSDoc comment on MessagingProvider.isConnected that still referenced the old credential/{service}/access_token key path. The registry now checks getConnectionByProvider().status instead.
- Other review items (test setupService migration, integration-status.ts, registry.ts, slack/share.ts) were already addressed by PRs #15617, #15624, #15627, and #15679.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
