### PR TITLE
fix: add OAuth connection cleanup to vault credential_store delete action

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -92,14 +92,24 @@ const mockProviders = new Map<
   }
 >();
 
-mock.module("../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (service: string) => mockConnections.get(service),
-  getApp: (id: string) => mockApps.get(id),
-  getProvider: (key: string) => mockProviders.get(key),
-  updateConnection: () => {},
-  getMostRecentAppByProvider: () => undefined,
-  listConnections: () => [],
-}));
+let mockDisconnectOAuthProvider: ReturnType<
+  typeof mock<(providerKey: string) => Promise<boolean>>
+>;
+
+mock.module("../oauth/oauth-store.js", () => {
+  mockDisconnectOAuthProvider = mock((providerKey: string) =>
+    Promise.resolve(mockConnections.has(providerKey)),
+  );
+  return {
+    disconnectOAuthProvider: mockDisconnectOAuthProvider,
+    getConnectionByProvider: (service: string) => mockConnections.get(service),
+    getApp: (id: string) => mockApps.get(id),
+    getProvider: (key: string) => mockProviders.get(key),
+    updateConnection: () => {},
+    getMostRecentAppByProvider: () => undefined,
+    listConnections: () => [],
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Import the module under test
@@ -249,12 +259,15 @@ describe("credential_store tool", () => {
     }
     _setStorePath(STORE_PATH);
     _setMetadataPath(join(TEST_DIR, "metadata.json"));
+    mockDisconnectOAuthProvider.mockClear();
+    mockConnections.clear();
   });
 
   afterEach(() => {
     _setMetadataPath(null);
     _setStorePath(null);
     _resetBackend();
+    mockConnections.clear();
   });
 
   afterAll(() => {
@@ -698,6 +711,44 @@ describe("credential_store tool", () => {
       });
       expect(result.isError).toBe(true);
       expect(result.content).toContain("field is required");
+    });
+
+    test("delete also disconnects OAuth connection for the service", async () => {
+      // Store a credential via the real tool so metadata exists
+      await credentialStoreTool.execute(
+        {
+          action: "store",
+          service: "integration:gmail",
+          field: "api_key",
+          value: "test-value",
+        },
+        _ctx,
+      );
+
+      // Simulate an active OAuth connection for this service
+      mockConnections.set("integration:gmail", {
+        id: "conn-gmail",
+        providerKey: "integration:gmail",
+        oauthAppId: "app-gmail",
+        expiresAt: Date.now() + 3600_000,
+      });
+
+      const result = await credentialStoreTool.execute(
+        {
+          action: "delete",
+          service: "integration:gmail",
+          field: "api_key",
+        },
+        _ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Deleted credential");
+      // Verify disconnectOAuthProvider was called with the service name
+      expect(mockDisconnectOAuthProvider).toHaveBeenCalledTimes(1);
+      expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith(
+        "integration:gmail",
+      );
     });
   });
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -1,6 +1,7 @@
 import { getConfig } from "../../config/loader.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import {
+  disconnectOAuthProvider,
   getAppByProviderAndClientId,
   getMostRecentAppByProvider,
   getProvider,
@@ -450,6 +451,8 @@ class CredentialStoreTool implements Tool {
             "metadata delete failed after removing credential",
           );
         }
+        // Also clean up any OAuth connection for this service
+        await disconnectOAuthProvider(service);
         return {
           content: `Deleted credential for ${service}/${field}.`,
           isError: false,


### PR DESCRIPTION
## Summary
- Wire up `disconnectOAuthProvider` in vault's `delete` action for full OAuth cleanup
- Add test verifying OAuth connection is cleaned up when deleting credentials

Part of plan: oauth-post-migration-cleanup.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
