### PR TITLE
fix: use `disconnectOAuthProvider` for OAuth cleanup in CLI credentials delete

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -165,6 +165,23 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock oauth-store
+// ---------------------------------------------------------------------------
+
+let disconnectOAuthProviderCalls: string[] = [];
+let disconnectOAuthProviderResult = false;
+
+mock.module("../oauth/oauth-store.js", () => ({
+  disconnectOAuthProvider: async (providerKey: string): Promise<boolean> => {
+    disconnectOAuthProviderCalls.push(providerKey);
+    return disconnectOAuthProviderResult;
+  },
+  getConnectionByProvider: (): undefined => undefined,
+  listConnections: (): never[] => [],
+  deleteConnection: (): boolean => false,
+}));
+
+// ---------------------------------------------------------------------------
 // Import the module under test (after mocks are registered)
 // ---------------------------------------------------------------------------
 
@@ -281,6 +298,8 @@ describe("assistant credentials CLI", () => {
     _listMetadataCalls = 0;
     _getMetadataCalls = 0;
     _getMetadataByIdCalls = 0;
+    disconnectOAuthProviderCalls = [];
+    disconnectOAuthProviderResult = false;
     process.exitCode = 0;
   });
 
@@ -610,6 +629,55 @@ describe("assistant credentials CLI", () => {
           (m) => m.service === "twilio" && m.field === "auth_token",
         ),
       ).toBeUndefined();
+    });
+
+    test("calls disconnectOAuthProvider for OAuth cleanup", async () => {
+      seedCredential("gmail", "access_token", "ya29.token_value");
+
+      const result = await runCli(["delete", "gmail:access_token", "--json"]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+
+      // disconnectOAuthProvider should have been called with the service name
+      expect(disconnectOAuthProviderCalls).toEqual(["gmail"]);
+    });
+
+    test("succeeds when only OAuth connection exists (no legacy credential)", async () => {
+      // No legacy credential seeded — only the OAuth disconnect finds something
+      disconnectOAuthProviderResult = true;
+
+      const result = await runCli(["delete", "gmail:access_token", "--json"]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.service).toBe("gmail");
+      expect(parsed.field).toBe("access_token");
+
+      expect(disconnectOAuthProviderCalls).toEqual(["gmail"]);
+    });
+
+    test("demonstrates colon-in-service-name parsing limitation with integration:gmail", async () => {
+      // parseCredentialName("integration:gmail:access_token") splits on the
+      // first colon, yielding service="integration" and field="gmail:access_token".
+      // This is incorrect for the intended service "integration:gmail". The fix
+      // for this limitation is addressed by introducing a dedicated `disconnect`
+      // subcommand (PR 5).
+      const result = await runCli([
+        "delete",
+        "integration:gmail:access_token",
+        "--json",
+      ]);
+      // The command parses as service="integration", field="gmail:access_token"
+      // which finds nothing and reports not-found.
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("not found");
+
+      // disconnectOAuthProvider was called with "integration" (wrong) instead
+      // of "integration:gmail" (intended).
+      expect(disconnectOAuthProviderCalls).toEqual(["integration"]);
     });
   });
 

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
 import {
-  deleteConnection,
+  disconnectOAuthProvider,
   getConnectionByProvider,
   listConnections,
   type OAuthConnectionRow,
@@ -78,17 +78,6 @@ function safeListConnections(): OAuthConnectionRow[] {
     return listConnections();
   } catch {
     return [];
-  }
-}
-
-/**
- * Safely delete an OAuth connection by ID. Returns false on error.
- */
-function safeDeleteConnection(id: string): boolean {
-  try {
-    return deleteConnection(id);
-  } catch {
-    return false;
   }
 }
 
@@ -443,20 +432,18 @@ Examples:
 
         const metadataDeleted = deleteCredentialMetadata(service, field);
 
-        if (secretResult !== "deleted" && !metadataDeleted) {
+        // Also clean up the OAuth connection and new-format secure keys.
+        // disconnectOAuthProvider is a no-op when no connection exists.
+        const oauthDisconnected = await disconnectOAuthProvider(service);
+
+        if (
+          secretResult !== "deleted" &&
+          !metadataDeleted &&
+          !oauthDisconnected
+        ) {
           writeOutput(cmd, { ok: false, error: "Credential not found" });
           process.exitCode = 1;
           return;
-        }
-
-        // Only delete the oauth_connection when removing the primary credential
-        // (access_token). Deleting auxiliary fields like client_secret should not
-        // destroy the connection that access_token depends on.
-        if (field === "access_token") {
-          const connection = safeGetConnectionByProvider(service);
-          if (connection) {
-            safeDeleteConnection(connection.id);
-          }
         }
 
         writeOutput(cmd, { ok: true, service, field });


### PR DESCRIPTION
## Summary
- Wire up `disconnectOAuthProvider` in CLI `credentials delete` for full OAuth cleanup
- Remove dead `safeDeleteConnection` helper (no longer referenced)
- Report not-found only when legacy delete AND OAuth disconnect both find nothing
- Add test demonstrating colon-in-service-name parsing limitation

Part of plan: oauth-post-migration-cleanup.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
