### PR TITLE
feat: add `credentials disconnect` subcommand for OAuth-aware service disconnect

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -11,6 +11,7 @@ import type { CredentialMetadata } from "../tools/credentials/metadata-store.js"
 
 let secureKeyStore = new Map<string, string>();
 let metadataStore: CredentialMetadata[] = [];
+let oauthConnectedProviders = new Set<string>();
 let idCounter = 0;
 
 function nextUUID(): string {
@@ -165,6 +166,23 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock oauth-store
+// ---------------------------------------------------------------------------
+
+mock.module("../oauth/oauth-store.js", () => ({
+  disconnectOAuthProvider: async (providerKey: string): Promise<boolean> => {
+    if (oauthConnectedProviders.has(providerKey)) {
+      oauthConnectedProviders.delete(providerKey);
+      return true;
+    }
+    return false;
+  },
+  getConnectionByProvider: (): undefined => undefined,
+  listConnections: (): [] => [],
+  deleteConnection: (): boolean => false,
+}));
+
+// ---------------------------------------------------------------------------
 // Import the module under test (after mocks are registered)
 // ---------------------------------------------------------------------------
 
@@ -274,6 +292,7 @@ describe("assistant credentials CLI", () => {
   beforeEach(() => {
     secureKeyStore = new Map();
     metadataStore = [];
+    oauthConnectedProviders = new Set();
     idCounter = 0;
     _getSecureKeyCalls = 0;
     _setSecureKeyCalls = 0;
@@ -610,6 +629,124 @@ describe("assistant credentials CLI", () => {
           (m) => m.service === "twilio" && m.field === "auth_token",
         ),
       ).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // disconnect
+  // =========================================================================
+
+  describe("disconnect", () => {
+    test("succeeds when an OAuth connection exists", async () => {
+      oauthConnectedProviders.add("integration:gmail");
+
+      const result = await runCli([
+        "disconnect",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.service).toBe("integration:gmail");
+
+      // OAuth connection should be removed
+      expect(oauthConnectedProviders.has("integration:gmail")).toBe(false);
+    });
+
+    test("reports not-found when nothing exists", async () => {
+      const result = await runCli([
+        "disconnect",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("No OAuth connection or credentials");
+      expect(parsed.error).toContain("integration:gmail");
+    });
+
+    test("cleans up legacy credential keys if present", async () => {
+      // Seed legacy credential keys (no OAuth connection)
+      const legacyFields = [
+        "access_token",
+        "refresh_token",
+        "client_id",
+        "client_secret",
+      ];
+      for (const field of legacyFields) {
+        secureKeyStore.set(
+          credentialKey("integration:gmail", field),
+          `legacy_${field}_value`,
+        );
+        metadataStore.push({
+          credentialId: nextUUID(),
+          service: "integration:gmail",
+          field,
+          allowedTools: [],
+          allowedDomains: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+      }
+
+      const result = await runCli([
+        "disconnect",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.service).toBe("integration:gmail");
+
+      // All legacy keys should be removed
+      for (const field of legacyFields) {
+        expect(
+          secureKeyStore.has(credentialKey("integration:gmail", field)),
+        ).toBe(false);
+        expect(
+          metadataStore.find(
+            (m) => m.service === "integration:gmail" && m.field === field,
+          ),
+        ).toBeUndefined();
+      }
+    });
+
+    test("cleans up both OAuth connection and legacy keys when both exist", async () => {
+      // Seed OAuth connection
+      oauthConnectedProviders.add("integration:gmail");
+
+      // Seed a legacy credential key
+      secureKeyStore.set(
+        credentialKey("integration:gmail", "access_token"),
+        "legacy_token",
+      );
+      metadataStore.push({
+        credentialId: nextUUID(),
+        service: "integration:gmail",
+        field: "access_token",
+        allowedTools: [],
+        allowedDomains: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      const result = await runCli([
+        "disconnect",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+
+      // Both should be cleaned up
+      expect(oauthConnectedProviders.has("integration:gmail")).toBe(false);
+      expect(
+        secureKeyStore.has(credentialKey("integration:gmail", "access_token")),
+      ).toBe(false);
     });
   });
 

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 
 import {
   deleteConnection,
+  disconnectOAuthProvider,
   getConnectionByProvider,
   listConnections,
   type OAuthConnectionRow,
@@ -463,6 +464,77 @@ Examples:
 
         if (!shouldOutputJson(cmd)) {
           log.info(`Deleted credential ${service}:${field}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // -------------------------------------------------------------------------
+  // disconnect
+  // -------------------------------------------------------------------------
+
+  credential
+    .command("disconnect <service>")
+    .description(
+      "Disconnect an OAuth integration and remove all associated credentials",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  service   The full provider key (e.g. integration:gmail, integration:slack)
+
+Removes the OAuth connection, tokens, and any legacy credential metadata for
+the service. The <service> argument is the full provider key as-is — it is not
+parsed through service:field splitting.
+
+Legacy credential keys for common fields (access_token, refresh_token,
+client_id, client_secret) are also cleaned up if present.
+
+Examples:
+  $ assistant credentials disconnect integration:gmail
+  $ assistant credentials disconnect integration:slack`,
+    )
+    .action(async (service: string, _opts: unknown, cmd: Command) => {
+      try {
+        let cleanedUp = false;
+
+        // 1. Disconnect the OAuth connection (new-format keys + connection row)
+        const oauthDisconnected = await disconnectOAuthProvider(service);
+        if (oauthDisconnected) cleanedUp = true;
+
+        // 2. Clean up legacy credential keys for common fields
+        const legacyFields = [
+          "access_token",
+          "refresh_token",
+          "client_id",
+          "client_secret",
+        ];
+        for (const field of legacyFields) {
+          const key = credentialKey(service, field);
+          const result = await deleteSecureKeyAsync(key);
+          if (result === "deleted") cleanedUp = true;
+
+          const metaDeleted = deleteCredentialMetadata(service, field);
+          if (metaDeleted) cleanedUp = true;
+        }
+
+        if (!cleanedUp) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `No OAuth connection or credentials found for "${service}"`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, { ok: true, service });
+
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Disconnected ${service}`);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Add `credentials disconnect <service>` CLI subcommand that takes the full provider key as-is
- Cleans up OAuth connection, secure keys, and legacy credential metadata
- No colon-parsing issue: `integration:gmail` works correctly
- Add tests covering success, not-found, and legacy cleanup paths

Part of plan: oauth-post-migration-cleanup.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
