### PR TITLE
fix: update tests broken by OAuth provider scaffolding removal

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -58,7 +58,7 @@ describe("browser skill cutover — startup tool payload", () => {
     // Floor at 15 000 catches accidental wholesale removal; ceiling at 35 000
     // gives headroom while still catching browser tool leakage
     // (~4 640 chars would push it past the ceiling).
-    expect(serialized.length).toBeGreaterThan(15_000);
+    expect(serialized.length).toBeGreaterThan(14_000);
     expect(serialized.length).toBeLessThan(35_000);
   });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -233,6 +233,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
+      "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -562,55 +562,38 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("service is required");
   });
 
-  test("requires auth_url for unknown service", async () => {
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "custom-svc",
-        token_url: "https://t",
-        scopes: ["read"],
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("auth_url is required");
-  });
-
-  test("requires token_url for unknown service", async () => {
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "custom-svc",
-        auth_url: "https://a",
-        scopes: ["read"],
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("token_url is required");
-  });
-
-  test("requires scopes for unknown service", async () => {
+  test("rejects unknown service without registered provider", async () => {
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
         service: "custom-svc",
         auth_url: "https://a",
         token_url: "https://t",
+        scopes: ["read"],
       },
       _ctx,
     );
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("scopes is required");
+    expect(result.content).toContain("no OAuth provider registered");
   });
 
   test("requires client_id", async () => {
+    mockGetProvider.mockImplementation((key: string) => {
+      if (key === "custom-svc") {
+        return {
+          key: "custom-svc",
+          authUrl: "https://auth.example.com",
+          tokenUrl: "https://token.example.com",
+          defaultScopes: JSON.stringify(["read"]),
+          scopePolicy: JSON.stringify({}),
+        };
+      }
+      return wellKnownProviders[key] ?? undefined;
+    });
     const result = await credentialStoreTool.execute(
       {
         action: "oauth2_connect",
         service: "custom-svc",
-        auth_url: "https://auth.example.com",
-        token_url: "https://token.example.com",
         scopes: ["read"],
       },
       _ctx,


### PR DESCRIPTION
## Summary
- Add `oauth/oauth-store.ts` to the authorized `secure-keys` importers allowlist in credential-security-invariants tests (it legitimately uses `deleteSecureKeyAsync` for OAuth disconnect)
- Replace three removed custom/unknown OAuth provider parameter validation tests with a single "rejects unknown service" test matching the new behavior from PR #15681
- Lower browser tool payload size floor from 15,000 to 14,000 chars to match current payload (14,911)

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23002544449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
