### PR TITLE
fix: address PR #15483 review feedback (oauth-conn-req)

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -28,7 +28,7 @@ graph TB
         DRAFT["messaging_draft"]
         SENDER_DIGEST["messaging_sender_digest"]
         ARCHIVE_BY_SENDER["messaging_archive_by_sender"]
-        SHARED["shared.ts<br/>resolveProvider + withProviderToken"]
+        SHARED["shared.ts<br/>resolveProvider + getProviderConnection"]
     end
 
     subgraph "Gmail Skill (bundled-skills/gmail/)"

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -6,14 +6,15 @@
  * with OAuth tokens, Telegram delivery is proxied through the gateway which
  * owns the bot token and handles Telegram API retries.
  *
- * The `token` parameter in MessagingProvider methods is unused for Telegram
- * because delivery is authenticated via the gateway's bearer token, not
- * a per-user OAuth token.
+ * The `connectionOrToken` parameter in MessagingProvider methods is unused
+ * for Telegram because delivery is authenticated via the gateway's bearer
+ * token, not a per-user OAuth token.
  */
 
 import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
+import type { OAuthConnection } from "../../../oauth/connection.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKey } from "../../../security/secure-keys.js";
@@ -69,7 +70,9 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     );
   },
 
-  async testConnection(_token: string): Promise<ConnectionInfo> {
+  async testConnection(
+    _connectionOrToken: OAuthConnection | string,
+  ): Promise<ConnectionInfo> {
     const botToken = getBotToken();
     if (!botToken) {
       return {
@@ -114,7 +117,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     _options?: SendOptions,
@@ -152,7 +155,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   // interact with chats where users have initiated contact or the bot
   // has been added to a group.
   async listConversations(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
     return [];
@@ -160,7 +163,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
 
   // Telegram Bot API does not provide message history retrieval.
   async getHistory(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _conversationId: string,
     _options?: HistoryOptions,
   ): Promise<Message[]> {
@@ -169,7 +172,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
 
   // Telegram Bot API does not support message search.
   async search(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _query: string,
     _options?: SearchOptions,
   ): Promise<SearchResult> {

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -5,14 +5,15 @@
  * endpoint. Delivery is proxied through the gateway which owns the Meta Cloud API
  * credentials (phone_number_id + access_token).
  *
- * The `token` parameter in MessagingProvider methods is unused for WhatsApp
- * because delivery is authenticated via the gateway's bearer token, not
- * a per-user OAuth token.
+ * The `connectionOrToken` parameter in MessagingProvider methods is unused
+ * for WhatsApp because delivery is authenticated via the gateway's bearer
+ * token, not a per-user OAuth token.
  */
 
 import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
+import type { OAuthConnection } from "../../../oauth/connection.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKey } from "../../../security/secure-keys.js";
@@ -61,7 +62,9 @@ export const whatsappMessagingProvider: MessagingProvider = {
     return hasWhatsAppCredentials();
   },
 
-  async testConnection(_token: string): Promise<ConnectionInfo> {
+  async testConnection(
+    _connectionOrToken: OAuthConnection | string,
+  ): Promise<ConnectionInfo> {
     if (!hasWhatsAppCredentials()) {
       return {
         connected: false,
@@ -89,7 +92,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     conversationId: string,
     text: string,
     options?: SendOptions,
@@ -133,7 +136,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not support listing conversations via this provider.
   async listConversations(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
     return [];
@@ -141,7 +144,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not provide message history retrieval via the gateway.
   async getHistory(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _conversationId: string,
     _options?: HistoryOptions,
   ): Promise<Message[]> {
@@ -150,7 +153,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not support message search.
   async search(
-    _token: string,
+    _connectionOrToken: OAuthConnection | string,
     _query: string,
     _options?: SearchOptions,
   ): Promise<SearchResult> {


### PR DESCRIPTION
Address reviewer feedback from PR #15483.

- Update Mermaid diagram in integrations.md to reference `getProviderConnection` instead of removed `withProviderToken`
- Update Telegram and WhatsApp adapter method signatures from `_token: string` to `_connectionOrToken: OAuthConnection | string` to match the MessagingProvider interface
- Update doc comments in both adapters to use the new parameter name
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
