### PR TITLE
fix: use Headers API for case-insensitive header merging in BYOOAuthConnection

### DIFF
--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -69,13 +69,22 @@ export class BYOOAuthConnection implements OAuthConnection {
         "Making authenticated request",
       );
 
+      // Use the Headers API for case-insensitive merging. Set defaults
+      // first so caller-supplied headers (in any casing) override them.
+      const headers = new Headers();
+      if (req.body) {
+        headers.set("Content-Type", "application/json");
+      }
+      if (req.headers) {
+        for (const [key, value] of Object.entries(req.headers)) {
+          headers.set(key, value);
+        }
+      }
+      headers.set("Authorization", `Bearer ${token}`);
+
       const resp = await fetch(fullUrl, {
         method: req.method,
-        headers: {
-          ...(req.body ? { "Content-Type": "application/json" } : {}),
-          ...req.headers,
-          Authorization: `Bearer ${token}`,
-        },
+        headers,
         body: req.body ? JSON.stringify(req.body) : undefined,
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });


### PR DESCRIPTION
## Summary
- Addresses feedback from PR #15489: Content-Type override should be handled case-insensitively
- Replaces plain-object spread with the `Headers` API, which natively handles case-insensitive key merging
- Ensures a caller providing `content-type` (lowercase) correctly overrides the default `Content-Type: application/json` instead of creating duplicate headers

## Test plan
- [ ] Verify requests with no explicit Content-Type still default to `application/json` when a body is present
- [ ] Verify requests with `content-type` (lowercase) override the default correctly
- [ ] Verify requests without a body do not set Content-Type at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
