### PR TITLE
refactor: restructure oauth CLI into directory, add provider subcommands

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -66,7 +66,7 @@ mock.module("../util/logger.js", () => ({
 // Import the module under test (after mocks are registered)
 // ---------------------------------------------------------------------------
 
-const { registerOAuthCommand } = await import("../cli/commands/oauth.js");
+const { registerOAuthCommand } = await import("../cli/commands/oauth/index.js");
 
 // ---------------------------------------------------------------------------
 // Test helper

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -1,30 +1,41 @@
 import type { Command } from "commander";
 
-import { withValidToken } from "../../security/token-manager.js";
-import { shouldOutputJson, writeOutput } from "../output.js";
+import { withValidToken } from "../../../security/token-manager.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+import { registerProviderCommands } from "./providers.js";
 
 export function registerOAuthCommand(program: Command): void {
   const oauth = program
     .command("oauth")
-    .description("Manage OAuth tokens for connected integrations")
+    .description("Manage OAuth providers, apps, connections, and tokens")
     .option("--json", "Machine-readable compact JSON output");
 
   oauth.addHelpText(
     "after",
     `
-OAuth tokens are managed automatically — the "token" command returns a
-guaranteed-valid access token, refreshing transparently if the stored token
-is expired or near-expiry. Callers never need to handle refresh themselves.
+The oauth command group manages the full OAuth lifecycle:
 
-The <service> argument is the short integration name (e.g. "twitter", "gmail",
-"slack"). The token is resolved from the corresponding OAuth connection.
+  providers   Protocol-level configurations (auth URLs, scopes, endpoints)
+  apps        Client credentials (client ID / secret pairs)
+  connections Active token grants per provider
+  token       Return a guaranteed-valid access token for a service
+
+Providers are seeded on startup for built-in integrations. Apps and connections
+are created during the OAuth authorization flow or can be managed manually via
+their respective subcommands.
 
 Examples:
   $ assistant oauth token twitter
-  $ assistant oauth token twitter --json
-  $ TOKEN=$(assistant oauth token gmail)
-  $ curl -H "Authorization: Bearer $(assistant oauth token twitter)" https://api.x.com/2/tweets`,
+  $ assistant oauth providers list
+  $ assistant oauth providers get integration:gmail
+  $ assistant oauth providers register --provider-key custom:myapi --auth-url https://example.com/auth --token-url https://example.com/token`,
   );
+
+  // ---------------------------------------------------------------------------
+  // providers — subcommand group
+  // ---------------------------------------------------------------------------
+
+  registerProviderCommands(oauth);
 
   // ---------------------------------------------------------------------------
   // token — return a guaranteed-valid access token

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -1,0 +1,155 @@
+import type { Command } from "commander";
+
+import {
+  getProvider,
+  listProviders,
+  registerProvider,
+} from "../../../oauth/oauth-store.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+
+const log = getCliLogger("cli");
+
+/** Parse stored JSON string fields into their native types. */
+function parseProviderRow(row: ReturnType<typeof getProvider>) {
+  if (!row) return row;
+  return {
+    ...row,
+    defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
+    scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
+    extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+  };
+}
+
+export function registerProviderCommands(oauth: Command): void {
+  const providers = oauth
+    .command("providers")
+    .description(
+      "Manage OAuth provider configurations (auth URLs, scopes, endpoints)",
+    );
+
+  providers.addHelpText(
+    "after",
+    `
+Providers define the protocol-level configuration for an OAuth integration:
+authorization URL, token URL, default scopes, and other endpoint details.
+
+They are seeded on startup for built-in integrations (e.g. Gmail, Twitter,
+Slack) but can also be registered dynamically via the "register" subcommand.
+
+Each provider is identified by a provider key (e.g. "integration:gmail").`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // providers list
+  // ---------------------------------------------------------------------------
+
+  providers
+    .command("list")
+    .description("List all registered OAuth providers")
+    .action((_opts: unknown, cmd: Command) => {
+      try {
+        const rows = listProviders().map(parseProviderRow);
+
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Found ${rows.length} provider(s)`);
+        }
+
+        writeOutput(cmd, rows);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // providers get <provider-key>
+  // ---------------------------------------------------------------------------
+
+  providers
+    .command("get <provider-key>")
+    .description("Show details of a specific OAuth provider")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider-key   The full provider key (e.g. "integration:gmail")`,
+    )
+    .action((providerKey: string, _opts: unknown, cmd: Command) => {
+      try {
+        const row = getProvider(providerKey);
+
+        if (!row) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Provider not found: ${providerKey}`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, parseProviderRow(row));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // providers register
+  // ---------------------------------------------------------------------------
+
+  providers
+    .command("register")
+    .description("Register a new OAuth provider configuration")
+    .requiredOption("--provider-key <key>", "Provider key")
+    .requiredOption("--auth-url <url>", "Authorization endpoint URL")
+    .requiredOption("--token-url <url>", "Token endpoint URL")
+    .option("--base-url <url>", "API base URL")
+    .option("--userinfo-url <url>", "Userinfo endpoint URL")
+    .option("--scopes <scopes>", "Comma-separated default scopes")
+    .option("--token-auth-method <method>", "Token endpoint auth method")
+    .option("--callback-transport <transport>", "Callback transport")
+    .option("--loopback-port <port>", "Loopback port", parseInt)
+    .action(
+      (
+        opts: {
+          providerKey: string;
+          authUrl: string;
+          tokenUrl: string;
+          baseUrl?: string;
+          userinfoUrl?: string;
+          scopes?: string;
+          tokenAuthMethod?: string;
+          callbackTransport?: string;
+          loopbackPort?: number;
+        },
+        cmd: Command,
+      ) => {
+        try {
+          const row = registerProvider({
+            providerKey: opts.providerKey,
+            authUrl: opts.authUrl,
+            tokenUrl: opts.tokenUrl,
+            baseUrl: opts.baseUrl,
+            userinfoUrl: opts.userinfoUrl,
+            defaultScopes: opts.scopes ? opts.scopes.split(",") : [],
+            scopePolicy: {},
+            tokenEndpointAuthMethod: opts.tokenAuthMethod,
+            callbackTransport: opts.callbackTransport,
+            loopbackPort: opts.loopbackPort,
+          });
+
+          writeOutput(cmd, parseProviderRow(row));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -19,7 +19,7 @@ import { registerKeysCommand } from "./commands/keys.js";
 import { registerMcpCommand } from "./commands/mcp.js";
 import { registerMemoryCommand } from "./commands/memory.js";
 import { registerNotificationsCommand } from "./commands/notifications.js";
-import { registerOAuthCommand } from "./commands/oauth.js";
+import { registerOAuthCommand } from "./commands/oauth/index.js";
 import { registerPlatformCommand } from "./commands/platform.js";
 import { registerSequenceCommand } from "./commands/sequence.js";
 import { registerSessionsCommand } from "./commands/sessions.js";

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -28,7 +28,7 @@ Commands:
   completions <shell>                      Generate shell completion script (e.g. assistant completions bash >> ~/.bashrc)
   notifications [options]                  Send and inspect notifications through the unified notification router
   platform [options]                       Manage platform integration for containerized deployments
-  oauth [options]                          Manage OAuth tokens for connected integrations
+  oauth [options]                          Manage OAuth providers, apps, connections, and tokens
   skills                                   Browse and install skills from the Vellum catalog
   browser                                  Browser automation, extension relay, and Chrome CDP management
   sequence [options]                       Manage email sequences


### PR DESCRIPTION
## Summary
- Restructure `assistant/src/cli/commands/oauth.ts` into `oauth/index.ts` + `oauth/providers.ts`
- Add `assistant oauth providers` subcommands: list, get, register
- Update description and help text for expanded command set
- Existing `assistant oauth token` continues to work unchanged
- Update imports in program.ts and oauth-cli.test.ts for new path

Part of plan: oauth-cli-crud-commands.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
