### PR TITLE
fix: repair broken credential-vault-unit and slack-share-routes tests

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -66,6 +66,7 @@ mock.module("../oauth/oauth-store.js", () => {
     getProvider: mockGetProvider,
     listConnections: mock(() => []),
     seedProviders: mock(() => {}),
+    disconnectOAuthProvider: mock(async () => false),
   };
 });
 

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { credentialKey } from "../security/credential-key.js";
-
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before any imports that pull in mocked modules
 // ---------------------------------------------------------------------------
@@ -183,18 +181,6 @@ describe("handleListSlackChannels", () => {
       type: "dm",
       isPrivate: true,
     });
-  });
-
-  test("falls back to legacy bot token", async () => {
-    secureKeyValues.set(
-      credentialKey("slack_channel", "bot_token"),
-      "xoxb-legacy",
-    );
-
-    listConversationsResult = { ok: true, channels: [] };
-
-    const res = await handleListSlackChannels();
-    expect(res.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `disconnectOAuthProvider` to the oauth-store mock in `credential-vault-unit.test.ts` — the delete action calls this function but the mock was missing it, causing a `no such table: oauth_connections` SQLite error
- Remove the stale "falls back to legacy bot token" test from `slack-share-routes.test.ts` — PR #15679 intentionally removed the legacy fallback from the handler but didn't clean up the test

## Original prompt
help me fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23002782161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
