### PR TITLE
fix: remove dead VELLUM_KEYCHAIN_BROKER_SOCKET env var and update broker docs

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -158,7 +158,7 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 ## Developer Experience
 
 - **Debug builds:** The `#if !DEBUG` guard compiles out the entire `KeychainBrokerServer`. The broker socket is not created, so clients see the broker as unavailable and use the encrypted store. Developers never encounter keychain prompts during the edit-build-run cycle.
-- **Release builds:** The broker starts automatically with the app. The daemon discovers it via the socket env var and token file. No configuration needed.
+- **Release builds:** The broker starts automatically with the app. The daemon discovers the broker via the derived socket path (`join(getRootDir(), "keychain-broker.sock")`) and token file. No configuration needed.
 - **CLI-only / headless:** No macOS app means no broker socket. All storage uses the encrypted file store. This is the expected path for CI, servers, and non-macOS platforms.
 
 ## Callsite Policy

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -673,18 +673,6 @@ final class AssistantCli {
             if let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
-            // Tell the daemon where the keychain broker socket is.
-            // Only set in release builds where the broker is running.
-            #if !DEBUG
-            let brokerBaseDir: String
-            if let baseDir = fullEnv["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-                brokerBaseDir = (baseDir as NSString).appendingPathComponent(".vellum")
-            } else {
-                brokerBaseDir = (NSHomeDirectory() as NSString).appendingPathComponent(".vellum")
-            }
-            env["VELLUM_KEYCHAIN_BROKER_SOCKET"] = (brokerBaseDir as NSString)
-                .appendingPathComponent("keychain-broker.sock")
-            #endif
             // Fall back to UserDefaults for the Anthropic API key when
             // it's not in the process environment (e.g. app launched from
             // Finder, not a terminal with ANTHROPIC_API_KEY set).


### PR DESCRIPTION
## Summary
- Remove the now-unused `VELLUM_KEYCHAIN_BROKER_SOCKET` env var setting from the macOS Swift app (`AssistantCli.swift`)
- Update `keychain-broker.md` architecture doc to reflect derived socket path discovery instead of env var

Follows up on #15567 review feedback about dead code removal and stale docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
