### PR TITLE
fix: add try-catch wrappers and assertMetadataWritable guard for OAuth disconnect

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -434,7 +434,12 @@ Examples:
 
         // Also clean up the OAuth connection and new-format secure keys.
         // disconnectOAuthProvider is a no-op when no connection exists.
-        const oauthDisconnected = await disconnectOAuthProvider(service);
+        let oauthDisconnected = false;
+        try {
+          oauthDisconnected = await disconnectOAuthProvider(service);
+        } catch {
+          // Best-effort — OAuth tables may not exist yet
+        }
 
         if (
           secretResult !== "deleted" &&
@@ -486,6 +491,8 @@ Examples:
     )
     .action(async (service: string, _opts: unknown, cmd: Command) => {
       try {
+        assertMetadataWritable();
+
         let cleanedUp = false;
 
         // 1. Disconnect the OAuth connection (new-format keys + connection row)

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -451,8 +451,15 @@ class CredentialStoreTool implements Tool {
             "metadata delete failed after removing credential",
           );
         }
-        // Also clean up any OAuth connection for this service
-        await disconnectOAuthProvider(service);
+        // Also clean up any OAuth connection for this service (best-effort)
+        try {
+          await disconnectOAuthProvider(service);
+        } catch (err) {
+          log.warn(
+            { service, err },
+            "OAuth disconnect failed after removing credential",
+          );
+        }
         return {
           content: `Deleted credential for ${service}/${field}.`,
           isError: false,


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during plan review for oauth-post-migration-cleanup.md.

- Wrap `disconnectOAuthProvider` in try-catch in vault delete action (best-effort pattern)
- Wrap `disconnectOAuthProvider` in try-catch in CLI credentials delete action
- Add `assertMetadataWritable()` guard to credentials disconnect subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
