### PR TITLE
chore: update stale SKILL.md instructions and fix test comment threshold

### DIFF
--- a/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
+++ b/assistant/src/__tests__/browser-skill-baseline-tool-payload.test.ts
@@ -55,7 +55,7 @@ describe("browser skill cutover — startup tool payload", () => {
     const definitions = getAllToolDefinitions();
     const serialized = JSON.stringify(definitions);
     // Startup payload is ~22 000 chars without browser tools.
-    // Floor at 15 000 catches accidental wholesale removal; ceiling at 35 000
+    // Floor at 14 000 catches accidental wholesale removal; ceiling at 35 000
     // gives headroom while still catching browser tool leakage
     // (~4 640 chars would push it past the ceiling).
     expect(serialized.length).toBeGreaterThan(14_000);

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -21,6 +21,7 @@ Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Pu
 ## Before You Start
 
 Tell the user:
+
 - "I'll walk you through creating a Notion integration so Vellum can read and write pages and databases in your workspace. The whole process takes a few minutes."
 - "I'll be automating the Notion integrations page in the browser — you'll be able to see everything I'm doing."
 - "I'll ask for your approval before each major step, so nothing happens without your say-so."
@@ -33,6 +34,7 @@ Tell the user: "First, let me open the Notion integrations page."
 Use `browser_navigate` to go to `https://www.notion.so/my-integrations`.
 
 Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+
 - **If a sign-in page appears:** Tell the user "Please sign in to your Notion account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
 - **If the integrations dashboard loads:** Tell the user "Notion integrations page is loaded. Let's create your integration!" and continue to Step 2.
 
@@ -47,6 +49,7 @@ Take a `browser_screenshot` to show the user what loaded, then take a `browser_s
 Wait for the user to approve. If they decline, explain that the integration is required for OAuth and offer to try again or cancel.
 
 Once approved:
+
 1. Click "New integration" (or the "+" button)
 2. Select "Public" as the integration type (required for OAuth)
 3. Enter integration name: "Vellum Assistant"
@@ -70,6 +73,7 @@ Navigate to the integration's "Distribution" or "OAuth Domain & URIs" tab.
 Wait for the user to approve.
 
 Once approved:
+
 1. Find the "Redirect URIs" field
 2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress).
 3. Save the settings
@@ -83,6 +87,7 @@ Tell the user: "Redirect URI configured. Now let's get your OAuth credentials."
 Stay on the integration settings page and navigate to the "Secrets" or "OAuth Clients" section.
 
 Use `browser_extract` to read:
+
 1. **OAuth client_id** — this is the integration's OAuth client ID
 2. **OAuth client_secret** — click "Show" or "Reveal" first, then extract the value
 
@@ -113,6 +118,7 @@ Once connected, tell the user:
 "**Notion is connected!** You're all set. You can now read and write pages and databases in your Notion workspace through Vellum. Try asking me to list your databases or read a specific page!"
 
 Summarize what was accomplished:
+
 - Created a Notion public integration called "Vellum Assistant"
 - Configured the OAuth redirect URI
 - Connected your Notion workspace with read and write access

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -101,11 +101,7 @@ action: "oauth2_connect"
 service: "integration:notion"
 client_id: "<the extracted OAuth client_id>"
 client_secret: "<the extracted OAuth client_secret>"
-auth_url: "https://api.notion.com/v1/oauth/authorize"
-token_url: "https://api.notion.com/v1/oauth/token"
 scopes: []
-extra_params: {"owner": "user"}
-token_endpoint_auth_method: "client_secret_basic"
 ```
 
 This will open the Notion authorization page in the user's browser. Wait for the flow to complete.

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -132,10 +132,7 @@ action: "oauth2_connect"
 service: "integration:slack"
 client_id: "<the extracted Client ID>"
 client_secret: "<the extracted Client Secret>"
-auth_url: "https://slack.com/oauth/v2/authorize"
-token_url: "https://slack.com/api/oauth.v2.access"
 scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
-extra_params: {"user_scope": "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write"}
 ```
 
 This will open the Slack authorization page in the user's browser. Wait for the flow to complete.

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -17,6 +17,7 @@ You are helping your user create a Slack App and OAuth credentials so the Messag
 ## Before You Start
 
 Tell the user:
+
 - "I'll walk you through creating a Slack App so Vellum can connect to your workspace. The whole process takes a few minutes."
 - "I'll be automating the Slack API website in the browser — you'll be able to see everything I'm doing."
 - "I'll ask for your approval before each major step, so nothing happens without your say-so."
@@ -29,6 +30,7 @@ Tell the user: "First, let me open the Slack API dashboard."
 Use `browser_navigate` to go to `https://api.slack.com/apps`.
 
 Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+
 - **If a sign-in page appears:** Tell the user "Please sign in to your Slack account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
 - **If the apps dashboard loads:** Tell the user "Slack API dashboard is loaded. Let's create your app!" and continue to Step 2.
 
@@ -43,6 +45,7 @@ Take a `browser_screenshot` to show the user what loaded, then take a `browser_s
 Wait for the user to approve. If they decline, explain that the app is required for OAuth and offer to try again or cancel.
 
 Once approved:
+
 1. Click "Create New App"
 2. Select "From scratch"
 3. Enter app name: "Vellum Assistant"
@@ -78,6 +81,7 @@ Tell the user: "App created! Now let's configure the permissions it needs."
 Wait for the user to approve.
 
 Once approved:
+
 1. Navigate to "OAuth & Permissions" in the left sidebar (or go to the app's OAuth page directly)
 2. Scroll to "User Token Scopes"
 3. Add each scope listed above using the "Add an OAuth Scope" button
@@ -100,6 +104,7 @@ credential_store describe:
 Read the `redirectUri` field from that response and use it exactly as shown.
 
 In the "Redirect URLs" section:
+
 1. If `redirectUri` says "automatic", skip adding a redirect URL for this provider.
 2. If `redirectUri` mentions "not currently configured" or `ingress.publicBaseUrl`, stop and ask the user to configure public ingress first.
 3. Otherwise, click "Add New Redirect URL" and enter the `redirectUri` value exactly as returned.
@@ -114,6 +119,7 @@ Tell the user: "Redirect URL configured using the redirect URI from Vellum's Sla
 Navigate to "Basic Information" in the left sidebar.
 
 Use `browser_extract` to read:
+
 1. **Client ID** from the "App Credentials" section
 2. **Client Secret** — click "Show" first, then extract the value
 
@@ -144,6 +150,7 @@ Once connected, tell the user:
 "**Slack is connected!** You're all set. You can now read channels, search messages, send messages, and manage your Slack workspace through Vellum. Try asking me to check your unread Slack messages!"
 
 Summarize what was accomplished:
+
 - Created a Slack App called "Vellum Assistant"
 - Configured User Token Scopes for reading, writing, and searching
 - Set up the OAuth redirect URL from the Slack OAuth profile


### PR DESCRIPTION
## Summary
Fixes 2 gaps identified during plan review for oauth-post-migration-cleanup.md.

- Remove references to removed oauth2_connect parameters (auth_url, token_url, extra_params, token_endpoint_auth_method) from slack-oauth-setup and notion-oauth-setup SKILL.md files
- Fix comment/threshold mismatch in browser-skill-baseline-tool-payload test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
