### PR TITLE
fix: check deleteSecureKeyAsync results in disconnectOAuthProvider

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -18,6 +18,9 @@ import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("oauth-store");
 
 // ---------------------------------------------------------------------------
 // Row types
@@ -437,8 +440,25 @@ export async function disconnectOAuthProvider(
   const conn = getConnectionByProvider(providerKey);
   if (!conn) return false;
 
-  await deleteSecureKeyAsync(`oauth_connection/${conn.id}/access_token`);
-  await deleteSecureKeyAsync(`oauth_connection/${conn.id}/refresh_token`);
+  const r1 = await deleteSecureKeyAsync(
+    `oauth_connection/${conn.id}/access_token`,
+  );
+  const r2 = await deleteSecureKeyAsync(
+    `oauth_connection/${conn.id}/refresh_token`,
+  );
+
+  if (r1 === "error" || r2 === "error") {
+    log.warn(
+      {
+        providerKey,
+        connectionId: conn.id,
+        accessTokenResult: r1,
+        refreshTokenResult: r2,
+      },
+      "Failed to delete OAuth secure keys — skipping connection row deletion to avoid orphaning secrets",
+    );
+    return false;
+  }
 
   deleteConnection(conn.id);
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-post-migration-cleanup.md.

**Gap:** disconnectOAuthProvider ignores deleteSecureKeyAsync error results
**What was expected:** Should abort connection row deletion if secure key deletion fails
**What was found:** Return values ignored, always deletes DB row, can orphan secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
