### PR TITLE
fix: align byo-connection test assertions with Content-Type and Headers API changes

### DIFF
--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -246,7 +246,7 @@ describe("BYOOAuthConnection", () => {
       expect(url).toBe(
         "https://gmail.googleapis.com/gmail/v1/users/me/messages",
       );
-      const headers = init.headers as Headers;
+      const headers = (init as RequestInit).headers as Headers;
       expect(headers.get("Authorization")).toBe("Bearer test-access-token");
       // GET requests have no body, so Content-Type should not be set
       expect(headers.has("Content-Type")).toBe(false);
@@ -299,7 +299,7 @@ describe("BYOOAuthConnection", () => {
       );
       expect((init as RequestInit).method).toBe("POST");
       // POST requests with a body should include Content-Type
-      const headers = init.headers as Headers;
+      const headers = (init as RequestInit).headers as Headers;
       expect(headers.get("Content-Type")).toBe("application/json");
     });
 
@@ -400,7 +400,7 @@ describe("BYOOAuthConnection", () => {
       });
 
       const [, init] = mockFetch.mock.calls[0];
-      const headers = init.headers as Headers;
+      const headers = (init as RequestInit).headers as Headers;
       expect(headers.get("X-Custom-Header")).toBe("custom-value");
       expect(headers.get("Authorization")).toBe("Bearer test-access-token");
     });
@@ -424,7 +424,7 @@ describe("BYOOAuthConnection", () => {
 
       // The request should use the refreshed token
       const [, init] = mockFetch.mock.calls[0];
-      const headers = init.headers as Headers;
+      const headers = (init as RequestInit).headers as Headers;
       expect(headers.get("Authorization")).toBe(
         "Bearer refreshed-access-token",
       );

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -246,10 +246,10 @@ describe("BYOOAuthConnection", () => {
       expect(url).toBe(
         "https://gmail.googleapis.com/gmail/v1/users/me/messages",
       );
-      expect((init as RequestInit).headers).toMatchObject({
-        Authorization: "Bearer test-access-token",
-        "Content-Type": "application/json",
-      });
+      const headers = init.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer test-access-token");
+      // GET requests have no body, so Content-Type should not be set
+      expect(headers.has("Content-Type")).toBe(false);
       expect((init as RequestInit).method).toBe("GET");
     });
 
@@ -298,6 +298,9 @@ describe("BYOOAuthConnection", () => {
         JSON.stringify({ raw: "base64-encoded-email" }),
       );
       expect((init as RequestInit).method).toBe("POST");
+      // POST requests with a body should include Content-Type
+      const headers = init.headers as Headers;
+      expect(headers.get("Content-Type")).toBe("application/json");
     });
 
     test("retries once on 401 response", async () => {
@@ -397,10 +400,9 @@ describe("BYOOAuthConnection", () => {
       });
 
       const [, init] = mockFetch.mock.calls[0];
-      expect((init as RequestInit).headers).toMatchObject({
-        "X-Custom-Header": "custom-value",
-        Authorization: "Bearer test-access-token",
-      });
+      const headers = init.headers as Headers;
+      expect(headers.get("X-Custom-Header")).toBe("custom-value");
+      expect(headers.get("Authorization")).toBe("Bearer test-access-token");
     });
   });
 
@@ -422,9 +424,10 @@ describe("BYOOAuthConnection", () => {
 
       // The request should use the refreshed token
       const [, init] = mockFetch.mock.calls[0];
-      expect((init as RequestInit).headers).toMatchObject({
-        Authorization: "Bearer refreshed-access-token",
-      });
+      const headers = init.headers as Headers;
+      expect(headers.get("Authorization")).toBe(
+        "Bearer refreshed-access-token",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #15495 (Devin review)
- Removes stale Content-Type assertion from GET request test (no body = no Content-Type)
- Adds Content-Type assertion to POST request test (body present = Content-Type set)
- Converts all header assertions from toMatchObject on plain objects to Headers API .get()/.has() calls, matching the Headers instance now used in byo-connection.ts

## Test plan
- [ ] Verify byo-connection.test.ts passes with updated assertions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
