### PR TITLE
fix: verify access token presence in OAuth connectivity checks

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -1,13 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { OAuthConnectionRow } from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 
 const secureKeyValues = new Map<string, string>();
 let mockTwilioAccountSid: string | undefined;
 
-/** Simulated active OAuth connections keyed by provider. */
-const oauthConnections = new Map<string, OAuthConnectionRow>();
+/** Set of providers that should report as connected via isProviderConnected(). */
+const connectedProviders = new Set<string>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
@@ -22,26 +21,13 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (providerKey: string) =>
-    oauthConnections.get(providerKey),
+  isProviderConnected: (providerKey: string) =>
+    connectedProviders.has(providerKey),
 }));
 
-/** Helper to insert a fake active connection for a provider. */
+/** Mark a provider as fully connected (active row + access token). */
 function setOAuthConnected(providerKey: string): void {
-  oauthConnections.set(providerKey, {
-    id: "fake-id",
-    oauthAppId: "fake-app",
-    providerKey,
-    accountInfo: null,
-    grantedScopes: "[]",
-    expiresAt: null,
-    hasRefreshToken: 0,
-    status: "active",
-    label: null,
-    metadata: null,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
-  });
+  connectedProviders.add(providerKey);
 }
 
 const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =
@@ -50,7 +36,7 @@ const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =
 describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
-    oauthConnections.clear();
+    connectedProviders.clear();
     mockTwilioAccountSid = undefined;
   });
 

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -27,9 +27,12 @@ const mockDeleteSecureKeyAsync = mock(() =>
   Promise.resolve("deleted" as const),
 );
 const mockSetSecureKeyAsync = mock(() => Promise.resolve(true));
+/** Simulated secure key store for getSecureKey lookups. */
+const secureKeyValues = new Map<string, string>();
 mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: mockDeleteSecureKeyAsync,
   setSecureKeyAsync: mockSetSecureKeyAsync,
+  getSecureKey: (account: string) => secureKeyValues.get(account),
 }));
 
 import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
@@ -43,6 +46,7 @@ import {
   getConnection,
   getConnectionByProvider,
   getProvider,
+  isProviderConnected,
   listConnections,
   registerProvider,
   seedProviders,
@@ -79,6 +83,7 @@ beforeEach(() => {
   resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
   mockDeleteSecureKeyAsync.mockClear();
   mockSetSecureKeyAsync.mockClear();
+  secureKeyValues.clear();
 });
 
 afterAll(() => {
@@ -440,6 +445,54 @@ describe("connection operations", () => {
 
     test("returns undefined when no active connections exist", () => {
       expect(getConnectionByProvider("github")).toBeUndefined();
+    });
+  });
+
+  describe("isProviderConnected", () => {
+    test("returns true when active connection has an access token in secure storage", async () => {
+      const app = await createTestApp("github", "client-1");
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      secureKeyValues.set(`oauth_connection/${conn.id}/access_token`, "tok");
+
+      expect(isProviderConnected("github")).toBe(true);
+    });
+
+    test("returns false when active connection exists but access token is missing", async () => {
+      const app = await createTestApp("github", "client-1");
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      // No secure key set — simulates failed token write
+      expect(isProviderConnected("github")).toBe(false);
+    });
+
+    test("returns false when no connection exists", () => {
+      expect(isProviderConnected("github")).toBe(false);
+    });
+
+    test("returns false when connection is revoked even with token in store", async () => {
+      const app = await createTestApp("github", "client-1");
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      updateConnection(conn.id, { status: "revoked" });
+      secureKeyValues.set(`oauth_connection/${conn.id}/access_token`, "tok");
+
+      expect(isProviderConnected("github")).toBe(false);
     });
   });
 

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -83,7 +83,7 @@ export interface MessagingProvider {
   /**
    * Override the default credential check used by getConnectedProviders().
    * When present, the registry calls this instead of checking for an
-   * active oauth-store connection via getConnectionByProvider(). Useful
+   * active oauth-store connection via isProviderConnected(). Useful
    * for providers that don't use OAuth (e.g. Telegram bot tokens stored
    * under a non-standard key).
    */

--- a/assistant/src/messaging/registry.ts
+++ b/assistant/src/messaging/registry.ts
@@ -2,7 +2,7 @@
  * Messaging provider registry — register/lookup providers by platform ID.
  */
 
-import { getConnectionByProvider } from "../oauth/oauth-store.js";
+import { isProviderConnected } from "../oauth/oauth-store.js";
 import type { MessagingProvider } from "./provider.js";
 
 const providers = new Map<string, MessagingProvider>();
@@ -26,7 +26,7 @@ export function getMessagingProvider(id: string): MessagingProvider {
 export function getConnectedProviders(): MessagingProvider[] {
   return Array.from(providers.values()).filter((p) => {
     if (p.isConnected) return p.isConnected();
-    return getConnectionByProvider(p.credentialService)?.status === "active";
+    return isProviderConnected(p.credentialService);
   });
 }
 

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -16,6 +16,7 @@ import {
 } from "../memory/schema/oauth.js";
 import {
   deleteSecureKeyAsync,
+  getSecureKey,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 
@@ -355,6 +356,20 @@ export function getConnectionByProvider(
     .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
     .limit(1)
     .get();
+}
+
+/**
+ * Check whether a provider has a usable OAuth connection: an active row in the
+ * database AND a corresponding access token in secure storage.
+ *
+ * This guards against the edge case where the connection row was created/updated
+ * but the secure-key write for the access token failed, which would make
+ * `resolveOAuthConnection()` throw at usage time.
+ */
+export function isProviderConnected(providerKey: string): boolean {
+  const conn = getConnectionByProvider(providerKey);
+  if (!conn || conn.status !== "active") return false;
+  return getSecureKey(`oauth_connection/${conn.id}/access_token`) !== undefined;
 }
 
 /**

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,5 +1,5 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
-import { getConnectionByProvider } from "../oauth/oauth-store.js";
+import { isProviderConnected } from "../oauth/oauth-store.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKey } from "../security/secure-keys.js";
 
@@ -14,14 +14,12 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Gmail",
     category: "email",
-    isConnected: () =>
-      getConnectionByProvider("integration:gmail")?.status === "active",
+    isConnected: () => isProviderConnected("integration:gmail"),
   },
   {
     name: "Slack",
     category: "messaging",
-    isConnected: () =>
-      getConnectionByProvider("integration:slack")?.status === "active",
+    isConnected: () => isProviderConnected("integration:slack"),
   },
   {
     name: "Twilio",


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #15617
- Adds `isProviderConnected()` helper to `oauth-store.ts` that checks both the active connection row AND access token in secure storage
- Updates `registry.ts` and `integration-status.ts` to use `isProviderConnected()` instead of raw `getConnectionByProvider()?.status === "active"`
- Updates stale JSDoc in `provider.ts` to reference `isProviderConnected()`
- Adds tests for the new `isProviderConnected()` function covering happy path, missing token, no connection, and revoked connection scenarios
- Simplifies `integration-status.test.ts` mock from a full `OAuthConnectionRow` map to a simple `Set<string>`

## Test plan
- [ ] Existing integration-status tests pass with updated mocks
- [ ] New `isProviderConnected` tests verify: active+token=true, active+no-token=false, no-connection=false, revoked+token=false
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
