### PR TITLE
feat: add `assistant oauth connections` CLI subcommands and move `token` under connections

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -117,19 +117,28 @@ async function runCli(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("assistant oauth token", () => {
+describe("assistant oauth connections token", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
   });
 
   test("prints bare token in human mode", async () => {
-    const { exitCode, stdout } = await runCli(["token", "twitter"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "twitter",
+    ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("mock-access-token-xyz\n");
   });
 
   test("prints JSON in --json mode", async () => {
-    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "twitter",
+      "--json",
+    ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toEqual({ ok: true, token: "mock-access-token-xyz" });
@@ -142,7 +151,7 @@ describe("assistant oauth token", () => {
       return cb("tok");
     };
 
-    await runCli(["token", "twitter"]);
+    await runCli(["connections", "token", "twitter"]);
     expect(capturedService).toBe("integration:twitter");
   });
 
@@ -153,7 +162,11 @@ describe("assistant oauth token", () => {
       return cb("gmail-token");
     };
 
-    const { exitCode, stdout } = await runCli(["token", "gmail"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "gmail",
+    ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
     expect(capturedService).toBe("integration:gmail");
@@ -166,7 +179,12 @@ describe("assistant oauth token", () => {
       );
     };
 
-    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "twitter",
+      "--json",
+    ]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -180,7 +198,12 @@ describe("assistant oauth token", () => {
       );
     };
 
-    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "twitter",
+      "--json",
+    ]);
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
@@ -191,13 +214,17 @@ describe("assistant oauth token", () => {
     // Simulate withValidToken refreshing and returning a new token
     mockWithValidToken = async (_service, cb) => cb("refreshed-new-token");
 
-    const { exitCode, stdout } = await runCli(["token", "twitter"]);
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "token",
+      "twitter",
+    ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("refreshed-new-token\n");
   });
 
   test("missing service argument exits non-zero", async () => {
-    const { exitCode } = await runCli(["token"]);
+    const { exitCode } = await runCli(["connections", "token"]);
     expect(exitCode).not.toBe(0);
   });
 });

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -1,0 +1,186 @@
+import type { Command } from "commander";
+
+import {
+  getConnection,
+  getConnectionByProvider,
+  listConnections,
+} from "../../../oauth/oauth-store.js";
+import { withValidToken } from "../../../security/token-manager.js";
+import { getCliLogger } from "../../logger.js";
+import { shouldOutputJson, writeOutput } from "../../output.js";
+
+const log = getCliLogger("cli");
+
+/** Parse stored JSON string fields and convert timestamps for a connection row. */
+function formatConnectionRow(row: ReturnType<typeof getConnection>) {
+  if (!row) return row;
+  return {
+    ...row,
+    grantedScopes: row.grantedScopes ? JSON.parse(row.grantedScopes) : [],
+    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    hasRefreshToken: row.hasRefreshToken === 1,
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+    expiresAt: row.expiresAt ? new Date(row.expiresAt).toISOString() : null,
+  };
+}
+
+export function registerConnectionCommands(oauth: Command): void {
+  const connections = oauth
+    .command("connections")
+    .description("Manage OAuth connections (active tokens and refresh state)");
+
+  connections.addHelpText(
+    "after",
+    `
+Connections represent active OAuth sessions — an access token bound to a
+provider through an app registration. Each connection tracks granted scopes,
+token expiry, refresh token availability, account info, and status.
+
+Examples:
+  $ assistant oauth connections list
+  $ assistant oauth connections list --provider integration:gmail
+  $ assistant oauth connections get --id <uuid>
+  $ assistant oauth connections get --provider integration:gmail
+  $ assistant oauth connections token twitter`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // connections list
+  // ---------------------------------------------------------------------------
+
+  connections
+    .command("list")
+    .description("List all OAuth connections")
+    .option(
+      "--provider <key>",
+      "Filter by provider key (e.g. integration:gmail)",
+    )
+    .addHelpText(
+      "after",
+      `
+Lists all OAuth connections, optionally filtered by provider key.
+
+Each connection shows its ID, provider, account info, granted scopes, token
+expiry, refresh token availability, and status.
+
+Examples:
+  $ assistant oauth connections list
+  $ assistant oauth connections list --provider integration:gmail`,
+    )
+    .action((opts: { provider?: string }, cmd: Command) => {
+      try {
+        const rows = listConnections(opts.provider).map(formatConnectionRow);
+
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Found ${rows.length} connection(s)`);
+        }
+
+        writeOutput(cmd, rows);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // connections get
+  // ---------------------------------------------------------------------------
+
+  connections
+    .command("get")
+    .description("Look up an OAuth connection by ID or provider")
+    .option("--id <id>", "Connection ID (UUID)")
+    .option(
+      "--provider <key>",
+      "Provider key (returns most recent active connection)",
+    )
+    .addHelpText(
+      "after",
+      `
+Two lookup modes are supported:
+
+  1. By connection ID:
+     $ assistant oauth connections get --id <uuid>
+
+  2. By provider (returns the most recent active connection):
+     $ assistant oauth connections get --provider integration:gmail
+
+At least --id or --provider must be specified.`,
+    )
+    .action((opts: { id?: string; provider?: string }, cmd: Command) => {
+      try {
+        let row;
+
+        if (opts.id) {
+          row = getConnection(opts.id);
+        } else if (opts.provider) {
+          row = getConnectionByProvider(opts.provider);
+        } else {
+          writeOutput(cmd, {
+            ok: false,
+            error: "Provide --id or --provider",
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!row) {
+          writeOutput(cmd, { ok: false, error: "Connection not found" });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, formatConnectionRow(row));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // connections token <service>
+  // ---------------------------------------------------------------------------
+
+  connections
+    .command("token <service>")
+    .description(
+      "Print a valid OAuth access token for a service, refreshing if expired",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  service   Integration name without the "integration:" prefix
+            (e.g. "twitter", "gmail", "slack")
+
+Returns a valid OAuth access token for the given service. If the stored token
+is expired or near-expiry, it is refreshed automatically before being returned.
+
+In human mode, prints the bare token to stdout (suitable for shell substitution).
+In JSON mode (--json), prints {"ok": true, "token": "..."}.
+
+Exits with code 1 if no access token exists or refresh fails.
+
+Examples:
+  $ assistant oauth connections token twitter
+  $ assistant oauth connections token gmail --json`,
+    )
+    .action(async (service: string, _opts: unknown, cmd: Command) => {
+      try {
+        const qualifiedService = `integration:${service}`;
+        const token = await withValidToken(qualifiedService, async (t) => t);
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, { ok: true, token });
+        } else {
+          process.stdout.write(token + "\n");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+}

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -1,8 +1,7 @@
 import type { Command } from "commander";
 
-import { withValidToken } from "../../../security/token-manager.js";
-import { shouldOutputJson, writeOutput } from "../../output.js";
 import { registerAppCommands } from "./apps.js";
+import { registerConnectionCommands } from "./connections.js";
 import { registerProviderCommands } from "./providers.js";
 
 export function registerOAuthCommand(program: Command): void {
@@ -18,15 +17,16 @@ The oauth command group manages the full OAuth lifecycle:
 
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider
-  token       Return a guaranteed-valid access token for a service
+  connections Active token grants per provider (list, get, token)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via
 their respective subcommands.
 
 Examples:
-  $ assistant oauth token twitter
+  $ assistant oauth connections token twitter
+  $ assistant oauth connections list
+  $ assistant oauth connections get --provider integration:gmail
   $ assistant oauth providers list
   $ assistant oauth providers get integration:gmail
   $ assistant oauth providers register --provider-key custom:myapi --auth-url https://example.com/auth --token-url https://example.com/token`,
@@ -45,51 +45,8 @@ Examples:
   registerAppCommands(oauth);
 
   // ---------------------------------------------------------------------------
-  // token — return a guaranteed-valid access token
+  // connections — subcommand group (includes token)
   // ---------------------------------------------------------------------------
 
-  oauth
-    .command("token <service>")
-    .description(
-      "Print a valid OAuth access token for a service, refreshing if expired",
-    )
-    .addHelpText(
-      "after",
-      `
-Arguments:
-  service   Integration name without the "integration:" prefix
-            (e.g. "twitter", "gmail", "slack")
-
-Returns a valid OAuth access token for the given service. If the stored token
-is expired or near-expiry, it is refreshed automatically before being returned.
-The refresh uses the stored refresh token and OAuth2 configuration from
-the OAuth connection store — no additional input is required.
-
-In human mode, prints the bare token to stdout (suitable for shell substitution).
-In JSON mode (--json), prints {"ok": true, "token": "..."}.
-
-Exits with code 1 if no access token exists for the service, no refresh token
-is available, or the token refresh fails (e.g. revoked credentials).
-
-Examples:
-  $ assistant oauth token twitter
-  $ assistant oauth token gmail --json
-  $ export TOKEN=$(assistant oauth token twitter)`,
-    )
-    .action(async (service: string, _opts: unknown, cmd: Command) => {
-      try {
-        const qualifiedService = `integration:${service}`;
-        const token = await withValidToken(qualifiedService, async (t) => t);
-
-        if (shouldOutputJson(cmd)) {
-          writeOutput(cmd, { ok: true, token });
-        } else {
-          process.stdout.write(token + "\n");
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+  registerConnectionCommands(oauth);
 }

--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -6,7 +6,7 @@ For account and auth workflows, prefer documented `assistant` CLI commands over
 any generic account registry:
 
 - `assistant credentials ...` for stored secrets and credential metadata
-- `assistant oauth token <service>` for OAuth-backed integrations
+- `assistant oauth connections token <service>` for OAuth-backed integrations
 - `assistant mcp auth <name>` when an MCP server needs browser login
 - `assistant platform status` for platform-linked deployment/auth context
 

--- a/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
@@ -38,7 +38,7 @@ describe("buildCliReferenceSection", () => {
       "prefer real `assistant` CLI workflows over any legacy account-record abstraction",
     );
     expect(result).toContain("assistant credentials");
-    expect(result).toContain("assistant oauth token <service>");
+    expect(result).toContain("assistant oauth connections token <service>");
     expect(result).toContain("assistant mcp auth <name>");
     expect(result).toContain("assistant platform status");
   });

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -848,7 +848,7 @@ export function buildCliReferenceSection(): string {
     "The `assistant` CLI is installed on the user's machine and available via `bash`.",
     "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
     "- Use `assistant credentials ...` for stored secrets and credential metadata.",
-    "- Use `assistant oauth token <service>` for connected integration tokens.",
+    "- Use `assistant oauth connections token <service>` for connected integration tokens.",
     "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
     "- Use `assistant platform status` for platform-linked deployment and auth context.",
     "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",


### PR DESCRIPTION
## Summary
- Add `assistant/src/cli/commands/oauth/connections.ts` with list, get, token subcommands
- Move `token` command from top-level `oauth token` to `oauth connections token`
- Update all consumers: system prompt, bundled skill docs, tests
- No backward-compatible alias — old path fully removed

Part of plan: oauth-cli-crud-commands.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
