### PR TITLE
fix: mock OAuth2 flow setup in credential-vault-unit tests

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -82,6 +82,25 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock prepareOAuth2Flow — unit tests should not start real loopback HTTP
+// servers. The connect orchestrator still runs its own validation logic
+// (scope policy, non-interactive ingress checks, etc.) but the actual
+// OAuth flow setup is stubbed.
+// ---------------------------------------------------------------------------
+
+mock.module("../security/oauth2.js", () => ({
+  prepareOAuth2Flow: mock(async () => ({
+    authUrl: "https://mock-auth-url.example.com/authorize",
+    state: "mock-state",
+    completion: new Promise(() => {}),
+  })),
+  startOAuth2Flow: mock(async () => ({
+    grantedScopes: [],
+    tokens: { access_token: "mock-token" },
+  })),
+}));
+
+// ---------------------------------------------------------------------------
 // Imports under test
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Mock `prepareOAuth2Flow` and `startOAuth2Flow` in `credential-vault-unit.test.ts` to prevent real loopback HTTP servers from starting during tests
- Tests from PR #15690 (`getAppByProviderAndClientId` and `getMostRecentAppByProvider` code paths) have never passed on CI because they hit the real OAuth flow infrastructure

## Original prompt
help me fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23002957904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
