### PR TITLE
fix: add missing deleteSecureKeyAsync mock to oauth-cli.test.ts

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -39,6 +39,12 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => undefined,
   setSecureKeyAsync: async () => true,
   deleteSecureKey: () => "not-found",
+  deleteSecureKeyAsync: async () => "not-found" as const,
+  listSecureKeys: () => [],
+  getBackendType: () => "encrypted",
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
 }));
 
 mock.module("../tools/credentials/metadata-store.js", () => ({


### PR DESCRIPTION
## Summary
Fixes integration gap from oauth-post-migration-cleanup plan.

**Gap:** Missing `deleteSecureKeyAsync` mock in oauth-cli.test.ts
**What was wrong:** Transitive import chain now reaches `oauth-store.ts` which imports `deleteSecureKeyAsync`, but the test mock didn't export it
**Fix:** Add the missing mock export

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
