### PR TITLE
fix: gate Logfire behind feature flag to prevent auto-enabling on token presence

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -22,7 +22,7 @@ import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";
 import { closeSentry, initSentry } from "../instrument.js";
-import { initLogfire } from "../logfire.js";
+import { disableLogfire, initLogfire } from "../logfire.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
@@ -249,6 +249,18 @@ export async function runDaemon(): Promise<void> {
     );
     if (!collectUsageData) {
       await closeSentry();
+    }
+
+    // If Logfire observability is not explicitly enabled, disable it so
+    // wrapWithLogfire() calls during provider setup become no-ops. Logfire
+    // is initialized eagerly (before config loads) for the same reason as
+    // Sentry — but the feature flag gates whether it actually traces.
+    const logfireEnabled = isAssistantFeatureFlagEnabled(
+      "feature_flags.logfire.enabled",
+      config,
+    );
+    if (!logfireEnabled) {
+      disableLogfire();
     }
 
     await initializeProvidersAndTools(config);

--- a/assistant/src/logfire.ts
+++ b/assistant/src/logfire.ts
@@ -13,7 +13,7 @@ const log = getLogger("logfire");
 
 type LogfireModule = typeof import("@pydantic/logfire-node");
 
-const LOGFIRE_ENABLED: boolean = !!getLogfireToken();
+let logfireEnabled: boolean = !!getLogfireToken();
 
 let logfireInstance: LogfireModule | null = null;
 
@@ -23,7 +23,7 @@ let logfireInstance: LogfireModule | null = null;
  * Non-fatal on failure (logs warning and continues).
  */
 export async function initLogfire(): Promise<void> {
-  if (!LOGFIRE_ENABLED) return;
+  if (!logfireEnabled) return;
 
   try {
     const logfire = await import("@pydantic/logfire-node");
@@ -43,11 +43,22 @@ export async function initLogfire(): Promise<void> {
 }
 
 /**
+ * Disable Logfire after early initialization. Called when the user has opted
+ * out via the feature flag. Nulls out the instance so future wrapWithLogfire
+ * calls become no-ops.
+ */
+export function disableLogfire(): void {
+  logfireEnabled = false;
+  logfireInstance = null;
+  log.info("Logfire disabled by feature flag");
+}
+
+/**
  * Wraps a provider with Logfire tracing spans.
- * When LOGFIRE_ENABLED is false, returns the provider as-is (no wrapper allocated).
+ * When logfireEnabled is false, returns the provider as-is (no wrapper allocated).
  */
 export function wrapWithLogfire(provider: Provider): Provider {
-  if (!LOGFIRE_ENABLED) return provider;
+  if (!logfireEnabled) return provider;
   return new LogfireProvider(provider);
 }
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
+    },
+    {
+      "id": "logfire",
+      "scope": "assistant",
+      "key": "feature_flags.logfire.enabled",
+      "label": "Logfire LLM Observability",
+      "description": "Enable Logfire tracing for LLM request/response telemetry when LOGFIRE_TOKEN is set",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Address review feedback from PR #15577: removing `isMonitoringEnabled()` (which was hardcoded to `false`) silently auto-enabled Logfire whenever `LOGFIRE_TOKEN` was set
- Add `feature_flags.logfire.enabled` feature flag (defaulting to `false`) to the registry so Logfire remains opt-in
- Add `disableLogfire()` export to `logfire.ts` following the same pattern as `closeSentry()`
- Check the feature flag in `lifecycle.ts` after config loads and disable Logfire if not explicitly enabled
- Change `LOGFIRE_ENABLED` from a `const` to a mutable `let` so it can be toggled at runtime

## Test plan
- [ ] Verify feature flag guard tests pass (the new key is declared in the registry)
- [ ] Verify Logfire is disabled by default (flag defaults to `false`)
- [ ] Verify setting `feature_flags.logfire.enabled: true` in config enables Logfire when `LOGFIRE_TOKEN` is set
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
