### PR TITLE
fix: seed ingress module-level state at daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -15,6 +15,7 @@ import {
   getQdrantUrlEnv,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
+  setIngressPublicBaseUrl,
   validateEnv,
 } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
@@ -233,6 +234,19 @@ export async function runDaemon(): Promise<void> {
 
     log.info("Daemon startup: loading config");
     const config = loadConfig();
+
+    // Seed module-level ingress state from the workspace config so that
+    // getIngressPublicBaseUrl() returns the correct value immediately after
+    // startup (before any handleIngressConfig("set") call). Without this,
+    // code paths that read the module-level state directly (e.g. session-slash
+    // pairing info) would see undefined until an explicit set.
+    if (config.ingress.enabled && config.ingress.publicBaseUrl) {
+      setIngressPublicBaseUrl(config.ingress.publicBaseUrl);
+      log.info(
+        { url: config.ingress.publicBaseUrl },
+        "Daemon startup: seeded ingress URL from workspace config",
+      );
+    }
 
     if (config.logFile.dir) {
       initLogger({


### PR DESCRIPTION
Addresses feedback from PR #15586: the module-level ingress state (_ingressPublicBaseUrl) was never seeded at startup, so getIngressPublicBaseUrl() returned undefined until handleIngressConfig('set') was explicitly called. This caused code paths reading the module-level state directly (e.g. session-slash pairing info, getPublicBaseUrl fallback) to miss a previously configured ingress URL after daemon restart.

Seeds the ingress URL from workspace config during runDaemon() right after loadConfig(), when ingress is enabled and a URL is configured.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
