### PR TITLE
fix: complete oauth-store migration for Slack channel and Telegram handlers

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -23,6 +23,10 @@ mock.module("../config/loader.js", () => ({
 mock.module("../oauth/oauth-store.js", () => ({
   isProviderConnected: (providerKey: string) =>
     connectedProviders.has(providerKey),
+  getConnectionByProvider: (providerKey: string) =>
+    connectedProviders.has(providerKey)
+      ? { id: `conn-${providerKey}`, status: "active" }
+      : undefined,
 }));
 
 /** Mark a provider as fully connected (active row + access token). */
@@ -56,11 +60,7 @@ describe("integration-status", () => {
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      secureKeyValues.set(
-        credentialKey("telegram", "webhook_secret"),
-        "secret",
-      );
+      setOAuthConnected("telegram");
 
       const summary = getIntegrationSummary();
       expect(summary.every((s: { connected: boolean }) => s.connected)).toBe(
@@ -71,11 +71,7 @@ describe("integration-status", () => {
     test("returns mixed status", () => {
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      secureKeyValues.set(
-        credentialKey("telegram", "webhook_secret"),
-        "secret",
-      );
+      setOAuthConnected("telegram");
 
       const summary = getIntegrationSummary();
       const connected = summary.filter(
@@ -103,9 +99,8 @@ describe("integration-status", () => {
       expect(twilio?.connected).toBe(false);
     });
 
-    test("Telegram disconnected when only bot_token is set (missing webhook_secret)", () => {
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-
+    test("Telegram disconnected when no connection record exists", () => {
+      // No oauth_connection record for telegram — should be disconnected
       const summary = getIntegrationSummary();
       const telegram = summary.find(
         (s: { name: string }) => s.name === "Telegram",
@@ -118,11 +113,7 @@ describe("integration-status", () => {
     test("shows checkmarks and crosses", () => {
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      secureKeyValues.set(
-        credentialKey("telegram", "webhook_secret"),
-        "secret",
-      );
+      setOAuthConnected("telegram");
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
@@ -142,11 +133,7 @@ describe("integration-status", () => {
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      secureKeyValues.set(
-        credentialKey("telegram", "webhook_secret"),
-        "secret",
-      );
+      setOAuthConnected("telegram");
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
@@ -162,17 +149,12 @@ describe("integration-status", () => {
     });
 
     test("returns true when any integration in category is connected", () => {
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      secureKeyValues.set(
-        credentialKey("telegram", "webhook_secret"),
-        "secret",
-      );
+      setOAuthConnected("telegram");
       expect(hasCapability("messaging")).toBe(true);
     });
 
-    test("returns false when only partial credentials exist for category integrations", () => {
-      secureKeyValues.set(credentialKey("telegram", "bot_token"), "tok");
-      // Missing webhook_secret — Telegram should not count as connected
+    test("returns false when no connection record exists for category integrations", () => {
+      // No oauth_connection record for telegram — should not count as connected
       expect(hasCapability("messaging")).toBe(false);
     });
 

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -114,6 +114,46 @@ mock.module("../security/secure-keys.js", () => {
   };
 });
 
+// Mock oauth-store (getConnectionByProvider)
+let oauthConnectionStore: Record<
+  string,
+  { id: string; status: string; accountInfo?: string | null }
+> = {};
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (providerKey: string) =>
+    oauthConnectionStore[providerKey] ?? undefined,
+  createConnection: () => ({ id: "test-conn-id" }),
+  updateConnection: () => true,
+  deleteConnection: (id: string) => {
+    for (const [key, conn] of Object.entries(oauthConnectionStore)) {
+      if (conn.id === id) {
+        delete oauthConnectionStore[key];
+        return true;
+      }
+    }
+    return false;
+  },
+  upsertApp: async () => ({ id: "test-app-id" }),
+}));
+
+// Mock manual-token-connection
+mock.module("../oauth/manual-token-connection.js", () => ({
+  ensureManualTokenConnection: async (
+    providerKey: string,
+    accountInfo?: string,
+  ) => {
+    oauthConnectionStore[providerKey] = {
+      id: `conn-${providerKey}`,
+      status: "active",
+      accountInfo: accountInfo ?? null,
+    };
+  },
+  removeManualTokenConnection: (providerKey: string) => {
+    delete oauthConnectionStore[providerKey];
+  },
+}));
+
 // Mock credential metadata store
 let credentialMetadataStore: Array<{
   service: string;
@@ -185,6 +225,7 @@ describe("Slack channel config handler", () => {
   beforeEach(() => {
     secureKeyStore = {};
     credentialMetadataStore = [];
+    oauthConnectionStore = {};
     configStore = {};
     globalThis.fetch = originalFetch;
   });
@@ -197,9 +238,11 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(false);
   });
 
-  test("GET returns connected: true when both tokens are set", () => {
-    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
-    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
+  test("GET returns connected: true when oauth_connection is active", () => {
+    oauthConnectionStore["slack_channel"] = {
+      id: "conn-slack",
+      status: "active",
+    };
 
     const result = getSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -209,7 +252,10 @@ describe("Slack channel config handler", () => {
   });
 
   test("GET returns metadata from config when available", () => {
-    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    oauthConnectionStore["slack_channel"] = {
+      id: "conn-slack",
+      status: "active",
+    };
     configStore = {
       slack: {
         teamId: "T123",

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -5,6 +5,11 @@ import {
   saveRawConfig,
   setNestedValue,
 } from "../../config/loader.js";
+import {
+  ensureManualTokenConnection,
+  removeManualTokenConnection,
+} from "../../oauth/manual-token-connection.js";
+import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -35,18 +40,14 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
-  const hasBotToken = !!getSecureKey(
-    credentialKey("slack_channel", "bot_token"),
-  );
-  const hasAppToken = !!getSecureKey(
-    credentialKey("slack_channel", "app_token"),
-  );
+  const conn = getConnectionByProvider("slack_channel");
+  const connected = !!(conn && conn.status === "active");
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
-    hasBotToken,
-    hasAppToken,
-    connected: hasBotToken && hasAppToken,
+    hasBotToken: connected,
+    hasAppToken: connected,
+    connected,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
     ...(botUserId ? { botUserId } : {}),
@@ -83,17 +84,13 @@ export async function setSlackChannelConfig(
         user?: string;
       };
       if (!data.ok) {
-        const storedBotToken = !!getSecureKey(
-          credentialKey("slack_channel", "bot_token"),
-        );
-        const storedAppToken = !!getSecureKey(
-          credentialKey("slack_channel", "app_token"),
-        );
+        const errConn = getConnectionByProvider("slack_channel");
+        const errConnected = !!(errConn && errConn.status === "active");
         return {
           success: false,
-          hasBotToken: storedBotToken,
-          hasAppToken: storedAppToken,
-          connected: storedBotToken && storedAppToken,
+          hasBotToken: errConnected,
+          hasAppToken: errConnected,
+          connected: errConnected,
           error: `Slack API validation failed: ${
             data.error ?? "unknown error"
           }`,
@@ -107,17 +104,13 @@ export async function setSlackChannelConfig(
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const storedBotToken = !!getSecureKey(
-        credentialKey("slack_channel", "bot_token"),
-      );
-      const storedAppToken = !!getSecureKey(
-        credentialKey("slack_channel", "app_token"),
-      );
+      const errConn = getConnectionByProvider("slack_channel");
+      const errConnected = !!(errConn && errConn.status === "active");
       return {
         success: false,
-        hasBotToken: storedBotToken,
-        hasAppToken: storedAppToken,
-        connected: storedBotToken && storedAppToken,
+        hasBotToken: errConnected,
+        hasAppToken: errConnected,
+        connected: errConnected,
         error: `Failed to validate bot token: ${message}`,
       };
     }
@@ -127,17 +120,13 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      const storedBotToken = !!getSecureKey(
-        credentialKey("slack_channel", "bot_token"),
-      );
-      const storedAppToken = !!getSecureKey(
-        credentialKey("slack_channel", "app_token"),
-      );
+      const errConn = getConnectionByProvider("slack_channel");
+      const errConnected = !!(errConn && errConn.status === "active");
       return {
         success: false,
-        hasBotToken: storedBotToken,
-        hasAppToken: storedAppToken,
-        connected: storedBotToken && storedAppToken,
+        hasBotToken: errConnected,
+        hasAppToken: errConnected,
+        connected: errConnected,
         error: "Failed to store bot token in secure storage",
       };
     }
@@ -165,17 +154,13 @@ export async function setSlackChannelConfig(
   // Validate and store app token
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
-      const storedBotToken = !!getSecureKey(
-        credentialKey("slack_channel", "bot_token"),
-      );
-      const storedAppToken = !!getSecureKey(
-        credentialKey("slack_channel", "app_token"),
-      );
+      const errConn = getConnectionByProvider("slack_channel");
+      const errConnected = !!(errConn && errConn.status === "active");
       return {
         success: false,
-        hasBotToken: storedBotToken,
-        hasAppToken: storedAppToken,
-        connected: storedBotToken && storedAppToken,
+        hasBotToken: errConnected,
+        hasAppToken: errConnected,
+        connected: errConnected,
         error: 'Invalid app token: must start with "xapp-"',
       };
     }
@@ -185,17 +170,13 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      const storedBotToken = !!getSecureKey(
-        credentialKey("slack_channel", "bot_token"),
-      );
-      const storedAppToken = !!getSecureKey(
-        credentialKey("slack_channel", "app_token"),
-      );
+      const errConn = getConnectionByProvider("slack_channel");
+      const errConnected = !!(errConn && errConn.status === "active");
       return {
         success: false,
-        hasBotToken: storedBotToken,
-        hasAppToken: storedAppToken,
-        connected: storedBotToken && storedAppToken,
+        hasBotToken: errConnected,
+        hasAppToken: errConnected,
+        connected: errConnected,
         error: "Failed to store app token in secure storage",
       };
     }
@@ -218,6 +199,17 @@ export async function setSlackChannelConfig(
       "App token stored but bot token is missing — connection incomplete.";
   }
 
+  // Sync oauth_connection record so getConnectionByProvider("slack_channel")
+  // reflects the current credential state.
+  if (hasBotToken && hasAppToken) {
+    const accountInfo = metadata.teamName
+      ? `${metadata.teamName}${metadata.botUsername ? ` (@${metadata.botUsername})` : ""}`
+      : undefined;
+    await ensureManualTokenConnection("slack_channel", accountInfo);
+  } else {
+    removeManualTokenConnection("slack_channel");
+  }
+
   return {
     success: true,
     hasBotToken,
@@ -237,23 +229,22 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
   );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey(
-      credentialKey("slack_channel", "bot_token"),
-    );
-    const hasAppToken = !!getSecureKey(
-      credentialKey("slack_channel", "app_token"),
-    );
+    const errConn = getConnectionByProvider("slack_channel");
+    const errConnected = !!(errConn && errConn.status === "active");
     return {
       success: false,
-      hasBotToken,
-      hasAppToken,
-      connected: hasBotToken && hasAppToken,
+      hasBotToken: errConnected,
+      hasAppToken: errConnected,
+      connected: errConnected,
       error: "Failed to delete Slack channel credentials from secure storage",
     };
   }
 
   deleteCredentialMetadata("slack_channel", "bot_token");
   deleteCredentialMetadata("slack_channel", "app_token");
+
+  // Remove the oauth_connection row so getConnectionByProvider returns undefined.
+  removeManualTokenConnection("slack_channel");
 
   const raw = loadRawConfig();
   setNestedValue(raw, "slack.teamId", "");

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -8,6 +8,11 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
+import {
+  ensureManualTokenConnection,
+  removeManualTokenConnection,
+} from "../../oauth/manual-token-connection.js";
+import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
@@ -61,17 +66,15 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
-  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-  const hasWebhookSecret = !!getSecureKey(
-    credentialKey("telegram", "webhook_secret"),
-  );
+  const conn = getConnectionByProvider("telegram");
+  const connected = !!(conn && conn.status === "active");
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
-    hasBotToken,
+    hasBotToken: connected,
     botUsername,
-    connected: hasBotToken && hasWebhookSecret,
-    hasWebhookSecret,
+    connected,
+    hasWebhookSecret: connected,
   };
 }
 
@@ -200,6 +203,13 @@ export async function setTelegramConfig(
     upsertCredentialMetadata("telegram", "webhook_secret", {});
   }
 
+  // Sync oauth_connection record so getConnectionByProvider("telegram")
+  // reflects the current credential state.
+  await ensureManualTokenConnection(
+    "telegram",
+    botUsername ? `@${botUsername}` : undefined,
+  );
+
   const result: TelegramConfigResult = {
     success: true,
     hasBotToken: true,
@@ -245,21 +255,23 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   );
 
   if (r1 === "error" || r2 === "error") {
-    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-    const hasWebhookSecret = !!getSecureKey(
-      credentialKey("telegram", "webhook_secret"),
-    );
+    // Check what's still in the keychain to report accurate status.
+    const errConn = getConnectionByProvider("telegram");
+    const errConnected = !!(errConn && errConn.status === "active");
     return {
       success: false,
-      hasBotToken,
-      connected: hasBotToken && hasWebhookSecret,
-      hasWebhookSecret,
+      hasBotToken: errConnected,
+      connected: errConnected,
+      hasWebhookSecret: errConnected,
       error: "Failed to delete Telegram credentials from secure storage",
     };
   }
 
   deleteCredentialMetadata("telegram", "bot_token");
   deleteCredentialMetadata("telegram", "webhook_secret");
+
+  // Remove the oauth_connection row so getConnectionByProvider returns undefined.
+  removeManualTokenConnection("telegram");
 
   // Clear bot username from config so getTelegramBotUsername() doesn't
   // return a stale value after disconnect.
@@ -306,38 +318,36 @@ export async function setTelegramCommands(
     );
     if (!res.ok) {
       const body = await res.text();
+      const cmdConn = getConnectionByProvider("telegram");
+      const cmdConnected = !!(cmdConn && cmdConn.status === "active");
       return {
         success: false,
         hasBotToken: true,
-        connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
-        hasWebhookSecret: !!getSecureKey(
-          credentialKey("telegram", "webhook_secret"),
-        ),
+        connected: cmdConnected,
+        hasWebhookSecret: cmdConnected,
         error: `Failed to set bot commands: ${body}`,
       };
     }
   } catch (err) {
     const message = summarizeTelegramError(err);
+    const cmdConn = getConnectionByProvider("telegram");
+    const cmdConnected = !!(cmdConn && cmdConn.status === "active");
     return {
       success: false,
       hasBotToken: true,
-      connected: !!getSecureKey(credentialKey("telegram", "webhook_secret")),
-      hasWebhookSecret: !!getSecureKey(
-        credentialKey("telegram", "webhook_secret"),
-      ),
+      connected: cmdConnected,
+      hasWebhookSecret: cmdConnected,
       error: `Failed to set bot commands: ${message}`,
     };
   }
 
-  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-  const hasWebhookSecret = !!getSecureKey(
-    credentialKey("telegram", "webhook_secret"),
-  );
+  const cmdConn = getConnectionByProvider("telegram");
+  const cmdConnected = !!(cmdConn && cmdConn.status === "active");
   return {
     success: true,
-    hasBotToken,
-    connected: hasBotToken && hasWebhookSecret,
-    hasWebhookSecret,
+    hasBotToken: cmdConnected,
+    connected: cmdConnected,
+    hasWebhookSecret: cmdConnected,
     commandsRegistered: resolvedCommands.map((c) => c.command),
   };
 }

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -1,0 +1,64 @@
+/**
+ * Helpers for managing oauth_connection records for non-OAuth (manual-token)
+ * providers like slack_channel and telegram.
+ *
+ * These providers store credentials via the keychain (setSecureKeyAsync) but
+ * also maintain an oauth_connection row so that getConnectionByProvider() can
+ * be used as the single source of truth for connection status across the
+ * codebase.
+ */
+
+import {
+  createConnection,
+  deleteConnection,
+  getConnectionByProvider,
+  updateConnection,
+  upsertApp,
+} from "./oauth-store.js";
+
+/** Sentinel client_id used for non-OAuth providers that don't have a real app. */
+const MANUAL_TOKEN_CLIENT_ID = "manual-config";
+
+/**
+ * Ensure an active oauth_connection row exists for the given manual-token
+ * provider. Creates the synthetic oauth_app row on first use.
+ *
+ * @param providerKey - The provider key (e.g. "slack_channel", "telegram")
+ * @param accountInfo - Optional account info to store (e.g. team name, bot username)
+ */
+export async function ensureManualTokenConnection(
+  providerKey: string,
+  accountInfo?: string,
+): Promise<void> {
+  const existing = getConnectionByProvider(providerKey);
+  if (existing) {
+    // Update account info if provided
+    if (accountInfo !== undefined) {
+      updateConnection(existing.id, { accountInfo });
+    }
+    return;
+  }
+
+  // Create synthetic app + connection
+  const app = await upsertApp(providerKey, MANUAL_TOKEN_CLIENT_ID);
+
+  createConnection({
+    oauthAppId: app.id,
+    providerKey,
+    accountInfo,
+    grantedScopes: [],
+    hasRefreshToken: false,
+  });
+}
+
+/**
+ * Remove the oauth_connection row for a manual-token provider.
+ *
+ * Note: This only removes the oauth_connection row. The caller is still
+ * responsible for deleting the keychain credentials separately.
+ */
+export function removeManualTokenConnection(providerKey: string): void {
+  const conn = getConnectionByProvider(providerKey);
+  if (!conn) return;
+  deleteConnection(conn.id);
+}

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -120,6 +120,35 @@ const PROVIDER_SEED_DATA: Record<
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "gateway",
   },
+
+  // Manual-token providers: these don't use OAuth2 flows but need provider
+  // rows so that oauth_app and oauth_connection FK chains can reference them.
+  // The authUrl/tokenUrl values are placeholders — never used at runtime.
+  slack_channel: {
+    providerKey: "slack_channel",
+    authUrl: "urn:manual-token",
+    tokenUrl: "urn:manual-token",
+    baseUrl: "https://slack.com/api",
+    defaultScopes: [],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+  },
+
+  telegram: {
+    providerKey: "telegram",
+    authUrl: "urn:manual-token",
+    tokenUrl: "urn:manual-token",
+    baseUrl: "https://api.telegram.org",
+    defaultScopes: [],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+  },
 };
 
 /**

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,7 +1,8 @@
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
-import { isProviderConnected } from "../oauth/oauth-store.js";
-import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import {
+  getConnectionByProvider,
+  isProviderConnected,
+} from "../oauth/oauth-store.js";
 
 interface IntegrationProbe {
   name: string;
@@ -29,9 +30,10 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Telegram",
     category: "messaging",
-    isConnected: () =>
-      !!getSecureKey(credentialKey("telegram", "bot_token")) &&
-      !!getSecureKey(credentialKey("telegram", "webhook_secret")),
+    isConnected: () => {
+      const conn = getConnectionByProvider("telegram");
+      return !!(conn && conn.status === "active");
+    },
   },
 ];
 


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #15619: the set/clear functions still used keychain while get functions were switched to oauth-store, creating an inconsistency where GET would report false status after a successful SET.

This PR completes the migration by:
- Seeding slack_channel and telegram as providers in the oauth_providers table
- Adding a manual-token-connection helper that creates/deletes synthetic oauth_connection records for non-OAuth providers
- Updating setSlackChannelConfig / setTelegramConfig to create oauth_connection records when tokens are stored
- Updating clearSlackChannelConfig / clearTelegramConfig to remove oauth_connection records
- Switching getSlackChannelConfig / getTelegramConfig to read from getConnectionByProvider()
- Updating integration-status.ts Telegram probe to use connection records instead of keychain reads
- Updating tests to use connection-based status checks

Keychain writes are preserved alongside the connection records because the gateway reads credentials via the keychain broker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
