### PR TITLE
fix: correct stale gatewayInternalBaseUrl docs claiming workspace config override

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -416,7 +416,7 @@ subgraph "Text Q&A Session"
     GW_ATTACH -->|"download from runtime<br/>+ upload to Telegram"| GW_WEBHOOK
 
     %% Gateway flow — Telegram deliver (runtime → gateway → Telegram)
-    %% replyCallbackUrl is built from gatewayInternalBaseUrl (hardcoded default, overridable via workspace config)
+    %% replyCallbackUrl is built from gatewayInternalBaseUrl (derived from GATEWAY_PORT)
     HTTP_RT -->|"POST /deliver/telegram<br/>(via gatewayInternalBaseUrl)"| GW_TG_DELIVER
     GW_TG_DELIVER --> GW_REPLY
     GW_TG_DELIVER --> GW_ATTACH

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -273,7 +273,7 @@ Outbound proactive (assistant → user, initiated by messaging provider):
   Runtime messaging provider → Gateway POST /deliver/telegram (bearer auth) → Telegram sendMessage/sendChatAction
 ```
 
-The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which defaults to `http://127.0.0.1:${GATEWAY_PORT}` and can be overridden via workspace config. This allows distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts).
+The `replyCallbackUrl` included in the inbound forward is built from the `gatewayInternalBaseUrl` config field, which is always derived from `GATEWAY_PORT` as `http://127.0.0.1:${GATEWAY_PORT}` (default port `7830`). In distributed deployments where the gateway and runtime are not co-located (e.g., separate containers or hosts), set `GATEWAY_PORT` appropriately so the runtime can reach the gateway for callbacks.
 
 The `/deliver/telegram` endpoint requires bearer auth unconditionally (fail-closed). If no bearer token is configured and the dev-only bypass flag (`telegram.deliverAuthBypass` in `workspace/config.json`) is not set, the endpoint returns 503 rather than allowing unauthenticated access. The bypass requires `APP_VERSION=0.0.0-dev`.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -291,7 +291,7 @@ docker run --rm -p 7830:7830 \
 
 The image runs as non-root user `gateway` (uid 1001) and exposes port `7830`.
 
-The runtime base URL is resolved from hardcoded defaults. The gateway internal base URL is always derived from `GATEWAY_PORT` (default `7830`). When the runtime and gateway run in separate containers or hosts, set `GATEWAY_PORT` appropriately so the runtime can reach the gateway for callbacks (e.g., Telegram reply delivery).
+The runtime base URL is derived from `RUNTIME_HTTP_PORT` as `http://localhost:${RUNTIME_HTTP_PORT}` (default port `7821`). The gateway internal base URL is always derived from `GATEWAY_PORT` as `http://127.0.0.1:${GATEWAY_PORT}` (default `7830`). This Docker example assumes the gateway and runtime are co-located (e.g., via `--network host` or Docker Compose). When running in separate containers, `localhost` inside the gateway container will not reach the host runtime.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Fix gateway/ARCHITECTURE.md incorrectly stating gatewayInternalBaseUrl can be overridden via workspace config (it is always derived from GATEWAY_PORT)
- Fix root ARCHITECTURE.md Mermaid comment with same stale claim
- Improve gateway/README.md Docker section to document RUNTIME_HTTP_PORT and clarify co-located deployment assumption

Addresses review feedback from #15591.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
