### PR TITLE
fix: add missing help text to apps CLI subcommands

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -57,6 +57,19 @@ Examples:
   apps
     .command("list")
     .description("List all OAuth app registrations")
+    .addHelpText(
+      "after",
+      `
+Returns all registered OAuth apps with their provider key, client ID, and
+timestamps. Output is an array of app objects.
+
+In JSON mode (--json), returns the array directly. In human mode, logs a
+summary count and prints the formatted list.
+
+Examples:
+  $ assistant oauth apps list
+  $ assistant oauth apps list --json`,
+    )
     .action((_opts: unknown, cmd: Command) => {
       try {
         const rows = listApps().map(formatAppRow);
@@ -152,6 +165,21 @@ At least --id or --provider must be specified.`,
       "--client-secret <secret>",
       "OAuth client secret (stored in secure keychain)",
     )
+    .addHelpText(
+      "after",
+      `
+Creates a new app registration or returns the existing one if an app with the
+same provider and client ID already exists. The client secret, if provided, is
+stored in the secure system keychain — not in the database.
+
+When an existing app is matched, the command returns it as-is without updating
+the client secret. To change a secret, delete and re-create the app.
+
+Examples:
+  $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
+  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
+  $ assistant oauth apps upsert --provider integration:gmail --client-id abc123 --json`,
+    )
     .action(
       async (
         opts: { provider: string; clientId: string; clientSecret?: string },
@@ -184,6 +212,22 @@ At least --id or --provider must be specified.`,
   apps
     .command("delete <id>")
     .description("Delete an OAuth app registration by ID")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  id   The app UUID to delete (as returned by "apps list" or "apps get")
+
+Permanently removes the app registration and its stored client secret from
+the keychain. Any OAuth connections that reference this app will no longer be
+able to refresh tokens.
+
+Exits with code 1 if the app ID is not found.
+
+Examples:
+  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000
+  $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000 --json`,
+    )
     .action((id: string, _opts: unknown, cmd: Command) => {
       try {
         const deleted = deleteApp(id);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-crud-commands.md.

**Gap:** Missing help text on apps subcommands
**What was expected:** Per AGENTS.md, every subcommand needs .addHelpText with arguments, notes, and examples
**What was found:** apps list, upsert, and delete lacked help text

Adds `.addHelpText("after", ...)` to the three subcommands:
- `apps list` — behavioral notes on output format, 2 examples
- `apps upsert` — notes on create-vs-return semantics and secret storage, 3 examples
- `apps delete` — Arguments block for the `id` positional arg, deletion side effects, 2 examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
