### PR TITLE
fix: validate --loopback-port in providers register command

### DIFF
--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { type Command, InvalidArgumentError } from "commander";
 
 import {
   getProvider,
@@ -136,7 +136,15 @@ Examples:
     .option("--scopes <scopes>", "Comma-separated default scopes")
     .option("--token-auth-method <method>", "Token endpoint auth method")
     .option("--callback-transport <transport>", "Callback transport")
-    .option("--loopback-port <port>", "Loopback port", parseInt)
+    .option("--loopback-port <port>", "Loopback port", (value: string) => {
+      const port = parseInt(value, 10);
+      if (isNaN(port) || port <= 0 || port > 65535) {
+        throw new InvalidArgumentError(
+          "Port must be a number between 1 and 65535",
+        );
+      }
+      return port;
+    })
     .addHelpText(
       "after",
       `
@@ -151,7 +159,7 @@ Arguments (via options):
   --token-auth-method   How the client authenticates at the token endpoint
                         (e.g. "client_secret_post", "client_secret_basic").
   --callback-transport  Transport method for the OAuth callback.
-  --loopback-port       Port number for the local loopback callback server.
+  --loopback-port       Port number for the local loopback callback server (1-65535).
 
 Registers a new OAuth provider configuration in the local store. This is
 used for custom integrations not covered by the built-in provider seeds.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-crud-commands.md.

**Gap:** --loopback-port NaN validation
**What was expected:** Invalid port values should produce a clear error
**What was found:** parseInt('abc') returns NaN which passes through silently

Replaced the raw `parseInt` callback with a custom parse function that validates the result is a positive integer within the valid port range (1-65535) and throws Commander's `InvalidArgumentError` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
