### PR TITLE
test: add test coverage for clientSecret parameter in upsertApp

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -275,6 +275,40 @@ describe("app operations", () => {
       expect(second.id).toBe(first.id);
       expect(second.createdAt).toBe(first.createdAt);
     });
+
+    test("stores clientSecret in secure storage on new app creation", async () => {
+      seedTestProvider("github");
+      const app = await upsertApp("github", "client-abc", "my-secret");
+
+      expect(mockSetSecureKeyAsync).toHaveBeenCalledTimes(1);
+      expect(mockSetSecureKeyAsync).toHaveBeenCalledWith(
+        `oauth_app/${app.id}/client_secret`,
+        "my-secret",
+      );
+    });
+
+    test("stores clientSecret in secure storage when upserting an existing app", async () => {
+      seedTestProvider("github");
+      const first = await upsertApp("github", "client-abc");
+      mockSetSecureKeyAsync.mockClear();
+
+      await upsertApp("github", "client-abc", "updated-secret");
+
+      expect(mockSetSecureKeyAsync).toHaveBeenCalledTimes(1);
+      expect(mockSetSecureKeyAsync).toHaveBeenCalledWith(
+        `oauth_app/${first.id}/client_secret`,
+        "updated-secret",
+      );
+    });
+
+    test("throws when setSecureKeyAsync returns false", async () => {
+      seedTestProvider("github");
+      mockSetSecureKeyAsync.mockResolvedValueOnce(false);
+
+      await expect(
+        upsertApp("github", "client-abc", "bad-secret"),
+      ).rejects.toThrow("Failed to store client_secret in secure storage");
+    });
   });
 
   describe("getApp", () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-crud-commands.md.

**Gap:** No test coverage for clientSecret parameter in upsertApp
**What was expected:** Tests verifying secret storage on new/existing app and error on storage failure
**What was found:** Existing tests don't exercise the clientSecret parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
