### PR TITLE
fix: clean up client_secret from secure storage when deleting an OAuth app

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -346,14 +346,14 @@ describe("app operations", () => {
   describe("deleteApp", () => {
     test("removes the row and returns true", async () => {
       const app = await createTestApp("github", "client-1");
-      const deleted = deleteApp(app.id);
+      const deleted = await deleteApp(app.id);
 
       expect(deleted).toBe(true);
       expect(getApp(app.id)).toBeUndefined();
     });
 
-    test("returns false for nonexistent id", () => {
-      expect(deleteApp("nonexistent-id")).toBe(false);
+    test("returns false for nonexistent id", async () => {
+      expect(await deleteApp("nonexistent-id")).toBe(false);
     });
   });
 });

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -228,9 +228,9 @@ Examples:
   $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000
   $ assistant oauth apps delete 550e8400-e29b-41d4-a716-446655440000 --json`,
     )
-    .action((id: string, _opts: unknown, cmd: Command) => {
+    .action(async (id: string, _opts: unknown, cmd: Command) => {
       try {
-        const deleted = deleteApp(id);
+        const deleted = await deleteApp(id);
 
         if (!deleted) {
           writeOutput(cmd, {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -278,8 +278,17 @@ export function listApps(): OAuthAppRow[] {
   return db.select().from(oauthApps).all();
 }
 
-/** Delete an app by ID. Returns true if a row was deleted. */
-export function deleteApp(id: string): boolean {
+/** Delete an app by ID. Cleans up the client_secret from secure storage. Returns true if a row was deleted. */
+export async function deleteApp(id: string): Promise<boolean> {
+  const result = await deleteSecureKeyAsync(`oauth_app/${id}/client_secret`);
+  if (result === "error") {
+    log.warn(
+      { appId: id },
+      "Failed to delete client_secret from secure storage — skipping app deletion to avoid orphaning secrets",
+    );
+    return false;
+  }
+
   const db = getDb();
   db.delete(oauthApps).where(eq(oauthApps.id, id)).run();
   return rawChanges() > 0;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-crud-commands.md.

**Gap:** deleteApp leaks client_secret in secure storage
**What was expected:** Deleting an app should clean up its client_secret from the keychain
**What was found:** deleteApp only deleted the DB row, leaving orphaned secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
