### PR TITLE
fix: change `connections token` to accept `<provider-key>` instead of `<service>`

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -123,7 +123,7 @@ async function runCli(
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("assistant oauth connections token", () => {
+describe("assistant oauth connections token <provider-key>", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
   });
@@ -132,7 +132,7 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "twitter",
+      "integration:twitter",
     ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("mock-access-token-xyz\n");
@@ -142,7 +142,7 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "twitter",
+      "integration:twitter",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -150,18 +150,18 @@ describe("assistant oauth connections token", () => {
     expect(parsed).toEqual({ ok: true, token: "mock-access-token-xyz" });
   });
 
-  test("qualifies service name with integration: prefix", async () => {
+  test("passes provider key directly to withValidToken", async () => {
     let capturedService: string | undefined;
     mockWithValidToken = async (service, cb) => {
       capturedService = service;
       return cb("tok");
     };
 
-    await runCli(["connections", "token", "twitter"]);
+    await runCli(["connections", "token", "integration:twitter"]);
     expect(capturedService).toBe("integration:twitter");
   });
 
-  test("works with other service names", async () => {
+  test("works with other provider keys", async () => {
     let capturedService: string | undefined;
     mockWithValidToken = async (service, cb) => {
       capturedService = service;
@@ -171,7 +171,7 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "gmail",
+      "integration:gmail",
     ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
@@ -188,7 +188,7 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "twitter",
+      "integration:twitter",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -207,7 +207,7 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "twitter",
+      "integration:twitter",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -223,13 +223,13 @@ describe("assistant oauth connections token", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "twitter",
+      "integration:twitter",
     ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("refreshed-new-token\n");
   });
 
-  test("missing service argument exits non-zero", async () => {
+  test("missing provider-key argument exits non-zero", async () => {
     const { exitCode } = await runCli(["connections", "token"]);
     expect(exitCode).not.toBe(0);
   });

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -42,7 +42,7 @@ Examples:
   $ assistant oauth connections list --provider integration:gmail
   $ assistant oauth connections get --id <uuid>
   $ assistant oauth connections get --provider integration:gmail
-  $ assistant oauth connections token twitter`,
+  $ assistant oauth connections token integration:twitter`,
   );
 
   // ---------------------------------------------------------------------------
@@ -141,22 +141,21 @@ At least --id or --provider must be specified.`,
     });
 
   // ---------------------------------------------------------------------------
-  // connections token <service>
+  // connections token <provider-key>
   // ---------------------------------------------------------------------------
 
   connections
-    .command("token <service>")
+    .command("token <provider-key>")
     .description(
-      "Print a valid OAuth access token for a service, refreshing if expired",
+      "Print a valid OAuth access token for a provider, refreshing if expired",
     )
     .addHelpText(
       "after",
       `
 Arguments:
-  service   Integration name without the "integration:" prefix
-            (e.g. "twitter", "gmail", "slack")
+  provider-key   Provider key (e.g. integration:gmail, integration:twitter)
 
-Returns a valid OAuth access token for the given service. If the stored token
+Returns a valid OAuth access token for the given provider. If the stored token
 is expired or near-expiry, it is refreshed automatically before being returned.
 
 In human mode, prints the bare token to stdout (suitable for shell substitution).
@@ -165,13 +164,12 @@ In JSON mode (--json), prints {"ok": true, "token": "..."}.
 Exits with code 1 if no access token exists or refresh fails.
 
 Examples:
-  $ assistant oauth connections token twitter
-  $ assistant oauth connections token gmail --json`,
+  $ assistant oauth connections token integration:twitter
+  $ assistant oauth connections token integration:gmail --json`,
     )
-    .action(async (service: string, _opts: unknown, cmd: Command) => {
+    .action(async (providerKey: string, _opts: unknown, cmd: Command) => {
       try {
-        const qualifiedService = `integration:${service}`;
-        const token = await withValidToken(qualifiedService, async (t) => t);
+        const token = await withValidToken(providerKey, async (t) => t);
         if (shouldOutputJson(cmd)) {
           writeOutput(cmd, { ok: true, token });
         } else {

--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -6,7 +6,7 @@ For account and auth workflows, prefer documented `assistant` CLI commands over
 any generic account registry:
 
 - `assistant credentials ...` for stored secrets and credential metadata
-- `assistant oauth connections token <service>` for OAuth-backed integrations
+- `assistant oauth connections token <provider-key>` for OAuth-backed integrations
 - `assistant mcp auth <name>` when an MCP server needs browser login
 - `assistant platform status` for platform-linked deployment/auth context
 

--- a/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
@@ -38,7 +38,9 @@ describe("buildCliReferenceSection", () => {
       "prefer real `assistant` CLI workflows over any legacy account-record abstraction",
     );
     expect(result).toContain("assistant credentials");
-    expect(result).toContain("assistant oauth connections token <service>");
+    expect(result).toContain(
+      "assistant oauth connections token <provider-key>",
+    );
     expect(result).toContain("assistant mcp auth <name>");
     expect(result).toContain("assistant platform status");
   });

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -848,7 +848,7 @@ export function buildCliReferenceSection(): string {
     "The `assistant` CLI is installed on the user's machine and available via `bash`.",
     "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
     "- Use `assistant credentials ...` for stored secrets and credential metadata.",
-    "- Use `assistant oauth connections token <service>` for connected integration tokens.",
+    "- Use `assistant oauth connections token <provider-key>` for connected integration tokens.",
     "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
     "- Use `assistant platform status` for platform-linked deployment and auth context.",
     "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",


### PR DESCRIPTION
## Summary
Fixes inconsistency identified during plan review for oauth-cli-crud-commands.md.

**Gap:** connections token uses inconsistent <service> arg instead of <provider-key>
**What was expected:** Consistent provider-key argument across all OAuth CLI commands
**What was found:** token accepted bare service name (twitter) while all other commands use full key (integration:twitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
