### PR TITLE
fix: add VELLUM_DEV to test safeKeys allowlist

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -485,6 +485,7 @@ describe("buildSanitizedEnv", () => {
       "SSH_AGENT_PID",
       "GPG_TTY",
       "GNUPGHOME",
+      "VELLUM_DEV",
       "INTERNAL_GATEWAY_BASE_URL",
       "VELLUM_DATA_DIR",
     ];


### PR DESCRIPTION
## Summary
- Adds missing VELLUM_DEV to the test's safeKeys array in terminal-tools.test.ts
- The SAFE_ENV_VARS list in safe-env.ts includes VELLUM_DEV, but the test's allowlist was missing it
- This fixes a pre-existing issue flagged in PR #15597 where the test would fail if VELLUM_DEV is set in the test environment

## Test plan
- The 'result is a plain object with no prototype-inherited secrets' test in terminal-tools.test.ts should now pass even when VELLUM_DEV is set in the environment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
