### PR TITLE
fix: sync bundled feature-flag-registry with canonical copy (add logfire flag)

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
+    },
+    {
+      "id": "logfire",
+      "scope": "assistant",
+      "key": "feature_flags.logfire.enabled",
+      "label": "Logfire LLM Observability",
+      "description": "Enable Logfire tracing for LLM request/response telemetry when LOGFIRE_TOKEN is set",
+      "defaultEnabled": false
     }
   ]
 }

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -120,6 +120,14 @@
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",
       "defaultEnabled": true
+    },
+    {
+      "id": "logfire",
+      "scope": "assistant",
+      "key": "feature_flags.logfire.enabled",
+      "label": "Logfire LLM Observability",
+      "description": "Enable Logfire tracing for LLM request/response telemetry when LOGFIRE_TOKEN is set",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Sync `gateway/src/feature-flag-registry.json` and `assistant/src/config/feature-flag-registry.json` with the canonical `meta/feature-flags/feature-flag-registry.json`
- Adds the missing `logfire` feature flag entry to both bundled copies
- Fixes the `feature-flag-defaults-sync.test.ts` CI failure

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23003782659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
