### PR TITLE
fix: migrate trusted contacts runbook from runtime to gateway URLs

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -1,17 +1,12 @@
 # Trusted Contacts — Operator Runbook
 
-Operational procedures for inspecting, managing, and debugging the trusted contact access flow. HTTP commands use the assistant runtime API (default `http://localhost:7821`) with bearer authentication.
-
-> **Note:** The `/v1/contacts` endpoints are served by the assistant runtime, not
-> the gateway. If you prefer to route through the gateway (`localhost:7830`), set
-> `"gateway": { "runtimeProxyEnabled": true }` in workspace config — the proxy is
-> disabled by default and these routes will 404 without it.
+Operational procedures for inspecting, managing, and debugging the trusted contact access flow. HTTP commands use the gateway API (default `http://localhost:7830`) with bearer authentication.
 
 ## Prerequisites
 
 ```bash
-# Base URL — assistant runtime (adjust if using a non-default port)
-BASE=http://localhost:7821
+# Base URL — gateway (adjust if using a non-default port)
+BASE=http://localhost:7830
 
 # Bearer token: for operator use, retrieve from the daemon process environment
 # or use `assistant` CLI commands which handle auth automatically.

--- a/assistant/src/__tests__/gateway-only-guard.test.ts
+++ b/assistant/src/__tests__/gateway-only-guard.test.ts
@@ -37,7 +37,6 @@ const ALLOWLIST = new Set([
   // --- Documentation and comments that mention the port for explanatory purposes ---
   "AGENTS.md", // documents the gateway-only rule itself
   "ARCHITECTURE.md", // architecture overview with port references
-  "assistant/docs/runbook-trusted-contacts.md", // operator runbook targeting runtime-only /v1/contacts endpoints
   "assistant/src/runtime/middleware/twilio-validation.ts", // comment explaining proxy URL rewriting
 ]);
 


### PR DESCRIPTION
Addresses review feedback on #15603. The trusted contacts runbook referenced localhost:7821 (runtime port) for HTTP commands, violating the gateway-only API consumption rule. The /v1/contacts endpoints are already proxied through the gateway via contacts-control-plane-proxy.ts (available even when broad runtime proxy is disabled), so the runbook should direct operators to the gateway URL (localhost:7830) instead. Also removes the stale note about enabling runtimeProxyEnabled for contacts endpoints and removes the runbook from the gateway-only-guard allowlist since it no longer references the runtime port.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
