### PR TITLE
fix: prevent channel setup UI race condition on Contact page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -85,6 +85,16 @@ struct AssistantChannelsDetailView: View {
                 stopCountdownTimer()
             }
         }
+        .onChange(of: store.channelSetupStatus["telegram"]) { _, status in
+            if status == nil || status == "not_configured" {
+                telegramSetupExpanded = false
+            }
+        }
+        .onChange(of: store.channelSetupStatus["slack"]) { _, status in
+            if status == nil || status == "not_configured" {
+                slackChannelSetupExpanded = false
+            }
+        }
         .onChange(of: store.channelSetupStatus["phone"]) { _, status in
             if status == nil || status == "not_configured" {
                 voiceSetupExpanded = false
@@ -264,7 +274,6 @@ struct AssistantChannelsDetailView: View {
                     VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                         store.saveTelegramToken(botToken: telegramBotTokenText)
                         telegramBotTokenText = ""
-                        telegramSetupExpanded = false
                     }
                     VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         telegramSetupExpanded = false
@@ -411,7 +420,6 @@ struct AssistantChannelsDetailView: View {
                         )
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
-                        slackChannelSetupExpanded = false
                     }
                     VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         slackChannelSetupExpanded = false
@@ -525,7 +533,6 @@ struct AssistantChannelsDetailView: View {
                         )
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
-                        voiceSetupExpanded = false
                     }
                     VButton(label: "Cancel", style: .tertiary, size: .medium) {
                         voiceSetupExpanded = false


### PR DESCRIPTION
## Summary
- Remove premature `*SetupExpanded = false` from Telegram, Slack, and Phone Connect button handlers — the expanded state was being cleared before the async `fetchChannelSetupStatus()` call completed, causing the UI to flash back to "Set Up"
- Add reactive `onChange` handlers for Telegram and Slack `channelSetupStatus` (matching the existing Phone pattern) so the form only collapses when the channel is disconnected/unconfigured
- Fixes all three channel types (Telegram, Slack, Phone) which shared the same race condition

## Original prompt
fix this bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
