### PR TITLE
fix: explicitly set runtimeProxyRequireAuth in gateway startup paths

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -148,6 +148,7 @@ cat > "\$HOME/.vellum/workspace/config.json" << CONFIG_EOF
   },
   "gateway": {
     "runtimeProxyEnabled": true,
+    "runtimeProxyRequireAuth": true,
     "unmappedPolicy": "default",
     "defaultAssistantId": "self"
   }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -903,6 +903,7 @@ export async function startGateway(
   // the gateway process. The gateway reads these at startup from config.json.
   writeGatewayConfig(resources?.instanceDir, {
     runtimeProxyEnabled: true,
+    runtimeProxyRequireAuth: true,
     unmappedPolicy: "default",
     defaultAssistantId: "self",
   });


### PR DESCRIPTION
## Summary
- Addresses review feedback from #15606
- `startGateway` in `cli/src/lib/local.ts` now explicitly sets `runtimeProxyRequireAuth: true` when writing gateway config
- Cloud startup script in `cli/src/commands/hatch.ts` also explicitly sets `runtimeProxyRequireAuth: true`

**Problem:** The `writeGatewayConfig` function preserves existing values for omitted keys. If a developer previously ran `enable-proxy.ts` (which sets `runtimeProxyRequireAuth: false` for local dev), a subsequent `vellum hatch` or `vellum wake` would inherit that stale `false` value — leaving the runtime proxy exposed without auth.

**Fix:** Both local and cloud gateway startup paths now explicitly write `runtimeProxyRequireAuth: true`, ensuring auth is always enforced in production regardless of prior config state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
