### PR TITLE
fix: gate channel setup on both Slack tokens and add optimistic disconnect status updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -164,6 +164,7 @@ struct AssistantChannelsDetailView: View {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
+                        store.channelSetupStatus["telegram"] = "not_configured"
                     }
                 }
             } else if (status == "incomplete" && store.telegramHasBotToken) || telegramSetupExpanded {
@@ -297,9 +298,10 @@ struct AssistantChannelsDetailView: View {
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
                         slackChannelSetupExpanded = false
+                        store.channelSetupStatus["slack"] = "not_configured"
                     }
                 }
-            } else if (status == "incomplete" && store.slackChannelHasBotToken) || slackChannelSetupExpanded {
+            } else if (status == "incomplete" && (store.slackChannelHasBotToken || store.slackChannelHasAppToken)) || slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
                 VButton(label: "Set Up", style: .secondary, size: .medium) {
@@ -441,6 +443,7 @@ struct AssistantChannelsDetailView: View {
                     VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
                     VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
+                        store.channelSetupStatus["phone"] = "not_configured"
                     }
                 }
             } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -854,10 +854,16 @@ public final class SettingsStore: ObservableObject {
     }
 
     func clearTelegramCredentials() {
+        telegramSaveInProgress = true
+        telegramError = nil
         do {
-            guard let daemonClient else { return }
+            guard let daemonClient else {
+                telegramSaveInProgress = false
+                return
+            }
             try daemonClient.sendTelegramConfig(action: "clear")
         } catch {
+            telegramSaveInProgress = false
             log.error("Failed to send Telegram config clear: \(error)")
         }
     }


### PR DESCRIPTION
## Summary
- Gate Slack credential entry UI on both `hasBotToken` and `hasAppToken` (not just `hasBotToken`), so a partial Slack state with only an app token shows the credential entry UI instead of falling through to "Set Up"
- Restore optimistic local `channelSetupStatus` updates after disconnect for all three channels (Telegram, Slack, Phone) so the UI immediately reflects the disconnected state without depending solely on `fetchChannelSetupStatus()` refetch
- Set `telegramSaveInProgress = true` during `clearTelegramCredentials()` for visual feedback during the async gap (Disconnect button becomes disabled)

Addresses review feedback on PR #15669.

## Test plan
- [ ] Verify Slack channel with only an app token (hasAppToken=true, hasBotToken=false) shows credential entry UI, not "Set Up" button
- [ ] Verify disconnecting any channel (Telegram, Slack, Phone) immediately shows "Set Up" button without waiting for refetch
- [ ] Verify Telegram "Disconnect" button shows disabled state during the async clear operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
