### PR TITLE
fix: anchor Guard 3 feature flag regex after .enabled

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flag-guardrails.test.ts
@@ -222,7 +222,7 @@ describe("assistant feature flag indirect key coverage guard", () => {
     let grepOutput = "";
     try {
       grepOutput = execSync(
-        `git grep -nE "feature_flags\\.[a-z0-9_-]+\\.enabled" -- 'assistant/src/**/*.ts' 'gateway/src/**/*.ts'`,
+        `git grep -nE "feature_flags\\.[a-z0-9_-]+\\.enabled\\b" -- 'assistant/src/**/*.ts' 'gateway/src/**/*.ts'`,
         { encoding: "utf-8", cwd: repoRoot },
       ).trim();
     } catch (err) {
@@ -233,7 +233,7 @@ describe("assistant feature flag indirect key coverage guard", () => {
       throw err;
     }
 
-    const keyPattern = /feature_flags\.[a-z0-9_-]+\.enabled/g;
+    const keyPattern = /feature_flags\.[a-z0-9_-]+\.enabled\b/g;
     const undeclared: string[] = [];
 
     for (const line of grepOutput.split("\n")) {


### PR DESCRIPTION
Adds \b word boundary anchor after .enabled in Guard 3's git grep pattern and JS extraction regex. Without this anchor, the pattern could match prefixes of longer strings (e.g. feature_flags.browser.enabled_experiment would match as feature_flags.browser.enabled), creating a false-negative gap where undeclared keys silently pass the guard.

Addresses reviewer feedback from PR #15674.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
