### PR TITLE
fix: throttle Gmail individual-fetch fallback to prevent unbounded parallelism

### DIFF
--- a/assistant/src/messaging/providers/gmail/client.ts
+++ b/assistant/src/messaging/providers/gmail/client.ts
@@ -358,10 +358,16 @@ async function executeBatchCall(
   return connection.withToken(doBatchFetch);
 }
 
+/** Max concurrent individual getMessage requests (matches batch concurrency) */
+const INDIVIDUAL_CONCURRENCY = BATCH_CONCURRENCY;
+
 /**
  * Fetch all messages individually using getMessage (no batch endpoint).
  * Used as a fallback when the batch API is unavailable (e.g. platform connections
  * that cannot expose raw tokens for the multipart batch endpoint).
+ *
+ * Processes messages in waves of INDIVIDUAL_CONCURRENCY to avoid unbounded
+ * parallelism that would trigger 429s on high-volume paths like senderDigest.
  */
 async function fetchMessagesIndividually(
   connection: OAuthConnection,
@@ -370,11 +376,17 @@ async function fetchMessagesIndividually(
   metadataHeaders?: string[],
   fields?: string,
 ): Promise<GmailMessage[]> {
-  return Promise.all(
-    messageIds.map((id) =>
-      getMessage(connection, id, format, metadataHeaders, fields),
-    ),
-  );
+  const results: GmailMessage[] = [];
+  for (let i = 0; i < messageIds.length; i += INDIVIDUAL_CONCURRENCY) {
+    const wave = messageIds.slice(i, i + INDIVIDUAL_CONCURRENCY);
+    const waveResults = await Promise.all(
+      wave.map((id) =>
+        getMessage(connection, id, format, metadataHeaders, fields),
+      ),
+    );
+    results.push(...waveResults);
+  }
+  return results;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #15673 (Codex P1): `fetchMessagesIndividually()` used `Promise.all` over all message IDs at once, creating unbounded parallelism that would trigger 429s/timeouts on high-volume paths like `senderDigest`
- Replaced with wave-based processing using `INDIVIDUAL_CONCURRENCY` (5, matching `BATCH_CONCURRENCY`) so only 5 individual `getMessage()` calls run concurrently at a time

## Test plan
- [ ] Verify platform-managed Gmail connections that fall back to individual fetches process messages in bounded waves
- [ ] Verify no regressions on batch-capable connections (batch path is unchanged)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
