### PR TITLE
fix: update stale help text example to use full provider key

### DIFF
--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -24,7 +24,7 @@ are created during the OAuth authorization flow or can be managed manually via
 their respective subcommands.
 
 Examples:
-  $ assistant oauth connections token twitter
+  $ assistant oauth connections token integration:twitter
   $ assistant oauth connections list
   $ assistant oauth connections get --provider integration:gmail
   $ assistant oauth providers list


### PR DESCRIPTION
## Summary
Updates the parent `oauth` command's help text example from `$ assistant oauth connections token twitter` to `$ assistant oauth connections token integration:twitter` to match the actual command behavior after the provider-key change.

Part of plan: oauth-cli-crud-commands.md (fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
