### PR TITLE
fix: correct apps upsert help text about secret update behavior

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -172,8 +172,8 @@ Creates a new app registration or returns the existing one if an app with the
 same provider and client ID already exists. The client secret, if provided, is
 stored in the secure system keychain — not in the database.
 
-When an existing app is matched, the command returns it as-is without updating
-the client secret. To change a secret, delete and re-create the app.
+When an existing app is matched and a --client-secret is provided, the stored
+secret is updated. The app row itself is returned as-is.
 
 Examples:
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123


### PR DESCRIPTION
## Summary
Fixes inaccurate help text in `apps upsert` that claimed "the command returns it as-is without updating the client secret." In reality, `upsertApp()` does update the client secret when one is provided for an existing app.

Part of plan: oauth-cli-crud-commands.md (fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
