### PR TITLE
docs: update OAuth connect orchestrator doc to reflect removal of caller overrides

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -250,7 +250,7 @@ Returns `{ ok: true, scopes }` or `{ ok: false, error, allowedScopes }`.
 1. **Resolve service** — alias expansion via `resolveService()`.
 2. **Load behavior** — `getProviderBehavior()` from the registry; load protocol fields from the `oauth_providers` DB table.
 3. **Compute scopes** — `resolveScopes()` with scope policy enforcement.
-4. **Build OAuth config** — merge profile defaults with caller overrides.
+4. **Build OAuth config** — assemble protocol-level config from the DB provider row.
 5. **Run flow** — interactive (opens browser, blocks until completion) or deferred (returns auth URL for the caller to deliver).
 6. **Verify identity** — runs the profile's `identityVerifier` if defined.
 7. **Store tokens** — `storeOAuth2Tokens()` persists access/refresh tokens, client credentials, and metadata.


### PR DESCRIPTION
## Summary
- Update integrations architecture doc (step 4 of Connect Orchestrator) to say 'assemble protocol-level config from the DB provider row' instead of 'merge profile defaults with caller overrides'
- The caller override path was removed in PR #15681 but the doc was not updated

Addresses review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15681
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
