### PR TITLE
fix: resolve canonical provider via oauth app in connection-resolver

### DIFF
--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -497,4 +497,41 @@ describe("resolveOAuthConnection", () => {
       /No base URL configured for "integration:custom-service"/,
     );
   });
+
+  test("resolves base URL via app's canonical providerKey for custom credential_service", () => {
+    // Set up a well-known provider with a baseUrl
+    mockProviders.set("github", {
+      key: "github",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      baseUrl: "https://api.github.com",
+    });
+    // The custom credential service has no provider entry of its own
+    // (getProvider("integration:github-work") returns undefined)
+
+    // App points to the canonical "github" provider
+    const appId = "app-github-work";
+    mockApps.set(appId, {
+      id: appId,
+      providerKey: "github",
+      clientId: "test-client-id",
+    });
+
+    // Connection uses the custom credential service as its providerKey
+    const connId = "conn-github-work";
+    mockConnections.set("integration:github-work", {
+      id: connId,
+      providerKey: "integration:github-work",
+      oauthAppId: appId,
+      expiresAt: Date.now() + 3600 * 1000,
+      grantedScopes: JSON.stringify(["repo"]),
+      accountInfo: null,
+    });
+    setSecureKey(`oauth_connection/${connId}/access_token`, "ghp-test-token");
+
+    const conn = resolveOAuthConnection("integration:github-work");
+
+    expect(conn).toBeInstanceOf(BYOOAuthConnection);
+    expect(conn.providerKey).toBe("integration:github-work");
+    expect(conn.grantedScopes).toEqual(["repo"]);
+  });
 });

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,7 +1,7 @@
 import { getSecureKey } from "../security/secure-keys.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
-import { getConnectionByProvider, getProvider } from "./oauth-store.js";
+import { getApp, getConnectionByProvider, getProvider } from "./oauth-store.js";
 
 /**
  * Resolve an OAuthConnection for a given credential service.
@@ -28,11 +28,15 @@ export function resolveOAuthConnection(
   }
 
   // Look up the provider by credentialService first; fall back to the
-  // connection's canonical providerKey so custom credential_service overrides
-  // (e.g. "integration:github-work") still resolve to the well-known provider's
-  // base URL.
+  // connection's app's canonical providerKey so custom credential_service
+  // overrides (e.g. "integration:github-work") still resolve to the well-known
+  // provider's base URL. We traverse conn -> oauthApp -> providerKey because
+  // conn.providerKey equals credentialService (getConnectionByProvider queries
+  // WHERE providerKey = credentialService), whereas the app's providerKey is a
+  // foreign key to the oauthProviders table.
   const provider =
-    getProvider(credentialService) ?? getProvider(conn.providerKey);
+    getProvider(credentialService) ??
+    getProvider(getApp(conn.oauthAppId)?.providerKey ?? "");
   const baseUrl = provider?.baseUrl;
 
   if (!baseUrl) {


### PR DESCRIPTION
## Summary
- Fixed the no-op provider fallback in `connection-resolver.ts` identified by reviewers on PR #15677
- The previous code `getProvider(credentialService) ?? getProvider(conn.providerKey)` never achieved its goal because `conn.providerKey === credentialService` always (the connection is fetched by `WHERE providerKey = credentialService`)
- Now traverses `conn.oauthAppId` -> `getApp()` -> `app.providerKey` to find the canonical provider key, which is a foreign key to the `oauthProviders` table
- Added a test case verifying that a custom credential service (e.g. `integration:github-work`) resolves the base URL from the app's canonical provider (`github`)

## Test plan
- [x] New test: custom credential_service resolves base URL via app's canonical providerKey
- [x] Existing tests continue to pass (direct provider match, missing credential, missing base URL)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
