### PR TITLE
docs: remove stale 'assistant dev' references from README

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -73,7 +73,6 @@ For low-level development (e.g., working on the assistant runtime itself):
 ```bash
 bun run src/index.ts daemon start   # start daemon only
 bun run src/index.ts                # interactive CLI session
-bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 ```
 
 ### CLI commands
@@ -84,7 +83,6 @@ bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 | `vellum sleep`                                | Stop assistant + gateway processes               |
 | `vellum ps`                                   | List assistants and per-assistant process status |
 | `assistant`                                   | Launch interactive CLI session                   |
-| `assistant dev`                               | Run assistant with auto-restart on file changes  |
 | `assistant sessions list\|new\|export\|clear` | Manage conversation sessions                     |
 | `assistant config set\|get\|list`             | Manage configuration                             |
 | `assistant keys set\|list\|delete`            | Manage API keys in secure storage                |


### PR DESCRIPTION
## Summary
- Removed two references to the `assistant dev` command from `assistant/README.md` that were missed in #15703
- Line 76: removed `bun run src/index.ts dev` from the raw bun commands section
- Line 87: removed `assistant dev` from the CLI commands table

Addresses review feedback on #15703.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
