### PR TITLE
fix: persist client_secret when oauthAppId is pre-resolved in storeOAuth2Tokens

### DIFF
--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -104,6 +104,17 @@ export async function storeOAuth2Tokens(
     ? { id: params.oauthAppId }
     : await upsertApp(service, clientId, clientSecret);
 
+  // When oauthAppId is pre-resolved, still persist clientSecret if provided.
+  if (params.oauthAppId && clientSecret) {
+    const stored = await setSecureKeyAsync(
+      `oauth_app/${params.oauthAppId}/client_secret`,
+      clientSecret,
+    );
+    if (!stored) {
+      throw new Error("Failed to store client_secret in secure storage");
+    }
+  }
+
   // 2. Upsert oauth_connection — reuse existing active connection for this
   //    provider, or create a new one.
   const existingConn = getConnectionByProvider(service);


### PR DESCRIPTION
## Summary
- When `params.oauthAppId` is pre-resolved, the code skips `upsertApp()` entirely, which means `clientSecret` is silently dropped
- Add explicit `setSecureKeyAsync` call for the pre-resolved `oauthAppId` path so client_secret is always persisted when provided
- Addresses review feedback on PR #15693
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
