### PR TITLE
fix: redact token fields from oauth connections list/get metadata output

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -18,13 +18,40 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 
 const log = getCliLogger("cli");
 
+/**
+ * Keys that may contain secrets in an OAuth token endpoint response.
+ * These are stripped from the `metadata` field before CLI output to prevent
+ * token leakage via shell history, logs, or agent transcript capture.
+ */
+const REDACTED_METADATA_KEYS = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+]);
+
+/** Recursively strip secret-bearing keys from a parsed metadata object. */
+function redactMetadata(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (REDACTED_METADATA_KEYS.has(key)) {
+      result[key] = "[REDACTED]";
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      result[key] = redactMetadata(value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 /** Parse stored JSON string fields and convert timestamps for a connection row. */
 function formatConnectionRow(row: ReturnType<typeof getConnection>) {
   if (!row) return row;
+  const parsed = row.metadata ? JSON.parse(row.metadata) : null;
   return {
     ...row,
     grantedScopes: row.grantedScopes ? JSON.parse(row.grantedScopes) : [],
-    metadata: row.metadata ? JSON.parse(row.metadata) : null,
+    metadata: parsed ? redactMetadata(parsed) : null,
     hasRefreshToken: row.hasRefreshToken === 1,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),


### PR DESCRIPTION
## Summary
- Redact `access_token`, `refresh_token`, and `id_token` from connection metadata in CLI output
- The `metadata` field in oauth_connections stores the raw token endpoint response, which contains secrets
- `formatConnectionRow` now strips these keys recursively (handles nested structures like Slack's `authed_user`) before writing to stdout
- Prevents token leakage via shell history, logs, or agent transcript capture

Addresses feedback from #15706.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
