### PR TITLE
fix: return discriminated union from disconnectOAuthProvider to distinguish not-found from error

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -66,7 +66,7 @@ mock.module("../oauth/oauth-store.js", () => {
     getProvider: mockGetProvider,
     listConnections: mock(() => []),
     seedProviders: mock(() => {}),
-    disconnectOAuthProvider: mock(async () => false),
+    disconnectOAuthProvider: mock(async () => "not-found" as const),
   };
 });
 

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -93,12 +93,18 @@ const mockProviders = new Map<
 >();
 
 let mockDisconnectOAuthProvider: ReturnType<
-  typeof mock<(providerKey: string) => Promise<boolean>>
+  typeof mock<
+    (providerKey: string) => Promise<"disconnected" | "not-found" | "error">
+  >
 >;
 
 mock.module("../oauth/oauth-store.js", () => {
   mockDisconnectOAuthProvider = mock((providerKey: string) =>
-    Promise.resolve(mockConnections.has(providerKey)),
+    Promise.resolve(
+      mockConnections.has(providerKey)
+        ? ("disconnected" as const)
+        : ("not-found" as const),
+    ),
   );
   return {
     disconnectOAuthProvider: mockDisconnectOAuthProvider,

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -169,10 +169,13 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 let disconnectOAuthProviderCalls: string[] = [];
-let disconnectOAuthProviderResult = false;
+let disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
+  "not-found";
 
 mock.module("../oauth/oauth-store.js", () => ({
-  disconnectOAuthProvider: async (providerKey: string): Promise<boolean> => {
+  disconnectOAuthProvider: async (
+    providerKey: string,
+  ): Promise<"disconnected" | "not-found" | "error"> => {
     disconnectOAuthProviderCalls.push(providerKey);
     return disconnectOAuthProviderResult;
   },
@@ -299,7 +302,7 @@ describe("assistant credentials CLI", () => {
     _getMetadataCalls = 0;
     _getMetadataByIdCalls = 0;
     disconnectOAuthProviderCalls = [];
-    disconnectOAuthProviderResult = false;
+    disconnectOAuthProviderResult = "not-found";
     process.exitCode = 0;
   });
 
@@ -645,7 +648,7 @@ describe("assistant credentials CLI", () => {
 
     test("succeeds when only OAuth connection exists (no legacy credential)", async () => {
       // No legacy credential seeded — only the OAuth disconnect finds something
-      disconnectOAuthProviderResult = true;
+      disconnectOAuthProviderResult = "disconnected";
 
       const result = await runCli(["delete", "gmail:access_token", "--json"]);
       expect(result.exitCode).toBe(0);

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -25,7 +25,8 @@ let metadataStore: Array<{
   updatedAt: number;
 }> = [];
 let disconnectOAuthProviderCalls: string[] = [];
-let disconnectOAuthProviderResult = false;
+let disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
+  "not-found";
 let idCounter = 0;
 
 function nextUUID(): string {
@@ -59,7 +60,9 @@ mock.module("../security/token-manager.js", () => ({
 // ---------------------------------------------------------------------------
 
 mock.module("../oauth/oauth-store.js", () => ({
-  disconnectOAuthProvider: async (providerKey: string): Promise<boolean> => {
+  disconnectOAuthProvider: async (
+    providerKey: string,
+  ): Promise<"disconnected" | "not-found" | "error"> => {
     disconnectOAuthProviderCalls.push(providerKey);
     return disconnectOAuthProviderResult;
   },
@@ -201,7 +204,7 @@ describe("assistant oauth connections token <provider-key>", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     disconnectOAuthProviderCalls = [];
-    disconnectOAuthProviderResult = false;
+    disconnectOAuthProviderResult = "not-found";
     idCounter = 0;
   });
 
@@ -322,12 +325,12 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     disconnectOAuthProviderCalls = [];
-    disconnectOAuthProviderResult = false;
+    disconnectOAuthProviderResult = "not-found";
     idCounter = 0;
   });
 
   test("succeeds when an OAuth connection exists", async () => {
-    disconnectOAuthProviderResult = true;
+    disconnectOAuthProviderResult = "disconnected";
 
     const result = await runCli([
       "connections",
@@ -408,7 +411,7 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
 
   test("cleans up both OAuth connection and legacy keys when both exist", async () => {
     // Seed OAuth connection
-    disconnectOAuthProviderResult = true;
+    disconnectOAuthProviderResult = "disconnected";
 
     // Seed a legacy credential key
     secureKeyStore.set(

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -675,13 +675,13 @@ describe("connection operations", () => {
 // ---------------------------------------------------------------------------
 
 describe("disconnectOAuthProvider", () => {
-  test("returns false when no connection exists for the provider", async () => {
+  test("returns 'not-found' when no connection exists for the provider", async () => {
     const result = await disconnectOAuthProvider("github");
-    expect(result).toBe(false);
+    expect(result).toBe("not-found");
     expect(mockDeleteSecureKeyAsync).not.toHaveBeenCalled();
   });
 
-  test("returns true and deletes connection row and secure keys when connection exists", async () => {
+  test("returns 'disconnected' and deletes connection row and secure keys when connection exists", async () => {
     const app = await createTestApp("github", "client-1");
     const conn = createConnection({
       oauthAppId: app.id,
@@ -691,7 +691,7 @@ describe("disconnectOAuthProvider", () => {
     });
 
     const result = await disconnectOAuthProvider("github");
-    expect(result).toBe(true);
+    expect(result).toBe("disconnected");
 
     // Verify secure keys were deleted
     expect(mockDeleteSecureKeyAsync).toHaveBeenCalledTimes(2);

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -434,17 +434,26 @@ Examples:
 
         // Also clean up the OAuth connection and new-format secure keys.
         // disconnectOAuthProvider is a no-op when no connection exists.
-        let oauthDisconnected = false;
+        let oauthResult: "disconnected" | "not-found" | "error" = "not-found";
         try {
-          oauthDisconnected = await disconnectOAuthProvider(service);
+          oauthResult = await disconnectOAuthProvider(service);
         } catch {
           // Best-effort — OAuth tables may not exist yet
+        }
+
+        if (oauthResult === "error") {
+          writeOutput(cmd, {
+            ok: false,
+            error: "Failed to disconnect OAuth provider — please try again",
+          });
+          process.exitCode = 1;
+          return;
         }
 
         if (
           secretResult !== "deleted" &&
           !metadataDeleted &&
-          !oauthDisconnected
+          oauthResult !== "disconnected"
         ) {
           writeOutput(cmd, { ok: false, error: "Credential not found" });
           process.exitCode = 1;

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -249,8 +249,16 @@ Examples:
         let cleanedUp = false;
 
         // 1. Disconnect the OAuth connection (new-format keys + connection row)
-        const oauthDisconnected = await disconnectOAuthProvider(providerKey);
-        if (oauthDisconnected) cleanedUp = true;
+        const oauthResult = await disconnectOAuthProvider(providerKey);
+        if (oauthResult === "error") {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Failed to disconnect OAuth provider "${providerKey}" — please try again`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+        if (oauthResult === "disconnected") cleanedUp = true;
 
         // 2. Clean up legacy credential keys for common fields
         const legacyFields = [

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -455,14 +455,16 @@ export function deleteConnection(id: string): boolean {
  * Fully disconnect an OAuth provider: delete the new-format secure keys
  * (access_token and refresh_token) and remove the connection row from SQLite.
  *
- * Returns `true` if a connection was found and cleaned up, `false` if no
- * active connection existed for the given provider.
+ * Returns `"disconnected"` if a connection was found and cleaned up,
+ * `"not-found"` if no active connection existed for the given provider,
+ * or `"error"` if secure key deletion failed (connection row is preserved
+ * to avoid orphaning secrets).
  */
 export async function disconnectOAuthProvider(
   providerKey: string,
-): Promise<boolean> {
+): Promise<"disconnected" | "not-found" | "error"> {
   const conn = getConnectionByProvider(providerKey);
-  if (!conn) return false;
+  if (!conn) return "not-found";
 
   const r1 = await deleteSecureKeyAsync(
     `oauth_connection/${conn.id}/access_token`,
@@ -481,10 +483,10 @@ export async function disconnectOAuthProvider(
       },
       "Failed to delete OAuth secure keys — skipping connection row deletion to avoid orphaning secrets",
     );
-    return false;
+    return "error";
   }
 
   deleteConnection(conn.id);
 
-  return true;
+  return "disconnected";
 }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -453,7 +453,13 @@ class CredentialStoreTool implements Tool {
         }
         // Also clean up any OAuth connection for this service (best-effort)
         try {
-          await disconnectOAuthProvider(service);
+          const oauthResult = await disconnectOAuthProvider(service);
+          if (oauthResult === "error") {
+            log.warn(
+              { service },
+              "OAuth disconnect failed after removing credential — secure key deletion error",
+            );
+          }
         } catch (err) {
           log.warn(
             { service, err },


### PR DESCRIPTION
## Summary
Addresses review feedback on #15700: `disconnectOAuthProvider` returned `false` for both "no connection found" and "key deletion error", causing callers to show misleading "not found" messages when the connection existed but cleanup failed.

- Changed `disconnectOAuthProvider` return type from `boolean` to `"disconnected" | "not-found" | "error"` discriminated union
- Updated `credentials.ts` delete command to surface a specific error message on OAuth disconnect failure
- Updated `connections.ts` disconnect command to surface a specific error message on OAuth disconnect failure
- Updated `vault.ts` best-effort caller to log the `"error"` result explicitly
- Updated all test mocks and assertions to use the new string return values
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
