### PR TITLE
fix: correct delete order in deleteApp and align error handling with upsertApp

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -352,8 +352,31 @@ describe("app operations", () => {
       expect(getApp(app.id)).toBeUndefined();
     });
 
+    test("cleans up client_secret from secure storage", async () => {
+      const app = await createTestApp("github", "client-1");
+      mockDeleteSecureKeyAsync.mockClear();
+
+      await deleteApp(app.id);
+
+      expect(mockDeleteSecureKeyAsync).toHaveBeenCalledWith(
+        `oauth_app/${app.id}/client_secret`,
+      );
+    });
+
     test("returns false for nonexistent id", async () => {
       expect(await deleteApp("nonexistent-id")).toBe(false);
+    });
+
+    test("throws when deleteSecureKeyAsync returns error", async () => {
+      const app = await createTestApp("github", "client-1");
+      mockDeleteSecureKeyAsync.mockResolvedValueOnce("error");
+
+      await expect(deleteApp(app.id)).rejects.toThrow(
+        /failed to remove client_secret from secure storage/i,
+      );
+
+      // DB row should already be deleted (delete happens before secure key cleanup)
+      expect(getApp(app.id)).toBeUndefined();
     });
   });
 });

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -23,8 +23,9 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-const mockDeleteSecureKeyAsync = mock(() =>
-  Promise.resolve("deleted" as const),
+const mockDeleteSecureKeyAsync = mock(
+  (): Promise<"deleted" | "not-found" | "error"> =>
+    Promise.resolve("deleted" as const),
 );
 const mockSetSecureKeyAsync = mock(() => Promise.resolve(true));
 /** Simulated secure key store for getSecureKey lookups. */

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -280,18 +280,22 @@ export function listApps(): OAuthAppRow[] {
 
 /** Delete an app by ID. Cleans up the client_secret from secure storage. Returns true if a row was deleted. */
 export async function deleteApp(id: string): Promise<boolean> {
-  const result = await deleteSecureKeyAsync(`oauth_app/${id}/client_secret`);
-  if (result === "error") {
-    log.warn(
-      { appId: id },
-      "Failed to delete client_secret from secure storage — skipping app deletion to avoid orphaning secrets",
-    );
-    return false;
-  }
-
+  // Delete the DB row first so that if it fails (e.g. FK constraint from
+  // existing connections), the secret in secure storage remains intact.
   const db = getDb();
   db.delete(oauthApps).where(eq(oauthApps.id, id)).run();
-  return rawChanges() > 0;
+  const deleted = rawChanges() > 0;
+
+  if (!deleted) return false;
+
+  const result = await deleteSecureKeyAsync(`oauth_app/${id}/client_secret`);
+  if (result === "error") {
+    throw new Error(
+      `Deleted app ${id} but failed to remove client_secret from secure storage`,
+    );
+  }
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes delete order in `deleteApp`: DB row is now deleted before the secure key, so if the DB delete fails (e.g. FK constraint from existing connections), the secret remains intact and token refresh still works.
- Aligns error handling with `upsertApp`: `deleteApp` now throws on secure storage failures instead of returning `false`, making the two functions consistent and allowing the CLI to display proper error messages.
- Fixes misleading CLI error: `deleteApp` returning `false` now strictly means "app not found", so the CLI's "App not found" message is always accurate.
- Adds tests for the secure-key-error path and secure key cleanup verification.

Addresses review feedback on #15717.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
