### PR TITLE
fix: restore per-field status accuracy and add startup backfill for oauth-store migration

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -238,11 +238,13 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(false);
   });
 
-  test("GET returns connected: true when oauth_connection is active", () => {
+  test("GET returns connected: true when oauth_connection is active and both keys exist", () => {
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",
       status: "active",
     };
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
 
     const result = getSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -251,11 +253,29 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(true);
   });
 
+  test("GET reports per-field token presence independently of connection row", () => {
+    // Only bot_token in keychain, no app_token, but connection row exists
+    oauthConnectionStore["slack_channel"] = {
+      id: "conn-slack",
+      status: "active",
+    };
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+
+    const result = getSlackChannelConfig();
+    expect(result.success).toBe(true);
+    expect(result.hasBotToken).toBe(true);
+    expect(result.hasAppToken).toBe(false);
+    // connected requires both keys AND connection row
+    expect(result.connected).toBe(false);
+  });
+
   test("GET returns metadata from config when available", () => {
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",
       status: "active",
     };
+    secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
+    secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
     configStore = {
       slack: {
         teamId: "T123",

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -40,13 +40,20 @@ export interface SlackChannelConfigResult {
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
+  const hasBotToken = !!getSecureKey(
+    credentialKey("slack_channel", "bot_token"),
+  );
+  const hasAppToken = !!getSecureKey(
+    credentialKey("slack_channel", "app_token"),
+  );
   const conn = getConnectionByProvider("slack_channel");
-  const connected = !!(conn && conn.status === "active");
+  const connected =
+    !!(conn && conn.status === "active") && hasBotToken && hasAppToken;
   const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
-    hasBotToken: connected,
-    hasAppToken: connected,
+    hasBotToken,
+    hasAppToken,
     connected,
     ...(teamId ? { teamId } : {}),
     ...(teamName ? { teamName } : {}),
@@ -229,13 +236,18 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
   );
 
   if (r1 === "error" || r2 === "error") {
-    const errConn = getConnectionByProvider("slack_channel");
-    const errConnected = !!(errConn && errConn.status === "active");
+    // Check each key individually so partial deletions report accurate status.
+    const hasBotToken = !!getSecureKey(
+      credentialKey("slack_channel", "bot_token"),
+    );
+    const hasAppToken = !!getSecureKey(
+      credentialKey("slack_channel", "app_token"),
+    );
     return {
       success: false,
-      hasBotToken: errConnected,
-      hasAppToken: errConnected,
-      connected: errConnected,
+      hasBotToken,
+      hasAppToken,
+      connected: hasBotToken && hasAppToken,
       error: "Failed to delete Slack channel credentials from secure storage",
     };
   }

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -66,15 +66,19 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 // -- Extracted business logic functions --
 
 export function getTelegramConfig(): TelegramConfigResult {
+  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+  const hasWebhookSecret = !!getSecureKey(
+    credentialKey("telegram", "webhook_secret"),
+  );
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
-    hasBotToken: connected,
+    hasBotToken,
     botUsername,
-    connected,
-    hasWebhookSecret: connected,
+    connected: connected && hasBotToken && hasWebhookSecret,
+    hasWebhookSecret,
   };
 }
 
@@ -255,14 +259,16 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   );
 
   if (r1 === "error" || r2 === "error") {
-    // Check what's still in the keychain to report accurate status.
-    const errConn = getConnectionByProvider("telegram");
-    const errConnected = !!(errConn && errConn.status === "active");
+    // Check each key individually so partial deletions report accurate status.
+    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+    const hasWebhookSecret = !!getSecureKey(
+      credentialKey("telegram", "webhook_secret"),
+    );
     return {
       success: false,
-      hasBotToken: errConnected,
-      connected: errConnected,
-      hasWebhookSecret: errConnected,
+      hasBotToken,
+      connected: hasBotToken && hasWebhookSecret,
+      hasWebhookSecret,
       error: "Failed to delete Telegram credentials from secure storage",
     };
   }
@@ -345,7 +351,7 @@ export async function setTelegramCommands(
   const cmdConnected = !!(cmdConn && cmdConn.status === "active");
   return {
     success: true,
-    hasBotToken: cmdConnected,
+    hasBotToken: true,
     connected: cmdConnected,
     hasWebhookSecret: cmdConnected,
     commandsRegistered: resolvedCommands.map((c) => c.command),

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -41,6 +41,7 @@ import {
   emitNotificationSignal,
   registerBroadcastFn,
 } from "../notifications/emit-signal.js";
+import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
@@ -158,6 +159,10 @@ export async function runDaemon(): Promise<void> {
     initializeDb();
     // Seed well-known OAuth provider configurations (insert-if-not-exists)
     seedOAuthProviders();
+    // Backfill oauth_connection rows for manual-token providers (Telegram,
+    // Slack channel) that already have keychain credentials from before the
+    // oauth_connection migration. Safe to call on every startup.
+    await backfillManualTokenConnections();
     log.info("Daemon startup: DB initialized");
 
     // Ensure a vellum guardian binding exists and mint the CLI edge token

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -15,6 +15,7 @@ import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
 import type { OAuthConnection } from "../../../oauth/connection.js";
+import { getConnectionByProvider } from "../../../oauth/oauth-store.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKey } from "../../../security/secure-keys.js";
@@ -54,20 +55,16 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   capabilities: new Set(["send"]),
 
   /**
-   * Custom connectivity check. The standard registry check looks for
-   * credential/telegram/access_token, but the Telegram bot token is
-   * stored as credential/telegram/bot_token. This method lets the
-   * registry detect that Telegram credentials exist.
+   * Custom connectivity check using the oauth_connection record as the
+   * single source of truth, consistent with integration-status.ts.
    *
    * Both bot_token and webhook_secret are required — the gateway's
    * /deliver/telegram endpoint rejects requests without the webhook
    * secret, so partial credentials would cause every send to fail.
    */
   isConnected(): boolean {
-    return (
-      getBotToken() !== undefined &&
-      !!getSecureKey(credentialKey("telegram", "webhook_secret"))
-    );
+    const conn = getConnectionByProvider("telegram");
+    return !!(conn && conn.status === "active");
   },
 
   async testConnection(

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -8,6 +8,8 @@
  * codebase.
  */
 
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import {
   createConnection,
   deleteConnection,
@@ -61,4 +63,42 @@ export function removeManualTokenConnection(providerKey: string): void {
   const conn = getConnectionByProvider(providerKey);
   if (!conn) return;
   deleteConnection(conn.id);
+}
+
+/**
+ * Backfill oauth_connection rows for manual-token providers that already
+ * have valid keychain credentials but are missing connection records.
+ *
+ * This handles the upgrade path from installations that stored credentials
+ * before the oauth_connection migration. Without this, existing Telegram
+ * and Slack channel integrations would appear disconnected after upgrading
+ * until the user reconfigures them.
+ *
+ * Safe to call on every startup — skips providers that already have a
+ * connection row.
+ */
+export async function backfillManualTokenConnections(): Promise<void> {
+  // Telegram: requires both bot_token and webhook_secret
+  if (!getConnectionByProvider("telegram")) {
+    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
+    const hasWebhookSecret = !!getSecureKey(
+      credentialKey("telegram", "webhook_secret"),
+    );
+    if (hasBotToken && hasWebhookSecret) {
+      await ensureManualTokenConnection("telegram");
+    }
+  }
+
+  // Slack channel: requires both bot_token and app_token
+  if (!getConnectionByProvider("slack_channel")) {
+    const hasBotToken = !!getSecureKey(
+      credentialKey("slack_channel", "bot_token"),
+    );
+    const hasAppToken = !!getSecureKey(
+      credentialKey("slack_channel", "app_token"),
+    );
+    if (hasBotToken && hasAppToken) {
+      await ensureManualTokenConnection("slack_channel");
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Restores per-field keychain checks in GET handlers and clear error paths for Slack channel and Telegram configs, so hasBotToken/hasAppToken/hasWebhookSecret accurately reflect individual credential presence instead of collapsing into a single oauth_connection boolean
- Fixes setTelegramCommands success path to report hasBotToken: true (the token was already verified and used)
- Adds startup backfill migration that creates oauth_connection rows for existing installations that already have valid keychain credentials
- Aligns Telegram messaging adapter isConnected() with integration-status.ts to use oauth_connection as single source of truth
- Updates tests to reflect per-field status behavior

Addresses review feedback from PR #15711.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
