### PR TITLE
fix: add OAuth connections CLI to secure-keys import allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -234,6 +234,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
+      "cli/commands/oauth/connections.ts", // CLI OAuth connection delete (legacy credential cleanup)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `cli/commands/oauth/connections.ts` to the `ALLOWED_IMPORTERS` set in the credential-security-invariants test — this file legitimately uses `deleteSecureKeyAsync` to clean up legacy credential fields when deleting OAuth connections

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23005674054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
