### PR TITLE
fix: handle GCP wizard flow and reuse browser tab in google-oauth skill

### DIFF
--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -45,12 +45,16 @@ You open pages via the `open` command (launches in the user's default browser �
 
 ## Opening URLs
 
-Every URL navigation uses this single command. It detects the default browser and reuses the front tab if possible, falling back to `open` for unknown browsers or if no browser window exists yet:
+### Setup: create the navigation helper (do this once at the start of the flow)
+
+Before opening any URLs, create the helper script:
 
 ```
 host_bash:
   command: |
-    URL="TARGET_URL"
+    cat > /tmp/vellum-nav.sh << 'NAVSCRIPT'
+    #!/bin/bash
+    URL="$1"
     BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h['LSHandlerRoleAll']) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
     case "$BROWSER" in
       com.google.chrome)
@@ -64,9 +68,21 @@ host_bash:
       *)
         open "$URL" ;;
     esac
+    NAVSCRIPT
+    chmod +x /tmp/vellum-nav.sh
+    echo "Navigation helper ready."
 ```
 
-Replace `TARGET_URL` with the actual URL for each step. The `|| open` fallback handles the first navigation (when no browser window exists yet) and unknown browsers gracefully.
+### Navigating to a URL
+
+For every URL in the flow, use:
+
+```
+host_bash:
+  command: /tmp/vellum-nav.sh "TARGET_URL"
+```
+
+Replace `TARGET_URL` with the actual URL. The helper detects the default browser and navigates in the existing tab. On the first call (no browser window yet), it falls back to opening a new tab.
 
 ## Step Pattern
 
@@ -82,7 +98,9 @@ Every step follows this rhythm:
 
 ## Pre-Flow
 
-Before beginning, tell the user:
+**First**, create the navigation helper script (see "Opening URLs" above). Do this silently before saying anything to the user.
+
+Then tell the user:
 
 > We're going to set up Google OAuth together — 9 steps, about 3–5 minutes. I'll open each page in your browser and tell you exactly what to do. You can pause anytime and pick up where you left off.
 >
@@ -264,21 +282,7 @@ Copy the required scopes to the clipboard, then open the Data Access page:
 ```
 host_bash:
   command: |
-    echo -n "https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly" | pbcopy
-    URL="https://console.cloud.google.com/auth/scopes?project=PROJECT_ID"
-    BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h['LSHandlerRoleAll']) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
-    case "$BROWSER" in
-      com.google.chrome)
-        osascript -e "tell application \"Google Chrome\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
-      com.apple.safari)
-        osascript -e "tell application \"Safari\" to set URL of current tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
-      company.thebrowser.Browser)
-        osascript -e "tell application \"Arc\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
-      com.brave.Browser)
-        osascript -e "tell application \"Brave Browser\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
-      *)
-        open "$URL" ;;
-    esac
+    echo -n "https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly" | pbcopy && /tmp/vellum-nav.sh "https://console.cloud.google.com/auth/scopes?project=PROJECT_ID"
 ```
 
 > Now I've opened the **Data Access** page and copied the required scopes to your clipboard. Click **Add or Remove Scopes**, find the **"Manually add scopes"** text box at the bottom, **paste** (Cmd+V), then click **Add to Table** (or **Update**), and **Save**.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -29,7 +29,7 @@ Determine which path applies before taking action:
 
 # Path A: Collaborative Browser Setup (macOS Desktop App)
 
-You open pages via the `open` command (launches in the user's default browser — no Chrome dependency). The user does the clicking and form-filling. You tell them exactly what to look for and click at each step.
+You open pages in the user's default browser using the `/tmp/vellum-nav.sh` helper (see "Opening URLs" below). The user does the clicking and form-filling. You tell them exactly what to look for and click at each step.
 
 ## Path A Rules
 
@@ -55,7 +55,7 @@ host_bash:
     cat > /tmp/vellum-nav.sh << 'NAVSCRIPT'
     #!/bin/bash
     URL="$1"
-    BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h['LSHandlerRoleAll']) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
+    BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h.get('LSHandlerRoleAll','')) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
     case "$BROWSER" in
       com.google.chrome)
         osascript -e "tell application \"Google Chrome\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
@@ -434,7 +434,7 @@ When the user reports something doesn't look right, offer to take a screenshot t
 
 ## Guardrails
 
-- **No browser automation tools.** Path A uses `host_bash` + `open` for navigation. No `browser_*`, no CDP, no `computer_use_*` for navigation.
+- **No browser automation tools.** Path A uses `host_bash` + `/tmp/vellum-nav.sh` for navigation. No `browser_*`, no CDP, no `computer_use_*` for navigation.
 - **Browser-aware tab reuse.** Every URL navigation uses the self-contained detect-and-navigate snippet from the "Opening URLs" section. The assistant does not need to remember the browser — the snippet detects it each time. Falls back to `open` for unknown browsers or when no window exists. Use `pbcopy` for clipboard operations.
 - **Do not delete and recreate OAuth clients.** That orphans stored credentials.
 - **Do not leave the credential dialog early.** The Client Secret is shown only once.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -285,7 +285,10 @@ host_bash:
     echo -n "https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly" | pbcopy && /tmp/vellum-nav.sh "https://console.cloud.google.com/auth/scopes?project=PROJECT_ID"
 ```
 
-> Now I've opened the **Data Access** page and copied the required scopes to your clipboard. Click **Add or Remove Scopes**, find the **"Manually add scopes"** text box at the bottom, **paste** (Cmd+V), then click **Add to Table** (or **Update**), and **Save**.
+> Now I've opened the **Data Access** page and copied the required scopes to your clipboard. There are two stages here:
+>
+> 1. Click **Add or Remove Scopes** — a panel will open. Scroll down to the **"Manually add scopes"** text box, **paste** (Cmd+V), then click **Update** at the bottom of the panel.
+> 2. Back on the main page, scroll down and click **Save**.
 >
 > When done, you should see them listed on the page:
 >

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -226,13 +226,16 @@ If the user lands on a page with numbered steps (App Information → Audience �
 > It looks like Google is showing the setup wizard. Let's walk through it:
 >
 > **Step 1 — App Information:**
+>
 > - **App name:** `Vellum Assistant`
 > - Leave everything else as-is
 >
 > **Step 2 — Audience:**
+>
 > - Select **External** — this lets any Google account authorize (it starts in testing mode, so only test users you add can access it)
 >
 > **Step 3 — Contact Information:**
+>
 > - Enter your email address
 >
 > Then click **Create** at the bottom.

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -33,7 +33,7 @@ You open pages via the `open` command (launches in the user's default browser �
 
 ## Path A Rules
 
-1. **Navigation is your job.** Use `host_bash` with `open "URL"` to open every URL. The user should never have to type a URL.
+1. **Navigation is your job.** Open every URL for the user — they should never have to type a URL. Use the browser-aware navigation pattern described in **Opening URLs** below.
 2. **Screenshots are a tool, not a routine.** Don't screenshot after every step. Give clear landmark-based instructions and let the user tell you how it's going. If the user reports something doesn't match or they're stuck, offer to take a screenshot: "Want me to take a look? I can screenshot your screen to see what you're seeing." Then adapt based on what you see.
 3. **Never auto-advance.** Wait for user confirmation ("done", "ok", "next", etc.) before proceeding to the next step.
 4. **Use landmarks, not coordinates.** Don't say "click the third item in the left sidebar." Say "Look for **APIs & Services** — it might be in the left sidebar, or you might need to click the hamburger menu first."
@@ -45,20 +45,34 @@ You open pages via the `open` command (launches in the user's default browser �
 
 ## Opening URLs
 
-All URL navigation uses this pattern:
+Every URL navigation uses this single command. It detects the default browser and reuses the front tab if possible, falling back to `open` for unknown browsers or if no browser window exists yet:
 
 ```
 host_bash:
-  command: open "TARGET_URL"
+  command: |
+    URL="TARGET_URL"
+    BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h['LSHandlerRoleAll']) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
+    case "$BROWSER" in
+      com.google.chrome)
+        osascript -e "tell application \"Google Chrome\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      com.apple.safari)
+        osascript -e "tell application \"Safari\" to set URL of current tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      company.thebrowser.Browser)
+        osascript -e "tell application \"Arc\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      com.brave.Browser)
+        osascript -e "tell application \"Brave Browser\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      *)
+        open "$URL" ;;
+    esac
 ```
 
-Replace `TARGET_URL` with the actual URL for each step. The `open` command launches the URL in whatever the user's default browser is.
+Replace `TARGET_URL` with the actual URL for each step. The `|| open` fallback handles the first navigation (when no browser window exists yet) and unknown browsers gracefully.
 
 ## Step Pattern
 
 Every step follows this rhythm:
 
-1. **Open the URL** via `open "https://..."`
+1. **Open the URL** using the browser-aware pattern above
 2. **Give a landmark-based instruction** — tell the user what to look for, not pixel-precise coordinates
 3. **User acts** and confirms
 4. **If the user reports a mismatch or is stuck** — offer to screenshot to see what they're seeing, then adapt
@@ -166,9 +180,12 @@ Wait for confirmation.
 
 ## Step 5: Configure OAuth Consent Screen
 
-This is the most variable step. Google has been actively redesigning this flow. Look for landmarks rather than assuming exact layout.
+This is the most variable step. Google has two different flows depending on whether the consent screen has been configured before:
 
-### Google Auth Platform Sidebar Reference
+- **New projects** → Google redirects to a **wizard** at `/auth/overview/create` with steps: App Information → Audience → Contact Information → Finish
+- **Previously configured projects** → Google shows separate pages: Branding, Audience, Data Access, etc.
+
+### Google Auth Platform Sidebar Reference (for previously configured projects)
 
 | Sidebar Item    | What It Contains                                             | URL Path         |
 | --------------- | ------------------------------------------------------------ | ---------------- |
@@ -178,13 +195,45 @@ This is the most variable step. Google has been actively redesigning this flow. 
 | **Data Access** | Scopes ("Add or Remove Scopes")                              | `/auth/scopes`   |
 | **Clients**     | OAuth client credentials                                     | `/auth/clients`  |
 
-### Step 5a: Branding / Initial setup
+### Step 5a: Open the consent screen
 
 Open: `https://console.cloud.google.com/auth/branding?project=PROJECT_ID`.
 
-The Branding page has App name, User support email, Developer contact email, and optionally logo/links. It does **not** have a User Type selector — that's on the Audience page (Step 5b).
+This may land on one of two pages:
 
-If the consent screen is already configured (app name and emails already filled in), recognize this and skip ahead.
+#### Case 1: Wizard flow (new/unconfigured projects)
+
+If the user lands on a page with numbered steps (App Information → Audience → Contact Information → Finish), or the URL shows `/auth/overview/create`, guide them through the wizard:
+
+> It looks like Google is showing the setup wizard. Let's walk through it:
+>
+> **Step 1 — App Information:**
+> - **App name:** `Vellum Assistant`
+> - Leave everything else as-is
+>
+> **Step 2 — Audience:**
+> - Select **External** — this lets any Google account authorize (it starts in testing mode, so only test users you add can access it)
+>
+> **Step 3 — Contact Information:**
+> - Enter your email address
+>
+> Then click **Create** at the bottom.
+
+Wait for confirmation. After the wizard completes, the user will be on the separate-page layout. **Skip Step 5b** (the wizard already set user type), and go directly to adding test users and scopes.
+
+Open the Audience page to add test users:
+
+Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`.
+
+> Great, the consent screen is configured! One more thing — scroll down to the **Test users** section, click **+ Add users**, enter your email address, and click **Save**.
+
+Wait for confirmation, then proceed to Step 5c.
+
+#### Case 2: Branding page (already configured projects)
+
+If the user sees a Branding page with fields for App name, User support email, Developer contact email — they've been here before or the consent screen is already set up.
+
+If already configured (app name and emails already filled in), skip ahead to Step 5b.
 
 If it needs setup:
 
@@ -195,9 +244,9 @@ If it needs setup:
 > 3. **Developer contact email:** enter your email
 > 4. Click **Save**
 
-Wait for confirmation. If already configured, skip directly to Step 5b.
+Wait for confirmation, then continue to Step 5b.
 
-### Step 5b: Audience and test users
+### Step 5b: Audience and test users (skip if wizard was used)
 
 Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`.
 
@@ -215,7 +264,21 @@ Copy the required scopes to the clipboard, then open the Data Access page:
 ```
 host_bash:
   command: |
-    echo -n "https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly" | pbcopy && open "https://console.cloud.google.com/auth/scopes?project=PROJECT_ID"
+    echo -n "https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly" | pbcopy
+    URL="https://console.cloud.google.com/auth/scopes?project=PROJECT_ID"
+    BROWSER=$(plutil -convert json -o - ~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist 2>/dev/null | python3 -c "import json,sys;[print(h['LSHandlerRoleAll']) for h in json.load(sys.stdin).get('LSHandlers',[]) if h.get('LSHandlerURLScheme')=='https']" 2>/dev/null)
+    case "$BROWSER" in
+      com.google.chrome)
+        osascript -e "tell application \"Google Chrome\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      com.apple.safari)
+        osascript -e "tell application \"Safari\" to set URL of current tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      company.thebrowser.Browser)
+        osascript -e "tell application \"Arc\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      com.brave.Browser)
+        osascript -e "tell application \"Brave Browser\" to set URL of active tab of front window to \"$URL\"" 2>/dev/null || open "$URL" ;;
+      *)
+        open "$URL" ;;
+    esac
 ```
 
 > Now I've opened the **Data Access** page and copied the required scopes to your clipboard. Click **Add or Remove Scopes**, find the **"Manually add scopes"** text box at the bottom, **paste** (Cmd+V), then click **Add to Table** (or **Update**), and **Save**.
@@ -365,7 +428,7 @@ When the user reports something doesn't look right, offer to take a screenshot t
 ## Guardrails
 
 - **No browser automation tools.** Path A uses `host_bash` + `open` for navigation. No `browser_*`, no CDP, no `computer_use_*` for navigation.
-- **Browser-agnostic.** Use `open` to launch URLs in the default browser. Do not use AppleScript to target any specific browser. Use `pbcopy` for clipboard operations.
+- **Browser-aware tab reuse.** Every URL navigation uses the self-contained detect-and-navigate snippet from the "Opening URLs" section. The assistant does not need to remember the browser — the snippet detects it each time. Falls back to `open` for unknown browsers or when no window exists. Use `pbcopy` for clipboard operations.
 - **Do not delete and recreate OAuth clients.** That orphans stored credentials.
 - **Do not leave the credential dialog early.** The Client Secret is shown only once.
 - **Google Cloud UI drift is normal.** Adapt instructions while preserving the same end state.

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -80,10 +80,11 @@ Tell the user:
 > **Then, regardless of which flow you saw:**
 >
 > - **Scopes** — Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
->   - Click **Add or Remove Scopes**
->   - Find the **"Manually add scopes"** text box and paste these (comma-separated):
+>   - Click **Add or Remove Scopes** — a panel will open
+>   - Scroll down to the **"Manually add scopes"** text box and paste these (comma-separated):
 >     `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
->   - Click **Add to Table**, then **Save**
+>   - Click **Update** at the bottom of the panel
+>   - Back on the main page, scroll down and click **Save**
 >
 > Let me know when all parts are done.
 

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -72,7 +72,6 @@ Tell the user:
 >   - User support email: **your email**
 >   - Developer contact email: **your email**
 >   - Click **Save**
->
 > - **3b. Audience** — Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
 >   - Set user type to **External** if not already set
 >   - Scroll to **Test users**, click **+ Add users**, add **your email**, click **Save**

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -54,32 +54,38 @@ Tell the user:
 
 > **Step 3: Configure the OAuth consent screen**
 >
-> This has a few parts. Work through them in order:
+> Open: `https://console.cloud.google.com/auth/branding?project=PROJECT_ID`
 >
-> **3a. Branding** — Open: `https://console.cloud.google.com/auth/branding?project=PROJECT_ID`
+> **If you see a setup wizard** (numbered steps: App Information → Audience → Contact Information → Finish):
 >
-> If the page is empty or shows **Get Started**, fill in:
+> 1. **App Information:** Set app name to **Vellum Assistant**
+> 2. **Audience:** Select **External**
+> 3. **Contact Information:** Enter your email
+> 4. Click **Create**
 >
-> - App name: **Vellum Assistant**
-> - User support email: **your email**
-> - Developer contact email: **your email**
-> - Click **Save**
+> After the wizard completes, open `https://console.cloud.google.com/auth/audience?project=PROJECT_ID` and scroll to **Test users** → click **+ Add users** → add your email → **Save**.
 >
-> If branding is already configured, skip to the next part.
+> **If you see a Branding page** (with fields for App name, support email, etc.):
 >
-> **3b. Audience** — Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
+> - **3a. Branding** — Fill in:
+>   - App name: **Vellum Assistant**
+>   - User support email: **your email**
+>   - Developer contact email: **your email**
+>   - Click **Save**
 >
-> - Set user type to **External** if not already set
-> - Scroll to **Test users**, click **+ Add users**, add **your email**, click **Save**
+> - **3b. Audience** — Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
+>   - Set user type to **External** if not already set
+>   - Scroll to **Test users**, click **+ Add users**, add **your email**, click **Save**
 >
-> **3c. Scopes** — Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
+> **Then, regardless of which flow you saw:**
 >
-> - Click **Add or Remove Scopes**
-> - Find the **"Manually add scopes"** text box and paste these (comma-separated):
->   `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
-> - Click **Add to Table**, then **Save**
+> - **Scopes** — Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
+>   - Click **Add or Remove Scopes**
+>   - Find the **"Manually add scopes"** text box and paste these (comma-separated):
+>     `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
+>   - Click **Add to Table**, then **Save**
 >
-> Let me know when all three parts are done.
+> Let me know when all parts are done.
 
 ## Path B Step 5: Create Web Application Credentials
 


### PR DESCRIPTION
## Summary
- **Wizard flow support**: Step 5 now detects whether GCP shows the combined wizard (`/auth/overview/create`) or the separate-page layout, and guides users through whichever flow they land on. Fixes the issue where users had to guess Internal vs External and got redundant Audience page confirmation.
- **Tab reuse**: Replaces raw `open` commands with a self-contained snippet that detects the default browser (Chrome, Safari, Arc, Brave) and navigates in the existing tab via AppleScript. Falls back to `open` for unknown browsers or first navigation.
- **Path B updated**: Manual channel setup also handles both wizard and separate-page flows.

## Test plan
- [ ] Run the OAuth setup flow on a fresh GCP project (no consent screen configured) — should get wizard guidance
- [ ] Run on a project with existing consent screen — should get separate-page guidance
- [ ] Verify tab reuse works (subsequent steps navigate in same tab, not new tabs)
- [ ] Verify first step still opens a new tab correctly (fallback when no window exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
