### PR TITLE
M1: Move error toast overlay from ChatView to MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -304,43 +304,6 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
-        .overlay(alignment: .top) {
-            VStack(spacing: VSpacing.xs) {
-                if !hasAPIKey {
-                    ChatSessionErrorToast(
-                        message: "API key not set. Add one in Settings to start chatting.",
-                        icon: .keyRound,
-                        accentColor: VColor.warning,
-                        actionLabel: "Open Settings",
-                        onAction: onOpenSettings
-                    )
-                }
-
-                if let sessionError {
-                    ChatSessionErrorToast(
-                        error: sessionError,
-                        onRetry: onRetry,
-                        onCopyDebugInfo: onCopyDebugInfo,
-                        onDismiss: onDismissSessionError
-                    )
-                }
-
-                if let errorText, sessionError == nil {
-                    ChatSessionErrorToast(
-                        message: errorText,
-                        subtitle: isConnectionError ? connectionDiagnosticHint : nil,
-                        actionLabel: isSecretBlockError ? "Send Anyway" : (isRetryableError || (isConnectionError && hasRetryPayload)) ? "Retry" : nil,
-                        onAction: isSecretBlockError ? onSendAnyway : (isRetryableError || (isConnectionError && hasRetryPayload)) ? onRetryError : nil,
-                        onDismiss: onDismissError
-                    )
-                }
-            }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.sm)
-            .animation(VAnimation.fast, value: hasAPIKey)
-            .animation(VAnimation.fast, value: sessionError != nil)
-            .animation(VAnimation.fast, value: errorText != nil)
-        }
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -8,22 +8,12 @@ struct ChatView: View {
     let hasAPIKey: Bool
     let isThinking: Bool
     let isSending: Bool
-    let errorText: String?
-    let pendingQueuedCount: Int
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
     var isLoadingAttachment: Bool = false
     let isRecording: Bool
-    let onOpenSettings: () -> Void
     let onSend: () -> Void
     let onStop: () -> Void
-    let onDismissError: () -> Void
-    let isRetryableError: Bool
-    let onRetryError: () -> Void
-    let isConnectionError: Bool
-    var hasRetryPayload: Bool = true
-    let isSecretBlockError: Bool
-    let onSendAnyway: () -> Void
     let onAcceptSuggestion: () -> Void
     let onAttach: () -> Void
     let onRemoveAttachment: (String) -> Void
@@ -45,10 +35,6 @@ struct ChatView: View {
     var onTemporaryAllow: ((String, String) -> Void)?
     var onGuardianAction: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
-    let sessionError: SessionError?
-    let onRetry: () -> Void
-    let onDismissSessionError: () -> Void
-    let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
@@ -70,7 +56,6 @@ struct ChatView: View {
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
-    var connectionDiagnosticHint: String? = nil
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
@@ -650,20 +635,11 @@ private struct ChatViewPreviewWrapper: View {
                 hasAPIKey: true,
                 isThinking: true,
                 isSending: false,
-                errorText: nil,
-                pendingQueuedCount: 0,
                 suggestion: "That sounds great, thanks!",
                 pendingAttachments: [],
                 isRecording: false,
-                onOpenSettings: {},
                 onSend: {},
                 onStop: {},
-                onDismissError: {},
-                isRetryableError: false,
-                onRetryError: {},
-                isConnectionError: false,
-                isSecretBlockError: false,
-                onSendAnyway: {},
                 onAcceptSuggestion: {},
                 onAttach: {},
                 onRemoveAttachment: { _ in },
@@ -679,10 +655,6 @@ private struct ChatViewPreviewWrapper: View {
                 onConfirmationDeny: { _ in },
                 onAlwaysAllow: { _, _, _, _ in },
                 onSurfaceAction: { _, _, _ in },
-                sessionError: nil,
-                onRetry: {},
-                onDismissSessionError: {},
-                onCopyDebugInfo: {},
                 watchSession: nil,
                 onStopWatch: {},
                 subagentDetailStore: SubagentDetailStore(),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -583,6 +583,45 @@ struct MainWindowView: View {
             }
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
+        .overlay(alignment: .top) {
+            VStack(spacing: VSpacing.xs) {
+                if !windowState.hasAPIKey {
+                    ChatSessionErrorToast(
+                        message: "API key not set. Add one in Settings to start chatting.",
+                        icon: .keyRound,
+                        accentColor: VColor.warning,
+                        actionLabel: "Open Settings",
+                        onAction: { windowState.selection = .panel(.settings) }
+                    )
+                }
+
+                if let sessionError = threadManager.activeViewModel?.sessionError {
+                    ChatSessionErrorToast(
+                        error: sessionError,
+                        onRetry: { threadManager.activeViewModel?.retryAfterSessionError() },
+                        onCopyDebugInfo: { threadManager.activeViewModel?.copySessionErrorDebugDetails() },
+                        onDismiss: { threadManager.activeViewModel?.dismissSessionError() }
+                    )
+                }
+
+                if let errorText = threadManager.activeViewModel?.errorText,
+                   threadManager.activeViewModel?.sessionError == nil {
+                    let vm = threadManager.activeViewModel!
+                    ChatSessionErrorToast(
+                        message: errorText,
+                        subtitle: vm.isConnectionError ? vm.connectionDiagnosticHint : nil,
+                        actionLabel: vm.isSecretBlockError ? "Send Anyway" : (vm.isRetryableError || (vm.isConnectionError && vm.hasRetryPayload)) ? "Retry" : nil,
+                        onAction: vm.isSecretBlockError ? { vm.sendAnyway() } : (vm.isRetryableError || (vm.isConnectionError && vm.hasRetryPayload)) ? { vm.retryLastMessage() } : nil,
+                        onDismiss: { vm.dismissError() }
+                    )
+                }
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .padding(.top, VSpacing.sm)
+            .animation(VAnimation.fast, value: windowState.hasAPIKey)
+            .animation(VAnimation.fast, value: threadManager.activeViewModel?.sessionError != nil)
+            .animation(VAnimation.fast, value: threadManager.activeViewModel?.errorText != nil)
+        }
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
                 VToast(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -584,8 +584,14 @@ struct MainWindowView: View {
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
         .overlay(alignment: .top) {
-            VStack(spacing: VSpacing.xs) {
-                if !windowState.hasAPIKey {
+            if let viewModel = threadManager.activeViewModel {
+                ErrorToastOverlay(
+                    viewModel: viewModel,
+                    hasAPIKey: windowState.hasAPIKey,
+                    onOpenSettings: { windowState.selection = .panel(.settings) }
+                )
+            } else if !windowState.hasAPIKey {
+                VStack(spacing: VSpacing.xs) {
                     ChatSessionErrorToast(
                         message: "API key not set. Add one in Settings to start chatting.",
                         icon: .keyRound,
@@ -594,33 +600,10 @@ struct MainWindowView: View {
                         onAction: { windowState.selection = .panel(.settings) }
                     )
                 }
-
-                if let sessionError = threadManager.activeViewModel?.sessionError {
-                    ChatSessionErrorToast(
-                        error: sessionError,
-                        onRetry: { threadManager.activeViewModel?.retryAfterSessionError() },
-                        onCopyDebugInfo: { threadManager.activeViewModel?.copySessionErrorDebugDetails() },
-                        onDismiss: { threadManager.activeViewModel?.dismissSessionError() }
-                    )
-                }
-
-                if let errorText = threadManager.activeViewModel?.errorText,
-                   threadManager.activeViewModel?.sessionError == nil {
-                    let vm = threadManager.activeViewModel!
-                    ChatSessionErrorToast(
-                        message: errorText,
-                        subtitle: vm.isConnectionError ? vm.connectionDiagnosticHint : nil,
-                        actionLabel: vm.isSecretBlockError ? "Send Anyway" : (vm.isRetryableError || (vm.isConnectionError && vm.hasRetryPayload)) ? "Retry" : nil,
-                        onAction: vm.isSecretBlockError ? { vm.sendAnyway() } : (vm.isRetryableError || (vm.isConnectionError && vm.hasRetryPayload)) ? { vm.retryLastMessage() } : nil,
-                        onDismiss: { vm.dismissError() }
-                    )
-                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.top, VSpacing.sm)
+                .animation(VAnimation.fast, value: windowState.hasAPIKey)
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.sm)
-            .animation(VAnimation.fast, value: windowState.hasAPIKey)
-            .animation(VAnimation.fast, value: threadManager.activeViewModel?.sessionError != nil)
-            .animation(VAnimation.fast, value: threadManager.activeViewModel?.errorText != nil)
         }
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
@@ -852,4 +835,57 @@ struct MainWindowView: View {
         // SidebarInteractionState.setThreadHover(threadId:hovering:)
     }
 
+}
+
+// MARK: - Error Toast Overlay
+
+/// Wrapper view that directly observes a `ChatViewModel` via `@ObservedObject`,
+/// ensuring error state changes (sessionError, errorText) trigger UI updates
+/// even though MainWindowView only observes ThreadManager.
+///
+/// By capturing the viewModel reference at render-time, closures always act on
+/// the correct thread's ViewModel — even if the user switches threads while a
+/// toast is visible.
+private struct ErrorToastOverlay: View {
+    @ObservedObject var viewModel: ChatViewModel
+    let hasAPIKey: Bool
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.xs) {
+            if !hasAPIKey {
+                ChatSessionErrorToast(
+                    message: "API key not set. Add one in Settings to start chatting.",
+                    icon: .keyRound,
+                    accentColor: VColor.warning,
+                    actionLabel: "Open Settings",
+                    onAction: onOpenSettings
+                )
+            }
+
+            if let sessionError = viewModel.sessionError {
+                ChatSessionErrorToast(
+                    error: sessionError,
+                    onRetry: { viewModel.retryAfterSessionError() },
+                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                    onDismiss: { viewModel.dismissSessionError() }
+                )
+            }
+
+            if let errorText = viewModel.errorText, viewModel.sessionError == nil {
+                ChatSessionErrorToast(
+                    message: errorText,
+                    subtitle: viewModel.isConnectionError ? viewModel.connectionDiagnosticHint : nil,
+                    actionLabel: viewModel.isSecretBlockError ? "Send Anyway" : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? "Retry" : nil,
+                    onAction: viewModel.isSecretBlockError ? { viewModel.sendAnyway() } : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? { viewModel.retryLastMessage() } : nil,
+                    onDismiss: { viewModel.dismissError() }
+                )
+            }
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.top, VSpacing.sm)
+        .animation(VAnimation.fast, value: hasAPIKey)
+        .animation(VAnimation.fast, value: viewModel.sessionError != nil)
+        .animation(VAnimation.fast, value: viewModel.errorText != nil)
+    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -599,27 +599,15 @@ struct ActiveChatViewWrapper: View {
             hasAPIKey: windowState.hasAPIKey,
             isThinking: viewModel.isThinking,
             isSending: viewModel.isSending,
-            errorText: viewModel.errorText,
-            pendingQueuedCount: viewModel.pendingQueuedCount,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,
             isLoadingAttachment: viewModel.isLoadingAttachment,
             isRecording: viewModel.isRecording,
-            onOpenSettings: {
-                windowState.selection = .panel(.settings)
-            },
             onSend: {
                 if viewModel.isRecording { onMicrophoneToggle() }
                 viewModel.sendMessage()
             },
             onStop: viewModel.stopGenerating,
-            onDismissError: viewModel.dismissError,
-            isRetryableError: viewModel.isRetryableError,
-            onRetryError: { viewModel.retryLastMessage() },
-            isConnectionError: viewModel.isConnectionError,
-            hasRetryPayload: viewModel.hasRetryPayload,
-            isSecretBlockError: viewModel.isSecretBlockError,
-            onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,
             onAttach: { openFilePicker(viewModel: viewModel) },
             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
@@ -652,10 +640,6 @@ struct ActiveChatViewWrapper: View {
             onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
             onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
-            sessionError: viewModel.sessionError,
-            onRetry: { viewModel.retryAfterSessionError() },
-            onDismissSessionError: { viewModel.dismissSessionError() },
-            onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
             watchSession: ambientAgent.activeWatchSession,
             onStopWatch: { viewModel.stopWatchSession() },
             onReportMessage: { daemonMessageId in
@@ -699,7 +683,7 @@ struct ActiveChatViewWrapper: View {
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
-            connectionDiagnosticHint: viewModel.connectionDiagnosticHint,
+
             voiceModeManager: voiceModeManager,
             voiceService: voiceService,
             onEndVoiceMode: onEndVoiceMode,


### PR DESCRIPTION
## Summary
- Removed error toast overlay (`.overlay(alignment: .top)`) from `ChatView.swift` — the block rendering `ChatSessionErrorToast` for API key missing, session errors, and general error text
- Added equivalent error toast overlay to `MainWindowView.swift` at the top level, so error toasts are visible on all panels (Chat, Settings, Debug), not just Chat
- Wired up error state from `threadManager.activeViewModel` and `windowState.hasAPIKey` with matching action callbacks and animation modifiers

## Test plan
- [ ] Verify error toasts appear when on the Chat panel (same as before)
- [ ] Verify error toasts appear when on the Settings panel
- [ ] Verify error toasts appear when on the Debug panel
- [ ] Verify "API key not set" toast shows with "Open Settings" action
- [ ] Verify session error toasts show retry/dismiss/copy-debug actions
- [ ] Verify general error toasts show appropriate retry/dismiss actions
- [ ] Verify toast animations (slide in/out) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
