### PR TITLE
Show error toasts on all windows, not just ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -69,7 +69,6 @@ struct ChatSessionErrorToast: View {
     var body: some View {
         HStack(spacing: VSpacing.sm) {
             VIconView(icon, size: 14)
-                .offset(y: -1)
 
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(message)
@@ -86,15 +85,17 @@ struct ChatSessionErrorToast: View {
                 }
             }
 
-            Spacer()
+            if actionLabel != nil || showCopyDebug || onDismiss != nil {
+                Spacer(minLength: 100)
+            }
 
             if let actionLabel, let onAction {
                 Button(action: onAction) {
                     Text(actionLabel)
-                        .font(VFont.bodyMedium)
+                        .font(VFont.caption)
                         .foregroundColor(.white)
-                        .padding(.horizontal, VSpacing.md)
-                        .frame(height: 28)
+                        .padding(.horizontal, VSpacing.sm)
+                        .frame(height: 24)
                         .overlay(
                             RoundedRectangle(cornerRadius: VRadius.md)
                                 .strokeBorder(Color.white, lineWidth: 1.5)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -47,8 +47,8 @@ struct ChatSessionErrorToast: View {
     init(
         message: String,
         subtitle: String? = nil,
-        icon: VIcon = .triangleAlert,
-        accentColor: Color = VColor.error,
+        icon: VIcon = .circleAlert,
+        accentColor: Color = Danger._700,
         actionLabel: String? = nil,
         onAction: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
@@ -89,7 +89,19 @@ struct ChatSessionErrorToast: View {
             Spacer()
 
             if let actionLabel, let onAction {
-                VButton(label: actionLabel, style: .ghost, size: .medium, action: onAction)
+                Button(action: onAction) {
+                    Text(actionLabel)
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, VSpacing.md)
+                        .frame(height: 28)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .strokeBorder(Color.white, lineWidth: 1.5)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(actionLabel)
             }
 
             if showCopyDebug, let onCopyDebugInfo {
@@ -143,7 +155,7 @@ struct ChatSessionErrorToast: View {
         case .authenticationRequired:
             return .lock
         case .unknown:
-            return .triangleAlert
+            return .circleAlert
         }
     }
 
@@ -152,15 +164,15 @@ struct ChatSessionErrorToast: View {
     private static func accentColor(for category: SessionErrorCategory) -> Color {
         switch category {
         case .rateLimit:
-            return VColor.warning
+            return Amber._550
         case .providerNetwork:
-            return Amber._500
+            return Amber._550
         case .sessionAborted:
-            return VColor.textSecondary
+            return Forest._700
         case .contextTooLarge:
-            return VColor.warning
+            return Amber._550
         default:
-            return VColor.error
+            return Danger._700
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -89,16 +89,7 @@ struct ChatSessionErrorToast: View {
             Spacer()
 
             if let actionLabel, let onAction {
-                Button(action: onAction) {
-                    Text(actionLabel)
-                        .font(VFont.captionMedium)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.vertical, VSpacing.xs)
-                        .background(Color.white.opacity(0.2)) // Intentional: translucent contrast on solid accent background
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(actionLabel)
+                VButton(label: actionLabel, style: .ghost, size: .medium, action: onAction)
             }
 
             if showCopyDebug, let onCopyDebugInfo {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -72,7 +72,7 @@ struct ChatSessionErrorToast: View {
 
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 Text(message)
-                    .font(VFont.caption)
+                    .font(VFont.body)
                     .lineLimit(4)
                     .textSelection(.enabled)
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -8,22 +8,12 @@ struct ChatView: View {
     let hasAPIKey: Bool
     let isThinking: Bool
     let isSending: Bool
-    let errorText: String?
-    let pendingQueuedCount: Int
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
     var isLoadingAttachment: Bool = false
     let isRecording: Bool
-    let onOpenSettings: () -> Void
     let onSend: () -> Void
     let onStop: () -> Void
-    let onDismissError: () -> Void
-    let isRetryableError: Bool
-    let onRetryError: () -> Void
-    let isConnectionError: Bool
-    var hasRetryPayload: Bool = true
-    let isSecretBlockError: Bool
-    let onSendAnyway: () -> Void
     let onAcceptSuggestion: () -> Void
     let onAttach: () -> Void
     let onRemoveAttachment: (String) -> Void
@@ -45,10 +35,6 @@ struct ChatView: View {
     var onTemporaryAllow: ((String, String) -> Void)?
     var onGuardianAction: ((String, String) -> Void)?
     let onSurfaceAction: (String, String, [String: AnyCodable]?) -> Void
-    let sessionError: SessionError?
-    let onRetry: () -> Void
-    let onDismissSessionError: () -> Void
-    let onCopyDebugInfo: () -> Void
     let watchSession: WatchSession?
     let onStopWatch: () -> Void
     var onReportMessage: ((String?) -> Void)?
@@ -70,7 +56,6 @@ struct ChatView: View {
     var isHistoryLoaded: Bool = true
     var dismissedDocumentSurfaceIds: Set<String> = []
     var onDismissDocumentWidget: ((String) -> Void)?
-    var connectionDiagnosticHint: String? = nil
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
@@ -303,43 +288,6 @@ struct ChatView: View {
                     .allowsHitTesting(false)
                     .transition(.opacity)
             }
-        }
-        .overlay(alignment: .top) {
-            VStack(spacing: VSpacing.xs) {
-                if !hasAPIKey {
-                    ChatSessionErrorToast(
-                        message: "API key not set. Add one in Settings to start chatting.",
-                        icon: .keyRound,
-                        accentColor: VColor.warning,
-                        actionLabel: "Open Settings",
-                        onAction: onOpenSettings
-                    )
-                }
-
-                if let sessionError {
-                    ChatSessionErrorToast(
-                        error: sessionError,
-                        onRetry: onRetry,
-                        onCopyDebugInfo: onCopyDebugInfo,
-                        onDismiss: onDismissSessionError
-                    )
-                }
-
-                if let errorText, sessionError == nil {
-                    ChatSessionErrorToast(
-                        message: errorText,
-                        subtitle: isConnectionError ? connectionDiagnosticHint : nil,
-                        actionLabel: isSecretBlockError ? "Send Anyway" : (isRetryableError || (isConnectionError && hasRetryPayload)) ? "Retry" : nil,
-                        onAction: isSecretBlockError ? onSendAnyway : (isRetryableError || (isConnectionError && hasRetryPayload)) ? onRetryError : nil,
-                        onDismiss: onDismissError
-                    )
-                }
-            }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.sm)
-            .animation(VAnimation.fast, value: hasAPIKey)
-            .animation(VAnimation.fast, value: sessionError != nil)
-            .animation(VAnimation.fast, value: errorText != nil)
         }
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
@@ -687,20 +635,11 @@ private struct ChatViewPreviewWrapper: View {
                 hasAPIKey: true,
                 isThinking: true,
                 isSending: false,
-                errorText: nil,
-                pendingQueuedCount: 0,
                 suggestion: "That sounds great, thanks!",
                 pendingAttachments: [],
                 isRecording: false,
-                onOpenSettings: {},
                 onSend: {},
                 onStop: {},
-                onDismissError: {},
-                isRetryableError: false,
-                onRetryError: {},
-                isConnectionError: false,
-                isSecretBlockError: false,
-                onSendAnyway: {},
                 onAcceptSuggestion: {},
                 onAttach: {},
                 onRemoveAttachment: { _ in },
@@ -716,10 +655,6 @@ private struct ChatViewPreviewWrapper: View {
                 onConfirmationDeny: { _ in },
                 onAlwaysAllow: { _, _, _, _ in },
                 onSurfaceAction: { _, _, _ in },
-                sessionError: nil,
-                onRetry: {},
-                onDismissSessionError: {},
-                onCopyDebugInfo: {},
                 watchSession: nil,
                 onStopWatch: {},
                 subagentDetailStore: SubagentDetailStore(),

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -586,9 +586,19 @@ struct MainWindowView: View {
         .overlay(alignment: .top) {
             if let viewModel = threadManager.activeViewModel {
                 ErrorToastOverlay(
-                    viewModel: viewModel,
+                    errorManager: viewModel.errorManager,
                     hasAPIKey: windowState.hasAPIKey,
-                    onOpenSettings: { windowState.selection = .panel(.settings) }
+                    isConnectionError: viewModel.isConnectionError,
+                    isSecretBlockError: viewModel.isSecretBlockError,
+                    isRetryableError: viewModel.isRetryableError,
+                    hasRetryPayload: viewModel.hasRetryPayload,
+                    onOpenSettings: { windowState.selection = .panel(.settings) },
+                    onRetrySessionError: { viewModel.retryAfterSessionError() },
+                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                    onDismissSessionError: { viewModel.dismissSessionError() },
+                    onSendAnyway: { viewModel.sendAnyway() },
+                    onRetryLastMessage: { viewModel.retryLastMessage() },
+                    onDismissError: { viewModel.dismissError() }
                 )
             } else if !windowState.hasAPIKey {
                 VStack(spacing: VSpacing.xs) {
@@ -847,9 +857,19 @@ struct MainWindowView: View {
 /// the correct thread's ViewModel — even if the user switches threads while a
 /// toast is visible.
 private struct ErrorToastOverlay: View {
-    @ObservedObject var viewModel: ChatViewModel
+    @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
+    let isConnectionError: Bool
+    let isSecretBlockError: Bool
+    let isRetryableError: Bool
+    let hasRetryPayload: Bool
     let onOpenSettings: () -> Void
+    let onRetrySessionError: () -> Void
+    let onCopyDebugInfo: () -> Void
+    let onDismissSessionError: () -> Void
+    let onSendAnyway: () -> Void
+    let onRetryLastMessage: () -> Void
+    let onDismissError: () -> Void
 
     var body: some View {
         VStack(spacing: VSpacing.xs) {
@@ -863,29 +883,29 @@ private struct ErrorToastOverlay: View {
                 )
             }
 
-            if let sessionError = viewModel.sessionError {
+            if let sessionError = errorManager.sessionError {
                 ChatSessionErrorToast(
                     error: sessionError,
-                    onRetry: { viewModel.retryAfterSessionError() },
-                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
-                    onDismiss: { viewModel.dismissSessionError() }
+                    onRetry: onRetrySessionError,
+                    onCopyDebugInfo: onCopyDebugInfo,
+                    onDismiss: onDismissSessionError
                 )
             }
 
-            if let errorText = viewModel.errorText, viewModel.sessionError == nil {
+            if let errorText = errorManager.errorText, errorManager.sessionError == nil {
                 ChatSessionErrorToast(
                     message: errorText,
-                    subtitle: viewModel.isConnectionError ? viewModel.connectionDiagnosticHint : nil,
-                    actionLabel: viewModel.isSecretBlockError ? "Send Anyway" : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? "Retry" : nil,
-                    onAction: viewModel.isSecretBlockError ? { viewModel.sendAnyway() } : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? { viewModel.retryLastMessage() } : nil,
-                    onDismiss: { viewModel.dismissError() }
+                    subtitle: isConnectionError ? errorManager.connectionDiagnosticHint : nil,
+                    actionLabel: isSecretBlockError ? "Send Anyway" : (isRetryableError || (isConnectionError && hasRetryPayload)) ? "Retry" : nil,
+                    onAction: isSecretBlockError ? onSendAnyway : (isRetryableError || (isConnectionError && hasRetryPayload)) ? onRetryLastMessage : nil,
+                    onDismiss: onDismissError
                 )
             }
         }
         .padding(.horizontal, VSpacing.xl)
         .padding(.top, VSpacing.sm)
         .animation(VAnimation.fast, value: hasAPIKey)
-        .animation(VAnimation.fast, value: viewModel.sessionError != nil)
-        .animation(VAnimation.fast, value: viewModel.errorText != nil)
+        .animation(VAnimation.fast, value: errorManager.sessionError != nil)
+        .animation(VAnimation.fast, value: errorManager.errorText != nil)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -583,6 +583,28 @@ struct MainWindowView: View {
             }
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
+        .overlay(alignment: .top) {
+            if let viewModel = threadManager.activeViewModel {
+                ErrorToastOverlay(
+                    viewModel: viewModel,
+                    hasAPIKey: windowState.hasAPIKey,
+                    onOpenSettings: { windowState.selection = .panel(.settings) }
+                )
+            } else if !windowState.hasAPIKey {
+                VStack(spacing: VSpacing.xs) {
+                    ChatSessionErrorToast(
+                        message: "API key not set. Add one in Settings to start chatting.",
+                        icon: .keyRound,
+                        accentColor: VColor.warning,
+                        actionLabel: "Open Settings",
+                        onAction: { windowState.selection = .panel(.settings) }
+                    )
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.top, VSpacing.sm)
+                .animation(VAnimation.fast, value: windowState.hasAPIKey)
+            }
+        }
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
                 VToast(
@@ -813,4 +835,57 @@ struct MainWindowView: View {
         // SidebarInteractionState.setThreadHover(threadId:hovering:)
     }
 
+}
+
+// MARK: - Error Toast Overlay
+
+/// Wrapper view that directly observes a `ChatViewModel` via `@ObservedObject`,
+/// ensuring error state changes (sessionError, errorText) trigger UI updates
+/// even though MainWindowView only observes ThreadManager.
+///
+/// By capturing the viewModel reference at render-time, closures always act on
+/// the correct thread's ViewModel — even if the user switches threads while a
+/// toast is visible.
+private struct ErrorToastOverlay: View {
+    @ObservedObject var viewModel: ChatViewModel
+    let hasAPIKey: Bool
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: VSpacing.xs) {
+            if !hasAPIKey {
+                ChatSessionErrorToast(
+                    message: "API key not set. Add one in Settings to start chatting.",
+                    icon: .keyRound,
+                    accentColor: VColor.warning,
+                    actionLabel: "Open Settings",
+                    onAction: onOpenSettings
+                )
+            }
+
+            if let sessionError = viewModel.sessionError {
+                ChatSessionErrorToast(
+                    error: sessionError,
+                    onRetry: { viewModel.retryAfterSessionError() },
+                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                    onDismiss: { viewModel.dismissSessionError() }
+                )
+            }
+
+            if let errorText = viewModel.errorText, viewModel.sessionError == nil {
+                ChatSessionErrorToast(
+                    message: errorText,
+                    subtitle: viewModel.isConnectionError ? viewModel.connectionDiagnosticHint : nil,
+                    actionLabel: viewModel.isSecretBlockError ? "Send Anyway" : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? "Retry" : nil,
+                    onAction: viewModel.isSecretBlockError ? { viewModel.sendAnyway() } : (viewModel.isRetryableError || (viewModel.isConnectionError && viewModel.hasRetryPayload)) ? { viewModel.retryLastMessage() } : nil,
+                    onDismiss: { viewModel.dismissError() }
+                )
+            }
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.top, VSpacing.sm)
+        .animation(VAnimation.fast, value: hasAPIKey)
+        .animation(VAnimation.fast, value: viewModel.sessionError != nil)
+        .animation(VAnimation.fast, value: viewModel.errorText != nil)
+    }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -584,35 +584,41 @@ struct MainWindowView: View {
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
         .overlay(alignment: .top) {
-            if let viewModel = threadManager.activeViewModel {
-                ErrorToastOverlay(
-                    errorManager: viewModel.errorManager,
-                    hasAPIKey: windowState.hasAPIKey,
-                    isConnectionError: viewModel.isConnectionError,
-                    isSecretBlockError: viewModel.isSecretBlockError,
-                    isRetryableError: viewModel.isRetryableError,
-                    hasRetryPayload: viewModel.hasRetryPayload,
-                    onOpenSettings: { windowState.selection = .panel(.settings) },
-                    onRetrySessionError: { viewModel.retryAfterSessionError() },
-                    onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
-                    onDismissSessionError: { viewModel.dismissSessionError() },
-                    onSendAnyway: { viewModel.sendAnyway() },
-                    onRetryLastMessage: { viewModel.retryLastMessage() },
-                    onDismissError: { viewModel.dismissError() }
-                )
-            } else if !windowState.hasAPIKey {
-                VStack(spacing: VSpacing.xs) {
-                    ChatSessionErrorToast(
-                        message: "API key not set. Add one in Settings to start chatting.",
-                        icon: .keyRound,
-                        accentColor: VColor.warning,
-                        actionLabel: "Open Settings",
-                        onAction: { windowState.selection = .panel(.settings) }
-                    )
+            GeometryReader { geo in
+                Group {
+                    if let viewModel = threadManager.activeViewModel {
+                        ErrorToastOverlay(
+                            errorManager: viewModel.errorManager,
+                            hasAPIKey: windowState.hasAPIKey,
+                            isConnectionError: viewModel.isConnectionError,
+                            isSecretBlockError: viewModel.isSecretBlockError,
+                            isRetryableError: viewModel.isRetryableError,
+                            hasRetryPayload: viewModel.hasRetryPayload,
+                            maxWidth: geo.size.width * 0.7,
+                            onOpenSettings: { windowState.selection = .panel(.settings) },
+                            onRetrySessionError: { viewModel.retryAfterSessionError() },
+                            onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                            onDismissSessionError: { viewModel.dismissSessionError() },
+                            onSendAnyway: { viewModel.sendAnyway() },
+                            onRetryLastMessage: { viewModel.retryLastMessage() },
+                            onDismissError: { viewModel.dismissError() }
+                        )
+                    } else if !windowState.hasAPIKey {
+                        VStack(spacing: VSpacing.xs) {
+                            ChatSessionErrorToast(
+                                message: "API key not set. Add one in Settings to start chatting.",
+                                icon: .keyRound,
+                                accentColor: VColor.warning,
+                                actionLabel: "Open Settings",
+                                onAction: { windowState.selection = .panel(.settings) }
+                            )
+                        }
+                        .frame(maxWidth: geo.size.width * 0.7)
+                        .padding(.top, VSpacing.sm)
+                        .animation(VAnimation.fast, value: windowState.hasAPIKey)
+                    }
                 }
-                .padding(.horizontal, VSpacing.xl)
-                .padding(.top, VSpacing.sm)
-                .animation(VAnimation.fast, value: windowState.hasAPIKey)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
         }
         .overlay(alignment: .bottom) {
@@ -863,6 +869,7 @@ private struct ErrorToastOverlay: View {
     let isSecretBlockError: Bool
     let isRetryableError: Bool
     let hasRetryPayload: Bool
+    var maxWidth: CGFloat = .infinity
     let onOpenSettings: () -> Void
     let onRetrySessionError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -902,7 +909,7 @@ private struct ErrorToastOverlay: View {
                 )
             }
         }
-        .padding(.horizontal, VSpacing.xl)
+        .frame(maxWidth: maxWidth)
         .padding(.top, VSpacing.sm)
         .animation(VAnimation.fast, value: hasAPIKey)
         .animation(VAnimation.fast, value: errorManager.sessionError != nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -604,15 +604,14 @@ struct MainWindowView: View {
                             onDismissError: { viewModel.dismissError() }
                         )
                     } else if !windowState.hasAPIKey {
-                        VStack(spacing: VSpacing.xs) {
-                            ChatSessionErrorToast(
-                                message: "API key not set. Add one in Settings to start chatting.",
-                                icon: .keyRound,
-                                accentColor: Amber._550,
-                                actionLabel: "Open Settings",
-                                onAction: { windowState.selection = .panel(.settings) }
-                            )
-                        }
+                        ChatSessionErrorToast(
+                            message: "API key not set. Add one in Settings to start chatting.",
+                            icon: .keyRound,
+                            accentColor: Amber._550,
+                            actionLabel: "Open Settings",
+                            onAction: { windowState.selection = .panel(.settings) }
+                        )
+                        .fixedSize(horizontal: true, vertical: false)
                         .frame(maxWidth: geo.size.width * 0.7)
                         .padding(.top, VSpacing.sm)
                         .animation(VAnimation.fast, value: windowState.hasAPIKey)
@@ -621,7 +620,6 @@ struct MainWindowView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
-
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
                 VToast(
@@ -880,7 +878,7 @@ private struct ErrorToastOverlay: View {
     let onDismissError: () -> Void
 
     var body: some View {
-        VStack(spacing: VSpacing.xs) {
+        VStack(alignment: .center, spacing: VSpacing.xs) {
             if !hasAPIKey {
                 ChatSessionErrorToast(
                     message: "API key not set. Add one in Settings to start chatting.",
@@ -889,6 +887,8 @@ private struct ErrorToastOverlay: View {
                     actionLabel: "Open Settings",
                     onAction: onOpenSettings
                 )
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: maxWidth)
             }
 
             if let sessionError = errorManager.sessionError {
@@ -898,6 +898,8 @@ private struct ErrorToastOverlay: View {
                     onCopyDebugInfo: onCopyDebugInfo,
                     onDismiss: onDismissSessionError
                 )
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: maxWidth)
             }
 
             if let errorText = errorManager.errorText, errorManager.sessionError == nil {
@@ -908,9 +910,10 @@ private struct ErrorToastOverlay: View {
                     onAction: isSecretBlockError ? onSendAnyway : (isRetryableError || (isConnectionError && hasRetryPayload)) ? onRetryLastMessage : nil,
                     onDismiss: onDismissError
                 )
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxWidth: maxWidth)
             }
         }
-        .frame(maxWidth: maxWidth)
         .padding(.top, VSpacing.sm)
         .animation(VAnimation.fast, value: hasAPIKey)
         .animation(VAnimation.fast, value: errorManager.sessionError != nil)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -608,7 +608,7 @@ struct MainWindowView: View {
                             ChatSessionErrorToast(
                                 message: "API key not set. Add one in Settings to start chatting.",
                                 icon: .keyRound,
-                                accentColor: VColor.warning,
+                                accentColor: Amber._550,
                                 actionLabel: "Open Settings",
                                 onAction: { windowState.selection = .panel(.settings) }
                             )
@@ -621,6 +621,7 @@ struct MainWindowView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
+
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
                 VToast(
@@ -884,7 +885,7 @@ private struct ErrorToastOverlay: View {
                 ChatSessionErrorToast(
                     message: "API key not set. Add one in Settings to start chatting.",
                     icon: .keyRound,
-                    accentColor: VColor.warning,
+                    accentColor: Amber._550,
                     actionLabel: "Open Settings",
                     onAction: onOpenSettings
                 )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -584,41 +584,34 @@ struct MainWindowView: View {
         }
         .animation(VAnimation.fast, value: zoomManager.showZoomIndicator)
         .overlay(alignment: .top) {
-            GeometryReader { geo in
-                Group {
-                    if let viewModel = threadManager.activeViewModel {
-                        ErrorToastOverlay(
-                            errorManager: viewModel.errorManager,
-                            hasAPIKey: windowState.hasAPIKey,
-                            isConnectionError: viewModel.isConnectionError,
-                            isSecretBlockError: viewModel.isSecretBlockError,
-                            isRetryableError: viewModel.isRetryableError,
-                            hasRetryPayload: viewModel.hasRetryPayload,
-                            maxWidth: geo.size.width * 0.7,
-                            onOpenSettings: { windowState.selection = .panel(.settings) },
-                            onRetrySessionError: { viewModel.retryAfterSessionError() },
-                            onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
-                            onDismissSessionError: { viewModel.dismissSessionError() },
-                            onSendAnyway: { viewModel.sendAnyway() },
-                            onRetryLastMessage: { viewModel.retryLastMessage() },
-                            onDismissError: { viewModel.dismissError() }
-                        )
-                    } else if !windowState.hasAPIKey {
-                        ChatSessionErrorToast(
-                            message: "API key not set. Add one in Settings to start chatting.",
-                            icon: .keyRound,
-                            accentColor: Amber._550,
-                            actionLabel: "Open Settings",
-                            onAction: { windowState.selection = .panel(.settings) }
-                        )
-                        .fixedSize(horizontal: true, vertical: false)
-                        .frame(maxWidth: geo.size.width * 0.7)
-                        .padding(.top, VSpacing.sm)
-                        .animation(VAnimation.fast, value: windowState.hasAPIKey)
-                    }
+            Group {
+                if let viewModel = threadManager.activeViewModel {
+                    ErrorToastOverlay(
+                        errorManager: viewModel.errorManager,
+                        hasAPIKey: windowState.hasAPIKey,
+                        onOpenSettings: { windowState.selection = .panel(.settings) },
+                        onRetrySessionError: { viewModel.retryAfterSessionError() },
+                        onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
+                        onDismissSessionError: { viewModel.dismissSessionError() },
+                        onSendAnyway: { viewModel.sendAnyway() },
+                        onRetryLastMessage: { viewModel.retryLastMessage() },
+                        onDismissError: { viewModel.dismissError() }
+                    )
+                } else if !windowState.hasAPIKey {
+                    ChatSessionErrorToast(
+                        message: "API key not set. Add one in Settings to start chatting.",
+                        icon: .keyRound,
+                        accentColor: Amber._550,
+                        actionLabel: "Open Settings",
+                        onAction: { windowState.selection = .panel(.settings) }
+                    )
+                    .fixedSize(horizontal: true, vertical: false)
+                    .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
+                    .padding(.top, VSpacing.sm)
+                    .animation(VAnimation.fast, value: windowState.hasAPIKey)
                 }
-                .frame(maxWidth: .infinity, alignment: .center)
             }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .overlay(alignment: .bottom) {
             if let toast = windowState.toastInfo {
@@ -864,11 +857,6 @@ struct MainWindowView: View {
 private struct ErrorToastOverlay: View {
     @ObservedObject var errorManager: ChatErrorManager
     let hasAPIKey: Bool
-    let isConnectionError: Bool
-    let isSecretBlockError: Bool
-    let isRetryableError: Bool
-    let hasRetryPayload: Bool
-    var maxWidth: CGFloat = .infinity
     let onOpenSettings: () -> Void
     let onRetrySessionError: () -> Void
     let onCopyDebugInfo: () -> Void
@@ -888,7 +876,7 @@ private struct ErrorToastOverlay: View {
                     onAction: onOpenSettings
                 )
                 .fixedSize(horizontal: true, vertical: false)
-                .frame(maxWidth: maxWidth)
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
             if let sessionError = errorManager.sessionError {
@@ -899,19 +887,19 @@ private struct ErrorToastOverlay: View {
                     onDismiss: onDismissSessionError
                 )
                 .fixedSize(horizontal: true, vertical: false)
-                .frame(maxWidth: maxWidth)
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
 
             if let errorText = errorManager.errorText, errorManager.sessionError == nil {
                 ChatSessionErrorToast(
                     message: errorText,
-                    subtitle: isConnectionError ? errorManager.connectionDiagnosticHint : nil,
-                    actionLabel: isSecretBlockError ? "Send Anyway" : (isRetryableError || (isConnectionError && hasRetryPayload)) ? "Retry" : nil,
-                    onAction: isSecretBlockError ? onSendAnyway : (isRetryableError || (isConnectionError && hasRetryPayload)) ? onRetryLastMessage : nil,
+                    subtitle: errorManager.isConnectionError ? errorManager.connectionDiagnosticHint : nil,
+                    actionLabel: errorManager.isSecretBlockError ? "Send Anyway" : (errorManager.isRetryableError || (errorManager.isConnectionError && errorManager.hasRetryPayload)) ? "Retry" : nil,
+                    onAction: errorManager.isSecretBlockError ? onSendAnyway : (errorManager.isRetryableError || (errorManager.isConnectionError && errorManager.hasRetryPayload)) ? onRetryLastMessage : nil,
                     onDismiss: onDismissError
                 )
                 .fixedSize(horizontal: true, vertical: false)
-                .frame(maxWidth: maxWidth)
+                .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
             }
         }
         .padding(.top, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -599,27 +599,15 @@ struct ActiveChatViewWrapper: View {
             hasAPIKey: windowState.hasAPIKey,
             isThinking: viewModel.isThinking,
             isSending: viewModel.isSending,
-            errorText: viewModel.errorText,
-            pendingQueuedCount: viewModel.pendingQueuedCount,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,
             isLoadingAttachment: viewModel.isLoadingAttachment,
             isRecording: viewModel.isRecording,
-            onOpenSettings: {
-                windowState.selection = .panel(.settings)
-            },
             onSend: {
                 if viewModel.isRecording { onMicrophoneToggle() }
                 viewModel.sendMessage()
             },
             onStop: viewModel.stopGenerating,
-            onDismissError: viewModel.dismissError,
-            isRetryableError: viewModel.isRetryableError,
-            onRetryError: { viewModel.retryLastMessage() },
-            isConnectionError: viewModel.isConnectionError,
-            hasRetryPayload: viewModel.hasRetryPayload,
-            isSecretBlockError: viewModel.isSecretBlockError,
-            onSendAnyway: { viewModel.sendAnyway() },
             onAcceptSuggestion: viewModel.acceptSuggestion,
             onAttach: { openFilePicker(viewModel: viewModel) },
             onRemoveAttachment: { viewModel.removeAttachment(id: $0) },
@@ -652,10 +640,6 @@ struct ActiveChatViewWrapper: View {
             onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
             onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
             onSurfaceAction: { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
-            sessionError: viewModel.sessionError,
-            onRetry: { viewModel.retryAfterSessionError() },
-            onDismissSessionError: { viewModel.dismissSessionError() },
-            onCopyDebugInfo: { viewModel.copySessionErrorDebugDetails() },
             watchSession: ambientAgent.activeWatchSession,
             onStopWatch: { viewModel.stopWatchSession() },
             onReportMessage: { daemonMessageId in
@@ -699,7 +683,7 @@ struct ActiveChatViewWrapper: View {
             isHistoryLoaded: viewModel.isHistoryLoaded,
             dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
             onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
-            connectionDiagnosticHint: viewModel.connectionDiagnosticHint,
+
             voiceModeManager: voiceModeManager,
             voiceService: voiceService,
             onEndVoiceMode: onEndVoiceMode,

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -79,6 +79,7 @@ public enum Amber {
     public static let _800 = Color(hex: 0xA35E0C)
     public static let _700 = Color(hex: 0xC97C10)
     public static let _600 = Color(hex: 0xE8A020)
+    public static let _550 = Color(hex: 0xF1B21E)
     public static let _500 = Color(hex: 0xFAC426)
     public static let _400 = Color(hex: 0xFDD94E)
     public static let _300 = Color(hex: 0xFEEC94)

--- a/clients/shared/Features/Chat/ChatErrorManager.swift
+++ b/clients/shared/Features/Chat/ChatErrorManager.swift
@@ -28,6 +28,20 @@ public final class ChatErrorManager: ObservableObject {
     /// Nil when no connection error is active or the error has been dismissed.
     @Published public var connectionDiagnosticHint: String? = nil
 
+    // MARK: - Retry state
+
+    /// Whether the current error is a daemon/assistant connection failure.
+    @Published public var isConnectionError: Bool = false
+
+    /// Whether the current error is a secret-ingress block that can be bypassed.
+    @Published public var isSecretBlockError: Bool = false
+
+    /// Whether the current error is retryable (send failure, not a connection error).
+    @Published public var isRetryableError: Bool = false
+
+    /// Whether there is a failed user message that can be retried.
+    @Published public var hasRetryPayload: Bool = false
+
     // MARK: - Connection diagnostics
 
     /// Map a raw connection error to a short, actionable diagnostic hint.

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -355,17 +355,23 @@ public final class ChatViewModel: ObservableObject {
     public var isVoiceModeActive: Bool = false
     var pendingUserAttachments: [UserMessageAttachment]?
     /// Stores the last user message that failed to send, enabling retry.
-    private(set) var lastFailedMessageText: String?
+    private(set) var lastFailedMessageText: String? {
+        didSet { syncRetryStateToErrorManager() }
+    }
     private(set) var lastFailedMessageDisplayText: String?
     private(set) var lastFailedMessageAttachments: [UserMessageAttachment]?
     /// Set only when a send operation (bootstrapSession or sendUserMessage) fails.
     /// Used by `isRetryableError` to ensure the retry button only appears for
     /// actual send failures, not for unrelated errors (attachment validation,
     /// confirmation response failures, regenerate errors, etc.).
-    private(set) var lastFailedSendError: String?
+    private(set) var lastFailedSendError: String? {
+        didSet { syncRetryStateToErrorManager() }
+    }
     /// Stores the text of a message that was blocked by the secret-ingress check.
     /// Set when an error with category "secret_blocked" arrives.
-    var secretBlockedMessageText: String?
+    var secretBlockedMessageText: String? {
+        didSet { syncRetryStateToErrorManager() }
+    }
     /// Stashed context from the blocked send, so sendAnyway() can reconstruct
     /// the original UserMessageMessage with attachments and surface metadata.
     var secretBlockedAttachments: [UserMessageAttachment]?
@@ -1991,6 +1997,17 @@ public final class ChatViewModel: ObservableObject {
     /// Whether the current error is a secret-ingress block that can be bypassed.
     public var isSecretBlockError: Bool {
         secretBlockedMessageText != nil
+    }
+
+    /// Forward retry-related state to `errorManager` so `@ObservedObject` views
+    /// (e.g. `ErrorToastOverlay`) receive reactive updates. Called automatically
+    /// via `didSet` on `lastFailedMessageText`, `lastFailedSendError`, and
+    /// `secretBlockedMessageText`.
+    private func syncRetryStateToErrorManager() {
+        errorManager.isConnectionError = isConnectionError
+        errorManager.isSecretBlockError = isSecretBlockError
+        errorManager.isRetryableError = isRetryableError
+        errorManager.hasRetryPayload = hasRetryPayload
     }
 
     /// Resend the secret-blocked message with the bypass flag so the backend skips the check.


### PR DESCRIPTION
## Summary
Move the error toast overlay from ChatView to MainWindowView so error toasts (API key missing, session errors, unstructured errors) are visible regardless of which panel is active — Chat, Settings, Debug, etc.

## Changes
- Removed error toast `.overlay(alignment: .top)` from `ChatView.swift`
- Added `ErrorToastOverlay` wrapper view in `MainWindowView.swift` with `@ObservedObject var viewModel: ChatViewModel` for proper reactivity
- Overlay renders at the MainWindowView level, visible on all panels
- Removed ~15 dead error-related properties from ChatView and PanelCoordinator that were only used by the removed overlay
- ViewModel is captured at render-time in closures (not deferred) to prevent wrong-thread actions on thread switch

## Milestone PRs (merged into feature branch)
- #15747: M1: Move error toast overlay from ChatView to MainWindowView

## Project issue
Closes #15745

## Test plan
- [ ] Trigger a session error while on Chat panel — toast appears at top
- [ ] Switch to Settings panel — toast remains visible
- [ ] Switch to Debug panel — toast remains visible
- [ ] Remove API key — warning toast appears on all panels
- [ ] Verify toast dismiss and retry actions work correctly
- [ ] Switch threads while error toast is visible — verify actions target correct thread

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
