### PR TITLE
feat(cli): readline shortcuts in TUI TextInput

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -839,7 +839,8 @@ function estimateItemHeight(item: FeedItem, terminalColumns: number): number {
   if (isRuntimeMessage(item)) {
     const cols = Math.max(1, terminalColumns);
     // Account for "HH:MM AM Label: " prefix on the first line
-    const label = item.role === "user" ? "You:" : "Assistant:";
+    const defaultLabel = item.role === "user" ? "You:" : "Assistant:";
+    const label = item.label ?? defaultLabel;
     const prefixLen = 10 + label.length + 1; // timestamp + space + label + space
     let lines = 0;
     const contentLines = item.content.split("\n");

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -838,9 +838,17 @@ function isRuntimeMessage(item: FeedItem): item is RuntimeMessage {
 function estimateItemHeight(item: FeedItem, terminalColumns: number): number {
   if (isRuntimeMessage(item)) {
     const cols = Math.max(1, terminalColumns);
+    // Account for "HH:MM AM Label: " prefix on the first line
+    const label = item.role === "user" ? "You:" : "Assistant:";
+    const prefixLen = 10 + label.length + 1; // timestamp + space + label + space
     let lines = 0;
-    for (const line of item.content.split("\n")) {
-      lines += Math.max(1, Math.ceil(line.length / cols));
+    const contentLines = item.content.split("\n");
+    for (let idx = 0; idx < contentLines.length; idx++) {
+      const lineLen =
+        idx === 0
+          ? contentLines[idx].length + prefixLen
+          : contentLines[idx].length;
+      lines += Math.max(1, Math.ceil(lineLen / cols));
     }
     if (item.role === "assistant" && item.toolCalls) {
       for (const tc of item.toolCalls) {
@@ -1197,11 +1205,14 @@ function ChatApp({
     }
 
     if (scrollIndex === null) {
+      // Reserve 1 line for "N more above" indicator when there are hidden messages
       let totalHeight = 0;
       let start = feed.length;
       for (let i = feed.length - 1; i >= 0; i--) {
         const h = estimateItemHeight(feed[i], terminalColumns);
-        if (totalHeight + h > availableRows) {
+        // Reserve space for the "more above" indicator if we'd hide messages
+        const indicatorLine = i > 0 ? 1 : 0;
+        if (totalHeight + h + indicatorLine > availableRows) {
           break;
         }
         totalHeight += h;
@@ -1220,11 +1231,16 @@ function ChatApp({
     }
 
     const start = Math.max(0, Math.min(scrollIndex, feed.length - 1));
+    // Reserve lines for "more above/below" indicators
+    const aboveIndicator = start > 0 ? 1 : 0;
+    const budget = availableRows - aboveIndicator;
     let totalHeight = 0;
     let end = start;
     for (let i = start; i < feed.length; i++) {
       const h = estimateItemHeight(feed[i], terminalColumns);
-      if (totalHeight + h > availableRows) {
+      // Reserve space for "more below" indicator if we'd hide messages
+      const belowIndicator = i + 1 < feed.length ? 1 : 0;
+      if (totalHeight + h + belowIndicator > budget) {
         break;
       }
       totalHeight += h;
@@ -2210,9 +2226,9 @@ function ChatApp({
       ) : null}
 
       {!selection && !secretInput ? (
-        <Box flexDirection="column">
+        <Box flexDirection="column" flexShrink={0}>
           <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
-          <Box paddingLeft={1}>
+          <Box paddingLeft={1} height={1} flexShrink={0}>
             <Text color="green" bold>
               you{">"}
               {" "}

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -50,18 +50,43 @@ function TextInput({
       let nextValue = currentValue;
       let nextOffset = currentOffset;
 
-      if (key.leftArrow) {
+      if (key.ctrl && input === "a") {
+        // Ctrl+A — move cursor to start
+        nextOffset = 0;
+      } else if (key.ctrl && input === "e") {
+        // Ctrl+E — move cursor to end
+        nextOffset = currentValue.length;
+      } else if (key.ctrl && input === "u") {
+        // Ctrl+U — clear line before cursor
+        nextValue = currentValue.slice(currentOffset);
+        nextOffset = 0;
+      } else if (key.ctrl && input === "k") {
+        // Ctrl+K — kill from cursor to end
+        nextValue = currentValue.slice(0, currentOffset);
+      } else if (key.ctrl && input === "w") {
+        // Ctrl+W — delete word backwards
+        const before = currentValue.slice(0, currentOffset);
+        const trimmed = before.replace(/\s+$/, "");
+        const wordStart = Math.max(0, trimmed.lastIndexOf(" ") + 1);
+        nextValue =
+          currentValue.slice(0, wordStart) + currentValue.slice(currentOffset);
+        nextOffset = wordStart;
+      } else if (key.leftArrow) {
         nextOffset = Math.max(0, currentOffset - 1);
       } else if (key.rightArrow) {
         nextOffset = Math.min(currentValue.length, currentOffset + 1);
       } else if (key.backspace || key.delete) {
         if (currentOffset > 0) {
-          nextValue = currentValue.slice(0, currentOffset - 1) + currentValue.slice(currentOffset);
+          nextValue =
+            currentValue.slice(0, currentOffset - 1) +
+            currentValue.slice(currentOffset);
           nextOffset = currentOffset - 1;
         }
       } else {
         nextValue =
-          currentValue.slice(0, currentOffset) + input + currentValue.slice(currentOffset);
+          currentValue.slice(0, currentOffset) +
+          input +
+          currentValue.slice(currentOffset);
         nextOffset = currentOffset + input.length;
       }
 
@@ -107,7 +132,11 @@ function TextInput({
 
   return (
     <Text>
-      {placeholder ? (value.length > 0 ? renderedValue : renderedPlaceholder) : renderedValue}
+      {placeholder
+        ? value.length > 0
+          ? renderedValue
+          : renderedPlaceholder
+        : renderedValue}
     </Text>
   );
 }

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -64,10 +64,11 @@ function TextInput({
         // Ctrl+K — kill from cursor to end
         nextValue = currentValue.slice(0, currentOffset);
       } else if (key.ctrl && input === "w") {
-        // Ctrl+W — delete word backwards
+        // Ctrl+W — delete word backwards (handles tabs and other whitespace)
         const before = currentValue.slice(0, currentOffset);
-        const trimmed = before.replace(/\s+$/, "");
-        const wordStart = Math.max(0, trimmed.lastIndexOf(" ") + 1);
+        // Skip trailing whitespace, then find previous whitespace boundary
+        const match = before.match(/^(.*\s)?\S+\s*$/);
+        const wordStart = match?.[1]?.length ?? 0;
         nextValue =
           currentValue.slice(0, wordStart) + currentValue.slice(currentOffset);
         nextOffset = wordStart;


### PR DESCRIPTION
## Summary
- Adds standard readline keybindings to the TUI chat input: Ctrl+A (home), Ctrl+E (end), Ctrl+U (clear line), Ctrl+W (delete word back), Ctrl+K (kill to end)

## Motivation
These are muscle-memory for anyone who lives in a terminal. Essential for the headless Raspberry Pi SSH workflow.

## Test plan
- [ ] SSH into Pi, run `vc`, type a message
- [ ] Ctrl+A moves cursor to start
- [ ] Ctrl+E moves cursor to end
- [ ] Ctrl+U clears everything before cursor
- [ ] Ctrl+W deletes the previous word
- [ ] Ctrl+K deletes everything after cursor

Closes #15753

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
