### PR TITLE
fix: add oauth/manual-token-connection.ts to secure-keys allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -235,6 +235,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_secret)
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
       "cli/commands/oauth/connections.ts", // CLI OAuth connection delete (legacy credential cleanup)
+      "oauth/manual-token-connection.ts", // manual-token provider backfill (keychain credential existence check)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `oauth/manual-token-connection.ts` to the `secure-keys` authorized importers allowlist in the credential security invariants guard test
- This file legitimately imports `getSecureKey` to check keychain credential existence during manual-token provider backfill

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23011693746/job/66823740995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
