### PR TITLE
fix: address review feedback from #15629 (Remove maximum attachments limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The assistant creates attachments from two sources:
 1. **Directives**: `<vellum-attachment source="sandbox|host" path="..." />` tags in response text. Sandbox paths are relative to the working directory; host paths require user approval.
 2. **Tool output**: Image and file content blocks from tool results are automatically converted into attachments.
 
-Limits: up to 5 attachments per turn, 20 MB each.
+Limits: 20 MB per attachment.
 
 </details>
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -283,7 +283,7 @@ function buildAttachmentSection(): string {
     "",
     'Example: `<vellum-attachment source="sandbox" path="scratch/chart.png" />`',
     "",
-    "Limits: up to 5 attachments per turn, 20 MB each. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
+    "Limits: 20 MB per attachment. Tool outputs that produce image or file content blocks are also automatically converted into attachments.",
     "",
     "### Inline Images and GIFs",
     "Embed images/GIFs inline using markdown: `![description](URL)`. Do NOT wrap in code fences.",

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -29,6 +29,11 @@ public final class ChatAttachmentManager: ObservableObject {
         didSet { isLoadingAttachment = loadingCount > 0 }
     }
 
+    /// Limits concurrent attachment I/O to avoid unbounded memory spikes when
+    /// many files are selected at once (each can read up to 20 MB).
+    private static let maxConcurrentLoads = 4
+    private let loadSemaphore = DispatchSemaphore(value: maxConcurrentLoads)
+
     // MARK: - Limits
 
     /// Maximum file size per attachment (20 MB).
@@ -61,7 +66,7 @@ public final class ChatAttachmentManager: ObservableObject {
         loadingCount += 1
         Task {
             defer { self.loadingCount -= 1 }
-            let result = await Self.loadAttachment(url: url)
+            let result = await self.loadAttachment(url: url)
             switch result {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
@@ -114,7 +119,7 @@ public final class ChatAttachmentManager: ObservableObject {
         loadingCount += 1
         Task {
             defer { self.loadingCount -= 1 }
-            let result = await Self.loadAttachment(imageData: imageData, filename: filename)
+            let result = await self.loadAttachment(imageData: imageData, filename: filename)
             switch result {
             case .failure(let attachmentError):
                 self.onError?(attachmentError.message)
@@ -129,9 +134,12 @@ public final class ChatAttachmentManager: ObservableObject {
     /// Reads, validates, compresses, and thumbnails an attachment from a file URL.
     /// All blocking work runs off the main actor; callers receive a ready-to-use
     /// ChatAttachment (or an error message) and can update UI state directly.
-    private static func loadAttachment(url: URL) async -> Result<ChatAttachment, AttachmentError> {
+    private func loadAttachment(url: URL) async -> Result<ChatAttachment, AttachmentError> {
+        let semaphore = self.loadSemaphore
         // Hop off the main actor for all blocking I/O and CPU work.
         return await Task.detached(priority: .userInitiated) {
+            semaphore.wait()
+            defer { semaphore.signal() }
             let data: Data
             do {
                 data = try Data(contentsOf: url)
@@ -204,8 +212,11 @@ public final class ChatAttachmentManager: ObservableObject {
 
     /// Converts, validates, compresses, and thumbnails an attachment from raw image data.
     /// All blocking work runs off the main actor.
-    private static func loadAttachment(imageData: Data, filename: String) async -> Result<ChatAttachment, AttachmentError> {
+    private func loadAttachment(imageData: Data, filename: String) async -> Result<ChatAttachment, AttachmentError> {
+        let semaphore = self.loadSemaphore
         return await Task.detached(priority: .userInitiated) {
+            semaphore.wait()
+            defer { semaphore.signal() }
             // Convert to PNG if needed — raw image data may be TIFF
             let pngData: Data
             #if os(macOS)


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15629

- Remove stale "up to 5 attachments per turn" text from system prompt and README
- Add bounded concurrency (max 4 parallel loads) to ChatAttachmentManager to prevent unbounded memory spikes when many files are selected at once
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
