### PR TITLE
fix: reject empty conversationKey in SSE events endpoint (feedback from #15647)

### DIFF
--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -63,6 +63,9 @@ export function handleSubscribeAssistantEvents(
   // scope and principal type requirements.
 
   const conversationKey = url.searchParams.get("conversationKey");
+  if (url.searchParams.has("conversationKey") && !conversationKey?.trim()) {
+    return httpError("BAD_REQUEST", "conversationKey must not be empty", 400);
+  }
 
   const hub = options?.hub ?? assistantEventHub;
   const heartbeatIntervalMs =


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15647

An empty conversationKey query param (e.g. `?conversationKey=`) was silently falling through to the unfiltered event stream, effectively upgrading a scoped request to global scope. This adds an explicit check that returns 400 when conversationKey is present but empty/whitespace.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
