### PR TITLE
fix: validate result block type against serverToolIds in ensureToolPairing

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -266,7 +266,8 @@ function normalizeFollowingUserContent(
     if (
       isToolResultBlock(block) &&
       pendingIds.has(block.tool_use_id) &&
-      !matchedById.has(block.tool_use_id)
+      !matchedById.has(block.tool_use_id) &&
+      !serverToolIds.has(block.tool_use_id)
     ) {
       matchedById.set(block.tool_use_id, block);
       continue;
@@ -274,7 +275,8 @@ function normalizeFollowingUserContent(
     if (
       isWebSearchToolResultBlock(block) &&
       pendingIds.has(block.tool_use_id) &&
-      !matchedById.has(block.tool_use_id)
+      !matchedById.has(block.tool_use_id) &&
+      serverToolIds.has(block.tool_use_id)
     ) {
       matchedById.set(
         block.tool_use_id,


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15632

The `normalizeFollowingUserContent` function matched `tool_result` and `web_search_tool_result` blocks solely by `tool_use_id`, without checking whether the ID came from a `server_tool_use` or regular `tool_use`. In malformed histories, this could cause cross-type mismatches where a `tool_result` incorrectly pairs with a `server_tool_use` ID (or vice versa), bypassing the synthetic repair logic and resulting in Anthropic API 400 errors.

Now `tool_result` blocks only match non-server tool IDs and `web_search_tool_result` blocks only match server tool IDs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
