### PR TITLE
fix: address review feedback from #15633 (session error debug details)

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -116,7 +116,14 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
 }
 
 /**
- * Reads the workspace config.json and strips sensitive fields (API keys).
+ * Replaces a string value with a presence flag: "(set)" if truthy, "(empty)" otherwise.
+ */
+function redactStringValue(val: unknown): string {
+  return val ? "(set)" : "(empty)";
+}
+
+/**
+ * Reads the workspace config.json and strips sensitive fields.
  * Returns undefined if the file is missing or unreadable.
  */
 function readSanitizedConfig(): Record<string, unknown> | undefined {
@@ -131,8 +138,47 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
     if (config.apiKeys && typeof config.apiKeys === "object") {
       const keys = config.apiKeys as Record<string, unknown>;
       config.apiKeys = Object.fromEntries(
-        Object.keys(keys).map((k) => [k, keys[k] ? "(set)" : "(empty)"]),
+        Object.keys(keys).map((k) => [k, redactStringValue(keys[k])]),
       );
+    }
+
+    // Strip ingress webhook secret
+    if (config.ingress && typeof config.ingress === "object") {
+      const ingress = config.ingress as Record<string, unknown>;
+      if (ingress.webhook && typeof ingress.webhook === "object") {
+        const webhook = ingress.webhook as Record<string, unknown>;
+        webhook.secret = redactStringValue(webhook.secret);
+        ingress.webhook = webhook;
+      }
+      config.ingress = ingress;
+    }
+
+    // Strip skill-level API keys and env vars
+    if (config.skills && typeof config.skills === "object") {
+      const skills = config.skills as Record<string, unknown>;
+      if (skills.entries && typeof skills.entries === "object") {
+        const entries = skills.entries as Record<string, unknown>;
+        for (const name of Object.keys(entries)) {
+          const entry = entries[name];
+          if (entry && typeof entry === "object") {
+            const e = entry as Record<string, unknown>;
+            if ("apiKey" in e) e.apiKey = redactStringValue(e.apiKey);
+            if (e.env && typeof e.env === "object") {
+              const env = e.env as Record<string, unknown>;
+              e.env = Object.fromEntries(
+                Object.keys(env).map((k) => [k, redactStringValue(env[k])]),
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // Strip Twilio accountSid
+    if (config.twilio && typeof config.twilio === "object") {
+      const twilio = config.twilio as Record<string, unknown>;
+      twilio.accountSid = redactStringValue(twilio.accountSid);
+      config.twilio = twilio;
     }
 
     return config;

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -525,7 +525,13 @@ enum LogExporter {
         try? data.write(to: url)
     }
 
-    /// Reads the workspace config.json and writes a sanitized copy with API key
+    /// Replaces a value with a presence flag: "(set)" if non-empty, "(empty)" otherwise.
+    private nonisolated static func redactValue(_ val: Any?) -> String {
+        if let str = val as? String { return str.isEmpty ? "(empty)" : "(set)" }
+        return val == nil ? "(empty)" : "(set)"
+    }
+
+    /// Reads the workspace config.json and writes a sanitized copy with sensitive
     /// values replaced by presence flags. Falls back silently if unreadable.
     private nonisolated static func writeSanitizedWorkspaceConfig(to url: URL) {
         var config = WorkspaceConfigIO.read()
@@ -534,9 +540,41 @@ enum LogExporter {
         // Strip API key values — preserve which providers have keys configured
         if var apiKeys = config["apiKeys"] as? [String: Any] {
             for key in apiKeys.keys {
-                apiKeys[key] = apiKeys[key] != nil ? "(set)" : "(empty)"
+                apiKeys[key] = redactValue(apiKeys[key])
             }
             config["apiKeys"] = apiKeys
+        }
+
+        // Strip ingress webhook secret
+        if var ingress = config["ingress"] as? [String: Any],
+           var webhook = ingress["webhook"] as? [String: Any] {
+            webhook["secret"] = redactValue(webhook["secret"])
+            ingress["webhook"] = webhook
+            config["ingress"] = ingress
+        }
+
+        // Strip skill-level API keys and env vars
+        if var skills = config["skills"] as? [String: Any],
+           var entries = skills["entries"] as? [String: [String: Any]] {
+            for name in entries.keys {
+                if entries[name]?["apiKey"] != nil {
+                    entries[name]?["apiKey"] = redactValue(entries[name]?["apiKey"])
+                }
+                if var env = entries[name]?["env"] as? [String: Any] {
+                    for envKey in env.keys {
+                        env[envKey] = redactValue(env[envKey])
+                    }
+                    entries[name]?["env"] = env
+                }
+            }
+            skills["entries"] = entries
+            config["skills"] = skills
+        }
+
+        // Strip Twilio accountSid
+        if var twilio = config["twilio"] as? [String: Any] {
+            twilio["accountSid"] = redactValue(twilio["accountSid"])
+            config["twilio"] = twilio
         }
 
         guard let data = try? JSONSerialization.data(


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15633

- Fix Swift apiKeys sanitization where `!= nil` check was always true (dead code). Now properly checks for empty strings using a `redactValue` helper.
- Sanitize additional sensitive config fields beyond `apiKeys` in both daemon (TypeScript) and client (Swift) paths: `ingress.webhook.secret`, `skills.entries[].apiKey`, `skills.entries[].env`, and `twilio.accountSid`.
- Extract `redactStringValue` / `redactValue` helpers for consistent truthiness-based redaction across both implementations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
