### PR TITLE
fix: prevent always_allow from cascading to high-risk confirmations

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -678,12 +678,17 @@ export class Session {
       return { allow: true };
     }
 
-    // Persistent allow: cascade if the pattern matches any allowlist candidate
+    // Persistent allow: cascade if the pattern matches any allowlist candidate.
+    // "always_allow" must NOT cascade to high-risk pending confirmations —
+    // only "always_allow_high_risk" has consent for those.
     if (
       (decision === "always_allow" || decision === "always_allow_high_risk") &&
       selectedPattern &&
       details
     ) {
+      if (decision === "always_allow" && details.riskLevel === "high") {
+        return null;
+      }
       for (const option of details.allowlistOptions) {
         if (patternMatchesCandidate(selectedPattern, option.pattern)) {
           return { allow: true };


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15644

The `shouldCascade()` method treated `always_allow` and `always_allow_high_risk` identically when cascading approval decisions to pending confirmations. This meant a normal `always_allow` decision could silently auto-approve queued high-risk confirmations, bypassing the high-risk consent boundary.

Now `always_allow` returns `null` (no cascade) when the pending confirmation has `riskLevel: "high"`, so only an explicit `always_allow_high_risk` decision can cascade to high-risk items.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
