### PR TITLE
fix: address review feedback from #15662 (defer slash command SSE events)

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -828,11 +828,12 @@ export async function handleSendMessage(
         sourceInterface,
       );
 
-      // Emit fresh model info before the text delta so the client has
-      // up-to-date configuredProviders when rendering /model, /models,
-      // and provider shortcut commands (/gpt4, /opus, etc.).
-      const shouldEmitModelInfo =
-        isModelSlashCommand(rawContent) || isProviderShortcut(rawContent);
+      // Snapshot model info now so the deferred callback cannot observe
+      // a config change from a concurrent request.
+      const modelInfoEvent =
+        isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)
+          ? buildModelInfoEvent()
+          : null;
 
       const response = Response.json(
         {
@@ -847,23 +848,33 @@ export async function handleSendMessage(
       // client first. This ensures the client's serverToLocalSessionMap is
       // populated before SSE events arrive, preventing dropped events in new
       // desktop threads.
+      //
+      // session.processing and drainQueue are also deferred so the current
+      // slash command's events are emitted before the next queued message
+      // starts processing.
       const conversationId = mapping.conversationId;
       const message = slashResult.message;
       setTimeout(() => {
-        if (shouldEmitModelInfo) {
-          onEvent(buildModelInfoEvent());
+        if (modelInfoEvent) {
+          onEvent(modelInfoEvent);
         }
         onEvent({ type: "assistant_text_delta", text: message });
         onEvent({
           type: "message_complete",
           sessionId: conversationId,
         });
+        session.processing = false;
+        session.drainQueue().catch(() => {});
       }, 0);
 
       return response;
     } finally {
-      session.processing = false;
-      session.drainQueue().catch(() => {});
+      // No-op for the slash-command early-return path (handled inside
+      // setTimeout above), but still needed for error paths.
+      if (session.processing) {
+        session.processing = false;
+        session.drainQueue().catch(() => {});
+      }
     }
   }
 


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15662

- Move session.processing=false and drainQueue() into the setTimeout callback so slash command events (text_delta, message_complete) are emitted before the next queued message starts processing
- Snapshot buildModelInfoEvent() before setTimeout to prevent observing stale/changed config from concurrent requests
- Guard the finally block with an if(session.processing) check so it only acts on error paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
