### PR TITLE
fix: address review feedback from #15636 (auto-install catalog skills)

### DIFF
--- a/assistant/src/__tests__/skills-uninstall.test.ts
+++ b/assistant/src/__tests__/skills-uninstall.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { uninstallSkillLocally } from "../cli/commands/skills.js";
+import { uninstallSkillLocally } from "../skills/catalog-install.js";
 
 let tempDir: string;
 let originalBaseDataDir: string | undefined;

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -1,38 +1,14 @@
 import type { Command } from "commander";
 
+import type { CatalogSkill } from "../../skills/catalog-install.js";
 import {
-  type CatalogManifest,
-  type CatalogSkill,
-  extractTarToDir,
-  fetchAndExtractSkill,
   fetchCatalog,
   getRepoSkillsDir,
-  getSkillsIndexPath,
   installSkillLocally,
   readLocalCatalog,
-  removeSkillsIndexEntry,
   uninstallSkillLocally,
-  upsertSkillsIndex,
 } from "../../skills/catalog-install.js";
 import { log } from "../logger.js";
-
-// ---------------------------------------------------------------------------
-// Exported types and functions for testing
-// ---------------------------------------------------------------------------
-
-export type { CatalogManifest, CatalogSkill };
-
-export {
-  extractTarToDir,
-  fetchAndExtractSkill,
-  fetchCatalog,
-  getSkillsIndexPath,
-  installSkillLocally,
-  readLocalCatalog,
-  removeSkillsIndexEntry,
-  uninstallSkillLocally,
-  upsertSkillsIndex,
-};
 
 // ---------------------------------------------------------------------------
 // Command registration

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -146,14 +146,23 @@ export interface SkillDefinition extends SkillSummary {
   body: string;
 }
 
+export type SkillLookupErrorCode =
+  | "not_found"
+  | "ambiguous"
+  | "empty_catalog"
+  | "invalid_selector"
+  | "load_failed";
+
 export interface SkillLookupResult {
   skill?: SkillDefinition;
   error?: string;
+  errorCode?: SkillLookupErrorCode;
 }
 
 export interface SkillSelectorResult {
   skill?: SkillSummary;
   error?: string;
+  errorCode?: SkillLookupErrorCode;
 }
 
 // ─── Skill Tool Manifest Types ────────────────────────────────────────────────
@@ -1210,6 +1219,7 @@ export function resolveSkillSelector(
   if (!needle) {
     return {
       error: "Skill selector is required and must be a non-empty string.",
+      errorCode: "invalid_selector",
     };
   }
 
@@ -1218,6 +1228,7 @@ export function resolveSkillSelector(
     return {
       error:
         "No skills are available. Configure ~/.vellum/workspace/skills/SKILLS.md or add skill directories.",
+      errorCode: "empty_catalog",
     };
   }
 
@@ -1236,7 +1247,10 @@ export function resolveSkillSelector(
   }
   if (exactNameMatches.length > 1) {
     const ids = exactNameMatches.map((skill) => skill.id).join(", ");
-    return { error: `Ambiguous skill name "${needle}". Matching IDs: ${ids}` };
+    return {
+      error: `Ambiguous skill name "${needle}". Matching IDs: ${ids}`,
+      errorCode: "ambiguous",
+    };
   }
 
   const idPrefixMatches = catalog.filter((skill) =>
@@ -1249,12 +1263,14 @@ export function resolveSkillSelector(
     const ids = idPrefixMatches.map((skill) => skill.id).join(", ");
     return {
       error: `Ambiguous skill id prefix "${needle}". Matching IDs: ${ids}`,
+      errorCode: "ambiguous",
     };
   }
 
   const knownSkills = catalog.map((skill) => skill.id).join(", ");
   return {
     error: `No skill matched "${needle}". Available skills: ${knownSkills}`,
+    errorCode: "not_found",
   };
 }
 
@@ -1264,7 +1280,10 @@ export function loadSkillBySelector(
 ): SkillLookupResult {
   const resolved = resolveSkillSelector(selector, workspaceSkillsDir);
   if (!resolved.skill) {
-    return { error: resolved.error ?? "Failed to resolve skill selector." };
+    return {
+      error: resolved.error ?? "Failed to resolve skill selector.",
+      errorCode: resolved.errorCode ?? "load_failed",
+    };
   }
   return loadSkillDefinition(resolved.skill);
 }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -141,7 +141,10 @@ export class SkillLoadTool implements Tool {
     let loaded = loadSkillBySelector(selector);
 
     // Auto-install from catalog if the skill isn't found locally
-    if (!loaded.skill && loaded.error?.includes("No skill matched")) {
+    if (
+      !loaded.skill &&
+      (loaded.errorCode === "not_found" || loaded.errorCode === "empty_catalog")
+    ) {
       try {
         const installed = await autoInstallFromCatalog(selector);
         if (installed) {
@@ -149,10 +152,15 @@ export class SkillLoadTool implements Tool {
           loaded = loadSkillBySelector(selector);
         }
       } catch (err) {
+        const installError = err instanceof Error ? err.message : String(err);
         log.warn(
           { err, skillId: selector },
           "Auto-install from catalog failed",
         );
+        return {
+          content: `Error: skill "${selector}" was found in the catalog but installation failed: ${installError}`,
+          isError: true,
+        };
       }
     }
 


### PR DESCRIPTION
Address review feedback from https://github.com/vellum-ai/vellum-assistant/pull/15636

## Changes

- Remove backward-compat re-export shims from `skills.ts` — update test to import directly from `catalog-install.ts`
- Add structured `errorCode` to `SkillLookupResult`/`SkillSelectorResult` — replace fragile string matching in `load.ts` with `errorCode === 'not_found'`
- Propagate auto-install errors to the caller — return a clear error message when the skill exists in the catalog but installation fails, instead of silently falling through to the original 'not found' message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
