### PR TITLE
fix: resolve overlapping access in LogExporter skill redaction

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -622,15 +622,17 @@ enum LogExporter {
         if var skills = config["skills"] as? [String: Any],
            var entries = skills["entries"] as? [String: [String: Any]] {
             for name in entries.keys {
-                if entries[name]?["apiKey"] != nil {
-                    entries[name]?["apiKey"] = redactValue(entries[name]?["apiKey"])
+                var entry = entries[name]!
+                if entry["apiKey"] != nil {
+                    entry["apiKey"] = redactValue(entry["apiKey"])
                 }
-                if var env = entries[name]?["env"] as? [String: Any] {
+                if var env = entry["env"] as? [String: Any] {
                     for envKey in env.keys {
                         env[envKey] = redactValue(env[envKey])
                     }
-                    entries[name]?["env"] = env
+                    entry["env"] = env
                 }
+                entries[name] = entry
             }
             skills["entries"] = entries
             config["skills"] = skills


### PR DESCRIPTION
## Summary
- Fix Swift exclusive access error in `LogExporter.swift` line 626 where `entries[name]?["apiKey"]` was read and written in the same expression
- Copy dictionary entry to a local `var entry` before mutating, then write it back — eliminates the overlapping access

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/23012358058

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
