### PR TITLE
feat: add computer_use_observe proxy tool for screen state capture

### DIFF
--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -459,10 +459,40 @@ export const computerUseRespondTool: Tool = {
 };
 
 // ---------------------------------------------------------------------------
+// observe
+// ---------------------------------------------------------------------------
+
+export const computerUseObserveTool: Tool = {
+  name: "computer_use_observe",
+  description:
+    "Capture the current screen state. Returns the accessibility tree (with [ID] element references for targeting) and a screenshot. Call this before your first computer use action to see what's on screen, or any time you need to check the current state without performing an action.",
+  category: "computer-use",
+  defaultRiskLevel: RiskLevel.Low,
+  executionMode: "proxy",
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          reason: reasonProperty,
+        },
+        required: ["reason"],
+      },
+    };
+  },
+
+  execute: proxyExecute,
+};
+
+// ---------------------------------------------------------------------------
 // All tools exported as array for convenience
 // ---------------------------------------------------------------------------
 
 export const allComputerUseTools: Tool[] = [
+  computerUseObserveTool,
   computerUseClickTool,
   computerUseTypeTextTool,
   computerUseKeyTool,


### PR DESCRIPTION
## Summary
- Add computerUseObserveTool definition with 'reason' parameter and proxy execution mode
- Include in allComputerUseTools array for CU tool registration

Part of plan: unify-cu-main-loop.md (PR 3 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
