### PR TITLE
feat: add host_cu_request/host_cu_result message types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -21,6 +21,7 @@ export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/host-bash.js";
+export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
 export * from "./message-types/inbox.js";
 export * from "./message-types/integrations.js";
@@ -69,6 +70,7 @@ import type {
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
+import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type {
   _InboxClientMessages,
@@ -180,6 +182,7 @@ export type ServerMessage =
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
   | _HostBashServerMessages
+  | _HostCuServerMessages
   | _HostFileServerMessages
   | _MemoryServerMessages
   | _WorkspaceServerMessages

--- a/assistant/src/daemon/message-types/host-cu.ts
+++ b/assistant/src/daemon/message-types/host-cu.ts
@@ -1,0 +1,19 @@
+// Host computer-use proxy types.
+// Enables proxying computer-use actions (click, type, screenshot, etc.)
+// to the desktop client when running as a managed assistant.
+
+// === Server → Client ===
+
+export interface HostCuRequest {
+  type: "host_cu_request";
+  requestId: string;
+  sessionId: string;
+  toolName: string; // "computer_use_click", "computer_use_type_text", etc.
+  input: Record<string, unknown>;
+  stepNumber: number;
+  reasoning?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostCuServerMessages = HostCuRequest;

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,12 +1,13 @@
 /**
  * In-memory tracker that maps requestId to session info for pending
- * confirmation, secret, host_bash, and host_file interactions.
+ * confirmation, secret, host_bash, host_file, and host_cu interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
- * host_bash_request, or host_file_request, the onEvent callback registers
- * the interaction here. Standalone HTTP endpoints (/v1/confirm, /v1/secret,
- * /v1/trust-rules, /v1/host-bash-result, /v1/host-file-result) look up
- * the session from this tracker to resolve the interaction.
+ * host_bash_request, host_file_request, or host_cu_request, the onEvent
+ * callback registers the interaction here. Standalone HTTP endpoints
+ * (/v1/confirm, /v1/secret, /v1/trust-rules, /v1/host-bash-result,
+ * /v1/host-file-result, /v1/host-cu-result) look up the session from
+ * this tracker to resolve the interaction.
  */
 
 import type { Session } from "../daemon/session.js";
@@ -29,7 +30,7 @@ export interface ConfirmationDetails {
 export interface PendingInteraction {
   session: Session;
   conversationId: string;
-  kind: "confirmation" | "secret" | "host_bash" | "host_file";
+  kind: "confirmation" | "secret" | "host_bash" | "host_file" | "host_cu";
   confirmationDetails?: ConfirmationDetails;
 }
 
@@ -82,19 +83,20 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given session.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash and host_file interactions are intentionally skipped — they
- * represent in-flight tool executions proxied to the client, not
+ * host_bash, host_file, and host_cu interactions are intentionally skipped
+ * — they represent in-flight tool executions proxied to the client, not
  * confirmations to auto-deny. Removing them would orphan the request: the
- * client would POST to /v1/host-bash-result or /v1/host-file-result after
- * completing the operation, get a 404, and the proxy timer would fire with
- * a spurious timeout error.
+ * client would POST to /v1/host-bash-result, /v1/host-file-result, or
+ * /v1/host-cu-result after completing the operation, get a 404, and the
+ * proxy timer would fire with a spurious timeout error.
  */
 export function removeBySession(session: Session): void {
   for (const [requestId, interaction] of pending) {
     if (
       interaction.session === session &&
       interaction.kind !== "host_bash" &&
-      interaction.kind !== "host_file"
+      interaction.kind !== "host_file" &&
+      interaction.kind !== "host_cu"
     ) {
       pending.delete(requestId);
     }


### PR DESCRIPTION
## Summary
- Add HostCuRequest interface and _HostCuServerMessages type alias in new host-cu.ts message types file
- Wire into ServerMessage union in message-protocol.ts
- Add 'host_cu' pending interaction kind with proper removeBySession skip behavior

Part of plan: unify-cu-main-loop.md (PR 1 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
