### PR TITLE
refactor: move watch endpoint to its own route file

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -530,6 +530,11 @@ export async function runDaemon(): Promise<void> {
           cuSessions: ctx.cuSessions,
           sharedRequestTimestamps: ctx.sharedRequestTimestamps,
           cuObservationParseSequence: ctx.cuObservationParseSequence,
+        };
+      },
+      getWatchDeps: () => {
+        const ctx = server.getHandlerContext();
+        return {
           handleWatchObservation: async (params) => {
             await handleWatchObservation(
               {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -155,6 +155,7 @@ import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
+import { watchRouteDefinitions } from "./routes/watch-routes.js";
 import { workItemRouteDefinitions } from "./routes/work-items-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
@@ -217,6 +218,7 @@ export class RuntimeHttpServer {
   private sessionManagementDeps?: RuntimeHttpServerOptions["sessionManagementDeps"];
   private getModelSetContext?: RuntimeHttpServerOptions["getModelSetContext"];
   private getComputerUseDeps?: RuntimeHttpServerOptions["getComputerUseDeps"];
+  private getWatchDeps?: RuntimeHttpServerOptions["getWatchDeps"];
   private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
   private router: HttpRouter;
 
@@ -238,6 +240,7 @@ export class RuntimeHttpServer {
     this.sessionManagementDeps = options.sessionManagementDeps;
     this.getModelSetContext = options.getModelSetContext;
     this.getComputerUseDeps = options.getComputerUseDeps;
+    this.getWatchDeps = options.getWatchDeps;
     this.getRecordingDeps = options.getRecordingDeps;
     this.router = new HttpRouter(this.buildRouteTable());
   }
@@ -976,6 +979,11 @@ export class RuntimeHttpServer {
       ...(this.getComputerUseDeps
         ? computerUseRouteDefinitions({
             getComputerUseDeps: this.getComputerUseDeps,
+          })
+        : []),
+      ...(this.getWatchDeps
+        ? watchRouteDefinitions({
+            getWatchDeps: this.getWatchDeps,
           })
         : []),
       ...(this.getRecordingDeps

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -221,6 +221,8 @@ export interface RuntimeHttpServerOptions {
   getModelSetContext?: () => import("../daemon/handlers/config-model.js").ModelSetContext;
   /** Provider for computer-use session dependencies (CU routes). */
   getComputerUseDeps?: () => import("./routes/computer-use-routes.js").ComputerUseDeps;
+  /** Provider for watch observation dependencies (watch routes). */
+  getWatchDeps?: () => import("./routes/watch-routes.js").WatchDeps;
   /** Provider for recording dependencies (recording routes). */
   getRecordingDeps?: () => import("./routes/recording-routes.js").RecordingDeps;
 }

--- a/assistant/src/runtime/routes/computer-use-routes.ts
+++ b/assistant/src/runtime/routes/computer-use-routes.ts
@@ -1,8 +1,7 @@
 /**
  * HTTP route handlers for computer use session lifecycle.
  *
- * These endpoints expose CU session management and watch
- * observation functionality over HTTP.
+ * These endpoints expose CU session management over HTTP.
  *
  * All CU write operations require the `chat.write` scope.
  */
@@ -37,18 +36,6 @@ export interface ComputerUseDeps {
   sharedRequestTimestamps: number[];
   /** Sequence tracker for CU observations (per session). */
   cuObservationParseSequence: Map<string, number>;
-  /** Handle a watch observation. */
-  handleWatchObservation: (params: {
-    watchId: string;
-    sessionId: string;
-    ocrText: string;
-    appName?: string;
-    windowTitle?: string;
-    bundleIdentifier?: string;
-    timestamp: number;
-    captureIndex: number;
-    totalExpected: number;
-  }) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -373,71 +360,6 @@ async function handleTaskSubmit(
   );
 }
 
-/**
- * POST /v1/computer-use/watch — send a watch observation.
- *
- * Body: { watchId, sessionId, ocrText, appName?, windowTitle?,
- *         bundleIdentifier?, timestamp, captureIndex, totalExpected }
- */
-async function handleWatchObservationRoute(
-  req: Request,
-  deps: ComputerUseDeps,
-): Promise<Response> {
-  const body = (await req.json()) as {
-    watchId?: string;
-    sessionId?: string;
-    ocrText?: string;
-    appName?: string;
-    windowTitle?: string;
-    bundleIdentifier?: string;
-    timestamp?: number;
-    captureIndex?: number;
-    totalExpected?: number;
-  };
-
-  if (!body.watchId || typeof body.watchId !== "string") {
-    return httpError("BAD_REQUEST", "watchId is required", 400);
-  }
-  if (!body.sessionId || typeof body.sessionId !== "string") {
-    return httpError("BAD_REQUEST", "sessionId is required", 400);
-  }
-  if (!body.ocrText || typeof body.ocrText !== "string") {
-    return httpError("BAD_REQUEST", "ocrText is required", 400);
-  }
-  if (typeof body.timestamp !== "number") {
-    return httpError("BAD_REQUEST", "timestamp is required", 400);
-  }
-  if (typeof body.captureIndex !== "number") {
-    return httpError("BAD_REQUEST", "captureIndex is required", 400);
-  }
-  if (typeof body.totalExpected !== "number") {
-    return httpError("BAD_REQUEST", "totalExpected is required", 400);
-  }
-
-  try {
-    await deps.handleWatchObservation({
-      watchId: body.watchId,
-      sessionId: body.sessionId,
-      ocrText: body.ocrText,
-      appName: body.appName,
-      windowTitle: body.windowTitle,
-      bundleIdentifier: body.bundleIdentifier,
-      timestamp: body.timestamp,
-      captureIndex: body.captureIndex,
-      totalExpected: body.totalExpected,
-    });
-
-    return Response.json({ ok: true });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error(
-      { err, watchId: body.watchId },
-      "Failed to handle watch observation via HTTP",
-    );
-    return httpError("INTERNAL_ERROR", message, 500);
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -476,12 +398,6 @@ export function computerUseRouteDefinitions(deps: {
       method: "POST",
       policyKey: "computer-use/tasks",
       handler: async ({ req }) => handleTaskSubmit(req, getDeps()),
-    },
-    {
-      endpoint: "computer-use/watch",
-      method: "POST",
-      policyKey: "computer-use/watch",
-      handler: async ({ req }) => handleWatchObservationRoute(req, getDeps()),
     },
   ];
 }

--- a/assistant/src/runtime/routes/watch-routes.ts
+++ b/assistant/src/runtime/routes/watch-routes.ts
@@ -1,0 +1,128 @@
+/**
+ * HTTP route handler for watch (ambient observation) functionality.
+ *
+ * Decoupled from computer-use routes so that the watch endpoint has
+ * zero dependency on CU session state.
+ */
+
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("watch-routes");
+
+// ---------------------------------------------------------------------------
+// Dependency injection interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for watch observation handling.
+ * The daemon wires a concrete implementation at startup.
+ */
+export interface WatchDeps {
+  /** Handle a watch observation. */
+  handleWatchObservation: (params: {
+    watchId: string;
+    sessionId: string;
+    ocrText: string;
+    appName?: string;
+    windowTitle?: string;
+    bundleIdentifier?: string;
+    timestamp: number;
+    captureIndex: number;
+    totalExpected: number;
+  }) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/computer-use/watch — send a watch observation.
+ *
+ * Body: { watchId, sessionId, ocrText, appName?, windowTitle?,
+ *         bundleIdentifier?, timestamp, captureIndex, totalExpected }
+ */
+async function handleWatchObservationRoute(
+  req: Request,
+  deps: WatchDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    watchId?: string;
+    sessionId?: string;
+    ocrText?: string;
+    appName?: string;
+    windowTitle?: string;
+    bundleIdentifier?: string;
+    timestamp?: number;
+    captureIndex?: number;
+    totalExpected?: number;
+  };
+
+  if (!body.watchId || typeof body.watchId !== "string") {
+    return httpError("BAD_REQUEST", "watchId is required", 400);
+  }
+  if (!body.sessionId || typeof body.sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+  if (!body.ocrText || typeof body.ocrText !== "string") {
+    return httpError("BAD_REQUEST", "ocrText is required", 400);
+  }
+  if (typeof body.timestamp !== "number") {
+    return httpError("BAD_REQUEST", "timestamp is required", 400);
+  }
+  if (typeof body.captureIndex !== "number") {
+    return httpError("BAD_REQUEST", "captureIndex is required", 400);
+  }
+  if (typeof body.totalExpected !== "number") {
+    return httpError("BAD_REQUEST", "totalExpected is required", 400);
+  }
+
+  try {
+    await deps.handleWatchObservation({
+      watchId: body.watchId,
+      sessionId: body.sessionId,
+      ocrText: body.ocrText,
+      appName: body.appName,
+      windowTitle: body.windowTitle,
+      bundleIdentifier: body.bundleIdentifier,
+      timestamp: body.timestamp,
+      captureIndex: body.captureIndex,
+      totalExpected: body.totalExpected,
+    });
+
+    return Response.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, watchId: body.watchId },
+      "Failed to handle watch observation via HTTP",
+    );
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function watchRouteDefinitions(deps: {
+  getWatchDeps?: () => WatchDeps;
+}): RouteDefinition[] {
+  const getDeps = (): WatchDeps => {
+    if (!deps.getWatchDeps) {
+      throw new Error("Watch deps not available");
+    }
+    return deps.getWatchDeps();
+  };
+
+  return [
+    {
+      endpoint: "computer-use/watch",
+      method: "POST",
+      policyKey: "computer-use/watch",
+      handler: async ({ req }) => handleWatchObservationRoute(req, getDeps()),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Create watch-routes.ts with WatchDeps interface and watchRouteDefinitions()
- Remove watch handler and route from computer-use-routes.ts
- Wire watch deps separately in lifecycle.ts
- Register watch routes independently in http-server.ts

Part of plan: unify-cu-main-loop.md (PR 10 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
