### PR TITLE
fix: replace DispatchSemaphore with async-compatible concurrency limiter

### DIFF
--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -11,6 +11,30 @@ import UIKit
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatAttachmentManager")
 
+/// Async-compatible semaphore that suspends (not blocks) waiting tasks.
+/// Drop-in replacement for DispatchSemaphore in structured concurrency contexts,
+/// avoiding thread starvation on the cooperative thread pool.
+private actor AsyncSemaphore {
+    private var count: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(value: Int) { self.count = value }
+
+    func wait() async {
+        if count > 0 { count -= 1; return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func signal() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            count += 1
+        }
+    }
+}
+
 /// Owns the pending-attachment list and all attachment-manipulation methods that
 /// were previously part of ChatViewModel / ChatViewModel+Attachments.
 /// ChatViewModel holds a reference to this object and forwards reads/writes via
@@ -32,7 +56,7 @@ public final class ChatAttachmentManager: ObservableObject {
     /// Limits concurrent attachment I/O to avoid unbounded memory spikes when
     /// many files are selected at once (each can read up to 20 MB).
     private static let maxConcurrentLoads = 4
-    private let loadSemaphore = DispatchSemaphore(value: maxConcurrentLoads)
+    private let loadSemaphore = AsyncSemaphore(value: maxConcurrentLoads)
 
     // MARK: - Limits
 
@@ -135,17 +159,16 @@ public final class ChatAttachmentManager: ObservableObject {
     /// All blocking work runs off the main actor; callers receive a ready-to-use
     /// ChatAttachment (or an error message) and can update UI state directly.
     private func loadAttachment(url: URL) async -> Result<ChatAttachment, AttachmentError> {
-        let semaphore = self.loadSemaphore
+        // Suspend (not block) until a concurrency slot is available.
+        await loadSemaphore.wait()
         // Hop off the main actor for all blocking I/O and CPU work.
-        return await Task.detached(priority: .userInitiated) {
-            semaphore.wait()
-            defer { semaphore.signal() }
+        let result = await Task.detached(priority: .userInitiated) {
             let data: Data
             do {
                 data = try Data(contentsOf: url)
             } catch {
                 log.error("Failed to read attachment: \(error.localizedDescription)")
-                return .failure(.message("Could not read file."))
+                return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
             }
 
             // Belt-and-suspenders: validate the actual byte count after reading.
@@ -208,15 +231,16 @@ public final class ChatAttachmentManager: ObservableObject {
             )
             return .success(attachment)
         }.value
+        await loadSemaphore.signal()
+        return result
     }
 
     /// Converts, validates, compresses, and thumbnails an attachment from raw image data.
     /// All blocking work runs off the main actor.
     private func loadAttachment(imageData: Data, filename: String) async -> Result<ChatAttachment, AttachmentError> {
-        let semaphore = self.loadSemaphore
-        return await Task.detached(priority: .userInitiated) {
-            semaphore.wait()
-            defer { semaphore.signal() }
+        // Suspend (not block) until a concurrency slot is available.
+        await loadSemaphore.wait()
+        let result = await Task.detached(priority: .userInitiated) {
             // Convert to PNG if needed — raw image data may be TIFF
             let pngData: Data
             #if os(macOS)
@@ -231,11 +255,11 @@ public final class ChatAttachmentManager: ObservableObject {
                     pngData = converted
                 } else {
                     log.error("Failed to convert dropped image to PNG")
-                    return .failure(.message("Could not process image."))
+                    return Result<ChatAttachment, AttachmentError>.failure(.message("Could not process image."))
                 }
             } else {
                 log.error("Dropped data is not a valid image")
-                return .failure(.message("Could not process image."))
+                return Result<ChatAttachment, AttachmentError>.failure(.message("Could not process image."))
             }
             #elseif os(iOS)
             if let image = UIImage(data: imageData) {
@@ -248,11 +272,11 @@ public final class ChatAttachmentManager: ObservableObject {
                     pngData = converted
                 } else {
                     log.error("Failed to convert dropped image to PNG")
-                    return .failure(.message("Could not process image."))
+                    return Result<ChatAttachment, AttachmentError>.failure(.message("Could not process image."))
                 }
             } else {
                 log.error("Dropped data is not a valid image")
-                return .failure(.message("Could not process image."))
+                return Result<ChatAttachment, AttachmentError>.failure(.message("Could not process image."))
             }
             #else
             #error("Unsupported platform")
@@ -302,6 +326,8 @@ public final class ChatAttachmentManager: ObservableObject {
             )
             return .success(attachment)
         }.value
+        await loadSemaphore.signal()
+        return result
     }
 
     // MARK: - Static helpers (shared with ChatViewModel+Attachments and mapMessageAttachments)


### PR DESCRIPTION
Address review feedback from #15771. Replace DispatchSemaphore.wait()/signal() with an actor-based AsyncSemaphore that suspends instead of blocking cooperative thread pool threads, preventing potential app-wide thread starvation when many attachments are loaded concurrently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
