### PR TITLE
fix: add computer_use_observe to test constants and TOOLS.json manifest

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
@@ -29,7 +29,7 @@ const manifestPath = resolve(
 const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
 
 describe("computer-use skill manifest regression", () => {
-  test("manifest has exactly 12 tools", () => {
+  test("manifest has exactly 11 tools", () => {
     expect(manifest.tools).toHaveLength(COMPUTER_USE_TOOL_COUNT);
   });
 

--- a/assistant/src/__tests__/computer-use-tools.test.ts
+++ b/assistant/src/__tests__/computer-use-tools.test.ts
@@ -40,8 +40,8 @@ const ctx: ToolContext = {
 // ── Tool definitions ────────────────────────────────────────────────
 
 describe("computer-use tool definitions", () => {
-  test("allComputerUseTools contains 10 tools", () => {
-    expect(allComputerUseTools.length).toBe(10);
+  test("allComputerUseTools contains 11 tools", () => {
+    expect(allComputerUseTools.length).toBe(11);
   });
 
   test("all tools have proxy execution mode", () => {

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -510,7 +510,7 @@ describe("computer-use registration split", () => {
   // Start each test from a completely empty registry so assertions are
   // non-vacuous — the split functions must actually register tools.
 
-  test("registerComputerUseActionTools registers all 10 CU action tools and nothing else", async () => {
+  test("registerComputerUseActionTools registers all 11 CU action tools and nothing else", async () => {
     const { registerComputerUseActionTools } =
       await import("../tools/computer-use/registry.js");
 
@@ -520,7 +520,7 @@ describe("computer-use registration split", () => {
     registerComputerUseActionTools();
 
     const registered = getAllTools();
-    expect(registered).toHaveLength(10);
+    expect(registered).toHaveLength(11);
     expect(registered.every((t) => t.name.startsWith("computer_use_"))).toBe(
       true,
     );

--- a/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
@@ -2,8 +2,9 @@
  * Reusable constants and helpers for the computer-use skill migration test suite.
  */
 
-/** The 10 computer_use_* action tool names provided by the bundled computer-use skill. */
+/** The 11 computer_use_* action tool names provided by the bundled computer-use skill. */
 export const COMPUTER_USE_TOOL_NAMES = [
+  "computer_use_observe",
   "computer_use_click",
   "computer_use_type_text",
   "computer_use_key",
@@ -20,7 +21,7 @@ export const COMPUTER_USE_TOOL_NAMES = [
 export const COMPUTER_USE_SKILL_ID = "computer-use";
 
 /** Number of computer_use_* tools. */
-export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 10
+export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 11
 
 import { expect } from "bun:test";
 

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -2,6 +2,24 @@
   "version": 1,
   "tools": [
     {
+      "name": "computer_use_observe",
+      "description": "Capture the current screen state. Returns the accessibility tree (with [ID] element references for targeting) and a screenshot. Call this before your first computer use action to see what's on screen, or any time you need to check the current state without performing an action.",
+      "category": "computer-use",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["reason"]
+      },
+      "executor": "tools/computer-use-observe.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "computer_use_click",
       "description": "Click on a UI element by its [ID] from the accessibility tree, or at raw screen coordinates as fallback. Supports single click, double-click, and right-click via the click_type parameter.",
       "category": "computer-use",


### PR DESCRIPTION
## Summary
- Add `computer_use_observe` to `COMPUTER_USE_TOOL_NAMES` array and TOOLS.json manifest (missed in #15779)
- Update tool count expectations from 10 to 11 in `registry.test.ts`, `computer-use-tools.test.ts`, and `computer-use-skill-manifest-regression.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23012613157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
