### PR TITLE
feat(cli): command history with up/down arrows in TUI

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -17,6 +17,7 @@ import { removeAssistantEntry } from "../lib/assistant-config";
 import { SPECIES_CONFIG, type Species } from "../lib/constants";
 import { callDoctorDaemon, type ChatLogEntry } from "../lib/doctor-client";
 import { checkHealth } from "../lib/health-check";
+import { appendHistory, loadHistory } from "../lib/input-history";
 import { statusEmoji, withStatusEmoji } from "../lib/status-emoji";
 import TextInput from "./TextInput";
 import { Tooltip } from "./Tooltip";
@@ -1137,6 +1138,9 @@ function ChatApp({
   handleRef,
 }: ChatAppProps): ReactElement {
   const [inputValue, setInputValue] = useState("");
+  const historyRef = useRef<string[]>(loadHistory());
+  const historyIndexRef = useRef(-1);
+  const savedInputRef = useRef("");
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [spinnerText, setSpinnerText] = useState<string | null>(null);
   const [selection, setSelection] = useState<SelectionRequest | null>(null);
@@ -2022,11 +2026,42 @@ function ChatApp({
 
   const handleSubmit = useCallback(
     (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        appendHistory(trimmed);
+        historyRef.current = loadHistory();
+      }
+      historyIndexRef.current = -1;
+      savedInputRef.current = "";
       setInputValue("");
       handleInput(value);
     },
     [handleInput],
   );
+
+  const handleHistoryUp = useCallback(() => {
+    const history = historyRef.current;
+    if (history.length === 0) return;
+    if (historyIndexRef.current === -1) {
+      savedInputRef.current = inputValue;
+    }
+    const nextIndex = Math.min(historyIndexRef.current + 1, history.length - 1);
+    historyIndexRef.current = nextIndex;
+    const entry = history[history.length - 1 - nextIndex];
+    setInputValue(entry);
+  }, [inputValue]);
+
+  const handleHistoryDown = useCallback(() => {
+    if (historyIndexRef.current <= 0) {
+      historyIndexRef.current = -1;
+      setInputValue(savedInputRef.current);
+      return;
+    }
+    historyIndexRef.current -= 1;
+    const history = historyRef.current;
+    const entry = history[history.length - 1 - historyIndexRef.current];
+    setInputValue(entry);
+  }, []);
 
   useEffect(() => {
     const handle: ChatAppHandle = {
@@ -2238,6 +2273,8 @@ function ChatApp({
               value={inputValue}
               onChange={setInputValue}
               onSubmit={handleSubmit}
+              onHistoryUp={handleHistoryUp}
+              onHistoryDown={handleHistoryDown}
               focus={inputFocused}
             />
           </Box>

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -2052,6 +2052,7 @@ function ChatApp({
   }, [inputValue]);
 
   const handleHistoryDown = useCallback(() => {
+    if (historyIndexRef.current === -1) return;
     if (historyIndexRef.current <= 0) {
       historyIndexRef.current = -1;
       setInputValue(savedInputRef.current);

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -6,6 +6,8 @@ interface TextInputProps {
   value: string;
   onChange: (value: string) => void;
   onSubmit?: (value: string) => void;
+  onHistoryUp?: () => void;
+  onHistoryDown?: () => void;
   focus?: boolean;
   placeholder?: string;
 }
@@ -14,6 +16,8 @@ function TextInput({
   value,
   onChange,
   onSubmit,
+  onHistoryUp,
+  onHistoryDown,
   focus = true,
   placeholder = "",
 }: TextInputProps): ReactElement {
@@ -30,13 +34,17 @@ function TextInput({
 
   useInput(
     (input, key) => {
-      if (
-        key.upArrow ||
-        key.downArrow ||
-        (key.ctrl && input === "c") ||
-        key.tab ||
-        (key.shift && key.tab)
-      ) {
+      if (key.upArrow) {
+        onHistoryUp?.();
+        setRenderTick((t) => t + 1);
+        return;
+      }
+      if (key.downArrow) {
+        onHistoryDown?.();
+        setRenderTick((t) => t + 1);
+        return;
+      }
+      if ((key.ctrl && input === "c") || key.tab || (key.shift && key.tab)) {
         return;
       }
 

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -34,13 +34,15 @@ function TextInput({
 
   useInput(
     (input, key) => {
-      if (key.upArrow) {
+      if (key.upArrow && !key.shift && !key.meta) {
         onHistoryUp?.();
+        cursorOffsetRef.current = Infinity;
         setRenderTick((t) => t + 1);
         return;
       }
-      if (key.downArrow) {
+      if (key.downArrow && !key.shift && !key.meta) {
         onHistoryDown?.();
+        cursorOffsetRef.current = Infinity;
         setRenderTick((t) => t + 1);
         return;
       }

--- a/cli/src/lib/input-history.ts
+++ b/cli/src/lib/input-history.ts
@@ -1,0 +1,44 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+const MAX_ENTRIES = 1000;
+
+function historyPath(): string {
+  return join(homedir(), ".vellum", "input-history");
+}
+
+export function loadHistory(): string[] {
+  try {
+    const path = historyPath();
+    if (!existsSync(path)) return [];
+    const content = readFileSync(path, "utf-8");
+    return content
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .slice(-MAX_ENTRIES);
+  } catch {
+    return [];
+  }
+}
+
+export function appendHistory(entry: string): void {
+  const trimmed = entry.trim();
+  if (!trimmed || trimmed.startsWith("/")) return;
+  try {
+    const path = historyPath();
+    const dir = dirname(path);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const existing = loadHistory();
+    // Deduplicate: remove previous occurrence of the same entry
+    const deduped = existing.filter((e) => e !== trimmed);
+    deduped.push(trimmed);
+    // Keep only the last MAX_ENTRIES
+    const trimmedList = deduped.slice(-MAX_ENTRIES);
+    writeFileSync(path, trimmedList.join("\n") + "\n", { mode: 0o600 });
+  } catch {
+    // Best-effort persistence — don't crash on write failure
+  }
+}


### PR DESCRIPTION
## Summary
- Up/down arrows recall previous messages in the TUI chat input
- History persisted to `~/.vellum/input-history` across sessions
- Current unsent input preserved when navigating history
- Deduplicates consecutive entries, max 1000

## Test plan
- [ ] Type and send a few messages
- [ ] Press up arrow — recalls last message
- [ ] Keep pressing up — walks through history
- [ ] Press down — goes forward, eventually returns to empty/unsent input
- [ ] Exit and reconnect — history persists
- [ ] Slash commands (`/help`, `/clear`) are not saved to history

Closes #15752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
