### PR TITLE
fix: prevent finally block from defeating deferred slash command cleanup

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -792,6 +792,7 @@ export async function handleSendMessage(
 
   if (slashResult.kind === "unknown") {
     session.processing = true;
+    let cleanupDeferred = false;
     try {
       const provenance = provenanceFromTrustContext(session.trustContext);
       const channelMeta = {
@@ -867,11 +868,12 @@ export async function handleSendMessage(
         session.drainQueue().catch(() => {});
       }, 0);
 
+      cleanupDeferred = true;
       return response;
     } finally {
       // No-op for the slash-command early-return path (handled inside
       // setTimeout above), but still needed for error paths.
-      if (session.processing) {
+      if (!cleanupDeferred && session.processing) {
         session.processing = false;
         session.drainQueue().catch(() => {});
       }


### PR DESCRIPTION
Address review feedback from #15776: The finally block in handleSendMessage runs synchronously before the setTimeout callback, defeating the deferred cleanup of session.processing and drainQueue(). Add a cleanupDeferred flag so the finally block is a no-op on the happy path (where cleanup is handled by setTimeout) while still cleaning up on error paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
