### PR TITLE
fix: redact MCP transport headers and env vars in config export

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -181,6 +181,38 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
       config.twilio = twilio;
     }
 
+    // Strip MCP transport headers (SSE/streamable-http) and env vars (stdio)
+    if (config.mcp && typeof config.mcp === "object") {
+      const mcp = config.mcp as Record<string, unknown>;
+      if (mcp.servers && typeof mcp.servers === "object") {
+        const servers = mcp.servers as Record<string, unknown>;
+        for (const name of Object.keys(servers)) {
+          const server = servers[name];
+          if (server && typeof server === "object") {
+            const s = server as Record<string, unknown>;
+            if (s.transport && typeof s.transport === "object") {
+              const transport = s.transport as Record<string, unknown>;
+              if (transport.headers && typeof transport.headers === "object") {
+                const headers = transport.headers as Record<string, unknown>;
+                transport.headers = Object.fromEntries(
+                  Object.keys(headers).map((k) => [
+                    k,
+                    redactStringValue(headers[k]),
+                  ]),
+                );
+              }
+              if (transport.env && typeof transport.env === "object") {
+                const env = transport.env as Record<string, unknown>;
+                transport.env = Object.fromEntries(
+                  Object.keys(env).map((k) => [k, redactStringValue(env[k])]),
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
     return config;
   } catch {
     return undefined;

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -644,6 +644,32 @@ enum LogExporter {
             config["twilio"] = twilio
         }
 
+        // Strip MCP transport headers (SSE/streamable-http) and env vars (stdio)
+        if var mcp = config["mcp"] as? [String: Any],
+           var servers = mcp["servers"] as? [String: [String: Any]] {
+            for name in servers.keys {
+                var server = servers[name]!
+                if var transport = server["transport"] as? [String: Any] {
+                    if var headers = transport["headers"] as? [String: Any] {
+                        for key in headers.keys {
+                            headers[key] = redactValue(headers[key])
+                        }
+                        transport["headers"] = headers
+                    }
+                    if var env = transport["env"] as? [String: Any] {
+                        for key in env.keys {
+                            env[key] = redactValue(env[key])
+                        }
+                        transport["env"] = env
+                    }
+                    server["transport"] = transport
+                }
+                servers[name] = server
+            }
+            mcp["servers"] = servers
+            config["mcp"] = mcp
+        }
+
         guard let data = try? JSONSerialization.data(
             withJSONObject: config,
             options: [.prettyPrinted, .sortedKeys]


### PR DESCRIPTION
Address review feedback from #15774: MCP server configs can contain sensitive data in transport.headers (SSE/streamable-http) and transport.env (stdio). Add redaction of these fields in both TS (readSanitizedConfig) and Swift (writeSanitizedWorkspaceConfig) sanitization paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
