### PR TITLE
fix: update CU tool count in tests to include computer_use_observe

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -142,7 +142,7 @@ describe("ComputerUseSession lifecycle", () => {
     expect(session.getState()).toBe("error");
   });
 
-  test("CU session passes exactly 10 computer_use_* tools to the agent loop", async () => {
+  test("CU session passes exactly 11 computer_use_* tools to the agent loop", async () => {
     let capturedTools: string[] = [];
     const provider: Provider = {
       name: "mock",
@@ -181,10 +181,11 @@ describe("ComputerUseSession lifecycle", () => {
     });
 
     const cuTools = capturedTools.filter((n) => n.startsWith("computer_use_"));
-    expect(cuTools).toHaveLength(10);
+    expect(cuTools).toHaveLength(11);
 
     // Assert exact set of expected CU tool names
     const expectedCuTools = [
+      "computer_use_observe",
       "computer_use_click",
       "computer_use_type_text",
       "computer_use_key",
@@ -250,7 +251,7 @@ describe("ComputerUseSession lifecycle", () => {
     expect(completes[0].isResponse).toBe(true);
   });
 
-  test("default construction preactivates computer-use skill and provides 10 CU tools", async () => {
+  test("default construction preactivates computer-use skill and provides 11 CU tools", async () => {
     let capturedTools: string[] = [];
     const provider: Provider = {
       name: "mock",
@@ -291,7 +292,7 @@ describe("ComputerUseSession lifecycle", () => {
     });
 
     const cuTools = capturedTools.filter((n) => n.startsWith("computer_use_"));
-    expect(cuTools).toHaveLength(10);
+    expect(cuTools).toHaveLength(11);
   });
 
   test("constructor accepts preactivatedSkillIds parameter", () => {

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -725,8 +725,9 @@ describe("bundled computer-use skill", () => {
     expect(cuSkill!.toolManifest).toBeDefined();
     expect(cuSkill!.toolManifest!.present).toBe(true);
     expect(cuSkill!.toolManifest!.valid).toBe(true);
-    expect(cuSkill!.toolManifest!.toolCount).toBe(10);
+    expect(cuSkill!.toolManifest!.toolCount).toBe(11);
     expect(cuSkill!.toolManifest!.toolNames).toEqual([
+      "computer_use_observe",
       "computer_use_click",
       "computer_use_type_text",
       "computer_use_key",


### PR DESCRIPTION
## Summary
- Updated hardcoded tool count expectations from 10 to 11 in `skills.test.ts` and `computer-use-session-lifecycle.test.ts`
- Added `computer_use_observe` to expected tool name lists to match the TOOLS.json manifest
- The recent addition of `computer_use_observe` to TOOLS.json (#15784) didn't update these test assertions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23012857764/job/66828028506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
