### PR TITLE
fix: exclude computer_use_observe from legacy fallback tool set

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -20,7 +20,7 @@ import type {
   Provider,
   ToolDefinition,
 } from "../providers/types.js";
-import { allComputerUseTools } from "../tools/computer-use/definitions.js";
+import { legacyFallbackComputerUseTools } from "../tools/computer-use/definitions.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { getTool, registerSkillTools } from "../tools/registry.js";
 import {
@@ -356,7 +356,7 @@ export class ComputerUseSession {
       // core-vs-skill collisions that would permanently block skill
       // projection recovery on subsequent sessions.
       const fallbackSkillId = this.preactivatedSkillIds[0] ?? "computer-use";
-      const fallbackTools: Tool[] = allComputerUseTools.map((t) => ({
+      const fallbackTools: Tool[] = legacyFallbackComputerUseTools.map((t) => ({
         ...t,
         origin: "skill" as const,
         ownerSkillId: fallbackSkillId,
@@ -365,7 +365,7 @@ export class ComputerUseSession {
       registerSkillTools(fallbackTools);
       // Track in the session map so resetSkillToolProjection cleans up
       this.skillProjectionState.set(fallbackSkillId, "fallback");
-      cuToolDefs = allComputerUseTools.map((t) => t.getDefinition());
+      cuToolDefs = legacyFallbackComputerUseTools.map((t) => t.getDefinition());
     }
 
     const toolDefs: ToolDefinition[] = [

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -504,3 +504,13 @@ export const allComputerUseTools: Tool[] = [
   computerUseDoneTool,
   computerUseRespondTool,
 ];
+
+/**
+ * Tools safe for the legacy fallback path (no skill projection).
+ *
+ * Excludes `computer_use_observe` because the macOS client doesn't handle it
+ * in the legacy code path — it falls back to `.done` which skips sending an
+ * observation, causing the daemon to block on `pendingObservation` until timeout.
+ */
+export const legacyFallbackComputerUseTools: Tool[] =
+  allComputerUseTools.filter((t) => t.name !== "computer_use_observe");


### PR DESCRIPTION
Address review feedback from #15779: The legacy fallback path in ComputerUseSession.runAgentLoop advertises computer_use_observe via allComputerUseTools, but the macOS client doesn't handle it and falls back to .done, causing the daemon to block on pendingObservation until timeout. Exclude observe from the fallback tool set while keeping it available via skill projection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
