### PR TITLE
feat: add collectAllMissing helper to skill include-graph

### DIFF
--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
 import {
+  collectAllMissing,
   getImmediateChildren,
   indexCatalogById,
   traverseIncludes,
@@ -296,5 +297,70 @@ describe("validateIncludes — cycle detection", () => {
     if (!result.ok) {
       expect(result.error).toBe("missing");
     }
+  });
+});
+
+describe("collectAllMissing", () => {
+  test("returns empty set when skill has no includes", () => {
+    const catalog = [makeSkill("root")];
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("root", index)).toEqual(new Set([]));
+  });
+
+  test("returns empty set when all includes are present", () => {
+    const catalog = [makeSkill("A", ["B"]), makeSkill("B")];
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("A", index)).toEqual(new Set([]));
+  });
+
+  test("returns immediate missing children", () => {
+    const catalog = [makeSkill("A", ["B", "C"]), makeSkill("C")];
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("A", index)).toEqual(new Set(["B"]));
+  });
+
+  test("returns transitive missing children", () => {
+    const catalog = [makeSkill("A", ["B"]), makeSkill("B", ["C"])];
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("A", index)).toEqual(new Set(["C"]));
+  });
+
+  test("returns multiple missing at different levels", () => {
+    // A→B→C, B present but C missing
+    const catalog1 = [makeSkill("A", ["B"]), makeSkill("B", ["C"])];
+    const index1 = indexCatalogById(catalog1);
+    expect(collectAllMissing("A", index1)).toEqual(new Set(["C"]));
+
+    // A includes B and C, both missing
+    const catalog2 = [makeSkill("A", ["B", "C"])];
+    const index2 = indexCatalogById(catalog2);
+    expect(collectAllMissing("A", index2)).toEqual(new Set(["B", "C"]));
+  });
+
+  test("handles diamond with missing leaf", () => {
+    const catalog = [
+      makeSkill("A", ["B", "C"]),
+      makeSkill("B", ["D"]),
+      makeSkill("C", ["D"]),
+    ];
+    const index = indexCatalogById(catalog);
+    const result = collectAllMissing("A", index);
+    expect(result).toEqual(new Set(["D"]));
+    // Verify no duplicates (Set handles this, but confirm size)
+    expect(result.size).toBe(1);
+  });
+
+  test("does not loop infinitely on cycles", () => {
+    const catalog = [makeSkill("A", ["B"]), makeSkill("B", ["A"])];
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("A", index)).toEqual(new Set([]));
+  });
+
+  test("handles cycle with missing node", () => {
+    const catalog = [makeSkill("A", ["B"]), makeSkill("B", ["C"])];
+    // C is missing, and if C referenced B it would be a cycle — but C isn't in catalog
+    // So A→B→C, C missing
+    const index = indexCatalogById(catalog);
+    expect(collectAllMissing("A", index)).toEqual(new Set(["C"]));
   });
 });

--- a/assistant/src/skills/include-graph.ts
+++ b/assistant/src/skills/include-graph.ts
@@ -151,3 +151,35 @@ export function traverseIncludes(
   dfs(rootId);
   return { visited };
 }
+
+/**
+ * Collect all missing skill IDs reachable from the root's include graph.
+ * DFS traversal that tracks visited nodes to prevent infinite loops on cycles.
+ * The root itself is never reported as missing (it's already loaded by the caller).
+ */
+export function collectAllMissing(
+  rootId: string,
+  catalogIndex: Map<string, SkillSummary>,
+): Set<string> {
+  const missing = new Set<string>();
+  const visited = new Set<string>();
+
+  function dfs(id: string): void {
+    if (visited.has(id)) return;
+    visited.add(id);
+
+    const skill = catalogIndex.get(id);
+    if (!skill?.includes) return;
+
+    for (const childId of skill.includes) {
+      if (!catalogIndex.has(childId)) {
+        missing.add(childId);
+      } else if (!visited.has(childId)) {
+        dfs(childId);
+      }
+    }
+  }
+
+  dfs(rootId);
+  return missing;
+}


### PR DESCRIPTION
## Summary
- Add `collectAllMissing(rootId, catalogIndex)` function to `include-graph.ts` that performs a DFS to collect all missing skill IDs reachable from a root skill's include graph
- Handles cycles, diamond dependencies, and transitive missing children
- 8 new tests covering all edge cases

Part of plan: auto-install-skill-deps.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
