### PR TITLE
fix: sync computer_use_observe manifest description with core definition

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "computer_use_observe",
-      "description": "Capture the current screen state. Returns the accessibility tree (with [ID] element references for targeting) and a screenshot. Call this before your first computer use action to see what's on screen, or any time you need to check the current state without performing an action.",
+      "description": "Capture the current screen state. Returns the accessibility tree with [ID] element references and optionally a screenshot.\n\nThe accessibility tree shows interactive elements like [3] AXButton 'Save' or [17] AXTextField 'Search'. Use element_id to target these elements in subsequent actions — this is much more reliable than pixel coordinates.\n\nCall this before your first computer use action, or to check screen state without acting.",
       "category": "computer-use",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Updated the `computer_use_observe` description in `TOOLS.json` manifest to match the updated core definition in `definitions.ts`
- The core definition was updated (more detailed description with accessibility tree examples) but the manifest was not synced, causing the regression test to fail

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23013159358/job/66829135939

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
