### PR TITLE
feat: add POST /v1/host-cu-result endpoint for CU observation results

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -50,6 +50,8 @@ import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
+import type { CuObservationResult } from "./host-cu-proxy.js";
+import { HostCuProxy } from "./host-cu-proxy.js";
 import { HostFileProxy } from "./host-file-proxy.js";
 import type {
   ServerMessage,
@@ -164,6 +166,7 @@ export class Session {
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
   /** @internal */ hostBashProxy?: HostBashProxy;
+  /** @internal */ hostCuProxy?: HostCuProxy;
   /** @internal */ hostFileProxy?: HostFileProxy;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
@@ -391,6 +394,7 @@ export class Session {
     this.traceEmitter.updateSender(sendToClient);
     if (!opts?.skipProxySenderUpdate) {
       this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
+      this.hostCuProxy?.updateSender(sendToClient, !hasNoClient);
       this.hostFileProxy?.updateSender(sendToClient, !hasNoClient);
     }
   }
@@ -403,6 +407,7 @@ export class Session {
   /** Mark host proxies as unavailable so tool execution uses local fallback. */
   clearProxyAvailability(): void {
     this.hostBashProxy?.updateSender(this.sendToClient, false);
+    this.hostCuProxy?.updateSender(this.sendToClient, false);
     this.hostFileProxy?.updateSender(this.sendToClient, false);
   }
 
@@ -410,6 +415,7 @@ export class Session {
   restoreProxyAvailability(): void {
     if (!this.hasNoClient) {
       this.hostBashProxy?.updateSender(this.sendToClient, true);
+      this.hostCuProxy?.updateSender(this.sendToClient, true);
       this.hostFileProxy?.updateSender(this.sendToClient, true);
     }
   }
@@ -450,6 +456,7 @@ export class Session {
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
     this.hostBashProxy?.dispose();
+    this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
     disposeSession(this);
   }
@@ -749,6 +756,17 @@ export class Session {
       this.hostFileProxy.dispose();
     }
     this.hostFileProxy = proxy;
+  }
+
+  resolveHostCu(requestId: string, observation: CuObservationResult): void {
+    this.hostCuProxy?.resolve(requestId, observation);
+  }
+
+  setHostCuProxy(proxy: HostCuProxy | undefined): void {
+    if (this.hostCuProxy && this.hostCuProxy !== proxy) {
+      this.hostCuProxy.dispose();
+    }
+    this.hostCuProxy = proxy;
   }
 
   // ── Server-authoritative state signals ─────────────────────────────

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -126,6 +126,7 @@ import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
+import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
@@ -949,6 +950,7 @@ export class RuntimeHttpServer {
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),
       ...hostBashRouteDefinitions(),
+      ...hostCuRouteDefinitions(),
       ...hostFileRouteDefinitions(),
       ...(this.getSkillContext
         ? skillRouteDefinitions({

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -1,0 +1,97 @@
+/**
+ * Route handler for host CU (computer-use) result submissions.
+ *
+ * Resolves pending host CU proxy requests by requestId when the desktop
+ * client returns observation results via HTTP.
+ */
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
+import type { AuthContext } from "../auth/types.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+/**
+ * POST /v1/host-cu-result — resolve a pending host CU request by requestId.
+ * Requires AuthContext with guardian-bound actor.
+ */
+export async function handleHostCuResult(
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const body = (await req.json()) as {
+    requestId?: string;
+    axTree?: string;
+    axDiff?: string;
+    screenshot?: string;
+    screenshotWidthPx?: number;
+    screenshotHeightPx?: number;
+    screenWidthPt?: number;
+    screenHeightPt?: number;
+    executionResult?: string;
+    executionError?: string;
+    secondaryWindows?: string;
+    userGuidance?: string;
+  };
+
+  const { requestId } = body;
+
+  if (!requestId || typeof requestId !== "string") {
+    return httpError("BAD_REQUEST", "requestId is required", 400);
+  }
+
+  // Peek first (non-destructive) so we can validate the interaction kind
+  // without accidentally consuming a confirmation or secret interaction.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    return httpError(
+      "NOT_FOUND",
+      "No pending interaction found for this requestId",
+      404,
+    );
+  }
+
+  if (peeked.kind !== "host_cu") {
+    return httpError(
+      "CONFLICT",
+      `Pending interaction is of kind "${peeked.kind}", expected "host_cu"`,
+      409,
+    );
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
+
+  interaction.session.resolveHostCu(requestId, {
+    axTree: body.axTree,
+    axDiff: body.axDiff,
+    screenshot: body.screenshot,
+    screenshotWidthPx: body.screenshotWidthPx,
+    screenshotHeightPx: body.screenshotHeightPx,
+    screenWidthPt: body.screenWidthPt,
+    screenHeightPt: body.screenHeightPt,
+    executionResult: body.executionResult,
+    executionError: body.executionError,
+    secondaryWindows: body.secondaryWindows,
+    userGuidance: body.userGuidance,
+  });
+
+  return Response.json({ accepted: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function hostCuRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "host-cu-result",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleHostCuResult(req, authContext),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Create `host-cu-routes.ts` with `handleHostCuResult` and `hostCuRouteDefinitions` — validates `requestId`, peeks pending interaction (kind must be `host_cu`), consumes it, and calls `session.resolveHostCu()`
- Add `hostCuProxy` property and methods to `Session` (`setHostCuProxy`, `resolveHostCu`, and wiring in `updateClient`, `clearProxyAvailability`, `restoreProxyAvailability`, `dispose`)
- Register host-cu routes in `http-server.ts` alongside existing host-bash and host-file routes

Part of plan: unify-cu-main-loop.md (PR 4 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
