### PR TITLE
fix: correct test title to say 11 tools instead of 12

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -718,7 +718,7 @@ describe("bundled computer-use skill", () => {
     expect(cuSkill!.disableModelInvocation).toBe(true);
   });
 
-  test("computer-use skill has a valid tool manifest with 12 tools", () => {
+  test("computer-use skill has a valid tool manifest with 11 tools", () => {
     const catalog = loadSkillCatalog();
     const cuSkill = catalog.find((s) => s.id === "computer-use");
     expect(cuSkill).toBeDefined();


### PR DESCRIPTION
Address review feedback from #15790: the test title said '12 tools' but the assertion expects 11 tools after the computer_use_observe addition.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
