### PR TITLE
feat: strip old AX tree snapshots from conversation history in agent loop

### DIFF
--- a/assistant/src/agent/ax-tree-compaction.test.ts
+++ b/assistant/src/agent/ax-tree-compaction.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Message } from "../providers/types.js";
+import { compactAxTreeHistory, escapeAxTreeContent } from "./loop.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a user message with a single tool_result containing an AX tree. */
+function axTreeToolResult(id: string, axContent: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: id,
+        content: `Some preamble\n<ax-tree>\n${axContent}\n</ax-tree>`,
+        is_error: false,
+      },
+    ],
+  };
+}
+
+/** Build an assistant message (no tool use). */
+function assistantText(text: string): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+  };
+}
+
+/** Build a user message without AX tree content. */
+function userText(text: string): Message {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// compactAxTreeHistory
+// ---------------------------------------------------------------------------
+
+describe("compactAxTreeHistory", () => {
+  test("returns messages unchanged when fewer than MAX_AX_TREES_IN_HISTORY AX trees", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+    ];
+    const result = compactAxTreeHistory(messages);
+    expect(result).toBe(messages); // same reference — no copy
+  });
+
+  test("returns messages unchanged when exactly MAX_AX_TREES_IN_HISTORY AX trees", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+    ];
+    const result = compactAxTreeHistory(messages);
+    expect(result).toBe(messages);
+  });
+
+  test("strips oldest AX trees, keeps only last 2 from 5", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+      assistantText("ok"),
+      axTreeToolResult("t3", "tree-3"),
+      assistantText("ok"),
+      axTreeToolResult("t4", "tree-4"),
+      assistantText("ok"),
+      axTreeToolResult("t5", "tree-5"),
+    ];
+
+    const result = compactAxTreeHistory(messages);
+
+    // Messages at indices 0, 2, 4 should have AX trees stripped (t1, t2, t3)
+    for (const idx of [0, 2, 4]) {
+      const block = result[idx].content[0];
+      expect(block.type).toBe("tool_result");
+      if (block.type === "tool_result") {
+        expect(block.content).not.toContain("<ax-tree>");
+        expect(block.content).toContain("<ax_tree_omitted />");
+      }
+    }
+
+    // Messages at indices 6, 8 should still have AX trees (t4, t5)
+    for (const idx of [6, 8]) {
+      const block = result[idx].content[0];
+      expect(block.type).toBe("tool_result");
+      if (block.type === "tool_result") {
+        expect(block.content).toContain("<ax-tree>");
+        expect(block.content).not.toContain("<ax_tree_omitted />");
+      }
+    }
+  });
+
+  test("does not modify assistant messages", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+      assistantText("response with <ax-tree>fake</ax-tree>"),
+      axTreeToolResult("t3", "tree-3"),
+    ];
+
+    const result = compactAxTreeHistory(messages);
+
+    // Assistant message should be unchanged
+    const assistantMsg = result[3];
+    expect(assistantMsg.content[0].type).toBe("text");
+    if (assistantMsg.content[0].type === "text") {
+      expect(assistantMsg.content[0].text).toContain("<ax-tree>");
+    }
+  });
+
+  test("does not modify user messages without tool_result blocks", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+      assistantText("ok"),
+      userText("Please help"),
+      axTreeToolResult("t3", "tree-3"),
+    ];
+
+    const result = compactAxTreeHistory(messages);
+
+    // The plain user text message should be untouched
+    expect(result[4]).toBe(messages[4]);
+  });
+
+  test("preserves non-AX-tree tool_result blocks in stripped messages", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "normal result without ax tree",
+            is_error: false,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "t1-ax",
+            content: "<ax-tree>\ntree-1\n</ax-tree>",
+            is_error: false,
+          },
+        ],
+      },
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+      assistantText("ok"),
+      axTreeToolResult("t3", "tree-3"),
+    ];
+
+    const result = compactAxTreeHistory(messages);
+
+    // First message should have the AX tree stripped but normal result preserved
+    const firstMsg = result[0];
+    const normalBlock = firstMsg.content[0];
+    expect(normalBlock.type).toBe("tool_result");
+    if (normalBlock.type === "tool_result") {
+      expect(normalBlock.content).toBe("normal result without ax tree");
+    }
+
+    const axBlock = firstMsg.content[1];
+    expect(axBlock.type).toBe("tool_result");
+    if (axBlock.type === "tool_result") {
+      expect(axBlock.content).toContain("<ax_tree_omitted />");
+      expect(axBlock.content).not.toContain("<ax-tree>");
+    }
+  });
+
+  test("returns empty array for empty input", () => {
+    const result = compactAxTreeHistory([]);
+    expect(result).toEqual([]);
+  });
+
+  test("is pure — does not mutate input messages", () => {
+    const messages: Message[] = [
+      axTreeToolResult("t1", "tree-1"),
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+      assistantText("ok"),
+      axTreeToolResult("t3", "tree-3"),
+    ];
+
+    // Deep copy to compare later
+    const originalContent = messages[0].content[0];
+    const originalText =
+      originalContent.type === "tool_result" ? originalContent.content : "";
+
+    compactAxTreeHistory(messages);
+
+    // Original message should be unchanged
+    const afterContent = messages[0].content[0];
+    const afterText =
+      afterContent.type === "tool_result" ? afterContent.content : "";
+    expect(afterText).toBe(originalText);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeAxTreeContent
+// ---------------------------------------------------------------------------
+
+describe("escapeAxTreeContent", () => {
+  test("escapes literal </ax-tree> inside content", () => {
+    const input = "Some XML: <div></ax-tree></div>";
+    const result = escapeAxTreeContent(input);
+    expect(result).toBe("Some XML: <div>&lt;/ax-tree&gt;</div>");
+  });
+
+  test("handles case-insensitive matches", () => {
+    const input = "</AX-TREE> and </Ax-Tree>";
+    const result = escapeAxTreeContent(input);
+    expect(result).toBe("&lt;/ax-tree&gt; and &lt;/ax-tree&gt;");
+  });
+
+  test("returns content unchanged when no closing tags present", () => {
+    const input = "Normal AX tree content with <ax-tree> opening tag";
+    const result = escapeAxTreeContent(input);
+    expect(result).toBe(input);
+  });
+
+  test("handles empty string", () => {
+    expect(escapeAxTreeContent("")).toBe("");
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -257,7 +257,11 @@ export class AgentLoop {
         // screenshots from accumulating in the context window. The LLM
         // already saw each image on the turn it was captured; keeping
         // base64 blobs in history rapidly exhausts the context budget.
-        const providerHistory = stripOldImageBlocks(history);
+        // Also strip old AX tree snapshots to keep TTFT from growing
+        // linearly with step count in computer-use sessions.
+        const providerHistory = compactAxTreeHistory(
+          stripOldImageBlocks(history),
+        );
 
         const response = await this.provider.sendMessage(
           providerHistory,
@@ -629,6 +633,78 @@ export class AgentLoop {
 
     return history;
   }
+}
+
+/** Number of most-recent AX tree snapshots to keep in conversation history. */
+const MAX_AX_TREES_IN_HISTORY = 2;
+
+/** Regex that matches the `<ax-tree>...</ax-tree>` markers. */
+const AX_TREE_PATTERN = /<ax-tree>[\s\S]*?<\/ax-tree>/g;
+const AX_TREE_PLACEHOLDER = "<ax_tree_omitted />";
+
+/**
+ * Escapes any literal `</ax-tree>` occurrences inside AX tree content so
+ * that the non-greedy compaction regex (`AX_TREE_PATTERN`) does not stop
+ * prematurely when the user happens to be viewing XML/HTML source that
+ * contains the closing tag.  The escaped content does not need to be
+ * unescaped because compaction replaces the entire block with a placeholder.
+ */
+export function escapeAxTreeContent(content: string): string {
+  return content.replace(/<\/ax-tree>/gi, "&lt;/ax-tree&gt;");
+}
+
+/**
+ * Returns a shallow copy of `messages` where all but the most recent
+ * `MAX_AX_TREES_IN_HISTORY` `<ax-tree>` blocks have been replaced with a
+ * short placeholder.  This keeps the conversation context small so that
+ * TTFT does not grow linearly with step count in computer-use sessions.
+ */
+export function compactAxTreeHistory(messages: Message[]): Message[] {
+  // Collect indices of user messages that contain an <ax-tree> block
+  const indicesWithAxTree: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    for (const block of msg.content) {
+      if (
+        block.type === "tool_result" &&
+        typeof block.content === "string" &&
+        block.content.includes("<ax-tree>")
+      ) {
+        indicesWithAxTree.push(i);
+        break;
+      }
+    }
+  }
+
+  if (indicesWithAxTree.length <= MAX_AX_TREES_IN_HISTORY) {
+    return messages;
+  }
+
+  const toStrip = new Set(indicesWithAxTree.slice(0, -MAX_AX_TREES_IN_HISTORY));
+
+  return messages.map((msg, idx) => {
+    if (!toStrip.has(idx)) return msg;
+    return {
+      ...msg,
+      content: msg.content.map((block) => {
+        if (
+          block.type === "tool_result" &&
+          typeof block.content === "string" &&
+          block.content.includes("<ax-tree>")
+        ) {
+          return {
+            ...block,
+            content: block.content.replace(
+              AX_TREE_PATTERN,
+              AX_TREE_PLACEHOLDER,
+            ),
+          };
+        }
+        return block;
+      }),
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `compactAxTreeHistory()` to strip old AX tree snapshots from conversation history before each LLM call
- Keep only the 2 most recent AX tree blocks, replace older ones with `<ax_tree_omitted />`
- Integrate into the history preparation pipeline alongside existing `stripOldImageBlocks()`
- Add `escapeAxTreeContent()` utility for safe AX tree content handling
- Add 12 unit tests covering compaction logic, edge cases, and purity

Part of plan: unify-cu-main-loop.md (PR 6 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
