### PR TITLE
fix: sync computer_use_type_text manifest description with core definition

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "computer_use_type_text",
-      "description": "Type text at the current cursor position. The target field must already be focused (click it first).",
+      "description": "Type text at the current cursor position. First click a text field (by element_id) to focus it, then call this tool. If a field shows 'FOCUSED', skip the click.",
       "category": "computer-use",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Sync the `computer_use_type_text` description in TOOLS.json manifest with the core definition in `definitions.ts`
- Follows the same pattern as recent PRs (#15796, #15793) that synced other CU tool descriptions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23013637500/job/66830849074

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
