### PR TITLE
feat: trigger session overlay from host_cu_request events in main session

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -346,8 +346,13 @@ extension AppDelegate {
         }
 
         // Register host CU handler so incoming host_cu_request messages
-        // execute locally (verify -> execute -> observe -> post result)
-        HostCuExecutor.register(on: daemonClient)
+        // execute locally (verify -> execute -> observe -> post result).
+        // The overlay provider lazily creates a session overlay on the first
+        // host_cu_request for each conversation.
+        HostCuExecutor.register(on: daemonClient) { [weak self] sessionId, request in
+            guard let self else { return nil }
+            return self.getOrCreateHostCuOverlay(sessionId: sessionId, request: request)
+        }
 
         Task {
             if !isCurrentAssistantRemote {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import UserNotifications
 import VellumAssistantShared
 import os
@@ -32,6 +33,9 @@ extension AppDelegate {
     /// Handle escalation from an active text_qa session to foreground computer use.
     func handleEscalationToComputerUse(routed: TaskRoutedMessage) {
         Task { @MainActor in
+            // Dismiss any active host CU overlay to avoid conflicts
+            self.dismissHostCuOverlay()
+
             let shouldAutoApproveTools = routed.escalatedFrom
                 .map { self.autoApproveEscalationSessionIds.contains($0) } ?? false
 
@@ -210,6 +214,8 @@ extension AppDelegate {
             let shouldAutoApproveTools = submission.isVoiceAction
             switch routed.interactionType {
             case "computer_use":
+                // Dismiss any active host CU overlay to avoid conflicts
+                self.dismissHostCuOverlay()
                 guard await self.waitForAccessibilityPermission() else {
                     log.error("Accessibility permission denied — cannot start computer use session \(routed.sessionId)")
                     do {
@@ -391,6 +397,99 @@ extension AppDelegate {
             overlay.close()
             self.overlayWindow = nil
             self.currentSession = nil
+        }
+    }
+
+    // MARK: - Host CU Overlay (Proxy-Based Computer Use)
+
+    /// Returns the existing or newly created `HostCuSessionProxy` for the given
+    /// session. On first call for a session, creates the overlay window and pauses
+    /// ambient monitoring — matching the UX of foreground CU sessions.
+    func getOrCreateHostCuOverlay(sessionId: String, request: HostCuRequest) -> HostCuSessionProxy? {
+        // If there's already a foreground CU session, skip the overlay to avoid conflicts
+        guard currentSession == nil else {
+            log.debug("Skipping host CU overlay — foreground CU session is active")
+            return nil
+        }
+
+        // Return existing proxy if this session already has one
+        if activeOverlayConversationId == sessionId, let proxy = activeHostCuProxy {
+            return proxy
+        }
+
+        // Dismiss any stale overlay from a previous session
+        dismissHostCuOverlay()
+
+        let taskDescription = request.reasoning ?? "Computer use"
+        let proxy = HostCuSessionProxy(task: taskDescription, sessionId: sessionId)
+        proxy.state = .thinking(step: request.stepNumber, maxSteps: 50)
+
+        // Wire cancel to abort the main conversation session on the daemon
+        proxy.onCancel = { [weak self] in
+            guard let self else { return }
+            do {
+                try self.daemonClient.send(CancelMessage(sessionId: sessionId))
+            } catch {
+                log.error("Failed to send cancel for host CU session \(sessionId): \(error)")
+            }
+            self.dismissHostCuOverlay()
+        }
+
+        self.activeHostCuProxy = proxy
+        self.activeOverlayConversationId = sessionId
+
+        let overlay = SessionOverlayWindow(session: proxy)
+        overlay.show()
+        self.overlayWindow = overlay
+        self.ambientAgent.pause()
+
+        // Hide main window so the target app becomes frontmost for CU
+        if mainWindow?.isVisible == true {
+            mainWindow?.hide()
+        }
+
+        // Watch for terminal states and auto-dismiss after a delay.
+        // Use Combine sink instead of async publisher to avoid holding
+        // a long-lived task that blocks forever if terminal state is never reached.
+        hostCuOverlayCleanupTask?.cancel()
+        hostCuOverlayCleanupTask = nil
+        proxy.statePublisher
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .completed, .responded, .failed, .cancelled:
+                    // Terminal state — schedule delayed cleanup
+                    self.hostCuOverlayCleanupTask?.cancel()
+                    self.hostCuOverlayCleanupTask = Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 10_000_000_000) // 10s
+                        guard !Task.isCancelled else { return }
+                        self?.dismissHostCuOverlay()
+                    }
+                default:
+                    break
+                }
+            }
+            .store(in: &hostCuOverlayCancellables)
+
+        log.info("Created host CU overlay for session \(sessionId)")
+        return proxy
+    }
+
+    /// Dismiss the host CU overlay and clean up all associated state.
+    func dismissHostCuOverlay() {
+        hostCuOverlayCleanupTask?.cancel()
+        hostCuOverlayCleanupTask = nil
+        hostCuOverlayCancellables.removeAll()
+
+        overlayWindow?.close()
+        overlayWindow = nil
+        activeHostCuProxy = nil
+        activeOverlayConversationId = nil
+        ambientAgent.resume()
+
+        // Restore main window if it was hidden
+        if mainWindow?.isVisible == false {
+            mainWindow?.show()
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -29,6 +29,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
+    /// Proxy state tracker for host CU overlay (proxy-based computer use sessions).
+    var activeHostCuProxy: HostCuSessionProxy?
+    /// Conversation/session ID of the active host CU overlay.
+    var activeOverlayConversationId: String?
+    /// Cleanup task for dismissing the host CU overlay after completion.
+    var hostCuOverlayCleanupTask: Task<Void, Never>?
+    /// Combine subscriptions for host CU overlay state observation.
+    var hostCuOverlayCancellables = Set<AnyCancellable>()
     /// text_qa session IDs that should auto-enable CU auto-approve if they escalate.
     var autoApproveEscalationSessionIds: Set<String> = []
     var isStartingSession = false

--- a/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
@@ -13,20 +13,35 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Call this once at setup time so that incoming `host_cu_request` messages
 /// from the daemon are handled by the local verify -> execute -> observe cycle.
 ///
+/// The `overlayProvider` callback supplies the `HostCuSessionProxy` for a given
+/// session ID, creating one lazily on the first request. The executor updates
+/// the proxy's state around each action so the overlay reflects progress.
+///
 /// Usage:
 /// ```swift
-/// HostCuExecutor.register(on: daemonClient)
+/// HostCuExecutor.register(on: daemonClient) { sessionId, request in
+///     return getOrCreateOverlayProxy(for: sessionId, request: request)
+/// }
 /// ```
 enum HostCuExecutor {
 
     /// Register the host CU handler on the given daemon client.
     /// The handler will execute CU actions locally and post results back.
+    ///
+    /// - Parameters:
+    ///   - client: The daemon client to register on.
+    ///   - overlayProvider: Called on each request to get the session proxy for
+    ///     overlay state updates. May return nil to skip overlay updates.
     @MainActor
-    static func register(on client: DaemonClient) {
+    static func register(
+        on client: DaemonClient,
+        overlayProvider: @escaping @MainActor (_ sessionId: String, _ request: HostCuRequest) -> HostCuSessionProxy? = { _, _ in nil }
+    ) {
         client.onHostCuRequest = { [weak client] request in
             guard let client else { return }
             Task { @MainActor in
-                let result = await HostCuActionRunner.perform(request)
+                let proxy = overlayProvider(request.sessionId, request)
+                let result = await HostCuActionRunner.perform(request, overlayProxy: proxy)
                 log.debug("Host CU completed — requestId=\(request.requestId, privacy: .public) toolName=\(request.toolName, privacy: .public)")
                 await client.httpTransport?.postHostCuResult(result)
             }
@@ -40,7 +55,10 @@ enum HostCuExecutor {
 @MainActor
 enum HostCuActionRunner {
 
-    static func perform(_ request: HostCuRequest) async -> HostCuResultPayload {
+    /// Default max steps shown in the overlay when the daemon doesn't provide one.
+    private static let defaultMaxSteps = 50
+
+    static func perform(_ request: HostCuRequest, overlayProxy: HostCuSessionProxy? = nil) async -> HostCuResultPayload {
         let enumerator = AccessibilityTreeEnumerator()
         let screenCapture = ScreenCapture()
         let executor = ActionExecutor()
@@ -65,11 +83,13 @@ enum HostCuActionRunner {
                     executionError: "Could not resolve element coordinates for action",
                     stepNumber: request.stepNumber
                 )
-                return buildResultPayload(requestId: request.requestId, observation: obs)
+                return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
             }
 
-            // Skip execution for done/respond — those are completion signals
-            if resolvedAction.type == .done || resolvedAction.type == .respond {
+            // Handle done/respond completion signals — transition overlay and skip execution
+            if resolvedAction.type == .done {
+                let summary = resolvedAction.summary ?? "Task completed"
+                overlayProxy?.state = .completed(summary: summary, steps: request.stepNumber)
                 let obs = await buildObservation(
                     enumerator: enumerator,
                     screenCapture: screenCapture,
@@ -77,8 +97,29 @@ enum HostCuActionRunner {
                     executionError: nil,
                     stepNumber: request.stepNumber
                 )
-                return buildResultPayload(requestId: request.requestId, observation: obs)
+                return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
             }
+
+            if resolvedAction.type == .respond {
+                let answer = resolvedAction.text ?? resolvedAction.summary ?? ""
+                overlayProxy?.state = .responded(answer: answer, steps: request.stepNumber)
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: nil,
+                    stepNumber: request.stepNumber
+                )
+                return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
+            }
+
+            // Update overlay state to running before execution
+            overlayProxy?.state = .running(
+                step: request.stepNumber,
+                maxSteps: defaultMaxSteps,
+                lastAction: resolvedAction.displayDescription,
+                reasoning: request.reasoning ?? ""
+            )
 
             // VERIFY (local safety check)
             let verifyResult = verifier.verify(resolvedAction)
@@ -104,7 +145,7 @@ enum HostCuActionRunner {
                         executionError: "BLOCKED: \(reason) (confirmation not available in proxy mode)",
                         stepNumber: request.stepNumber
                     )
-                    return buildResultPayload(requestId: request.requestId, observation: obs)
+                    return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
                 }
 
             case .blocked(let reason):
@@ -116,7 +157,7 @@ enum HostCuActionRunner {
                     executionError: "BLOCKED: \(reason)",
                     stepNumber: request.stepNumber
                 )
-                return buildResultPayload(requestId: request.requestId, observation: obs)
+                return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
             }
 
             // EXECUTE
@@ -138,6 +179,9 @@ enum HostCuActionRunner {
             }
         }
 
+        // Update overlay state to thinking after execution
+        overlayProxy?.state = .thinking(step: request.stepNumber + 1, maxSteps: defaultMaxSteps)
+
         // OBSERVE — capture AX tree, screenshot, etc.
         let obs = await buildObservation(
             enumerator: enumerator,
@@ -147,7 +191,7 @@ enum HostCuActionRunner {
             stepNumber: request.stepNumber
         )
 
-        return buildResultPayload(requestId: request.requestId, observation: obs)
+        return buildResultPayload(requestId: request.requestId, observation: obs, proxy: overlayProxy)
     }
 
     // MARK: - Tool Name Mapping
@@ -377,8 +421,12 @@ enum HostCuActionRunner {
     }
 
     /// Package observation data into a `HostCuResultPayload`.
-    private static func buildResultPayload(requestId: String, observation: ObservationData) -> HostCuResultPayload {
-        HostCuResultPayload(
+    /// Drains any pending user guidance from the proxy.
+    private static func buildResultPayload(requestId: String, observation: ObservationData, proxy: HostCuSessionProxy? = nil) -> HostCuResultPayload {
+        let guidance = proxy?.pendingUserGuidance
+        proxy?.pendingUserGuidance = nil
+
+        return HostCuResultPayload(
             requestId: requestId,
             axTree: observation.axTree,
             axDiff: nil, // Diff requires tracking previous state across requests; handled server-side
@@ -390,7 +438,7 @@ enum HostCuActionRunner {
             executionResult: observation.executionResult,
             executionError: observation.executionError,
             secondaryWindows: observation.secondaryWindows,
-            userGuidance: nil
+            userGuidance: guidance
         )
     }
 

--- a/clients/macos/vellum-assistant/ComputerUse/HostCuSessionProxy.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/HostCuSessionProxy.swift
@@ -1,0 +1,84 @@
+import Combine
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HostCuSessionProxy")
+
+/// Protocol that abstracts the session interface needed by `SessionOverlayWindow`.
+/// Both `ComputerUseSession` (foreground CU) and `HostCuSessionProxy` (proxy CU)
+/// conform to this protocol so the overlay can display either type of session.
+@MainActor
+protocol SessionOverlayProviding: AnyObject {
+    var task: String { get }
+    var state: SessionState { get set }
+    var undoCount: Int { get set }
+    var autoApproveTools: Bool { get set }
+    var pendingUserGuidance: String? { get set }
+
+    var statePublisher: Published<SessionState>.Publisher { get }
+    var undoCountPublisher: Published<Int>.Publisher { get }
+    var autoApproveToolsPublisher: Published<Bool>.Publisher { get }
+
+    func cancel()
+    func pause()
+    func resume()
+    func undo()
+    func approveConfirmation()
+    func rejectConfirmation()
+}
+
+/// Lightweight state tracker for proxy-based CU sessions.
+/// Provides the same observable interface as `ComputerUseSession` so
+/// `SessionOverlayWindow` can display proxy CU progress.
+@MainActor
+final class HostCuSessionProxy: ObservableObject, SessionOverlayProviding {
+    @Published var state: SessionState = .idle
+    @Published var undoCount: Int = 0
+    @Published var autoApproveTools: Bool = false
+    @Published var pendingUserGuidance: String?
+
+    let task: String
+    let sessionId: String
+
+    /// Callback invoked when the user cancels via the overlay.
+    /// The AppDelegate wires this to abort the main session.
+    var onCancel: (() -> Void)?
+
+    var statePublisher: Published<SessionState>.Publisher { $state }
+    var undoCountPublisher: Published<Int>.Publisher { $undoCount }
+    var autoApproveToolsPublisher: Published<Bool>.Publisher { $autoApproveTools }
+
+    init(task: String, sessionId: String) {
+        self.task = task
+        self.sessionId = sessionId
+    }
+
+    func cancel() {
+        state = .cancelled
+        onCancel?()
+    }
+
+    func pause() {
+        // Pause is not supported in proxy mode — the daemon controls pacing.
+        log.info("Pause requested in proxy CU mode — not supported")
+    }
+
+    func resume() {
+        // Resume is not supported in proxy mode.
+        log.info("Resume requested in proxy CU mode — not supported")
+    }
+
+    func undo() {
+        // Undo is not meaningful in proxy mode since we don't own the action loop.
+        log.info("Undo requested in proxy CU mode — not supported")
+    }
+
+    func approveConfirmation() {
+        // Confirmation is handled server-side in proxy mode.
+    }
+
+    func rejectConfirmation() {
+        cancel()
+    }
+}

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import VellumAssistantShared
 import CoreGraphics
@@ -19,12 +20,16 @@ enum SessionState: Equatable {
 }
 
 @MainActor
-final class ComputerUseSession: ObservableObject {
+final class ComputerUseSession: ObservableObject, SessionOverlayProviding {
     @Published var state: SessionState = .idle
     @Published var undoCount = 0
     @Published var autoApproveTools = false
     /// Free-form guidance from the user, consumed on the next observation.
     @Published var pendingUserGuidance: String?
+
+    var statePublisher: Published<SessionState>.Publisher { $state }
+    var undoCountPublisher: Published<Int>.Publisher { $undoCount }
+    var autoApproveToolsPublisher: Published<Bool>.Publisher { $autoApproveTools }
 
     let task: String
     let id: String

--- a/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/SessionOverlayWindow.swift
@@ -6,7 +6,7 @@ import VellumAssistantShared
 @MainActor
 final class SessionOverlayWindow {
     private var panel: NSPanel?
-    private let session: ComputerUseSession
+    private let session: any SessionOverlayProviding
     private var cancellables = Set<AnyCancellable>()
 
     // Retained views for in-place updates
@@ -23,7 +23,7 @@ final class SessionOverlayWindow {
     private let padding: CGFloat = 16
     private let sectionSpacing: CGFloat = 14 // VSpacing.md + VSpacing.xxs
 
-    init(session: ComputerUseSession) {
+    init(session: any SessionOverlayProviding) {
         self.session = session
     }
 
@@ -64,19 +64,19 @@ final class SessionOverlayWindow {
         self.panel = panel
 
         // Observe state, undoCount, and autoApproveTools changes
-        session.$state
+        session.statePublisher
             .sink { [weak self] state in
                 self?.updateState(state)
             }
             .store(in: &cancellables)
 
-        session.$undoCount
+        session.undoCountPublisher
             .sink { [weak self] _ in
                 self?.updateControls()
             }
             .store(in: &cancellables)
 
-        session.$autoApproveTools
+        session.autoApproveToolsPublisher
             .sink { [weak self] _ in
                 self?.updateControls()
             }
@@ -731,10 +731,10 @@ final class SessionOverlayWindow {
 // MARK: - Button Target (NSObject for selectors)
 
 private class SessionOverlayButtonTarget: NSObject {
-    private let session: ComputerUseSession
+    private let session: any SessionOverlayProviding
     weak var overlayWindow: SessionOverlayWindow?
 
-    init(session: ComputerUseSession) {
+    init(session: any SessionOverlayProviding) {
         self.session = session
     }
 


### PR DESCRIPTION
## Summary
- Add `SessionOverlayProviding` protocol and `HostCuSessionProxy` class so the existing `SessionOverlayWindow` can display both foreground and proxy-based CU sessions
- Wire `HostCuExecutor.register()` with an overlay provider callback that lazily creates the overlay on the first `host_cu_request` for each session
- Update `HostCuActionRunner.perform()` to update overlay state (running/thinking/completed/responded) around action execution and drain user guidance into the result payload
- Add `getOrCreateHostCuOverlay()` and `dismissHostCuOverlay()` to AppDelegate for overlay lifecycle management with 10s auto-dismiss on terminal states
- Cancel via overlay sends `CancelMessage` to abort the daemon session
- Guard against conflicts between foreground CU sessions and host CU overlays

Part of plan: unify-cu-main-loop.md (PR 9 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
