### PR TITLE
fix: make postHostCuResult public for cross-module access

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+HostCu.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostCu.swift
@@ -8,7 +8,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 extension HTTPTransport {
 
     /// Post the result of a host CU action execution back to the daemon.
-    func postHostCuResult(_ result: HostCuResultPayload, isRetry: Bool = false) async {
+    public func postHostCuResult(_ result: HostCuResultPayload, isRetry: Bool = false) async {
         guard let url = buildURL(for: .hostCuResult) else {
             log.error("Failed to build URL for host_cu_result")
             return


### PR DESCRIPTION
## Summary
- `postHostCuResult` on `HTTPTransport` was `internal` (default), but it's called from `HostCuExecutor` in the `VellumAssistantLib` module. Added `public` access modifier to fix the build error.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23013831313/job/66831543059

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
