### PR TITLE
feat: route CU proxy tools through HostCuProxy in main session

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -35,6 +35,7 @@ import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { truncate } from "../../util/truncate.js";
 import { HostBashProxy } from "../host-bash-proxy.js";
+import { HostCuProxy } from "../host-cu-proxy.js";
 import { HostFileProxy } from "../host-file-proxy.js";
 import type {
   CancelRequest,
@@ -164,6 +165,12 @@ export function makeEventSender(params: {
         session,
         conversationId,
         kind: "host_file",
+      });
+    } else if (event.type === "host_cu_request") {
+      pendingInteractions.register(event.requestId, {
+        session,
+        conversationId,
+        kind: "host_cu",
       });
     }
 
@@ -431,6 +438,8 @@ export async function handleSessionCreate(
         pendingInteractions.resolve(requestId);
       });
       session.setHostFileProxy(fileProxy);
+      const cuProxy = new HostCuProxy(sendEvent);
+      session.setHostCuProxy(cuProxy);
     }
     session.updateClient(sendEvent, false);
     session

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -57,6 +57,7 @@ import type {
 } from "./handlers/shared.js";
 import type { SkillOperationContext } from "./handlers/skills.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
+import { HostCuProxy } from "./host-cu-proxy.js";
 import { HostFileProxy } from "./host-file-proxy.js";
 import type { ServerMessage } from "./message-protocol.js";
 import {
@@ -213,6 +214,12 @@ function makePendingInteractionRegistrar(
         session,
         conversationId,
         kind: "host_file",
+      });
+    } else if (msg.type === "host_cu_request") {
+      pendingInteractions.register(msg.requestId, {
+        session,
+        conversationId,
+        kind: "host_cu",
       });
     }
   };
@@ -665,9 +672,13 @@ export class DaemonServer {
           }),
         );
       }
+      if (!session.isProcessing() || !session.hostCuProxy) {
+        session.setHostCuProxy(new HostCuProxy(session.getCurrentSender()));
+      }
     } else if (!session.isProcessing()) {
       session.setHostBashProxy(undefined);
       session.setHostFileProxy(undefined);
+      session.setHostCuProxy(undefined);
     }
     session.setCommandIntent(options?.commandIntent ?? null);
     session.setTurnChannelContext({

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -203,6 +203,8 @@ export interface SurfaceSessionContext {
     display?: string;
   }>;
   onEscalateToComputerUse?: (task: string, sourceSessionId: string) => boolean;
+  /** Optional proxy for delegating computer-use actions to a connected desktop client. */
+  hostCuProxy?: import("./host-cu-proxy.js").HostCuProxy;
   isProcessing(): boolean;
   enqueueMessage(
     content: string,
@@ -931,13 +933,54 @@ export function buildUserFacingLabel(
 
 /**
  * Resolve a proxy tool call that targets a UI surface.
- * Handles ui_show, ui_update, ui_dismiss, computer_use_request_control, and app_open.
+ * Handles ui_show, ui_update, ui_dismiss, computer_use_request_control,
+ * computer_use_* proxy tools, and app_open.
  */
 export async function surfaceProxyResolver(
   ctx: SurfaceSessionContext,
   toolName: string,
   input: Record<string, unknown>,
 ): Promise<ToolExecutionResult> {
+  // Route CU proxy tools (all computer_use_* except the escalation tool)
+  if (
+    toolName.startsWith("computer_use_") &&
+    toolName !== "computer_use_request_control"
+  ) {
+    if (!ctx.hostCuProxy) {
+      return {
+        content: "Computer use is not available — no desktop client connected.",
+        isError: true,
+      };
+    }
+
+    // Terminal tools resolve immediately without a client round-trip
+    if (
+      toolName === "computer_use_done" ||
+      toolName === "computer_use_respond"
+    ) {
+      const summary =
+        typeof input.summary === "string"
+          ? input.summary
+          : typeof input.answer === "string"
+            ? input.answer
+            : "Task complete";
+      ctx.hostCuProxy.reset();
+      return { content: summary, isError: false };
+    }
+
+    // Record the action and proxy to the connected desktop client
+    const reasoning =
+      typeof input.reasoning === "string" ? input.reasoning : undefined;
+    ctx.hostCuProxy.recordAction(toolName, input, reasoning);
+    return ctx.hostCuProxy.request(
+      toolName,
+      input,
+      ctx.conversationId,
+      ctx.hostCuProxy.stepCount,
+      reasoning,
+    );
+  }
+
   if (toolName === "ui_show" || toolName === "ui_update") {
     const caps = ctx.channelCapabilities;
     if (caps && !caps.supportsDynamicUi) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -17,6 +17,7 @@ import {
 import { getConfig } from "../../config/loader.js";
 import { renderHistoryContent } from "../../daemon/handlers/shared.js";
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
+import { HostCuProxy } from "../../daemon/host-cu-proxy.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
@@ -449,6 +450,12 @@ function makeHubPublisher(
         conversationId,
         kind: "host_file",
       });
+    } else if (msg.type === "host_cu_request") {
+      pendingInteractions.register(msg.requestId, {
+        session,
+        conversationId,
+        kind: "host_cu",
+      });
     }
 
     // ServerMessage is a large union; sessionId exists on most but not all variants.
@@ -640,9 +647,14 @@ export async function handleSendMessage(
       });
       session.setHostFileProxy(fileProxy);
     }
+    if (!session.isProcessing() || !session.hostCuProxy) {
+      const cuProxy = new HostCuProxy(onEvent);
+      session.setHostCuProxy(cuProxy);
+    }
   } else if (!session.isProcessing()) {
     session.setHostBashProxy(undefined);
     session.setHostFileProxy(undefined);
+    session.setHostCuProxy(undefined);
   }
   // Wire sendToClient to the SSE hub so all subsystems can reach the HTTP client.
   // Called after setHostBashProxy so updateSender targets the current proxy.


### PR DESCRIPTION
## Summary
- Add `hostCuProxy` to `SurfaceSessionContext` so the surface proxy resolver can route CU tools
- Route `computer_use_*` tools (except `computer_use_request_control`) through `HostCuProxy` in `surfaceProxyResolver`: terminal tools (`computer_use_done`, `computer_use_respond`) resolve immediately; action tools proxy to the connected desktop client via `host_cu_request` SSE events
- Create `HostCuProxy` in all 3 proxy creation sites (`handlers/sessions.ts`, `conversation-routes.ts`, `server.ts`) within the desktop client guard (macos/ios)
- Register `host_cu_request` in pending interactions in all 3 event sender locations (`makeEventSender`, `makeHubPublisher`, `makePendingInteractionRegistrar`)
- Clear `hostCuProxy` alongside `hostBashProxy`/`hostFileProxy` when a non-desktop interface connects

Part of plan: unify-cu-main-loop.md (PR 5 of 13)

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] When model calls `computer_use_click` in main session with desktop client, it routes through HostCuProxy and sends `host_cu_request` via SSE
- [ ] Terminal tools (`computer_use_done`, `computer_use_respond`) resolve immediately without client round-trip
- [ ] CU proxy is only created when a desktop client is connected (macos/ios interfaces)
- [ ] Without desktop client, CU tool calls return "Computer use is not available" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
