### PR TITLE
feat(cli): tab completion for slash commands

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -2276,6 +2276,7 @@ function ChatApp({
               onSubmit={handleSubmit}
               onHistoryUp={handleHistoryUp}
               onHistoryDown={handleHistoryDown}
+              completionCommands={SLASH_COMMANDS}
               focus={inputFocused}
             />
           </Box>

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -95,7 +95,14 @@ function TextInput({
 
         // Start completion mode
         const matches = getMatches(currentValue);
-        if (matches.length > 0) {
+        if (matches.length === 1) {
+          // Single match — accept immediately with trailing space
+          const completed = matches[0]! + " ";
+          valueRef.current = completed;
+          cursorOffsetRef.current = completed.length;
+          onChange(completed);
+          setRenderTick((t) => t + 1);
+        } else if (matches.length > 1) {
           setCompletionMatches(matches);
           const idx = key.shift ? matches.length - 1 : 0;
           setCompletionIndex(idx);
@@ -120,8 +127,18 @@ function TextInput({
 
       // Enter accepts completion and submits
       if (key.return) {
-        clearCompletion();
-        onSubmit?.(valueRef.current);
+        if (completionMatches.length > 0) {
+          // Append trailing space so the command is recognized by handleInput
+          const completed = valueRef.current + " ";
+          valueRef.current = completed;
+          cursorOffsetRef.current = completed.length;
+          onChange(completed);
+          clearCompletion();
+          onSubmit?.(completed);
+        } else {
+          clearCompletion();
+          onSubmit?.(valueRef.current);
+        }
         return;
       }
 

--- a/cli/src/components/TextInput.tsx
+++ b/cli/src/components/TextInput.tsx
@@ -8,6 +8,7 @@ interface TextInputProps {
   onSubmit?: (value: string) => void;
   onHistoryUp?: () => void;
   onHistoryDown?: () => void;
+  completionCommands?: string[];
   focus?: boolean;
   placeholder?: string;
 }
@@ -18,11 +19,16 @@ function TextInput({
   onSubmit,
   onHistoryUp,
   onHistoryDown,
+  completionCommands,
   focus = true,
   placeholder = "",
 }: TextInputProps): ReactElement {
   const cursorOffsetRef = useRef(value.length);
   const valueRef = useRef(value);
+
+  // Tab completion state
+  const [completionIndex, setCompletionIndex] = useState(-1);
+  const [completionMatches, setCompletionMatches] = useState<string[]>([]);
 
   valueRef.current = value;
 
@@ -32,27 +38,100 @@ function TextInput({
 
   const [, setRenderTick] = useState(0);
 
+  const clearCompletion = () => {
+    setCompletionIndex(-1);
+    setCompletionMatches([]);
+  };
+
+  const getMatches = (text: string): string[] => {
+    if (!completionCommands || !text.startsWith("/") || text.includes(" ")) {
+      return [];
+    }
+    const prefix = text.toLowerCase();
+    return completionCommands.filter((cmd) =>
+      cmd.toLowerCase().startsWith(prefix),
+    );
+  };
+
   useInput(
     (input, key) => {
       if (key.upArrow && !key.shift && !key.meta) {
+        clearCompletion();
         onHistoryUp?.();
         cursorOffsetRef.current = Infinity;
         setRenderTick((t) => t + 1);
         return;
       }
       if (key.downArrow && !key.shift && !key.meta) {
+        clearCompletion();
         onHistoryDown?.();
         cursorOffsetRef.current = Infinity;
         setRenderTick((t) => t + 1);
         return;
       }
-      if ((key.ctrl && input === "c") || key.tab || (key.shift && key.tab)) {
+      if (key.ctrl && input === "c") {
         return;
       }
 
+      // Tab completion handling
+      if (key.tab) {
+        const currentValue = valueRef.current;
+
+        if (completionMatches.length > 0) {
+          // Already in completion mode — cycle through matches
+          const direction = key.shift ? -1 : 1;
+          const nextIndex =
+            (completionIndex + direction + completionMatches.length) %
+            completionMatches.length;
+          setCompletionIndex(nextIndex);
+
+          const completed = completionMatches[nextIndex]!;
+          valueRef.current = completed;
+          cursorOffsetRef.current = completed.length;
+          onChange(completed);
+          setRenderTick((t) => t + 1);
+          return;
+        }
+
+        // Start completion mode
+        const matches = getMatches(currentValue);
+        if (matches.length > 0) {
+          setCompletionMatches(matches);
+          const idx = key.shift ? matches.length - 1 : 0;
+          setCompletionIndex(idx);
+
+          const completed = matches[idx]!;
+          valueRef.current = completed;
+          cursorOffsetRef.current = completed.length;
+          onChange(completed);
+          setRenderTick((t) => t + 1);
+        }
+        return;
+      }
+
+      // Escape cancels completion mode
+      if (key.escape) {
+        if (completionMatches.length > 0) {
+          clearCompletion();
+          setRenderTick((t) => t + 1);
+          return;
+        }
+      }
+
+      // Enter accepts completion and submits
       if (key.return) {
+        clearCompletion();
         onSubmit?.(valueRef.current);
         return;
+      }
+
+      // Space accepts completion, then continues editing
+      if (input === " " && completionMatches.length > 0) {
+        clearCompletion();
+        // Let the space be inserted normally below
+      } else if (completionMatches.length > 0) {
+        // Any other key exits completion mode
+        clearCompletion();
       }
 
       const currentValue = valueRef.current;
@@ -114,6 +193,14 @@ function TextInput({
   );
 
   const cursorOffset = cursorOffsetRef.current;
+  const isCompleting = completionMatches.length > 0;
+
+  // Build completion hint text
+  let completionHint = "";
+  if (isCompleting && completionMatches.length > 1) {
+    completionHint = ` [${completionIndex + 1}/${completionMatches.length}]`;
+  }
+
   let renderedValue: string;
   let renderedPlaceholder: string | undefined;
 
@@ -132,6 +219,9 @@ function TextInput({
       }
       if (cursorOffset === value.length) {
         renderedValue += chalk.inverse(" ");
+      }
+      if (completionHint) {
+        renderedValue += chalk.grey(completionHint);
       }
     } else {
       renderedValue = chalk.inverse(" ");


### PR DESCRIPTION
## Summary
- Adds tab completion for `/` slash commands in the TUI text input
- When user types `/` followed by partial text and presses Tab, matching commands are cycled through
- Shift+Tab cycles backward, Enter/Space accepts, Escape cancels completion mode
- Shows inline `[n/m]` counter when multiple matches exist
- Passes `SLASH_COMMANDS` list from `DefaultMainScreen` to `TextInput` via new `completionCommands` prop

## Test plan
- [ ] Type `/h` and press Tab — should complete to `/help`
- [ ] Type `/` and press Tab repeatedly — should cycle through all commands
- [ ] Press Shift+Tab to cycle backwards
- [ ] Press Enter to accept and submit the completed command
- [ ] Press Space to accept the completion and continue typing
- [ ] Press Escape to cancel completion mode
- [ ] Verify `[n/m]` counter appears when multiple matches exist

Closes #15755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
