### PR TITLE
feat(cli): add terminal capability detection

### DIFF
--- a/cli/src/commands/clean.ts
+++ b/cli/src/commands/clean.ts
@@ -6,7 +6,9 @@ export async function clean(): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
     console.log("Usage: vellum clean");
     console.log("");
-    console.log("Kill all orphaned vellum processes that are not tracked by any assistant.");
+    console.log(
+      "Kill all orphaned vellum processes that are not tracked by any assistant.",
+    );
     process.exit(0);
   }
 
@@ -17,18 +19,21 @@ export async function clean(): Promise<void> {
     return;
   }
 
-  console.log(`Found ${orphans.length} orphaned process${orphans.length === 1 ? "" : "es"}.\n`);
+  console.log(
+    `Found ${orphans.length} orphaned process${orphans.length === 1 ? "" : "es"}.\n`,
+  );
 
   let killed = 0;
   for (const orphan of orphans) {
     const pid = parseInt(orphan.pid, 10);
-    const stopped = await stopProcess(pid, `${orphan.name} (PID ${orphan.pid})`);
+    const stopped = await stopProcess(
+      pid,
+      `${orphan.name} (PID ${orphan.pid})`,
+    );
     if (stopped) {
       killed++;
     }
   }
 
-  console.log(
-    `\nCleaned up ${killed} process${killed === 1 ? "" : "es"}.`,
-  );
+  console.log(`\nCleaned up ${killed} process${killed === 1 ? "" : "es"}.`);
 }

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -150,7 +150,13 @@ async function detectProcess(spec: ProcessSpec): Promise<DetectedProcess> {
   const pids = await pgrepExact(spec.pgrepName);
   if (pids.length > 0) {
     const watch = await isWatchMode(pids[0]);
-    return { name: spec.name, pid: pids[0], port: spec.port, running: true, watch };
+    return {
+      name: spec.name,
+      pid: pids[0],
+      port: spec.port,
+      running: true,
+      watch,
+    };
   }
 
   // Tier 2: TCP port probe (skip for processes without a port)
@@ -171,10 +177,22 @@ async function detectProcess(spec: ProcessSpec): Promise<DetectedProcess> {
   const filePid = readPidFile(spec.pidFile);
   if (filePid && isProcessAlive(filePid)) {
     const watch = await isWatchMode(filePid);
-    return { name: spec.name, pid: filePid, port: spec.port, running: true, watch };
+    return {
+      name: spec.name,
+      pid: filePid,
+      port: spec.port,
+      running: true,
+      watch,
+    };
   }
 
-  return { name: spec.name, pid: null, port: spec.port, running: false, watch: false };
+  return {
+    name: spec.name,
+    pid: null,
+    port: spec.port,
+    running: false,
+    watch: false,
+  };
 }
 
 function formatDetectionInfo(proc: DetectedProcess): string {

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -19,6 +19,10 @@ import { callDoctorDaemon, type ChatLogEntry } from "../lib/doctor-client";
 import { checkHealth } from "../lib/health-check";
 import { appendHistory, loadHistory } from "../lib/input-history";
 import { statusEmoji, withStatusEmoji } from "../lib/status-emoji";
+import {
+  getTerminalCapabilities,
+  unicodeOrFallback,
+} from "../lib/terminal-capabilities";
 import TextInput from "./TextInput";
 import { Tooltip } from "./Tooltip";
 
@@ -56,7 +60,8 @@ const DEFAULT_TERMINAL_COLUMNS = 80;
 const DEFAULT_TERMINAL_ROWS = 24;
 const LEFT_PANEL_WIDTH = 36;
 
-const HEADER_PREFIX = "── Vellum ";
+const HEADER_PREFIX_UNICODE = "── Vellum ";
+const HEADER_PREFIX_ASCII = "-- Vellum ";
 
 // Left panel structure: HEADER lines + art + FOOTER lines
 const LEFT_HEADER_LINES = 3; // spacer + heading + spacer
@@ -706,6 +711,11 @@ function DefaultMainScreen({
   const config = SPECIES_CONFIG[species];
   const art = config.art;
   const accentColor = species === "openclaw" ? "red" : "magenta";
+  const caps = getTerminalCapabilities();
+  const headerPrefix = caps.unicodeSupported
+    ? HEADER_PREFIX_UNICODE
+    : HEADER_PREFIX_ASCII;
+  const headerSep = caps.unicodeSupported ? "─" : "-";
 
   const { stdout } = useStdout();
   const terminalColumns = stdout.columns || DEFAULT_TERMINAL_COLUMNS;
@@ -730,7 +740,10 @@ function DefaultMainScreen({
     { text: "Assistant", style: "heading" },
     { text: assistantId, style: "dim" },
     { text: "Species", style: "heading" },
-    { text: `${config.hatchedEmoji} ${species}`, style: "dim" },
+    {
+      text: `${unicodeOrFallback(config.hatchedEmoji, `[${species}]`)} ${species}`,
+      style: "dim",
+    },
     { text: "Status", style: "heading" },
     { text: withStatusEmoji(healthStatus ?? "checking..."), style: "dim" },
   ];
@@ -740,8 +753,8 @@ function DefaultMainScreen({
   return (
     <Box flexDirection="column" width={totalWidth}>
       <Text dimColor>
-        {HEADER_PREFIX +
-          "─".repeat(Math.max(0, totalWidth - HEADER_PREFIX.length))}
+        {headerPrefix +
+          headerSep.repeat(Math.max(0, totalWidth - headerPrefix.length))}
       </Text>
       <Box flexDirection="row">
         <Box flexDirection="column" width={LEFT_PANEL_WIDTH}>
@@ -756,7 +769,7 @@ function DefaultMainScreen({
             }
             if (i > 2 && i <= 2 + art.length) {
               return (
-                <Text key={i} color={accentColor}>
+                <Text key={i} color={caps.isDumb ? undefined : accentColor}>
                   {line}
                 </Text>
               );

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -806,7 +806,7 @@ function DefaultMainScreen({
           })}
         </Box>
       </Box>
-      <Text dimColor>{"─".repeat(totalWidth)}</Text>
+      <Text dimColor>{headerSep.repeat(totalWidth)}</Text>
       <Text> </Text>
     </Box>
   );
@@ -2277,7 +2277,9 @@ function ChatApp({
 
       {!selection && !secretInput ? (
         <Box flexDirection="column" flexShrink={0}>
-          <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
+          <Text dimColor>
+            {unicodeOrFallback("\u2500", "-").repeat(terminalColumns)}
+          </Text>
           <Box paddingLeft={1} height={1} flexShrink={0}>
             <Text color="green" bold>
               you{">"}
@@ -2292,7 +2294,9 @@ function ChatApp({
               focus={inputFocused}
             />
           </Box>
-          <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
+          <Text dimColor>
+            {unicodeOrFallback("\u2500", "-").repeat(terminalColumns)}
+          </Text>
           <Text dimColor> ? for shortcuts</Text>
         </Box>
       ) : null}

--- a/cli/src/lib/constants.ts
+++ b/cli/src/lib/constants.ts
@@ -8,7 +8,13 @@ export const DEFAULT_DAEMON_PORT = 7821;
 export const DEFAULT_GATEWAY_PORT = 7830;
 export const DEFAULT_QDRANT_PORT = 6333;
 
-export const VALID_REMOTE_HOSTS = ["local", "gcp", "aws", "docker", "custom"] as const;
+export const VALID_REMOTE_HOSTS = [
+  "local",
+  "gcp",
+  "aws",
+  "docker",
+  "custom",
+] as const;
 export type RemoteHost = (typeof VALID_REMOTE_HOSTS)[number];
 export const VALID_SPECIES = ["openclaw", "vellum"] as const;
 export type Species = (typeof VALID_SPECIES)[number];

--- a/cli/src/lib/http-client.ts
+++ b/cli/src/lib/http-client.ts
@@ -32,8 +32,7 @@ export function buildDaemonUrl(port: number): string {
  */
 export function readHttpToken(instanceDir?: string): string | undefined {
   const baseDataDir =
-    instanceDir ??
-    (process.env.BASE_DATA_DIR?.trim() || homedir());
+    instanceDir ?? (process.env.BASE_DATA_DIR?.trim() || homedir());
   const tokenPath = join(baseDataDir, ".vellum", "http-token");
   try {
     const token = readFileSync(tokenPath, "utf-8").trim();

--- a/cli/src/lib/terminal-capabilities.ts
+++ b/cli/src/lib/terminal-capabilities.ts
@@ -18,7 +18,7 @@ export interface TerminalCapabilities {
   columns: number;
   /** Current terminal rows (falls back to 24) */
   rows: number;
-  /** True when TERM=dumb or NO_COLOR is set — disables all decoration */
+  /** True when TERM=dumb — indicates a terminal with no cursor addressing */
   isDumb: boolean;
 }
 
@@ -77,7 +77,7 @@ export function detectCapabilities(
   env: NodeJS.ProcessEnv = process.env,
 ): TerminalCapabilities {
   const term = (env.TERM ?? "").toLowerCase();
-  const isDumb = term === "dumb" || env.NO_COLOR !== undefined;
+  const isDumb = term === "dumb";
   const colorLevel = detectColorLevel(env);
   const unicodeSupported = detectUnicode(env, isDumb);
 

--- a/cli/src/lib/terminal-capabilities.ts
+++ b/cli/src/lib/terminal-capabilities.ts
@@ -1,0 +1,124 @@
+/**
+ * Terminal capability detection module.
+ *
+ * Detects color support, unicode availability, and terminal dimensions
+ * by inspecting TERM, COLORTERM, NO_COLOR, and related environment
+ * variables. Designed to enable graceful degradation on dumb terminals
+ * and constrained environments (e.g. SSH to a Raspberry Pi).
+ */
+
+export type ColorLevel = "none" | "basic" | "256" | "truecolor";
+
+export interface TerminalCapabilities {
+  /** Detected color support level */
+  colorLevel: ColorLevel;
+  /** Whether the terminal likely supports unicode glyphs */
+  unicodeSupported: boolean;
+  /** Current terminal width in columns (falls back to 80) */
+  columns: number;
+  /** Current terminal rows (falls back to 24) */
+  rows: number;
+  /** True when TERM=dumb or NO_COLOR is set — disables all decoration */
+  isDumb: boolean;
+}
+
+/**
+ * Detect the color support level from environment variables.
+ *
+ * Precedence (highest to lowest):
+ *   1. NO_COLOR or TERM=dumb  → "none"
+ *   2. COLORTERM=truecolor / 24bit → "truecolor"
+ *   3. TERM contains "256color" → "256"
+ *   4. Any other interactive terminal → "basic"
+ *   5. Non-TTY → "none"
+ */
+function detectColorLevel(env: NodeJS.ProcessEnv): ColorLevel {
+  // NO_COLOR spec: https://no-color.org/
+  if (env.NO_COLOR !== undefined) return "none";
+
+  const term = (env.TERM ?? "").toLowerCase();
+  if (term === "dumb") return "none";
+
+  const colorterm = (env.COLORTERM ?? "").toLowerCase();
+
+  if (colorterm === "truecolor" || colorterm === "24bit") return "truecolor";
+  if (term.includes("256color")) return "256";
+
+  // If we have a TERM value at all, assume basic color support
+  if (term.length > 0) return "basic";
+
+  // Fallback: if stdout is a TTY, assume basic
+  if (process.stdout.isTTY) return "basic";
+
+  return "none";
+}
+
+/**
+ * Heuristic for unicode support.
+ *
+ * Checks LANG / LC_ALL / LC_CTYPE for UTF-8. Falls back to false on
+ * dumb terminals since many dumb terminal emulators lack glyph support.
+ */
+function detectUnicode(env: NodeJS.ProcessEnv, isDumb: boolean): boolean {
+  if (isDumb) return false;
+
+  const locale = (env.LC_ALL ?? env.LC_CTYPE ?? env.LANG ?? "").toLowerCase();
+
+  return locale.includes("utf-8") || locale.includes("utf8");
+}
+
+/**
+ * Detect terminal capabilities from the current process environment.
+ *
+ * The result is a plain object (no singletons) so tests can call this
+ * with a mocked env if needed.
+ */
+export function detectCapabilities(
+  env: NodeJS.ProcessEnv = process.env,
+): TerminalCapabilities {
+  const term = (env.TERM ?? "").toLowerCase();
+  const isDumb = term === "dumb" || env.NO_COLOR !== undefined;
+  const colorLevel = detectColorLevel(env);
+  const unicodeSupported = detectUnicode(env, isDumb);
+
+  return {
+    colorLevel,
+    unicodeSupported,
+    columns: process.stdout.columns || 80,
+    rows: process.stdout.rows || 24,
+    isDumb,
+  };
+}
+
+/** Lazily-cached capabilities for the current process. */
+let _cached: TerminalCapabilities | undefined;
+
+/**
+ * Return (and cache) the terminal capabilities for the running process.
+ *
+ * Safe to call multiple times — subsequent calls return the cached
+ * result. Use `detectCapabilities()` directly if you need a fresh read
+ * (e.g. after a terminal resize).
+ */
+export function getTerminalCapabilities(): TerminalCapabilities {
+  if (!_cached) {
+    _cached = detectCapabilities();
+  }
+  return _cached;
+}
+
+// ── Convenience helpers ──────────────────────────────────────
+
+/** True when colors should be used (any level above "none"). */
+export function supportsColor(): boolean {
+  return getTerminalCapabilities().colorLevel !== "none";
+}
+
+/**
+ * Return `fancy` when unicode is supported, otherwise `fallback`.
+ *
+ * Example: `unicodeOrFallback("🟢", "[ok]")`
+ */
+export function unicodeOrFallback(fancy: string, fallback: string): string {
+  return getTerminalCapabilities().unicodeSupported ? fancy : fallback;
+}


### PR DESCRIPTION
## Summary
- Add `cli/src/lib/terminal-capabilities.ts` module that detects color support level (none/basic/256/truecolor), unicode availability, and terminal dimensions from environment variables (TERM, COLORTERM, NO_COLOR, locale)
- Graceful degradation for dumb terminals (TERM=dumb) and NO_COLOR environments
- Integrate into DefaultMainScreen header: ASCII fallbacks for box-drawing characters and emoji, suppress color on dumb terminals

## Test plan
- [ ] Verify normal terminal renders unicode header separator and emoji as before
- [ ] Test with `TERM=dumb` — header should use ASCII dashes and `[species]` instead of emoji, art should render without color
- [ ] Test with `NO_COLOR=1` — colors suppressed, treated as dumb
- [ ] Test over SSH (e.g. Raspberry Pi) with various TERM values
- [ ] Verify `detectCapabilities()` returns correct values for `COLORTERM=truecolor`, `TERM=xterm-256color`, etc.

Closes #15751

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
