### PR TITLE
fix: add missing setHostCuProxy mock and sync CU done description

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -118,6 +118,7 @@ function makeIdleSession(opts?: {
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (
@@ -181,6 +182,7 @@ function makeConfirmationEmittingSession(opts?: {
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -171,6 +171,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -246,6 +247,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -317,6 +319,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
         requestId === "tool-approval-live",
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -392,6 +395,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: (id: string) => id === "tool-req-code-1",
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -463,6 +467,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: (id: string) => id === "pending-reject-1",
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -528,6 +533,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: (id: string) => id === "pending-1",
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -595,6 +601,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -663,6 +670,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       hasPendingConfirmation: () => false,
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
+      setHostCuProxy: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -203,6 +203,7 @@ function makeSession() {
     hasPendingConfirmation: () => false,
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     usageStats: {
       inputTokens: 1000,
       outputTokens: 500,

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -169,6 +169,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     emitConfirmationStateChanged: () => {},
     emitActivityState: () => {},
     setTurnChannelContext: () => {},

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -117,6 +117,7 @@ function makeCompletingSession(): Session {
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -173,6 +174,7 @@ function makeHangingSession(): Session {
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -257,6 +259,7 @@ function makePendingApprovalSession(
     updateClient: () => {},
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
+    setHostCuProxy: () => {},
     hasAnyPendingConfirmation: () => pending.size > 0,
     hasPendingConfirmation: (candidateRequestId: string) =>
       pending.has(candidateRequestId),

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -279,7 +279,7 @@
     },
     {
       "name": "computer_use_done",
-      "description": "Task is complete",
+      "description": "Signal that the computer use task is complete. Provide a summary of what was accomplished. This ends the computer use session.",
       "category": "computer-use",
       "risk": "low",
       "input_schema": {


### PR DESCRIPTION
## Summary
- Add `setHostCuProxy: () => {}` to mock session objects in 5 test files that were missing it after #15804 introduced `session.setHostCuProxy()` in conversation-routes.ts
- Sync `computer_use_done` description in TOOLS.json manifest to match the core definition in definitions.ts

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23014159766

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
