### PR TITLE
feat: support OR filtering in `providers list --provider-key` via comma-separated values

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -14,6 +14,7 @@ let mockWithValidToken: <T>(
 ) => Promise<T>;
 
 // Disconnect mock state
+let mockListProviders: () => Array<Record<string, unknown>> = () => [];
 let secureKeyStore = new Map<string, string>();
 let metadataStore: Array<{
   credentialId: string;
@@ -78,7 +79,7 @@ mock.module("../oauth/oauth-store.js", () => ({
   listApps: () => [],
   deleteApp: async () => false,
   getProvider: () => undefined,
-  listProviders: () => [],
+  listProviders: () => mockListProviders(),
   registerProvider: () => ({}),
   seedProviders: () => {},
   createConnection: () => ({}),
@@ -443,5 +444,119 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     expect(
       secureKeyStore.has(credentialKey("integration:gmail", "access_token")),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providers list
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers list", () => {
+  const fakeProviders = [
+    {
+      providerKey: "integration:gmail",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    },
+    {
+      providerKey: "integration:google-calendar",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    },
+    {
+      providerKey: "integration:slack",
+      authUrl: "https://slack.com/oauth/v2/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    },
+    {
+      providerKey: "integration:twitter",
+      authUrl: "https://twitter.com/i/oauth2/authorize",
+      tokenUrl: "https://api.twitter.com/2/oauth2/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    },
+  ];
+
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockListProviders = () => fakeProviders;
+    secureKeyStore = new Map();
+    metadataStore = [];
+    disconnectOAuthProviderCalls = [];
+    disconnectOAuthProviderResult = "not-found";
+    idCounter = 0;
+  });
+
+  test("returns all providers when no --provider-key is given", async () => {
+    const { exitCode, stdout } = await runCli(["providers", "list", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(4);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google-calendar");
+    expect(keys).toContain("integration:slack");
+    expect(keys).toContain("integration:twitter");
+  });
+
+  test("filters by single --provider-key value", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--provider-key",
+      "gmail",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].providerKey).toBe("integration:gmail");
+  });
+
+  test("filters by comma-separated OR values", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--provider-key",
+      "gmail,google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(2);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google-calendar");
+  });
+
+  test("returns empty array when comma-separated filter has no matches", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--provider-key",
+      "notion,linear",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(0);
   });
 });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -51,7 +51,7 @@ Each provider is identified by a provider key (e.g. "integration:gmail").`,
     .description("List all registered OAuth providers")
     .option(
       "--provider-key <key>",
-      "Filter by provider key substring (case-insensitive)",
+      'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "gmail,google")',
     )
     .addHelpText(
       "after",
@@ -60,8 +60,10 @@ Returns registered OAuth providers, including both built-in providers
 seeded at startup and any dynamically registered via "providers register".
 
 When --provider-key is specified, only providers whose key contains the
-given substring (case-insensitive) are returned. Without the flag, all
-providers are listed.
+given substring (case-insensitive) are returned. Multiple substrings can
+be OR'd together using commas (e.g. "gmail,google" matches any provider
+whose key contains "gmail" OR "google"). Without the flag, all providers
+are listed.
 
 Each provider row includes its key, auth URL, token URL, default scopes,
 and configuration timestamps.
@@ -69,6 +71,7 @@ and configuration timestamps.
 Examples:
   $ assistant oauth providers list
   $ assistant oauth providers list --provider-key gmail
+  $ assistant oauth providers list --provider-key "gmail,google"
   $ assistant oauth providers list --provider-key slack --json`,
     )
     .action((opts: { providerKey?: string }, cmd: Command) => {
@@ -76,9 +79,16 @@ Examples:
         let rows = listProviders().map(parseProviderRow);
 
         if (opts.providerKey) {
-          const needle = opts.providerKey.toLowerCase();
+          const needles = opts.providerKey
+            .split(",")
+            .map((n) => n.trim().toLowerCase())
+            .filter(Boolean);
           rows = rows.filter(
-            (r) => r && r.providerKey.toLowerCase().includes(needle),
+            (r) =>
+              r &&
+              needles.some((needle) =>
+                r.providerKey.toLowerCase().includes(needle),
+              ),
           );
         }
 


### PR DESCRIPTION
## Summary
- Update `--provider-key` filter to support comma-separated OR operations (e.g. `gmail,google`)
- Each comma-separated value is matched as a case-insensitive substring against provider keys
- Add unit tests for single-value, multi-value OR, no-match, and unfiltered cases

Part of plan: oauth-provider-key-or-filter.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
