### PR TITLE
fix: add edge case tests for --provider-key OR filter

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -559,4 +559,36 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(0);
   });
+
+  test("trims whitespace around commas in --provider-key", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--provider-key",
+      "gmail, google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(2);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google-calendar");
+  });
+
+  test("ignores empty segments from extra commas in --provider-key", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--provider-key",
+      "gmail,,google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(2);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google-calendar");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for oauth-provider-key-or-filter.md.

**Gap 1:** No unit test for whitespace trimming around commas
**What was expected:** Tests verify that `"gmail, google"` works the same as `"gmail,google"`
**What was found:** Code handles it correctly but no test exercised this path

**Gap 2:** No unit test for empty segments from extra commas
**What was expected:** Tests verify that `"gmail,,google"` works correctly
**What was found:** Code handles it correctly but no test exercised this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
