### PR TITLE
fix: route desktop access-request notifications to Slack DMs

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -424,11 +424,17 @@ const accessRequestResolver: GuardianRequestResolver = {
           dedupeKey: `trusted-contact:denied:${request.id}`,
         });
       } else if (desktopDeliverUrl && requesterChatId) {
+        // For Slack, route to DM via requesterExternalUserId (user ID) instead
+        // of requesterChatId (channel ID) to avoid posting in public channels.
+        const targetChatId =
+          channel === "slack" && requesterExternalUserId
+            ? requesterExternalUserId
+            : requesterChatId;
         try {
           await deliverChannelReply(
             desktopDeliverUrl,
             {
-              chatId: requesterChatId,
+              chatId: targetChatId,
               text: "Your access request has been denied by the guardian.",
               assistantId,
             },
@@ -601,11 +607,17 @@ const accessRequestResolver: GuardianRequestResolver = {
         });
       }
     } else if (desktopDeliverUrl && requesterChatId) {
+      // For Slack, route to DM via requesterExternalUserId (user ID) instead
+      // of requesterChatId (channel ID) to avoid posting in public channels.
+      const targetChatId =
+        channel === "slack" && requesterExternalUserId
+          ? requesterExternalUserId
+          : requesterChatId;
       try {
         await deliverChannelReply(
           desktopDeliverUrl,
           {
-            chatId: requesterChatId,
+            chatId: targetChatId,
             text:
               "Your access request has been approved! " +
               "Please enter the 6-digit verification code you receive from the guardian.",

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -334,7 +334,7 @@ export async function enforceIngressAcl(
                   dmCallbackUrl,
                   {
                     chatId: senderUserId,
-                    text: "I've notified the owner. They'll share a verification code with you if they approve access. You can reply with the code here.",
+                    text: "I've notified the owner that you'd like to chat with me. If they approve your request, they'll share a 6-digit verification code with you. You can reply with the code here.",
                     assistantId,
                   },
                   mintBearerToken(),
@@ -579,7 +579,7 @@ export async function enforceIngressAcl(
                     dmCallbackUrl,
                     {
                       chatId: senderUserId,
-                      text: "I've notified the owner. They'll share a verification code with you if they approve access. You can reply with the code here.",
+                      text: "I've notified the owner that you'd like to chat with me. If they approve your request, they'll share a 6-digit verification code with you. You can reply with the code here.",
                       assistantId,
                     },
                     mintBearerToken(),


### PR DESCRIPTION
## Summary
- **Desktop approval path posted to public channel**: When a guardian approved/denied an access request from the macOS client, notifications to the requester used `requesterChatId` (Slack channel ID) instead of `requesterExternalUserId` (Slack user ID), causing messages to appear in the public channel. Now routes to DMs, matching the Slack callback strategy behavior.
- **Clarified trusted contact message**: The message sent to new users requesting access ("I've notified the owner.") was ambiguous — users didn't understand what to do next. Expanded to: "I've notified the owner that you'd like to chat with me. If they approve your request, they'll share a 6-digit verification code with you."

## Test plan
- [ ] Approve an access request from the macOS client and verify the requester receives a DM (not a public channel message)
- [ ] Deny an access request from the macOS client and verify the denial goes to DM
- [ ] Verify the trusted contact prompt message is clear to new users
- [ ] Approve via Slack and confirm existing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
