### PR TITLE
feat: add `assistant oauth connections connect` CLI command

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -30,6 +30,21 @@ let disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
   "not-found";
 let idCounter = 0;
 
+// Connect mock state
+let mockOrchestrateOAuthConnect: (
+  opts: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+let mockGetAppByProviderAndClientId: (
+  providerKey: string,
+  clientId: string,
+) => Record<string, unknown> | undefined = () => undefined;
+let mockGetMostRecentAppByProvider: (
+  providerKey: string,
+) => Record<string, unknown> | undefined = () => undefined;
+let mockGetProvider: (
+  providerKey: string,
+) => Record<string, unknown> | undefined = () => undefined;
+
 function nextUUID(): string {
   idCounter += 1;
   return `00000000-0000-0000-0000-${String(idCounter).padStart(12, "0")}`;
@@ -74,11 +89,13 @@ mock.module("../oauth/oauth-store.js", () => ({
   // Stubs required by apps.ts and providers.ts (transitively loaded via oauth/index.ts)
   upsertApp: async () => ({}),
   getApp: () => undefined,
-  getAppByProviderAndClientId: () => undefined,
-  getMostRecentAppByProvider: () => undefined,
+  getAppByProviderAndClientId: (providerKey: string, clientId: string) =>
+    mockGetAppByProviderAndClientId(providerKey, clientId),
+  getMostRecentAppByProvider: (providerKey: string) =>
+    mockGetMostRecentAppByProvider(providerKey),
   listApps: () => [],
   deleteApp: async () => false,
-  getProvider: () => undefined,
+  getProvider: (providerKey: string) => mockGetProvider(providerKey),
   listProviders: () => mockListProviders(),
   registerProvider: () => ({}),
   seedProviders: () => {},
@@ -127,6 +144,24 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
     metadataStore.splice(idx, 1);
     return true;
   },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock connect-orchestrator
+// ---------------------------------------------------------------------------
+
+mock.module("../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: (opts: Record<string, unknown>) =>
+    mockOrchestrateOAuthConnect(opts),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock provider-behaviors
+// ---------------------------------------------------------------------------
+
+mock.module("../oauth/provider-behaviors.js", () => ({
+  resolveService: (service: string) => service,
+  getProviderBehavior: () => undefined,
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -590,5 +625,130 @@ describe("assistant oauth providers list", () => {
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("integration:gmail");
     expect(keys).toContain("integration:google-calendar");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connect
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connections connect <provider-key>", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    secureKeyStore = new Map();
+    metadataStore = [];
+    disconnectOAuthProviderCalls = [];
+    disconnectOAuthProviderResult = "not-found";
+    idCounter = 0;
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockGetProvider = () => undefined;
+  });
+
+  test("completes interactive flow and prints success (human mode)", async () => {
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: ["read"],
+      accountInfo: "user@example.com",
+    });
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:gmail",
+      "--client-id",
+      "test-id",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Connected");
+  });
+
+  test("returns auth URL in url-only mode (JSON)", async () => {
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: true,
+      authUrl: "https://example.com/auth",
+      state: "abc",
+      service: "integration:gmail",
+    });
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:gmail",
+      "--client-id",
+      "test-id",
+      "--url-only",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(parsed.authUrl).toBe("https://example.com/auth");
+  });
+
+  test("fails when no client_id available", async () => {
+    mockGetMostRecentAppByProvider = () => undefined;
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:gmail",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_id");
+  });
+
+  test("resolves client_id from DB when not provided", async () => {
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "db-client-id",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    let capturedClientId: string | undefined;
+    mockOrchestrateOAuthConnect = async (opts) => {
+      capturedClientId = opts.clientId as string;
+      return {
+        success: true,
+        deferred: false,
+        grantedScopes: [],
+      };
+    };
+
+    await runCli(["connections", "connect", "integration:gmail"]);
+    expect(capturedClientId).toBe("db-client-id");
+  });
+
+  test("outputs error from orchestrator", async () => {
+    mockOrchestrateOAuthConnect = async () => ({
+      success: false,
+      error: "Something went wrong",
+    });
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:gmail",
+      "--client-id",
+      "x",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("Something went wrong");
   });
 });

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -1,13 +1,24 @@
 import type { Command } from "commander";
 
+import { orchestrateOAuthConnect } from "../../../oauth/connect-orchestrator.js";
 import {
   disconnectOAuthProvider,
+  getAppByProviderAndClientId,
   getConnection,
   getConnectionByProvider,
+  getMostRecentAppByProvider,
+  getProvider,
   listConnections,
 } from "../../../oauth/oauth-store.js";
+import {
+  getProviderBehavior,
+  resolveService,
+} from "../../../oauth/provider-behaviors.js";
 import { credentialKey } from "../../../security/credential-key.js";
-import { deleteSecureKeyAsync } from "../../../security/secure-keys.js";
+import {
+  deleteSecureKeyAsync,
+  getSecureKey,
+} from "../../../security/secure-keys.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import {
   assertMetadataWritable,
@@ -296,4 +307,167 @@ Examples:
         process.exitCode = 1;
       }
     });
+
+  // ---------------------------------------------------------------------------
+  // connections connect <provider-key>
+  // ---------------------------------------------------------------------------
+
+  connections
+    .command("connect <provider-key>")
+    .description("Initiate an OAuth2 authorization flow for a provider")
+    .option("--client-id <id>", "Override the OAuth client ID")
+    .option("--client-secret <secret>", "Override the OAuth client secret")
+    .option(
+      "--scopes <scopes...>",
+      "Additional scopes beyond the provider's defaults",
+    )
+    .option("--url-only", "Print the auth URL instead of opening the browser")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider-key   Provider key (e.g. integration:gmail) or alias (e.g. gmail)
+
+Initiates an OAuth2 authorization flow for the given provider. By default,
+opens the authorization URL in your browser and waits for completion.
+
+With --url-only, prints the auth URL instead — useful for headless/remote
+sessions. The token exchange completes in the background when the user
+authorizes.
+
+Client credentials are resolved from the OAuth app store unless overridden
+with --client-id and --client-secret.
+
+Examples:
+  $ assistant oauth connections connect integration:gmail
+  $ assistant oauth connections connect gmail --url-only
+  $ assistant oauth connections connect integration:slack --client-id abc --client-secret s3cret
+  $ assistant oauth connections connect integration:gmail --scopes calendar.readonly --json`,
+    )
+    .action(
+      async (
+        providerKey: string,
+        opts: {
+          clientId?: string;
+          clientSecret?: string;
+          scopes?: string[];
+          urlOnly?: boolean;
+        },
+        cmd: Command,
+      ) => {
+        try {
+          // a. Resolve service alias
+          const resolvedServiceKey = resolveService(providerKey);
+
+          // b. Resolve client credentials
+          let clientId = opts.clientId;
+          let clientSecret = opts.clientSecret;
+
+          if (!clientId || !clientSecret) {
+            const dbApp = clientId
+              ? getAppByProviderAndClientId(resolvedServiceKey, clientId)
+              : getMostRecentAppByProvider(resolvedServiceKey);
+
+            if (dbApp) {
+              if (!clientId) clientId = dbApp.clientId;
+              if (!clientSecret) {
+                const storedSecret = getSecureKey(
+                  `oauth_app/${dbApp.id}/client_secret`,
+                );
+                if (storedSecret) clientSecret = storedSecret;
+              }
+            }
+          }
+
+          // c. Validate client_id
+          if (!clientId) {
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                "No client_id found. Provide --client-id or register an app first with 'assistant oauth apps upsert'.",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          // d. Check if client_secret is required but missing
+          if (clientSecret === undefined) {
+            const providerRow = getProvider(resolvedServiceKey);
+            const behavior = getProviderBehavior(resolvedServiceKey);
+
+            const requiresSecret = behavior?.setup?.requiresClientSecret
+              ? true
+              : !!(
+                  providerRow?.tokenEndpointAuthMethod ||
+                  providerRow?.extraParams
+                );
+
+            if (requiresSecret) {
+              writeOutput(cmd, {
+                ok: false,
+                error: `client_secret is required for ${resolvedServiceKey} but not found. Provide --client-secret or store it first with 'assistant oauth apps upsert --client-secret'.`,
+              });
+              process.exitCode = 1;
+              return;
+            }
+          }
+
+          // e. Call the orchestrator
+          const result = await orchestrateOAuthConnect({
+            service: providerKey,
+            clientId,
+            clientSecret,
+            isInteractive: !opts.urlOnly,
+            openUrl: !opts.urlOnly
+              ? (url) => {
+                  Bun.spawn(["open", url], {
+                    stdout: "ignore",
+                    stderr: "ignore",
+                  });
+                }
+              : undefined,
+            ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),
+          });
+
+          // f. Handle results
+          if (!result.success) {
+            writeOutput(cmd, { ok: false, error: result.error });
+            process.exitCode = 1;
+            return;
+          }
+
+          if (result.deferred) {
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                deferred: true,
+                authUrl: result.authUrl,
+                service: result.service,
+              });
+            } else {
+              process.stdout.write(
+                `Open this URL to authorize:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
+              );
+            }
+            return;
+          }
+
+          // Interactive mode completed
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              grantedScopes: result.grantedScopes,
+              accountInfo: result.accountInfo,
+            });
+          } else {
+            const msg = `Connected to ${resolvedServiceKey}${result.accountInfo ? ` as ${result.accountInfo}` : ""}`;
+            process.stdout.write(msg + "\n");
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
 }


### PR DESCRIPTION
## Summary
- Adds a new `connect <provider-key>` subcommand to `assistant oauth connections` that initiates an OAuth2 authorization code flow
- Supports interactive mode (opens browser, waits for completion) and `--url-only` mode (prints auth URL for headless sessions)
- Resolves client credentials from the OAuth app store when not explicitly provided via CLI flags

Part of plan: oauth-cli-connect-cmd.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
