### PR TITLE
fix: include secondaryWindows in HostCuProxy observation formatting

### DIFF
--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -507,6 +507,35 @@ describe("HostCuProxy", () => {
       expect(result.content).toMatch(/<\/ax-tree>$/m);
     });
 
+    test("includes secondaryWindows after AX tree with cross-window note", () => {
+      setup();
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]\nLabel [2]",
+        secondaryWindows: "Safari — Window [10]\n  Link [11]",
+      });
+
+      expect(result.content).toContain("Safari — Window [10]");
+      expect(result.content).toContain("Link [11]");
+      expect(result.content).toContain(
+        "Note: The element [ID]s above are from other windows",
+      );
+      // secondaryWindows should appear after the AX tree
+      const axTreeEnd = result.content.indexOf("</ax-tree>");
+      const secondaryIdx = result.content.indexOf("Safari — Window [10]");
+      expect(axTreeEnd).toBeLessThan(secondaryIdx);
+    });
+
+    test("omits secondaryWindows section when field is absent", () => {
+      setup();
+
+      const result = proxy.formatObservation({
+        axTree: "Button [1]",
+      });
+
+      expect(result.content).not.toContain("other windows");
+    });
+
     test("includes diff when present", () => {
       setup();
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -304,6 +304,16 @@ export class HostCuProxy {
       parts.push("</ax-tree>");
     }
 
+    // Secondary windows for cross-app awareness
+    if (obs.secondaryWindows) {
+      parts.push("");
+      parts.push(obs.secondaryWindows);
+      parts.push("");
+      parts.push(
+        "Note: The element [ID]s above are from other windows — you can reference them for context but can only interact with the focused window's elements.",
+      );
+    }
+
     // Screenshot metadata
     const screenshotMeta = this.formatScreenshotMetadata(obs);
     if (screenshotMeta.length > 0) {


### PR DESCRIPTION
## Summary
- **Gap:** `HostCuProxy.formatObservation()` accepted `secondaryWindows` in `CuObservationResult` but silently dropped it from the output text.
- **Fix:** Added secondary windows section after the AX tree, with a cross-window note, matching the old `ComputerUseSession.buildObservationResultContent` behavior.
- Added 2 tests: one verifying the section appears after `</ax-tree>` with the note, one verifying omission when absent.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/host-cu-proxy.test.ts` — 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
