### PR TITLE
fix: remove dead TaskRouted type and legacyFallbackComputerUseTools export

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -968,7 +968,7 @@ The text_qa system prompt includes an action execution hierarchy that guides too
 | **GOOD**        | Headless browser               | `browser_*` (bundled `browser` skill) | Web automation, form filling, scraping (background)         |
 | **LAST RESORT** | Foreground computer use        | `computer_use_request_control`        | Only on explicit user request ("go ahead", "take over")     |
 
-The `computer_use_request_control` tool is a core proxy tool available only to text*qa sessions. When invoked, the session's `surfaceProxyResolver` creates a CU session and sends a `task_routed` message to the client, effectively escalating from text_qa to foreground computer use. The CU session constructor sets `preactivatedSkillIds: ['computer-use']`, and its `getProjectedCuToolDefinitions()` calls `projectSkillTools()` to load the 12 `computer_use*\*`action tools from the bundled`computer-use` skill (via TOOLS.json). These tools are not core-registered at daemon startup; they exist only within CU sessions through skill projection.
+The `computer_use_request_control` tool is a core proxy tool available only to text*qa sessions. When invoked, the session's `surfaceProxyResolver` creates a CU session, effectively escalating from text_qa to foreground computer use. The CU session constructor sets `preactivatedSkillIds: ['computer-use']`, and its `getProjectedCuToolDefinitions()` calls `projectSkillTools()` to load the 12 `computer_use*\*`action tools from the bundled`computer-use` skill (via TOOLS.json). These tools are not core-registered at daemon startup; they exist only within CU sessions through skill projection.
 
 ### Sandbox Filesystem and Host Access
 

--- a/assistant/src/daemon/message-types/computer-use.ts
+++ b/assistant/src/daemon/message-types/computer-use.ts
@@ -1,4 +1,4 @@
-// Computer use, task routing, and watch observation types.
+// Computer use and watch observation types.
 
 import type { CommandIntent, UserMessageAttachment } from "./shared.js";
 
@@ -89,16 +89,6 @@ export interface RecordingResume {
   recordingId: string;
 }
 
-export interface TaskRouted {
-  type: "task_routed";
-  sessionId: string;
-  interactionType: "computer_use" | "text_qa";
-  /** The task text passed to the escalated session. */
-  task?: string;
-  /** Set when a text_qa session escalates to computer_use. */
-  escalatedFrom?: string;
-}
-
 export interface WatchStarted {
   type: "watch_started";
   sessionId: string;
@@ -121,7 +111,6 @@ export type _ComputerUseClientMessages =
   | RecordingStatus;
 
 export type _ComputerUseServerMessages =
-  | TaskRouted
   | WatchStarted
   | WatchCompleteRequest
   | RecordingStart

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -499,13 +499,3 @@ export const allComputerUseTools: Tool[] = [
   computerUseDoneTool,
   computerUseRespondTool,
 ];
-
-/**
- * Tools safe for the legacy fallback path (no skill projection).
- *
- * Excludes `computer_use_observe` because the macOS client doesn't handle it
- * in the legacy code path — it falls back to `.done` which skips sending an
- * observation, causing the daemon to block on `pendingObservation` until timeout.
- */
-export const legacyFallbackComputerUseTools: Tool[] =
-  allComputerUseTools.filter((t) => t.name !== "computer_use_observe");

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4285,24 +4285,6 @@ public struct SurfaceAction: Codable, Sendable {
     }
 }
 
-public struct TaskRouted: Codable, Sendable {
-    public let type: String
-    public let sessionId: String
-    public let interactionType: String
-    /// The task text passed to the escalated session.
-    public let task: String?
-    /// Set when a text_qa session escalates to computer_use via computer_use_request_control.
-    public let escalatedFrom: String?
-
-    public init(type: String, sessionId: String, interactionType: String, task: String? = nil, escalatedFrom: String? = nil) {
-        self.type = type
-        self.sessionId = sessionId
-        self.interactionType = interactionType
-        self.task = task
-        self.escalatedFrom = escalatedFrom
-    }
-}
-
 /// Server push — broadcast when a task run creates a conversation, so the client can show it as a chat thread.
 public struct TaskRunThreadCreated: Codable, Sendable {
     public let type: String


### PR DESCRIPTION
## Summary

- **Gap 7:** Remove `TaskRouted` interface from `message-types/computer-use.ts` and its entry in `_ComputerUseServerMessages` — no daemon code constructs or emits `task_routed` messages, and the client-side handler was already removed. Also removes the dead `TaskRouted` struct from `GeneratedAPITypes.swift`.
- **Gap 8:** Remove `legacyFallbackComputerUseTools` export from `definitions.ts` — zero importers remain.
- Updates ARCHITECTURE.md to remove the stale `task_routed` message reference.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Prettier + ESLint pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
