### PR TITLE
fix: add onInternalResolve, isAvailable, and signal propagation to HostCuProxy

### DIFF
--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -50,7 +50,7 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   function setupProxy(maxSteps?: number): SurfaceSessionContext {
     sentMessages = [];
     const sendToClient = (msg: unknown) => sentMessages.push(msg);
-    proxy = new HostCuProxy(sendToClient as never, maxSteps);
+    proxy = new HostCuProxy(sendToClient as never, undefined, maxSteps);
     // Mark client as connected so requests are sent
     proxy.updateSender(sendToClient as never, true);
     return buildMockContext(proxy);
@@ -87,6 +87,20 @@ describe("surfaceProxyResolver — CU tool routing", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("not available");
+    });
+
+    test("returns error when proxy exists but client not connected", async () => {
+      const sendToClient = () => {};
+      const proxyObj = new HostCuProxy(sendToClient as never);
+      // Default clientConnected is false — do NOT call updateSender with true
+      const ctx = buildMockContext(proxyObj);
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not available");
+      proxyObj.dispose();
     });
 
     test("returns error for terminal tools when no proxy", async () => {

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -6,11 +6,17 @@ describe("HostCuProxy", () => {
   let proxy: InstanceType<typeof HostCuProxy>;
   let sentMessages: unknown[];
   let sendToClient: (msg: unknown) => void;
+  let resolvedRequestIds: string[];
 
   function setup(maxSteps?: number) {
     sentMessages = [];
+    resolvedRequestIds = [];
     sendToClient = (msg: unknown) => sentMessages.push(msg);
-    proxy = new HostCuProxy(sendToClient as never, maxSteps);
+    proxy = new HostCuProxy(
+      sendToClient as never,
+      (requestId: string) => resolvedRequestIds.push(requestId),
+      maxSteps,
+    );
   }
 
   afterEach(() => {
@@ -594,6 +600,79 @@ describe("HostCuProxy", () => {
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
       expect(resultPromise).rejects.toThrow("Host CU proxy disposed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onInternalResolve callback
+  // -------------------------------------------------------------------------
+
+  describe("onInternalResolve", () => {
+    test("calls onInternalResolve when abort signal fires", async () => {
+      setup();
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      controller.abort();
+
+      await resultPromise;
+      expect(resolvedRequestIds).toContain(requestId);
+    });
+
+    test("calls onInternalResolve on dispose", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      proxy.dispose();
+
+      // dispose rejects pending requests — catch to avoid unhandled rejection
+      await resultPromise.catch(() => {});
+
+      expect(resolvedRequestIds).toContain(requestId);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isAvailable
+  // -------------------------------------------------------------------------
+
+  describe("isAvailable", () => {
+    test("returns false by default", () => {
+      setup();
+      expect(proxy.isAvailable()).toBe(false);
+    });
+
+    test("returns true after updateSender with clientConnected=true", () => {
+      setup();
+      proxy.updateSender(sendToClient as never, true);
+      expect(proxy.isAvailable()).toBe(true);
+    });
+
+    test("returns false after updateSender with clientConnected=false", () => {
+      setup();
+      proxy.updateSender(sendToClient as never, true);
+      proxy.updateSender(sendToClient as never, false);
+      expect(proxy.isAvailable()).toBe(false);
     });
   });
 

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -421,7 +421,9 @@ export async function handleSessionCreate(
         pendingInteractions.resolve(requestId);
       });
       session.setHostFileProxy(fileProxy);
-      const cuProxy = new HostCuProxy(sendEvent);
+      const cuProxy = new HostCuProxy(sendEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
       session.setHostCuProxy(cuProxy);
     }
     session.updateClient(sendEvent, false);

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -65,6 +65,7 @@ interface PendingRequest {
 export class HostCuProxy {
   private pending = new Map<string, PendingRequest>();
   private sendToClient: (msg: ServerMessage) => void;
+  private onInternalResolve?: (requestId: string) => void;
   private clientConnected = false;
 
   // CU state tracking (per-conversation)
@@ -76,9 +77,11 @@ export class HostCuProxy {
 
   constructor(
     sendToClient: (msg: ServerMessage) => void,
+    onInternalResolve?: (requestId: string) => void,
     maxSteps = MAX_STEPS,
   ) {
     this.sendToClient = sendToClient;
+    this.onInternalResolve = onInternalResolve;
     this._maxSteps = maxSteps;
   }
 
@@ -150,6 +153,7 @@ export class HostCuProxy {
     return new Promise<ToolExecutionResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.onInternalResolve?.(requestId);
         log.warn({ requestId, toolName }, "Host CU proxy request timed out");
         resolve({
           content: "Host CU proxy timed out waiting for client response",
@@ -164,6 +168,7 @@ export class HostCuProxy {
           if (this.pending.has(requestId)) {
             clearTimeout(timer);
             this.pending.delete(requestId);
+            this.onInternalResolve?.(requestId);
             resolve({ content: "Aborted", isError: true });
           }
         };
@@ -200,6 +205,10 @@ export class HostCuProxy {
 
   hasPendingRequest(requestId: string): boolean {
     return this.pending.has(requestId);
+  }
+
+  isAvailable(): boolean {
+    return this.clientConnected;
   }
 
   // ---------------------------------------------------------------------------
@@ -342,8 +351,9 @@ export class HostCuProxy {
   // ---------------------------------------------------------------------------
 
   dispose(): void {
-    for (const [_requestId, entry] of this.pending) {
+    for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
+      this.onInternalResolve?.(requestId);
       entry.reject(
         new AssistantError("Host CU proxy disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -663,7 +663,11 @@ export class DaemonServer {
         );
       }
       if (!session.isProcessing() || !session.hostCuProxy) {
-        session.setHostCuProxy(new HostCuProxy(session.getCurrentSender()));
+        session.setHostCuProxy(
+          new HostCuProxy(session.getCurrentSender(), (requestId) => {
+            pendingInteractions.resolve(requestId);
+          }),
+        );
       }
     } else if (!session.isProcessing()) {
       session.setHostBashProxy(undefined);

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -938,10 +938,11 @@ export async function surfaceProxyResolver(
   ctx: SurfaceSessionContext,
   toolName: string,
   input: Record<string, unknown>,
+  signal?: AbortSignal,
 ): Promise<ToolExecutionResult> {
   // Route CU proxy tools (all computer_use_* action tools)
   if (toolName.startsWith("computer_use_")) {
-    if (!ctx.hostCuProxy) {
+    if (!ctx.hostCuProxy || !ctx.hostCuProxy.isAvailable()) {
       return {
         content: "Computer use is not available — no desktop client connected.",
         isError: true,
@@ -973,6 +974,7 @@ export async function surfaceProxyResolver(
       ctx.conversationId,
       ctx.hostCuProxy.stepCount,
       reasoning,
+      signal,
     );
   }
 

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -208,7 +208,13 @@ export function createToolExecutor(
       proxyToolResolver: (
         toolName: string,
         proxyInput: Record<string, unknown>,
-      ) => surfaceProxyResolver(ctx, toolName, proxyInput),
+      ) =>
+        surfaceProxyResolver(
+          ctx,
+          toolName,
+          proxyInput,
+          ctx.abortController?.signal,
+        ),
       proxyApprovalCallback: createProxyApprovalCallback(prompter, ctx),
       requestSecret: async (params) => {
         return secretPrompter.prompt(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -648,7 +648,9 @@ export async function handleSendMessage(
       session.setHostFileProxy(fileProxy);
     }
     if (!session.isProcessing() || !session.hostCuProxy) {
-      const cuProxy = new HostCuProxy(onEvent);
+      const cuProxy = new HostCuProxy(onEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
       session.setHostCuProxy(cuProxy);
     }
   } else if (!session.isProcessing()) {


### PR DESCRIPTION
## Summary
- Add `onInternalResolve` callback to `HostCuProxy` constructor, matching the pattern from `HostBashProxy` and `HostFileProxy`. Called on timeout, abort, and dispose to clean up stale pending interaction entries.
- Add `isAvailable()` guard so `surfaceProxyResolver` returns an immediate error when no client is connected, instead of dispatching and waiting for timeout.
- Thread `AbortSignal` from the agent loop's abort controller through `surfaceProxyResolver` to `HostCuProxy.request()` so CU requests are cancelled promptly on abort.
- Update all 3 construction sites (`handlers/sessions.ts`, `conversation-routes.ts`, `server.ts`) to pass `(requestId) => pendingInteractions.resolve(requestId)`.

## Test plan
- [x] Type-check passes (`bunx tsc --noEmit`)
- [x] `host-cu-proxy.test.ts` — 32 tests pass (including new `onInternalResolve` and `isAvailable` tests)
- [x] `cu-unified-flow.test.ts` — 20 tests pass (including new `isAvailable` guard test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
