### PR TITLE
fix: use nullish coalescing for requiresClientSecret check in connect command

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -395,12 +395,11 @@ Examples:
             const providerRow = getProvider(resolvedServiceKey);
             const behavior = getProviderBehavior(resolvedServiceKey);
 
-            const requiresSecret = behavior?.setup?.requiresClientSecret
-              ? true
-              : !!(
-                  providerRow?.tokenEndpointAuthMethod ||
-                  providerRow?.extraParams
-                );
+            const requiresSecret =
+              behavior?.setup?.requiresClientSecret ??
+              !!(
+                providerRow?.tokenEndpointAuthMethod || providerRow?.extraParams
+              );
 
             if (requiresSecret) {
               writeOutput(cmd, {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-connect-cmd.md.

**Gap:** requiresClientSecret ternary does not respect explicit false — breaks Twitter connects
**What was expected:** The requiresClientSecret check should use ?? to respect explicit false values, matching vault.ts and settings-routes.ts
**What was found:** Used ternary (? true :) instead of ??, causing PKCE providers like Twitter to incorrectly require a client_secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
