### PR TITLE
fix: use cross-platform URL opening in oauth connect command

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -24,6 +24,7 @@ import {
   assertMetadataWritable,
   deleteCredentialMetadata,
 } from "../../../tools/credentials/metadata-store.js";
+import { isLinux, isMacOS } from "../../../util/platform.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -420,10 +421,22 @@ Examples:
             isInteractive: !opts.urlOnly,
             openUrl: !opts.urlOnly
               ? (url) => {
-                  Bun.spawn(["open", url], {
-                    stdout: "ignore",
-                    stderr: "ignore",
-                  });
+                  if (isMacOS()) {
+                    Bun.spawn(["open", url], {
+                      stdout: "ignore",
+                      stderr: "ignore",
+                    });
+                  } else if (isLinux()) {
+                    Bun.spawn(["xdg-open", url], {
+                      stdout: "ignore",
+                      stderr: "ignore",
+                    });
+                  } else {
+                    // Fallback: print URL for manual opening
+                    process.stdout.write(
+                      `Open this URL to authorize:\n\n${url}\n`,
+                    );
+                  }
                 }
               : undefined,
             ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-connect-cmd.md.

**Gap:** Bun.spawn(["open", url]) is macOS-only — silently fails on Linux
**What was expected:** Cross-platform URL opening using isMacOS()/isLinux() from util/platform.ts
**What was found:** Hardcoded macOS-only open command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
