### PR TITLE
test: add configurable getSecureKey mock and client_secret resolution test

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -44,6 +44,7 @@ let mockGetMostRecentAppByProvider: (
 let mockGetProvider: (
   providerKey: string,
 ) => Record<string, unknown> | undefined = () => undefined;
+let mockGetSecureKey: (account: string) => string | undefined = () => undefined;
 
 function nextUUID(): string {
   idCounter += 1;
@@ -106,7 +107,7 @@ mock.module("../oauth/oauth-store.js", () => ({
 
 // Stub out transitive dependencies that token-manager would normally pull in
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => undefined,
+  getSecureKey: (account: string) => mockGetSecureKey(account),
   setSecureKey: () => true,
   getSecureKeyAsync: async () => undefined,
   setSecureKeyAsync: async () => true,
@@ -648,6 +649,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     mockGetAppByProviderAndClientId = () => undefined;
     mockGetMostRecentAppByProvider = () => undefined;
     mockGetProvider = () => undefined;
+    mockGetSecureKey = () => undefined;
   });
 
   test("completes interactive flow and prints success (human mode)", async () => {
@@ -730,6 +732,34 @@ describe("assistant oauth connections connect <provider-key>", () => {
 
     await runCli(["connections", "connect", "integration:gmail"]);
     expect(capturedClientId).toBe("db-client-id");
+  });
+
+  test("resolves client_secret from secure store when not provided", async () => {
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-1",
+      clientId: "db-client-id",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockGetSecureKey = (account: string) =>
+      account === "oauth_app/app-1/client_secret" ? "db-secret" : undefined;
+
+    let capturedOpts: Record<string, unknown> | undefined;
+    mockOrchestrateOAuthConnect = async (opts) => {
+      capturedOpts = opts;
+      return {
+        success: true,
+        deferred: false,
+        grantedScopes: [],
+      };
+    };
+
+    await runCli(["connections", "connect", "integration:gmail"]);
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.clientId).toBe("db-client-id");
+    expect(capturedOpts!.clientSecret).toBe("db-secret");
   });
 
   test("outputs error from orchestrator", async () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-connect-cmd.md.

**Gap:** getSecureKey mock is not configurable — cannot test client_secret resolution from DB
**What was expected:** A configurable mock for getSecureKey and a test verifying client_secret is resolved from secure storage
**What was found:** The mock always returned undefined, making it impossible to test the credential resolution path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
