### PR TITLE
test: add test for client_secret required but missing in connect command

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -44,6 +44,9 @@ let mockGetMostRecentAppByProvider: (
 let mockGetProvider: (
   providerKey: string,
 ) => Record<string, unknown> | undefined = () => undefined;
+let mockGetProviderBehavior: (
+  providerKey: string,
+) => Record<string, unknown> | undefined = () => undefined;
 
 function nextUUID(): string {
   idCounter += 1;
@@ -161,7 +164,8 @@ mock.module("../oauth/connect-orchestrator.js", () => ({
 
 mock.module("../oauth/provider-behaviors.js", () => ({
   resolveService: (service: string) => service,
-  getProviderBehavior: () => undefined,
+  getProviderBehavior: (providerKey: string) =>
+    mockGetProviderBehavior(providerKey),
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -648,6 +652,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     mockGetAppByProviderAndClientId = () => undefined;
     mockGetMostRecentAppByProvider = () => undefined;
     mockGetProvider = () => undefined;
+    mockGetProviderBehavior = () => undefined;
   });
 
   test("completes interactive flow and prints success (human mode)", async () => {
@@ -750,5 +755,30 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toBe("Something went wrong");
+  });
+
+  test("fails when client_secret is required but missing", async () => {
+    mockGetProviderBehavior = () => ({
+      setup: {
+        requiresClientSecret: true,
+        displayName: "Test",
+        dashboardUrl: "https://example.com",
+        appType: "app",
+      },
+    });
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:gmail",
+      "--client-id",
+      "test-id",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("client_secret");
+    expect(parsed.error).toContain("apps upsert");
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-cli-connect-cmd.md.

**Gap:** Missing test for client_secret required but missing acceptance criterion
**What was expected:** A test verifying the error message when client_secret is required but not provided
**What was found:** No test exercised the requiresSecret code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
