### PR TITLE
refactor: read client_secret using stored credential path instead of derived pattern

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -160,7 +160,7 @@ async function handleOAuthConnectStart(body: {
     const app = getApp(conn.oauthAppId);
     if (app) {
       clientId = app.clientId;
-      clientSecret = getSecureKey(`oauth_app/${app.id}/client_secret`);
+      clientSecret = getSecureKey(app.clientSecretCredentialPath);
     }
   }
 
@@ -170,7 +170,7 @@ async function handleOAuthConnectStart(body: {
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
-        clientSecret = getSecureKey(`oauth_app/${dbApp.id}/client_secret`);
+        clientSecret = getSecureKey(dbApp.clientSecretCredentialPath);
       }
     }
   }

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -225,7 +225,7 @@ function resolveRefreshConfig(service: string): RefreshConfig {
     );
   }
 
-  const secret = getSecureKey(`oauth_app/${app.id}/client_secret`);
+  const secret = getSecureKey(app.clientSecretCredentialPath);
 
   const refreshToken = getSecureKey(
     `oauth_connection/${conn.id}/refresh_token`,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -747,9 +747,7 @@ class CredentialStoreTool implements Tool {
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
             if (!clientSecret) {
-              clientSecret = getSecureKey(
-                `oauth_app/${dbApp.id}/client_secret`,
-              );
+              clientSecret = getSecureKey(dbApp.clientSecretCredentialPath);
             }
           }
         }


### PR DESCRIPTION
## Summary
- Update token-manager, settings-routes, and vault to read client secrets using the stored `clientSecretCredentialPath` from the app row
- Eliminates all production code that constructs the `oauth_app/${id}/client_secret` pattern for reading secrets
- Behavior unchanged for existing data since backfilled rows use the same path

Part of plan: oauth-client-secret-cred-path.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
