### PR TITLE
feat: update upsertApp to accept value or path, use stored path in deleteApp

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -34,6 +34,8 @@ mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: mockDeleteSecureKeyAsync,
   setSecureKeyAsync: mockSetSecureKeyAsync,
   getSecureKey: (account: string) => secureKeyValues.get(account),
+  getSecureKeyAsync: (account: string) =>
+    Promise.resolve(secureKeyValues.get(account)),
 }));
 
 import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
@@ -279,12 +281,17 @@ describe("app operations", () => {
 
     test("stores clientSecret in secure storage on new app creation", async () => {
       seedTestProvider("github");
-      const app = await upsertApp("github", "client-abc", "my-secret");
+      const app = await upsertApp("github", "client-abc", {
+        clientSecretValue: "my-secret",
+      });
 
       expect(mockSetSecureKeyAsync).toHaveBeenCalledTimes(1);
       expect(mockSetSecureKeyAsync).toHaveBeenCalledWith(
         `oauth_app/${app.id}/client_secret`,
         "my-secret",
+      );
+      expect(app.clientSecretCredentialPath).toBe(
+        `oauth_app/${app.id}/client_secret`,
       );
     });
 
@@ -293,11 +300,13 @@ describe("app operations", () => {
       const first = await upsertApp("github", "client-abc");
       mockSetSecureKeyAsync.mockClear();
 
-      await upsertApp("github", "client-abc", "updated-secret");
+      await upsertApp("github", "client-abc", {
+        clientSecretValue: "updated-secret",
+      });
 
       expect(mockSetSecureKeyAsync).toHaveBeenCalledTimes(1);
       expect(mockSetSecureKeyAsync).toHaveBeenCalledWith(
-        `oauth_app/${first.id}/client_secret`,
+        first.clientSecretCredentialPath,
         "updated-secret",
       );
     });
@@ -307,8 +316,69 @@ describe("app operations", () => {
       mockSetSecureKeyAsync.mockResolvedValueOnce(false);
 
       await expect(
-        upsertApp("github", "client-abc", "bad-secret"),
+        upsertApp("github", "client-abc", { clientSecretValue: "bad-secret" }),
       ).rejects.toThrow("Failed to store client_secret in secure storage");
+    });
+
+    test("accepts clientSecretCredentialPath and verifies existence", async () => {
+      seedTestProvider("github");
+      secureKeyValues.set("custom/path", "stored-secret");
+
+      const app = await upsertApp("github", "client-abc", {
+        clientSecretCredentialPath: "custom/path",
+      });
+
+      expect(app.clientSecretCredentialPath).toBe("custom/path");
+      // Should not have called setSecureKeyAsync since we only provided a path
+      expect(mockSetSecureKeyAsync).not.toHaveBeenCalled();
+    });
+
+    test("throws when clientSecretCredentialPath points to nonexistent secret", async () => {
+      seedTestProvider("github");
+
+      await expect(
+        upsertApp("github", "client-abc", {
+          clientSecretCredentialPath: "nonexistent/path",
+        }),
+      ).rejects.toThrow("No secret found at credential path: nonexistent/path");
+    });
+
+    test("throws when both clientSecretValue and clientSecretCredentialPath are provided", async () => {
+      seedTestProvider("github");
+
+      await expect(
+        upsertApp("github", "client-abc", {
+          clientSecretValue: "my-secret",
+          clientSecretCredentialPath: "custom/path",
+        }),
+      ).rejects.toThrow(
+        "Cannot provide both clientSecretValue and clientSecretCredentialPath",
+      );
+    });
+
+    test("records default clientSecretCredentialPath when neither value nor path is provided", async () => {
+      seedTestProvider("github");
+      const app = await upsertApp("github", "client-abc");
+
+      expect(app.clientSecretCredentialPath).toBe(
+        `oauth_app/${app.id}/client_secret`,
+      );
+    });
+
+    test("updates clientSecretCredentialPath on existing row when path is provided", async () => {
+      seedTestProvider("github");
+      const first = await upsertApp("github", "client-abc");
+      expect(first.clientSecretCredentialPath).toBe(
+        `oauth_app/${first.id}/client_secret`,
+      );
+
+      secureKeyValues.set("new/custom/path", "stored-secret");
+      const updated = await upsertApp("github", "client-abc", {
+        clientSecretCredentialPath: "new/custom/path",
+      });
+
+      expect(updated.id).toBe(first.id);
+      expect(updated.clientSecretCredentialPath).toBe("new/custom/path");
     });
   });
 
@@ -353,14 +423,29 @@ describe("app operations", () => {
       expect(getApp(app.id)).toBeUndefined();
     });
 
-    test("cleans up client_secret from secure storage", async () => {
+    test("cleans up client_secret from secure storage using stored path", async () => {
       const app = await createTestApp("github", "client-1");
       mockDeleteSecureKeyAsync.mockClear();
 
       await deleteApp(app.id);
 
       expect(mockDeleteSecureKeyAsync).toHaveBeenCalledWith(
-        `oauth_app/${app.id}/client_secret`,
+        app.clientSecretCredentialPath,
+      );
+    });
+
+    test("uses custom clientSecretCredentialPath when deleting", async () => {
+      seedTestProvider("github");
+      secureKeyValues.set("custom/secret/path", "the-secret");
+      const app = await upsertApp("github", "client-1", {
+        clientSecretCredentialPath: "custom/secret/path",
+      });
+      mockDeleteSecureKeyAsync.mockClear();
+
+      await deleteApp(app.id);
+
+      expect(mockDeleteSecureKeyAsync).toHaveBeenCalledWith(
+        "custom/secret/path",
       );
     });
 

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -189,7 +189,9 @@ Examples:
           const row = await upsertApp(
             opts.provider,
             opts.clientId,
-            opts.clientSecret,
+            opts.clientSecret
+              ? { clientSecretValue: opts.clientSecret }
+              : undefined,
           );
 
           if (!shouldOutputJson(cmd)) {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -17,6 +17,7 @@ import {
 import {
   deleteSecureKeyAsync,
   getSecureKey,
+  getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
@@ -178,11 +179,35 @@ export function registerProvider(params: {
 export async function upsertApp(
   providerKey: string,
   clientId: string,
-  clientSecret?: string,
+  clientSecretOpts?: {
+    clientSecretValue?: string;
+    clientSecretCredentialPath?: string;
+  },
 ): Promise<OAuthAppRow> {
+  const { clientSecretValue, clientSecretCredentialPath } =
+    clientSecretOpts ?? {};
+
+  if (clientSecretValue && clientSecretCredentialPath) {
+    throw new Error(
+      "Cannot provide both clientSecretValue and clientSecretCredentialPath",
+    );
+  }
+
+  const defaultCredPath = (appId: string) => `oauth_app/${appId}/client_secret`;
+
+  // Verify the credential path points to an existing secret.
+  if (clientSecretCredentialPath) {
+    const existing = await getSecureKeyAsync(clientSecretCredentialPath);
+    if (existing === undefined) {
+      throw new Error(
+        `No secret found at credential path: ${clientSecretCredentialPath}`,
+      );
+    }
+  }
+
   const db = getDb();
 
-  const existing = db
+  const existingRow = db
     .select()
     .from(oauthApps)
     .where(
@@ -193,40 +218,54 @@ export async function upsertApp(
     )
     .get();
 
-  if (existing) {
-    if (clientSecret) {
+  if (existingRow) {
+    if (clientSecretValue) {
       const stored = await setSecureKeyAsync(
-        `oauth_app/${existing.id}/client_secret`,
-        clientSecret,
+        existingRow.clientSecretCredentialPath,
+        clientSecretValue,
       );
       if (!stored) {
         throw new Error("Failed to store client_secret in secure storage");
       }
     }
-    return existing;
+    if (clientSecretCredentialPath) {
+      db.update(oauthApps)
+        .set({
+          clientSecretCredentialPath,
+          updatedAt: Date.now(),
+        })
+        .where(eq(oauthApps.id, existingRow.id))
+        .run();
+      return db
+        .select()
+        .from(oauthApps)
+        .where(eq(oauthApps.id, existingRow.id))
+        .get()!;
+    }
+    return existingRow;
   }
 
   const now = Date.now();
   const id = uuid();
+  const credPath = clientSecretCredentialPath ?? defaultCredPath(id);
+
+  if (clientSecretValue) {
+    const stored = await setSecureKeyAsync(credPath, clientSecretValue);
+    if (!stored) {
+      throw new Error("Failed to store client_secret in secure storage");
+    }
+  }
+
   const row = {
     id,
     providerKey,
     clientId,
+    clientSecretCredentialPath: credPath,
     createdAt: now,
     updatedAt: now,
   };
 
   db.insert(oauthApps).values(row).run();
-
-  if (clientSecret) {
-    const stored = await setSecureKeyAsync(
-      `oauth_app/${id}/client_secret`,
-      clientSecret,
-    );
-    if (!stored) {
-      throw new Error("Failed to store client_secret in secure storage");
-    }
-  }
 
   return row;
 }
@@ -280,15 +319,16 @@ export function listApps(): OAuthAppRow[] {
 
 /** Delete an app by ID. Cleans up the client_secret from secure storage. Returns true if a row was deleted. */
 export async function deleteApp(id: string): Promise<boolean> {
+  const db = getDb();
+
+  const app = db.select().from(oauthApps).where(eq(oauthApps.id, id)).get();
+  if (!app) return false;
+
   // Delete the DB row first so that if it fails (e.g. FK constraint from
   // existing connections), the secret in secure storage remains intact.
-  const db = getDb();
   db.delete(oauthApps).where(eq(oauthApps.id, id)).run();
-  const deleted = rawChanges() > 0;
 
-  if (!deleted) return false;
-
-  const result = await deleteSecureKeyAsync(`oauth_app/${id}/client_secret`);
+  const result = await deleteSecureKeyAsync(app.clientSecretCredentialPath);
   if (result === "error") {
     throw new Error(
       `Deleted app ${id} but failed to remove client_secret from secure storage`,

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -22,6 +22,7 @@ import type { CredentialInjectionTemplate } from "../tools/credentials/policy-ty
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
 import {
   createConnection,
+  getApp,
   getConnectionByProvider,
   updateConnection,
   upsertApp,
@@ -101,13 +102,20 @@ export async function storeOAuth2Tokens(
 
   // 1. Upsert the oauth_app row (or use the pre-resolved ID).
   const app = params.oauthAppId
-    ? { id: params.oauthAppId }
-    : await upsertApp(service, clientId, clientSecret);
+    ? (getApp(params.oauthAppId) ?? {
+        id: params.oauthAppId,
+        clientSecretCredentialPath: `oauth_app/${params.oauthAppId}/client_secret`,
+      })
+    : await upsertApp(
+        service,
+        clientId,
+        clientSecret ? { clientSecretValue: clientSecret } : undefined,
+      );
 
   // When oauthAppId is pre-resolved, still persist clientSecret if provided.
   if (params.oauthAppId && clientSecret) {
     const stored = await setSecureKeyAsync(
-      `oauth_app/${params.oauthAppId}/client_secret`,
+      app.clientSecretCredentialPath,
       clientSecret,
     );
     if (!stored) {


### PR DESCRIPTION
## Summary
- Update `upsertApp` signature to accept `{ clientSecretValue?, clientSecretCredentialPath? }` instead of plain string
- When `clientSecretCredentialPath` is provided, verify secret exists at that path before recording
- Update `deleteApp` to use the stored `clientSecretCredentialPath` instead of deriving the pattern
- Update `token-persistence.ts` to use the new signature and stored paths
- Update CLI `apps.ts` command to wrap clientSecret in new object format
- Add tests for new credential path options and mutual exclusivity validation

Part of plan: oauth-client-secret-cred-path.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
