### PR TITLE
feat: add nullable `ping_url` column to `oauth_providers` table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -67,6 +67,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateOAuthAppsClientSecretPath,
+  migrateOAuthProvidersPingUrl,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameGuardianVerificationValues,
@@ -347,6 +348,9 @@ export function initializeDb(): void {
 
   // 54. Add explicit client_secret_credential_path to oauth_apps
   migrateOAuthAppsClientSecretPath(database);
+
+  // 55. Add ping_url column to oauth_providers
+  migrateOAuthProvidersPingUrl(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/149-oauth-tables.ts
+++ b/assistant/src/memory/migrations/149-oauth-tables.ts
@@ -18,6 +18,7 @@ export function createOAuthTables(database: DrizzleDb): void {
       extra_params TEXT,
       callback_transport TEXT,
       loopback_port INTEGER,
+      ping_url TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     )

--- a/assistant/src/memory/migrations/151-oauth-providers-ping-url.ts
+++ b/assistant/src/memory/migrations/151-oauth-providers-ping-url.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersPingUrl(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(/*sql*/ `ALTER TABLE oauth_providers ADD COLUMN ping_url TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -92,6 +92,7 @@ export { migrateRemindersToSchedules } from "./147-migrate-reminders-to-schedule
 export { migrateDropRemindersTable } from "./148-drop-reminders-table.js";
 export { createOAuthTables } from "./149-oauth-tables.js";
 export { migrateOAuthAppsClientSecretPath } from "./150-oauth-apps-client-secret-path.js";
+export { migrateOAuthProvidersPingUrl } from "./151-oauth-providers-ping-url.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -18,6 +18,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   extraParams: text("extra_params"),
   callbackTransport: text("callback_transport"),
   loopbackPort: integer("loopback_port"),
+  pingUrl: text("ping_url"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -158,6 +158,7 @@ export function registerProvider(params: {
     extraParams: params.extraParams ? JSON.stringify(params.extraParams) : null,
     callbackTransport: params.callbackTransport ?? null,
     loopbackPort: params.loopbackPort ?? null,
+    pingUrl: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -208,10 +209,12 @@ export async function upsertApp(
 
   const now = Date.now();
   const id = uuid();
+  const clientSecretCredentialPath = `oauth_app/${id}/client_secret`;
   const row = {
     id,
     providerKey,
     clientId,
+    clientSecretCredentialPath,
     createdAt: now,
     updatedAt: now,
   };
@@ -220,7 +223,7 @@ export async function upsertApp(
 
   if (clientSecret) {
     const stored = await setSecureKeyAsync(
-      `oauth_app/${id}/client_secret`,
+      clientSecretCredentialPath,
       clientSecret,
     );
     if (!stored) {


### PR DESCRIPTION
## Summary
- Add `ping_url TEXT` nullable column to the `oauth_providers` table via ALTER TABLE migration (151)
- Update initial DDL in migration 149 so new installs get the column
- Add `pingUrl` field to the Drizzle schema definition
- Wire migration into db-init.ts startup sequence
- Fix pre-existing TSC errors in oauth-store.ts (missing `pingUrl` and `clientSecretCredentialPath` in row literals)

Part of plan: oauth-ping-endpoint.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
