### PR TITLE
feat: add --client-secret-credential-path option to assistant oauth apps upsert

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -30,6 +30,23 @@ let disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
   "not-found";
 let idCounter = 0;
 
+// App upsert mock state
+let mockUpsertAppCalls: Array<{
+  provider: string;
+  clientId: string;
+  clientSecretOpts?: {
+    clientSecretValue?: string;
+    clientSecretCredentialPath?: string;
+  };
+}> = [];
+let mockUpsertAppResult: Record<string, unknown> = {
+  id: "app-upsert-1",
+  providerKey: "integration:test",
+  clientId: "test-client-id",
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+};
+
 // Connect mock state
 let mockOrchestrateOAuthConnect: (
   opts: Record<string, unknown>,
@@ -91,7 +108,17 @@ mock.module("../oauth/oauth-store.js", () => ({
   listConnections: () => [],
   deleteConnection: () => false,
   // Stubs required by apps.ts and providers.ts (transitively loaded via oauth/index.ts)
-  upsertApp: async () => ({}),
+  upsertApp: async (
+    provider: string,
+    clientId: string,
+    clientSecretOpts?: {
+      clientSecretValue?: string;
+      clientSecretCredentialPath?: string;
+    },
+  ) => {
+    mockUpsertAppCalls.push({ provider, clientId, clientSecretOpts });
+    return mockUpsertAppResult;
+  },
   getApp: () => undefined,
   getAppByProviderAndClientId: (providerKey: string, clientId: string) =>
     mockGetAppByProviderAndClientId(providerKey, clientId),
@@ -810,5 +837,125 @@ describe("assistant oauth connections connect <provider-key>", () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("client_secret");
     expect(parsed.error).toContain("apps upsert");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apps upsert --client-secret-credential-path
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth apps upsert --client-secret-credential-path", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    secureKeyStore = new Map();
+    metadataStore = [];
+    disconnectOAuthProviderCalls = [];
+    disconnectOAuthProviderResult = "not-found";
+    idCounter = 0;
+    mockUpsertAppCalls = [];
+    mockUpsertAppResult = {
+      id: "app-upsert-1",
+      providerKey: "integration:gmail",
+      clientId: "abc123",
+      createdAt: 1700000000000,
+      updatedAt: 1700000000000,
+    };
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockGetProvider = () => undefined;
+    mockGetProviderBehavior = () => undefined;
+    mockGetSecureKey = () => undefined;
+  });
+
+  test("upsert with --client-secret-credential-path passes path to upsertApp", async () => {
+    const { exitCode, stdout } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "integration:gmail",
+      "--client-id",
+      "abc123",
+      "--client-secret-credential-path",
+      "custom/path",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpsertAppCalls).toHaveLength(1);
+    expect(mockUpsertAppCalls[0]).toEqual({
+      provider: "integration:gmail",
+      clientId: "abc123",
+      clientSecretOpts: { clientSecretCredentialPath: "custom/path" },
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toBe("app-upsert-1");
+  });
+
+  test("upsert with both --client-secret and --client-secret-credential-path returns error", async () => {
+    const { exitCode, stdout } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "integration:gmail",
+      "--client-id",
+      "abc123",
+      "--client-secret",
+      "s3cret",
+      "--client-secret-credential-path",
+      "custom/path",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain(
+      "Cannot provide both --client-secret and --client-secret-credential-path",
+    );
+    // upsertApp should NOT have been called
+    expect(mockUpsertAppCalls).toHaveLength(0);
+  });
+
+  test("upsert with --client-secret passes clientSecretValue to upsertApp", async () => {
+    const { exitCode } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "integration:gmail",
+      "--client-id",
+      "abc123",
+      "--client-secret",
+      "s3cret",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpsertAppCalls).toHaveLength(1);
+    expect(mockUpsertAppCalls[0]).toEqual({
+      provider: "integration:gmail",
+      clientId: "abc123",
+      clientSecretOpts: { clientSecretValue: "s3cret" },
+    });
+  });
+
+  test("upsert without any secret option passes undefined", async () => {
+    const { exitCode } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "integration:gmail",
+      "--client-id",
+      "abc123",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpsertAppCalls).toHaveLength(1);
+    expect(mockUpsertAppCalls[0]).toEqual({
+      provider: "integration:gmail",
+      clientId: "abc123",
+      clientSecretOpts: undefined,
+    });
   });
 });

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -165,6 +165,10 @@ At least --id or --provider must be specified.`,
       "--client-secret <secret>",
       "OAuth client secret (stored in secure keychain)",
     )
+    .option(
+      "--client-secret-credential-path <path>",
+      "Path to an existing client secret in the credential store (mutually exclusive with --client-secret)",
+    )
     .addHelpText(
       "after",
       `
@@ -175,23 +179,46 @@ stored in the secure system keychain — not in the database.
 When an existing app is matched and a --client-secret is provided, the stored
 secret is updated. The app row itself is returned as-is.
 
+You can supply the client secret directly via --client-secret, or reference an
+existing credential in the store via --client-secret-credential-path. These two
+options are mutually exclusive — providing both is an error.
+
 Examples:
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
   $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
+  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "custom/path"
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123 --json`,
     )
     .action(
       async (
-        opts: { provider: string; clientId: string; clientSecret?: string },
+        opts: {
+          provider: string;
+          clientId: string;
+          clientSecret?: string;
+          clientSecretCredentialPath?: string;
+        },
         cmd: Command,
       ) => {
         try {
+          if (opts.clientSecret && opts.clientSecretCredentialPath) {
+            writeOutput(cmd, {
+              ok: false,
+              error:
+                "Cannot provide both --client-secret and --client-secret-credential-path",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          const clientSecretOpts = opts.clientSecret
+            ? { clientSecretValue: opts.clientSecret }
+            : opts.clientSecretCredentialPath
+              ? { clientSecretCredentialPath: opts.clientSecretCredentialPath }
+              : undefined;
           const row = await upsertApp(
             opts.provider,
             opts.clientId,
-            opts.clientSecret
-              ? { clientSecretValue: opts.clientSecret }
-              : undefined,
+            clientSecretOpts,
           );
 
           if (!shouldOutputJson(cmd)) {


### PR DESCRIPTION
## Summary
- Add `--client-secret-credential-path` option to `assistant oauth apps upsert` CLI command
- Validates mutual exclusivity with `--client-secret` (errors if both provided)
- Updated help text to document the new option
- Added CLI tests for the new option and mutual exclusivity validation

Part of plan: oauth-client-secret-cred-path.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
