### PR TITLE
fix: add missing clientSecretCredentialPath to credential-vault-unit test mocks

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -689,6 +689,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       id: "test-app-id",
       providerKey: "integration:gmail",
       clientId: "stored-client-id-123",
+      clientSecretCredentialPath: "oauth_app/test-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
@@ -737,6 +738,8 @@ describe("credential_store tool — oauth2_connect error paths", () => {
             id: "matched-app-id",
             providerKey: "integration:gmail",
             clientId: "caller-supplied-client-id",
+            clientSecretCredentialPath:
+              "oauth_app/matched-app-id/client_secret",
             createdAt: Date.now(),
           };
         }
@@ -781,6 +784,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       id: "recent-app-id",
       providerKey: "integration:gmail",
       clientId: "recent-client-id",
+      clientSecretCredentialPath: "oauth_app/recent-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({


### PR DESCRIPTION
## Summary
- Add `clientSecretCredentialPath` to mock app objects returned by `getMostRecentAppByProvider` and `getAppByProviderAndClientId` in `credential-vault-unit.test.ts`
- The vault code reads `dbApp.clientSecretCredentialPath` to resolve the client_secret, but the test mocks were missing this field, causing `getSecureKey(undefined)` to return undefined

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23017031800/job/66842919708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
