### PR TITLE
fix: deduplicate escapeAxTreeContent

### DIFF
--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -9,6 +9,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { escapeAxTreeContent } from "../agent/loop.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -309,7 +310,7 @@ export class HostCuProxy {
     if (obs.axTree) {
       parts.push("<ax-tree>");
       parts.push("CURRENT SCREEN STATE:");
-      parts.push(HostCuProxy.escapeAxTreeContent(obs.axTree));
+      parts.push(escapeAxTreeContent(obs.axTree));
       parts.push("</ax-tree>");
     }
 
@@ -409,13 +410,5 @@ export class HostCuProxy {
       );
     }
     return lines;
-  }
-
-  /**
-   * Escapes literal `</ax-tree>` inside AX tree content so compaction
-   * regex does not stop prematurely.
-   */
-  static escapeAxTreeContent(content: string): string {
-    return content.replace(/<\/ax-tree>/gi, "&lt;/ax-tree&gt;");
   }
 }


### PR DESCRIPTION
## Summary
Remove duplicated `escapeAxTreeContent` implementation from `HostCuProxy` static method. Import from `agent/loop.ts` instead of maintaining two identical copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
