### PR TITLE
fix: remove stale computer_use_request_control dead code

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -524,6 +524,5 @@ describe("computer-use registration split", () => {
     expect(registered.every((t) => t.name.startsWith("computer_use_"))).toBe(
       true,
     );
-    expect(getTool("computer_use_request_control")).toBeUndefined();
   });
 });

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1042,8 +1042,6 @@ public struct ToolCallData: Identifiable, Equatable {
             return "Ran an AppleScript"
         case "computer_use_wait":
             return "Waited for the screen"
-        case "computer_use_request_control":
-            return "Requested computer control"
         case "computer_use_done", "computer_use_respond":
             return "Finished the task"
         case "ui_show":


### PR DESCRIPTION
## Summary
- Remove dead `computer_use_request_control` display label case from ChatMessage.swift
- Remove vacuous test assertion for deleted tool in registry.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
