### PR TITLE
fix: project CU tools into session for desktop clients and add observe executor

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/tools/computer-use-observe.ts
+++ b/assistant/src/config/bundled-skills/computer-use/tools/computer-use-observe.ts
@@ -1,0 +1,12 @@
+import { forwardComputerUseProxyTool } from "../../../../tools/computer-use/skill-proxy-bridge.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardComputerUseProxyTool("computer_use_observe", input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -48,6 +48,7 @@ import * as computerUseClick from "./bundled-skills/computer-use/tools/computer-
 import * as computerUseDone from "./bundled-skills/computer-use/tools/computer-use-done.js";
 import * as computerUseDrag from "./bundled-skills/computer-use/tools/computer-use-drag.js";
 import * as computerUseKey from "./bundled-skills/computer-use/tools/computer-use-key.js";
+import * as computerUseObserve from "./bundled-skills/computer-use/tools/computer-use-observe.js";
 import * as computerUseOpenApp from "./bundled-skills/computer-use/tools/computer-use-open-app.js";
 import * as computerUseRespond from "./bundled-skills/computer-use/tools/computer-use-respond.js";
 import * as computerUseRunApplescript from "./bundled-skills/computer-use/tools/computer-use-run-applescript.js";
@@ -219,6 +220,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["claude-code:tools/claude-code.ts", claudeCode],
 
   // computer-use
+  ["computer-use:tools/computer-use-observe.ts", computerUseObserve],
   ["computer-use:tools/computer-use-click.ts", computerUseClick],
   ["computer-use:tools/computer-use-type-text.ts", computerUseTypeText],
   ["computer-use:tools/computer-use-key.ts", computerUseKey],

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -425,6 +425,7 @@ export async function handleSessionCreate(
         pendingInteractions.resolve(requestId);
       });
       session.setHostCuProxy(cuProxy);
+      session.addPreactivatedSkillId("computer-use");
     }
     session.updateClient(sendEvent, false);
     session

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -669,6 +669,7 @@ export class DaemonServer {
           }),
         );
       }
+      session.addPreactivatedSkillId("computer-use");
     } else if (!session.isProcessing()) {
       session.setHostBashProxy(undefined);
       session.setHostFileProxy(undefined);

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -822,6 +822,18 @@ export class Session {
     this.preactivatedSkillIds = ids;
   }
 
+  /**
+   * Add a skill ID to the preactivated set without replacing existing entries.
+   * No-op if the ID is already present.
+   */
+  addPreactivatedSkillId(id: string): void {
+    if (!this.preactivatedSkillIds) {
+      this.preactivatedSkillIds = [id];
+    } else if (!this.preactivatedSkillIds.includes(id)) {
+      this.preactivatedSkillIds.push(id);
+    }
+  }
+
   setTurnChannelContext(ctx: TurnChannelContext): void {
     this.currentTurnChannelContext = ctx;
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -653,6 +653,7 @@ export async function handleSendMessage(
       });
       session.setHostCuProxy(cuProxy);
     }
+    session.addPreactivatedSkillId("computer-use");
   } else if (!session.isProcessing()) {
     session.setHostBashProxy(undefined);
     session.setHostFileProxy(undefined);


### PR DESCRIPTION
## Summary
- Ensure `computer-use` skill is preactivated when a desktop client (macOS/iOS) connects, so CU tool definitions are projected into the LLM's tool list
- Create missing `computer-use-observe.ts` executor script in bundled skill
- Add `computer-use-observe` entry to bundled tool registry

Fixes critical gap: CU tools were fully wired in proxy execution path but LLM never saw them because tool definitions weren't projected.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] Lint passes
- [ ] Verify CU tools appear in LLM tool list when desktop client connects
- [ ] Verify `computer_use_observe` executor resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
