### PR TITLE
feat: add `pingUrl` to PROVIDER_SEED_DATA and oauth-store operations

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -181,6 +181,35 @@ describe("provider operations", () => {
       // createdAt should be preserved from the original insert
       expect(row!.createdAt).toBe(originalCreatedAt);
     });
+
+    test("persists pingUrl when provided", () => {
+      seedProviders([
+        {
+          providerKey: "github",
+          authUrl: "https://github.com/authorize",
+          tokenUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+          pingUrl: "https://api.github.com/user",
+        },
+      ]);
+      const row = getProvider("github");
+      expect(row!.pingUrl).toBe("https://api.github.com/user");
+    });
+
+    test("pingUrl defaults to null when omitted", () => {
+      seedProviders([
+        {
+          providerKey: "github",
+          authUrl: "https://github.com/authorize",
+          tokenUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+      const row = getProvider("github");
+      expect(row!.pingUrl).toBeNull();
+    });
   });
 
   describe("getProvider", () => {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -48,6 +48,7 @@ export function seedProviders(
     tokenUrl: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
+    pingUrl?: string;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
@@ -63,6 +64,7 @@ export function seedProviders(
     const tokenUrl = p.tokenUrl;
     const tokenEndpointAuthMethod = p.tokenEndpointAuthMethod ?? null;
     const userinfoUrl = p.userinfoUrl ?? null;
+    const pingUrl = p.pingUrl ?? null;
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
@@ -83,6 +85,7 @@ export function seedProviders(
         extraParams,
         callbackTransport,
         loopbackPort,
+        pingUrl,
         createdAt: now,
         updatedAt: now,
       })
@@ -99,6 +102,7 @@ export function seedProviders(
           extraParams,
           callbackTransport,
           loopbackPort,
+          pingUrl,
           updatedAt: now,
         },
       })
@@ -132,6 +136,7 @@ export function registerProvider(params: {
   tokenUrl: string;
   tokenEndpointAuthMethod?: string;
   userinfoUrl?: string;
+  pingUrl?: string;
   baseUrl?: string;
   defaultScopes: string[];
   scopePolicy: Record<string, unknown>;
@@ -159,7 +164,7 @@ export function registerProvider(params: {
     extraParams: params.extraParams ? JSON.stringify(params.extraParams) : null,
     callbackTransport: params.callbackTransport ?? null,
     loopbackPort: params.loopbackPort ?? null,
-    pingUrl: null,
+    pingUrl: params.pingUrl ?? null,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -17,6 +17,7 @@ const PROVIDER_SEED_DATA: Record<
     tokenUrl: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
+    pingUrl?: string;
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: {
@@ -34,6 +35,7 @@ const PROVIDER_SEED_DATA: Record<
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     tokenUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     defaultScopes: [
       "https://www.googleapis.com/auth/gmail.readonly",
@@ -57,6 +59,7 @@ const PROVIDER_SEED_DATA: Record<
     providerKey: "integration:slack",
     authUrl: "https://slack.com/oauth/v2/authorize",
     tokenUrl: "https://slack.com/api/oauth.v2.access",
+    pingUrl: "https://slack.com/api/auth.test",
     baseUrl: "https://slack.com/api",
     defaultScopes: [
       "channels:read",
@@ -90,6 +93,7 @@ const PROVIDER_SEED_DATA: Record<
     providerKey: "integration:notion",
     authUrl: "https://api.notion.com/v1/oauth/authorize",
     tokenUrl: "https://api.notion.com/v1/oauth/token",
+    pingUrl: "https://api.notion.com/v1/users/me",
     baseUrl: "https://api.notion.com",
     defaultScopes: [],
     scopePolicy: {
@@ -105,6 +109,7 @@ const PROVIDER_SEED_DATA: Record<
     providerKey: "integration:twitter",
     authUrl: "https://twitter.com/i/oauth2/authorize",
     tokenUrl: "https://api.x.com/2/oauth2/token",
+    pingUrl: "https://api.x.com/2/users/me",
     baseUrl: "https://api.x.com",
     defaultScopes: [
       "tweet.read",
@@ -128,6 +133,7 @@ const PROVIDER_SEED_DATA: Record<
     providerKey: "slack_channel",
     authUrl: "urn:manual-token",
     tokenUrl: "urn:manual-token",
+    pingUrl: "https://slack.com/api/auth.test",
     baseUrl: "https://slack.com/api",
     defaultScopes: [],
     scopePolicy: {


### PR DESCRIPTION
## Summary
- Add `pingUrl` field to PROVIDER_SEED_DATA type and populate for all built-in providers (Gmail, Slack, Notion, Twitter, slack_channel)
- Update `seedProviders()` to persist and upsert `pingUrl`
- Update `registerProvider()` to accept optional `pingUrl` parameter
- Add store-level tests verifying `pingUrl` persistence and null default

Part of plan: oauth-ping-endpoint.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
