### PR TITLE
fix: add missing getSecureKeyAsync to secure-keys test mocks

### DIFF
--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -44,6 +44,7 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKey: (key: string) => storedKeys.get(key) ?? null,
+    getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
     setSecureKey: syncSet,
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -43,6 +43,7 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKey: (key: string) => storedKeys.get(key) ?? null,
+    getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
     setSecureKey: syncSet,
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),


### PR DESCRIPTION
## Summary
- Added `getSecureKeyAsync` to the `secure-keys.js` mock in `secret-onetime-send.test.ts` and `credential-security-e2e.test.ts`
- The mock was missing this export, causing a `SyntaxError` when transitive dependencies (vault.ts → oauth-store.ts) tried to import it

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23017370420/job/66844145078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
