### PR TITLE
feat: add `oauth connections ping` command for token health checks

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -984,3 +984,145 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// ping
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connections ping <provider-key>", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    secureKeyStore = new Map();
+    metadataStore = [];
+    disconnectOAuthProviderCalls = [];
+    disconnectOAuthProviderResult = "not-found";
+    idCounter = 0;
+  });
+
+  test("returns ok when ping endpoint returns 200", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:gmail",
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    try {
+      const { exitCode, stdout } = await runCli([
+        "connections",
+        "ping",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.status).toBe(200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("exits 1 when provider not found", async () => {
+    mockGetProvider = () => undefined;
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "ping",
+      "integration:unknown",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Provider not found");
+  });
+
+  test("exits 1 when no ping URL configured", async () => {
+    mockGetProvider = () => ({
+      providerKey: "telegram",
+      pingUrl: null,
+      authUrl: "urn:manual-token",
+      tokenUrl: "urn:manual-token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "ping",
+      "telegram",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No ping URL configured");
+  });
+
+  test("exits 1 when ping endpoint returns non-2xx", async () => {
+    mockGetProvider = () => ({
+      providerKey: "integration:gmail",
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("Unauthorized", { status: 401 })) as unknown as typeof fetch;
+    try {
+      const { exitCode, stdout } = await runCli([
+        "connections",
+        "ping",
+        "integration:gmail",
+        "--json",
+      ]);
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.status).toBe(401);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("exits 1 when no token exists", async () => {
+    mockWithValidToken = async () => {
+      throw new Error('No access token found for "integration:gmail".');
+    };
+    mockGetProvider = () => ({
+      providerKey: "integration:gmail",
+      pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "ping",
+      "integration:gmail",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No access token");
+  });
+});

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -88,7 +88,8 @@ Examples:
   $ assistant oauth connections list --provider integration:gmail
   $ assistant oauth connections get --id <uuid>
   $ assistant oauth connections get --provider integration:gmail
-  $ assistant oauth connections token integration:twitter`,
+  $ assistant oauth connections token integration:twitter
+  $ assistant oauth connections ping integration:gmail`,
   );
 
   // ---------------------------------------------------------------------------
@@ -220,6 +221,93 @@ Examples:
           writeOutput(cmd, { ok: true, token });
         } else {
           process.stdout.write(token + "\n");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // connections ping <provider-key>
+  // ---------------------------------------------------------------------------
+
+  connections
+    .command("ping <provider-key>")
+    .description(
+      "Verify that a stored OAuth token is still valid by hitting the provider's health-check endpoint",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider-key   Provider key (e.g. integration:gmail, integration:twitter)
+
+Fetches a valid access token (refreshing if needed) and sends a GET request
+to the provider's configured ping URL. Reports success (HTTP 2xx) or failure.
+
+The ping URL is set per-provider in seed data or via "providers register --ping-url".
+If no ping URL is configured for the provider, exits with an error.
+
+Examples:
+  $ assistant oauth connections ping integration:gmail
+  $ assistant oauth connections ping integration:twitter --json`,
+    )
+    .action(async (providerKey: string, _opts: unknown, cmd: Command) => {
+      try {
+        const provider = getProvider(providerKey);
+        if (!provider) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Provider not found: ${providerKey}`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!provider.pingUrl) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `No ping URL configured for "${providerKey}"`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        const pingUrl = provider.pingUrl;
+
+        const result = await withValidToken(providerKey, async (token) => {
+          const res = await fetch(pingUrl, {
+            method: "GET",
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          return { status: res.status, ok: res.ok };
+        });
+
+        if (result.ok) {
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, {
+              ok: true,
+              provider: providerKey,
+              status: result.status,
+            });
+          } else {
+            log.info(`${providerKey}: OK (HTTP ${result.status})`);
+            writeOutput(cmd, {
+              ok: true,
+              provider: providerKey,
+              status: result.status,
+            });
+          }
+        } else {
+          writeOutput(cmd, {
+            ok: false,
+            provider: providerKey,
+            status: result.status,
+            error: `Ping failed with HTTP ${result.status}`,
+          });
+          process.exitCode = 1;
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Add `connections ping <provider-key>` CLI command that validates a stored OAuth token by hitting the provider's ping URL
- GET request with Bearer token to the provider's configured ping endpoint
- Reports HTTP status (2xx = OK, else failure)
- Tests cover: success, provider not found, no ping URL, non-2xx, no token

Part of plan: oauth-ping-endpoint.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
