### PR TITLE
fix: filter expired canonical guardian requests from pending discovery

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -31,6 +31,7 @@ import {
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationChat,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
+  listPendingRequestsByConversationScope,
   resolveCanonicalGuardianRequest,
   updateCanonicalGuardianDelivery,
   updateCanonicalGuardianRequest,
@@ -716,5 +717,44 @@ describe("canonical-guardian-store", () => {
       "different-chat-id",
     );
     expect(pending).toHaveLength(0);
+  });
+
+  // ── listPendingRequestsByConversationScope expiry filtering ─────────
+
+  test("listPendingRequestsByConversationScope excludes expired requests", () => {
+    // Create a pending request that has already expired
+    createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-scope-1",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+
+    // Create a pending request that has not expired
+    const unexpired = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-scope-1",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const results = listPendingRequestsByConversationScope("conv-scope-1");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(unexpired.id);
+  });
+
+  test("listPendingRequestsByConversationScope includes requests with no expiresAt", () => {
+    const noExpiry = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-scope-2",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+
+    const results = listPendingRequestsByConversationScope("conv-scope-2");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(noExpiry.id);
   });
 });

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -1427,3 +1427,96 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
     expect(resolved!.status).toBe("approved");
   });
 });
+
+// ===========================================================================
+// SECTION 11: Expired requests are excluded from routing
+// ===========================================================================
+
+describe("routing invariant: expired requests are excluded from pending discovery", () => {
+  beforeEach(() => resetTables());
+
+  test("expired request with hinted IDs is excluded from disambiguation", async () => {
+    const expired = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "EXP001",
+      toolName: "shell",
+      expiresAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+
+    const active = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "ACT001",
+      toolName: "file_write",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    registerPendingToolApprovalInteraction(active.id, "conv-1", "file_write");
+
+    // Both IDs are hinted but only the active one should be considered
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "approve",
+        conversationId: "conv-guardian-thread",
+        pendingRequestIds: [expired.id, active.id],
+        approvalConversationGenerator: undefined,
+      }),
+    );
+
+    // Single active request — should apply directly, no disambiguation
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolvedActive = getCanonicalGuardianRequest(active.id);
+    expect(resolvedActive!.status).toBe("approved");
+
+    // Expired request untouched
+    const resolvedExpired = getCanonicalGuardianRequest(expired.id);
+    expect(resolvedExpired!.status).toBe("pending");
+  });
+
+  test("all expired hinted requests means no pending found — not consumed", async () => {
+    const expired1 = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "EXP002",
+      toolName: "shell",
+      expiresAt: new Date(Date.now() - 10_000).toISOString(),
+    });
+
+    const expired2 = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "EXP003",
+      toolName: "file_write",
+      expiresAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "approve",
+        conversationId: "conv-guardian-thread",
+        pendingRequestIds: [expired1.id, expired2.id],
+        approvalConversationGenerator: undefined,
+      }),
+    );
+
+    // No active pending requests — falls through
+    expect(result.consumed).toBe(false);
+    expect(result.type).toBe("not_consumed");
+    expect(result.decisionApplied).toBe(false);
+  });
+});

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -18,6 +18,21 @@ import {
 } from "./schema.js";
 
 // ---------------------------------------------------------------------------
+// Expiry helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when a canonical request has passed its `expiresAt` deadline.
+ * Requests without an `expiresAt` are never considered expired by this check.
+ */
+export function isRequestExpired(
+  request: Pick<CanonicalGuardianRequest, "expiresAt">,
+): boolean {
+  if (!request.expiresAt) return false;
+  return new Date(request.expiresAt).getTime() < Date.now();
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -624,14 +639,14 @@ export function listPendingRequestsByConversationScope(
   const result: CanonicalGuardianRequest[] = [];
 
   for (const req of bySource) {
-    if (!seen.has(req.id)) {
+    if (!seen.has(req.id) && !isRequestExpired(req)) {
       seen.add(req.id);
       result.push(req);
     }
   }
 
   for (const req of byDestination) {
-    if (!seen.has(req.id)) {
+    if (!seen.has(req.id) && !isRequestExpired(req)) {
       seen.add(req.id);
       result.push(req);
     }

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -30,6 +30,7 @@ import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
   getCanonicalGuardianRequestByCode,
+  isRequestExpired,
   listCanonicalGuardianRequests,
 } from "../memory/canonical-guardian-store.js";
 import {
@@ -198,49 +199,50 @@ function findPendingCanonicalRequests(
   pendingRequestIds?: string[],
   conversationId?: string,
 ): CanonicalGuardianRequest[] {
+  let results: CanonicalGuardianRequest[];
+
   // When explicit IDs are provided, look them up directly
   if (pendingRequestIds) {
     if (pendingRequestIds.length === 0) {
       return [];
     }
-    return pendingRequestIds
+    results = pendingRequestIds
       .map(getCanonicalGuardianRequest)
       .filter((r): r is CanonicalGuardianRequest => r?.status === "pending");
-  }
-
-  // Query by guardian identity when available
-  if (actor.actorExternalUserId) {
-    return listCanonicalGuardianRequests({
+  } else if (actor.actorExternalUserId) {
+    // Query by guardian identity when available
+    results = listCanonicalGuardianRequests({
       status: "pending",
       guardianExternalUserId: actor.actorExternalUserId,
     });
-  }
-
-  // Actors without an actorExternalUserId: scope by conversationId so the NL
-  // path can discover pending requests bound to this conversation.
-  // Include guardianPrincipalId filter when available so the guardian only
-  // sees requests they are authorized to act on.
-  if (conversationId) {
-    return listCanonicalGuardianRequests({
+  } else if (conversationId) {
+    // Actors without an actorExternalUserId: scope by conversationId so the NL
+    // path can discover pending requests bound to this conversation.
+    // Include guardianPrincipalId filter when available so the guardian only
+    // sees requests they are authorized to act on.
+    results = listCanonicalGuardianRequests({
       status: "pending",
       conversationId,
       ...(actor.guardianPrincipalId
         ? { guardianPrincipalId: actor.guardianPrincipalId }
         : {}),
     });
-  }
-
-  // Actors with a guardianPrincipalId but no actorExternalUserId or
-  // conversationId: query by principal so desktop sessions can still
-  // discover pending guardian work via their bound principal.
-  if (actor.guardianPrincipalId) {
-    return listCanonicalGuardianRequests({
+  } else if (actor.guardianPrincipalId) {
+    // Actors with a guardianPrincipalId but no actorExternalUserId or
+    // conversationId: query by principal so desktop sessions can still
+    // discover pending guardian work via their bound principal.
+    results = listCanonicalGuardianRequests({
       status: "pending",
       guardianPrincipalId: actor.guardianPrincipalId,
     });
+  } else {
+    return [];
   }
 
-  return [];
+  // Exclude requests that have passed their expiresAt deadline — they can
+  // no longer be resolved and should not trigger disambiguation or NL
+  // classification.
+  return results.filter((r) => !isRequestExpired(r));
 }
 
 /** Map an approval action string to the NL engine's allowed actions for guardians. */


### PR DESCRIPTION
## Summary
- Add `isRequestExpired()` helper to `canonical-guardian-store.ts` that checks `expiresAt < now()`
- Filter expired requests in `listPendingRequestsByConversationScope` (store layer) and `findPendingCanonicalRequests` (router layer)
- Add tests in both `canonical-guardian-store.test.ts` and `guardian-routing-invariants.test.ts` verifying expired requests are excluded

## Original prompt
Filter by `expiresAt` in listing functions so expired canonical guardian requests don't trigger disambiguation or NL classification after daemon restart.

## Test plan
- [x] Expired requests excluded from `listPendingRequestsByConversationScope`
- [x] Requests with no `expiresAt` still included
- [x] Expired hinted request excluded from router disambiguation (single active request applies directly)
- [x] All-expired hinted requests result in `not_consumed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
