### PR TITLE
fix: extract duration_ms from computer_use_wait input in Swift client

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/HostCuExecutor.swift
@@ -230,7 +230,8 @@ enum HostCuActionRunner {
             ?? extractInt(from: input, key: "scrollAmount")
             ?? extractInt(from: input, key: "scroll_amount")
         let summary = input["summary"]?.value as? String
-        let waitDuration = extractInt(from: input, key: "duration")
+        let waitDuration = extractInt(from: input, key: "duration_ms")
+            ?? extractInt(from: input, key: "duration")
             ?? extractInt(from: input, key: "waitDuration")
             ?? extractInt(from: input, key: "wait_duration")
         let appName = input["app_name"]?.value as? String


### PR DESCRIPTION
## Summary
- Add `duration_ms` key extraction in `HostCuExecutor.mapToAgentAction()` to match the daemon's tool definition schema
- Without this, the LLM's requested wait duration was silently dropped and always fell back to 500ms
- `duration_ms` is checked first (highest priority), preserving backward compat with existing `duration`/`waitDuration`/`wait_duration` keys

## Test plan
- [ ] Verify `computer_use_wait` with `{ "duration_ms": 2000 }` input waits for 2 seconds instead of 500ms
- [ ] Verify legacy keys (`duration`, `waitDuration`, `wait_duration`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
