### PR TITLE
fix: use stored clientSecretCredentialPath in connections.ts instead of derived pattern

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -772,6 +772,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     mockGetMostRecentAppByProvider = () => ({
       id: "app-1",
       clientId: "db-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
       providerKey: "integration:gmail",
       createdAt: 0,
       updatedAt: 0,
@@ -795,6 +796,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     mockGetMostRecentAppByProvider = () => ({
       id: "app-1",
       clientId: "db-client-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
       providerKey: "integration:gmail",
       createdAt: 0,
       updatedAt: 0,

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -461,7 +461,7 @@ Examples:
               if (!clientId) clientId = dbApp.clientId;
               if (!clientSecret) {
                 const storedSecret = getSecureKey(
-                  `oauth_app/${dbApp.id}/client_secret`,
+                  dbApp.clientSecretCredentialPath,
                 );
                 if (storedSecret) clientSecret = storedSecret;
               }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-client-secret-cred-path.md.

**Gap:** connections.ts still uses hardcoded credential path pattern
**What was expected:** All production read sites should use `app.clientSecretCredentialPath`
**What was found:** `connections.ts` was missed and still constructs `oauth_app/${id}/client_secret`

- Updated `connections.ts` to use `dbApp.clientSecretCredentialPath`
- Updated `oauth-cli.test.ts` connect test mock to include `clientSecretCredentialPath`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
