### PR TITLE
fix: add clientSecretCredentialPath to test mock app objects

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -81,7 +81,12 @@ const mockConnections = new Map<
 >();
 const mockApps = new Map<
   string,
-  { id: string; providerKey: string; clientId: string }
+  {
+    id: string;
+    providerKey: string;
+    clientId: string;
+    clientSecretCredentialPath: string;
+  }
 >();
 const mockProviders = new Map<
   string,
@@ -1313,6 +1318,7 @@ describe("withValidToken refresh deduplication", () => {
       id: appId,
       providerKey: service,
       clientId: "test-client-id",
+      clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
     });
     mockConnections.set(service, {
       id: connId,

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -81,7 +81,12 @@ const mockConnections = new Map<
 >();
 const mockApps = new Map<
   string,
-  { id: string; providerKey: string; clientId: string }
+  {
+    id: string;
+    providerKey: string;
+    clientId: string;
+    clientSecretCredentialPath: string;
+  }
 >();
 const mockProviders = new Map<
   string,
@@ -192,6 +197,7 @@ function setupCredential(
     id: appId,
     providerKey: service,
     clientId: "test-client-id",
+    clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
   });
   mockConnections.set(service, {
     id: connId,
@@ -514,6 +520,7 @@ describe("resolveOAuthConnection", () => {
       id: appId,
       providerKey: "github",
       clientId: "test-client-id",
+      clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
     });
 
     // Connection uses the custom credential service as its providerKey


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-client-secret-cred-path.md.

**Gap:** Test mocks missing clientSecretCredentialPath field
**What was expected:** Mock app objects should include the new field to match OAuthAppRow schema
**What was found:** credential-vault.test.ts and byo-connection.test.ts mock apps lack the field

- Updated mock app types and objects in both test files to include `clientSecretCredentialPath`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
