### PR TITLE
fix: expire all pending canonical guardian requests on daemon startup

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -26,6 +26,7 @@ mock.module("../util/logger.js", () => ({
 import {
   createCanonicalGuardianDelivery,
   createCanonicalGuardianRequest,
+  expireAllPendingCanonicalRequests,
   getCanonicalGuardianRequest,
   listCanonicalGuardianDeliveries,
   listCanonicalGuardianRequests,
@@ -756,5 +757,59 @@ describe("canonical-guardian-store", () => {
     const results = listPendingRequestsByConversationScope("conv-scope-2");
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe(noExpiry.id);
+  });
+
+  // ── expireAllPendingCanonicalRequests ───────────────────────────────
+
+  test("expireAllPendingCanonicalRequests transitions all pending to expired", () => {
+    const req1 = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-bulk-1",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const req2 = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-bulk-2",
+      guardianPrincipalId: TEST_PRINCIPAL,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const count = expireAllPendingCanonicalRequests();
+    expect(count).toBe(2);
+
+    expect(getCanonicalGuardianRequest(req1.id)!.status).toBe("expired");
+    expect(getCanonicalGuardianRequest(req2.id)!.status).toBe("expired");
+  });
+
+  test("expireAllPendingCanonicalRequests does not affect already-resolved requests", () => {
+    const approved = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-bulk-3",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+    updateCanonicalGuardianRequest(approved.id, { status: "approved" });
+
+    const denied = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-bulk-3",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+    updateCanonicalGuardianRequest(denied.id, { status: "denied" });
+
+    const count = expireAllPendingCanonicalRequests();
+    expect(count).toBe(0);
+
+    expect(getCanonicalGuardianRequest(approved.id)!.status).toBe("approved");
+    expect(getCanonicalGuardianRequest(denied.id)!.status).toBe("denied");
+  });
+
+  test("expireAllPendingCanonicalRequests returns 0 when no pending requests exist", () => {
+    const count = expireAllPendingCanonicalRequests();
+    expect(count).toBe(0);
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -26,6 +26,7 @@ import { closeSentry, initSentry } from "../instrument.js";
 import { disableLogfire, initLogfire } from "../logfire.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
+import { expireAllPendingCanonicalRequests } from "../memory/canonical-guardian-store.js";
 import {
   deleteMessageById,
   getConversationThreadType,
@@ -164,6 +165,18 @@ export async function runDaemon(): Promise<void> {
     // oauth_connection migration. Safe to call on every startup.
     await backfillManualTokenConnections();
     log.info("Daemon startup: DB initialized");
+
+    // Expire any pending canonical guardian requests left over from before
+    // this process started.  Their in-memory pending-interaction session
+    // references are gone, so they can never be completed.  The agent loop
+    // will re-request tool approvals on the next turn.
+    const expiredCount = expireAllPendingCanonicalRequests();
+    if (expiredCount > 0) {
+      log.info(
+        { event: "startup_expired_stale_requests", expiredCount },
+        `Expired ${expiredCount} stale pending canonical request(s) from previous process`,
+      );
+    }
 
     // Ensure a vellum guardian binding exists and mint the CLI edge token
     // as an actor token bound to the guardian principal.

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -459,6 +459,27 @@ export function resolveCanonicalGuardianRequest(
   return getCanonicalGuardianRequest(id);
 }
 
+/**
+ * Expire all pending canonical guardian requests in a single bulk update.
+ *
+ * Called at daemon startup to clean up requests that can never be completed
+ * because the in-memory pending-interactions Map (which holds session
+ * references needed by resolvers) was wiped on restart.
+ *
+ * Returns the number of requests transitioned from pending → expired.
+ */
+export function expireAllPendingCanonicalRequests(): number {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  db.update(canonicalGuardianRequests)
+    .set({ status: "expired", updatedAt: now })
+    .where(eq(canonicalGuardianRequests.status, "pending"))
+    .run();
+
+  return rawChanges();
+}
+
 // ---------------------------------------------------------------------------
 // Canonical Guardian Deliveries
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `expireAllPendingCanonicalRequests()` to `canonical-guardian-store.ts` — bulk transitions all `status="pending"` requests to `"expired"` in a single DB update
- Call it in `lifecycle.ts` after DB init but before accepting requests, with startup log
- Add tests verifying the bulk expiry transitions pending requests, skips resolved ones, and handles empty table

## Original prompt
Expire all pending canonical guardian requests on daemon startup to prevent stale requests from causing `pending_interaction_not_found` errors after restart.

## Test plan
- [x] All pending requests transitioned to expired
- [x] Already-resolved requests (approved, denied) not affected
- [x] Returns 0 when no pending requests exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
