### PR TITLE
fix: add missing addPreactivatedSkillId to session mocks

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -119,6 +119,7 @@ function makeIdleSession(opts?: {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (
@@ -183,6 +184,7 @@ function makeConfirmationEmittingSession(opts?: {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     enqueueMessage: () => ({ queued: false, requestId: "noop" }),
     hasAnyPendingConfirmation: () => false,
     runAgentLoop: async (

--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -172,6 +172,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -248,6 +249,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -320,6 +322,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -396,6 +399,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -468,6 +472,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -534,6 +539,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -602,6 +608,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {
@@ -671,6 +678,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
       setHostBashProxy: () => {},
       setHostFileProxy: () => {},
       setHostCuProxy: () => {},
+      addPreactivatedSkillId: () => {},
     } as unknown as import("../daemon/session.js").Session;
 
     const req = new Request("http://localhost/v1/messages", {

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -204,6 +204,7 @@ function makeSession() {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     usageStats: {
       inputTokens: 1000,
       outputTokens: 500,

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -170,6 +170,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     emitConfirmationStateChanged: () => {},
     emitActivityState: () => {},
     setTurnChannelContext: () => {},

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -118,6 +118,7 @@ function makeCompletingSession(): Session {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -175,6 +176,7 @@ function makeHangingSession(): Session {
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     hasAnyPendingConfirmation: () => false,
     hasPendingConfirmation: () => false,
     denyAllPendingConfirmations: () => {},
@@ -260,6 +262,7 @@ function makePendingApprovalSession(
     setHostBashProxy: () => {},
     setHostFileProxy: () => {},
     setHostCuProxy: () => {},
+    addPreactivatedSkillId: () => {},
     hasAnyPendingConfirmation: () => pending.size > 0,
     hasPendingConfirmation: (candidateRequestId: string) =>
       pending.has(candidateRequestId),


### PR DESCRIPTION
## Summary
- Add missing `addPreactivatedSkillId` no-op to session mocks in 5 test files
- The method was added to `conversation-routes.ts` in #15841 but the mock session objects in tests were not updated, causing `TypeError: session.addPreactivatedSkillId is not a function`
- Fixes failures in: `send-endpoint-busy`, `approval-routes-http`, `conversation-routes-guardian-reply`, `conversation-routes-slash-commands`, `http-user-message-parity`

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
