### PR TITLE
fix(cli): improve compact mode for narrow terminals

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1240,7 +1240,7 @@ function ChatApp({
   const headerHeight = calculateHeaderHeight(species, terminalColumns);
 
   const isCompact = terminalColumns < COMPACT_THRESHOLD;
-  const compactInputAreaHeight = 2; // separator + input row only
+  const compactInputAreaHeight = 1; // input row only, no separators
   const inputAreaHeight = isCompact
     ? compactInputAreaHeight
     : INPUT_AREA_HEIGHT;
@@ -2274,8 +2274,9 @@ function ChatApp({
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {visibleWindow.hiddenAbove > 0 ? (
           <Text dimColor>
-            {"\u2191"} {visibleWindow.hiddenAbove} more above
-            (Shift+\u2191/Cmd+\u2191)
+            {isCompact
+              ? `\u2191 ${visibleWindow.hiddenAbove} more above`
+              : `\u2191 ${visibleWindow.hiddenAbove} more above (Shift+\u2191/Cmd+\u2191)`}
           </Text>
         ) : null}
 
@@ -2341,12 +2342,14 @@ function ChatApp({
 
       {!selection && !secretInput ? (
         <Box flexDirection="column" flexShrink={0}>
-          <Text dimColor>
-            {unicodeOrFallback("\u2500", "-").repeat(terminalColumns)}
-          </Text>
-          <Box paddingLeft={1} height={1} flexShrink={0}>
+          {isCompact ? null : (
+            <Text dimColor>
+              {unicodeOrFallback("\u2500", "-").repeat(terminalColumns)}
+            </Text>
+          )}
+          <Box paddingLeft={isCompact ? 0 : 1} height={1} flexShrink={0}>
             <Text color="green" bold>
-              you{">"}
+              {isCompact ? ">" : "you>"}
               {" "}
             </Text>
             <TextInput


### PR DESCRIPTION
## Summary
- Remove top separator line in compact mode (<60 cols) to prevent line wrapping
- Shorten input prompt from `you>` to `>` in compact mode to save space
- Remove left padding in compact mode input area
- Shorten "hidden above" indicator text in compact mode
- Fix inputAreaHeight calculation (1 row instead of 2 since no separator)

## Test plan
- [ ] SSH into Pi, resize terminal to <60 cols, verify clean single-line header + minimal input area
- [ ] Verify normal mode (>60 cols) still shows full separators and `you>` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
