### PR TITLE
fix: sanitize Gmail MIME headers against CRLF injection

### DIFF
--- a/assistant/src/__tests__/mime-builder.test.ts
+++ b/assistant/src/__tests__/mime-builder.test.ts
@@ -81,4 +81,32 @@ describe("buildMultipartMime", () => {
     expect(decoded).toContain('filename="b.png"');
     expect(decoded).toContain("Content-Type: image/png");
   });
+
+  test("sanitizes CRLF from header values to prevent header injection", () => {
+    const result = buildMultipartMime({
+      to: "victim@example.com\r\nBcc: attacker@example.com",
+      subject: "Fwd: Hello\r\nCc: attacker@example.com",
+      body: "Body",
+      cc: "team@example.com\nX-Injected: yes",
+      bcc: "audit@example.com\r\nX-Another: value",
+      inReplyTo: "<id@example.com>\nReferences: <evil@example.com>",
+      attachments: [],
+    });
+
+    const decoded = Buffer.from(
+      result.replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    ).toString("utf-8");
+
+    expect(decoded).toContain("To: victim@example.com Bcc: attacker@example.com");
+    expect(decoded).toContain("Subject: Fwd: Hello Cc: attacker@example.com");
+    expect(decoded).toContain("Cc: team@example.com X-Injected: yes");
+    expect(decoded).toContain("Bcc: audit@example.com X-Another: value");
+    expect(decoded).toContain(
+      "In-Reply-To: <id@example.com> References: <evil@example.com>",
+    );
+    expect(decoded).not.toContain("\r\nBcc: attacker@example.com");
+    expect(decoded).not.toContain("\r\nCc: attacker@example.com");
+  });
+
 });

--- a/assistant/src/messaging/providers/gmail/mime-builder.ts
+++ b/assistant/src/messaging/providers/gmail/mime-builder.ts
@@ -21,6 +21,10 @@ export interface MimeMessageOptions {
   attachments: MimeAttachment[];
 }
 
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
 function toBase64Url(input: Buffer): string {
   return input
     .toString("base64")
@@ -37,17 +41,23 @@ export function buildMultipartMime(options: MimeMessageOptions): string {
   const { to, subject, body, inReplyTo, cc, bcc, attachments } = options;
   const boundary = `----=_Part_${randomBytes(16).toString("hex")}`;
 
+  const sanitizedTo = sanitizeHeaderValue(to);
+  const sanitizedSubject = sanitizeHeaderValue(subject);
+  const sanitizedCc = cc ? sanitizeHeaderValue(cc) : undefined;
+  const sanitizedBcc = bcc ? sanitizeHeaderValue(bcc) : undefined;
+  const sanitizedInReplyTo = inReplyTo ? sanitizeHeaderValue(inReplyTo) : undefined;
+
   const headers = [
-    `To: ${to}`,
-    `Subject: ${subject}`,
+    `To: ${sanitizedTo}`,
+    `Subject: ${sanitizedSubject}`,
     "MIME-Version: 1.0",
     `Content-Type: multipart/mixed; boundary="${boundary}"`,
   ];
-  if (cc) headers.push(`Cc: ${cc}`);
-  if (bcc) headers.push(`Bcc: ${bcc}`);
-  if (inReplyTo) {
-    headers.push(`In-Reply-To: ${inReplyTo}`);
-    headers.push(`References: ${inReplyTo}`);
+  if (sanitizedCc) headers.push(`Cc: ${sanitizedCc}`);
+  if (sanitizedBcc) headers.push(`Bcc: ${sanitizedBcc}`);
+  if (sanitizedInReplyTo) {
+    headers.push(`In-Reply-To: ${sanitizedInReplyTo}`);
+    headers.push(`References: ${sanitizedInReplyTo}`);
   }
 
   const parts: string[] = [];


### PR DESCRIPTION
### Motivation

- Prevent CRLF/header injection when untrusted header values (e.g. original `Subject`) are reused to build raw MIME messages, which could silently add recipients (Bcc/Cc) or leak content.

### Description

- Add `sanitizeHeaderValue()` in `assistant/src/messaging/providers/gmail/mime-builder.ts` to strip CR/LF sequences and trim header values before assembling MIME headers.
- Apply sanitization to `to`, `subject`, `cc`, `bcc`, and `inReplyTo` before they are interpolated into header lines in `buildMultipartMime()`.
- Add a regression unit test in `assistant/src/__tests__/mime-builder.test.ts` that supplies CRLF-containing inputs and asserts injected header lines are flattened and not emitted as separate headers.
- Preserve existing MIME structure and encoding behavior (output remains base64url-encoded multipart MIME compatible with Gmail API).

### Testing

- Added a unit test exercising CRLF-containing header inputs at `assistant/src/__tests__/mime-builder.test.ts` that verifies sanitization prevents header injection and preserves header content in a flattened form.
- Attempted to run the targeted test with `cd assistant && bun test src/__tests__/mime-builder.test.ts`, but the `bun` toolchain was unavailable in this environment, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b115f678b88323831b2053a101f618)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
