### PR TITLE
feat(memory): add tier classification and staleness annotation modules

### DIFF
--- a/assistant/src/memory/search/staleness.ts
+++ b/assistant/src/memory/search/staleness.ts
@@ -1,0 +1,47 @@
+import type { StalenessLevel } from "./types.js";
+import type { TieredCandidate } from "./tier-classifier.js";
+
+const BASE_LIFETIME_MS: Record<string, number> = {
+  identity: 180 * 86_400_000, // 6 months
+  preference: 90 * 86_400_000, // 3 months
+  constraint: 30 * 86_400_000, // 1 month
+  project: 14 * 86_400_000, // 2 weeks
+  decision: 14 * 86_400_000, // 2 weeks
+  event: 3 * 86_400_000, // 3 days
+};
+
+const DEFAULT_LIFETIME_MS = 30 * 86_400_000;
+
+export function computeStaleness(
+  item: {
+    kind: string;
+    firstSeenAt: number;
+    sourceConversationCount: number;
+  },
+  now: number,
+): { level: StalenessLevel; ratio: number } {
+  const baseLifetime = BASE_LIFETIME_MS[item.kind] ?? DEFAULT_LIFETIME_MS;
+  const reinforcement = 1 + 0.3 * (item.sourceConversationCount - 1);
+  const effectiveLifetime = baseLifetime * reinforcement;
+  const age = now - item.firstSeenAt;
+  const ratio = age / effectiveLifetime;
+
+  if (ratio < 0.5) return { level: "fresh", ratio };
+  if (ratio <= 1) return { level: "aging", ratio };
+  if (ratio <= 2) return { level: "stale", ratio };
+  return { level: "very_stale", ratio };
+}
+
+/**
+ * Demote very_stale tier-1 candidates to tier 2.
+ */
+export function applyStaleDemotion(
+  candidates: TieredCandidate[],
+): TieredCandidate[] {
+  return candidates.map((c) => {
+    if (c.tier === 1 && c.staleness === "very_stale") {
+      return { ...c, tier: 2 as const };
+    }
+    return c;
+  });
+}

--- a/assistant/src/memory/search/tier-classifier.ts
+++ b/assistant/src/memory/search/tier-classifier.ts
@@ -1,0 +1,21 @@
+import type { Candidate } from "./types.js";
+
+export type Tier = 1 | 2 | null;
+
+export interface TieredCandidate extends Candidate {
+  tier: Tier;
+}
+
+export function classifyTier(score: number): Tier {
+  if (score > 0.8) return 1;
+  if (score > 0.6) return 2;
+  return null;
+}
+
+export function classifyTiers(candidates: Candidate[]): TieredCandidate[] {
+  return candidates
+    .map((c) => ({ ...c, tier: classifyTier(c.finalScore) }))
+    .filter(
+      (c): c is TieredCandidate & { tier: 1 | 2 } => c.tier !== null,
+    );
+}

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -7,6 +7,8 @@ export type CandidateSource =
   | "entity_relation"
   | "item_direct";
 
+export type StalenessLevel = "fresh" | "aging" | "stale" | "very_stale";
+
 export interface Candidate {
   key: string;
   type: CandidateType;
@@ -22,6 +24,8 @@ export interface Candidate {
   semantic: number;
   recency: number;
   finalScore: number;
+  tier?: 1 | 2;
+  staleness?: StalenessLevel;
 }
 
 export interface MemoryRecallCandiateDebug {
@@ -139,6 +143,7 @@ export interface ItemMetadata {
   accessCount: number;
   lastUsedAt: number | null;
   verificationState: string;
+  sourceConversationCount?: number;
 }
 
 import type { EntityRelationType, EntityType } from "../entity-extractor.js";


### PR DESCRIPTION
## Summary
- Add tier-classifier.ts with classifyTier() (tier 1 > 0.8, tier 2 > 0.6, skip below) and classifyTiers()
- Add staleness.ts with computeStaleness() using kind-specific base lifetimes × reinforcement multiplier
- Extend Candidate type in types.ts with tier and staleness fields

Part of plan: memory-system-redesign.md (PR 6 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
