### PR TITLE
feat(memory): add supersession columns and overrideConfidence to memoryItems

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -63,6 +63,7 @@ import {
   migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
   migrateInviteCodeHashColumn,
+  migrateMemoryItemSupersession,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
@@ -351,6 +352,9 @@ export function initializeDb(): void {
 
   // 55. Add ping_url column to oauth_providers
   migrateOAuthProvidersPingUrl(database);
+
+  // 56. Add supersession tracking columns and override confidence to memory_items
+  migrateMemoryItemSupersession(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -27,18 +27,12 @@ import { clampUnitInterval } from "./validation.js";
 const log = getLogger("memory-items-extractor");
 
 export type MemoryItemKind =
+  | "identity"
   | "preference"
-  | "profile"
   | "project"
   | "decision"
-  | "todo"
-  | "fact"
   | "constraint"
-  | "relationship"
-  | "event"
-  | "opinion"
-  | "instruction"
-  | "style";
+  | "event";
 
 interface ExtractedItem {
   kind: MemoryItemKind;
@@ -50,24 +44,32 @@ interface ExtractedItem {
 }
 
 const VALID_KINDS = new Set<string>([
+  "identity",
   "preference",
-  "profile",
   "project",
   "decision",
-  "todo",
-  "fact",
   "constraint",
-  "relationship",
   "event",
-  "opinion",
-  "instruction",
-  "style",
 ]);
 
+/** Maps old kind names to their new equivalents for graceful migration. */
+const KIND_MIGRATION_MAP: Record<string, MemoryItemKind> = {
+  profile: "identity",
+  fact: "identity",
+  relationship: "identity",
+  opinion: "preference",
+  todo: "project",
+  instruction: "constraint",
+  style: "preference",
+};
+
 const SUPERSEDE_KINDS = new Set<MemoryItemKind>([
-  "decision",
+  "identity",
   "preference",
+  "project",
+  "decision",
   "constraint",
+  "event",
 ]);
 
 // ── Semantic density gating ────────────────────────────────────────────
@@ -132,18 +134,12 @@ function hasSemanticDensity(text: string): boolean {
 const EXTRACTION_SYSTEM_PROMPT = `You are a memory extraction system. Given a message from a conversation, extract structured memory items that would be valuable to remember for future interactions.
 
 Extract items in these categories:
-- preference: User likes, dislikes, preferred approaches/tools/styles
-- profile: Personal info (name, role, location, timezone, background)
-- project: Project names, repos, tech stacks, architecture details
+- identity: Personal info (name, role, location, timezone, background), notable facts, relationships between people/teams/systems
+- preference: User likes, dislikes, preferred approaches/tools/styles, communication style patterns, opinions and evaluations
+- project: Project names, repos, tech stacks, architecture details, action items, follow-ups, things to do later
 - decision: Choices made, approaches selected, trade-offs resolved
-- todo: Action items, follow-ups, things to do later
-- fact: Notable facts, definitions, technical details worth remembering
-- constraint: Rules, requirements, things that must/must not be done
-- relationship: Connections between people, teams, projects, systems
+- constraint: Rules, requirements, things that must/must not be done, explicit directives on how the assistant should behave
 - event: Deadlines, milestones, meetings, releases, dates
-- opinion: Viewpoints, assessments, evaluations of tools/approaches
-- instruction: Explicit directives on how the assistant should behave
-- style: Communication style patterns — writing tone, formatting habits, vocabulary choices, greeting/sign-off conventions
 
 For each item, provide:
 - kind: One of the categories above
@@ -272,7 +268,9 @@ async function extractItemsWithLLM(
 
       const items: ExtractedItem[] = [];
       for (const raw of input.items) {
-        if (!VALID_KINDS.has(raw.kind)) continue;
+        // Apply kind migration map for old kind names, then validate
+        const resolvedKind = KIND_MIGRATION_MAP[raw.kind] ?? raw.kind;
+        if (!VALID_KINDS.has(resolvedKind)) continue;
         if (!raw.subject || !raw.statement) continue;
         const subject = truncate(String(raw.subject), 80, "");
         const statement = truncate(String(raw.statement), 500, "");
@@ -280,12 +278,12 @@ async function extractItemsWithLLM(
         const importance = clampUnitInterval(parseScore(raw.importance, 0.5));
         const fingerprint = computeMemoryFingerprint(
           scopeId,
-          raw.kind,
+          resolvedKind,
           subject,
           statement,
         );
         items.push({
-          kind: raw.kind as MemoryItemKind,
+          kind: resolvedKind as MemoryItemKind,
           subject,
           statement,
           confidence,
@@ -533,7 +531,7 @@ function classifySentence(
       "timezone",
     ])
   ) {
-    return { kind: "profile", confidence: 0.72, importance: 0.8 };
+    return { kind: "identity", confidence: 0.72, importance: 0.8 };
   }
   if (includesAny(lower, ["project", "repository", "repo", "codebase"])) {
     return { kind: "project", confidence: 0.68, importance: 0.6 };
@@ -546,7 +544,7 @@ function classifySentence(
   if (
     includesAny(lower, ["todo", "to do", "next step", "follow up", "need to"])
   ) {
-    return { kind: "todo", confidence: 0.74, importance: 0.6 };
+    return { kind: "project", confidence: 0.74, importance: 0.6 };
   }
   if (
     includesAny(lower, [
@@ -560,7 +558,7 @@ function classifySentence(
     return { kind: "constraint", confidence: 0.7, importance: 0.7 };
   }
   if (includesAny(lower, ["remember", "important", "fact", "noted"])) {
-    return { kind: "fact", confidence: 0.62, importance: 0.5 };
+    return { kind: "identity", confidence: 0.62, importance: 0.5 };
   }
   return null;
 }

--- a/assistant/src/memory/migrations/152-memory-item-supersession.ts
+++ b/assistant/src/memory/migrations/152-memory-item-supersession.ts
@@ -1,0 +1,44 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add supersession tracking columns and override confidence to memory_items.
+ *
+ * - `supersedes` — references the ID of the item this one replaces
+ * - `superseded_by` — references the ID of the item that replaced this one
+ * - `override_confidence` — enum: "explicit", "tentative", "inferred" (default "inferred")
+ * - Index on (status, superseded_by) for filtering active non-superseded items
+ *
+ * All columns are added via ALTER TABLE with try/catch for idempotency.
+ */
+export function migrateMemoryItemSupersession(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_items ADD COLUMN supersedes TEXT DEFAULT NULL`,
+    );
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_items ADD COLUMN superseded_by TEXT DEFAULT NULL`,
+    );
+  } catch {
+    // Column already exists
+  }
+
+  try {
+    raw.exec(
+      /*sql*/ `ALTER TABLE memory_items ADD COLUMN override_confidence TEXT DEFAULT 'inferred'`,
+    );
+  } catch {
+    // Column already exists
+  }
+
+  raw.exec(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_memory_items_status_superseded_by ON memory_items(status, superseded_by)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -93,6 +93,7 @@ export { migrateDropRemindersTable } from "./148-drop-reminders-table.js";
 export { createOAuthTables } from "./149-oauth-tables.js";
 export { migrateOAuthAppsClientSecretPath } from "./150-oauth-apps-client-secret-path.js";
 export { migrateOAuthProvidersPingUrl } from "./151-oauth-providers-ping-url.js";
+export { migrateMemoryItemSupersession } from "./152-memory-item-supersession.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -53,6 +53,9 @@ export const memoryItems = sqliteTable(
     lastUsedAt: integer("last_used_at"),
     validFrom: integer("valid_from"),
     invalidAt: integer("invalid_at"),
+    supersedes: text("supersedes"),
+    supersededBy: text("superseded_by"),
+    overrideConfidence: text("override_confidence").default("inferred"),
   },
   (table) => [
     index("idx_memory_items_scope_id").on(table.scopeId),


### PR DESCRIPTION
## Summary
- Add supersedes, supersededBy, and overrideConfidence columns to memoryItems table via migration 152
- Update MemoryItemKind to 6-kind enum (identity, preference, project, decision, constraint, event) with migration map from old kinds
- Add KIND_MIGRATION_MAP for graceful transition from old 12-kind set

Part of plan: memory-system-redesign.md (PR 1 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
