### PR TITLE
feat(memory): upgrade Qdrant client to support named vectors and hybrid search

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -11,6 +11,7 @@ import {
   embeddingInputContentHash,
   type MultimodalEmbeddingInput,
   normalizeEmbeddingInput,
+  type SparseEmbedding,
   type TextEmbeddingInput,
 } from "./embedding-types.js";
 
@@ -613,4 +614,69 @@ function isOllamaConfigured(config: AssistantConfig): boolean {
     Boolean(config.apiKeys.ollama) ||
     Boolean(getOllamaBaseUrlEnv())
   );
+}
+
+// ── TF-IDF sparse embedding ───────────────────────────────────────
+// Simple tokenizer + TF-IDF sparse encoder. Produces a SparseEmbedding
+// with term indices (hashed to a fixed vocabulary) and TF-IDF weights.
+// Can be upgraded to a learned sparse encoder (e.g. SPLADE) later.
+
+const SPARSE_VOCAB_SIZE = 30_000;
+
+/** Tokenize text into lowercase alphanumeric tokens. */
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+/** Hash a token to a stable index in [0, vocabSize). */
+function tokenHash(token: string, vocabSize: number): number {
+  // FNV-1a 32-bit hash for speed
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < token.length; i++) {
+    hash ^= token.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash % vocabSize;
+}
+
+/**
+ * Generate a TF-IDF-based sparse embedding for the given text.
+ *
+ * Term frequency is computed from the input. IDF is approximated using
+ * sub-linear TF weighting (1 + log(tf)) since we don't have a corpus-level
+ * document frequency table. This still produces useful sparse vectors for
+ * lexical matching via Qdrant's sparse vector support.
+ */
+export function generateSparseEmbedding(text: string): SparseEmbedding {
+  const tokens = tokenize(text);
+  if (tokens.length === 0) {
+    return { indices: [], values: [] };
+  }
+
+  // Count term frequencies per hash bucket
+  const tf = new Map<number, number>();
+  for (const token of tokens) {
+    const idx = tokenHash(token, SPARSE_VOCAB_SIZE);
+    tf.set(idx, (tf.get(idx) ?? 0) + 1);
+  }
+
+  // Convert to sub-linear TF weights: 1 + log(tf)
+  const indices: number[] = [];
+  const values: number[] = [];
+  for (const [idx, count] of tf) {
+    indices.push(idx);
+    values.push(1 + Math.log(count));
+  }
+
+  // L2-normalize the sparse vector so scores are comparable
+  let norm = 0;
+  for (const v of values) norm += v * v;
+  norm = Math.sqrt(norm);
+  if (norm > 0) {
+    for (let i = 0; i < values.length; i++) {
+      values[i] /= norm;
+    }
+  }
+
+  return { indices, values };
 }

--- a/assistant/src/memory/embedding-types.ts
+++ b/assistant/src/memory/embedding-types.ts
@@ -47,6 +47,12 @@ export function normalizeEmbeddingInput(input: EmbeddingInput): MultimodalEmbedd
   return input;
 }
 
+/** Sparse vector representation: parallel arrays of term indices and weights. */
+export interface SparseEmbedding {
+  indices: number[];
+  values: number[];
+}
+
 export function embeddingInputContentHash(input: EmbeddingInput): string {
   const normalized = normalizeEmbeddingInput(input);
   const hash = createHash("sha256");

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -5,6 +5,11 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("qdrant-client");
 
+export interface QdrantSparseVector {
+  indices: number[];
+  values: number[];
+}
+
 export interface QdrantClientConfig {
   url: string;
   collection: string;
@@ -12,6 +17,7 @@ export interface QdrantClientConfig {
   onDisk: boolean;
   quantization: "scalar" | "none";
   embeddingModel?: string;
+  sparseModel?: string;
 }
 
 export interface QdrantPointPayload {
@@ -63,6 +69,7 @@ export class VellumQdrantClient {
   private readonly onDisk: boolean;
   private readonly quantization: "scalar" | "none";
   private readonly embeddingModel?: string;
+  private readonly sparseModel?: string;
   private collectionReady = false;
 
   private readonly SENTINEL_ID = "00000000-0000-0000-0000-000000000000";
@@ -77,6 +84,7 @@ export class VellumQdrantClient {
     this.onDisk = config.onDisk;
     this.quantization = config.quantization;
     this.embeddingModel = config.embeddingModel;
+    this.sparseModel = config.sparseModel;
   }
 
   async ensureCollection(): Promise<void> {
@@ -87,9 +95,21 @@ export class VellumQdrantClient {
       if (exists.exists) {
         try {
           const info = await this.client.getCollection(this.collection);
-          const currentSize = (
-            info.config?.params?.vectors as { size?: number }
-          )?.size;
+          const vectorsConfig = info.config?.params?.vectors;
+
+          // Detect whether the collection uses unnamed vectors (legacy) vs named vectors
+          const isUnnamedVectors =
+            vectorsConfig != null &&
+            typeof vectorsConfig === "object" &&
+            "size" in vectorsConfig;
+
+          const currentSize = isUnnamedVectors
+            ? (vectorsConfig as { size?: number })?.size
+            : (
+                (vectorsConfig as Record<string, { size?: number }> | undefined)
+                  ?.dense
+              )?.size;
+
           const dimMismatch =
             currentSize != null && currentSize !== this.vectorSize;
 
@@ -102,7 +122,18 @@ export class VellumQdrantClient {
             }
           }
 
-          if (dimMismatch || modelMismatch) {
+          if (isUnnamedVectors) {
+            log.warn(
+              {
+                collection: this.collection,
+                currentSize,
+                expectedSize: this.vectorSize,
+              },
+              "Qdrant collection uses unnamed vectors (legacy) — deleting and recreating with named vectors. Embeddings will be re-indexed.",
+            );
+            await this.client.deleteCollection(this.collection);
+            // Fall through to collection creation below
+          } else if (dimMismatch || modelMismatch) {
             log.warn(
               {
                 collection: this.collection,
@@ -137,15 +168,20 @@ export class VellumQdrantClient {
 
     log.info(
       { collection: this.collection, vectorSize: this.vectorSize },
-      "Creating Qdrant collection",
+      "Creating Qdrant collection with named vectors (dense + sparse)",
     );
 
     try {
       await this.client.createCollection(this.collection, {
         vectors: {
-          size: this.vectorSize,
-          distance: "Cosine",
-          on_disk: this.onDisk,
+          dense: {
+            size: this.vectorSize,
+            distance: "Cosine",
+            on_disk: this.onDisk,
+          },
+        },
+        sparse_vectors: {
+          sparse: {}, // Qdrant auto-infers sparse vector params
         },
         hnsw_config: {
           on_disk: this.onDisk,
@@ -198,6 +234,7 @@ export class VellumQdrantClient {
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,
+    sparseVector?: QdrantSparseVector,
   ): Promise<string> {
     await this.ensureCollection();
 
@@ -205,20 +242,30 @@ export class VellumQdrantClient {
     const existing = await this.findByTarget(targetType, targetId);
     const pointId = existing ?? uuid();
 
+    const namedVector: Record<string, unknown> = {
+      dense: vector,
+    };
+    if (sparseVector) {
+      namedVector.sparse = {
+        indices: sparseVector.indices,
+        values: sparseVector.values,
+      };
+    }
+
+    const point = {
+      id: pointId,
+      vector: namedVector,
+      payload: {
+        target_type: targetType,
+        target_id: targetId,
+        ...payload,
+      },
+    };
+
     try {
       await this.client.upsert(this.collection, {
         wait: true,
-        points: [
-          {
-            id: pointId,
-            vector,
-            payload: {
-              target_type: targetType,
-              target_id: targetId,
-              ...payload,
-            },
-          },
-        ],
+        points: [point],
       });
     } catch (err) {
       if (this.isCollectionMissing(err)) {
@@ -226,17 +273,7 @@ export class VellumQdrantClient {
         await this.ensureCollection();
         await this.client.upsert(this.collection, {
           wait: true,
-          points: [
-            {
-              id: pointId,
-              vector,
-              payload: {
-                target_type: targetType,
-                target_id: targetId,
-                ...payload,
-              },
-            },
-          ],
+          points: [point],
         });
       } else {
         throw err;
@@ -253,26 +290,22 @@ export class VellumQdrantClient {
   ): Promise<QdrantSearchResult[]> {
     await this.ensureCollection();
 
+    const searchParams = {
+      vector: { name: "dense", vector },
+      limit,
+      with_payload: true,
+      score_threshold: 0.0,
+      filter: filter as Parameters<QdrantRestClient["search"]>[1]["filter"],
+    };
+
     let results;
     try {
-      results = await this.client.search(this.collection, {
-        vector,
-        limit,
-        with_payload: true,
-        score_threshold: 0.0,
-        filter: filter as Parameters<QdrantRestClient["search"]>[1]["filter"],
-      });
+      results = await this.client.search(this.collection, searchParams);
     } catch (err) {
       if (this.isCollectionMissing(err)) {
         this.collectionReady = false;
         await this.ensureCollection();
-        results = await this.client.search(this.collection, {
-          vector,
-          limit,
-          with_payload: true,
-          score_threshold: 0.0,
-          filter: filter as Parameters<QdrantRestClient["search"]>[1]["filter"],
-        });
+        results = await this.client.search(this.collection, searchParams);
       } else {
         throw err;
       }
@@ -332,6 +365,65 @@ export class VellumQdrantClient {
     };
 
     return this.search(vector, limit, filter);
+  }
+
+  /**
+   * Hybrid search using both dense and sparse vectors with RRF fusion.
+   * Performs two prefetch queries (dense + sparse) and fuses results
+   * using Reciprocal Rank Fusion via Qdrant's query API.
+   */
+  async hybridSearch(params: {
+    denseVector: number[];
+    sparseVector: QdrantSparseVector;
+    filter?: object;
+    limit: number;
+    prefetchLimit?: number;
+  }): Promise<QdrantSearchResult[]> {
+    await this.ensureCollection();
+
+    const { denseVector, sparseVector, filter, limit, prefetchLimit } = params;
+    const effectivePrefetchLimit = prefetchLimit ?? 40;
+
+    const queryParams = {
+      prefetch: [
+        {
+          query: denseVector as unknown as number[],
+          using: "dense",
+          limit: effectivePrefetchLimit,
+        },
+        {
+          query: {
+            indices: sparseVector.indices,
+            values: sparseVector.values,
+          },
+          using: "sparse",
+          limit: effectivePrefetchLimit,
+        },
+      ],
+      query: { fusion: "rrf" as const },
+      limit,
+      filter: filter as Record<string, unknown> | undefined,
+      with_payload: true,
+    };
+
+    let results;
+    try {
+      results = await this.client.query(this.collection, queryParams);
+    } catch (err) {
+      if (this.isCollectionMissing(err)) {
+        this.collectionReady = false;
+        await this.ensureCollection();
+        results = await this.client.query(this.collection, queryParams);
+      } else {
+        throw err;
+      }
+    }
+
+    return (results.points ?? []).map((point) => ({
+      id: typeof point.id === "string" ? point.id : String(point.id),
+      score: point.score ?? 0,
+      payload: point.payload as unknown as QdrantPointPayload,
+    }));
   }
 
   async deleteByTarget(targetType: string, targetId: string): Promise<void> {
@@ -492,7 +584,9 @@ export class VellumQdrantClient {
       points: [
         {
           id: this.SENTINEL_ID,
-          vector: new Array(this.vectorSize).fill(0), // zero vector, never matched in search
+          vector: {
+            dense: new Array(this.vectorSize).fill(0), // zero vector, never matched in search
+          },
           payload: { _meta: true, embedding_model: model },
         },
       ],


### PR DESCRIPTION
## Summary
- Upgrade Qdrant collection to named vectors (dense + sparse) with auto-migration from unnamed vectors
- Add hybridSearch() method using Qdrant query API with RRF fusion of dense and sparse prefetch
- Add TF-IDF-based sparse embedding generation in embedding-backend.ts
- Keep existing search() working via dense named vector for backwards compatibility

Part of plan: memory-system-redesign.md (PR 3 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
