### PR TITLE
fix(tests): lengthen test messages to pass needsMemory gate

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -547,9 +547,9 @@ describe("Session conflict soft gate (non-interruptive)", () => {
     const session = makeSession();
     await session.loadFromDb();
 
-    // "use MySQL" is a clarification reply (action cue "use") with topical
-    // relevance to the conflict statements.
-    await session.processMessage("use MySQL", [], () => {});
+    // "use MySQL for our database" is a clarification reply (action cue "use")
+    // with topical relevance to the conflict statements.
+    await session.processMessage("use MySQL for our database", [], () => {});
 
     expect(resolverCallCount).toBe(1);
     // Agent loop still runs — no blocking
@@ -655,7 +655,7 @@ describe("Session conflict soft gate (non-interruptive)", () => {
     });
     await session.loadFromDb();
 
-    await session.processMessage("tabs or spaces?", [], () => {});
+    await session.processMessage("should we use tabs or spaces for indentation?", [], () => {});
 
     // Every call to listPendingConflictDetails should use the session's scopeId
     expect(conflictScopeCalls.length).toBeGreaterThan(0);
@@ -746,7 +746,7 @@ describe("Session conflict soft gate (non-interruptive)", () => {
     await session.loadFromDb();
 
     const events: ServerMessage[] = [];
-    await session.processMessage("Check latest PRs", [], (event) =>
+    await session.processMessage("Check the latest PRs for review", [], (event) =>
       events.push(event),
     );
 

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -517,7 +517,7 @@ describe("Session dynamic profile injection", () => {
     const session = makeSession(privatePolicy);
     await session.loadFromDb();
 
-    await session.processMessage("What do I prefer?", [], () => {});
+    await session.processMessage("What do I prefer for databases?", [], () => {});
 
     // Profile compiler should receive the private scope with fallback enabled
     expect(profileCompilerCalls).toBe(1);


### PR DESCRIPTION
## Summary
- The `needsMemory()` gate skips the memory pipeline for messages < 20 chars, which caused 4 tests across 2 files to fail after the gate was introduced
- Lengthened test messages in `session-conflict-gate.test.ts` (3 tests) and `session-profile-injection.test.ts` (1 test) so they pass the gate

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23018167796/job/66847023691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
