### PR TITLE
feat(memory): index sparse vectors alongside dense in embedding job

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -8,6 +8,7 @@ import { getLogger } from "../util/logger.js";
 import { getDb } from "./db.js";
 import {
   embedWithBackend,
+  generateSparseEmbedding,
   getMemoryBackendStatus,
 } from "./embedding-backend.js";
 import type { EmbeddingInput } from "./embedding-types.js";
@@ -201,6 +202,14 @@ export async function embedAndUpsert(
       ? normalized.text
       : `[${normalized.type}:${normalized.mimeType}]`;
 
+  // Generate sparse embedding from the same source text used for dense embedding.
+  // For non-text (media) inputs, sparse vectors are skipped since tokenization
+  // only applies to text content.
+  const sparseVector =
+    normalized.type === "text"
+      ? generateSparseEmbedding(normalized.text)
+      : undefined;
+
   // Persist embedding in SQLite for cross-restart cache
   const now = Date.now();
   try {
@@ -249,12 +258,18 @@ export async function embedAndUpsert(
   try {
     const modality = normalized.type;
     await withQdrantBreaker(() =>
-      qdrant.upsert(targetType, targetId, vector, {
-        text: payloadText,
-        modality,
-        created_at: (extraPayload?.created_at as number) ?? now,
-        ...(extraPayload as Record<string, unknown> | undefined),
-      }),
+      qdrant.upsert(
+        targetType,
+        targetId,
+        vector,
+        {
+          text: payloadText,
+          modality,
+          created_at: (extraPayload?.created_at as number) ?? now,
+          ...(extraPayload as Record<string, unknown> | undefined),
+        },
+        sparseVector,
+      ),
     );
   } catch (err) {
     log.warn(


### PR DESCRIPTION
## Summary
- Generate sparse embeddings alongside dense in the embedding job handler
- Update Qdrant upsert calls to include both dense and sparse vectors per point
- Use entity-rich source text format for sparse encoding to maximize term overlap

Part of plan: memory-system-redesign.md (PR 4 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
