### PR TITLE
feat(memory): two-layer XML injection format with budget allocation

### DIFF
--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -1,3 +1,5 @@
+import { estimateTextTokens } from "../../context/token-estimator.js";
+import type { TieredCandidate } from "./tier-classifier.js";
 import type { Candidate } from "./types.js";
 
 const MEMORY_RECALL_OPEN_TAG =
@@ -242,6 +244,241 @@ export function formatRelativeTime(epochMs: number): string {
   }
   const y = Math.floor(days / 365);
   return `${y} year${y === 1 ? "" : "s"} ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Two-layer injection format
+// ---------------------------------------------------------------------------
+
+/** Kinds classified as identity for the <user_identity> section. */
+export const IDENTITY_KINDS = new Set(["identity"]);
+
+/** Kinds classified as preferences for the <applicable_preferences> section. */
+export const PREFERENCE_KINDS = new Set(["preference", "constraint"]);
+
+/** Per-item token budget for tier 1 items. */
+const TIER1_PER_ITEM_TOKENS = 150;
+
+/** Per-item token budget for tier 2 items. */
+const TIER2_PER_ITEM_TOKENS = 100;
+
+/** Approximate chars-per-token for truncation (matches token-estimator). */
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * Build a two-layer XML injection block from tiered candidates.
+ *
+ * Sections:
+ * - `<user_identity>`: identity-kind items from tier 1 (plain statements)
+ * - `<relevant_context>`: tier 1 non-identity, non-preference items (episode-wrapped)
+ * - `<applicable_preferences>`: preference/constraint items from tier 1 (plain statements)
+ * - `<possibly_relevant>`: tier 2 items (episode-wrapped with optional staleness)
+ *
+ * Empty sections are omitted. If all sections are empty, returns `""`.
+ */
+export function buildTwoLayerInjection(params: {
+  identityItems: TieredCandidate[];
+  tier1Candidates: TieredCandidate[];
+  tier2Candidates: TieredCandidate[];
+  preferences: TieredCandidate[];
+  totalBudgetTokens?: number;
+}): string {
+  const {
+    identityItems,
+    tier1Candidates,
+    tier2Candidates,
+    preferences,
+    totalBudgetTokens,
+  } = params;
+
+  // If everything is empty, return empty string
+  if (
+    identityItems.length === 0 &&
+    tier1Candidates.length === 0 &&
+    tier2Candidates.length === 0 &&
+    preferences.length === 0
+  ) {
+    return "";
+  }
+
+  // Budget tracking — tier 1 gets priority
+  let remainingTokens = totalBudgetTokens ?? Infinity;
+
+  // Render tier 1 items first (identity, relevant context, preferences)
+  const identityLines = renderPlainStatements(
+    identityItems,
+    TIER1_PER_ITEM_TOKENS,
+    remainingTokens,
+  );
+  remainingTokens -= estimateTextTokens(identityLines.join("\n"));
+
+  const relevantEpisodes = renderEpisodes(
+    tier1Candidates,
+    TIER1_PER_ITEM_TOKENS,
+    remainingTokens,
+  );
+  remainingTokens -= estimateTextTokens(relevantEpisodes.join("\n"));
+
+  const preferenceLines = renderPlainStatements(
+    preferences,
+    TIER1_PER_ITEM_TOKENS,
+    remainingTokens,
+  );
+  remainingTokens -= estimateTextTokens(preferenceLines.join("\n"));
+
+  // Tier 2 uses remaining budget
+  const possiblyRelevantEpisodes = renderEpisodesWithStaleness(
+    tier2Candidates,
+    TIER2_PER_ITEM_TOKENS,
+    remainingTokens,
+  );
+
+  // Assemble sections — omit empty ones
+  const sections: string[] = [];
+
+  if (identityLines.length > 0) {
+    sections.push(
+      `<user_identity>\n${identityLines.join("\n")}\n</user_identity>`,
+    );
+  }
+
+  if (relevantEpisodes.length > 0) {
+    sections.push(
+      `<relevant_context>\n${relevantEpisodes.join("\n")}\n</relevant_context>`,
+    );
+  }
+
+  if (preferenceLines.length > 0) {
+    sections.push(
+      `<applicable_preferences>\n${preferenceLines.join("\n")}\n</applicable_preferences>`,
+    );
+  }
+
+  if (possiblyRelevantEpisodes.length > 0) {
+    sections.push(
+      `<possibly_relevant>\n${possiblyRelevantEpisodes.join("\n")}\n</possibly_relevant>`,
+    );
+  }
+
+  if (sections.length === 0) return "";
+
+  return `<memory_context>\n\n${sections.join("\n\n")}\n\n</memory_context>`;
+}
+
+/**
+ * Render candidates as plain statement lines (for identity / preference sections).
+ */
+function renderPlainStatements(
+  items: TieredCandidate[],
+  perItemBudgetTokens: number,
+  remainingBudget: number,
+): string[] {
+  const lines: string[] = [];
+  let used = 0;
+  for (const item of items) {
+    if (used >= remainingBudget) break;
+    const maxChars = perItemBudgetTokens * CHARS_PER_TOKEN;
+    const text = escapeXmlTags(truncate(item.text, maxChars));
+    const tokens = estimateTextTokens(text);
+    if (used + tokens > remainingBudget) break;
+    lines.push(text);
+    used += tokens;
+  }
+  return lines;
+}
+
+/**
+ * Render candidates as `<episode>` elements with source attribution.
+ */
+function renderEpisodes(
+  items: TieredCandidate[],
+  perItemBudgetTokens: number,
+  remainingBudget: number,
+): string[] {
+  const lines: string[] = [];
+  let used = 0;
+  for (const item of items) {
+    if (used >= remainingBudget) break;
+    const maxChars = perItemBudgetTokens * CHARS_PER_TOKEN;
+    const text = escapeXmlTags(truncate(item.text, maxChars));
+    const sourceAttr = buildSourceAttr(item);
+    const line = `<episode${sourceAttr}>\n${text}\n</episode>`;
+    const tokens = estimateTextTokens(line);
+    if (used + tokens > remainingBudget) break;
+    lines.push(line);
+    used += tokens;
+  }
+  return lines;
+}
+
+/**
+ * Render tier 2 candidates as `<episode>` elements with staleness annotation.
+ */
+function renderEpisodesWithStaleness(
+  items: TieredCandidate[],
+  perItemBudgetTokens: number,
+  remainingBudget: number,
+): string[] {
+  const lines: string[] = [];
+  let used = 0;
+  for (const item of items) {
+    if (used >= remainingBudget) break;
+    const maxChars = perItemBudgetTokens * CHARS_PER_TOKEN;
+    const text = escapeXmlTags(truncate(item.text, maxChars));
+    const sourceAttr = buildSourceAttr(item);
+    const stalenessAttr =
+      item.staleness && item.staleness !== "fresh"
+        ? ` staleness="${escapeXmlAttr(item.staleness)}"`
+        : "";
+    const line = `<episode${sourceAttr}${stalenessAttr}>\n${text}\n</episode>`;
+    const tokens = estimateTextTokens(line);
+    if (used + tokens > remainingBudget) break;
+    lines.push(line);
+    used += tokens;
+  }
+  return lines;
+}
+
+/**
+ * Build the `source="..."` attribute for an episode tag.
+ * Uses the candidate's sourceLabel (conversation title) if available,
+ * combined with a short date from createdAt.
+ */
+function buildSourceAttr(item: TieredCandidate): string {
+  const date = formatShortDate(item.createdAt);
+  if (item.sourceLabel) {
+    return ` source="${escapeXmlAttr(`${item.sourceLabel} (${date})`)}"`;
+  }
+  return ` source="${escapeXmlAttr(date)}"`;
+}
+
+/**
+ * Format epoch-ms as a short human-readable date like "Mar 7" or "Mar 7 2024".
+ * Omits the year when the date is in the current year.
+ */
+function formatShortDate(epochMs: number): string {
+  const date = new Date(epochMs);
+  const now = new Date();
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  const month = months[date.getMonth()];
+  const day = date.getDate();
+  if (date.getFullYear() === now.getFullYear()) {
+    return `${month} ${day}`;
+  }
+  return `${month} ${day} ${date.getFullYear()}`;
 }
 
 function truncate(text: string, max: number): string {

--- a/assistant/src/memory/search/tier-classifier.ts
+++ b/assistant/src/memory/search/tier-classifier.ts
@@ -4,6 +4,8 @@ export type Tier = 1 | 2 | null;
 
 export interface TieredCandidate extends Candidate {
   tier: Tier;
+  /** Human-readable label for the source conversation/summary (e.g. conversation title). */
+  sourceLabel?: string;
 }
 
 export function classifyTier(score: number): Tier {


### PR DESCRIPTION
## Summary
- Add buildTwoLayerInjection() that produces XML with user_identity, relevant_context, applicable_preferences, and possibly_relevant sections
- Budget allocation: tier 1 items get ~150 tokens, tier 2 items get ~100 tokens with tier 1 priority
- Source attribution on episodic tags, staleness annotations on stale tier 2 items
- Empty sections omitted, fully empty result returns empty string

Part of plan: memory-system-redesign.md (PR 7 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
