### PR TITLE
fix(tests): mock named-vector format in qdrant collection migration tests

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -21,12 +21,14 @@ interface MockCallLog {
 
 let mockCollectionExists: boolean;
 let mockCollectionSize: number;
+let mockUseNamedVectors: boolean;
 let mockSentinelPayload: Record<string, unknown> | null;
 let callLog: MockCallLog;
 
 function resetMockState() {
   mockCollectionExists = false;
   mockCollectionSize = 384;
+  mockUseNamedVectors = false;
   mockSentinelPayload = null;
   callLog = {
     collectionExists: 0,
@@ -51,7 +53,9 @@ mock.module("@qdrant/js-client-rest", () => ({
       return {
         config: {
           params: {
-            vectors: { size: mockCollectionSize },
+            vectors: mockUseNamedVectors
+              ? { dense: { size: mockCollectionSize } }
+              : { size: mockCollectionSize },
           },
         },
       };
@@ -97,6 +101,7 @@ beforeEach(() => {
 describe("Qdrant collection migration", () => {
   test("deletes and recreates collection on dimension mismatch", async () => {
     mockCollectionExists = true;
+    mockUseNamedVectors = true;
     mockCollectionSize = 384; // Current collection has 384-dim vectors
 
     const client = new VellumQdrantClient({
@@ -116,6 +121,7 @@ describe("Qdrant collection migration", () => {
 
   test("deletes and recreates collection on model-only mismatch", async () => {
     mockCollectionExists = true;
+    mockUseNamedVectors = true;
     mockCollectionSize = 768; // Same dimension
     mockSentinelPayload = {
       _meta: true,
@@ -141,6 +147,7 @@ describe("Qdrant collection migration", () => {
 
   test("leaves collection untouched when dimensions and model match", async () => {
     mockCollectionExists = true;
+    mockUseNamedVectors = true;
     mockCollectionSize = 768;
     mockSentinelPayload = {
       _meta: true,
@@ -164,6 +171,7 @@ describe("Qdrant collection migration", () => {
 
   test("does not rebuild pre-existing collection without sentinel (graceful upgrade)", async () => {
     mockCollectionExists = true;
+    mockUseNamedVectors = true;
     mockCollectionSize = 768;
     mockSentinelPayload = null; // No sentinel — pre-existing collection
 


### PR DESCRIPTION
## Summary
- The `getCollection` mock in `qdrant-collection-migration.test.ts` always returned unnamed-vector format (`{ size: N }`), which triggers the legacy migration codepath (`isUnnamedVectors = true`) and always deletes the collection
- Added a `mockUseNamedVectors` flag so tests representing modern collections return named-vector format (`{ dense: { size: N } }`), fixing 2 failing tests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23018390698/job/66847812721

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
