### PR TITLE
fix(types): correct qdrant-client and tier-classifier type errors

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -242,7 +242,7 @@ export class VellumQdrantClient {
     const existing = await this.findByTarget(targetType, targetId);
     const pointId = existing ?? uuid();
 
-    const namedVector: Record<string, unknown> = {
+    const namedVector: Record<string, number[] | { indices: number[]; values: number[] }> = {
       dense: vector,
     };
     if (sparseVector) {

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -24,7 +24,7 @@ export interface Candidate {
   semantic: number;
   recency: number;
   finalScore: number;
-  tier?: 1 | 2;
+  tier?: 1 | 2 | null;
   staleness?: StalenessLevel;
 }
 


### PR DESCRIPTION
## Summary
- Type `namedVector` in `qdrant-client.ts` as `Record<string, number[] | { indices: number[]; values: number[] }>` instead of `Record<string, unknown>` to satisfy the Qdrant SDK's `VectorStruct` type
- Add `null` to `Candidate.tier` type in `search/types.ts` so `TieredCandidate` (which uses `Tier = 1 | 2 | null`) correctly extends `Candidate`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23018390698/job/66847812787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
