### PR TITLE
fix: use platform healthz endpoint for managed assistant health checks

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -6,7 +6,7 @@ import {
   loadAllAssistants,
   type AssistantEntry,
 } from "../lib/assistant-config";
-import { checkHealth } from "../lib/health-check";
+import { checkHealth, checkManagedHealth } from "../lib/health-check";
 import {
   classifyProcess,
   detectOrphanedProcesses,
@@ -359,6 +359,8 @@ async function listAllAssistants(): Promise<void> {
         } else {
           health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
         }
+      } else if (a.cloud === "vellum") {
+        health = await checkManagedHealth(a.runtimeUrl, a.assistantId);
       } else {
         health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
       }

--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -10,6 +10,56 @@ export interface HealthCheckResult {
   detail: string | null;
 }
 
+export async function checkManagedHealth(
+  runtimeUrl: string,
+  assistantId: string,
+): Promise<HealthCheckResult> {
+  const { readPlatformToken } = await import("./platform-client.js");
+  const token = readPlatformToken();
+  if (!token) {
+    return {
+      status: "error (auth)",
+      detail: "not logged in — run `vellum login`",
+    };
+  }
+
+  try {
+    const url = `${runtimeUrl}/v1/assistants/${assistantId}/healthz/`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      HEALTH_CHECK_TIMEOUT_MS,
+    );
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Session-Token": token,
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return { status: `error (${response.status})`, detail: null };
+    }
+
+    const data = (await response.json()) as HealthResponse;
+    const status = data.status || "unknown";
+    return {
+      status,
+      detail: status !== "healthy" ? (data.message ?? null) : null,
+    };
+  } catch (error) {
+    const status =
+      error instanceof Error && error.name === "AbortError"
+        ? "timeout"
+        : "unreachable";
+    return { status, detail: null };
+  }
+}
+
 export async function checkHealth(
   runtimeUrl: string,
   bearerToken?: string,


### PR DESCRIPTION
## Summary
- `vellum ps` was showing `error (404)` for managed (cloud: "vellum") assistants because it hit `/v1/health` — an endpoint that doesn't exist on the platform
- Added `checkManagedHealth()` in `cli/src/lib/health-check.ts` that hits `/v1/assistants/{id}/healthz/` with `X-Session-Token` auth
- Routed managed assistants through the new function in `cli/src/commands/ps.ts`; local and other cloud types are unchanged
- Shows `error (auth)` with a helpful message when not logged in

## Test plan
- [ ] Run `vellum ps` with a managed assistant in the lockfile — should show `healthy` or a meaningful status instead of `error (404)`
- [ ] Run `vellum ps` with a local assistant — should behave exactly as before
- [ ] Run `vellum ps` without a platform token — should show `error (auth)` instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
