### PR TITLE
feat(macos): add Cmd+F in-chat search

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -5,6 +5,11 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+MenuBar")
 
+extension Notification.Name {
+    /// Posted when the user triggers Edit > Find (Cmd+F) from the menu bar.
+    static let activateChatSearch = Notification.Name("activateChatSearch")
+}
+
 extension AppDelegate {
 
     // MARK: - Menu Bar
@@ -68,6 +73,27 @@ extension AppDelegate {
         let fileMenuItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
         fileMenuItem.submenu = fileMenu
         mainMenu.insertItem(fileMenuItem, at: 1)
+
+        // Edit menu — provides Cmd+F "Find" so the shortcut works regardless of focus state.
+        if mainMenu.indexOfItem(withTitle: "Edit") < 0 {
+            let editMenu = NSMenu(title: "Edit")
+
+            // Standard edit actions so Cmd+C/V/X/A work in text fields
+            editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+            editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+            editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+            editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+            editMenu.addItem(NSMenuItem.separator())
+
+            let findItem = NSMenuItem(title: "Find...", action: #selector(activateChatSearch), keyEquivalent: "f")
+            findItem.keyEquivalentModifierMask = .command
+            findItem.target = self
+            editMenu.addItem(findItem)
+
+            let editMenuItem = NSMenuItem(title: "Edit", action: nil, keyEquivalent: "")
+            editMenuItem.submenu = editMenu
+            mainMenu.insertItem(editMenuItem, at: 2)
+        }
     }
 
     // MARK: - Menu Item Validation
@@ -370,6 +396,10 @@ extension AppDelegate {
             mainWindow?.windowState.selection = .thread(id)
         }
         UserDefaults.standard.set(false, forKey: "sidebarExpanded")
+    }
+
+    @objc func activateChatSearch() {
+        NotificationCenter.default.post(name: .activateChatSearch, object: nil)
     }
 
     @objc func openAppCollection() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// In-chat find bar (Cmd+F). Searches message text and navigates between matches.
+struct ChatSearchBar: View {
+    @Binding var searchText: String
+    let matchCount: Int
+    let currentMatchIndex: Int
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+    let onDismiss: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(.search, size: 12)
+                .foregroundColor(VColor.textMuted)
+
+            TextField("Find in conversation...", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .focused($isFocused)
+                .onSubmit { onNext() }
+
+            if !searchText.isEmpty {
+                Text(matchCount > 0 ? "\(currentMatchIndex + 1) of \(matchCount)" : "No results")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .fixedSize()
+
+                Button(action: onPrevious) {
+                    VIconView(.chevronUp, size: 12)
+                        .foregroundColor(matchCount > 0 ? VColor.textPrimary : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .disabled(matchCount == 0)
+                .accessibilityLabel("Previous match")
+
+                Button(action: onNext) {
+                    VIconView(.chevronDown, size: 12)
+                        .foregroundColor(matchCount > 0 ? VColor.textPrimary : VColor.textMuted)
+                }
+                .buttonStyle(.plain)
+                .disabled(matchCount == 0)
+                .accessibilityLabel("Next match")
+            }
+
+            Button(action: onDismiss) {
+                VIconView(.x, size: 12)
+                    .foregroundColor(VColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close search")
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .frame(height: 32)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .vShadow(VShadow.sm)
+        .onAppear { isFocused = true }
+        .onKeyPress(.escape) {
+            onDismiss()
+            return .handled
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -106,8 +106,20 @@ struct ChatView: View {
     @State private var containerWidth: CGFloat = 0
     @State private var appearance = AvatarAppearanceManager.shared
 
+    // MARK: - In-Chat Search (Cmd+F)
+    @State private var isSearchActive = false
+    @State private var searchText = ""
+    @State private var currentMatchIndex = 0
+
     private var isEmptyState: Bool {
         messages.isEmpty && isHistoryLoaded
+    }
+
+    /// Message IDs whose text contains the search query, ordered chronologically.
+    private var searchMatches: [UUID] {
+        guard !searchText.isEmpty else { return [] }
+        let query = searchText.lowercased()
+        return messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
     }
 
     var body: some View {
@@ -345,11 +357,43 @@ struct ChatView: View {
             handleDrop(providers: providers)
         }
         .onKeyPress(.escape) {
+            if isSearchActive {
+                dismissSearch()
+                return .handled
+            }
             if btwResponse != nil {
                 onDismissBtw?()
                 return .handled
             }
             return .ignored
+        }
+        .onKeyPress("f", modifiers: .command) {
+            activateSearch()
+            return .handled
+        }
+        .overlay(alignment: .topTrailing) {
+            if isSearchActive {
+                ChatSearchBar(
+                    searchText: $searchText,
+                    matchCount: searchMatches.count,
+                    currentMatchIndex: currentMatchIndex,
+                    onPrevious: { navigateMatch(delta: -1) },
+                    onNext: { navigateMatch(delta: 1) },
+                    onDismiss: { dismissSearch() }
+                )
+                .padding(.trailing, VSpacing.xl)
+                .padding(.top, VSpacing.sm)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .animation(VAnimation.fast, value: isSearchActive)
+        .onChange(of: searchText) {
+            // Reset to first match when query changes
+            currentMatchIndex = 0
+            scrollToCurrentMatch()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { _ in
+            activateSearch()
         }
     }
 
@@ -474,6 +518,31 @@ struct ChatView: View {
             if !urls.isEmpty { onDropFiles(urls) }
         }
         return true
+    }
+
+    // MARK: - Search Helpers
+
+    private func activateSearch() {
+        isSearchActive = true
+    }
+
+    private func dismissSearch() {
+        isSearchActive = false
+        searchText = ""
+        currentMatchIndex = 0
+    }
+
+    private func navigateMatch(delta: Int) {
+        let matches = searchMatches
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex + delta + matches.count) % matches.count
+        scrollToCurrentMatch()
+    }
+
+    private func scrollToCurrentMatch() {
+        let matches = searchMatches
+        guard !matches.isEmpty, currentMatchIndex < matches.count else { return }
+        anchorMessageId = matches[currentMatchIndex]
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds an in-chat find bar activated by Cmd+F that searches message text content
- Shows match count ("2 of 5"), with up/down navigation (chevrons + Enter) and Escape to dismiss
- Uses existing `anchorMessageId` scroll infrastructure to navigate to matching messages
- Adds an Edit menu with standard Cut/Copy/Paste/Select All and a Find item (Cmd+F) so the shortcut works regardless of focus state

## Original prompt
Add Cmd+F search to the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
