### PR TITLE
security: disable git hook execution for workspace auto-commits by default

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -1205,6 +1205,113 @@ describe("WorkspaceGitService", () => {
     });
   });
 
+  describe("hook suppression (fail-closed auto-commits)", () => {
+    /**
+     * Helper: write an executable hook script that touches a sentinel file
+     * so we can detect if the hook ran.
+     */
+    function installHook(
+      repoDir: string,
+      hookName: string,
+      sentinelPath: string,
+    ): void {
+      const hooksDir = join(repoDir, ".git", "hooks");
+      mkdirSync(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, hookName);
+      writeFileSync(hookPath, `#!/bin/sh\ntouch "${sentinelPath}"\nexit 0\n`, {
+        mode: 0o755,
+      });
+    }
+
+    test("initial commit in ensureInitialized does not run pre-commit hook", async () => {
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+
+      // Initialize the service so git init has run, but no initial commit yet.
+      // We need to install the hook AFTER git init but BEFORE the initial commit.
+      // Since ensureInitialized() does both atomically, we instead:
+      // 1. Manually git-init the directory.
+      // 2. Install the hook.
+      // 3. Then call ensureInitialized() so it creates the initial commit.
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      installHook(testDir, "pre-commit", sentinel);
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("initial commit in ensureInitialized does not run commit-msg hook", async () => {
+      const sentinel = join(testDir, "commit-msg-ran.marker");
+
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      installHook(testDir, "commit-msg", sentinel);
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitChanges does not run pre-commit hook", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: hook suppression");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitChanges does not run commit-msg hook", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "commit-msg-ran.marker");
+      installHook(testDir, "commit-msg", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: commit-msg hook suppression");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitIfDirty does not run pre-commit hook", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty");
+      const result = await service.commitIfDirty(() => ({
+        message: "test: commitIfDirty hook suppression",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitIfDirty does not run commit-msg hook", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "commit-msg-ran.marker");
+      installHook(testDir, "commit-msg", sentinel);
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty");
+      const result = await service.commitIfDirty(() => ({
+        message: "test: commitIfDirty commit-msg hook suppression",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+  });
+
   describe("isDeadlineExpired helper", () => {
     test("returns false when deadlineMs is undefined", () => {
       expect(isDeadlineExpired(undefined)).toBe(false);

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -376,6 +376,62 @@ describe("WorkspaceHeartbeatService", () => {
     });
   });
 
+  describe("hook suppression (fail-closed auto-commits)", () => {
+    function installHook(
+      repoDir: string,
+      hookName: string,
+      sentinelPath: string,
+    ): void {
+      const hooksDir = join(repoDir, ".git", "hooks");
+      mkdirSync(hooksDir, { recursive: true });
+      const hookPath = join(hooksDir, hookName);
+      writeFileSync(hookPath, `#!/bin/sh\ntouch "${sentinelPath}"\nexit 0\n`, {
+        mode: 0o755,
+      });
+    }
+
+    test("heartbeat check commit does not run pre-commit hook", async () => {
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+
+      let currentTime = 1000000;
+      const heartbeat = new WorkspaceHeartbeatService({
+        ageThresholdMs: 5 * 60 * 1000,
+        fileThreshold: 100,
+        getServices: () => services,
+        now: () => currentTime,
+      });
+
+      // First check: registers dirty state
+      await heartbeat.check();
+      // Advance past threshold
+      currentTime += 6 * 60 * 1000;
+      // Second check: should commit without running the hook
+      const result = await heartbeat.check();
+
+      expect(result.committed).toBe(1);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("shutdown commit (commitAllPending) does not run pre-commit hook", async () => {
+      const sentinel = join(testDir, "pre-commit-shutdown.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "unsaved.txt"), "uncommitted content");
+
+      const heartbeat = new WorkspaceHeartbeatService({
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.commitAllPending();
+
+      expect(result.committed).toBe(1);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+  });
+
   describe("start and stop", () => {
     test("start and stop are idempotent", async () => {
       const heartbeat = new WorkspaceHeartbeatService({

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -136,6 +136,23 @@ interface GitStatus {
 }
 
 /**
+ * An empty directory path that git resolves to "no hooks directory".
+ *
+ * Git looks for hook scripts in `core.hooksPath`. When set to a path that
+ * contains no executable files, all hook types (pre-commit, commit-msg,
+ * post-commit, etc.) are silently skipped.
+ *
+ * We use `/dev/null` because:
+ * 1. It always exists on POSIX systems (macOS + Linux).
+ * 2. It is not a directory, so git will not find any hook scripts there.
+ * 3. It produces no side effects.
+ *
+ * This is intentionally stronger than `--no-verify`, which only suppresses
+ * pre-commit and commit-msg hooks and leaves post-commit hooks running.
+ */
+const EMPTY_HOOKS_PATH = "/dev/null";
+
+/**
  * Git service for workspace change management.
  *
  * Provides git-backed tracking of workspace state with lazy initialization.
@@ -146,6 +163,7 @@ interface GitStatus {
  * - Mutex-protected operations: prevents concurrent git command conflicts
  * - Handles both new and existing workspaces transparently
  * - Synchronous initial commit within mutex to prevent races
+ * - Fail-closed hook policy: auto-commits never run repository hooks
  */
 export class WorkspaceGitService {
   private readonly workspaceDir: string;
@@ -418,7 +436,7 @@ export class WorkspaceGitService {
             ? "Initial commit: migrated existing workspace"
             : "Initial commit: new workspace";
 
-          await this.execGit(["commit", "-m", message, "--allow-empty"]);
+          await this.execGitCommit(["-m", message, "--allow-empty"]);
 
           this.initialized = true;
           this.recordInitSuccess();
@@ -454,7 +472,7 @@ export class WorkspaceGitService {
       }
 
       // Commit (will succeed even if no changes)
-      await this.execGit(["commit", "-m", fullMessage, "--allow-empty"]);
+      await this.execGitCommit(["-m", fullMessage, "--allow-empty"]);
     });
   }
 
@@ -592,7 +610,7 @@ export class WorkspaceGitService {
               .join("\n");
         }
 
-        await this.execGit(["commit", "-m", fullMessage]);
+        await this.execGitCommit(["-m", fullMessage]);
         return { committed: true, status, didRunGit: true as const };
       });
       if (result.didRunGit) {
@@ -774,6 +792,27 @@ export class WorkspaceGitService {
         await this.execGit(["switch", "-c", "main"]);
       }
     }
+  }
+
+  /**
+   * Execute a git commit command with hooks suppressed via `core.hooksPath`.
+   *
+   * All workspace auto-commits go through this helper so that repository
+   * hook scripts (pre-commit, commit-msg, post-commit, etc.) are never
+   * executed without an explicit user trust decision.
+   *
+   * Uses `-c core.hooksPath=<EMPTY_HOOKS_PATH>` rather than `--no-verify`
+   * because `--no-verify` only suppresses pre-commit and commit-msg hooks
+   * while leaving post-commit hooks (and others) intact.
+   */
+  private async execGitCommit(
+    commitArgs: string[],
+    options?: { signal?: AbortSignal },
+  ): Promise<{ stdout: string; stderr: string }> {
+    return this.execGit(
+      ["-c", `core.hooksPath=${EMPTY_HOOKS_PATH}`, "commit", ...commitArgs],
+      options,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add fail-closed commit helper that suppresses all git hooks via `core.hooksPath` override
- Route all auto-commit paths through the helper (initial, commitChanges, commitIfDirty)
- Add regression tests verifying hooks are not executed during auto-commits

Part of plan: git-hooks-trust-prompt-exploit-fix.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
