### PR TITLE
feat: surface error details as Sentry context on macOS log reports

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -66,6 +66,37 @@ enum LogExporter {
             if formData.reason == .assistantBehavior {
                 tags["client"] = "macos"
             }
+
+            // Surface active session state as tags so the Sentry event itself
+            // is useful for triage without downloading the log archive.
+            var extra: [String: Any] = [:]
+            let threadManager = AppDelegate.shared?.mainWindow?.threadManager
+            if let activeThread = threadManager?.activeThread {
+                extra["thread_title"] = activeThread.title
+                if let sessionId = activeThread.sessionId {
+                    tags["session_id"] = sessionId
+                }
+            }
+            if let vm = threadManager?.activeViewModel {
+                extra["message_count"] = vm.messages.count
+                if let sessionError = vm.sessionError {
+                    tags["session_error_category"] = "\(sessionError.category)"
+                    if let debugDetails = sessionError.debugDetails {
+                        tags["session_error_debug_details"] = debugDetails
+                    }
+                }
+                if let sessionId = vm.sessionId {
+                    // Prefer the view model's sessionId (most up-to-date)
+                    tags["session_id"] = sessionId
+                }
+            }
+            if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+                tags["assistant_id"] = assistantId
+            }
+            if !extra.isEmpty {
+                event.extra = extra
+            }
+
             event.tags = tags
             // Group all reports by reason so different user messages don't
             // fragment into separate Sentry issues.


### PR DESCRIPTION
## Summary
- Add sessionErrorCategory, sessionErrorDebugDetails, sessionId as Sentry tags on log report events
- Include assistant_id as a Sentry tag from the connected assistant
- Include thread title and message count as structured context (event.extra)
- Eliminates need to download tar.gz attachments for most triage scenarios

Part of plan: sentry-observability-improvements.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
