### PR TITLE
feat: add persisted per-workspace git hook trust state and hook detection

### DIFF
--- a/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
+++ b/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
@@ -1,0 +1,303 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ─── Test isolation: redirect trust store writes to a temp dir ────────────────
+
+const testDir = mkdtempSync(join(tmpdir(), "git-hooks-trust-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import { clearCache } from "../permissions/trust-store.js";
+import {
+  detectConfiguredHooks,
+  getGitHooksTrustDecision,
+  GIT_HOOKS_TRUST_PSEUDO_TOOL,
+  type GitServiceLike,
+  setGitHooksTrustDecision,
+} from "../workspace/git-hooks-trust.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const trustPath = join(testDir, "protected", "trust.json");
+
+/** Make a fake GitServiceLike that returns a canned core.hooksPath value. */
+function makeGitService(hooksPath?: string): GitServiceLike {
+  return {
+    async runReadOnlyGit(args: string[]) {
+      if (
+        args.length >= 3 &&
+        args[0] === "config" &&
+        args[2] === "core.hooksPath"
+      ) {
+        if (hooksPath == null) {
+          // Simulate "not set" — git exits non-zero
+          throw new Error("git config: not found");
+        }
+        return { stdout: hooksPath + "\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    },
+  };
+}
+
+/** Write an executable hook file to the given directory. */
+function writeHook(dir: string, name: string): string {
+  const path = join(dir, name);
+  writeFileSync(path, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  return path;
+}
+
+// ─── Trust decision tri-state lookup ─────────────────────────────────────────
+
+describe("getGitHooksTrustDecision / setGitHooksTrustDecision", () => {
+  beforeEach(() => {
+    clearCache();
+    try {
+      rmSync(trustPath);
+    } catch {
+      /* may not exist */
+    }
+  });
+
+  afterEach(() => {
+    clearCache();
+  });
+
+  test("returns 'ask' when no decision has been persisted", () => {
+    const decision = getGitHooksTrustDecision("/some/workspace");
+    expect(decision).toBe("ask");
+  });
+
+  test("returns 'allow' after setGitHooksTrustDecision('allow')", () => {
+    const ws = "/projects/my-workspace";
+    setGitHooksTrustDecision(ws, "allow");
+    clearCache(); // simulate restart (forces re-read from disk)
+    expect(getGitHooksTrustDecision(ws)).toBe("allow");
+  });
+
+  test("returns 'deny' after setGitHooksTrustDecision('deny')", () => {
+    const ws = "/projects/my-workspace";
+    setGitHooksTrustDecision(ws, "deny");
+    clearCache();
+    expect(getGitHooksTrustDecision(ws)).toBe("deny");
+  });
+
+  test("updating from allow to deny replaces the rule (idempotent write)", () => {
+    const ws = "/projects/workspace-flip";
+    setGitHooksTrustDecision(ws, "allow");
+    setGitHooksTrustDecision(ws, "deny");
+    clearCache();
+    expect(getGitHooksTrustDecision(ws)).toBe("deny");
+  });
+
+  test("writing the same decision twice does not create duplicate rules", () => {
+    const ws = "/projects/workspace-dup";
+    setGitHooksTrustDecision(ws, "allow");
+    setGitHooksTrustDecision(ws, "allow");
+    clearCache();
+    expect(getGitHooksTrustDecision(ws)).toBe("allow");
+  });
+
+  test("clearing the decision (undefined) reverts to 'ask'", () => {
+    const ws = "/projects/workspace-clear";
+    setGitHooksTrustDecision(ws, "allow");
+    setGitHooksTrustDecision(ws, undefined);
+    clearCache();
+    expect(getGitHooksTrustDecision(ws)).toBe("ask");
+  });
+
+  test("decisions are scoped per workspace — different workspaces are independent", () => {
+    const wsA = "/projects/workspace-a";
+    const wsB = "/projects/workspace-b";
+    setGitHooksTrustDecision(wsA, "allow");
+    setGitHooksTrustDecision(wsB, "deny");
+    clearCache();
+    expect(getGitHooksTrustDecision(wsA)).toBe("allow");
+    expect(getGitHooksTrustDecision(wsB)).toBe("deny");
+  });
+
+  test("trust decision survives a cache clear (persisted to disk)", () => {
+    const ws = "/projects/persisted-workspace";
+    setGitHooksTrustDecision(ws, "allow");
+    // Simulate process restart: wipe in-memory cache so next read loads from disk
+    clearCache();
+    const after = getGitHooksTrustDecision(ws);
+    expect(after).toBe("allow");
+  });
+
+  test("pseudo-tool key is the expected reserved constant", () => {
+    expect(GIT_HOOKS_TRUST_PSEUDO_TOOL).toBe("__internal:git-hooks-trust");
+  });
+});
+
+// ─── Hook detection ───────────────────────────────────────────────────────────
+
+describe("detectConfiguredHooks", () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "vellum-hook-detect-"));
+  });
+
+  afterEach(() => {
+    if (existsSync(workspaceDir)) {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns hasHooks=false when .git/hooks has only .sample stubs", async () => {
+    const hooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(join(hooksDir, "pre-commit.sample"), "#!/bin/sh\n");
+    writeFileSync(join(hooksDir, "pre-push.sample"), "#!/bin/sh\n");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hasHooks).toBe(false);
+    expect(result.hookFiles).toHaveLength(0);
+    expect(result.hooksDir).toBe(join(workspaceDir, ".git", "hooks"));
+  });
+
+  test("returns hasHooks=true when an explicit hook file exists in .git/hooks", async () => {
+    const hooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const hookPath = writeHook(hooksDir, "pre-commit");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hasHooks).toBe(true);
+    expect(result.hookFiles).toContain(hookPath);
+  });
+
+  test("detects hooks in a custom core.hooksPath (relative)", async () => {
+    const customDir = join(workspaceDir, ".githooks");
+    mkdirSync(customDir, { recursive: true });
+    const hookPath = writeHook(customDir, "commit-msg");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(".githooks"),
+    );
+
+    expect(result.hasHooks).toBe(true);
+    expect(result.hookFiles).toContain(hookPath);
+    expect(result.hooksDir).toBe(customDir);
+  });
+
+  test("detects hooks in a custom core.hooksPath (absolute)", async () => {
+    const customDir = join(workspaceDir, "custom-hooks");
+    mkdirSync(customDir, { recursive: true });
+    const hookPath = writeHook(customDir, "pre-push");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(customDir),
+    );
+
+    expect(result.hasHooks).toBe(true);
+    expect(result.hookFiles).toContain(hookPath);
+    expect(result.hooksDir).toBe(customDir);
+  });
+
+  test("falls back to .git/hooks when core.hooksPath is not configured", async () => {
+    const defaultHooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(defaultHooksDir, { recursive: true });
+    writeHook(defaultHooksDir, "post-commit");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hooksDir).toBe(defaultHooksDir);
+    expect(result.hasHooks).toBe(true);
+  });
+
+  test("returns hasHooks=false when hooks directory does not exist", async () => {
+    // Don't create .git/hooks at all
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hasHooks).toBe(false);
+    expect(result.hookFiles).toHaveLength(0);
+  });
+
+  test("ignores non-standard filenames in the hooks directory", async () => {
+    const hooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    // Non-standard name — should be ignored
+    writeFileSync(join(hooksDir, "my-custom-hook"), "#!/bin/sh\n", {
+      mode: 0o755,
+    });
+    // Standard stub (.sample) — should also be ignored
+    writeFileSync(join(hooksDir, "pre-commit.sample"), "#!/bin/sh\n");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hasHooks).toBe(false);
+  });
+
+  test("multiple hooks are all returned in hookFiles", async () => {
+    const hooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const p1 = writeHook(hooksDir, "pre-commit");
+    const p2 = writeHook(hooksDir, "pre-push");
+    const p3 = writeHook(hooksDir, "commit-msg");
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      makeGitService(undefined),
+    );
+
+    expect(result.hasHooks).toBe(true);
+    expect(result.hookFiles).toContain(p1);
+    expect(result.hookFiles).toContain(p2);
+    expect(result.hookFiles).toContain(p3);
+  });
+});

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -600,6 +600,95 @@ export function clearCache(): void {
   invalidPatterns.clear();
 }
 
+// ─── Pseudo-rule helpers (internal use only) ────────────────────────────────
+//
+// Pseudo-rules store non-tool metadata (e.g. workspace feature flags) inside
+// the trust store so they persist across restarts via the existing mechanism.
+// They use a reserved tool-name prefix ("__internal:") that is never matched
+// against real tool invocations.
+
+/**
+ * Insert or replace a pseudo-rule for the given tool+pattern pair.
+ *
+ * If a rule with the same tool and pattern already exists it is replaced
+ * in-place (idempotent).  This prevents duplicate / conflicting entries from
+ * accumulating when the caller writes the same decision more than once.
+ */
+export function upsertPseudoRule(
+  tool: string,
+  pattern: string,
+  scope: string,
+  decision: "allow" | "deny" | "ask",
+): TrustRule {
+  // Re-read from disk to avoid lost updates from concurrent modifications.
+  cachedRules = null;
+  const rules = [...getRules()];
+
+  const existingIndex = rules.findIndex(
+    (r) => r.tool === tool && r.pattern === pattern,
+  );
+
+  if (existingIndex !== -1) {
+    const existing = rules[existingIndex];
+    if (existing.decision === decision && existing.scope === scope) {
+      // Already up to date — return as-is without a disk write.
+      return existing;
+    }
+    const updated: TrustRule = {
+      ...existing,
+      decision,
+      scope,
+    };
+    rules[existingIndex] = updated;
+    rules.sort(ruleOrder);
+    cachedRules = rules;
+    rebuildPatternCache(rules);
+    saveToDisk(rules);
+    notifyRulesChanged();
+    log.info({ rule: updated }, "Updated pseudo trust rule");
+    return updated;
+  }
+
+  const rule: TrustRule = {
+    id: uuid(),
+    tool,
+    pattern,
+    scope,
+    decision,
+    priority: 0,
+    createdAt: Date.now(),
+  };
+  rules.push(rule);
+  rules.sort(ruleOrder);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  notifyRulesChanged();
+  log.info({ rule }, "Added pseudo trust rule");
+  return rule;
+}
+
+/**
+ * Remove a pseudo-rule matching the given tool and pattern.
+ * Returns true if a rule was removed, false if none matched.
+ */
+export function removePseudoRule(tool: string, pattern: string): boolean {
+  // Re-read from disk to avoid lost updates from concurrent modifications.
+  cachedRules = null;
+  const rules = [...getRules()];
+  const index = rules.findIndex(
+    (r) => r.tool === tool && r.pattern === pattern,
+  );
+  if (index === -1) return false;
+  const [removed] = rules.splice(index, 1);
+  cachedRules = rules;
+  rebuildPatternCache(rules);
+  saveToDisk(rules);
+  notifyRulesChanged();
+  log.info({ id: removed.id, tool, pattern }, "Removed pseudo trust rule");
+  return true;
+}
+
 // ─── Starter approval bundle ────────────────────────────────────────────────
 //
 // A curated set of low-risk tool rules that most users would approve

--- a/assistant/src/workspace/git-hooks-trust.ts
+++ b/assistant/src/workspace/git-hooks-trust.ts
@@ -1,0 +1,198 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  getAllRules,
+  removePseudoRule,
+  upsertPseudoRule,
+} from "../permissions/trust-store.js";
+
+/**
+ * Pseudo-tool key used to persist git hook trust decisions in the trust store.
+ * Prefixed with "__internal:" to avoid collision with real tool names and to
+ * signal that these rules are not user-visible permission rules.
+ */
+export const GIT_HOOKS_TRUST_PSEUDO_TOOL = "__internal:git-hooks-trust";
+
+/**
+ * Pattern suffix that encodes the workspace directory in a trust rule pattern
+ * so that one workspace's decision does not bleed into another.
+ */
+function patternForWorkspace(workspaceDir: string): string {
+  return workspaceDir;
+}
+
+/**
+ * Retrieve the persisted git hooks trust decision for a workspace.
+ *
+ * Returns:
+ * - `"allow"` — user has explicitly trusted this workspace's hooks.
+ * - `"deny"`  — user has explicitly denied hook execution for this workspace.
+ * - `"ask"`   — no persisted decision; the user should be prompted.
+ */
+export function getGitHooksTrustDecision(
+  workspaceDir: string,
+): "allow" | "deny" | "ask" {
+  const pattern = patternForWorkspace(workspaceDir);
+  const rules = getAllRules();
+  for (const rule of rules) {
+    if (
+      rule.tool === GIT_HOOKS_TRUST_PSEUDO_TOOL &&
+      rule.pattern === pattern &&
+      (rule.decision === "allow" || rule.decision === "deny")
+    ) {
+      return rule.decision;
+    }
+  }
+  return "ask";
+}
+
+/**
+ * Persist a git hooks trust decision for a workspace.
+ *
+ * Idempotent: replaces any existing pseudo-rule for this workspace so there
+ * are never two conflicting entries.
+ *
+ * @param workspaceDir - Absolute path to the workspace directory.
+ * @param decision     - `"allow"` to trust hooks, `"deny"` to block them.
+ *                       Pass `undefined` to clear a previously stored decision.
+ */
+export function setGitHooksTrustDecision(
+  workspaceDir: string,
+  decision: "allow" | "deny" | undefined,
+): void {
+  const pattern = patternForWorkspace(workspaceDir);
+  if (decision === undefined) {
+    removePseudoRule(GIT_HOOKS_TRUST_PSEUDO_TOOL, pattern);
+    return;
+  }
+  upsertPseudoRule(
+    GIT_HOOKS_TRUST_PSEUDO_TOOL,
+    pattern,
+    workspaceDir,
+    decision,
+  );
+}
+
+// ─── Hook detection ──────────────────────────────────────────────────────────
+
+/**
+ * Minimal interface for the git service dependency used during hook detection.
+ * Accepting an interface rather than the concrete class keeps this module
+ * testable without spawning a real git subprocess.
+ */
+export interface GitServiceLike {
+  runReadOnlyGit(args: string[]): Promise<{ stdout: string; stderr: string }>;
+}
+
+/**
+ * The canonical set of standard git hook names.
+ * Only hooks in this list are considered "active" during detection — we
+ * intentionally ignore the `.sample` stubs that `git init` writes by default.
+ */
+const STANDARD_HOOK_NAMES = new Set([
+  "applypatch-msg",
+  "pre-applypatch",
+  "post-applypatch",
+  "pre-commit",
+  "prepare-commit-msg",
+  "commit-msg",
+  "post-commit",
+  "pre-rebase",
+  "post-checkout",
+  "post-merge",
+  "pre-push",
+  "pre-receive",
+  "update",
+  "post-receive",
+  "post-update",
+  "push-to-checkout",
+  "pre-auto-gc",
+  "post-rewrite",
+  "sendemail-validate",
+  "fsmonitor-watchman",
+  "p4-changelist",
+  "p4-prepare-changelist",
+  "p4-post-changelist",
+  "p4-pre-submit",
+  "post-index-change",
+]);
+
+export interface DetectedHooks {
+  /** Absolute paths to active (non-sample) hook files found. */
+  hookFiles: string[];
+  /** The resolved hooks directory path (either `.git/hooks` or `core.hooksPath`). */
+  hooksDir: string;
+  /** Whether any executable hook files were found (i.e. hooks are configured). */
+  hasHooks: boolean;
+}
+
+/**
+ * Detect whether a workspace has git hooks configured.
+ *
+ * Checks both the default `.git/hooks` directory and any `core.hooksPath`
+ * configured in the repo's git config.  Only files whose names match the
+ * canonical hook-name list are counted — this conservatively ignores the
+ * `.sample` stubs that `git init` installs by default.
+ *
+ * @param workspaceDir  - Absolute path to the workspace directory.
+ * @param gitService    - A `GitServiceLike` object whose `runReadOnlyGit` is
+ *                        used to read git config.  Pass the real
+ *                        `WorkspaceGitService` in production and a test double
+ *                        in unit tests.
+ */
+export async function detectConfiguredHooks(
+  workspaceDir: string,
+  gitService: GitServiceLike,
+): Promise<DetectedHooks> {
+  // 1. Resolve the effective hooks directory.
+  let hooksDir = join(workspaceDir, ".git", "hooks");
+  try {
+    const { stdout } = await gitService.runReadOnlyGit([
+      "config",
+      "--local",
+      "core.hooksPath",
+    ]);
+    const customPath = stdout.trim();
+    if (customPath) {
+      // Resolve relative paths against the workspace directory.
+      hooksDir = customPath.startsWith("/")
+        ? customPath
+        : join(workspaceDir, customPath);
+    }
+  } catch {
+    // core.hooksPath not set — fall back to the default .git/hooks directory.
+  }
+
+  // 2. Scan the hooks directory for active (non-sample) hook files.
+  const hookFiles: string[] = [];
+
+  if (existsSync(hooksDir)) {
+    const { readdirSync, statSync } = await import("node:fs");
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(hooksDir);
+    } catch {
+      // Directory exists but is not readable — treat as no hooks.
+    }
+
+    for (const entry of entries) {
+      if (!STANDARD_HOOK_NAMES.has(entry)) continue;
+      const fullPath = join(hooksDir, entry);
+      try {
+        const stat = statSync(fullPath);
+        if (stat.isFile()) {
+          hookFiles.push(fullPath);
+        }
+      } catch {
+        // File disappeared between readdir and stat — ignore.
+      }
+    }
+  }
+
+  return {
+    hookFiles,
+    hooksDir,
+    hasHooks: hookFiles.length > 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Create git-hooks-trust.ts with getGitHooksTrustDecision, setGitHooksTrustDecision, and detectConfiguredHooks APIs
- Persist trust decisions using a reserved pseudo-tool key in trust rules (workspace-scoped)
- Add unit tests for tri-state lookup and hook detection edge cases

Part of plan: git-hooks-trust-prompt-exploit-fix.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
