### PR TITLE
fix(lint): sort imports in memory/retriever.ts

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -46,7 +46,7 @@ import {
   rerankWithLLM,
 } from "./search/ranking.js";
 import { isQdrantConnectionError, semanticSearch } from "./search/semantic.js";
-import { computeStaleness, applyStaleDemotion } from "./search/staleness.js";
+import { applyStaleDemotion, computeStaleness } from "./search/staleness.js";
 import { classifyTiers } from "./search/tier-classifier.js";
 import type {
   Candidate,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/memory/retriever.ts` by alphabetizing named imports from `./search/staleness.js`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23018726819/job/66849010419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
