### PR TITLE
feat: add structured tags to daemon Sentry events

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -26,6 +26,10 @@ import { estimatePromptTokens } from "../context/token-estimator.js";
 import type { ContextWindowManager } from "../context/window-manager.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
+import {
+  clearSentrySessionContext,
+  setSentrySessionContext,
+} from "../instrument.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles } from "../memory/app-store.js";
 import {
@@ -349,6 +353,18 @@ export async function runAgentLoopImpl(
 
   ctx.profiler.startRequest();
   let turnStarted = false;
+
+  // Populate Sentry scope with session-specific tags so any exception
+  // captured during this turn (e.g. inside agent/loop.ts) can be
+  // filtered by conversation, assistant, or user in the dashboard.
+  setSentrySessionContext({
+    assistantId: ctx.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+    conversationId: ctx.conversationId,
+    messageCount: ctx.messages.length,
+    userIdentifier:
+      ctx.trustContext?.guardianPrincipalId ??
+      ctx.trustContext?.requesterExternalUserId,
+  });
 
   try {
     // Auto-complete stale interactive surfaces from previous turns.
@@ -1515,6 +1531,10 @@ export async function runAgentLoopImpl(
     }
 
     ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");
+
+    // Clear session tags so they don't leak into unrelated error captures
+    // (e.g. unhandledRejection from a different async chain).
+    clearSentrySessionContext();
   }
 }
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -1,4 +1,4 @@
-import { arch, platform, release } from "node:os";
+import { arch, hostname, platform, release } from "node:os";
 
 import * as Sentry from "@sentry/node";
 
@@ -47,12 +47,14 @@ export function initSentry(): void {
     dist: COMMIT_SHA,
     environment: APP_VERSION === "0.0.0-dev" ? "development" : "production",
     sendDefaultPii: false,
+    serverName: hostname(),
     initialScope: {
       tags: {
         commit: COMMIT_SHA,
         os_platform: platform(),
         os_release: release(),
         os_arch: arch(),
+        server_name: hostname(),
         runtime: "bun",
         runtime_version:
           typeof Bun !== "undefined" ? Bun.version : process.version,
@@ -89,4 +91,62 @@ export function initSentry(): void {
  */
 export async function closeSentry(): Promise<void> {
   await Sentry.close();
+}
+
+// ── Dynamic session-scoped Sentry tags ──────────────────────────────
+//
+// These tags change per conversation turn and are set on the current
+// Sentry scope before the agent loop runs. Any `Sentry.captureException`
+// call within that async execution chain (e.g. inside agent/loop.ts)
+// will inherit these tags, enabling filtering by conversation, session,
+// user, or assistant in the Sentry dashboard.
+
+/** Tag keys set by {@link setSentrySessionContext}. */
+const SESSION_TAG_KEYS = [
+  "assistant_id",
+  "conversation_id",
+  "session_id",
+  "message_count",
+  "user_identifier",
+] as const;
+
+export interface SentrySessionContext {
+  /** Internal assistant ID (daemon uses 'self'). */
+  assistantId: string;
+  /** Conversation/session identifier. */
+  conversationId: string;
+  /** Number of messages in the conversation at time of the turn. */
+  messageCount: number;
+  /** Stable per-user identifier (guardian principal ID or similar). */
+  userIdentifier?: string;
+}
+
+/**
+ * Set session-scoped tags on the current Sentry scope.
+ *
+ * Call at the start of each agent loop turn so that any exceptions
+ * captured within the turn include conversation/session context.
+ */
+export function setSentrySessionContext(ctx: SentrySessionContext): void {
+  Sentry.setTag("assistant_id", ctx.assistantId);
+  Sentry.setTag("conversation_id", ctx.conversationId);
+  // session_id mirrors conversation_id — in this codebase they are the
+  // same value, but downstream Sentry users may search by either name.
+  Sentry.setTag("session_id", ctx.conversationId);
+  Sentry.setTag("message_count", String(ctx.messageCount));
+  if (ctx.userIdentifier) {
+    Sentry.setTag("user_identifier", ctx.userIdentifier);
+  }
+}
+
+/**
+ * Clear session-scoped tags from the current Sentry scope.
+ *
+ * Call in the finally block after the agent loop completes so tags
+ * from one conversation do not leak into unrelated error captures.
+ */
+export function clearSentrySessionContext(): void {
+  for (const key of SESSION_TAG_KEYS) {
+    Sentry.setTag(key, undefined);
+  }
 }


### PR DESCRIPTION
## Summary
- Add dynamic Sentry tags for assistant_id, conversation_id, session_id, message_count, and user_identifier to daemon events
- Enables filtering brain Sentry errors by user, assistant, or conversation without downloading logs
- Tags are set dynamically as session context changes, not just at init time
- Add server_name (hostname) as a static tag at Sentry init time for host-level filtering

Part of plan: sentry-observability-improvements.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
