### PR TITLE
feat: improve log report Sentry issue grouping by error category

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -77,10 +77,13 @@ enum LogExporter {
                     tags["session_id"] = sessionId
                 }
             }
+            var errorCategoryString: String?
             if let vm = threadManager?.activeViewModel {
                 extra["message_count"] = vm.messages.count
                 if let sessionError = vm.sessionError {
-                    tags["session_error_category"] = "\(sessionError.category)"
+                    let category = "\(sessionError.category)"
+                    tags["session_error_category"] = category
+                    errorCategoryString = category
                     if let debugDetails = sessionError.debugDetails {
                         tags["session_error_debug_details"] = debugDetails
                     }
@@ -98,9 +101,11 @@ enum LogExporter {
             }
 
             event.tags = tags
-            // Group all reports by reason so different user messages don't
-            // fragment into separate Sentry issues.
-            event.fingerprint = ["log_report", formData.reason.rawValue]
+            // Group reports by reason and error category so different root
+            // causes (e.g. providerApi vs contextTooLarge) create separate
+            // Sentry issues instead of being mixed into one.
+            let categoryComponent = errorCategoryString ?? "none"
+            event.fingerprint = ["log_report", formData.reason.rawValue, categoryComponent]
 
             // User-provided context (message, email, category) is sent via
             // Sentry's UserFeedback API, linked to the event. This keeps PII


### PR DESCRIPTION
## Summary
- Add Sentry fingerprinting based on sessionErrorCategory to separate different root causes into distinct issues
- Captures error category from the active ChatViewModel (building on PR 2's context enrichment) and uses it as the third fingerprint component
- Fingerprint format: `["log_report", reason, errorCategory]` — so e.g. `providerApi` vs `contextTooLarge` create separate Sentry issues
- When no session error is active, uses `"none"` as the category component

Part of plan: sentry-observability-improvements.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
