### PR TITLE
fix(types): update CLI memory_recalled display for V2 retrieval fields

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -637,7 +637,7 @@ export async function startCli(): Promise<void> {
       case "memory_recalled":
         spinner.stop();
         process.stdout.write(
-          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | lexical ${msg.lexicalHits} | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | entity ${msg.entityHits} | merged ${msg.mergedCount} → selected ${msg.selectedCount}${msg.rerankApplied ? " (reranked)" : ""} | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
+          `\n\x1B[2m[Memory recalled: ${msg.injectedTokens} tokens | semantic ${msg.semanticHits} | recency ${msg.recencyHits} | tier1 ${msg.tier1Count} | tier2 ${msg.tier2Count} | merged ${msg.mergedCount} → selected ${msg.selectedCount} | hybrid ${msg.hybridSearchMs}ms | ${msg.provider}/${msg.model} | ${msg.latencyMs}ms]\x1B[0m\n`,
         );
         spinner.start("Thinking...");
         break;


### PR DESCRIPTION
## Summary
- Updated the `memory_recalled` CLI display string in `cli.ts` to use the current `MemoryRecalled` interface fields (`tier1Count`, `tier2Count`, `hybridSearchMs`) instead of the removed fields (`lexicalHits`, `entityHits`, `rerankApplied`).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23019130414/job/66850446316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
