### PR TITLE
fix(test): add missing memory config fields to test mocks

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -131,6 +131,13 @@ mock.module("../config/loader.js", () => ({
           targetHeadroomTokens: 10000,
         },
       },
+      embeddings: {
+        provider: "auto",
+        required: true,
+      },
+      entity: {
+        enabled: false,
+      },
       conflicts: {
         enabled: true,
         gateMode: "soft",

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -80,6 +80,13 @@ mock.module("../config/loader.js", () => ({
           targetHeadroomTokens: 10000,
         },
       },
+      embeddings: {
+        provider: "auto",
+        required: true,
+      },
+      entity: {
+        enabled: false,
+      },
       conflicts: {
         enabled: false,
         gateMode: "soft",


### PR DESCRIPTION
## Summary
- Add missing `memory.embeddings` and `memory.entity` fields to mock configs in `session-conflict-gate.test.ts` and `session-profile-injection.test.ts`
- These fields are required by `buildConfigFingerprint()` in `retriever.ts` after the V2 retrieval pipeline rewire

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23019130414/job/66850446398

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
