### PR TITLE
feat: enable auto-commit hooks only for explicitly trusted workspaces

### DIFF
--- a/assistant/src/__tests__/workspace-git-service-hook-trust.test.ts
+++ b/assistant/src/__tests__/workspace-git-service-hook-trust.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the policy-based hook execution in WorkspaceGitService.
+ *
+ * These tests verify that:
+ * - When the trust decision is "allow", git hooks execute normally.
+ * - When the trust decision is "deny" or "ask", git hooks are suppressed.
+ *
+ * They use mock.module to control the getGitHooksTrustDecision return value
+ * without touching the real trust store on disk.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ─── Mocks (must be declared before imports that transitively load them) ──────
+
+// Control the trust decision for each test via this variable.
+let mockDecision: "allow" | "deny" | "ask" = "ask";
+
+mock.module("../workspace/git-hooks-trust.js", () => ({
+  getGitHooksTrustDecision: (_workspaceDir: string) => mockDecision,
+  setGitHooksTrustDecision: () => {},
+  detectConfiguredHooks: async () => ({
+    hookFiles: [],
+    hooksDir: "",
+    hasHooks: false,
+  }),
+  GIT_HOOKS_TRUST_PSEUDO_TOOL: "__internal:git-hooks-trust",
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import {
+  _resetGitServiceRegistry,
+  WorkspaceGitService,
+} from "../workspace/git-service.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Write an executable hook script that touches a sentinel file when it runs.
+ * This lets us detect whether a hook was executed.
+ */
+function installHook(
+  repoDir: string,
+  hookName: string,
+  sentinelPath: string,
+): void {
+  const hooksDir = join(repoDir, ".git", "hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  const hookPath = join(hooksDir, hookName);
+  writeFileSync(hookPath, `#!/bin/sh\ntouch "${sentinelPath}"\nexit 0\n`, {
+    mode: 0o755,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("WorkspaceGitService — hook trust policy", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `vellum-hook-trust-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+    _resetGitServiceRegistry();
+    // Reset decision to fail-closed default before each test.
+    mockDecision = "ask";
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('decision: "deny" — hooks suppressed', () => {
+    test("commitChanges does not run pre-commit hook when decision is deny", async () => {
+      mockDecision = "deny";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: deny suppresses pre-commit");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitIfDirty does not run pre-commit hook when decision is deny", async () => {
+      mockDecision = "deny";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty content");
+      const result = await service.commitIfDirty(() => ({
+        message: "test: deny suppresses pre-commit in commitIfDirty",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+  });
+
+  describe('decision: "ask" — hooks suppressed (fail-closed default)', () => {
+    test("commitChanges does not run pre-commit hook when decision is ask", async () => {
+      mockDecision = "ask";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: ask suppresses pre-commit");
+
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("commitIfDirty does not run pre-commit hook when decision is ask", async () => {
+      mockDecision = "ask";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty content");
+      const result = await service.commitIfDirty(() => ({
+        message: "test: ask suppresses pre-commit in commitIfDirty",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+  });
+
+  describe('decision: "allow" — hooks execute for trusted workspaces', () => {
+    test("commitChanges runs pre-commit hook when decision is allow", async () => {
+      mockDecision = "allow";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: allow enables pre-commit");
+
+      expect(existsSync(sentinel)).toBe(true);
+    });
+
+    test("commitChanges runs post-commit hook when decision is allow", async () => {
+      mockDecision = "allow";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "post-commit-ran.marker");
+      installHook(testDir, "post-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: allow enables post-commit");
+
+      expect(existsSync(sentinel)).toBe(true);
+    });
+
+    test("commitIfDirty runs pre-commit hook when decision is allow", async () => {
+      mockDecision = "allow";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty content");
+      const result = await service.commitIfDirty(() => ({
+        message: "test: allow enables pre-commit in commitIfDirty",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(true);
+    });
+
+    test("hooks do not run for untrusted workspace when another workspace is trusted (decision is workspace-scoped)", async () => {
+      // This test verifies that the decision is per-workspace. Since mock returns
+      // the same decision for all dirs, we verify by testing deny path in sequence.
+
+      // First, verify allow path works
+      mockDecision = "allow";
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const allowSentinel = join(testDir, "hook-allow.marker");
+      installHook(testDir, "pre-commit", allowSentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "v1");
+      await service.commitChanges("test: allow mode");
+      expect(existsSync(allowSentinel)).toBe(true);
+
+      // Now switch to deny and verify hooks are suppressed on next commit
+      mockDecision = "deny";
+      writeFileSync(join(testDir, "file.txt"), "v2");
+      await service.commitChanges("test: deny mode");
+
+      // The sentinel was already created in allow mode — use a second sentinel
+      // to verify no additional hook execution occurs in deny mode.
+      const denySentinel = join(testDir, "hook-deny.marker");
+      // Replace the hook with one that writes the deny sentinel
+      installHook(testDir, "pre-commit", denySentinel);
+      writeFileSync(join(testDir, "file.txt"), "v3");
+      await service.commitChanges("test: deny suppresses second hook");
+      expect(existsSync(denySentinel)).toBe(false);
+    });
+  });
+});

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { PromiseGuard } from "../util/promise-guard.js";
+import { getGitHooksTrustDecision } from "./git-hooks-trust.js";
 
 const execFileAsync = promisify(execFile);
 const log = getLogger("workspace-git");
@@ -163,7 +164,7 @@ const EMPTY_HOOKS_PATH = "/dev/null";
  * - Mutex-protected operations: prevents concurrent git command conflicts
  * - Handles both new and existing workspaces transparently
  * - Synchronous initial commit within mutex to prevent races
- * - Fail-closed hook policy: auto-commits never run repository hooks
+ * - Policy-based hook execution: hooks run only for explicitly trusted workspaces
  */
 export class WorkspaceGitService {
   private readonly workspaceDir: string;
@@ -795,20 +796,39 @@ export class WorkspaceGitService {
   }
 
   /**
-   * Execute a git commit command with hooks suppressed via `core.hooksPath`.
+   * Execute a git commit command with policy-based hook execution.
    *
-   * All workspace auto-commits go through this helper so that repository
-   * hook scripts (pre-commit, commit-msg, post-commit, etc.) are never
-   * executed without an explicit user trust decision.
+   * Consults `getGitHooksTrustDecision(workspaceDir)` to decide whether hooks
+   * should run for this commit:
    *
-   * Uses `-c core.hooksPath=<EMPTY_HOOKS_PATH>` rather than `--no-verify`
-   * because `--no-verify` only suppresses pre-commit and commit-msg hooks
-   * while leaving post-commit hooks (and others) intact.
+   * - `"allow"`: the user has explicitly trusted this workspace. Commits run
+   *   without any hook override so repository hooks execute normally.
+   * - `"deny"` / `"ask"`: hooks are suppressed via
+   *   `-c core.hooksPath=<EMPTY_HOOKS_PATH>`. This is the fail-closed default
+   *   for untrusted or undecided workspaces.
+   *
+   * Using `-c core.hooksPath=…` is intentionally stronger than `--no-verify`,
+   * which only suppresses pre-commit and commit-msg hooks and leaves
+   * post-commit hooks (and others) intact.
    */
   private async execGitCommit(
     commitArgs: string[],
     options?: { signal?: AbortSignal },
   ): Promise<{ stdout: string; stderr: string }> {
+    const decision = getGitHooksTrustDecision(this.workspaceDir);
+
+    if (decision === "allow") {
+      log.debug(
+        { workspaceDir: this.workspaceDir, hooks_enabled: true },
+        "Running commit with hooks enabled (trusted workspace)",
+      );
+      return this.execGit(["commit", ...commitArgs], options);
+    }
+
+    log.debug(
+      { workspaceDir: this.workspaceDir, hooks_suppressed: true, decision },
+      "Running commit with hooks suppressed (untrusted workspace)",
+    );
     return this.execGit(
       ["-c", `core.hooksPath=${EMPTY_HOOKS_PATH}`, "commit", ...commitArgs],
       options,


### PR DESCRIPTION
## Summary
- Replace unconditional hook suppression with policy-based behavior using getGitHooksTrustDecision
- Add hooks_enabled/hooks_suppressed logging for observability
- Add tests for both allow and deny decisions with marker-producing hook scripts

Part of plan: git-hooks-trust-prompt-exploit-fix.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
