### PR TITLE
feat: add specific user-facing error messages for provider errors

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -276,6 +276,7 @@ mock.module("../daemon/session-error.js", () => ({
     code: "SESSION_PROCESSING_FAILED",
     userMessage: "Something went wrong processing your message.",
     retryable: false,
+    errorCategory: "processing_failed",
   }),
   isUserCancellation: (err: unknown, ctx: { aborted?: boolean }) => {
     if (!ctx.aborted) return false;

--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -77,6 +77,7 @@ describe("classifySessionError", () => {
         const result = classifySessionError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_NETWORK");
         expect(result.retryable).toBe(true);
+        expect(result.errorCategory).toBe("provider_network");
       });
     }
   });
@@ -95,6 +96,8 @@ describe("classifySessionError", () => {
         const result = classifySessionError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_RATE_LIMIT");
         expect(result.retryable).toBe(true);
+        expect(result.userMessage).toContain("busy");
+        expect(result.errorCategory).toBe("rate_limit");
       });
     }
   });
@@ -127,6 +130,7 @@ describe("classifySessionError", () => {
         expect(result.code).toBe("PROVIDER_API");
         expect(result.userMessage).toContain("timed out");
         expect(result.retryable).toBe(true);
+        expect(result.errorCategory).toBe("provider_timeout");
       });
     }
 
@@ -166,6 +170,8 @@ describe("classifySessionError", () => {
         const result = classifySessionError(new Error(msg), baseCtx);
         expect(result.code).toBe("CONTEXT_TOO_LARGE");
         expect(result.retryable).toBe(false);
+        expect(result.userMessage).toContain("too long");
+        expect(result.errorCategory).toBe("context_too_large");
       });
     }
   });
@@ -205,6 +211,71 @@ describe("classifySessionError", () => {
     });
   });
 
+  describe("ordering errors (tool_use/tool_result mismatches)", () => {
+    const cases = [
+      "tool_result block not immediately after tool_use block",
+      "tool_use block must have a matching tool_result",
+      "tool_use_id abc123 without corresponding tool_result",
+      "tool_result references tool_use_id not found in conversation",
+      "messages have invalid order",
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_ORDERING`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe("PROVIDER_ORDERING");
+        expect(result.retryable).toBe(true);
+        expect(result.userMessage).toBe(
+          "An internal error occurred. Retrying...",
+        );
+        expect(result.errorCategory).toBe("tool_ordering");
+      });
+    }
+
+    it("classifies ProviderError 400 with ordering message as PROVIDER_ORDERING", () => {
+      const err = new ProviderError(
+        "Anthropic API error (400): tool_use_id abc without tool_result",
+        "anthropic",
+        400,
+      );
+      const result = classifySessionError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_ORDERING");
+      expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("tool_ordering");
+    });
+  });
+
+  describe("web search ordering errors", () => {
+    const cases = [
+      "web_search tool_use block without result",
+      "web_search tool_result missing from conversation",
+    ];
+
+    for (const msg of cases) {
+      it(`classifies "${msg}" as PROVIDER_WEB_SEARCH`, () => {
+        const result = classifySessionError(new Error(msg), baseCtx);
+        expect(result.code).toBe("PROVIDER_WEB_SEARCH");
+        expect(result.retryable).toBe(true);
+        expect(result.userMessage).toBe(
+          "An internal error occurred with web search. Retrying...",
+        );
+        expect(result.errorCategory).toBe("web_search_ordering");
+      });
+    }
+
+    it("classifies ProviderError 400 with web_search ordering message as PROVIDER_WEB_SEARCH", () => {
+      const err = new ProviderError(
+        "Anthropic API error (400): web_search tool_use without result block",
+        "anthropic",
+        400,
+      );
+      const result = classifySessionError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_WEB_SEARCH");
+      expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("web_search_ordering");
+    });
+  });
+
   describe("abort/cancel errors (non-user-initiated)", () => {
     it('classifies "aborted" as SESSION_ABORTED', () => {
       const result = classifySessionError(
@@ -232,6 +303,7 @@ describe("classifySessionError", () => {
       expect(result.code).toBe("REGENERATE_FAILED");
       expect(result.retryable).toBe(true);
       expect(result.userMessage).toContain("regenerate");
+      expect(result.errorCategory).toContain("regenerate:");
     });
 
     it("returns REGENERATE_FAILED for generic errors", () => {
@@ -251,6 +323,7 @@ describe("classifySessionError", () => {
       expect(result.code).toBe("SESSION_PROCESSING_FAILED");
       expect(result.retryable).toBe(false);
       expect(result.userMessage).toContain("something completely unexpected");
+      expect(result.errorCategory).toBe("processing_failed");
     });
 
     it("includes debugDetails with stack trace", () => {
@@ -291,6 +364,7 @@ describe("classifySessionError", () => {
       const result = classifySessionError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_RATE_LIMIT");
       expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("rate_limit");
     });
 
     it("classifies ProviderError with 500 as PROVIDER_API (retryable)", () => {
@@ -344,19 +418,39 @@ describe("classifySessionError", () => {
     });
   });
 
+  describe("errorCategory is always present", () => {
+    it("includes errorCategory on all classified errors", () => {
+      const cases: Array<{ error: unknown; ctx: ErrorContext }> = [
+        { error: new Error("ECONNREFUSED"), ctx: baseCtx },
+        { error: new Error("rate limit"), ctx: baseCtx },
+        { error: new Error("prompt is too long"), ctx: baseCtx },
+        { error: new Error("unknown"), ctx: baseCtx },
+        {
+          error: new ProviderError("error", "anthropic", 500),
+          ctx: baseCtx,
+        },
+      ];
+      for (const { error, ctx } of cases) {
+        const result = classifySessionError(error, ctx);
+        expect(result.errorCategory).toBeDefined();
+        expect(result.errorCategory.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
   describe("debug detail truncation", () => {
     it("truncates debugDetails longer than 4000 chars", () => {
       const longMsg = "x".repeat(5000);
       const result = classifySessionError(new Error(longMsg), baseCtx);
       expect(result.debugDetails!.length).toBeLessThanOrEqual(4020); // 4000 + truncation marker
-      expect(result.debugDetails!).toContain("… (truncated)");
+      expect(result.debugDetails!).toContain("(truncated)");
     });
 
     it("preserves debugDetails under 4000 chars", () => {
       const shortMsg = "short error message";
       const result = classifySessionError(new Error(shortMsg), baseCtx);
       expect(result.debugDetails).toBeDefined();
-      expect(result.debugDetails!).not.toContain("… (truncated)");
+      expect(result.debugDetails!).not.toContain("(truncated)");
     });
   });
 
@@ -391,6 +485,7 @@ describe("buildSessionErrorMessage", () => {
       userMessage: "Network error",
       retryable: true,
       debugDetails: "ECONNREFUSED",
+      errorCategory: "provider_network",
     });
 
     expect(msg.type).toBe("session_error");
@@ -399,6 +494,7 @@ describe("buildSessionErrorMessage", () => {
     expect(msg.userMessage).toBe("Network error");
     expect(msg.retryable).toBe(true);
     expect(msg.debugDetails).toBe("ECONNREFUSED");
+    expect(msg.errorCategory).toBe("provider_network");
   });
 
   it("omits debugDetails when not provided", () => {
@@ -406,9 +502,35 @@ describe("buildSessionErrorMessage", () => {
       code: "UNKNOWN",
       userMessage: "Something went wrong",
       retryable: false,
+      errorCategory: "processing_failed",
     });
 
     expect(msg.type).toBe("session_error");
     expect(msg.debugDetails).toBeUndefined();
+    expect(msg.errorCategory).toBe("processing_failed");
+  });
+
+  it("includes errorCategory for ordering errors", () => {
+    const msg = buildSessionErrorMessage("session-789", {
+      code: "PROVIDER_ORDERING",
+      userMessage: "An internal error occurred. Retrying...",
+      retryable: true,
+      errorCategory: "tool_ordering",
+    });
+
+    expect(msg.errorCategory).toBe("tool_ordering");
+    expect(msg.code).toBe("PROVIDER_ORDERING");
+  });
+
+  it("includes errorCategory for web search errors", () => {
+    const msg = buildSessionErrorMessage("session-abc", {
+      code: "PROVIDER_WEB_SEARCH",
+      userMessage: "An internal error occurred with web search. Retrying...",
+      retryable: true,
+      errorCategory: "web_search_ordering",
+    });
+
+    expect(msg.errorCategory).toBe("web_search_ordering");
+    expect(msg.code).toBe("PROVIDER_WEB_SEARCH");
   });
 });

--- a/assistant/src/daemon/message-types/sessions.ts
+++ b/assistant/src/daemon/message-types/sessions.ts
@@ -394,6 +394,8 @@ export type SessionErrorCode =
   | "PROVIDER_RATE_LIMIT"
   | "PROVIDER_API"
   | "PROVIDER_BILLING"
+  | "PROVIDER_ORDERING"
+  | "PROVIDER_WEB_SEARCH"
   | "CONTEXT_TOO_LARGE"
   | "SESSION_ABORTED"
   | "SESSION_PROCESSING_FAILED"
@@ -407,6 +409,8 @@ export interface SessionErrorMessage {
   userMessage: string;
   retryable: boolean;
   debugDetails?: string;
+  /** Machine-readable error category for log report metadata and triage. */
+  errorCategory?: string;
 }
 
 /** Server push — broadcast when a schedule creates a conversation, so the client can show it as a chat thread. */

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -601,6 +601,14 @@ export function handleError(
     });
     if (classified.code === "CONTEXT_TOO_LARGE") {
       state.contextTooLargeDetected = true;
+    } else if (
+      classified.code === "PROVIDER_ORDERING" ||
+      classified.code === "PROVIDER_WEB_SEARCH"
+    ) {
+      // Ordering errors detected via classifySessionError (e.g. from ProviderError
+      // with statusCode 400 and ordering message) — trigger the retry path.
+      state.orderingErrorDetected = true;
+      state.deferredOrderingError = event.error.message;
     } else {
       deps.onEvent(
         buildSessionErrorMessage(deps.ctx.conversationId, classified),

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1289,8 +1289,7 @@ export async function runAgentLoopImpl(
           recall.injectedText,
           "separate_context_message",
         ),
-      stripDynamicProfile: (msgs) =>
-        stripDynamicProfileMessages(msgs, ""),
+      stripDynamicProfile: (msgs) => stripDynamicProfileMessages(msgs, ""),
     });
 
     emitUsage(
@@ -1458,12 +1457,17 @@ export async function runAgentLoopImpl(
       const message = err instanceof Error ? err.message : String(err);
       const errorClass = err instanceof Error ? err.constructor.name : "Error";
       rlog.error({ err }, "Session processing error");
+      const classified = classifySessionError(err, errorCtx);
       ctx.traceEmitter.emit("request_error", truncate(message, 200, ""), {
         requestId: reqId,
         status: "error",
-        attributes: { errorClass, message: truncate(message, 500, "") },
+        attributes: {
+          errorClass,
+          message: truncate(message, 500, ""),
+          errorCategory: classified.errorCategory,
+          errorCode: classified.code,
+        },
       });
-      const classified = classifySessionError(err, errorCtx);
       onEvent({ type: "error", message: classified.userMessage });
       onEvent(buildSessionErrorMessage(ctx.conversationId, classified));
       void getHookManager().trigger("on-error", {

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -12,6 +12,8 @@ export interface ClassifiedSessionError {
   userMessage: string;
   retryable: boolean;
   debugDetails?: string;
+  /** Machine-readable error category for log report metadata and triage. */
+  errorCategory: string;
 }
 
 // Network-level error patterns (connection refused, timeout, DNS, reset)
@@ -66,6 +68,21 @@ const PROVIDER_API_PATTERNS = [
   /bad gateway/i,
   /service unavailable/i,
   /gateway timeout/i,
+];
+
+// Provider ordering error patterns (tool_use/tool_result mismatches)
+const ORDERING_ERROR_PATTERNS = [
+  /tool_result.*not immediately after.*tool_use/i,
+  /tool_use.*must have.*tool_result/i,
+  /tool_use_id.*without.*tool_result/i,
+  /tool_result.*tool_use_id.*not found/i,
+  /messages.*invalid.*order/i,
+];
+
+// Web-search-specific ordering error patterns
+const WEB_SEARCH_ORDERING_PATTERNS = [
+  /web_search.*tool_use.*without/i,
+  /web_search.*tool_result/i,
 ];
 
 // User-initiated cancellation patterns — these should NOT produce session_error
@@ -131,6 +148,7 @@ export function classifySessionError(
       userMessage: `Could not regenerate the response. ${base.userMessage}`,
       retryable: true,
       debugDetails,
+      errorCategory: `regenerate:${base.errorCategory}`,
     };
   }
 
@@ -155,8 +173,10 @@ function classifyCore(
     if (error.statusCode === 413) {
       return {
         code: "CONTEXT_TOO_LARGE",
-        userMessage: "This conversation exceeds the model's context limit.",
+        userMessage:
+          "This conversation is too long. Please start a new thread.",
         retryable: false,
+        errorCategory: "context_too_large",
       };
     }
     if (error.statusCode === 401) {
@@ -164,13 +184,15 @@ function classifyCore(
         code: "PROVIDER_BILLING",
         userMessage: "Your API key is invalid or expired.",
         retryable: false,
+        errorCategory: "provider_billing",
       };
     }
     if (error.statusCode === 429) {
       return {
         code: "PROVIDER_RATE_LIMIT",
-        userMessage: "The AI provider is rate limiting requests.",
+        userMessage: "The AI provider is busy. Please try again in a moment.",
         retryable: true,
+        errorCategory: "rate_limit",
       };
     }
     if (error.statusCode >= 500) {
@@ -178,15 +200,35 @@ function classifyCore(
         code: "PROVIDER_API",
         userMessage: "The AI provider returned a server error.",
         retryable: true,
+        errorCategory: "provider_server_error",
       };
     }
-    // 4xx (non-429) — check for context-too-large before generic fallback
+    // 4xx (non-429) — check for context-too-large, ordering errors, then generic fallback
     if (error.statusCode >= 400) {
       if (isContextTooLarge(message)) {
         return {
           code: "CONTEXT_TOO_LARGE",
-          userMessage: "This conversation exceeds the model's context limit.",
+          userMessage:
+            "This conversation is too long. Please start a new thread.",
           retryable: false,
+          errorCategory: "context_too_large",
+        };
+      }
+      if (isWebSearchOrderingError(message)) {
+        return {
+          code: "PROVIDER_WEB_SEARCH",
+          userMessage:
+            "An internal error occurred with web search. Retrying...",
+          retryable: true,
+          errorCategory: "web_search_ordering",
+        };
+      }
+      if (isOrderingError(message)) {
+        return {
+          code: "PROVIDER_ORDERING",
+          userMessage: "An internal error occurred. Retrying...",
+          retryable: true,
+          errorCategory: "tool_ordering",
         };
       }
       if (/credit balance is too low|insufficient.*credits?/i.test(message)) {
@@ -194,6 +236,7 @@ function classifyCore(
           code: "PROVIDER_BILLING",
           userMessage: "Your API key has insufficient credits.",
           retryable: false,
+          errorCategory: "provider_billing",
         };
       }
       if (
@@ -205,12 +248,14 @@ function classifyCore(
           code: "PROVIDER_BILLING",
           userMessage: "Your API key is invalid.",
           retryable: false,
+          errorCategory: "provider_billing",
         };
       }
       return {
         code: "PROVIDER_API",
         userMessage: "The AI provider rejected the request.",
         retryable: true,
+        errorCategory: "provider_api_error",
       };
     }
   }
@@ -224,6 +269,16 @@ export function isContextTooLarge(message: string): boolean {
   return CONTEXT_TOO_LARGE_PATTERNS.some((p) => p.test(message));
 }
 
+/** Check whether an error message indicates a web-search-specific ordering failure. */
+export function isWebSearchOrderingError(message: string): boolean {
+  return WEB_SEARCH_ORDERING_PATTERNS.some((p) => p.test(message));
+}
+
+/** Check whether an error message indicates a tool_use/tool_result ordering failure. */
+export function isOrderingError(message: string): boolean {
+  return ORDERING_ERROR_PATTERNS.some((p) => p.test(message));
+}
+
 function classifyByMessage(
   message: string,
 ): Omit<ClassifiedSessionError, "debugDetails"> {
@@ -231,8 +286,9 @@ function classifyByMessage(
   if (isContextTooLarge(message)) {
     return {
       code: "CONTEXT_TOO_LARGE",
-      userMessage: "This conversation exceeds the model's context limit.",
+      userMessage: "This conversation is too long. Please start a new thread.",
       retryable: false,
+      errorCategory: "context_too_large",
     };
   }
 
@@ -241,10 +297,31 @@ function classifyByMessage(
     if (pattern.test(message)) {
       return {
         code: "PROVIDER_RATE_LIMIT",
-        userMessage: "The AI provider is rate limiting requests.",
+        userMessage: "The AI provider is busy. Please try again in a moment.",
         retryable: true,
+        errorCategory: "rate_limit",
       };
     }
+  }
+
+  // Web-search ordering errors (before general ordering errors)
+  if (isWebSearchOrderingError(message)) {
+    return {
+      code: "PROVIDER_WEB_SEARCH",
+      userMessage: "An internal error occurred with web search. Retrying...",
+      retryable: true,
+      errorCategory: "web_search_ordering",
+    };
+  }
+
+  // General tool_use/tool_result ordering errors
+  if (isOrderingError(message)) {
+    return {
+      code: "PROVIDER_ORDERING",
+      userMessage: "An internal error occurred. Retrying...",
+      retryable: true,
+      errorCategory: "tool_ordering",
+    };
   }
 
   // Network errors (before timeout so "connection timeout" is classified as network)
@@ -254,6 +331,7 @@ function classifyByMessage(
         code: "PROVIDER_NETWORK",
         userMessage: "Could not connect to the AI provider.",
         retryable: true,
+        errorCategory: "provider_network",
       };
     }
   }
@@ -265,6 +343,7 @@ function classifyByMessage(
         code: "PROVIDER_API",
         userMessage: "The AI provider returned a server error.",
         retryable: true,
+        errorCategory: "provider_server_error",
       };
     }
   }
@@ -277,6 +356,7 @@ function classifyByMessage(
         code: "PROVIDER_API",
         userMessage: "The request to the AI provider timed out.",
         retryable: true,
+        errorCategory: "provider_timeout",
       };
     }
   }
@@ -288,6 +368,7 @@ function classifyByMessage(
         code: "SESSION_ABORTED",
         userMessage: "The request was interrupted.",
         retryable: true,
+        errorCategory: "session_aborted",
       };
     }
   }
@@ -308,6 +389,7 @@ function classifyByMessage(
     code: "SESSION_PROCESSING_FAILED",
     userMessage,
     retryable: false,
+    errorCategory: "processing_failed",
   };
 }
 
@@ -325,5 +407,6 @@ export function buildSessionErrorMessage(
     userMessage: classified.userMessage,
     retryable: classified.retryable,
     debugDetails: classified.debugDetails,
+    errorCategory: classified.errorCategory,
   };
 }

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -614,6 +614,7 @@ export function handleSurfaceAction(
             userMessage: `Something went wrong: ${message}`,
             retryable: false,
             debugDetails: `History-restored relay prompt processing failed: ${message}`,
+            errorCategory: "processing_failed",
           }),
         );
       });

--- a/clients/shared/Features/Chat/ChatSessionError.swift
+++ b/clients/shared/Features/Chat/ChatSessionError.swift
@@ -6,6 +6,8 @@ public enum SessionErrorCategory: Equatable, Sendable {
     case rateLimit
     case providerApi
     case providerBilling
+    case providerOrdering
+    case providerWebSearch
     case contextTooLarge
     case sessionAborted
     case processingFailed
@@ -23,6 +25,10 @@ public enum SessionErrorCategory: Equatable, Sendable {
             self = .providerApi
         case .providerBilling:
             self = .providerBilling
+        case .providerOrdering:
+            self = .providerOrdering
+        case .providerWebSearch:
+            self = .providerWebSearch
         case .contextTooLarge:
             self = .contextTooLarge
         case .sessionAborted:
@@ -49,6 +55,10 @@ public enum SessionErrorCategory: Equatable, Sendable {
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
             return "Please add credits to your account or update your API key in Settings."
+        case .providerOrdering:
+            return "This is usually temporary — click Retry to continue."
+        case .providerWebSearch:
+            return "This is usually temporary — click Retry to continue."
         case .contextTooLarge:
             return "Start a new thread to reset context, or try a shorter message."
         case .sessionAborted:
@@ -73,6 +83,8 @@ public struct SessionError: Equatable {
     public let recoverySuggestion: String
     public let sessionId: String
     public let debugDetails: String?
+    /// Machine-readable error category for log report metadata and triage.
+    public let errorCategory: String?
 
     public init(from msg: SessionErrorMessage) {
         self.category = SessionErrorCategory(from: msg.code)
@@ -81,14 +93,16 @@ public struct SessionError: Equatable {
         self.recoverySuggestion = self.category.recoverySuggestion
         self.sessionId = msg.sessionId
         self.debugDetails = msg.debugDetails
+        self.errorCategory = msg.errorCategory
     }
 
-    public init(category: SessionErrorCategory, message: String, isRetryable: Bool, sessionId: String, debugDetails: String? = nil) {
+    public init(category: SessionErrorCategory, message: String, isRetryable: Bool, sessionId: String, debugDetails: String? = nil, errorCategory: String? = nil) {
         self.category = category
         self.message = message
         self.isRetryable = isRetryable
         self.recoverySuggestion = category.recoverySuggestion
         self.sessionId = sessionId
         self.debugDetails = debugDetails
+        self.errorCategory = errorCategory
     }
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1255,6 +1255,8 @@ public enum SessionErrorCode: String, CaseIterable, Codable, Sendable {
     case providerRateLimit = "PROVIDER_RATE_LIMIT"
     case providerApi = "PROVIDER_API"
     case providerBilling = "PROVIDER_BILLING"
+    case providerOrdering = "PROVIDER_ORDERING"
+    case providerWebSearch = "PROVIDER_WEB_SEARCH"
     case contextTooLarge = "CONTEXT_TOO_LARGE"
     case sessionAborted = "SESSION_ABORTED"
     case sessionProcessingFailed = "SESSION_PROCESSING_FAILED"
@@ -1279,17 +1281,20 @@ public struct SessionErrorMessage: Decodable, Sendable {
     public let userMessage: String
     public let retryable: Bool
     public let debugDetails: String?
+    /// Machine-readable error category for log report metadata and triage.
+    public let errorCategory: String?
     /// Non-nil when the error is a client-side HTTP send failure.
     /// Contains the message content that failed to send, used to mark
     /// the specific user message as `.sendFailed` in the chat.
     public let failedMessageContent: String?
 
-    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil, failedMessageContent: String? = nil) {
+    public init(sessionId: String, code: SessionErrorCode, userMessage: String, retryable: Bool, debugDetails: String? = nil, errorCategory: String? = nil, failedMessageContent: String? = nil) {
         self.sessionId = sessionId
         self.code = code
         self.userMessage = userMessage
         self.retryable = retryable
         self.debugDetails = debugDetails
+        self.errorCategory = errorCategory
         self.failedMessageContent = failedMessageContent
     }
 }


### PR DESCRIPTION
## Summary
- Map ProviderError subtypes to distinct, actionable user-facing messages:
  - Context too large: "This conversation is too long. Please start a new thread."
  - Rate limit: "The AI provider is busy. Please try again in a moment."
  - Tool ordering errors: "An internal error occurred. Retrying..."
  - Web search errors: "An internal error occurred with web search. Retrying..."
- Add `errorCategory` field to `ClassifiedSessionError` and `SessionErrorMessage` for log report metadata and triage
- Include `errorCategory` and `errorCode` in trace event attributes for Sentry observability
- Add `PROVIDER_ORDERING` and `PROVIDER_WEB_SEARCH` session error codes with Swift client support

## Test plan
- [x] All 80 `session-error.test.ts` tests pass (including new ordering/web-search error tests)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes on all changed files
- [ ] CI validates Swift compilation
- [ ] Verify macOS client gracefully handles new error codes (falls back to `.unknown` for old clients)

Part of plan: sentry-observability-improvements.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
