### PR TITLE
feat: prompt user to trust project before enabling git hooks

### DIFF
--- a/assistant/src/__tests__/git-hooks-approval.test.ts
+++ b/assistant/src/__tests__/git-hooks-approval.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  GIT_HOOKS_TRUST_TOOL_NAME,
+  requestGitHooksTrustApproval,
+} from "../daemon/git-hooks-approval.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { UserDecision } from "../permissions/types.js";
+
+function createMockPrompter(decision: UserDecision): PermissionPrompter {
+  const promptFn = mock(() =>
+    Promise.resolve({
+      decision,
+      selectedPattern: undefined,
+      selectedScope: undefined,
+      decisionContext: undefined,
+    }),
+  );
+  return { prompt: promptFn } as unknown as PermissionPrompter;
+}
+
+describe("requestGitHooksTrustApproval", () => {
+  // ── Prompt shape ──
+
+  test("uses the reserved pseudo tool name", async () => {
+    const prompter = createMockPrompter("allow");
+    await requestGitHooksTrustApproval(prompter);
+
+    expect(prompter.prompt).toHaveBeenCalledTimes(1);
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    expect(args[0]).toBe(GIT_HOOKS_TRUST_TOOL_NAME);
+  });
+
+  test("passes medium risk level", async () => {
+    const prompter = createMockPrompter("allow");
+    await requestGitHooksTrustApproval(prompter);
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // riskLevel is the 3rd argument (index 2)
+    expect(args[2]).toBe("medium");
+  });
+
+  test("provides empty allowlist and scope options", async () => {
+    const prompter = createMockPrompter("allow");
+    await requestGitHooksTrustApproval(prompter);
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // allowlistOptions (index 3) and scopeOptions (index 4)
+    expect(args[3]).toEqual([]);
+    expect(args[4]).toEqual([]);
+  });
+
+  test("sets persistentDecisionsAllowed to false (one-shot prompt)", async () => {
+    const prompter = createMockPrompter("allow");
+    await requestGitHooksTrustApproval(prompter);
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // persistentDecisionsAllowed is index 9
+    expect(args[9]).toBe(false);
+  });
+
+  test("includes explicit user-facing description in the input", async () => {
+    const prompter = createMockPrompter("allow");
+    await requestGitHooksTrustApproval(prompter);
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // input is the 2nd argument (index 1)
+    const input = args[1] as Record<string, unknown>;
+    expect(typeof input.description).toBe("string");
+    expect(input.description).toContain("git hooks");
+    expect(input.description).toContain("trust");
+  });
+
+  // ── Decision mapping ──
+
+  test("maps allow decision to approved: true", async () => {
+    const prompter = createMockPrompter("allow");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: true });
+  });
+
+  test("maps deny decision to approved: false", async () => {
+    const prompter = createMockPrompter("deny");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: false });
+  });
+
+  test("maps always_deny decision to approved: false", async () => {
+    const prompter = createMockPrompter("always_deny");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: false });
+  });
+
+  test("maps always_allow decision to approved: true", async () => {
+    const prompter = createMockPrompter("always_allow");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: true });
+  });
+
+  test("maps allow_10m decision to approved: true", async () => {
+    const prompter = createMockPrompter("allow_10m");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: true });
+  });
+
+  test("maps allow_thread decision to approved: true", async () => {
+    const prompter = createMockPrompter("allow_thread");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: true });
+  });
+
+  // ── Signal forwarding ──
+
+  test("forwards abort signal to prompter", async () => {
+    const controller = new AbortController();
+    const prompter = createMockPrompter("allow");
+
+    await requestGitHooksTrustApproval(prompter, {
+      signal: controller.signal,
+    });
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // signal is index 10
+    expect(args[10]).toBe(controller.signal);
+  });
+
+  test("works without signal option", async () => {
+    const prompter = createMockPrompter("allow");
+    const result = await requestGitHooksTrustApproval(prompter);
+    expect(result).toEqual({ approved: true });
+
+    const args = (prompter.prompt as ReturnType<typeof mock>).mock.calls[0];
+    // signal should be undefined when not provided
+    expect(args[10]).toBeUndefined();
+  });
+
+  // ── Tool name constant ──
+
+  test("GIT_HOOKS_TRUST_TOOL_NAME is the reserved internal pseudo tool name", () => {
+    expect(GIT_HOOKS_TRUST_TOOL_NAME).toBe("__internal:git-hooks-trust");
+  });
+});

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -265,10 +265,38 @@ mock.module("../workspace/turn-commit.js", () => ({
   commitTurnChanges: async () => {},
 }));
 
+let mockGitServiceRunReadOnlyGit: (
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }> = async () => ({
+  stdout: "",
+  stderr: "",
+});
 mock.module("../workspace/git-service.js", () => ({
   getWorkspaceGitService: () => ({
     ensureInitialized: async () => {},
+    runReadOnlyGit: (args: string[]) => mockGitServiceRunReadOnlyGit(args),
   }),
+}));
+
+// Git hooks trust mocks
+let mockGitHooksTrustDecision: "allow" | "deny" | "ask" = "ask";
+const setGitHooksTrustDecisionMock = mock((_dir: string, _dec: string) => {});
+const detectConfiguredHooksMock = mock(async () => ({
+  hasHooks: false,
+  hookFiles: [] as string[],
+  hooksDir: "/tmp/.git/hooks",
+}));
+mock.module("../workspace/git-hooks-trust.js", () => ({
+  getGitHooksTrustDecision: (_dir: string) => mockGitHooksTrustDecision,
+  setGitHooksTrustDecision: setGitHooksTrustDecisionMock,
+  detectConfiguredHooks: detectConfiguredHooksMock,
+}));
+
+// Git hooks approval mock
+let mockGitHooksTrustApprovalResult = { approved: false };
+mock.module("../daemon/git-hooks-approval.js", () => ({
+  requestGitHooksTrustApproval: async () => mockGitHooksTrustApprovalResult,
+  GIT_HOOKS_TRUST_TOOL_NAME: "__internal:git-hooks-trust",
 }));
 
 mock.module("../daemon/session-error.js", () => ({
@@ -454,6 +482,16 @@ beforeEach(() => {
   mockOverflowAction = "fail_gracefully";
   mockApprovalResult = { approved: false };
   recordUsageMock.mockClear();
+  mockGitHooksTrustDecision = "ask";
+  mockGitHooksTrustApprovalResult = { approved: false };
+  setGitHooksTrustDecisionMock.mockClear();
+  detectConfiguredHooksMock.mockClear();
+  detectConfiguredHooksMock.mockImplementation(async () => ({
+    hasHooks: false,
+    hookFiles: [],
+    hooksDir: "/tmp/.git/hooks",
+  }));
+  mockGitServiceRunReadOnlyGit = async () => ({ stdout: "", stderr: "" });
 });
 
 describe("session-agent-loop", () => {
@@ -1819,6 +1857,131 @@ describe("session-agent-loop", () => {
         (e) => e.type === "assistant_text_delta",
       );
       expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("git hooks trust prompt", () => {
+    test("does not prompt when workspace has no hooks configured", async () => {
+      mockGitHooksTrustDecision = "ask";
+      detectConfiguredHooksMock.mockImplementation(async () => ({
+        hasHooks: false,
+        hookFiles: [],
+        hooksDir: "/tmp/.git/hooks",
+      }));
+
+      const ctx = makeCtx({ hasNoClient: false });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      // Wait a tick for the fire-and-forget promise chain to settle.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(setGitHooksTrustDecisionMock).not.toHaveBeenCalled();
+    });
+
+    test("does not prompt when trust decision is already 'allow'", async () => {
+      mockGitHooksTrustDecision = "allow";
+
+      const ctx = makeCtx({ hasNoClient: false });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(detectConfiguredHooksMock).not.toHaveBeenCalled();
+      expect(setGitHooksTrustDecisionMock).not.toHaveBeenCalled();
+    });
+
+    test("does not prompt when trust decision is already 'deny'", async () => {
+      mockGitHooksTrustDecision = "deny";
+
+      const ctx = makeCtx({ hasNoClient: false });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(detectConfiguredHooksMock).not.toHaveBeenCalled();
+      expect(setGitHooksTrustDecisionMock).not.toHaveBeenCalled();
+    });
+
+    test("does not prompt when hasNoClient is true (non-interactive)", async () => {
+      mockGitHooksTrustDecision = "ask";
+      detectConfiguredHooksMock.mockImplementation(async () => ({
+        hasHooks: true,
+        hookFiles: ["/tmp/.git/hooks/pre-commit"],
+        hooksDir: "/tmp/.git/hooks",
+      }));
+
+      const ctx = makeCtx({ hasNoClient: true });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(setGitHooksTrustDecisionMock).not.toHaveBeenCalled();
+    });
+
+    test("persists 'allow' when user approves and hooks are detected", async () => {
+      mockGitHooksTrustDecision = "ask";
+      mockGitHooksTrustApprovalResult = { approved: true };
+      detectConfiguredHooksMock.mockImplementation(async () => ({
+        hasHooks: true,
+        hookFiles: ["/tmp/.git/hooks/pre-commit"],
+        hooksDir: "/tmp/.git/hooks",
+      }));
+
+      const ctx = makeCtx({ hasNoClient: false });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      // Drain the microtask queue to let the fire-and-forget chain settle.
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(setGitHooksTrustDecisionMock).toHaveBeenCalledWith(
+        "/tmp",
+        "allow",
+      );
+    });
+
+    test("persists 'deny' when user denies and hooks are detected", async () => {
+      mockGitHooksTrustDecision = "ask";
+      mockGitHooksTrustApprovalResult = { approved: false };
+      detectConfiguredHooksMock.mockImplementation(async () => ({
+        hasHooks: true,
+        hookFiles: ["/tmp/.git/hooks/pre-commit"],
+        hooksDir: "/tmp/.git/hooks",
+      }));
+
+      const ctx = makeCtx({ hasNoClient: false });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(setGitHooksTrustDecisionMock).toHaveBeenCalledWith("/tmp", "deny");
+    });
+
+    test("does not prompt again in the same session for the same workspace", async () => {
+      mockGitHooksTrustDecision = "ask";
+      detectConfiguredHooksMock.mockImplementation(async () => ({
+        hasHooks: true,
+        hookFiles: ["/tmp/.git/hooks/pre-commit"],
+        hooksDir: "/tmp/.git/hooks",
+      }));
+
+      const ctx = makeCtx({ hasNoClient: false });
+
+      // First turn — should trigger the prompt flow.
+      await runAgentLoopImpl(ctx, "turn 1", "msg-1", () => {});
+      await new Promise((r) => setTimeout(r, 10));
+
+      const firstCallCount = detectConfiguredHooksMock.mock.calls.length;
+      expect(firstCallCount).toBe(1);
+
+      // Reset the abortController for the second turn (simulating Session re-arming it).
+      ctx.abortController = new AbortController();
+      ctx.currentRequestId = "test-req-2";
+
+      // Second turn in same session — should NOT re-issue the prompt.
+      await runAgentLoopImpl(ctx, "turn 2", "msg-2", () => {});
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(detectConfiguredHooksMock.mock.calls.length).toBe(firstCallCount);
     });
   });
 });

--- a/assistant/src/daemon/git-hooks-approval.ts
+++ b/assistant/src/daemon/git-hooks-approval.ts
@@ -1,0 +1,48 @@
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import { isAllowDecision } from "../permissions/types.js";
+
+/**
+ * Reserved pseudo tool name used for git hooks trust prompts.
+ * This is not a real tool — it provides a recognizable identifier
+ * in the confirmation UI so the user can see what is being requested.
+ */
+export const GIT_HOOKS_TRUST_TOOL_NAME = "__internal:git-hooks-trust";
+
+export type GitHooksTrustApprovalResult =
+  | { approved: true }
+  | { approved: false };
+
+/**
+ * Prompts the user to decide whether to trust the project's git hooks
+ * and allow them to run during assistant auto-commits.
+ *
+ * Uses the existing PermissionPrompter / `/v1/confirm` resolution flow with:
+ * - A reserved pseudo tool name so the UI can display a meaningful label
+ * - Medium risk level (hooks run arbitrary code)
+ * - No persistent decision affordances (decision is one-shot per session prompt;
+ *   persistence is handled separately via the trust-state helper)
+ * - Empty allowlist/scope options (no "always allow" or scope variants)
+ */
+export async function requestGitHooksTrustApproval(
+  prompter: PermissionPrompter,
+  opts?: { signal?: AbortSignal },
+): Promise<GitHooksTrustApprovalResult> {
+  const result = await prompter.prompt(
+    GIT_HOOKS_TRUST_TOOL_NAME,
+    {
+      description:
+        "This project has git hooks. Do you trust this project and want to enable hooks for assistant auto-commits?",
+    },
+    "medium",
+    [],
+    [],
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    false,
+    opts?.signal,
+  );
+
+  return { approved: isAllowDecision(result.decision) };
+}

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -352,16 +352,13 @@ export async function runAgentLoopImpl(
   ctx.lastAttachmentWarnings = [];
 
   // Ensure workspace git repo is initialized before any tools run.
-  let workspaceGitServiceForHooks: {
-    runReadOnlyGit(args: string[]): Promise<{ stdout: string; stderr: string }>;
-  } | null = null;
+  let gitInitSucceeded = false;
   try {
     const getWorkspaceGitServiceFn =
       ctx.getWorkspaceGitService ?? getWorkspaceGitService;
     const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
     await gitService.ensureInitialized();
-    workspaceGitServiceForHooks =
-      gitService as typeof workspaceGitServiceForHooks;
+    gitInitSucceeded = true;
   } catch (err) {
     rlog.warn({ err }, "Failed to initialize workspace git repo (non-fatal)");
   }
@@ -372,17 +369,19 @@ export async function runAgentLoopImpl(
   // that the prompt does not delay normal message processing.  The result is
   // persisted via setGitHooksTrustDecision so it survives restarts.
   if (
-    workspaceGitServiceForHooks &&
+    gitInitSucceeded &&
     !ctx.hasNoClient &&
     ctx.gitHooksTrustPromptIssuedForWorkspace !== ctx.workingDir
   ) {
     const trustDecision = getGitHooksTrustDecision(ctx.workingDir);
     if (trustDecision === "ask") {
-      const gitSvc = workspaceGitServiceForHooks;
       const workingDir = ctx.workingDir;
+      // Obtain the git service again — this time using the module-level function
+      // which returns the full WorkspaceGitService with runReadOnlyGit support.
+      const gitSvcForDetection = getWorkspaceGitService(workingDir);
       // Mark as issued immediately to prevent duplicate prompts on concurrent turns.
       ctx.gitHooksTrustPromptIssuedForWorkspace = workingDir;
-      detectConfiguredHooks(workingDir, gitSvc)
+      detectConfiguredHooks(workingDir, gitSvcForDetection)
         .then(async (detected) => {
           if (!detected.hasHooks) return;
           // Re-check in case another turn resolved it while we were detecting.

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -53,6 +53,11 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
+import {
+  detectConfiguredHooks,
+  getGitHooksTrustDecision,
+  setGitHooksTrustDecision,
+} from "../workspace/git-hooks-trust.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
 import { commitTurnChanges } from "../workspace/turn-commit.js";
 import {
@@ -70,6 +75,7 @@ import {
   buildTemporalContext,
   extractUserTimeZoneFromDynamicProfile,
 } from "./date-context.js";
+import { requestGitHooksTrustApproval } from "./git-hooks-approval.js";
 import { deepRepairHistory, repairHistory } from "./history-repair.js";
 import type {
   DynamicPageSurfaceData,
@@ -215,6 +221,14 @@ export interface AgentLoopSessionContext {
   readonly prompter: PermissionPrompter;
   readonly queue: MessageQueue;
 
+  /**
+   * Tracks whether the git hooks trust prompt has already been issued
+   * for the current workspace during this session.  Set to `true` after
+   * the first prompt so subsequent turns in the same session don't
+   * re-prompt the user.
+   */
+  gitHooksTrustPromptIssuedForWorkspace?: string;
+
   emitActivityState(
     phase:
       | "idle"
@@ -338,13 +352,64 @@ export async function runAgentLoopImpl(
   ctx.lastAttachmentWarnings = [];
 
   // Ensure workspace git repo is initialized before any tools run.
+  let workspaceGitServiceForHooks: {
+    runReadOnlyGit(args: string[]): Promise<{ stdout: string; stderr: string }>;
+  } | null = null;
   try {
     const getWorkspaceGitServiceFn =
       ctx.getWorkspaceGitService ?? getWorkspaceGitService;
     const gitService = getWorkspaceGitServiceFn(ctx.workingDir);
     await gitService.ensureInitialized();
+    workspaceGitServiceForHooks =
+      gitService as typeof workspaceGitServiceForHooks;
   } catch (err) {
     rlog.warn({ err }, "Failed to initialize workspace git repo (non-fatal)");
+  }
+
+  // After workspace initialization: if the workspace has git hooks configured
+  // and the user hasn't made a trust decision yet, prompt them once per session.
+  // This runs fire-and-forget (we don't await it blocking the main loop) so
+  // that the prompt does not delay normal message processing.  The result is
+  // persisted via setGitHooksTrustDecision so it survives restarts.
+  if (
+    workspaceGitServiceForHooks &&
+    !ctx.hasNoClient &&
+    ctx.gitHooksTrustPromptIssuedForWorkspace !== ctx.workingDir
+  ) {
+    const trustDecision = getGitHooksTrustDecision(ctx.workingDir);
+    if (trustDecision === "ask") {
+      const gitSvc = workspaceGitServiceForHooks;
+      const workingDir = ctx.workingDir;
+      // Mark as issued immediately to prevent duplicate prompts on concurrent turns.
+      ctx.gitHooksTrustPromptIssuedForWorkspace = workingDir;
+      detectConfiguredHooks(workingDir, gitSvc)
+        .then(async (detected) => {
+          if (!detected.hasHooks) return;
+          // Re-check in case another turn resolved it while we were detecting.
+          if (getGitHooksTrustDecision(workingDir) !== "ask") return;
+          try {
+            const approval = await requestGitHooksTrustApproval(ctx.prompter, {
+              signal: abortController.signal,
+            });
+            setGitHooksTrustDecision(
+              workingDir,
+              approval.approved ? "allow" : "deny",
+            );
+          } catch (err) {
+            rlog.warn(
+              { err },
+              "Git hooks trust prompt failed (non-fatal); defaulting to deny",
+            );
+            setGitHooksTrustDecision(workingDir, "deny");
+          }
+        })
+        .catch((err) => {
+          rlog.warn(
+            { err },
+            "Git hooks trust hook detection failed (non-fatal)",
+          );
+        });
+    }
   }
 
   ctx.profiler.startRequest();


### PR DESCRIPTION
## Summary
- Add git-hooks-approval.ts with PermissionPrompter-based trust prompt
- Integrate prompt into session-agent-loop.ts after workspace initialization
- Guard against repeat prompts per session; persist allow/deny via trust state helper

Part of plan: git-hooks-trust-prompt-exploit-fix.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
