### PR TITLE
feat: link macOS log reports to daemon errors via shared conversation_id

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -75,6 +75,12 @@ enum LogExporter {
                 extra["thread_title"] = activeThread.title
                 if let sessionId = activeThread.sessionId {
                     tags["session_id"] = sessionId
+                    // conversation_id mirrors session_id — the daemon tags its
+                    // Sentry events with both names for the same value. Setting
+                    // it here enables cross-project search: find the daemon error
+                    // that corresponds to a macOS log report by querying
+                    // conversation_id in the vellum-assistant-brain Sentry project.
+                    tags["conversation_id"] = sessionId
                 }
             }
             var errorCategoryString: String?
@@ -91,6 +97,7 @@ enum LogExporter {
                 if let sessionId = vm.sessionId {
                     // Prefer the view model's sessionId (most up-to-date)
                     tags["session_id"] = sessionId
+                    tags["conversation_id"] = sessionId
                 }
             }
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {


### PR DESCRIPTION
## Summary
- Add conversation_id as a shared correlation tag between macOS log reports and daemon Sentry events
- Enables cross-referencing between vellum-assistant-macos and vellum-assistant-brain Sentry projects
- Click from a log report directly to the daemon error that caused it

Part of plan: sentry-observability-improvements.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
