### PR TITLE
fix(macos): add missing error category cases and fix onKeyPress API

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -147,6 +147,10 @@ struct ChatSessionErrorToast: View {
             return .cloudOff
         case .providerBilling:
             return .creditCard
+        case .providerOrdering:
+            return .cloudOff
+        case .providerWebSearch:
+            return .cloudOff
         case .contextTooLarge:
             return .fileText
         case .sessionAborted:

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -315,7 +315,8 @@ struct ChatView: View {
             }
             return .ignored
         }
-        .onKeyPress("f", modifiers: .command) {
+        .onKeyPress("f", phases: .down) { press in
+            guard press.modifiers.contains(.command) else { return .ignored }
             activateSearch()
             return .handled
         }


### PR DESCRIPTION
## Summary
- Add missing `.providerOrdering` and `.providerWebSearch` cases to the `iconForCategory` switch in `ChatErrorToastView.swift`, fixing non-exhaustive switch error
- Fix `onKeyPress("f", modifiers: .command)` in `ChatView.swift` to use `.onKeyPress("f", phases: .down) { press in ... }` with `press.modifiers` check — the `modifiers` parameter doesn't exist on `onKeyPress`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23019404443/job/66851419990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
