### PR TITLE
test/docs: add exploit regression coverage and user-facing update notes

### DIFF
--- a/assistant/src/__tests__/approval-message-composer.test.ts
+++ b/assistant/src/__tests__/approval-message-composer.test.ts
@@ -32,6 +32,10 @@ const ALL_SCENARIOS: ApprovalMessageScenario[] = [
   "guardian_verify_status_unbound",
   "guardian_deny_no_identity",
   "guardian_deny_no_binding",
+  "requester_cancel",
+  "approval_already_resolved",
+  "guardian_text_unavailable",
+  "git_hooks_trust_prompt",
 ];
 
 describe("approval-message-composer", () => {
@@ -245,6 +249,56 @@ describe("approval-message-composer", () => {
       });
       expect(typeof msg).toBe("string");
       expect(msg.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Git hooks trust prompt — explicit trust decision copy
+  // -----------------------------------------------------------------------
+
+  describe("git_hooks_trust_prompt scenario", () => {
+    test("produces a non-empty string", () => {
+      const msg = getFallbackMessage({ scenario: "git_hooks_trust_prompt" });
+      expect(typeof msg).toBe("string");
+      expect(msg.trim().length).toBeGreaterThan(0);
+    });
+
+    test("mentions git hooks", () => {
+      const msg = getFallbackMessage({ scenario: "git_hooks_trust_prompt" });
+      expect(msg.toLowerCase()).toContain("git hooks");
+    });
+
+    test("mentions trust decision", () => {
+      const msg = getFallbackMessage({ scenario: "git_hooks_trust_prompt" });
+      expect(msg.toLowerCase()).toContain("trust");
+    });
+
+    test("explains default fail-closed behavior", () => {
+      const msg = getFallbackMessage({ scenario: "git_hooks_trust_prompt" });
+      // Should tell the user that hooks are disabled by default
+      expect(msg.toLowerCase()).toContain("disabled");
+    });
+
+    test("provides clear yes/no guidance", () => {
+      const msg = getFallbackMessage({ scenario: "git_hooks_trust_prompt" });
+      // Should instruct user how to respond
+      expect(msg.toLowerCase()).toMatch(/yes|allow|no|deny/);
+    });
+
+    test("composeApprovalMessage returns assistantPreface when provided", () => {
+      const preface = "I found git hooks in this project.";
+      const msg = composeApprovalMessage({
+        scenario: "git_hooks_trust_prompt",
+        assistantPreface: preface,
+      });
+      expect(msg).toBe(preface);
+    });
+
+    test("composeApprovalMessage falls back to deterministic template when no preface", () => {
+      const msg = composeApprovalMessage({
+        scenario: "git_hooks_trust_prompt",
+      });
+      expect(msg.toLowerCase()).toContain("git hooks");
     });
   });
 });

--- a/assistant/src/__tests__/commit-guarantee.test.ts
+++ b/assistant/src/__tests__/commit-guarantee.test.ts
@@ -4,12 +4,60 @@
  * These tests verify that workspace changes are committed even when
  * post-processing errors occur after the agent loop completes, and
  * that the shutdown sequence commits changes made during server.stop().
+ *
+ * Also contains end-to-end regression tests for the git hook exploit chain:
+ * a malicious pre-commit hook planted in a workspace must NOT execute during
+ * any auto-commit path (turn, heartbeat, shutdown) unless the workspace has
+ * been explicitly trusted by the user.
  */
+
+// ─── Bun mock.module calls must appear before all other imports ───────────────
+// These intercept the git-hooks-trust, logger, and config modules so tests can
+// control trust state without touching the real trust store on disk.
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Control the hook trust decision from each test via this variable.
+let _exploitMockDecision: "allow" | "deny" | "ask" = "ask";
+
+mock.module("../workspace/git-hooks-trust.js", () => ({
+  getGitHooksTrustDecision: (_workspaceDir: string) => _exploitMockDecision,
+  setGitHooksTrustDecision: () => {},
+  detectConfiguredHooks: async () => ({
+    hookFiles: [],
+    hooksDir: "",
+    hasHooks: false,
+  }),
+  GIT_HOOKS_TRUST_PSEUDO_TOOL: "__internal:git-hooks-trust",
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// ─── Module imports (after mocks) ────────────────────────────────────────────
+
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   _resetGitServiceRegistry,
@@ -339,6 +387,178 @@ describe("Commit guarantees", () => {
       const postStop = await heartbeat.commitAllPending();
       expect(postStop.committed).toBe(0);
       expect(commitCount(testDir)).toBe(2); // unchanged
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Git hook exploit regression
+  //
+  // These tests reproduce the full exploit chain:
+  //   1. A malicious pre-commit hook is planted in the workspace.
+  //   2. The assistant triggers an auto-commit (turn / heartbeat / shutdown).
+  //   3. Under the default "ask" trust state the hook MUST NOT execute.
+  //   4. Only after the trust decision is explicitly "allow" may the hook run.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("git hook exploit chain regression", () => {
+    /**
+     * Write an executable hook script that touches a sentinel file.
+     * If the sentinel file exists after a commit the hook ran.
+     */
+    function plantMaliciousHook(
+      repoDir: string,
+      hookName: string,
+      sentinelPath: string,
+    ): void {
+      const hooksDir = join(repoDir, ".git", "hooks");
+      mkdirSync(hooksDir, { recursive: true });
+      writeFileSync(
+        join(hooksDir, hookName),
+        `#!/bin/sh\ntouch "${sentinelPath}"\nexit 0\n`,
+        { mode: 0o755 },
+      );
+    }
+
+    beforeEach(() => {
+      // Default: fail-closed (no explicit trust decision)
+      _exploitMockDecision = "ask";
+    });
+
+    test("turn-boundary auto-commit does NOT execute pre-commit hook when trust is ask (default)", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "exploit-ran.marker");
+      plantMaliciousHook(testDir, "pre-commit", sentinel);
+
+      // Simulate a turn: write a file and commit
+      writeFileSync(join(testDir, "work.ts"), "export const x = 1;");
+      await commitTurnChanges(testDir, "sess_exploit_turn", 1);
+
+      // Hook must NOT have run
+      expect(existsSync(sentinel)).toBe(false);
+      // But commit should still have been created
+      expect(commitCount(testDir)).toBe(2);
+    });
+
+    test("turn-boundary auto-commit does NOT execute pre-commit hook when trust is deny", async () => {
+      _exploitMockDecision = "deny";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "exploit-ran-deny.marker");
+      plantMaliciousHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "work.ts"), "export const x = 2;");
+      await commitTurnChanges(testDir, "sess_exploit_deny", 1);
+
+      expect(existsSync(sentinel)).toBe(false);
+      expect(commitCount(testDir)).toBe(2);
+    });
+
+    test("heartbeat auto-commit does NOT execute pre-commit hook when trust is ask", async () => {
+      _exploitMockDecision = "ask";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "heartbeat-exploit.marker");
+      plantMaliciousHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "background.log.txt"), "background output");
+
+      const services = new Map<string, WorkspaceGitService>();
+      services.set(testDir, service);
+
+      let fakeTime = 1_000_000;
+      const heartbeat = new WorkspaceHeartbeatService({
+        ageThresholdMs: 0, // trigger immediately
+        fileThreshold: 1,
+        getServices: () => services,
+        now: () => fakeTime,
+      });
+
+      fakeTime += 1;
+      const result = await heartbeat.check();
+      expect(result.committed).toBe(1);
+
+      // Hook must NOT have run
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("shutdown auto-commit does NOT execute pre-commit hook when trust is ask", async () => {
+      _exploitMockDecision = "ask";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "shutdown-exploit.marker");
+      plantMaliciousHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "unsaved.txt"), "important data");
+
+      const services = new Map<string, WorkspaceGitService>();
+      services.set(testDir, service);
+
+      const heartbeat = new WorkspaceHeartbeatService({
+        getServices: () => services,
+      });
+
+      const result = await heartbeat.commitAllPending();
+      expect(result.committed).toBe(1);
+
+      // Hook must NOT have run
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    test("hook IS allowed to run when trust decision is explicitly allow", async () => {
+      _exploitMockDecision = "allow";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "trusted-hook.marker");
+      plantMaliciousHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "work.ts"), "export const x = 3;");
+      await service.commitChanges("test: hooks allowed for trusted workspace");
+
+      // Hook SHOULD have run for explicitly trusted workspace
+      expect(existsSync(sentinel)).toBe(true);
+    });
+
+    test("multiple auto-commit triggers all blocked when trust is ask", async () => {
+      _exploitMockDecision = "ask";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const turnSentinel = join(testDir, "turn-exploit.marker");
+      const hbSentinel = join(testDir, "hb-exploit.marker");
+
+      plantMaliciousHook(testDir, "pre-commit", turnSentinel);
+
+      // Turn commit
+      writeFileSync(join(testDir, "file1.ts"), "content1");
+      await commitTurnChanges(testDir, "sess_multi", 1);
+      expect(existsSync(turnSentinel)).toBe(false);
+
+      // Swap sentinel and trigger heartbeat
+      plantMaliciousHook(testDir, "pre-commit", hbSentinel);
+      writeFileSync(join(testDir, "file2.ts"), "content2");
+
+      const services = new Map<string, WorkspaceGitService>();
+      services.set(testDir, service);
+
+      const heartbeat = new WorkspaceHeartbeatService({
+        ageThresholdMs: 0,
+        fileThreshold: 1,
+        getServices: () => services,
+      });
+
+      await heartbeat.check();
+      expect(existsSync(hbSentinel)).toBe(false);
     });
   });
 });

--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -4,19 +4,64 @@
  *
  * This test wires together WorkspaceGitService, commitTurnChanges, and WorkspaceHeartbeatService
  * in the same flow a real daemon session would follow.
+ *
+ * Also contains hook-trust lifecycle tests that verify hooks stay suppressed through
+ * the full workspace lifecycle until an explicit trust decision is made.
  */
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+
+// ─── Bun mock.module calls must appear before all other imports ───────────────
+
 import {
   afterAll,
   afterEach,
   beforeEach,
   describe,
   expect,
+  mock,
   test,
 } from "bun:test";
+
+// Default: fail-closed ("ask"). Hook trust tests switch to "allow".
+let _lifecycleMockDecision: "allow" | "deny" | "ask" = "ask";
+
+mock.module("../workspace/git-hooks-trust.js", () => ({
+  getGitHooksTrustDecision: (_workspaceDir: string) => _lifecycleMockDecision,
+  setGitHooksTrustDecision: () => {},
+  detectConfiguredHooks: async () => ({
+    hookFiles: [],
+    hooksDir: "",
+    hasHooks: false,
+  }),
+  GIT_HOOKS_TRUST_PSEUDO_TOOL: "__internal:git-hooks-trust",
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+// ─── Module imports (after mocks) ────────────────────────────────────────────
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   _resetEnrichmentService,
@@ -335,5 +380,90 @@ describe("Workspace git lifecycle (integration)", () => {
 
     expect(fromTurnCommitPath).toBe(fromHeartbeatPath);
     expect(fromHeartbeatPath).toBe(fromDirectCall);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Hook trust lifecycle — fail-closed through the full session lifecycle
+  // ─────────────────────────────────────────────────────────────────────────
+
+  test("hooks remain suppressed throughout full lifecycle when trust is ask (default)", async () => {
+    // Ensure default fail-closed behavior
+    _lifecycleMockDecision = "ask";
+
+    const sessionId = "sess_hook_trust_lifecycle";
+
+    // Plant a hook that writes a sentinel if it executes
+    const sentinel = join(testDir, "hook-lifecycle.marker");
+    const hooksDir = join(testDir, ".git", "hooks");
+
+    const service = getWorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    // .git/hooks exists only after init
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(
+      join(hooksDir, "pre-commit"),
+      `#!/bin/sh\ntouch "${sentinel}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    // Turn 1 commit
+    writeFileSync(join(testDir, "turn1.ts"), "content");
+    await commitTurnChanges(testDir, sessionId, 1);
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Turn 2 commit
+    writeFileSync(join(testDir, "turn2.ts"), "more content");
+    await commitTurnChanges(testDir, sessionId, 2);
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Heartbeat commit
+    writeFileSync(join(testDir, "background.txt"), "bg work");
+
+    const services = new Map<string, WorkspaceGitService>();
+    services.set(testDir, service);
+
+    const heartbeat = new WorkspaceHeartbeatService({
+      ageThresholdMs: 0,
+      fileThreshold: 1,
+      getServices: () => services,
+    });
+
+    const hbResult = await heartbeat.check();
+    expect(hbResult.committed).toBe(1);
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Shutdown commit
+    writeFileSync(join(testDir, "final.txt"), "final write");
+    const shutdownResult = await heartbeat.commitAllPending();
+    expect(shutdownResult.committed).toBe(1);
+    expect(existsSync(sentinel)).toBe(false);
+
+    // All commits were created without the hook running
+    expect(commitCount(testDir)).toBeGreaterThanOrEqual(4); // init + 2 turns + heartbeat + shutdown
+  });
+
+  test("hooks run for every commit once workspace is explicitly trusted", async () => {
+    // Simulate the user granting trust
+    _lifecycleMockDecision = "allow";
+
+    const sentinel = join(testDir, "trusted-lifecycle.marker");
+    const hooksDir = join(testDir, ".git", "hooks");
+
+    const service = getWorkspaceGitService(testDir);
+    await service.ensureInitialized();
+
+    mkdirSync(hooksDir, { recursive: true });
+    writeFileSync(
+      join(hooksDir, "pre-commit"),
+      `#!/bin/sh\ntouch "${sentinel}"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    writeFileSync(join(testDir, "trusted.ts"), "export const y = 1;");
+    await service.commitChanges("test: trust lifecycle allow");
+
+    // Hook should have run for the trusted workspace
+    expect(existsSync(sentinel)).toBe(true);
   });
 });

--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -10,6 +10,21 @@ _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
 
+<!-- vellum-update-release:git-hooks-trust-prompt -->
+
+### Git hook trust prompt — auto-commits are now fail-closed by default
+
+The assistant auto-commit system (turn checkpoints, heartbeat safety net, and shutdown commits) no longer runs git hooks unless you explicitly trust the project.
+
+**What changed:**
+
+- **Default behavior is fail-closed.** When the assistant commits workspace changes, it suppresses all git hooks (`core.hooksPath=/dev/null`) unless you have explicitly said to trust the project's hooks. This prevents untrusted hook scripts from executing arbitrary code during routine auto-commits.
+- **New trust prompt.** When the assistant detects a workspace with git hooks configured, it will ask you once: "This project has git hooks. Do you trust this project and want to enable hooks for assistant auto-commits?" Answering yes stores an explicit allow decision; answering no (or dismissing the prompt) keeps hooks suppressed.
+- **Per-project decisions.** Trust decisions are scoped to each workspace directory. Trusting one project does not affect others.
+- **No impact on your manual git workflow.** Only the assistant's auto-commits are affected. Your own `git commit` commands run hooks as normal.
+
+<!-- /vellum-update-release:git-hooks-trust-prompt -->
+
 <!-- vellum-update-release:schedule-reminder-unification -->
 
 ### Reminders are now one-shot schedules

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -36,7 +36,8 @@ export type ApprovalMessageScenario =
   | "guardian_deny_no_binding"
   | "requester_cancel"
   | "approval_already_resolved"
-  | "guardian_text_unavailable";
+  | "guardian_text_unavailable"
+  | "git_hooks_trust_prompt";
 
 export interface ApprovalMessageContext {
   scenario: ApprovalMessageScenario;
@@ -292,6 +293,14 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
 
     case "guardian_text_unavailable":
       return "I can't process text replies for approvals right now. Please use the approve/deny buttons above to respond.";
+
+    case "git_hooks_trust_prompt":
+      return (
+        "This project has git hooks configured. " +
+        "By default, hooks are disabled for assistant auto-commits to prevent untrusted code from running. " +
+        "Do you trust this project and want to enable hooks for assistant auto-commits? " +
+        "Reply yes to allow hooks, or no to keep them disabled."
+      );
 
     default: {
       // Exhaustive check — TypeScript will flag if a scenario is missing.


### PR DESCRIPTION
## Summary
- Add end-to-end regression tests replicating the git hook exploit chain
- Update approval-message-composer.ts to render trust prompt clearly for non-Vellum channels
- Add release notes to UPDATES.md describing the trust prompt and fail-closed behavior

Part of plan: git-hooks-trust-prompt-exploit-fix.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
