### PR TITLE
fix: add org header for managed assistant healthz checks

### DIFF
--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -10,6 +10,32 @@ export interface HealthCheckResult {
   detail: string | null;
 }
 
+interface OrgListResponse {
+  results: { id: string }[];
+}
+
+async function fetchOrganizationId(
+  platformUrl: string,
+  token: string,
+): Promise<{ orgId: string } | { error: string }> {
+  try {
+    const response = await fetch(`${platformUrl}/v1/organizations/`, {
+      headers: { "X-Session-Token": token },
+    });
+    if (!response.ok) {
+      return { error: `org lookup failed (${response.status})` };
+    }
+    const body = (await response.json()) as OrgListResponse;
+    const orgId = body.results?.[0]?.id;
+    if (!orgId) {
+      return { error: "no organization found" };
+    }
+    return { orgId };
+  } catch {
+    return { error: "org lookup unreachable" };
+  }
+}
+
 export async function checkManagedHealth(
   runtimeUrl: string,
   assistantId: string,
@@ -23,20 +49,31 @@ export async function checkManagedHealth(
     };
   }
 
+  const orgResult = await fetchOrganizationId(runtimeUrl, token);
+  if ("error" in orgResult) {
+    return {
+      status: "error (auth)",
+      detail: orgResult.error,
+    };
+  }
+  const { orgId } = orgResult;
+
   try {
-    const url = `${runtimeUrl}/v1/assistants/${assistantId}/healthz/`;
+    const url = `${runtimeUrl}/v1/assistants/${encodeURIComponent(assistantId)}/healthz/`;
     const controller = new AbortController();
     const timeoutId = setTimeout(
       () => controller.abort(),
       HEALTH_CHECK_TIMEOUT_MS,
     );
 
+    const headers: Record<string, string> = {
+      "X-Session-Token": token,
+      "Vellum-Organization-Id": orgId,
+    };
+
     const response = await fetch(url, {
       signal: controller.signal,
-      headers: {
-        "Content-Type": "application/json",
-        "X-Session-Token": token,
-      },
+      headers,
     });
 
     clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- The managed healthz proxy requires `Vellum-Organization-Id` header, which was missing
- Fetches org ID from `GET /v1/organizations/` (doesn't require the header itself), then passes it to the healthz request
- Uses `runtimeUrl` from the lockfile instead of `getPlatformUrl()`, since the token is scoped to the specific platform host
- Adds descriptive error messages for auth failures (e.g. "org lookup failed (403)")

## Test plan
- [x] `vellum ps` with a managed assistant shows `healthy` instead of `error (404)` / `error (403)`
- [x] Token scoped to dev platform works correctly (uses runtimeUrl, not hardcoded production URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
