### PR TITLE
fix: don't persist git hooks trust deny on abort/timeout/error

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -390,16 +390,27 @@ export async function runAgentLoopImpl(
             const approval = await requestGitHooksTrustApproval(ctx.prompter, {
               signal: abortController.signal,
             });
+            // If the session was aborted mid-prompt, do not persist any
+            // decision — the prompter resolves with "deny" on abort but that
+            // is an infrastructure event, not a real user choice.  Reset the
+            // guard so the user is re-prompted in the next session.
+            if (abortController.signal.aborted) {
+              ctx.gitHooksTrustPromptIssuedForWorkspace = undefined;
+              return;
+            }
             setGitHooksTrustDecision(
               workingDir,
               approval.approved ? "allow" : "deny",
             );
           } catch (err) {
+            // Infrastructure errors (disposed prompter, timeout, etc.) should
+            // not permanently silence the trust prompt.  Reset the guard so
+            // the user is re-prompted next session.
             rlog.warn(
               { err },
-              "Git hooks trust prompt failed (non-fatal); defaulting to deny",
+              "Git hooks trust prompt failed (non-fatal); will re-prompt next session",
             );
-            setGitHooksTrustDecision(workingDir, "deny");
+            ctx.gitHooksTrustPromptIssuedForWorkspace = undefined;
           }
         })
         .catch((err) => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** Abort signal/timeout silently persists permanent 'deny' without user consent
**What was expected:** Only explicit user deny should write a deny decision; infrastructure events should leave state as 'ask' for re-prompt next session
**What was found:** Abort signal and catch handler both unconditionally wrote deny to trust store

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
