### PR TITLE
fix: enforce hook suppression policy through runWithMutex exec path

### DIFF
--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -297,7 +297,7 @@ export async function restoreAppVersion(
   const appsDir = getAppsDir();
   const gitService = getWorkspaceGitService(appsDir);
 
-  await gitService.runWithMutex(async (exec) => {
+  await gitService.runWithMutex(async (exec, execCommit) => {
     // Checkout the app's files at the target commit.
     // --no-overlay removes files that don't exist at the target commit.
     await exec([
@@ -327,10 +327,10 @@ export async function restoreAppVersion(
 
     const shortHash = commitHash.substring(0, 7);
 
-    // Stage only this app's files and commit atomically within the same mutex lock
+    // Stage only this app's files and commit atomically within the same mutex lock.
+    // Use execCommit (not exec) so the hook suppression policy is enforced.
     await exec(["add", "--", `${appId}.json`, `${appId}/`]);
-    await exec([
-      "commit",
+    await execCommit([
       "-m",
       `Restore app: ${appName} to ${shortHash}`,
       "--allow-empty",

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -904,15 +904,28 @@ export class WorkspaceGitService {
    * Run a sequence of git commands atomically under the workspace mutex.
    * Use this for write operations that need serialization with other
    * git mutations (e.g. checkout + commit).
+   *
+   * The callback receives two helpers:
+   * - `exec`       — runs any git command (non-commit operations).
+   * - `execCommit` — runs `git commit` through `execGitCommit`, which
+   *                  enforces the hook suppression policy. Always use
+   *                  `execCommit` instead of `exec(["commit", ...])` to
+   *                  ensure the trust-based hook policy is applied.
    */
   async runWithMutex(
     fn: (
       exec: (args: string[]) => Promise<{ stdout: string; stderr: string }>,
+      execCommit: (
+        commitArgs: string[],
+      ) => Promise<{ stdout: string; stderr: string }>,
     ) => Promise<void>,
   ): Promise<void> {
     await this.ensureInitialized();
     await this.mutex.withLock(async () => {
-      await fn((args) => this.execGit(args));
+      await fn(
+        (args) => this.execGit(args),
+        (commitArgs) => this.execGitCommit(commitArgs),
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** runWithMutex exposes raw exec that bypasses hook suppression in app-git-service.ts
**What was expected:** All commit paths enforce the hook trust policy via execGitCommit
**What was found:** restoreAppVersion called exec(['commit', ...]) directly, bypassing execGitCommit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
