### PR TITLE
fix: add missing providerOrdering and providerWebSearch switch cases in iOS client

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -420,6 +420,8 @@ struct ChatContentView: View {
         case .providerNetwork: return .wifiOff
         case .rateLimit: return .clockAlert
         case .providerApi: return .cloudOff
+        case .providerOrdering: return .cloudOff
+        case .providerWebSearch: return .cloudOff
         case .sessionAborted: return .circleStop
         case .processingFailed, .regenerateFailed: return .refreshCw
         case .contextTooLarge: return .fileText


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sentry-observability-improvements.md.

**Gap:** Missing switch cases cause build failure
**What was expected:** All `SessionErrorCategory` cases handled in switch statements across both iOS and macOS clients
**What was found:** `providerOrdering` and `providerWebSearch` cases were missing from `sessionErrorIcon()` in `ChatContentView.swift` (iOS client). The macOS `ChatErrorToastView.swift` already had these cases.

Adds `.providerOrdering` and `.providerWebSearch` cases to the iOS `sessionErrorIcon` switch, using `.cloudOff` icon (consistent with the macOS client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
