### PR TITLE
fix: move session_error_debug_details from Sentry tag to extra

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -91,7 +91,7 @@ enum LogExporter {
                     tags["session_error_category"] = category
                     errorCategoryString = category
                     if let debugDetails = sessionError.debugDetails {
-                        tags["session_error_debug_details"] = debugDetails
+                        extra["session_error_debug_details"] = debugDetails
                     }
                 }
                 if let sessionId = vm.sessionId {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sentry-observability-improvements.md.

- **Gap:** Debug details stored as Sentry tag instead of extra context
- **What was expected:** Full debug details preserved (up to 4000 chars with stack traces)
- **What was found:** Tag values truncated at ~200 chars by Sentry, silently losing debug info

Moves `session_error_debug_details` from the `tags` dictionary to `extra` in `LogExporter.swift`. The `extra` dictionary already holds `thread_title` and `message_count`, so this follows the existing pattern and preserves the full debug details value without Sentry's tag length limit truncating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
