### PR TITLE
fix: hide and protect pseudo-rules from user-facing trust APIs and CLI

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -443,6 +443,8 @@ export function updateRule(
   const rules = [...getRules()];
   const index = rules.findIndex((r) => r.id === id);
   if (index === -1) throw new Error(`Trust rule not found: ${id}`);
+  if (rules[index]!.tool.startsWith("__internal:"))
+    throw new Error(`Cannot modify internal pseudo-rule: ${id}`);
   const rule = { ...rules[index] };
   if (updates.tool != null) rule.tool = updates.tool;
   if (updates.pattern != null) rule.pattern = updates.pattern;
@@ -469,6 +471,8 @@ export function removeRule(id: string): boolean {
   const rules = [...getRules()];
   const index = rules.findIndex((r) => r.id === id);
   if (index === -1) return false;
+  if (rules[index]!.tool.startsWith("__internal:"))
+    throw new Error(`Cannot remove internal pseudo-rule: ${id}`);
   rules.splice(index, 1);
   cachedRules = rules;
   rebuildPatternCache(rules);
@@ -576,14 +580,22 @@ export function findDenyRule(
 }
 
 export function getAllRules(): TrustRule[] {
-  return [...getRules()];
+  // Filter out internal pseudo-rules — they are not user-visible permission
+  // rules and must not be exposed through user-facing APIs or CLI commands.
+  return getRules().filter((r) => !r.tool.startsWith("__internal:"));
 }
 
 export function clearAllRules(): void {
   // Reset the starter bundle flag so the bundle can be re-accepted after clear.
   cachedStarterBundleAccepted = false;
+  // Preserve internal pseudo-rules (e.g. git-hooks-trust state) — they must
+  // not be exposed to users and must survive a clear.
+  cachedRules = null;
+  const pseudoRules = getRules().filter((r) =>
+    r.tool.startsWith("__internal:"),
+  );
   // Re-backfill default rules so protected directory stays guarded.
-  const rules: TrustRule[] = [];
+  const rules: TrustRule[] = [...pseudoRules];
   backfillDefaults(rules);
   rules.sort(ruleOrder);
   cachedRules = rules;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** Pseudo-rules leaked and mutable via CLI and HTTP API
**What was expected:** Internal __internal:* rules must not appear in trust list/API or be mutable via removeRule/updateRule/clearAllRules
**What was found:** No filtering or guarding was in place; pseudo-rules were fully exposed and modifiable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
