### PR TITLE
fix: route git hooks trust prompt to correct approval scenario in channel-approvals

### DIFF
--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -9,6 +9,7 @@
  *   3. Consume user decisions and apply them to the underlying session
  */
 
+import { GIT_HOOKS_TRUST_TOOL_NAME } from "../daemon/git-hooks-approval.js";
 import { addRule } from "../permissions/trust-store.js";
 import type { UserDecision } from "../permissions/types.js";
 import { getTool } from "../tools/registry.js";
@@ -87,8 +88,12 @@ export function getApprovalInfoByConversation(
 function buildPromptFromApprovalInfo(
   info: PendingApprovalInfo,
 ): ChannelApprovalPrompt {
+  const scenario =
+    info.toolName === GIT_HOOKS_TRUST_TOOL_NAME
+      ? "git_hooks_trust_prompt"
+      : "standard_prompt";
   const promptText = composeApprovalMessage({
-    scenario: "standard_prompt",
+    scenario,
     toolName: info.toolName,
   });
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** git_hooks_trust_prompt scenario never routed to from channel-approvals.ts
**What was expected:** buildPromptFromApprovalInfo routes to git_hooks_trust_prompt scenario when toolName is the git hooks pseudo-tool
**What was found:** Scenario existed as dead code — always resolved to standard_prompt regardless of tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
