### PR TITLE
test: add explicit allow/deny hook trust decision tests to workspace-git-service.test.ts

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -8,7 +8,23 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ─── Trust decision mock (must be declared before the git-service import) ─────
+// Controls what getGitHooksTrustDecision returns in hook-trust policy tests.
+// Default is "ask" (fail-closed) which matches the existing suppression tests.
+let mockTrustDecision: "allow" | "deny" | "ask" = "ask";
+
+mock.module("../workspace/git-hooks-trust.js", () => ({
+  getGitHooksTrustDecision: (_workspaceDir: string) => mockTrustDecision,
+  setGitHooksTrustDecision: () => {},
+  detectConfiguredHooks: async () => ({
+    hookFiles: [],
+    hooksDir: "",
+    hasHooks: false,
+  }),
+  GIT_HOOKS_TRUST_PSEUDO_TOOL: "__internal:git-hooks-trust",
+}));
 
 import {
   _getConsecutiveFailures,
@@ -32,6 +48,9 @@ describe("WorkspaceGitService", () => {
     );
     mkdirSync(testDir, { recursive: true });
     _resetGitServiceRegistry();
+    // Reset trust decision to "ask" (fail-closed default) before each test so
+    // existing suppression tests continue to work correctly.
+    mockTrustDecision = "ask";
   });
 
   afterEach(() => {
@@ -1308,6 +1327,38 @@ describe("WorkspaceGitService", () => {
       }));
 
       expect(result.committed).toBe(true);
+      expect(existsSync(sentinel)).toBe(false);
+    });
+
+    // ── Explicit trust-decision tests ──────────────────────────────────────
+
+    test('trust decision "allow" — commitChanges runs pre-commit hook', async () => {
+      mockTrustDecision = "allow";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: allow enables pre-commit hook");
+
+      expect(existsSync(sentinel)).toBe(true);
+    });
+
+    test('trust decision "deny" — commitChanges does not run pre-commit hook', async () => {
+      mockTrustDecision = "deny";
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const sentinel = join(testDir, "pre-commit-ran.marker");
+      installHook(testDir, "pre-commit", sentinel);
+
+      writeFileSync(join(testDir, "file.txt"), "content");
+      await service.commitChanges("test: deny suppresses pre-commit hook");
+
       expect(existsSync(sentinel)).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** PR 4 allow/deny hook trust tests not present in workspace-git-service.test.ts as plan specified
**What was expected:** Explicit allow and deny decision tests with marker-producing hook scripts in the primary service test file
**What was found:** Tests were only in workspace-lifecycle.test.ts and commit-guarantee.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
