### PR TITLE
fix(ios): rename systemDanger* color tokens to systemNegative*

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -389,7 +389,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemDangerStrong banner
+                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemNegativeStrong banner
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             } else if viewModel.isRetryableError {
@@ -399,7 +399,7 @@ struct ChatContentView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemDangerStrong banner
+                        .background(Color.white.opacity(0.25)) // Intentional: translucent contrast on VColor.systemNegativeStrong banner
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                 }
             }
@@ -411,7 +411,7 @@ struct ChatContentView: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.sm)
-        .background(VColor.systemDangerStrong)
+        .background(VColor.systemNegativeStrong)
         .transition(.move(edge: .top).combined(with: .opacity))
     }
 
@@ -433,11 +433,11 @@ struct ChatContentView: View {
 
     private func sessionErrorAccent(_ category: SessionErrorCategory) -> Color {
         switch category {
-        case .rateLimit: return VColor.systemDangerHover
+        case .rateLimit: return VColor.systemNegativeHover
         case .providerNetwork: return .orange
         case .sessionAborted: return VColor.contentSecondary
-        case .contextTooLarge: return VColor.systemDangerHover
-        default: return VColor.systemDangerStrong
+        case .contextTooLarge: return VColor.systemNegativeHover
+        default: return VColor.systemNegativeStrong
         }
     }
 

--- a/clients/ios/Views/DebugPanelView.swift
+++ b/clients/ios/Views/DebugPanelView.swift
@@ -84,7 +84,7 @@ struct DebugPanelView: View {
                         icon: .triangleAlert,
                         label: "Failures",
                         value: "\(failures)",
-                        color: VColor.systemDangerStrong
+                        color: VColor.systemNegativeStrong
                     )
                 }
             }
@@ -224,7 +224,7 @@ struct TraceTimelineIOSView: View {
                         }
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
-                        .foregroundColor(VColor.systemDangerHover)
+                        .foregroundColor(VColor.systemNegativeHover)
                         .background(VColor.surfaceActive)
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         .overlay(
@@ -257,7 +257,7 @@ struct TraceTimelineIOSView: View {
                 if groupStatus == .cancelled {
                     Text("Cancelled")
                         .font(VFont.small)
-                        .foregroundColor(VColor.systemDangerHover)
+                        .foregroundColor(VColor.systemNegativeHover)
                 } else if groupStatus == .handedOff {
                     Text("Handed off")
                         .font(VFont.small)
@@ -265,7 +265,7 @@ struct TraceTimelineIOSView: View {
                 } else if groupStatus == .error {
                     Text("Error")
                         .font(VFont.small)
-                        .foregroundColor(VColor.systemDangerStrong)
+                        .foregroundColor(VColor.systemNegativeStrong)
                 }
 
                 Rectangle()
@@ -293,9 +293,9 @@ struct TraceTimelineIOSView: View {
         switch status {
         case .active: return VColor.systemPositiveStrong
         case .completed: return VColor.systemPositiveStrong
-        case .cancelled: return VColor.systemDangerHover
+        case .cancelled: return VColor.systemNegativeHover
         case .handedOff: return VColor.systemPositiveWeak
-        case .error: return VColor.systemDangerStrong
+        case .error: return VColor.systemNegativeStrong
         }
     }
 
@@ -401,8 +401,8 @@ struct TraceTimelineIOSView: View {
 
     private func statusColor(for status: String?) -> Color {
         switch status {
-        case "error": return VColor.systemDangerStrong
-        case "warning": return VColor.systemDangerHover
+        case "error": return VColor.systemNegativeStrong
+        case "warning": return VColor.systemNegativeHover
         case "success": return VColor.systemPositiveStrong
         default: return VColor.contentTertiary
         }

--- a/clients/ios/Views/LoginView.swift
+++ b/clients/ios/Views/LoginView.swift
@@ -30,7 +30,7 @@ struct LoginView: View {
             if let error = authManager.errorMessage {
                 Text(error)
                     .font(VFont.caption)
-                    .foregroundColor(VColor.systemDangerStrong)
+                    .foregroundColor(VColor.systemNegativeStrong)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, VSpacing.xl)
             }

--- a/clients/ios/Views/Settings/ChannelsGuardianSection.swift
+++ b/clients/ios/Views/Settings/ChannelsGuardianSection.swift
@@ -119,7 +119,7 @@ struct ChannelsGuardianSection: View {
                 showRevokeConfirmation = true
             } label: {
                 VIconView(.circleX, size: 14)
-                    .foregroundColor(VColor.systemDangerStrong)
+                    .foregroundColor(VColor.systemNegativeStrong)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Revoke channel \(channel.address)")
@@ -155,8 +155,8 @@ struct ChannelsGuardianSection: View {
         let (color, label): (Color, String) = {
             switch policy {
             case "allow": return (VColor.systemPositiveStrong, "Allow")
-            case "deny": return (VColor.systemDangerStrong, "Deny")
-            case "escalate": return (VColor.systemDangerHover, "Escalate")
+            case "deny": return (VColor.systemNegativeStrong, "Deny")
+            case "escalate": return (VColor.systemNegativeHover, "Escalate")
             default: return (VColor.contentTertiary, policy.capitalized)
             }
         }()
@@ -175,8 +175,8 @@ struct ChannelsGuardianSection: View {
         let (color, label): (Color, String) = {
             switch status {
             case "active": return (VColor.systemPositiveStrong, "Active")
-            case "revoked": return (VColor.systemDangerStrong, "Revoked")
-            case "pending": return (VColor.systemDangerHover, "Pending")
+            case "revoked": return (VColor.systemNegativeStrong, "Revoked")
+            case "pending": return (VColor.systemNegativeHover, "Pending")
             default: return (VColor.contentTertiary, status.capitalized)
             }
         }()

--- a/clients/ios/Views/Settings/ConnectionSettingsSection.swift
+++ b/clients/ios/Views/Settings/ConnectionSettingsSection.swift
@@ -73,7 +73,7 @@ struct DaemonConnectionSection: View {
                         // Disconnected state — gateway configured but not connected
                         HStack {
                             VIconView(.circleAlert, size: 16)
-                                .foregroundColor(VColor.systemDangerStrong)
+                                .foregroundColor(VColor.systemNegativeStrong)
                             Text("Disconnected")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.contentDefault)
@@ -159,7 +159,7 @@ struct DaemonConnectionSection: View {
                 if let error = authManager.errorMessage {
                     Text(error)
                         .font(VFont.caption)
-                        .foregroundColor(VColor.systemDangerStrong)
+                        .foregroundColor(VColor.systemNegativeStrong)
                 }
             } header: {
                 Text("Vellum Account")

--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -38,7 +38,7 @@ struct IntegrationsSection: View {
                                     disconnectIntegration(integration.id)
                                 }
                                 .font(.caption)
-                                .foregroundColor(VColor.systemDangerStrong)
+                                .foregroundColor(VColor.systemNegativeStrong)
                             } else {
                                 Button("Connect") {
                                     connectIntegration(integration.id)

--- a/clients/ios/Views/Settings/PermissionRowView.swift
+++ b/clients/ios/Views/Settings/PermissionRowView.swift
@@ -61,7 +61,7 @@ struct PermissionRowView: View {
     private var statusColor: Color {
         switch status {
         case .granted: return VColor.systemPositiveStrong
-        case .denied: return VColor.systemDangerStrong
+        case .denied: return VColor.systemNegativeStrong
         case .notDetermined: return VColor.contentTertiary
         }
     }

--- a/clients/ios/Views/Settings/PrivacySection.swift
+++ b/clients/ios/Views/Settings/PrivacySection.swift
@@ -69,8 +69,8 @@ struct PrivacySection: View {
         let (color, label): (Color, String) = {
             switch status {
             case .granted: return (VColor.systemPositiveStrong, "Granted")
-            case .denied: return (VColor.systemDangerStrong, "Denied")
-            case .notDetermined: return (VColor.systemDangerHover, "Not Set")
+            case .denied: return (VColor.systemNegativeStrong, "Denied")
+            case .notDetermined: return (VColor.systemNegativeHover, "Not Set")
             }
         }()
         Text(label)

--- a/clients/ios/Views/Settings/QRPairingSheet.swift
+++ b/clients/ios/Views/Settings/QRPairingSheet.swift
@@ -184,7 +184,7 @@ struct QRPairingSheet: View {
             Spacer()
 
             VIconView(.triangleAlert, size: 48)
-                .foregroundColor(VColor.systemDangerStrong)
+                .foregroundColor(VColor.systemNegativeStrong)
 
             Text("Pairing Failed")
                 .font(VFont.title)

--- a/clients/ios/Views/Settings/RemindersSection.swift
+++ b/clients/ios/Views/Settings/RemindersSection.swift
@@ -75,7 +75,7 @@ struct RemindersSection: View {
     private func statusBadge(_ status: String) -> some View {
         let (color, label): (Color, String) = {
             switch status {
-            case "active": return (VColor.systemDangerHover, "Active")
+            case "active": return (VColor.systemNegativeHover, "Active")
             case "fired": return (VColor.systemPositiveStrong, "Fired")
             case "cancelled": return (VColor.contentTertiary, "Cancelled")
             default: return (VColor.contentSecondary, status.capitalized)

--- a/clients/ios/Views/Settings/TrustRulesSection.swift
+++ b/clients/ios/Views/Settings/TrustRulesSection.swift
@@ -93,8 +93,8 @@ struct TrustRulesSection: View {
         let (color, label): (Color, String) = {
             switch decision {
             case "allow": return (VColor.systemPositiveStrong, "Allow")
-            case "deny": return (VColor.systemDangerStrong, "Deny")
-            default: return (VColor.systemDangerHover, "Ask")
+            case "deny": return (VColor.systemNegativeStrong, "Deny")
+            default: return (VColor.systemNegativeHover, "Ask")
             }
         }()
         Text(label)

--- a/clients/ios/Views/Settings/TwilioSettingsSection.swift
+++ b/clients/ios/Views/Settings/TwilioSettingsSection.swift
@@ -44,7 +44,7 @@ struct TwilioSettingsSection: View {
                                 .foregroundStyle(.secondary)
                         } else {
                             VIconView(.circleX, size: 16)
-                                .foregroundColor(VColor.systemDangerStrong)
+                                .foregroundColor(VColor.systemNegativeStrong)
                             Text("Not configured")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
@@ -163,7 +163,7 @@ struct TwilioSettingsSection: View {
                     if let error = errorMessage {
                         Text(error)
                             .font(.caption)
-                            .foregroundColor(VColor.systemDangerStrong)
+                            .foregroundColor(VColor.systemNegativeStrong)
                     }
                 }
             }

--- a/clients/ios/Views/SettingsView.swift
+++ b/clients/ios/Views/SettingsView.swift
@@ -197,7 +197,7 @@ struct AccountSection: View {
             if let error = authManager.errorMessage {
                 Text(error)
                     .font(VFont.caption)
-                    .foregroundColor(VColor.systemDangerStrong)
+                    .foregroundColor(VColor.systemNegativeStrong)
             }
         }
     }

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -378,7 +378,7 @@ struct ThreadListView: View {
                         } label: {
                             Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                         }
-                        .tint(VColor.systemDangerHover)
+                        .tint(VColor.systemNegativeHover)
                     }
                     .swipeActions(edge: .leading) {
                         Button {
@@ -508,7 +508,7 @@ struct ThreadListView: View {
                     } label: {
                         Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                     }
-                    .tint(VColor.systemDangerHover)
+                    .tint(VColor.systemNegativeHover)
                 }
                 .swipeActions(edge: .leading) {
                     Button {
@@ -543,7 +543,7 @@ struct ThreadListView: View {
                             } label: {
                                 Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
                             }
-                            .tint(VColor.systemDangerHover)
+                            .tint(VColor.systemNegativeHover)
                         }
                         .swipeActions(edge: .leading) {
                             Button {
@@ -569,7 +569,7 @@ struct ThreadListView: View {
                                 .accessibilityLabel("Pinned")
                         }
                         if scheduleGroupHasUnread(group) {
-                            VBadge(style: .dot, color: VColor.systemDangerHover)
+                            VBadge(style: .dot, color: VColor.systemNegativeHover)
                                 .accessibilityLabel("Unread")
                         }
                         Text("\(group.threads.count)")
@@ -609,7 +609,7 @@ struct ThreadListView: View {
                         .accessibilityLabel("Pinned")
                 }
                 if store.isConnectedMode && thread.hasUnseenLatestAssistantMessage {
-                    VBadge(style: .dot, color: VColor.systemDangerHover)
+                    VBadge(style: .dot, color: VColor.systemNegativeHover)
                         .accessibilityLabel("Unread")
                 }
                 Spacer()


### PR DESCRIPTION
## Summary
- Renamed all `VColor.systemDangerStrong` → `VColor.systemNegativeStrong` and `VColor.systemDangerHover` → `VColor.systemNegativeHover` across 14 iOS view files
- These references were stale after ColorTokens.swift adopted the Figma design system naming (`systemNegative*`), breaking the iOS build

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23020007410/job/66853569671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
