### PR TITLE
fix: use unfiltered rule store for internal trust decision lookup

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -585,6 +585,11 @@ export function getAllRules(): TrustRule[] {
   return getRules().filter((r) => !r.tool.startsWith("__internal:"));
 }
 
+/** @internal For use by pseudo-rule consumers only. Do not use in user-facing routes or CLI. */
+export function getAllRulesIncludingInternal(): TrustRule[] {
+  return getRules();
+}
+
 export function clearAllRules(): void {
   // Reset the starter bundle flag so the bundle can be re-accepted after clear.
   cachedStarterBundleAccepted = false;

--- a/assistant/src/workspace/git-hooks-trust.ts
+++ b/assistant/src/workspace/git-hooks-trust.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import {
-  getAllRules,
+  getAllRulesIncludingInternal,
   removePseudoRule,
   upsertPseudoRule,
 } from "../permissions/trust-store.js";
@@ -34,7 +34,7 @@ export function getGitHooksTrustDecision(
   workspaceDir: string,
 ): "allow" | "deny" | "ask" {
   const pattern = patternForWorkspace(workspaceDir);
-  const rules = getAllRules();
+  const rules = getAllRulesIncludingInternal();
   for (const rule of rules) {
     if (
       rule.tool === GIT_HOOKS_TRUST_PSEUDO_TOOL &&


### PR DESCRIPTION
## Summary
Fixes critical regression introduced by PR #15901.

**Gap:** getAllRules() now filters __internal: rules, breaking getGitHooksTrustDecision which always returned 'ask'
**What was expected:** Persisted trust decisions (allow/deny) should be readable after being written
**What was found:** getAllRulesIncludingInternal() was missing; git-hooks-trust.ts read from filtered store

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
