### PR TITLE
fix: block creation of __internal: pseudo-rules via addRule and HTTP API

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -395,6 +395,8 @@ export function addRule(
     executionTarget?: string;
   },
 ): TrustRule {
+  if (tool.startsWith("__internal:"))
+    throw new Error(`Cannot create internal pseudo-rule via addRule: ${tool}`);
   // Re-read from disk to avoid lost updates if another call modified rules
   // between our last read and now (e.g. two rapid trust rule additions).
   cachedRules = null;

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -48,6 +48,13 @@ export async function handleAddTrustRuleManage(
   if (!toolName || typeof toolName !== "string") {
     return httpError("BAD_REQUEST", "toolName is required", 400);
   }
+  if (toolName.startsWith("__internal:")) {
+    return httpError(
+      "BAD_REQUEST",
+      "toolName must not start with __internal:",
+      400,
+    );
+  }
   if (!pattern || typeof pattern !== "string") {
     return httpError("BAD_REQUEST", "pattern is required", 400);
   }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review round 2 for git-hooks-trust-prompt-exploit-fix.md.

**Gap:** addRule() allowed injection of __internal: pseudo-rules via the HTTP API
**What was expected:** All user-facing trust rule APIs should block __internal: tool names
**What was found:** PR #15901 added guards to update/remove/clear/list but missed addRule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
