### PR TITLE
fix(lint): remove unused import and fix import sorting

### DIFF
--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -11,7 +11,6 @@ import {
   test,
 } from "bun:test";
 
-
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 
 const testDir = mkdtempSync(join(tmpdir(), "memory-lifecycle-e2e-"));

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
-import { getDb, rawAll, rawChanges, rawGet } from "./db.js";
+import { getDb, rawAll, rawChanges } from "./db.js";
 import { memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-jobs-store");


### PR DESCRIPTION
## Summary
- Remove unused `rawGet` import from `assistant/src/memory/jobs-store.ts`
- Fix import sorting (extra blank line) in `assistant/src/__tests__/memory-lifecycle-e2e.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23020312680/job/66854645985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
