### PR TITLE
test: fix git-hooks-trust mock to handle rev-parse --git-path hooks

### DIFF
--- a/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
+++ b/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
@@ -59,6 +59,11 @@ const trustPath = join(testDir, "protected", "trust.json");
 function makeGitService(hooksPath?: string): GitServiceLike {
   return {
     async runReadOnlyGit(args: string[]) {
+      if (args[0] === "rev-parse" && args[1] === "--git-path") {
+        // Simulate git not being in a worktree context — triggers the fallback
+        // to workspaceDir/.git/hooks in detectConfiguredHooks.
+        throw new Error("not a git repository");
+      }
       if (
         args.length >= 3 &&
         args[0] === "config" &&


### PR DESCRIPTION
## Summary
Fixes 4 failing tests in workspace-git-hooks-trust.test.ts.

**Gap:** makeGitService mock returned empty stdout for rev-parse --git-path hooks, causing hooks dir to resolve to workspace root instead of .git/hooks
**Fix:** Mock now throws on rev-parse --git-path hooks, triggering the fallback path to .git/hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
