### PR TITLE
fix: include web_search_tool_result in all tool_result type checks

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -671,7 +671,10 @@ function countPersistedMessages(messages: Message[]): number {
 function isToolResultOnly(message: Message): boolean {
   return (
     message.content.length > 0 &&
-    message.content.every((block) => block.type === "tool_result")
+    message.content.every(
+      (block) =>
+        block.type === "tool_result" || block.type === "web_search_tool_result",
+    )
   );
 }
 

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -21,6 +21,14 @@ const log = getLogger("session-history");
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+function isToolResultBlock(
+  block: ContentBlock | Record<string, unknown>,
+): boolean {
+  return (
+    block.type === "tool_result" || block.type === "web_search_tool_result"
+  );
+}
+
 function isUndoableUserMessage(message: Message): boolean {
   if (message.role !== "user") return false;
   if (getSummaryFromContextMessage(message) != null) return false;
@@ -30,7 +38,7 @@ function isUndoableUserMessage(message: Message): boolean {
   // (e.g. after repairHistory merges a tool_result turn with a user prompt) are still
   // undoable because they contain real user content.
   const hasNonToolResultContent = message.content.some(
-    (block) => block.type !== "tool_result",
+    (block) => !isToolResultBlock(block),
   );
   if (!hasNonToolResultContent) return false;
   return true;
@@ -143,7 +151,9 @@ export function consolidateAssistantMessages(
         const content = JSON.parse(msg.content);
         const isToolResultOnly =
           Array.isArray(content) &&
-          content.every((block) => block.type === "tool_result") &&
+          content.every((block: Record<string, unknown>) =>
+            isToolResultBlock(block),
+          ) &&
           content.length > 0;
         if (isToolResultOnly) {
           internalToolResultMessages.push(msg);
@@ -229,8 +239,8 @@ export function consolidateAssistantMessages(
     try {
       const content = JSON.parse(msg.content);
       if (Array.isArray(content)) {
-        const toolResultBlocks = content.filter(
-          (b: Record<string, unknown>) => b.type === "tool_result",
+        const toolResultBlocks = content.filter((b: Record<string, unknown>) =>
+          isToolResultBlock(b),
         );
         log.info(
           {
@@ -253,8 +263,8 @@ export function consolidateAssistantMessages(
   const toolUseBlocksInConsolidated = consolidatedContent.filter(
     (b) => b.type === "tool_use",
   ).length;
-  const toolResultBlocksInConsolidated = consolidatedContent.filter(
-    (b) => b.type === "tool_result",
+  const toolResultBlocksInConsolidated = consolidatedContent.filter((b) =>
+    isToolResultBlock(b),
   ).length;
   log.info(
     {
@@ -471,7 +481,7 @@ export async function regenerate(
       if (
         Array.isArray(parsed) &&
         parsed.length > 0 &&
-        parsed.every((b: Record<string, unknown>) => b.type === "tool_result")
+        parsed.every((b: Record<string, unknown>) => isToolResultBlock(b))
       ) {
         continue; // Skip tool_result-only user messages
       }


### PR DESCRIPTION
## Summary
- Adds isToolResultBlock() helper function to check for both tool_result and web_search_tool_result types
- Fixes consolidateAssistantMessages() to preserve web_search_tool_result blocks
- Fixes isUndoableUserMessage() to recognize web_search_tool_result-only messages
- Fixes regenerate() to handle web_search_tool_result blocks
- Fixes isToolResultOnly() in window-manager.ts for context window compaction

Part of plan: JARVIS-188-web-search-tool-result-dropped.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
