### PR TITLE
feat: add mid-loop token budget check via onCheckpoint

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -869,11 +869,13 @@ describe("AgentLoop", () => {
     await loop.run([userMessage], () => {}, undefined, undefined, onCheckpoint);
 
     expect(checkpoints).toHaveLength(1);
-    expect(checkpoints[0]).toEqual({
+    expect(checkpoints[0]).toMatchObject({
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
     });
+    // history should contain the full conversation at checkpoint time
+    expect(checkpoints[0].history.length).toBeGreaterThanOrEqual(3);
   });
 
   // 17. Returning 'continue' lets the loop proceed normally

--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -1204,39 +1204,358 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
   // ── Test 6 ────────────────────────────────────────────────────────
   // Tests mid-loop budget check via onCheckpoint.
-  // Depends on PR 3 which adds token estimation to the onCheckpoint callback.
-  //
-  // After PR 3:
-  // - The onCheckpoint callback will estimate prompt tokens after each tool round
-  // - When estimate exceeds a mid-loop threshold (e.g., 85% of budget),
-  //   it returns "yield" to break the agent loop
-  // - The session-agent-loop then runs compaction on the yielded history
-  //   and re-enters the agent loop
-  //
-  // Test setup:
-  // - Mock estimatePromptTokens to return increasing values per call
-  //   (simulating growing history from tool results)
-  // - After 3 tool rounds, estimate exceeds mid-loop threshold
-  // - Assert onCheckpoint returns "yield"
-  // - Assert compaction runs on the yielded history
-  // - Assert agent loop re-enters and completes
-  test.todo(
-    "onCheckpoint yields when token estimate exceeds mid-loop budget threshold",
-    () => {},
-  );
+  // The onCheckpoint callback estimates prompt tokens after each tool round.
+  // When estimate exceeds the mid-loop threshold (85% of budget),
+  // it returns "yield" to break the agent loop.
+  // The session-agent-loop then runs compaction and re-enters the agent loop.
+  test("onCheckpoint yields when token estimate exceeds mid-loop budget threshold", async () => {
+    const events: ServerMessage[] = [];
+    let compactionCalled = false;
+
+    // estimatePromptTokens is called:
+    // 1. During preflight budget check (low value, below budget)
+    // 2. During onCheckpoint mid-loop check (high value, above 85% threshold)
+    // Budget = 200_000 * 0.95 = 190_000
+    // Mid-loop threshold = 190_000 * 0.85 = 161_500
+    let estimateCallCount = 0;
+    mockEstimateTokens = () => {
+      estimateCallCount++;
+      // First call: preflight check — below budget
+      if (estimateCallCount === 1) return 100_000;
+      // Subsequent calls: mid-loop check — above 85% threshold
+      return 170_000;
+    };
+
+    let agentLoopCallCount = 0;
+    const agentLoopRun: AgentLoopRun = async (
+      messages,
+      onEvent,
+      _signal,
+      _requestId,
+      onCheckpoint,
+    ) => {
+      agentLoopCallCount++;
+
+      if (agentLoopCallCount === 1) {
+        // Simulate a tool round: assistant calls a tool, results come back
+        const withProgress: Message[] = [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: "Let me check." },
+              {
+                type: "tool_use",
+                id: "tu-1",
+                name: "bash",
+                input: { command: "ls" },
+              },
+            ] as ContentBlock[],
+          },
+          {
+            role: "user" as const,
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-1",
+                content: "file1.ts\nfile2.ts",
+                is_error: false,
+              },
+            ] as ContentBlock[],
+          },
+        ];
+
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Let me check." },
+              {
+                type: "tool_use",
+                id: "tu-1",
+                name: "bash",
+                input: { command: "ls" },
+              },
+            ],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 100,
+          outputTokens: 50,
+          model: "test-model",
+          providerDurationMs: 100,
+        });
+
+        // Call onCheckpoint — this should trigger the mid-loop budget check
+        // which sees 170_000 > 161_500 and returns "yield"
+        if (onCheckpoint) {
+          const decision = onCheckpoint({
+            turnIndex: 0,
+            toolCount: 1,
+            hasToolUse: true,
+            history: withProgress,
+          });
+          if (decision === "yield") {
+            // Agent loop stops when checkpoint yields
+            return withProgress;
+          }
+        }
+
+        return withProgress;
+      }
+
+      // Second call (after compaction): complete successfully
+      onEvent({
+        type: "message_complete",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done after compaction" }],
+        },
+      });
+      onEvent({
+        type: "usage",
+        inputTokens: 50,
+        outputTokens: 25,
+        model: "test-model",
+        providerDurationMs: 100,
+      });
+      return [
+        ...messages,
+        {
+          role: "assistant" as const,
+          content: [
+            { type: "text", text: "done after compaction" },
+          ] as ContentBlock[],
+        },
+      ];
+    };
+
+    const ctx = makeCtx({
+      agentLoopRun,
+      contextWindowManager: {
+        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+        maybeCompact: async () => {
+          compactionCalled = true;
+          return {
+            compacted: true,
+            messages: [
+              {
+                role: "user" as const,
+                content: [{ type: "text", text: "Hello" }],
+              },
+            ] as Message[],
+            compactedPersistedMessages: 5,
+            summaryText: "Mid-loop compaction summary",
+            previousEstimatedInputTokens: 170_000,
+            estimatedInputTokens: 80_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 10,
+            summaryCalls: 1,
+            summaryInputTokens: 500,
+            summaryOutputTokens: 200,
+            summaryModel: "mock-model",
+          };
+        },
+      } as unknown as AgentLoopSessionContext["contextWindowManager"],
+    });
+
+    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+    // The mid-loop budget check should have triggered compaction
+    expect(compactionCalled).toBe(true);
+
+    // Agent loop should have been called twice: once before yield, once after compaction
+    expect(agentLoopCallCount).toBe(2);
+
+    // No session_error should be emitted
+    const sessionError = events.find((e) => e.type === "session_error");
+    expect(sessionError).toBeUndefined();
+
+    // A context_compacted event should have been emitted
+    const compacted = events.find((e) => e.type === "context_compacted");
+    expect(compacted).toBeDefined();
+  });
 
   // ── Test 7 ────────────────────────────────────────────────────────
   // Tests that mid-loop budget check prevents context_too_large entirely.
-  // Depends on PR 3 which adds token estimation to the onCheckpoint callback.
-  //
-  // After PR 3:
-  // - Agent loop runs 5 tool calls, each adding ~10k tokens of results
-  // - After tool call 3, estimated tokens exceed mid-loop threshold
-  // - Assert that the loop yields, compaction runs, and the loop resumes
-  // - Assert that the provider NEVER rejects with context_too_large
-  //   (the mid-loop check prevents us from ever hitting the limit)
-  test.todo(
-    "mid-loop budget check prevents context_too_large when tools produce large results",
-    () => {},
-  );
+  // Agent loop runs tool calls with growing history. After the estimate
+  // exceeds the mid-loop threshold, the loop yields, compaction runs,
+  // and the loop resumes. The provider NEVER rejects with context_too_large.
+  test("mid-loop budget check prevents context_too_large when tools produce large results", async () => {
+    const events: ServerMessage[] = [];
+    let compactionCalled = false;
+
+    // Budget = 200_000 * 0.95 = 190_000
+    // Mid-loop threshold = 190_000 * 0.85 = 161_500
+    // Simulate token growth: preflight = 50k, then each checkpoint call
+    // returns a growing estimate. By tool call 3, we exceed the threshold.
+    let estimateCallCount = 0;
+    mockEstimateTokens = () => {
+      estimateCallCount++;
+      // First call: preflight — well below budget
+      if (estimateCallCount === 1) return 50_000;
+      // Checkpoint calls grow with each tool round
+      if (estimateCallCount === 2) return 100_000; // tool 1
+      if (estimateCallCount === 3) return 140_000; // tool 2
+      // Tool 3: exceeds 161_500 threshold
+      return 175_000;
+    };
+
+    let agentLoopCallCount = 0;
+    let contextTooLargeEmitted = false;
+
+    const agentLoopRun: AgentLoopRun = async (
+      messages,
+      onEvent,
+      _signal,
+      _requestId,
+      onCheckpoint,
+    ) => {
+      agentLoopCallCount++;
+
+      if (agentLoopCallCount === 1) {
+        const currentHistory = [...messages];
+
+        // Simulate 5 tool rounds — but the checkpoint should yield at round 3
+        for (let i = 0; i < 5; i++) {
+          const toolId = `tu-${i}`;
+          const assistantMsg: Message = {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: `Step ${i}` },
+              {
+                type: "tool_use",
+                id: toolId,
+                name: "bash",
+                input: { command: `cmd-${i}` },
+              },
+            ] as ContentBlock[],
+          };
+          const resultMsg: Message = {
+            role: "user" as const,
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: toolId,
+                content: "x".repeat(10_000),
+                is_error: false,
+              },
+            ] as ContentBlock[],
+          };
+          currentHistory.push(assistantMsg, resultMsg);
+
+          onEvent({
+            type: "message_complete",
+            message: assistantMsg,
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 50_000 + i * 20_000,
+            outputTokens: 50,
+            model: "test-model",
+            providerDurationMs: 100,
+          });
+
+          if (onCheckpoint) {
+            const decision = onCheckpoint({
+              turnIndex: i,
+              toolCount: 1,
+              hasToolUse: true,
+              history: currentHistory,
+            });
+            if (decision === "yield") {
+              return currentHistory;
+            }
+          }
+        }
+
+        return currentHistory;
+      }
+
+      // Second call (after compaction): complete
+      onEvent({
+        type: "message_complete",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "completed after mid-loop compaction" },
+          ],
+        },
+      });
+      onEvent({
+        type: "usage",
+        inputTokens: 60_000,
+        outputTokens: 100,
+        model: "test-model",
+        providerDurationMs: 200,
+      });
+      return [
+        ...messages,
+        {
+          role: "assistant" as const,
+          content: [
+            { type: "text", text: "completed after mid-loop compaction" },
+          ] as ContentBlock[],
+        },
+      ];
+    };
+
+    const ctx = makeCtx({
+      agentLoopRun,
+      contextWindowManager: {
+        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+        maybeCompact: async () => {
+          compactionCalled = true;
+          return {
+            compacted: true,
+            messages: [
+              {
+                role: "user" as const,
+                content: [{ type: "text", text: "Hello" }],
+              },
+            ] as Message[],
+            compactedPersistedMessages: 8,
+            summaryText: "Compacted large tool results",
+            previousEstimatedInputTokens: 175_000,
+            estimatedInputTokens: 60_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 15,
+            summaryCalls: 1,
+            summaryInputTokens: 800,
+            summaryOutputTokens: 300,
+            summaryModel: "mock-model",
+          };
+        },
+      } as unknown as AgentLoopSessionContext["contextWindowManager"],
+    });
+
+    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => {
+      events.push(msg);
+      // Track if context_too_large was ever emitted
+      if (
+        msg.type === "session_error" &&
+        "code" in msg &&
+        msg.code === "SESSION_PROCESSING_FAILED"
+      ) {
+        contextTooLargeEmitted = true;
+      }
+    });
+
+    // Compaction should have been triggered by mid-loop budget check
+    expect(compactionCalled).toBe(true);
+
+    // The provider should NEVER have rejected with context_too_large
+    expect(contextTooLargeEmitted).toBe(false);
+
+    // Agent loop called twice: once (yielded at tool 3), once after compaction
+    expect(agentLoopCallCount).toBe(2);
+
+    // No session_error
+    const sessionError = events.find((e) => e.type === "session_error");
+    expect(sessionError).toBeUndefined();
+  });
 });

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -1293,6 +1293,7 @@ describe("session-agent-loop", () => {
             turnIndex: 0,
             toolCount: 1,
             hasToolUse: true,
+            history: messages,
           });
           if (decision === "yield") {
             return [
@@ -1356,7 +1357,12 @@ describe("session-agent-loop", () => {
           providerDurationMs: 100,
         });
         if (onCheckpoint) {
-          onCheckpoint({ turnIndex: 0, toolCount: 1, hasToolUse: true });
+          onCheckpoint({
+            turnIndex: 0,
+            toolCount: 1,
+            hasToolUse: true,
+            history: messages,
+          });
         }
         return [
           ...messages,
@@ -1418,7 +1424,12 @@ describe("session-agent-loop", () => {
           providerDurationMs: 100,
         });
         if (onCheckpoint) {
-          onCheckpoint({ turnIndex: 0, toolCount: 1, hasToolUse: true });
+          onCheckpoint({
+            turnIndex: 0,
+            toolCount: 1,
+            hasToolUse: true,
+            history: messages,
+          });
         }
         return [
           ...messages,

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -726,7 +726,6 @@ describe("Session message queue", () => {
     // msg-3 should have completed successfully
     expect(events3.some((e) => e.type === "message_complete")).toBe(true);
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -864,6 +863,7 @@ describe("Session checkpoint handoff", () => {
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
+      history: [],
     });
 
     // Because there is a queued message, the callback should return 'yield'
@@ -906,6 +906,7 @@ describe("Session checkpoint handoff", () => {
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
+      history: [],
     });
 
     // No queued messages → continue
@@ -948,6 +949,7 @@ describe("Session checkpoint handoff", () => {
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
+      history: [],
     });
     expect(decision).toBe("yield");
 
@@ -1001,6 +1003,7 @@ describe("Session checkpoint handoff", () => {
       turnIndex: 0,
       toolCount: 1,
       hasToolUse: true,
+      history: [],
     });
     expect(decision).toBe("yield");
 
@@ -1062,7 +1065,12 @@ describe("Session checkpoint handoff", () => {
     const runA = pendingRuns[0];
     expect(runA.onCheckpoint).toBeDefined();
     expect(
-      runA.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true }),
+      runA.onCheckpoint!({
+        turnIndex: 0,
+        toolCount: 1,
+        hasToolUse: true,
+        history: [],
+      }),
     ).toBe("yield");
     resolveRun(0);
     await pA;
@@ -1074,7 +1082,12 @@ describe("Session checkpoint handoff", () => {
     const runB = pendingRuns[1];
     expect(runB.onCheckpoint).toBeDefined();
     expect(
-      runB.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true }),
+      runB.onCheckpoint!({
+        turnIndex: 0,
+        toolCount: 1,
+        hasToolUse: true,
+        history: [],
+      }),
     ).toBe("yield");
     resolveRun(1);
     await waitForPendingRun(3);
@@ -1084,7 +1097,12 @@ describe("Session checkpoint handoff", () => {
     expect(runC.onCheckpoint).toBeDefined();
     // Only D remains, still should yield
     expect(
-      runC.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true }),
+      runC.onCheckpoint!({
+        turnIndex: 0,
+        toolCount: 1,
+        hasToolUse: true,
+        history: [],
+      }),
     ).toBe("yield");
     resolveRun(2);
     await waitForPendingRun(4);
@@ -1093,7 +1111,12 @@ describe("Session checkpoint handoff", () => {
     const runD = pendingRuns[3];
     expect(runD.onCheckpoint).toBeDefined();
     expect(
-      runD.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true }),
+      runD.onCheckpoint!({
+        turnIndex: 0,
+        toolCount: 1,
+        hasToolUse: true,
+        history: [],
+      }),
     ).toBe("continue");
 
     resolveRun(3);
@@ -1491,7 +1514,12 @@ describe("Session attachment event payloads", () => {
     const run = pendingRuns[0];
     expect(run.onCheckpoint).toBeDefined();
     expect(
-      run.onCheckpoint!({ turnIndex: 0, toolCount: 1, hasToolUse: true }),
+      run.onCheckpoint!({
+        turnIndex: 0,
+        toolCount: 1,
+        hasToolUse: true,
+        history: [],
+      }),
     ).toBe("yield");
 
     const assistantMsg: Message = {
@@ -1828,15 +1856,11 @@ describe("MessageQueue byte budget", () => {
     // Total ~6512 bytes. Budget of 5000 should reject.
     const q = new MessageQueue(5_000);
     expect(
-      q.push(
-        makeItem("x".repeat(1000), "r1", [{ data: "a".repeat(2000) }]),
-      ),
+      q.push(makeItem("x".repeat(1000), "r1", [{ data: "a".repeat(2000) }])),
     ).toBe(true); // first message always accepted
     // Second message of same size should be rejected
     expect(
-      q.push(
-        makeItem("y".repeat(100), "r2", [{ data: "b".repeat(100) }]),
-      ),
+      q.push(makeItem("y".repeat(100), "r2", [{ data: "b".repeat(100) }])),
     ).toBe(false);
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -35,6 +35,7 @@ export interface CheckpointInfo {
   turnIndex: number;
   toolCount: number;
   hasToolUse: boolean;
+  history: Message[]; // current history snapshot for token estimation
 }
 
 export type CheckpointDecision = "continue" | "yield";
@@ -561,6 +562,7 @@ export class AgentLoop {
             turnIndex: toolUseTurns - 1, // 0-based (toolUseTurns was already incremented)
             toolCount: toolUseBlocks.length,
             hasToolUse: true,
+            history,
           });
           if (decision === "yield") {
             break;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -13,6 +13,7 @@ import type {
   AgentEvent,
   AgentLoop,
   CheckpointDecision,
+  CheckpointInfo,
 } from "../agent/loop.js";
 import { createAssistantMessage } from "../agent/message-types.js";
 import type {
@@ -796,7 +797,9 @@ export async function runAgentLoopImpl(
     const eventHandler = (event: AgentEvent) =>
       dispatchAgentEvent(state, deps, event);
 
-    const onCheckpoint = (): CheckpointDecision => {
+    let yieldedForBudget = false;
+
+    const onCheckpoint = (checkpoint: CheckpointInfo): CheckpointDecision => {
       const turnTools = state.currentTurnToolNames;
       state.currentTurnToolNames = [];
 
@@ -809,6 +812,26 @@ export async function runAgentLoopImpl(
           return "yield";
         }
       }
+
+      // Mid-loop token budget check: estimate current context size and
+      // yield if we're approaching the preflight budget. This lets the
+      // session-agent-loop run compaction before the provider rejects.
+      if (overflowRecovery.enabled) {
+        const midLoopThreshold = preflightBudget * 0.85;
+        const estimated = estimatePromptTokens(
+          checkpoint.history,
+          ctx.systemPrompt,
+        );
+        if (estimated > midLoopThreshold) {
+          rlog.warn(
+            { phase: "mid-loop", estimated, threshold: midLoopThreshold },
+            "Token estimate approaching budget — yielding for compaction",
+          );
+          yieldedForBudget = true;
+          return "yield";
+        }
+      }
+
       return "continue";
     };
 
@@ -823,6 +846,106 @@ export async function runAgentLoopImpl(
       reqId,
       onCheckpoint,
     );
+
+    // ── Proactive mid-loop compaction ───────────────────────────────
+    // When the agent loop yielded because the token budget check in
+    // onCheckpoint detected approaching limits, run compaction on the
+    // accumulated history and re-enter the agent loop. This is distinct
+    // from the reactive convergence loop below that fires after a
+    // provider rejection — here we compact *before* hitting the limit.
+    while (
+      yieldedForBudget &&
+      !state.contextTooLargeDetected &&
+      !abortController.signal.aborted
+    ) {
+      yieldedForBudget = false;
+
+      rlog.info(
+        { phase: "mid-loop-compact" },
+        "Running compaction after checkpoint yield",
+      );
+
+      // Strip injected context from updated history before compacting,
+      // so we compact the "raw" persistent messages.
+      const rawHistory = stripInjectedContext(updatedHistory, {
+        stripRecall: (msgs) =>
+          stripMemoryRecallMessages(
+            msgs,
+            recall.injectedText,
+            "separate_context_message",
+          ),
+      });
+      ctx.messages = rawHistory;
+
+      ctx.emitActivityState(
+        "thinking",
+        "thinking_delta",
+        "assistant_turn",
+        reqId,
+        "Compacting context",
+      );
+      const midLoopCompact = await ctx.contextWindowManager.maybeCompact(
+        ctx.messages,
+        abortController.signal,
+        {
+          lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+          force: true,
+          targetInputTokensOverride: preflightBudget,
+        },
+      );
+      if (midLoopCompact.compacted) {
+        ctx.messages = midLoopCompact.messages;
+        ctx.contextCompactedMessageCount +=
+          midLoopCompact.compactedPersistedMessages;
+        ctx.contextCompactedAt = Date.now();
+        updateConversationContextWindow(
+          ctx.conversationId,
+          midLoopCompact.summaryText,
+          ctx.contextCompactedMessageCount,
+        );
+        onEvent({
+          type: "context_compacted",
+          previousEstimatedInputTokens:
+            midLoopCompact.previousEstimatedInputTokens,
+          estimatedInputTokens: midLoopCompact.estimatedInputTokens,
+          maxInputTokens: midLoopCompact.maxInputTokens,
+          thresholdTokens: midLoopCompact.thresholdTokens,
+          compactedMessages: midLoopCompact.compactedMessages,
+          summaryCalls: midLoopCompact.summaryCalls,
+          summaryInputTokens: midLoopCompact.summaryInputTokens,
+          summaryOutputTokens: midLoopCompact.summaryOutputTokens,
+          summaryModel: midLoopCompact.summaryModel,
+        });
+        emitUsage(
+          ctx,
+          midLoopCompact.summaryInputTokens,
+          midLoopCompact.summaryOutputTokens,
+          midLoopCompact.summaryModel,
+          onEvent,
+          "context_compactor",
+          reqId,
+          midLoopCompact.summaryCacheCreationInputTokens ?? 0,
+          midLoopCompact.summaryCacheReadInputTokens ?? 0,
+          collapseRawResponses(midLoopCompact.summaryRawResponses),
+        );
+      }
+
+      // Re-inject runtime context and re-enter the agent loop
+      runMessages = applyRuntimeInjections(ctx.messages, {
+        ...injectionOpts,
+        mode: currentInjectionMode,
+      });
+      preRepairMessages = runMessages;
+      preRunHistoryLength = runMessages.length;
+
+      updatedHistory = await ctx.agentLoop.run(
+        runMessages,
+        eventHandler,
+        abortController.signal,
+        reqId,
+        onCheckpoint,
+      );
+    }
 
     // One-shot ordering error retry
     if (


### PR DESCRIPTION
## Summary
- Extend `CheckpointInfo` with current `history` for token estimation
- Add token budget check in `onCheckpoint` callback (yields at 85% of preflight budget)
- Handle checkpoint yield in session-agent-loop with proactive compaction
- Prevents context overflow during long tool-use sequences by compacting before hitting provider limit

Part of plan: JARVIS-110-context-overflow-recovery-fails.md (PR 3 of 5)

Closes JARVIS-110

## Test plan
- [x] Tests 6 and 7 in `session-agent-loop-overflow.test.ts` converted from `.todo()` to active tests and passing
- [x] All 32 existing `session-agent-loop.test.ts` tests pass
- [x] All 39 existing `agent-loop.test.ts` tests pass (updated `toEqual` -> `toMatchObject` for checkpoint assertion)
- [x] All 39 existing `session-queue.test.ts` tests pass (added `history: []` to checkpoint objects)
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
