### PR TITLE
fix(ngrok): detect Twilio webhooks, fix daemon-only gateway cycling, fix SIGPIPE kill

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -762,32 +762,36 @@ async function hatchLocal(
 
   await startLocalDaemon(watch, resources);
 
-  let runtimeUrl: string;
-  try {
-    runtimeUrl = await startGateway(watch, resources);
-  } catch (error) {
-    // Gateway failed — stop the daemon we just started so we don't leave
-    // orphaned processes with no lock file entry.
-    console.error(
-      `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
-    );
-    await stopLocalProcesses(resources);
-    throw error;
-  }
+  // When daemonOnly is set, skip gateway and ngrok — the caller only wants
+  // the daemon restarted (e.g. macOS app bootstrap retry).
+  let runtimeUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+  if (!daemonOnly) {
+    try {
+      runtimeUrl = await startGateway(watch, resources);
+    } catch (error) {
+      // Gateway failed — stop the daemon we just started so we don't leave
+      // orphaned processes with no lock file entry.
+      console.error(
+        `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
+      );
+      await stopLocalProcesses(resources);
+      throw error;
+    }
 
-  // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.
-  // Set BASE_DATA_DIR so ngrok reads the correct instance config.
-  const prevBaseDataDir = process.env.BASE_DATA_DIR;
-  process.env.BASE_DATA_DIR = resources.instanceDir;
-  const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
-  if (ngrokChild?.pid) {
-    const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
-    writeFileSync(ngrokPidFile, String(ngrokChild.pid));
-  }
-  if (prevBaseDataDir !== undefined) {
-    process.env.BASE_DATA_DIR = prevBaseDataDir;
-  } else {
-    delete process.env.BASE_DATA_DIR;
+    // Auto-start ngrok if webhook integrations (e.g. Telegram, Twilio) are configured.
+    // Set BASE_DATA_DIR so ngrok reads the correct instance config.
+    const prevBaseDataDir = process.env.BASE_DATA_DIR;
+    process.env.BASE_DATA_DIR = resources.instanceDir;
+    const ngrokChild = await maybeStartNgrokTunnel(resources.gatewayPort);
+    if (ngrokChild?.pid) {
+      const ngrokPidFile = join(resources.instanceDir, ".vellum", "ngrok.pid");
+      writeFileSync(ngrokPidFile, String(ngrokChild.pid));
+    }
+    if (prevBaseDataDir !== undefined) {
+      process.env.BASE_DATA_DIR = prevBaseDataDir;
+    } else {
+      delete process.env.BASE_DATA_DIR;
+    }
   }
 
   // Read the bearer token (JWT) written by the daemon so the CLI can

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -170,14 +170,16 @@ function clearIngressUrl(): void {
 }
 
 /**
- * Check whether any webhook-based integrations (e.g. Telegram) are configured
- * that require a public ingress URL.
+ * Check whether any webhook-based integrations (e.g. Telegram, Twilio) are
+ * configured that require a public ingress URL.
  */
 function hasWebhookIntegrationsConfigured(): boolean {
   try {
     const config = loadRawConfig();
     const telegram = config.telegram as Record<string, unknown> | undefined;
     if (telegram?.botUsername) return true;
+    const twilio = config.twilio as Record<string, unknown> | undefined;
+    if (twilio?.accountSid || twilio?.phoneNumber) return true;
     return false;
   } catch {
     return false;
@@ -243,11 +245,11 @@ export async function maybeStartNgrokTunnel(
     console.log(`   Tunnel established: ${publicUrl}`);
 
     // Detach the ngrok process so the CLI (hatch/wake) can exit without
-    // keeping it alive. Remove stdout/stderr listeners and unref all handles.
+    // keeping it alive. Only remove listeners and unref — do NOT destroy
+    // the streams, as closing the read end of the pipe sends SIGPIPE to
+    // ngrok and causes it to exit.
     ngrokProcess.stdout?.removeAllListeners("data");
     ngrokProcess.stderr?.removeAllListeners("data");
-    ngrokProcess.stdout?.destroy();
-    ngrokProcess.stderr?.destroy();
     ngrokProcess.unref();
 
     return ngrokProcess;


### PR DESCRIPTION
## Summary

Three fixes for webhook ingress reliability affecting Twilio phone call users:

- **Twilio not triggering ngrok**: `hasWebhookIntegrationsConfigured()` only checked for Telegram `botUsername`. Twilio users never got an auto-started ngrok tunnel, forcing manual setup (and they'd inevitably point it at the wrong port). Added check for `twilio.accountSid` / `twilio.phoneNumber`.

- **Gateway cycling on macOS app retry**: `hatchLocal(daemonOnly: true)` still called `startGateway()` despite the `--daemon-only` flag and help text saying "skip gateway". The macOS app's `startBootstrapRetryCoordinator` calls `hatch --daemon-only` every 2s when the daemon is down, which repeatedly killed and restarted the gateway. Wrapped `startGateway()` + `maybeStartNgrokTunnel()` in a `!daemonOnly` guard.

- **ngrok dying after `vellum wake`**: `maybeStartNgrokTunnel()` called `stdout?.destroy()` after obtaining the tunnel URL. Destroying the read end of the pipe sends SIGPIPE to ngrok, causing silent exit. Removed `destroy()` calls — `removeAllListeners()` + `unref()` is sufficient.

## Test plan

- [ ] `vellum wake` with Twilio configured in workspace config auto-starts ngrok pointing at gateway port (7830)
- [ ] ngrok process stays alive after `vellum wake` exits
- [ ] macOS app bootstrap retry (daemon not alive) no longer kills the running gateway
- [ ] Telegram users unaffected — ngrok still auto-starts when `botUsername` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
