### PR TITLE
fix(memory): add missing entity migration call and fix migration 155 signature

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -50,6 +50,7 @@ import {
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
   migrateDropConflicts,
+  migrateDropEntityTables,
   migrateDropLegacyMemberGuardianTables,
   migrateDropMemorySegmentFts,
   migrateDropRemindersTable,
@@ -358,11 +359,14 @@ export function initializeDb(): void {
   // 56. Add supersession tracking columns and override confidence to memory_items
   migrateMemoryItemSupersession(database);
 
+  // 56b. Drop unused entity tables (entity search replaced by hybrid search on item statements)
+  migrateDropEntityTables(database);
+
   // 57. Drop memory_segment_fts virtual table and triggers (replaced by Qdrant hybrid search)
   migrateDropMemorySegmentFts(database);
 
   // 58. Drop memory_item_conflicts table (conflict resolution system removed)
-  migrateDropConflicts();
+  migrateDropConflicts(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/155-drop-conflicts.ts
+++ b/assistant/src/memory/migrations/155-drop-conflicts.ts
@@ -1,5 +1,7 @@
-import { rawRun } from "../db.js";
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
 
-export function migrateDropConflicts(): void {
-  rawRun(`DROP TABLE IF EXISTS memory_item_conflicts`);
+export function migrateDropConflicts(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_item_conflicts`);
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-system-redesign.md.

**Gap 1:** Migration 153 (drop entity tables) was exported but never called in db-init.ts
**Gap 2:** Migration 155 used inconsistent function signature (rawRun vs DrizzleDb parameter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
