### PR TITLE
fix: sort imports in memory-regressions test

### DIFF
--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -68,7 +68,6 @@ mock.module("../config/loader.js", () => ({
 }));
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { indexMessageNow } from "../memory/indexer.js";
-
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import {
   resetCleanupScheduleThrottle,


### PR DESCRIPTION
## Summary
- Remove stray blank line between imports in `memory-regressions.experimental.test.ts` that caused `simple-import-sort/imports` lint failure in CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23021779722/job/66859746217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
