### PR TITLE
docs: require test.todo for regression tests before fix lands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
   `cd assistant && bun test src/path/to/file.test.ts`
 - To run tests matching a pattern: `cd assistant && bun test src/path/to/file.test.ts --grep "pattern"`
 - Use `bunx tsc --noEmit` for full-project type-checking instead of running all tests.
+- **Regression tests for unfixed bugs**: When adding tests that reproduce a bug or document expected behavior before the fix lands, use `test.todo("description", () => {})` so mainline stays green. Never commit normally-failing `test(...)` cases — red CI blocks merges and erodes signal. Convert `test.todo` to `test` when the implementation PR lands.
 
 ## PR Workflow
 


### PR DESCRIPTION
## Summary
- Adds a testing rule to AGENTS.md: regression tests that reproduce bugs before the fix lands must use `test.todo()`, not normal `test()` cases
- Keeping mainline tests failing by design blocks merges/cherry-picks and erodes CI signal
- Prompted by [review feedback on #15914](https://github.com/vellum-ai/vellum-assistant/pull/15914#discussion_r2927095620)

## Original prompt
go for it in a worktree/feature branch, tag vargas on the PR, and merge the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
