### PR TITLE
feat: show compaction status indicator during context overflow recovery

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -290,6 +290,7 @@ export interface AssistantActivityState {
     | "tool_result_received"
     | "confirmation_requested"
     | "confirmation_resolved"
+    | "context_compacting"
     | "message_complete"
     | "generation_cancelled"
     | "error_terminal";

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -229,6 +229,7 @@ export interface AgentLoopSessionContext {
       | "tool_result_received"
       | "confirmation_requested"
       | "confirmation_resolved"
+      | "context_compacting"
       | "message_complete"
       | "generation_cancelled"
       | "error_terminal",
@@ -442,10 +443,9 @@ export async function runAgentLoopImpl(
     if (compactCheck.needed) {
       ctx.emitActivityState(
         "thinking",
-        "thinking_delta",
+        "context_compacting",
         "assistant_turn",
         reqId,
-        "Compacting context",
       );
     }
     const compacted = await ctx.contextWindowManager.maybeCompact(
@@ -692,10 +692,9 @@ export async function runAgentLoopImpl(
         preflightAttempts++;
         ctx.emitActivityState(
           "thinking",
-          "thinking_delta",
+          "context_compacting",
           "assistant_turn",
           reqId,
-          "Compacting context",
         );
         const step = await reduceContextOverflow(
           ctx.messages,
@@ -889,10 +888,9 @@ export async function runAgentLoopImpl(
 
         ctx.emitActivityState(
           "thinking",
-          "thinking_delta",
+          "context_compacting",
           "assistant_turn",
           reqId,
-          "Compacting context",
         );
         const step = await reduceContextOverflow(
           ctx.messages,
@@ -1081,10 +1079,9 @@ export async function runAgentLoopImpl(
           // Non-interactive — auto-compress without asking
           ctx.emitActivityState(
             "thinking",
-            "thinking_delta",
+            "context_compacting",
             "assistant_turn",
             reqId,
-            "Compacting context",
           );
           const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
             ctx.messages,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -7,6 +7,7 @@ struct ChatView: View {
     @Binding var inputText: String
     let hasAPIKey: Bool
     let isThinking: Bool
+    let isCompacting: Bool
     let isSending: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
@@ -175,6 +176,7 @@ struct ChatView: View {
                             messages: messages,
                             isSending: isSending,
                             isThinking: isThinking,
+                            isCompacting: isCompacting,
                             assistantActivityPhase: assistantActivityPhase,
                             assistantActivityAnchor: assistantActivityAnchor,
                             assistantActivityReason: assistantActivityReason,
@@ -704,6 +706,7 @@ private struct ChatViewPreviewWrapper: View {
                 inputText: $text,
                 hasAPIKey: true,
                 isThinking: true,
+                isCompacting: false,
                 isSending: false,
                 suggestion: "That sounds great, thanks!",
                 pendingAttachments: [],

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -45,6 +45,7 @@ struct MessageListView: View {
     let messages: [ChatMessage]
     let isSending: Bool
     let isThinking: Bool
+    let isCompacting: Bool
     let assistantActivityPhase: String
     let assistantActivityAnchor: String
     let assistantActivityReason: String?
@@ -313,6 +314,17 @@ struct MessageListView: View {
         .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 
+    @ViewBuilder
+    private func compactingIndicatorRow() -> some View {
+        RunningIndicator(
+            label: "Compacting context\u{2026}",
+            showIcon: false
+        )
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+        .id("compacting-indicator")
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
+    }
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -454,6 +466,10 @@ struct MessageListView: View {
 
                     if shouldShowThinkingIndicator && anchoredThinkingIndex == nil {
                         thinkingIndicatorRow(displayMessages: displayMessages)
+                    }
+
+                    if isCompacting && !shouldShowThinkingIndicator {
+                        compactingIndicatorRow()
                     }
 
                     Color.clear.frame(height: 1)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -598,6 +598,7 @@ struct ActiveChatViewWrapper: View {
             ),
             hasAPIKey: windowState.hasAPIKey,
             isThinking: viewModel.isThinking,
+            isCompacting: viewModel.isCompacting,
             isSending: viewModel.isSending,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -30,6 +30,7 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var assistantActivityAnchor: String = "global"
     @Published public var assistantActivityReason: String?
     @Published public var assistantStatusText: String?
+    @Published public var isCompacting: Bool = false
     @Published public var pendingQueuedCount: Int = 0
     @Published public var suggestion: String?
     @Published public var isRecording: Bool = false

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1893,6 +1893,7 @@ extension ChatViewModel {
             assistantActivityAnchor = msg.anchor
             assistantActivityReason = msg.reason
             assistantStatusText = msg.statusText
+            isCompacting = msg.reason == "context_compacting"
             switch msg.phase {
             case "thinking":
                 isThinking = true

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,6 +149,10 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.assistantStatusText }
         set { messageManager.assistantStatusText = newValue }
     }
+    public var isCompacting: Bool {
+        get { messageManager.isCompacting }
+        set { messageManager.isCompacting = newValue }
+    }
     public var hasPendingConfirmation: Bool {
         messages.contains(where: { $0.confirmation?.state == .pending })
     }


### PR DESCRIPTION
## Summary
- Add `context_compacting` to `AssistantActivityState` reason union in daemon message types
- Update all compaction emission points in session-agent-loop to use the new reason (4 call sites)
- Add `isCompacting` state to shared ChatMessageManager/ChatViewModel
- macOS MessageListView shows "Compacting context..." indicator when compacting and thinking indicator is hidden
- Users now see feedback instead of an apparently frozen app during long conversation compaction

Part of plan: JARVIS-110-context-overflow-recovery-fails.md (PR 5 of 5)

Closes JARVIS-110

## Test plan
- [x] TypeScript type checker passes (`bunx tsc --noEmit`)
- [x] session-agent-loop tests pass (32/32)
- [x] Swift build succeeds (`swift build --product vellum-assistant`)
- [ ] Manual: trigger context compaction in a long conversation and verify "Compacting context..." indicator appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
