### PR TITLE
fix: include web_search_tool_result in remaining tool_result checks

### DIFF
--- a/assistant/src/daemon/session-media-retry.ts
+++ b/assistant/src/daemon/session-media-retry.ts
@@ -143,7 +143,10 @@ function fileBlockToStub(
 function isToolResultOnlyMessage(message: Message): boolean {
   return (
     message.content.length > 0 &&
-    message.content.every((block) => block.type === "tool_result")
+    message.content.every(
+      (block) =>
+        block.type === "tool_result" || block.type === "web_search_tool_result",
+    )
   );
 }
 

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -36,7 +36,10 @@ function isToolResultOnlyUserTurn(message: Message | undefined): boolean {
   return (
     message?.role === "user" &&
     message.content.length > 0 &&
-    message.content.every((block) => block.type === "tool_result")
+    message.content.every(
+      (block) =>
+        block.type === "tool_result" || block.type === "web_search_tool_result",
+    )
   );
 }
 

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -174,7 +174,9 @@ export function isLastUserMessageToolResult(conversationId: string): boolean {
       Array.isArray(parsed) &&
       parsed.length > 0 &&
       parsed.every(
-        (block: Record<string, unknown>) => block.type === "tool_result",
+        (block: Record<string, unknown>) =>
+          block.type === "tool_result" ||
+          block.type === "web_search_tool_result",
       )
     ) {
       return true;


### PR DESCRIPTION
## Summary
Fixes 3 additional locations missed by PR #15915 that check for `tool_result` without also handling `web_search_tool_result`:

- `conversation-queries.ts:isLastUserMessageToolResult` — undo logic DB check
- `session-memory.ts:isToolResultOnlyUserTurn` — memory retrieval gate
- `session-media-retry.ts:isToolResultOnlyMessage` — media retry message identification

Part of plan: JARVIS-188-web-search-tool-result-dropped.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
