### PR TITLE
fix: improve token estimation accuracy and compaction targets

### DIFF
--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -57,6 +57,8 @@ export interface EventHandlerState {
   orderingErrorDetected: boolean;
   deferredOrderingError: string | null;
   contextTooLargeDetected: boolean;
+  /** The raw error message from the provider when context_too_large is detected. */
+  contextTooLargeErrorMessage: string | null;
   providerErrorUserMessage: string | null;
   lastAssistantMessageId: string | undefined;
   readonly pendingToolResults: Map<string, PendingToolResult>;
@@ -121,6 +123,7 @@ export function createEventHandlerState(): EventHandlerState {
     orderingErrorDetected: false,
     deferredOrderingError: null,
     contextTooLargeDetected: false,
+    contextTooLargeErrorMessage: null,
     providerErrorUserMessage: null,
     lastAssistantMessageId: undefined,
     pendingToolResults: new Map(),
@@ -595,12 +598,14 @@ export function handleError(
     state.deferredOrderingError = event.error.message;
   } else if (isContextTooLarge(event.error.message)) {
     state.contextTooLargeDetected = true;
+    state.contextTooLargeErrorMessage = event.error.message;
   } else {
     const classified = classifySessionError(event.error, {
       phase: "agent_loop",
     });
     if (classified.code === "CONTEXT_TOO_LARGE") {
       state.contextTooLargeDetected = true;
+      state.contextTooLargeErrorMessage = event.error.message;
     } else if (
       classified.code === "PROVIDER_ORDERING" ||
       classified.code === "PROVIDER_WEB_SEARCH"

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -122,6 +122,40 @@ import type { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("session-agent-loop");
 
+/**
+ * Parse the actual token count reported by the provider in a context-too-large
+ * error message. Providers typically include the prompt size, e.g.:
+ *   "prompt is too long: 242201 tokens > 200000 maximum"
+ *   "too many input tokens: 242201 > 200000"
+ *
+ * Returns the actual token count or null if it cannot be parsed.
+ */
+function parseActualTokensFromError(
+  errorMessage: string | null,
+): number | null {
+  if (!errorMessage) return null;
+
+  // Match patterns like "242201 tokens > 200000" or "242201 > 200000 maximum"
+  const match = errorMessage.match(
+    /(\d[\d,]*)\s*tokens?\s*[>≥]|:\s*(\d[\d,]*)\s*[>≥]/i,
+  );
+  if (match) {
+    const raw = (match[1] || match[2]).replace(/,/g, "");
+    const parsed = parseInt(raw, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+
+  // Fallback: match "too many input tokens: N > M"
+  const fallback = errorMessage.match(/(\d[\d,]*)\s*[>≥]\s*\d/);
+  if (fallback) {
+    const raw = fallback[1].replace(/,/g, "");
+    const parsed = parseInt(raw, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+
+  return null;
+}
+
 /** Title-cased friendly labels for tool names, used in confirmation chips. */
 const TOOL_FRIENDLY_LABEL: Record<string, string> = {
   bash: "Run Command",
@@ -663,7 +697,12 @@ export async function runAgentLoopImpl(
     const config = getConfig();
     const overflowRecovery = config.contextWindow.overflowRecovery;
     const providerMaxTokens = config.contextWindow.maxInputTokens;
-    const safetyMargin = overflowRecovery.safetyMarginRatio;
+    // Widen safety margin for large conversations where estimation error
+    // compounds across many messages with tool results.
+    const baseSafetyMargin = overflowRecovery.safetyMarginRatio;
+    const messageCount = ctx.messages.length;
+    const safetyMargin =
+      messageCount > 50 ? Math.max(baseSafetyMargin, 0.15) : baseSafetyMargin;
     const preflightBudget = Math.floor(providerMaxTokens * (1 - safetyMargin));
     let reducerState: ReducerState | undefined;
 
@@ -1003,6 +1042,38 @@ export async function runAgentLoopImpl(
         reducerState = createInitialReducerState();
       }
 
+      // When the provider reveals the actual token count in its error
+      // message (e.g. "242201 tokens > 200000"), use it to correct the
+      // compaction target. The estimator may significantly underestimate
+      // (e.g. estimated 185k but actual was 242k), so using the
+      // uncorrected preflightBudget would still be too high.
+      const actualTokens = parseActualTokensFromError(
+        state.contextTooLargeErrorMessage,
+      );
+      const estimatedTokensAtOverflow = estimatePromptTokens(
+        ctx.messages,
+        ctx.systemPrompt,
+        { providerName: ctx.provider.name },
+      );
+      let correctedTarget = preflightBudget;
+      if (actualTokens && estimatedTokensAtOverflow > 0) {
+        const estimationErrorRatio = actualTokens / estimatedTokensAtOverflow;
+        if (estimationErrorRatio > 1.0) {
+          correctedTarget = Math.floor(preflightBudget / estimationErrorRatio);
+          rlog.warn(
+            {
+              phase: "convergence",
+              actualTokens,
+              estimatedTokens: estimatedTokensAtOverflow,
+              estimationErrorRatio: estimationErrorRatio.toFixed(2),
+              preflightBudget,
+              correctedTarget,
+            },
+            "Adjusting compaction target based on observed estimation error",
+          );
+        }
+      }
+
       let convergenceAttempts = 0;
       const maxAttempts = overflowRecovery.maxAttempts;
 
@@ -1033,7 +1104,7 @@ export async function runAgentLoopImpl(
             providerName: ctx.provider.name,
             systemPrompt: ctx.systemPrompt,
             contextWindow: config.contextWindow,
-            targetTokens: preflightBudget,
+            targetTokens: correctedTarget,
           },
           reducerState,
           (msgs, signal, opts) =>
@@ -1116,7 +1187,7 @@ export async function runAgentLoopImpl(
             lastCompactedAt: ctx.contextCompactedAt ?? undefined,
             force: true,
             minKeepRecentUserTurns: 0,
-            targetInputTokensOverride: preflightBudget,
+            targetInputTokensOverride: correctedTarget,
           },
         );
         if (emergencyCompact.compacted) {
@@ -1196,7 +1267,7 @@ export async function runAgentLoopImpl(
                   lastCompactedAt: ctx.contextCompactedAt ?? undefined,
                   force: true,
                   minKeepRecentUserTurns: 0,
-                  targetInputTokensOverride: preflightBudget,
+                  targetInputTokensOverride: correctedTarget,
                 },
               );
             if (emergencyCompact.compacted) {
@@ -1300,7 +1371,7 @@ export async function runAgentLoopImpl(
               lastCompactedAt: ctx.contextCompactedAt ?? undefined,
               force: true,
               minKeepRecentUserTurns: 0,
-              targetInputTokensOverride: preflightBudget,
+              targetInputTokensOverride: correctedTarget,
             },
           );
           if (emergencyCompact.compacted) {


### PR DESCRIPTION
## Summary
- Parse actual token count from provider error messages (e.g. "242201 tokens > 200000 maximum") to calculate estimation error ratio
- Correct compaction targets based on observed error — if estimation underestimates by 31%, compact to a 31% lower target so actual fits
- Widen safety margin from 5% to 15% for conversations with 50+ messages where estimation error compounds
- Pass corrected targets to all compaction paths (convergence loop, emergency compaction, overflow policy)
- Store the provider's context-too-large error message in EventHandlerState for downstream parsing

Part of plan: JARVIS-110-context-overflow-recovery-fails.md (PR 4 of 5)

## Test plan
- [x] Test 3 (forced compaction targets lower budget when estimation inaccurate) now passes
- [x] All 7 overflow recovery tests pass
- [x] All 32 session-agent-loop tests pass
- [x] All 11 context-overflow-reducer tests pass
- [x] TypeScript type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
