### PR TITLE
docs: denoise Linear status for multi-PR plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,13 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
 
 - **Linear tickets**: When a Linear ticket is provided anywhere in context (user message, TODO, plan), use the issue identifier (e.g. `JARVIS-123`) throughout:
   - **Branch name**: Include the identifier, e.g. `do/jarvis-123-fix-stale-approvals`. Linear auto-links branches that contain the issue ID.
-  - **Commit message**: Include `Closes JARVIS-123` (or `Fixes`, `Resolves`) in the commit body so Linear auto-closes the issue when the PR merges.
-  - **PR description**: Mention the identifier (e.g. `Closes JARVIS-123`) in the PR body for redundancy — Linear also parses PR descriptions.
-  - **Status sync**: Transition the ticket to In Progress when starting work, In Review when the PR is created, and Done when merged. Use the Linear MCP tools when available.
+  - **Single-PR workflows** (`/do`, `/work`, standalone PRs):
+    - **Commit message**: Include `Closes JARVIS-123` (or `Fixes`, `Resolves`) in the commit body so Linear auto-closes the issue when the PR merges.
+    - **PR description**: Mention `Closes JARVIS-123` in the PR body for redundancy.
+  - **Multi-PR plans** (`/run-plan`, `/blitz`, `/safe-blitz`):
+    - **Intermediate PRs**: Use `Part of JARVIS-123` in commit messages and PR bodies. This links the PR to the issue without triggering Linear's auto-close automation.
+    - **Final PR only**: Use `Closes JARVIS-123` to trigger the auto-close.
+  - **Status sync**: Set In Progress once when starting the first PR. Do not toggle status between PRs in a multi-PR plan — let the final PR's `Closes` keyword handle the Done transition.
 - **Track merged PRs**: Append PR URL to `.private/UNREVIEWED_PRS.md` so `/check-reviews` can triage.
 - **Human attention comments**: After creating a PR with non-routine changes (architectural decisions, security, complex logic, deletions, low confidence), leave a `gh pr comment` highlighting where to focus review and the risk level. Skip for routine changes.
 


### PR DESCRIPTION
## Summary
- Use `Part of JARVIS-XXX` for intermediate PRs in multi-PR plans instead of `Closes JARVIS-XXX`
- Reserve `Closes` keyword for only the final PR, preventing Linear's auto-close from toggling status on every merge
- Only set In Progress once at plan start; let the final PR handle Done transition

## Context
When running multi-PR plans (via `/run-plan`, `/blitz`, `/safe-blitz`), every PR previously included `Closes JARVIS-XXX`. Each merge triggered Linear's GitHub automation to mark the issue Done, then the next PR reopened it to In Progress — creating noisy status churn.

## Test plan
- [ ] Verify next multi-PR plan execution only closes the Linear issue on the final PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
