### PR TITLE
fix(memory): normalize RRF fusion scores for tier classification compatibility

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -48,7 +48,9 @@ export async function semanticSearch(
   // When a sparse vector is available, use hybrid search (dense + sparse RRF fusion)
   // for better recall; otherwise fall back to dense-only search.
   let results: QdrantSearchResult[];
+  let isHybrid = false;
   if (sparseVector && sparseVector.indices.length > 0) {
+    isHybrid = true;
     const filter = buildHybridFilter(excludedMessageIds, scopeIds);
     results = await withQdrantBreaker(() =>
       qdrant.hybridSearch({
@@ -152,13 +154,27 @@ export async function semanticSearch(
     for (const row of rows) mediaScopeMap.set(row.id, row.memoryScopeId);
   }
 
+  // For hybrid search (RRF fusion), Qdrant returns Reciprocal Rank Fusion
+  // scores (typically 0.01-0.033) which are incompatible with tier
+  // classification thresholds. Normalize relative to the batch maximum so the
+  // top result gets 1.0 and others are proportional.
+  // For dense-only search, scores are cosine similarities in [-1, 1] and
+  // mapCosineToUnit correctly maps them to [0, 1].
+  const maxRrfScore =
+    isHybrid && results.length > 0
+      ? Math.max(...results.map((r) => r.score))
+      : 0;
+
   const excludedSet =
     excludedMessageIds.length > 0 ? new Set(excludedMessageIds) : null;
 
   const candidates: Candidate[] = [];
   for (const result of results) {
     const { payload, score } = result;
-    const semantic = mapCosineToUnit(score);
+    const semantic =
+      isHybrid && maxRrfScore > 0
+        ? score / maxRrfScore
+        : mapCosineToUnit(score);
     const createdAt = payload.created_at ?? Date.now();
 
     if (payload.target_type === "item") {


### PR DESCRIPTION
## Summary
RRF fusion scores from Qdrant hybrid search are tiny (0.01-0.03) and incompatible with tier classification thresholds (>0.8 for tier 1, >0.6 for tier 2). Applying mapCosineToUnit() to RRF scores maps them to ~0.50-0.52, making tier 1 unreachable and most results filtered out.

Fix: normalize hybrid search scores relative to the batch maximum (top result = 1.0), so tier classification thresholds work correctly. Dense-only fallback path retains mapCosineToUnit() for cosine similarities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
