### PR TITLE
fix: mid-loop compaction consistency and safety fixes

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -859,6 +859,7 @@ export async function runAgentLoopImpl(
         const estimated = estimatePromptTokens(
           checkpoint.history,
           ctx.systemPrompt,
+          { providerName: ctx.provider.name },
         );
         if (estimated > midLoopThreshold) {
           rlog.warn(
@@ -891,11 +892,14 @@ export async function runAgentLoopImpl(
     // accumulated history and re-enter the agent loop. This is distinct
     // from the reactive convergence loop below that fires after a
     // provider rejection — here we compact *before* hitting the limit.
+    let midLoopCompactAttempts = 0;
     while (
       yieldedForBudget &&
+      midLoopCompactAttempts < overflowRecovery.maxAttempts &&
       !state.contextTooLargeDetected &&
       !abortController.signal.aborted
     ) {
+      midLoopCompactAttempts++;
       yieldedForBudget = false;
 
       rlog.info(
@@ -917,7 +921,7 @@ export async function runAgentLoopImpl(
 
       ctx.emitActivityState(
         "thinking",
-        "thinking_delta",
+        "context_compacting",
         "assistant_turn",
         reqId,
         "Compacting context",

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -140,7 +140,8 @@ export interface ProcessSessionContext {
       | "message_complete"
       | "generation_cancelled"
       | "error_terminal"
-      | "preview_start",
+      | "preview_start"
+      | "context_compacting",
     anchor?: "assistant_turn" | "user_turn" | "global",
     requestId?: string,
     statusText?: string,


### PR DESCRIPTION
## Summary
Fixes 4 gaps identified during plan review for JARVIS-110:

1. **Activity reason**: Mid-loop compaction now emits `context_compacting` (was `thinking_delta`), enabling macOS compaction indicator
2. **providerName**: Mid-loop `estimatePromptTokens` now includes provider name for accurate image/PDF estimation
3. **Iteration bound**: Mid-loop compaction loop now has `maxAttempts` guard matching convergence loop
4. **Type consistency**: Added `context_compacting` to `ProcessSessionContext` reason union

Closes JARVIS-110

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
