### PR TITLE
Move assistant avatar to conversation tail

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -90,7 +90,6 @@ struct ChatView: View {
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
     @State private var containerWidth: CGFloat = 0
-    @State private var appearance = AvatarAppearanceManager.shared
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
@@ -211,18 +210,6 @@ struct ChatView: View {
                             isNearBottom: $isNearBottom,
                             containerWidth: containerWidth
                         )
-
-                        // Assistant avatar pinned above the composer, Claude-style.
-                        if messages.contains(where: { $0.role == .assistant }) || isSending {
-                            HStack {
-                                VAvatarImage(image: appearance.chatAvatarImage, size: 52)
-                                Spacer()
-                            }
-                            .padding(.horizontal, VSpacing.xl)
-                            .padding(.vertical, VSpacing.sm)
-                            .frame(maxWidth: VSpacing.chatColumnMaxWidth)
-                            .frame(maxWidth: .infinity)
-                        }
 
                         let composerMessages: [ChatMessage] = {
                             let all = messages.filter { !$0.isSubagentNotification }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+AvatarFollower.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+AvatarFollower.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+enum ConversationAvatarFollower {
+    static let coalesceInterval: TimeInterval = 0.1
+    static let visibilityPadding: CGFloat = 24
+    static let verticalOffset: CGFloat = 10
+    static let avatarSize: CGFloat = 52
+    static let bottomInset: CGFloat = avatarSize + verticalOffset + 2
+    static let spring = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.84, blendDuration: 0.12)
+
+    static func shouldShow(anchorY: CGFloat, viewportHeight: CGFloat) -> Bool {
+        guard anchorY.isFinite, viewportHeight.isFinite else { return false }
+        return anchorY >= -visibilityPadding && anchorY <= viewportHeight + visibilityPadding
+    }
+
+    static func shouldCoalesce(isSending: Bool, isThinking: Bool, isLastMessageStreaming: Bool) -> Bool {
+        isSending || isThinking || isLastMessageStreaming
+    }
+
+    static func coalescedDelay(lastAppliedAt: Date?, now: Date) -> TimeInterval {
+        guard let lastAppliedAt else { return 0 }
+        let elapsed = now.timeIntervalSince(lastAppliedAt)
+        return max(0, coalesceInterval - elapsed)
+    }
+
+    static func smoothingDelay(
+        isSending: Bool,
+        isThinking: Bool,
+        isLastMessageStreaming: Bool,
+        lastAppliedAt: Date?,
+        now: Date
+    ) -> TimeInterval {
+        guard shouldCoalesce(
+            isSending: isSending,
+            isThinking: isThinking,
+            isLastMessageStreaming: isLastMessageStreaming
+        ) else { return 0 }
+        return coalescedDelay(lastAppliedAt: lastAppliedAt, now: now)
+    }
+}
+
+/// Preference key that tracks the conversation-tail anchor's maxY so the avatar
+/// can follow the latest rendered content rather than staying pinned above input.
+struct ConversationTailAnchorYKey: PreferenceKey {
+    static var defaultValue: CGFloat = .infinity
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        // Use min so sibling views in the LazyVStack (which report the default
+        // value of .infinity) don't overwrite the anchor's actual Y position.
+        value = min(value, nextValue())
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -41,45 +41,6 @@ extension EnvironmentValues {
     }
 }
 
-enum ConversationAvatarFollower {
-    static let coalesceInterval: TimeInterval = 0.1
-    static let visibilityPadding: CGFloat = 24
-    static let verticalOffset: CGFloat = 10
-    static let avatarSize: CGFloat = 52
-    static let bottomInset: CGFloat = avatarSize + verticalOffset + 2
-    static let spring = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.84, blendDuration: 0.12)
-
-    static func shouldShow(anchorY: CGFloat, viewportHeight: CGFloat) -> Bool {
-        guard anchorY.isFinite, viewportHeight.isFinite else { return false }
-        return anchorY >= -visibilityPadding && anchorY <= viewportHeight + visibilityPadding
-    }
-
-    static func shouldCoalesce(isSending: Bool, isThinking: Bool, isLastMessageStreaming: Bool) -> Bool {
-        isSending || isThinking || isLastMessageStreaming
-    }
-
-    static func coalescedDelay(lastAppliedAt: Date?, now: Date) -> TimeInterval {
-        guard let lastAppliedAt else { return 0 }
-        let elapsed = now.timeIntervalSince(lastAppliedAt)
-        return max(0, coalesceInterval - elapsed)
-    }
-
-    static func smoothingDelay(
-        isSending: Bool,
-        isThinking: Bool,
-        isLastMessageStreaming: Bool,
-        lastAppliedAt: Date?,
-        now: Date
-    ) -> TimeInterval {
-        guard shouldCoalesce(
-            isSending: isSending,
-            isThinking: isThinking,
-            isLastMessageStreaming: isLastMessageStreaming
-        ) else { return 0 }
-        return coalescedDelay(lastAppliedAt: lastAppliedAt, now: now)
-    }
-}
-
 struct MessageListView: View {
     let messages: [ChatMessage]
     let isSending: Bool
@@ -258,6 +219,8 @@ struct MessageListView: View {
     }
 
     private var shouldShowConversationTailAvatar: Bool {
+        // Intentionally show the avatar under the latest rendered conversation tail
+        // (user or assistant content), not only after the first assistant bubble.
         guard !visibleMessages.isEmpty else { return false }
         return ConversationAvatarFollower.shouldShow(
             anchorY: avatarTargetY,
@@ -1393,14 +1356,5 @@ private struct AnchorMinYKey: PreferenceKey {
         // Use min so sibling views in the LazyVStack (which report the default
         // value of .infinity) don't overwrite the anchor's actual Y position.
         value = min(value, nextValue())
-    }
-}
-
-/// Preference key that tracks the conversation-tail anchor's maxY so the avatar
-/// can follow the latest rendered content rather than staying pinned above input.
-private struct ConversationTailAnchorYKey: PreferenceKey {
-    static var defaultValue: CGFloat = .infinity
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -41,6 +41,45 @@ extension EnvironmentValues {
     }
 }
 
+enum ConversationAvatarFollower {
+    static let coalesceInterval: TimeInterval = 0.1
+    static let visibilityPadding: CGFloat = 24
+    static let verticalOffset: CGFloat = 10
+    static let avatarSize: CGFloat = 52
+    static let bottomInset: CGFloat = avatarSize + verticalOffset + 2
+    static let spring = Animation.interactiveSpring(response: 0.28, dampingFraction: 0.84, blendDuration: 0.12)
+
+    static func shouldShow(anchorY: CGFloat, viewportHeight: CGFloat) -> Bool {
+        guard anchorY.isFinite, viewportHeight.isFinite else { return false }
+        return anchorY >= -visibilityPadding && anchorY <= viewportHeight + visibilityPadding
+    }
+
+    static func shouldCoalesce(isSending: Bool, isThinking: Bool, isLastMessageStreaming: Bool) -> Bool {
+        isSending || isThinking || isLastMessageStreaming
+    }
+
+    static func coalescedDelay(lastAppliedAt: Date?, now: Date) -> TimeInterval {
+        guard let lastAppliedAt else { return 0 }
+        let elapsed = now.timeIntervalSince(lastAppliedAt)
+        return max(0, coalesceInterval - elapsed)
+    }
+
+    static func smoothingDelay(
+        isSending: Bool,
+        isThinking: Bool,
+        isLastMessageStreaming: Bool,
+        lastAppliedAt: Date?,
+        now: Date
+    ) -> TimeInterval {
+        guard shouldCoalesce(
+            isSending: isSending,
+            isThinking: isThinking,
+            isLastMessageStreaming: isLastMessageStreaming
+        ) else { return 0 }
+        return coalescedDelay(lastAppliedAt: lastAppliedAt, now: now)
+    }
+}
+
 struct MessageListView: View {
     let messages: [ChatMessage]
     let isSending: Bool
@@ -102,6 +141,7 @@ struct MessageListView: View {
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
+    @State private var appearance = AvatarAppearanceManager.shared
     /// Read once at the list level and passed down to each ChatBubble so that
     /// individual bubbles don't each subscribe to the shared ObservableObject.
     @State private var scrollDebounceTask: Task<Void, Never>?
@@ -158,6 +198,11 @@ struct MessageListView: View {
     /// restore began. Ensures anchorTracker.isVisible reflects real geometry
     /// rather than the manual reset applied on thread switch.
     @State private var hasFreshAnchorMeasurement: Bool = false
+    @State private var avatarTargetY: CGFloat = .infinity
+    @State private var avatarDisplayY: CGFloat = .infinity
+    @State private var pendingAvatarY: CGFloat?
+    @State private var avatarSmoothingTask: Task<Void, Never>?
+    @State private var avatarLastAppliedAt: Date?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -199,6 +244,107 @@ struct MessageListView: View {
             }
         }
         return result
+    }
+
+    private var lastRenderableMessage: ChatMessage? {
+        messages.last(where: {
+            if case .queued = $0.status { return false }
+            return true
+        })
+    }
+
+    private var isLastMessageStreaming: Bool {
+        lastRenderableMessage?.isStreaming == true
+    }
+
+    private var shouldShowConversationTailAvatar: Bool {
+        guard !visibleMessages.isEmpty else { return false }
+        return ConversationAvatarFollower.shouldShow(
+            anchorY: avatarTargetY,
+            viewportHeight: scrollViewportHeight
+        )
+    }
+
+    private var shouldCoalesceAvatarUpdates: Bool {
+        ConversationAvatarFollower.shouldCoalesce(
+            isSending: isSending,
+            isThinking: isThinking,
+            isLastMessageStreaming: isLastMessageStreaming
+        )
+    }
+
+    private func applyAvatarDisplayY(forAnchorY anchorY: CGFloat) {
+        let y = anchorY + ConversationAvatarFollower.verticalOffset
+        withAnimation(ConversationAvatarFollower.spring) {
+            avatarDisplayY = y
+        }
+    }
+
+    private func updateAvatarFollower(anchorY: CGFloat) {
+        avatarTargetY = anchorY
+
+        guard anchorY.isFinite else {
+            avatarSmoothingTask?.cancel()
+            avatarSmoothingTask = nil
+            pendingAvatarY = nil
+            avatarLastAppliedAt = nil
+            avatarDisplayY = .infinity
+            return
+        }
+
+        let now = Date()
+        let delay = ConversationAvatarFollower.smoothingDelay(
+            isSending: isSending,
+            isThinking: isThinking,
+            isLastMessageStreaming: isLastMessageStreaming,
+            lastAppliedAt: avatarLastAppliedAt,
+            now: now
+        )
+
+        if delay <= 0 {
+            avatarSmoothingTask?.cancel()
+            avatarSmoothingTask = nil
+            pendingAvatarY = nil
+            avatarLastAppliedAt = now
+            applyAvatarDisplayY(forAnchorY: anchorY)
+            return
+        }
+
+        pendingAvatarY = anchorY
+        guard avatarSmoothingTask == nil else { return }
+
+        avatarSmoothingTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            guard let pendingAvatarY else {
+                avatarSmoothingTask = nil
+                return
+            }
+            self.pendingAvatarY = nil
+            avatarLastAppliedAt = Date()
+            applyAvatarDisplayY(forAnchorY: pendingAvatarY)
+            avatarSmoothingTask = nil
+        }
+    }
+
+    @ViewBuilder
+    private var conversationTailAvatar: some View {
+        if shouldShowConversationTailAvatar {
+            HStack {
+                VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.xl)
+            .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+            .frame(maxWidth: .infinity)
+            .offset(y: avatarDisplayY)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
     }
 
     private var shouldShowThreadScrollbar: Bool {
@@ -472,6 +618,24 @@ struct MessageListView: View {
                         compactingIndicatorRow()
                     }
 
+                    Color.clear
+                        .frame(height: 1)
+                        .id("conversation-tail-anchor")
+                        .background {
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: ConversationTailAnchorYKey.self,
+                                    value: geo.frame(in: .named("chatScrollView")).maxY
+                                )
+                            }
+                        }
+
+                    if !displayMessages.isEmpty && ConversationAvatarFollower.bottomInset > 0 {
+                        Color.clear
+                            .frame(height: ConversationAvatarFollower.bottomInset)
+                            .accessibilityHidden(true)
+                    }
+
                     Color.clear.frame(height: 1)
                         .id("scroll-bottom-anchor")
                         .onAppear {
@@ -551,6 +715,12 @@ struct MessageListView: View {
                 anchorTracker.update(minY: minY, viewportHeight: scrollViewportHeight)
                 if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
                 os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
+            }
+            .onPreferenceChange(ConversationTailAnchorYKey.self) { anchorY in
+                updateAvatarFollower(anchorY: anchorY)
+            }
+            .overlay(alignment: .topLeading) {
+                conversationTailAvatar
             }
             .overlay(alignment: .bottom) {
                 if (!isNearBottom || !hasReceivedScrollEvent) && !anchorTracker.isVisible {
@@ -634,6 +804,8 @@ struct MessageListView: View {
                 expandSuppressionTask = nil
                 scrollRestoreTask?.cancel()
                 scrollRestoreTask = nil
+                avatarSmoothingTask?.cancel()
+                avatarSmoothingTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -651,6 +823,11 @@ struct MessageListView: View {
                     }
                 }
             }
+            .onChange(of: shouldCoalesceAvatarUpdates) {
+                if !shouldCoalesceAvatarUpdates {
+                    updateAvatarFollower(anchorY: pendingAvatarY ?? avatarTargetY)
+                }
+            }
             .onChange(of: streamingScrollTrigger) {
                 if isNearBottom && !isSuppressingBottomScroll {
                     // Throttle pattern: fire immediately then suppress for 200ms.
@@ -660,15 +837,23 @@ struct MessageListView: View {
                         scrollDebounceTask = Task {
                             defer { if !Task.isCancelled { scrollDebounceTask = nil } }
                             guard isNearBottom && !isSuppressingBottomScroll else { return }
-                            withAnimation(VAnimation.fast) {
+                            if isLastMessageStreaming {
                                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                            } else {
+                                withAnimation(VAnimation.fast) {
+                                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                }
                             }
                             try? await Task.sleep(nanoseconds: 200_000_000)
                             // If the task was cancelled during the sleep (user scrolled up), do not fire trailing-edge scroll.
                             guard !Task.isCancelled else { return }
                             if isNearBottom && !isSuppressingBottomScroll {
-                                withAnimation(VAnimation.fast) {
+                                if isLastMessageStreaming {
                                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                } else {
+                                    withAnimation(VAnimation.fast) {
+                                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                                    }
                                 }
                             }
                         }
@@ -770,6 +955,8 @@ struct MessageListView: View {
                 resizeScrollTask = nil
                 expandSuppressionTask?.cancel()
                 expandSuppressionTask = nil
+                avatarSmoothingTask?.cancel()
+                avatarSmoothingTask = nil
                 isPaginationInFlight = false
                 isSuppressingBottomScroll = false
                 isNearBottom = true
@@ -796,6 +983,10 @@ struct MessageListView: View {
                     threadSwitchSuppressionTask = nil
                 }
                 isThreadContentHovered = false
+                avatarTargetY = .infinity
+                avatarDisplayY = .infinity
+                pendingAvatarY = nil
+                avatarLastAppliedAt = nil
                 restoreScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {
@@ -1202,5 +1393,14 @@ private struct AnchorMinYKey: PreferenceKey {
         // Use min so sibling views in the LazyVStack (which report the default
         // value of .infinity) don't overwrite the anchor's actual Y position.
         value = min(value, nextValue())
+    }
+}
+
+/// Preference key that tracks the conversation-tail anchor's maxY so the avatar
+/// can follow the latest rendered content rather than staying pinned above input.
+private struct ConversationTailAnchorYKey: PreferenceKey {
+    static var defaultValue: CGFloat = .infinity
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }

--- a/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationAvatarFollowerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class ConversationAvatarFollowerTests: XCTestCase {
+    func testStreamingCoalescingUsesMinimumInterval() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let lastAppliedAt = now.addingTimeInterval(-0.04)
+
+        let delay = ConversationAvatarFollower.smoothingDelay(
+            isSending: true,
+            isThinking: false,
+            isLastMessageStreaming: true,
+            lastAppliedAt: lastAppliedAt,
+            now: now
+        )
+
+        XCTAssertEqual(delay, 0.06, accuracy: 0.001)
+    }
+
+    func testVisibilityBoundsMatchViewportGate() {
+        XCTAssertTrue(ConversationAvatarFollower.shouldShow(anchorY: -24, viewportHeight: 500))
+        XCTAssertTrue(ConversationAvatarFollower.shouldShow(anchorY: 524, viewportHeight: 500))
+        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: -24.1, viewportHeight: 500))
+        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: 524.1, viewportHeight: 500))
+        XCTAssertFalse(ConversationAvatarFollower.shouldShow(anchorY: .infinity, viewportHeight: 500))
+    }
+
+    func testIdleBypassesCoalescing() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let lastAppliedAt = now
+
+        let delay = ConversationAvatarFollower.smoothingDelay(
+            isSending: false,
+            isThinking: false,
+            isLastMessageStreaming: false,
+            lastAppliedAt: lastAppliedAt,
+            now: now
+        )
+
+        XCTAssertEqual(delay, 0, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- remove the fixed avatar row from ChatView so avatar rendering is owned only by MessageListView.
- add a conversation-tail anchor + preference propagation and a damped avatar follower that coalesces updates during streaming and springs to target positions.
- render the avatar as a non-interactive overlay in the scroll area with viewport-based visibility and composer-safe bottom inset handling.
- keep streaming auto-scroll smooth by using non-animated bottom scrolls while the last assistant message is actively streaming.
- add follower-focused unit tests for coalescing, visibility gates, and idle behavior.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ConversationAvatarFollowerTests`

## Reviewer Focus (Risk: Medium)
- `MessageListView` streaming scroll path: verify conditional non-animated `scrollTo` behavior while actively streaming.
- Avatar placement math around the composer boundary: validate `bottomInset` and overlay Y never clip behind composer.
- Visibility gating: confirm avatar appears only at conversation tail and leaves viewport naturally when scrolling away.
- Manual UX check: hover buttons near the latest assistant message should remain readable and unobstructed.

## Apple Refs Checked (2026-03-12)
- [Demystify SwiftUI performance (WWDC23)](https://developer.apple.com/videos/play/wwdc2023/10160/): keep dependency graphs tight and avoid unnecessary body invalidations; this change keeps follower math/state localized in `MessageListView`.
- [Beyond scroll views (WWDC23)](https://developer.apple.com/videos/play/wwdc2023/10159/): lazy stacks and scroll-content spacing principles align with the `LazyVStack` + tail-anchor approach.
- [Explore SwiftUI animation (WWDC23)](https://developer.apple.com/videos/play/wwdc2023/10156/): spring-based, interruptible motion is used for the avatar follower to reduce visual jank while streaming.

### Intentional tradeoff
- We keep `ScrollViewReader`-based scrolling in this PR (instead of migrating to `scrollPosition`) because this view already has extensive suppression/pagination edge-case handling; this change was scoped to avatar behavior and preserves existing scroll stability logic.
