### PR TITLE
fix(security): prevent preflight bypass via empty required_tools snapshot

### DIFF
--- a/assistant/src/runtime/routes/work-items-routes.test.ts
+++ b/assistant/src/runtime/routes/work-items-routes.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the work-item preflight and run permission bypass fix.
+ *
+ * Verifies that an empty requiredTools snapshot on a work item falls back
+ * to the task template's tools instead of skipping the permission dialog.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "work-items-routes-test-"));
+
+// ── Module mocks (must precede production imports) ───────────────────
+
+mock.module("../../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../permissions/checker.js", () => ({
+  check: async () => ({ decision: "prompt" }),
+  classifyRisk: async () => "high",
+}));
+
+// ── Production imports (after mocks) ─────────────────────────────────
+
+import { getDb, initializeDb, resetDb } from "../../memory/db.js";
+import { createTask } from "../../tasks/task-store.js";
+import { createWorkItem } from "../../work-items/work-item-store.js";
+import { preflightWorkItem } from "./work-items-routes.js";
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+beforeAll(() => {
+  initializeDb();
+});
+
+afterAll(() => {
+  resetDb();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const db = getDb();
+  db.run("DELETE FROM work_items");
+  db.run("DELETE FROM tasks");
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("preflightWorkItem", () => {
+  test("falls back to task required tools when snapshot requiredTools is empty", async () => {
+    const task = createTask({
+      title: "Review",
+      template: "Run review",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Review item",
+      requiredTools: JSON.stringify([]),
+    });
+
+    const result = await preflightWorkItem(workItem.id);
+
+    expect(result.success).toBe(true);
+    expect(result.permissions).toBeDefined();
+    expect(result.permissions!.length).toBeGreaterThanOrEqual(1);
+    expect(result.permissions!.some((p) => p.tool === "host_bash")).toBe(true);
+  });
+
+  test("uses snapshot tools when snapshot requiredTools is non-empty", async () => {
+    const task = createTask({
+      title: "Review",
+      template: "Run review",
+      requiredTools: ["host_bash", "file_write"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Review item",
+      requiredTools: JSON.stringify(["file_write"]),
+    });
+
+    const result = await preflightWorkItem(workItem.id);
+
+    expect(result.success).toBe(true);
+    expect(result.permissions).toBeDefined();
+    expect(result.permissions!.length).toBe(1);
+    expect(result.permissions![0].tool).toBe("file_write");
+  });
+
+  test("falls back to task tools when snapshot requiredTools is null", async () => {
+    const task = createTask({
+      title: "Review",
+      template: "Run review",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Review item",
+      // requiredTools omitted — stored as null
+    });
+
+    const result = await preflightWorkItem(workItem.id);
+
+    expect(result.success).toBe(true);
+    expect(result.permissions).toBeDefined();
+    expect(result.permissions!.some((p) => p.tool === "host_bash")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -24,6 +24,7 @@ import {
   getWorkItem,
   listWorkItems,
   updateWorkItem,
+  type WorkItem,
   type WorkItemStatus,
 } from "../../work-items/work-item-store.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -61,6 +62,30 @@ function broadcastWorkItemStatus(id: string): void {
       },
     });
   }
+}
+
+/**
+ * Resolve the effective required tools for a work item.
+ *
+ * When the work-item snapshot is null/undefined, fall back to the task
+ * template's tools. When the snapshot exists but is empty, also fall back
+ * — an empty snapshot must not suppress the task's actual requirements,
+ * as that would bypass the preflight permission dialog.
+ */
+function resolveRequiredTools(
+  workItem: WorkItem,
+  taskRequiredTools: string[],
+): string[] {
+  if (workItem.requiredTools == null) {
+    return taskRequiredTools;
+  }
+
+  const snapshotTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+  if (snapshotTools.length > 0) {
+    return snapshotTools;
+  }
+
+  return taskRequiredTools;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,21 +346,18 @@ export async function preflightWorkItem(
     return { success: false, error: "Work item not found" };
   }
 
-  let requiredTools: string[];
-  if (workItem.requiredTools != null) {
-    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-  } else {
-    const task = getTask(workItem.taskId);
-    if (!task) {
-      return {
-        success: false,
-        error: `Associated task not found: ${workItem.taskId}`,
-      };
-    }
-    requiredTools = task.requiredTools
-      ? sanitizeToolList(JSON.parse(task.requiredTools))
-      : getRegisteredToolNames();
+  const task = getTask(workItem.taskId);
+  if (!task) {
+    return {
+      success: false,
+      error: `Associated task not found: ${workItem.taskId}`,
+    };
   }
+
+  const taskRequiredTools = task.requiredTools
+    ? sanitizeToolList(JSON.parse(task.requiredTools))
+    : getRegisteredToolNames();
+  let requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
   if (requiredTools.length === 0) {
     return { success: true, permissions: [] };
@@ -648,15 +670,10 @@ export function workItemRouteDefinitions(
           );
         }
 
-        // Compute required tools
-        let requiredTools: string[];
-        if (workItem.requiredTools != null) {
-          requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-        } else {
-          requiredTools = task.requiredTools
-            ? sanitizeToolList(JSON.parse(task.requiredTools))
-            : getRegisteredToolNames();
-        }
+        const taskRequiredTools = task.requiredTools
+          ? sanitizeToolList(JSON.parse(task.requiredTools))
+          : getRegisteredToolNames();
+        const requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
         // Permission checkpoint
         let approvedTools: string[] | undefined;


### PR DESCRIPTION
## Summary
- **Security fix**: When a work item was created with `required_tools: []`, the preflight check returned no permissions needed and the run handler skipped the permission checkpoint. However, `runTask` still built ephemeral allow rules from the task template's tools, enabling unapproved medium-risk tool execution (curl, wget, git push, etc.) without any user approval dialog.
- **Fix**: Add `resolveRequiredTools()` helper that treats an empty snapshot the same as null — falling back to the task template's required tools. Applied to both `preflightWorkItem()` and the run route handler.
- **Tests**: Added test coverage verifying preflight falls back to task tools when the snapshot is empty, uses snapshot tools when non-empty, and falls back when snapshot is null.

## Original prompt
Security Fix: Preflight bypass via empty required_tools snapshot — when a work item is created with `required_tools: []`, preflight returns empty permissions, but `runTask` falls back to the task template's tools with ephemeral allow rules, bypassing user approval for medium-risk operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
