### PR TITLE
fix(security): remove secondaryWindows from LLM-facing observation content

### DIFF
--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -513,7 +513,7 @@ describe("HostCuProxy", () => {
       expect(result.content).toMatch(/<\/ax-tree>$/m);
     });
 
-    test("includes secondaryWindows after AX tree with cross-window note", () => {
+    test("does not include secondaryWindows in model-facing observation content", () => {
       setup();
 
       const result = proxy.formatObservation({
@@ -521,15 +521,9 @@ describe("HostCuProxy", () => {
         secondaryWindows: "Safari — Window [10]\n  Link [11]",
       });
 
-      expect(result.content).toContain("Safari — Window [10]");
-      expect(result.content).toContain("Link [11]");
-      expect(result.content).toContain(
-        "Note: The element [ID]s above are from other windows",
-      );
-      // secondaryWindows should appear after the AX tree
-      const axTreeEnd = result.content.indexOf("</ax-tree>");
-      const secondaryIdx = result.content.indexOf("Safari — Window [10]");
-      expect(axTreeEnd).toBeLessThan(secondaryIdx);
+      expect(result.content).not.toContain("Safari — Window [10]");
+      expect(result.content).not.toContain("Link [11]");
+      expect(result.content).not.toContain("other windows");
     });
 
     test("omits secondaryWindows section when field is absent", () => {

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -314,16 +314,6 @@ export class HostCuProxy {
       parts.push("</ax-tree>");
     }
 
-    // Secondary windows for cross-app awareness
-    if (obs.secondaryWindows) {
-      parts.push("");
-      parts.push(obs.secondaryWindows);
-      parts.push("");
-      parts.push(
-        "Note: The element [ID]s above are from other windows — you can reference them for context but can only interact with the focused window's elements.",
-      );
-    }
-
     // Screenshot metadata
     const screenshotMeta = this.formatScreenshotMetadata(obs);
     if (screenshotMeta.length > 0) {


### PR DESCRIPTION
## Summary

- Remove the `secondaryWindows` block from `HostCuProxy.formatObservation` to prevent cross-app AX tree content (from other visible windows) from being forwarded to the LLM and persisted in message history
- This addresses a confidentiality regression where sensitive text from unrelated background windows could leak to model providers without user consent
- macOS client collection and server API acceptance are left intact so the feature can be re-enabled later behind an explicit user consent mechanism

## Original prompt
Security fix: Remove secondaryWindows from LLM-facing observation content in HostCuProxy.formatObservation. The `formatObservation` method appends `obs.secondaryWindows` — AX trees from other visible apps — directly into the tool_result content that is sent to the LLM and persisted in message history. This leaks potentially sensitive content (passwords, tokens, private messages) from unrelated background windows without user consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
