### PR TITLE
fix(memory): auto-enqueue rebuild_index after Qdrant collection migration

### DIFF
--- a/assistant/src/__tests__/qdrant-collection-migration.test.ts
+++ b/assistant/src/__tests__/qdrant-collection-migration.test.ts
@@ -118,10 +118,11 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview",
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     expect(callLog.deleteCollection).toBe(1);
     expect(callLog.createCollection).toBe(1);
+    expect(result.migrated).toBe(true);
   });
 
   test("deletes and recreates collection on model-only mismatch", async () => {
@@ -142,12 +143,13 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview", // New model
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     expect(callLog.deleteCollection).toBe(1);
     expect(callLog.createCollection).toBe(1);
     // Sentinel should be written for the new model
     expect(callLog.upsert).toBe(1);
+    expect(result.migrated).toBe(true);
   });
 
   test("leaves collection untouched when dimensions and model match", async () => {
@@ -168,10 +170,11 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview",
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     expect(callLog.deleteCollection).toBe(0);
     expect(callLog.createCollection).toBe(0);
+    expect(result.migrated).toBe(false);
   });
 
   test("does not rebuild pre-existing collection without sentinel (graceful upgrade)", async () => {
@@ -189,11 +192,12 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview",
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     // No sentinel found → no model mismatch → collection kept
     expect(callLog.deleteCollection).toBe(0);
     expect(callLog.createCollection).toBe(0);
+    expect(result.migrated).toBe(false);
   });
 
   test("writes sentinel point when creating a new collection", async () => {
@@ -208,11 +212,13 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview",
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     expect(callLog.createCollection).toBe(1);
     // Sentinel upsert should be called
     expect(callLog.upsert).toBe(1);
+    // Fresh collection, not a migration
+    expect(result.migrated).toBe(false);
   });
 
   test("deletes and recreates collection when migrating from unnamed to named vectors", async () => {
@@ -229,13 +235,14 @@ describe("Qdrant collection migration", () => {
       embeddingModel: "gemini:gemini-embedding-2-preview",
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     // Unnamed vectors should trigger delete + recreate with named vectors
     expect(callLog.deleteCollection).toBe(1);
     expect(callLog.createCollection).toBe(1);
     // Sentinel should be written for the new collection
     expect(callLog.upsert).toBe(1);
+    expect(result.migrated).toBe(true);
   });
 
   test("does not write sentinel when embeddingModel is not provided", async () => {
@@ -250,10 +257,12 @@ describe("Qdrant collection migration", () => {
       // No embeddingModel
     });
 
-    await client.ensureCollection();
+    const result = await client.ensureCollection();
 
     expect(callLog.createCollection).toBe(1);
     // No sentinel should be written
     expect(callLog.upsert).toBe(0);
+    // Fresh collection, not a migration
+    expect(result.migrated).toBe(false);
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -34,6 +34,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db.js";
 import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
 import { QdrantManager } from "../memory/qdrant-manager.js";
@@ -320,7 +321,7 @@ export async function runDaemon(): Promise<void> {
       const embeddingModel = embeddingSelection.backend
         ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
         : undefined;
-      initQdrantClient({
+      const qdrantClient = initQdrantClient({
         url: qdrantUrl,
         collection: config.memory.qdrant.collection,
         vectorSize: config.memory.qdrant.vectorSize,
@@ -328,6 +329,19 @@ export async function runDaemon(): Promise<void> {
         quantization: config.memory.qdrant.quantization,
         embeddingModel,
       });
+
+      // Eagerly ensure the collection exists so we detect migrations
+      // (unnamed→named vectors, dimension/model changes) at startup.
+      // If a destructive migration occurred, enqueue a rebuild_index job
+      // to re-embed all memory items from the SQLite cache.
+      const { migrated } = await qdrantClient.ensureCollection();
+      if (migrated) {
+        enqueueMemoryJob("rebuild_index", {});
+        log.info(
+          "Qdrant collection was migrated — enqueued rebuild_index job",
+        );
+      }
+
       log.info("Qdrant vector store initialized");
     } catch (err) {
       log.warn(

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -86,8 +86,10 @@ export class VellumQdrantClient {
     this.sparseModel = config.sparseModel;
   }
 
-  async ensureCollection(): Promise<void> {
-    if (this.collectionReady) return;
+  async ensureCollection(): Promise<{ migrated: boolean }> {
+    if (this.collectionReady) return { migrated: false };
+
+    let migrated = false;
 
     try {
       const exists = await this.client.collectionExists(this.collection);
@@ -129,6 +131,7 @@ export class VellumQdrantClient {
               "Qdrant collection uses unnamed vectors (legacy) — deleting and recreating with named vectors. Embeddings will be re-indexed.",
             );
             await this.client.deleteCollection(this.collection);
+            migrated = true;
             // Fall through to collection creation below
           } else if (dimMismatch || modelMismatch) {
             log.warn(
@@ -141,12 +144,13 @@ export class VellumQdrantClient {
               "Qdrant collection incompatible (dimension or model change) — deleting and recreating. Embeddings will be regenerated on demand.",
             );
             await this.client.deleteCollection(this.collection);
+            migrated = true;
             // Fall through to collection creation below
           } else {
             if (await this.ensurePayloadIndexesSafe()) {
               this.collectionReady = true;
             }
-            return;
+            return { migrated: false };
           }
         } catch (err) {
           log.warn(
@@ -156,7 +160,7 @@ export class VellumQdrantClient {
           if (await this.ensurePayloadIndexesSafe()) {
             this.collectionReady = true;
           }
-          return;
+          return { migrated: false };
         }
       }
     } catch {
@@ -207,7 +211,7 @@ export class VellumQdrantClient {
         if (await this.ensurePayloadIndexesSafe()) {
           this.collectionReady = true;
         }
-        return;
+        return { migrated };
       }
       throw err;
     }
@@ -224,6 +228,8 @@ export class VellumQdrantClient {
         "Qdrant collection created with payload indexes",
       );
     }
+
+    return { migrated };
   }
 
   async upsert(


### PR DESCRIPTION
## Summary
When ensureCollection() migrates from unnamed to named vectors, all existing vectors are lost. Now returns a migration flag so callers can trigger a rebuild_index job to re-embed from SQLite cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)