### PR TITLE
fix(test): increase timeout for script-proxy-certs multi-hostname test

### DIFF
--- a/assistant/src/__tests__/script-proxy-certs.test.ts
+++ b/assistant/src/__tests__/script-proxy-certs.test.ts
@@ -84,7 +84,7 @@ describe("issueLeafCert", () => {
 
     expect(certA.cert).not.toBe(certB.cert);
     expect(certA.key).not.toBe(certB.key);
-  });
+  }, 15_000);
 });
 
 describe("getCAPath", () => {


### PR DESCRIPTION
## Summary
- Increased timeout for the `generates different certs for different hostnames` test in `script-proxy-certs.test.ts` from 5s (default) to 15s
- This test spawns 6 openssl subprocesses sequentially and was timing out under CI load (8 parallel workers)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23023826497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
