### PR TITLE
fix(security): stop system prompt from encouraging raw OAuth token retrieval

### DIFF
--- a/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
+++ b/assistant/src/config/bundled-skills/_shared/CLI_RETRIEVAL_PATTERN.md
@@ -6,7 +6,7 @@ For account and auth workflows, prefer documented `assistant` CLI commands over
 any generic account registry:
 
 - `assistant credentials ...` for stored secrets and credential metadata
-- `assistant oauth connections token <provider-key>` for OAuth-backed integrations
+- Do not retrieve raw OAuth token values unless the user explicitly asks for the token itself
 - `assistant mcp auth <name>` when an MCP server needs browser login
 - `assistant platform status` for platform-linked deployment/auth context
 

--- a/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
@@ -39,7 +39,7 @@ describe("buildCliReferenceSection", () => {
     );
     expect(result).toContain("assistant credentials");
     expect(result).toContain(
-      "assistant oauth connections token <provider-key>",
+      "Never retrieve raw OAuth tokens unless the user explicitly asks for the token value",
     );
     expect(result).toContain("assistant mcp auth <name>");
     expect(result).toContain("assistant platform status");

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -848,7 +848,7 @@ export function buildCliReferenceSection(): string {
     "The `assistant` CLI is installed on the user's machine and available via `bash`.",
     "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
     "- Use `assistant credentials ...` for stored secrets and credential metadata.",
-    "- Use `assistant oauth connections token <provider-key>` for connected integration tokens.",
+    "- Never retrieve raw OAuth tokens unless the user explicitly asks for the token value.",
     "- Use `assistant mcp auth <name>` when an MCP server needs OAuth login.",
     "- Use `assistant platform status` for platform-linked deployment and auth context.",
     "- If a bundled skill documents a service-specific `assistant <service>` auth or session flow, follow that CLI exactly.",


### PR DESCRIPTION
## Summary

- Replaces system prompt guidance that directed the model to use `assistant oauth connections token <provider-key>` with a warning to never retrieve raw OAuth tokens unless the user explicitly asks
- Applies the same change to the bundled skill CLI retrieval pattern
- Updates the corresponding test expectation

Skills that need authenticated API calls should use proxied `bash` with `credential_ids` (as the Notion skill already demonstrates) rather than raw token retrieval.

Addresses Codex finding [416bfb63e4e88191ab0745e6adce29cf](https://chatgpt.com/codex/security/findings/416bfb63e4e88191ab0745e6adce29cf).

## Original prompt

Security fix: Stop system prompt from encouraging raw OAuth token retrieval via CLI. Codex finding identified that the system prompt and bundled skill guidance explicitly direct the model to use `assistant oauth connections token <provider-key>`, which prints raw OAuth access tokens to stdout. This creates a prompt-injection-driven token exfiltration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
