### PR TITLE
fix: refactor how server side anthropic tools work to fix web lookup tool

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -836,8 +836,8 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
     // The server_tool_use pair (server_tool_use + web_search_tool_result) should
     // be in the leading portion of the assistant message, before tool_use.
-    // splitAssistantForToolPairing: leading=[server_tool_use, web_search_tool_result],
-    // toolUseBlocks=[tool_use], carryover=[text]
+    // splitAssistantForToolPairing: leading=[server_tool_use, web_search_tool_result, text],
+    // toolUseBlocks=[tool_use], carryover=[]
     const assistantMsg = sent[1];
     expect(assistantMsg.role).toBe("assistant");
     const blockTypes = assistantMsg.content.map((b) => b.type);

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -670,7 +670,9 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   // ensureToolPairing — server_tool_use / web_search_tool_result pairing
   // -----------------------------------------------------------------------
 
-  test("server_tool_use with missing web_search_tool_result gets synthetic result injected", async () => {
+  test("server_tool_use without web_search_tool_result passes through as-is (no synthetic injection)", async () => {
+    // Server-side tools are self-paired within the assistant message.
+    // ensureToolPairing should NOT inject synthetic results for them.
     const messages: Message[] = [
       userMsg("Search for something"),
       {
@@ -684,7 +686,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
           },
         ],
       },
-      userMsg("Thanks"), // user text but no web_search_tool_result
+      userMsg("Thanks"),
     ];
     await provider.sendMessage(messages);
 
@@ -697,14 +699,17 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       }>;
     }>;
 
-    // The user message after assistant should contain a synthetic web_search_tool_result
-    const userAfterAssistant = sent[2];
-    expect(userAfterAssistant.role).toBe("user");
-    expect(userAfterAssistant.content[0].type).toBe("web_search_tool_result");
-    expect(userAfterAssistant.content[0].tool_use_id).toBe("srvtoolu_abc123");
+    // server_tool_use stays in the assistant message, no synthetic result injected
+    expect(sent).toHaveLength(3);
+    expect(sent[1].role).toBe("assistant");
+    expect(sent[1].content[0].type).toBe("server_tool_use");
+    expect(sent[2].role).toBe("user");
+    expect(sent[2].content[0].type).toBe("text"); // original user text, not a synthetic result
   });
 
-  test("server_tool_use at end of messages gets synthetic web_search_tool_result appended", async () => {
+  test("server_tool_use at end of messages is not modified (no synthetic append)", async () => {
+    // Server-side tools don't need cross-message pairing, so no synthetic
+    // user message should be appended.
     const messages: Message[] = [
       userMsg("Search something"),
       {
@@ -726,11 +731,10 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       content: Array<{ type: string; tool_use_id?: string }>;
     }>;
 
-    // A synthetic user message should have been appended
-    expect(sent).toHaveLength(3);
-    expect(sent[2].role).toBe("user");
-    expect(sent[2].content[0].type).toBe("web_search_tool_result");
-    expect(sent[2].content[0].tool_use_id).toBe("srvtoolu_end");
+    // No synthetic user message appended — just the original 2 messages
+    expect(sent).toHaveLength(2);
+    expect(sent[1].role).toBe("assistant");
+    expect(sent[1].content[0].type).toBe("server_tool_use");
   });
 
   test("server_tool_use with matching web_search_tool_result passes through unchanged", async () => {
@@ -781,7 +785,85 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(resultBlocks[0].tool_use_id).toBe("srvtoolu_ok");
   });
 
-  test("mixed tool_use and server_tool_use with partial results gets missing ones filled", async () => {
+  test("server_tool_use + web_search_tool_result + tool_use in same assistant message stays intact", async () => {
+    // This is the core bug scenario: Anthropic returns server_tool_use,
+    // web_search_tool_result, text, and tool_use all in one assistant message.
+    // The server pair must stay together in the assistant message.
+    const messages: Message[] = [
+      userMsg("Search and fetch"),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "srvtoolu_search",
+            name: "web_search",
+            input: { query: "test" },
+          },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_search",
+            content: [
+              {
+                type: "web_search_result",
+                url: "https://example.com",
+                title: "Example",
+                encrypted_content: "enc_123",
+              },
+            ],
+          },
+          { type: "text", text: "Based on the search results..." },
+          {
+            type: "tool_use",
+            id: "tu_fetch",
+            name: "fetch_url",
+            input: { url: "https://example.com" },
+          },
+        ],
+      },
+      toolResultMsg("tu_fetch", "page content here"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        id?: string;
+        tool_use_id?: string;
+      }>;
+    }>;
+
+    // The server_tool_use pair (server_tool_use + web_search_tool_result) should
+    // be in the leading portion of the assistant message, before tool_use.
+    // splitAssistantForToolPairing: leading=[server_tool_use, web_search_tool_result],
+    // toolUseBlocks=[tool_use], carryover=[text]
+    const assistantMsg = sent[1];
+    expect(assistantMsg.role).toBe("assistant");
+    const blockTypes = assistantMsg.content.map((b) => b.type);
+    expect(blockTypes).toContain("server_tool_use");
+    expect(blockTypes).toContain("web_search_tool_result");
+    expect(blockTypes).toContain("tool_use");
+
+    // The tool_result for the client-side tool_use should be in the user message
+    const userMsg2 = sent[2];
+    expect(userMsg2.role).toBe("user");
+    expect(
+      userMsg2.content.some(
+        (b) => b.type === "tool_result" && b.tool_use_id === "tu_fetch",
+      ),
+    ).toBe(true);
+
+    // No synthetic web_search_tool_result injected anywhere
+    const allBlocks = sent.flatMap((m) => m.content);
+    const webSearchResults = allBlocks.filter(
+      (b) => b.type === "web_search_tool_result",
+    );
+    expect(webSearchResults).toHaveLength(1); // only the original one
+    expect(webSearchResults[0].tool_use_id).toBe("srvtoolu_search");
+  });
+
+  test("mixed tool_use and server_tool_use — only client-side tool_use gets pairing, server tools pass through", async () => {
     const messages: Message[] = [
       userMsg("Do things"),
       {
@@ -796,7 +878,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
           },
         ],
       },
-      // Only tu_a has a result
+      // Only tu_a has a result — server_tool_use doesn't need one in the user message
       toolResultMsg("tu_a", "result A"),
     ];
     await provider.sendMessage(messages);
@@ -806,20 +888,29 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       content: Array<{
         type: string;
         tool_use_id?: string;
+        id?: string;
       }>;
     }>;
 
+    // Assistant message should have tool_use in paired portion, server_tool_use in carryover
+    // ensureToolPairing splits: paired = [tool_use(tu_a)], carryover = [server_tool_use(srvtoolu_b)]
+    // Result: assistant(tool_use) → user(tool_result) → assistant(server_tool_use) → user(continue)
+    const assistantMsg = sent[1];
+    expect(assistantMsg.role).toBe("assistant");
+    expect(assistantMsg.content[0].type).toBe("tool_use");
+
     const userAfterAssistant = sent[2];
-    // Should have tool_result for tu_a and synthetic web_search_tool_result for srvtoolu_b
-    expect(userAfterAssistant.content).toHaveLength(2);
+    expect(userAfterAssistant.role).toBe("user");
+    // Only tool_result for tu_a — no synthetic web_search_tool_result
     expect(userAfterAssistant.content[0]).toMatchObject({
       type: "tool_result",
       tool_use_id: "tu_a",
     });
-    expect(userAfterAssistant.content[1]).toMatchObject({
-      type: "web_search_tool_result",
-      tool_use_id: "srvtoolu_b",
-    });
+
+    // server_tool_use preserved in a carryover assistant message
+    const carryoverAssistant = sent[3];
+    expect(carryoverAssistant.role).toBe("assistant");
+    expect(carryoverAssistant.content[0].type).toBe("server_tool_use");
   });
 
   test("assistant message with only unknown blocks gets placeholder text", async () => {

--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -429,7 +429,8 @@ describe("repairHistory", () => {
     expect(stats.consecutiveSameRoleMerged).toBe(0);
   });
 
-  test("preserves server_tool_use and web_search_tool_result pairing", () => {
+  test("keeps server_tool_use + web_search_tool_result paired in assistant message", () => {
+    // Both blocks should stay in the assistant message (self-paired)
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "Search for cats" }] },
       {
@@ -441,21 +442,13 @@ describe("repairHistory", () => {
             name: "web_search",
             input: { query: "cats" },
           },
-        ],
-      },
-      {
-        role: "user",
-        content: [
           {
             type: "web_search_tool_result",
             tool_use_id: "stu_1",
             content: [{ type: "web_search_result", url: "https://cats.com" }],
           },
+          { type: "text", text: "Here are some results about cats." },
         ],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Here are the results." }],
       },
     ];
 
@@ -466,7 +459,9 @@ describe("repairHistory", () => {
     expect(stats.orphanToolResultsDowngraded).toBe(0);
   });
 
-  test("inserts synthetic web_search_tool_result when missing", () => {
+  test("synthesizes web_search_tool_result in assistant message when missing (interrupted stream)", () => {
+    // If server_tool_use has no paired result (e.g. stream was interrupted),
+    // the synthetic result goes in the SAME assistant message, not a user message
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "Search" }] },
       {
@@ -490,21 +485,23 @@ describe("repairHistory", () => {
 
     expect(stats.missingToolResultsInserted).toBe(1);
 
-    const userMsg = repaired[2];
-    const wsBlocks = userMsg.content.filter(
-      (b) => b.type === "web_search_tool_result",
-    );
-    expect(wsBlocks).toHaveLength(1);
-    expect(wsBlocks[0]).toMatchObject({
+    // Synthetic result is in the assistant message, not the user message
+    const assistantMsg = repaired[1];
+    expect(assistantMsg.content).toHaveLength(2);
+    expect(assistantMsg.content[1]).toMatchObject({
       type: "web_search_tool_result",
       tool_use_id: "stu_1",
       content: { type: "web_search_tool_result_error", error_code: "unavailable" },
     });
+
+    // User message has no web_search_tool_result
+    const userMsg = repaired[2];
+    expect(userMsg.content.every((b) => b.type !== "web_search_tool_result")).toBe(true);
   });
 
-  test("does not orphan web_search_tool_result paired with server_tool_use", () => {
-    // This is the exact scenario from the bug: server_tool_use followed by
-    // web_search_tool_result should NOT be treated as orphaned
+  test("migrates legacy web_search_tool_result from user message to assistant message", () => {
+    // Old history format: server_tool_use in assistant, web_search_tool_result in user.
+    // Repair: synthesize result in assistant, orphan-downgrade the user-side result.
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "Search" }] },
       {
@@ -543,12 +540,25 @@ describe("repairHistory", () => {
 
     const { messages: repaired, stats } = repairHistory(messages);
 
-    expect(stats.orphanToolResultsDowngraded).toBe(0);
-    expect(stats.missingToolResultsInserted).toBe(0);
-    expect(repaired).toEqual(messages);
+    // Synthetic web_search_tool_result added to assistant message
+    expect(stats.missingToolResultsInserted).toBe(1);
+
+    // The assistant message now has the server pair + client tool_use
+    const assistantMsg = repaired[1];
+    const serverToolUse = assistantMsg.content.find((b) => b.type === "server_tool_use");
+    const webSearchResult = assistantMsg.content.find((b) => b.type === "web_search_tool_result");
+    expect(serverToolUse).toBeDefined();
+    expect(webSearchResult).toBeDefined();
+
+    // The user message has tool_result for tu_1, and the old web_search_tool_result is downgraded
+    const userMsg = repaired[2];
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    expect(userMsg.content.some((b) => b.type === "tool_result")).toBe(true);
+    expect(userMsg.content.every((b) => b.type !== "web_search_tool_result")).toBe(true);
   });
 
-  test("injects synthetic user message for trailing server_tool_use", () => {
+  test("trailing server_tool_use gets synthetic result in same assistant message", () => {
+    // No trailing user message needed — result goes in the assistant message
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "Go" }] },
       {
@@ -567,9 +577,11 @@ describe("repairHistory", () => {
     const { messages: repaired, stats } = repairHistory(messages);
 
     expect(stats.missingToolResultsInserted).toBe(1);
-    expect(repaired).toHaveLength(3);
-    expect(repaired[2].role).toBe("user");
-    expect(repaired[2].content[0]).toMatchObject({
+    // Result is in the assistant message
+    expect(repaired).toHaveLength(2);
+    expect(repaired[1].role).toBe("assistant");
+    expect(repaired[1].content).toHaveLength(2);
+    expect(repaired[1].content[1]).toMatchObject({
       type: "web_search_tool_result",
       tool_use_id: "stu_1",
       content: { type: "web_search_tool_result_error", error_code: "unavailable" },
@@ -577,8 +589,8 @@ describe("repairHistory", () => {
   });
 
   test("downgrades type-mismatched tool_result for server_tool_use", () => {
-    // A tool_result paired with a server_tool_use ID is a type mismatch —
-    // the provider requires web_search_tool_result for server_tool_use
+    // A tool_result in the user message for a server_tool_use ID is orphaned —
+    // server-side results belong in the assistant message
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "Search" }] },
       {
@@ -606,20 +618,19 @@ describe("repairHistory", () => {
 
     const { messages: repaired, stats } = repairHistory(messages);
 
-    // The mismatched tool_result should be downgraded and a synthetic web_search_tool_result inserted
-    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    // Synthetic web_search_tool_result added to assistant message
     expect(stats.missingToolResultsInserted).toBe(1);
+    // The mismatched tool_result in user message is orphaned (no pending client tool_use)
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
 
+    // Assistant message has the server pair
+    const assistantMsg = repaired[1];
+    expect(assistantMsg.content.some((b) => b.type === "web_search_tool_result")).toBe(true);
+
+    // User message has no web_search_tool_result — the tool_result was downgraded to text
     const userMsg = repaired[2];
-    const wsBlocks = userMsg.content.filter(
-      (b) => b.type === "web_search_tool_result",
-    );
-    expect(wsBlocks).toHaveLength(1);
-    expect(wsBlocks[0]).toMatchObject({
-      type: "web_search_tool_result",
-      tool_use_id: "stu_1",
-      content: { type: "web_search_tool_result_error", error_code: "unavailable" },
-    });
+    expect(userMsg.content.every((b) => b.type !== "web_search_tool_result")).toBe(true);
+    expect(userMsg.content.every((b) => b.type !== "tool_result")).toBe(true);
   });
 
   test("downgrades type-mismatched web_search_tool_result for tool_use", () => {

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -4,7 +4,6 @@ import type {
   ServerToolUseContent,
   ToolResultContent,
   ToolUseContent,
-  WebSearchToolResultContent,
 } from "../providers/types.js";
 
 export interface RepairStats {
@@ -37,13 +36,8 @@ export function repairHistory(messages: Message[]): RepairResult {
 
   const result: Message[] = [];
   let pendingToolUseIds = new Set<string>();
-  // IDs of server_tool_use blocks (need web_search_tool_result, not tool_result)
-  let serverToolUseIds = new Set<string>();
-  // tool_result/web_search_tool_result blocks stripped from assistant messages, keyed by tool_use_id
-  let recoveredResults = new Map<
-    string,
-    ToolResultContent | WebSearchToolResultContent
-  >();
+  // tool_result blocks stripped from assistant messages, keyed by tool_use_id
+  let recoveredResults = new Map<string, ToolResultContent>();
 
   for (const msg of messages) {
     if (msg.role === "assistant") {
@@ -51,31 +45,21 @@ export function repairHistory(messages: Message[]): RepairResult {
       // using recovered results where available, synthetic for the rest
       if (pendingToolUseIds.size > 0) {
         result.push(
-          buildResultMessage(
-            pendingToolUseIds,
-            serverToolUseIds,
-            recoveredResults,
-            stats,
-          ),
+          buildResultMessage(pendingToolUseIds, recoveredResults, stats),
         );
         pendingToolUseIds = new Set();
-        serverToolUseIds = new Set();
         recoveredResults = new Map();
       }
 
-      // Strip tool_result/web_search_tool_result blocks from assistant messages,
-      // preserving them so they can be migrated to the correct user message position
+      // Strip client-side tool_result blocks from assistant messages,
+      // preserving them so they can be migrated to the correct user message.
+      // Server-side tools (server_tool_use / web_search_tool_result) are
+      // self-paired within the assistant message and must NOT be separated.
       const cleanedContent: ContentBlock[] = [];
-      const newRecovered = new Map<
-        string,
-        ToolResultContent | WebSearchToolResultContent
-      >();
+      const newRecovered = new Map<string, ToolResultContent>();
       for (const block of msg.content) {
-        if (
-          block.type === "tool_result" ||
-          block.type === "web_search_tool_result"
-        ) {
-          const tr = block as ToolResultContent | WebSearchToolResultContent;
+        if (block.type === "tool_result") {
+          const tr = block as ToolResultContent;
           newRecovered.set(tr.tool_use_id, tr);
           stats.assistantToolResultsMigrated++;
         } else {
@@ -83,22 +67,37 @@ export function repairHistory(messages: Message[]): RepairResult {
         }
       }
 
-      result.push({ role: "assistant", content: cleanedContent });
-
-      // Collect tool_use and server_tool_use IDs from this assistant message
-      pendingToolUseIds = new Set(
-        cleanedContent
-          .filter(
-            (b): b is ToolUseContent | ServerToolUseContent =>
-              b.type === "tool_use" || b.type === "server_tool_use",
-          )
-          .map((b) => b.id),
-      );
-      serverToolUseIds = new Set(
+      // Ensure every server_tool_use has a paired web_search_tool_result
+      // in the same assistant message (handles interrupted streams)
+      const serverToolIds = new Set(
         cleanedContent
           .filter(
             (b): b is ServerToolUseContent => b.type === "server_tool_use",
           )
+          .map((b) => b.id),
+      );
+      const matchedServerIds = new Set(
+        cleanedContent
+          .filter((b) => b.type === "web_search_tool_result")
+          .map((b) => (b as { tool_use_id: string }).tool_use_id),
+      );
+      for (const id of serverToolIds) {
+        if (!matchedServerIds.has(id)) {
+          cleanedContent.push({
+            type: "web_search_tool_result",
+            tool_use_id: id,
+            content: SYNTHETIC_WEB_SEARCH_ERROR,
+          });
+          stats.missingToolResultsInserted++;
+        }
+      }
+
+      result.push({ role: "assistant", content: cleanedContent });
+
+      // Only track client-side tool_use IDs as pending (not server_tool_use)
+      pendingToolUseIds = new Set(
+        cleanedContent
+          .filter((b): b is ToolUseContent => b.type === "tool_use")
           .map((b) => b.id),
       );
       recoveredResults = newRecovered;
@@ -109,22 +108,24 @@ export function repairHistory(messages: Message[]): RepairResult {
         const newContent: ContentBlock[] = [];
 
         for (const block of msg.content) {
-          if (
-            block.type === "tool_result" ||
-            block.type === "web_search_tool_result"
-          ) {
-            const tr = block as ToolResultContent | WebSearchToolResultContent;
-            const isTypeMatch =
-              pendingToolUseIds.has(tr.tool_use_id) &&
-              (block.type === "web_search_tool_result") ===
-                serverToolUseIds.has(tr.tool_use_id);
-            if (isTypeMatch) {
+          if (block.type === "tool_result") {
+            const tr = block as ToolResultContent;
+            if (pendingToolUseIds.has(tr.tool_use_id)) {
               matchedIds.add(tr.tool_use_id);
               newContent.push(block);
             } else {
               stats.orphanToolResultsDowngraded++;
               newContent.push(downgradeResult(tr));
             }
+          } else if (block.type === "web_search_tool_result") {
+            // web_search_tool_result in a user message is orphaned — server-side
+            // results belong in the assistant message, not here
+            stats.orphanToolResultsDowngraded++;
+            newContent.push(
+              downgradeResult(
+                block as { type: "web_search_tool_result"; tool_use_id: string; content: unknown },
+              ),
+            );
           } else {
             newContent.push(block);
           }
@@ -134,47 +135,35 @@ export function repairHistory(messages: Message[]): RepairResult {
         for (const id of pendingToolUseIds) {
           if (!matchedIds.has(id)) {
             const recovered = recoveredResults.get(id);
-            const isRecoveredTypeMatch =
-              recovered &&
-              (recovered.type === "web_search_tool_result") ===
-                serverToolUseIds.has(id);
-            if (isRecoveredTypeMatch) {
+            if (recovered) {
               newContent.push(recovered);
               // Already counted in assistantToolResultsMigrated
             } else {
               stats.missingToolResultsInserted++;
-              if (serverToolUseIds.has(id)) {
-                newContent.push({
-                  type: "web_search_tool_result",
-                  tool_use_id: id,
-                  content: SYNTHETIC_WEB_SEARCH_ERROR,
-                });
-              } else {
-                newContent.push({
-                  type: "tool_result",
-                  tool_use_id: id,
-                  content: SYNTHETIC_RESULT,
-                  is_error: true,
-                });
-              }
+              newContent.push({
+                type: "tool_result",
+                tool_use_id: id,
+                content: SYNTHETIC_RESULT,
+                is_error: true,
+              });
             }
           }
         }
 
         result.push({ role: "user", content: newContent });
         pendingToolUseIds = new Set();
-        serverToolUseIds = new Set();
         recoveredResults = new Map();
       } else {
         // No pending tool_use — any tool_result/web_search_tool_result here is orphaned
         const newContent: ContentBlock[] = msg.content.map((block) => {
-          if (
-            block.type === "tool_result" ||
-            block.type === "web_search_tool_result"
-          ) {
+          if (block.type === "tool_result") {
+            stats.orphanToolResultsDowngraded++;
+            return downgradeResult(block as ToolResultContent);
+          }
+          if (block.type === "web_search_tool_result") {
             stats.orphanToolResultsDowngraded++;
             return downgradeResult(
-              block as ToolResultContent | WebSearchToolResultContent,
+              block as { type: "web_search_tool_result"; tool_use_id: string; content: unknown },
             );
           }
           return block;
@@ -187,14 +176,7 @@ export function repairHistory(messages: Message[]): RepairResult {
 
   // Trailing unfulfilled tool_use at end of history
   if (pendingToolUseIds.size > 0) {
-    result.push(
-      buildResultMessage(
-        pendingToolUseIds,
-        serverToolUseIds,
-        recoveredResults,
-        stats,
-      ),
-    );
+    result.push(buildResultMessage(pendingToolUseIds, recoveredResults, stats));
   }
 
   // Merge consecutive same-role messages. This can occur after a checkpoint
@@ -219,28 +201,18 @@ export function repairHistory(messages: Message[]): RepairResult {
 
 function buildResultMessage(
   ids: Set<string>,
-  serverIds: Set<string>,
-  recovered: Map<string, ToolResultContent | WebSearchToolResultContent>,
+  recovered: Map<string, ToolResultContent>,
   stats: RepairStats,
 ): Message {
   return {
     role: "user",
     content: Array.from(ids).map((id) => {
       const rec = recovered.get(id);
-      const isRecTypeMatch =
-        rec && (rec.type === "web_search_tool_result") === serverIds.has(id);
-      if (isRecTypeMatch) {
+      if (rec) {
         // Already counted in assistantToolResultsMigrated
         return rec;
       }
       stats.missingToolResultsInserted++;
-      if (serverIds.has(id)) {
-        return {
-          type: "web_search_tool_result" as const,
-          tool_use_id: id,
-          content: SYNTHETIC_WEB_SEARCH_ERROR,
-        };
-      }
       return {
         type: "tool_result" as const,
         tool_use_id: id,
@@ -284,7 +256,7 @@ export function deepRepairHistory(messages: Message[]): RepairResult {
 }
 
 function downgradeResult(
-  tr: ToolResultContent | WebSearchToolResultContent,
+  tr: { type: string; tool_use_id: string; content?: unknown },
 ): ContentBlock {
   const content =
     tr.type === "tool_result" ? tr.content : "[web search result]"; // guard:allow-tool-result-only — distinguishes content format between the two types

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -107,11 +107,6 @@ function buildSyntheticToolResult(
   };
 }
 
-function buildSyntheticResult(
-  toolUseId: string,
-): Anthropic.ToolResultBlockParam {
-  return buildSyntheticToolResult(toolUseId);
-}
 
 /**
  * Collect ordered IDs of client-side tool_use blocks only.
@@ -226,7 +221,7 @@ function normalizeFollowingUserContent(
 
   const missingIds = orderedToolUseIds.filter((id) => !matchedById.has(id));
   const orderedResults = orderedToolUseIds.map(
-    (id) => matchedById.get(id) ?? buildSyntheticResult(id),
+    (id) => matchedById.get(id) ?? buildSyntheticToolResult(id),
   );
 
   return {
@@ -356,7 +351,7 @@ function ensureToolPairing(
       );
       result.push({
         role: "user" as const,
-        content: toolUseIds.map((id) => buildSyntheticResult(id)),
+        content: toolUseIds.map((id) => buildSyntheticToolResult(id)),
       });
 
       // If the assistant contained collapsed post-tool text, preserve it as a

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -63,20 +63,6 @@ function isToolUseBlock(block: unknown): block is Anthropic.ToolUseBlockParam {
   );
 }
 
-/** Type-guard for server_tool_use blocks (e.g. native web search). */
-function isServerToolUseBlock(block: unknown): block is {
-  type: "server_tool_use";
-  id: string;
-  name: string;
-  input: unknown;
-} {
-  return (
-    typeof block === "object" &&
-    block != null &&
-    (block as { type: string }).type === "server_tool_use"
-  );
-}
-
 /** Type-guard for tool_result blocks in Anthropic-formatted content. */
 function isToolResultBlock(
   block: unknown,
@@ -85,19 +71,6 @@ function isToolResultBlock(
     typeof block === "object" &&
     block != null &&
     (block as { type: string }).type === "tool_result"
-  );
-}
-
-/** Type-guard for web_search_tool_result blocks. */
-function isWebSearchToolResultBlock(block: unknown): block is {
-  type: "web_search_tool_result";
-  tool_use_id: string;
-  content: unknown;
-} {
-  return (
-    typeof block === "object" &&
-    block != null &&
-    (block as { type: string }).type === "web_search_tool_result"
   );
 }
 
@@ -134,79 +107,60 @@ function buildSyntheticToolResult(
   };
 }
 
-function buildSyntheticWebSearchToolResult(
-  toolUseId: string,
-): Anthropic.ContentBlockParam {
-  return {
-    type: "web_search_tool_result",
-    tool_use_id: toolUseId,
-    content: {
-      type: "web_search_tool_result_error",
-      error_code: "unavailable",
-    },
-  } as unknown as Anthropic.ContentBlockParam;
-}
-
-/** Build the appropriate synthetic result block based on whether the ID is for a server tool or regular tool. */
 function buildSyntheticResult(
   toolUseId: string,
-  serverToolIds: ReadonlySet<string>,
-): Anthropic.ContentBlockParam {
-  if (serverToolIds.has(toolUseId)) {
-    return buildSyntheticWebSearchToolResult(toolUseId);
-  }
+): Anthropic.ToolResultBlockParam {
   return buildSyntheticToolResult(toolUseId);
 }
 
-function getOrderedToolUseIds(content: Anthropic.ContentBlockParam[]): {
-  ids: string[];
-  serverToolIds: Set<string>;
-} {
+/**
+ * Collect ordered IDs of client-side tool_use blocks only.
+ * Server-side tools (server_tool_use / web_search_tool_result) are self-paired
+ * within the assistant message and do not need cross-message pairing.
+ */
+function getOrderedToolUseIds(
+  content: Anthropic.ContentBlockParam[],
+): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
-  const serverToolIds = new Set<string>();
   for (const block of content) {
     if (isToolUseBlock(block)) {
       if (!seen.has(block.id)) {
         seen.add(block.id);
         ids.push(block.id);
       }
-    } else if (isServerToolUseBlock(block)) {
-      if (!seen.has(block.id)) {
-        seen.add(block.id);
-        ids.push(block.id);
-        serverToolIds.add(block.id);
-      }
     }
   }
-  return { ids, serverToolIds };
+  return ids;
 }
 
 function hasOrderedToolResultPrefix(
   content: Anthropic.ContentBlockParam[],
   orderedToolUseIds: string[],
-  serverToolIds: ReadonlySet<string>,
 ): boolean {
   if (content.length < orderedToolUseIds.length) return false;
   for (let idx = 0; idx < orderedToolUseIds.length; idx++) {
     const block = content[idx];
     const expectedId = orderedToolUseIds[idx];
-    if (serverToolIds.has(expectedId)) {
-      if (!isWebSearchToolResultBlock(block)) return false;
-      if (block.tool_use_id !== expectedId) return false;
-    } else {
-      if (!isToolResultBlock(block)) return false;
-      if (block.tool_use_id !== expectedId) return false;
-    }
+    if (!isToolResultBlock(block)) return false;
+    if (block.tool_use_id !== expectedId) return false;
   }
   return true;
 }
 
+/**
+ * Split an assistant message into:
+ * - pairedContent: everything up to and including client-side tool_use blocks
+ * - carryoverContent: trailing non-tool blocks after the last tool_use
+ *
+ * Server-side tools (server_tool_use / web_search_tool_result) are treated as
+ * regular content — they are self-paired within the assistant message and must
+ * not be separated by the cross-message pairing logic.
+ */
 function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
   pairedContent: Anthropic.ContentBlockParam[];
   carryoverContent: Anthropic.ContentBlockParam[];
   toolUseIds: string[];
-  serverToolIds: Set<string>;
 } {
   const leading: Anthropic.ContentBlockParam[] = [];
   const toolUseBlocks: Anthropic.ContentBlockParam[] = [];
@@ -214,7 +168,7 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
   let seenToolUse = false;
 
   for (const block of content) {
-    if (isToolUseBlock(block) || isServerToolUseBlock(block)) {
+    if (isToolUseBlock(block)) {
       seenToolUse = true;
       toolUseBlocks.push(block);
       continue;
@@ -231,7 +185,6 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
       pairedContent: content,
       carryoverContent: [],
       toolUseIds: [],
-      serverToolIds: new Set(),
     };
   }
 
@@ -239,19 +192,16 @@ function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
     ...leading,
     ...toolUseBlocks,
   ];
-  const { ids, serverToolIds } = getOrderedToolUseIds(pairedContent);
   return {
     pairedContent,
     carryoverContent: carryover,
-    toolUseIds: ids,
-    serverToolIds,
+    toolUseIds: getOrderedToolUseIds(pairedContent),
   };
 }
 
 function normalizeFollowingUserContent(
   nextContent: Anthropic.ContentBlockParam[],
   orderedToolUseIds: string[],
-  serverToolIds: ReadonlySet<string>,
 ): {
   toolResultPrefix: Anthropic.ContentBlockParam[];
   remainingContent: Anthropic.ContentBlockParam[];
@@ -266,22 +216,9 @@ function normalizeFollowingUserContent(
     if (
       isToolResultBlock(block) &&
       pendingIds.has(block.tool_use_id) &&
-      !matchedById.has(block.tool_use_id) &&
-      !serverToolIds.has(block.tool_use_id)
+      !matchedById.has(block.tool_use_id)
     ) {
       matchedById.set(block.tool_use_id, block);
-      continue;
-    }
-    if (
-      isWebSearchToolResultBlock(block) &&
-      pendingIds.has(block.tool_use_id) &&
-      !matchedById.has(block.tool_use_id) &&
-      serverToolIds.has(block.tool_use_id)
-    ) {
-      matchedById.set(
-        block.tool_use_id,
-        block as unknown as Anthropic.ContentBlockParam,
-      );
       continue;
     }
     remaining.push(block);
@@ -289,18 +226,14 @@ function normalizeFollowingUserContent(
 
   const missingIds = orderedToolUseIds.filter((id) => !matchedById.has(id));
   const orderedResults = orderedToolUseIds.map(
-    (id) => matchedById.get(id) ?? buildSyntheticResult(id, serverToolIds),
+    (id) => matchedById.get(id) ?? buildSyntheticResult(id),
   );
 
   return {
     toolResultPrefix: orderedResults,
     remainingContent: remaining,
     missingIds,
-    hadOrderedPrefix: hasOrderedToolResultPrefix(
-      nextContent,
-      orderedToolUseIds,
-      serverToolIds,
-    ),
+    hadOrderedPrefix: hasOrderedToolResultPrefix(nextContent, orderedToolUseIds),
   };
 }
 
@@ -328,7 +261,7 @@ function ensureToolPairing(
     }
 
     const content = Array.isArray(msg.content) ? msg.content : [];
-    const { pairedContent, carryoverContent, toolUseIds, serverToolIds } =
+    const { pairedContent, carryoverContent, toolUseIds } =
       splitAssistantForToolPairing(content);
 
     if (toolUseIds.length === 0) {
@@ -337,7 +270,7 @@ function ensureToolPairing(
       continue;
     }
 
-    // Assistant message — push the paired portion (pre-tool text + tool_use/server_tool_use blocks)
+    // Assistant message — push the paired portion (pre-tool text + tool_use blocks)
     result.push({
       role: "assistant" as const,
       content: pairedContent,
@@ -358,11 +291,7 @@ function ensureToolPairing(
     const next = messages[i + 1];
     if (next && next.role === "user") {
       const nextContent = Array.isArray(next.content) ? next.content : [];
-      const normalized = normalizeFollowingUserContent(
-        nextContent,
-        toolUseIds,
-        serverToolIds,
-      );
+      const normalized = normalizeFollowingUserContent(nextContent, toolUseIds);
       if (normalized.missingIds.length > 0) {
         log.warn(
           {
@@ -427,9 +356,7 @@ function ensureToolPairing(
       );
       result.push({
         role: "user" as const,
-        content: toolUseIds.map((id) =>
-          buildSyntheticResult(id, serverToolIds),
-        ),
+        content: toolUseIds.map((id) => buildSyntheticResult(id)),
       });
 
       // If the assistant contained collapsed post-tool text, preserve it as a
@@ -445,13 +372,14 @@ function ensureToolPairing(
     }
   }
 
-  // Self-validation: verify no tool_use/tool_result mismatches remain
+  // Self-validation: verify no client-side tool_use/tool_result mismatches remain.
+  // Server-side tools (server_tool_use / web_search_tool_result) are self-paired
+  // within assistant messages and are not validated here.
   for (let j = 0; j < result.length; j++) {
     const m = result[j];
     if (m.role !== "assistant") continue;
     const c = Array.isArray(m.content) ? m.content : [];
-    const { ids: validationIds, serverToolIds: validationServerToolIds } =
-      getOrderedToolUseIds(c);
+    const validationIds = getOrderedToolUseIds(c);
     if (validationIds.length === 0) continue;
 
     const nxt = result[j + 1];
@@ -459,20 +387,9 @@ function ensureToolPairing(
       nxt && nxt.role === "user" && Array.isArray(nxt.content)
         ? nxt.content
         : [];
-    if (
-      !hasOrderedToolResultPrefix(
-        nxtContent,
-        validationIds,
-        validationServerToolIds,
-      )
-    ) {
+    if (!hasOrderedToolResultPrefix(nxtContent, validationIds)) {
       const unmatchedIds = validationIds.filter((id, idx) => {
         const block = nxtContent[idx];
-        if (validationServerToolIds.has(id)) {
-          return !(
-            isWebSearchToolResultBlock(block) && block.tool_use_id === id
-          );
-        }
         return !(isToolResultBlock(block) && block.tool_use_id === id);
       });
       log.error(


### PR DESCRIPTION
## Summary
- **Commit 1 — `ensureToolPairing` fix**: `splitAssistantForToolPairing` included `server_tool_use` in `toolUseIds`, causing `ensureToolPairing` to rip apart the `server_tool_use` / `web_search_tool_result` pair. Removed server-side tools from the pairing logic entirely — they are self-paired within assistant messages and do not need cross-message repair.
- **Commit 2 — `history-repair` fix**: `repairHistory()` was stripping `web_search_tool_result` from assistant messages and placing them in user messages (cross-message pairing). This broke the self-pairing that Anthropic requires. Fix: keep `web_search_tool_result` in assistant messages, don't track `server_tool_use` as pending cross-message IDs, synthesize missing results in the assistant message for interrupted streams, and downgrade orphaned `web_search_tool_result` in user messages (legacy format).

Both layers were independently breaking server-side tool pairing — the first fix alone was insufficient because `history-repair` runs upstream of `ensureToolPairing`.

Sentry: VELLUM-ASSISTANT-BRAIN-5A (38 events), VELLUM-ASSISTANT-BRAIN-5K (1 event)

Closes JARVIS-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)