### PR TITLE
fix: restore evicted sessions on regenerate and undo

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -578,23 +578,24 @@ export function handleCancel(msg: CancelRequest, ctx: HandlerContext): void {
 }
 
 /**
- * Undo the last message in a session. Returns the removed count, or null if session not found.
+ * Undo the last message in a session. Returns the removed count, or null if
+ * the conversation does not exist. Restores evicted sessions from the database.
  */
-export function undoLastMessage(
+export async function undoLastMessage(
   sessionId: string,
   ctx: HandlerContext,
-): { removedCount: number } | null {
-  const session = ctx.sessions.get(sessionId);
-  if (!session) {
+): Promise<{ removedCount: number } | null> {
+  if (!getConversation(sessionId)) {
     return null;
   }
+  const session = await ctx.getOrCreateSession(sessionId);
   ctx.touchSession(sessionId);
   const removedCount = session.undo();
   return { removedCount };
 }
 
-export function handleUndo(msg: UndoRequest, ctx: HandlerContext): void {
-  const result = undoLastMessage(msg.sessionId, ctx);
+export async function handleUndo(msg: UndoRequest, ctx: HandlerContext): Promise<void> {
+  const result = await undoLastMessage(msg.sessionId, ctx);
   if (!result) {
     ctx.send({ type: "error", message: "No active session" });
     return;
@@ -609,17 +610,18 @@ export function handleUndo(msg: UndoRequest, ctx: HandlerContext): void {
 /**
  * Regenerate the last assistant response for a session. The caller provides
  * a `sendEvent` callback for delivering streaming events via HTTP/SSE.
- * Returns null if the session is not found. Throws on regeneration errors.
+ * Returns null if the conversation does not exist. Restores evicted sessions
+ * from the database when needed. Throws on regeneration errors.
  */
 export async function regenerateResponse(
   sessionId: string,
   ctx: HandlerContext,
   sendEvent: (event: ServerMessage) => void,
 ): Promise<{ requestId: string } | null> {
-  const session = ctx.sessions.get(sessionId);
-  if (!session) {
+  if (!getConversation(sessionId)) {
     return null;
   }
+  const session = await ctx.getOrCreateSession(sessionId);
   ctx.touchSession(sessionId);
   session.updateClient(sendEvent, false);
   const requestId = uuid();
@@ -650,11 +652,11 @@ export async function handleRegenerate(
   msg: RegenerateRequest,
   ctx: HandlerContext,
 ): Promise<void> {
-  const session = ctx.sessions.get(msg.sessionId);
-  if (!session) {
+  if (!getConversation(msg.sessionId)) {
     ctx.send({ type: "error", message: "No active session" });
     return;
   }
+  const session = await ctx.getOrCreateSession(msg.sessionId);
 
   const regenerateChannel =
     parseChannelId(session.getTurnChannelContext()?.assistantMessageChannel) ??

--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -29,7 +29,7 @@ export interface SessionManagementDeps {
   renameSession: (sessionId: string, name: string) => boolean;
   clearAllSessions: () => number;
   cancelGeneration: (sessionId: string) => boolean;
-  undoLastMessage: (sessionId: string) => { removedCount: number } | null;
+  undoLastMessage: (sessionId: string) => Promise<{ removedCount: number } | null>;
   regenerateResponse: (
     sessionId: string,
   ) => Promise<{ requestId: string } | null>;
@@ -115,8 +115,8 @@ export function sessionManagementRouteDefinitions(
       endpoint: "conversations/:id/undo",
       method: "POST",
       policyKey: "conversations/undo",
-      handler: ({ params }) => {
-        const result = deps.undoLastMessage(params.id);
+      handler: async ({ params }) => {
+        const result = await deps.undoLastMessage(params.id);
         if (!result) {
           return httpError(
             "NOT_FOUND",


### PR DESCRIPTION
## Summary
- Regenerate and undo handlers now restore evicted sessions from SQLite instead of failing with "No active session" / HTTP 404
- Uses the same `getConversation()` + `getOrCreateSession()` pattern already used by session switching and message sending
- Updated `undoLastMessage` to be async and propagated the change through the HTTP route handler and dep interface

## Original prompt
start implementing the fix (make regenerate reload evicted sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
