### PR TITLE
fix: auto-scroll composer to bottom when typing long messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -226,24 +226,16 @@ struct ComposerView: View {
         let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
         let hasSlashHighlight = slashCommandRange != nil
 
-        return ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                ZStack(alignment: .leading) {
-                    composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-                    composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-                }
-                .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
-                .padding(.trailing, 70)
-                // Invisible anchor at the bottom of the content for auto-scrolling.
-                Color.clear
-                    .frame(height: 1)
-                    .id("composerBottom")
+        return ScrollView(.vertical, showsIndicators: false) {
+            ZStack(alignment: .leading) {
+                composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+                composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
             }
-            .scrollBounceBehavior(.basedOnSize)
-            .onChange(of: inputText) {
-                proxy.scrollTo("composerBottom", anchor: .bottom)
-            }
+            .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
+            .padding(.trailing, 70)
         }
+        .scrollBounceBehavior(.basedOnSize)
+        .defaultScrollAnchor(.bottom)
         .frame(minHeight: composerCompactHeight, maxHeight: inputText.isEmpty ? composerCompactHeight : composerMaxHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -226,15 +226,24 @@ struct ComposerView: View {
         let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
         let hasSlashHighlight = slashCommandRange != nil
 
-        return ScrollView(.vertical, showsIndicators: false) {
-            ZStack(alignment: .leading) {
-                composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-                composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+        return ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                ZStack(alignment: .leading) {
+                    composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+                    composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+                }
+                .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
+                .padding(.trailing, 70)
+                // Invisible anchor at the bottom of the content for auto-scrolling.
+                Color.clear
+                    .frame(height: 1)
+                    .id("composerBottom")
             }
-            .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
-            .padding(.trailing, 70)
+            .scrollBounceBehavior(.basedOnSize)
+            .onChange(of: inputText) {
+                proxy.scrollTo("composerBottom", anchor: .bottom)
+            }
         }
-        .scrollBounceBehavior(.basedOnSize)
         .frame(minHeight: composerCompactHeight, maxHeight: inputText.isEmpty ? composerCompactHeight : composerMaxHeight)
         .accessibilityLabel("Message")
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Add `ScrollViewReader` with a bottom anchor to the composer's `ScrollView` so it automatically scrolls to show the latest text as the user types
- Fixes LUM-172: chatbar text gets cut off at the bottom when writing long messages because the scroll position wasn't tracking input changes

## Original prompt
--safe https://linear.app/vellum/issue/LUM-172/chatbar-bottom-text-disappears-when-writing-a-long-message has to scroll to bottom, it's getting into a cutoff state because with more text it's not scrolling to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
