### PR TITLE
fix(memory): exclude event kind from fallback supersession

### DIFF
--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -74,7 +74,6 @@ const SUPERSEDE_KINDS = new Set<MemoryItemKind>([
   "project",
   "decision",
   "constraint",
-  "event",
 ]);
 
 // ── Semantic density gating ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses review feedback from #15858.

- Remove `event` from `SUPERSEDE_KINDS` in `items-extractor.ts` — events are temporal records where multiple items with the same subject are expected and valid (e.g., "Sprint planning on March 5" and "Sprint planning on March 12"). The previous change incorrectly expanded `SUPERSEDE_KINDS` to all 6 kinds, causing newer events to mark older same-subject events as superseded.

Other review comments from #15858 were either already addressed in subsequent commits (memory tool definitions already use new kind vocabulary, supersession columns are populated) or reference files that no longer exist (`profile-compiler.ts`, `conflict-policy.ts` were removed in #15945/#15950).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
