### PR TITLE
fix: clarify host_cu docs and comments per #15780 review

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -43,6 +43,15 @@ Host file allows the assistant to perform file operations (read, write, edit) on
   - `POST /v1/host-file-result` — `{ requestId, content, isError }`
 - **Tracking**: Uses the same `pending-interactions` tracker as approvals and host bash, with `kind: "host_file"`. The endpoint validates the interaction kind before resolving.
 
+### Host CU (desktop proxy computer-use execution)
+
+Host CU will allow the assistant to proxy computer-use actions (screenshots, mouse/keyboard input) to the desktop host via the client, following the same pattern as host bash and host file.
+
+- **Discovery**: Clients will discover pending host CU requests via SSE events (`host_cu_request`) which include a `requestId`.
+- **Resolution**: Clients will execute the CU action on the host and respond via:
+  - `POST /v1/host-cu-result` — `{ requestId, ... }` (schema TBD in implementation PR)
+- **Tracking**: Uses the same `pending-interactions` tracker as the other host proxy types, with `kind: "host_cu"`. The type union already includes `host_cu`; registration and route will be added in a follow-up PR.
+
 ### Channel approvals (Telegram, Slack)
 
 Channel approval flows use `requestId` (not `runId`) as the primary identifier:

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -3,11 +3,13 @@
  * confirmation, secret, host_bash, host_file, and host_cu interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
- * host_bash_request, host_file_request, or host_cu_request, the onEvent
- * callback registers the interaction here. Standalone HTTP endpoints
- * (/v1/confirm, /v1/secret, /v1/trust-rules, /v1/host-bash-result,
- * /v1/host-file-result, /v1/host-cu-result) look up the session from
- * this tracker to resolve the interaction.
+ * host_bash_request, or host_file_request, the onEvent callback registers
+ * the interaction here. Standalone HTTP endpoints (/v1/confirm, /v1/secret,
+ * /v1/trust-rules, /v1/host-bash-result, /v1/host-file-result) look up the
+ * session from this tracker to resolve the interaction.
+ *
+ * host_cu_request registration and /v1/host-cu-result will be added in a
+ * follow-up PR as part of the unify-cu-loop plan.
  */
 
 import type { Session } from "../daemon/session.js";
@@ -83,12 +85,15 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given session.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, and host_cu interactions are intentionally skipped
- * — they represent in-flight tool executions proxied to the client, not
+ * host_bash and host_file interactions are intentionally skipped — they
+ * represent in-flight tool executions proxied to the client, not
  * confirmations to auto-deny. Removing them would orphan the request: the
- * client would POST to /v1/host-bash-result, /v1/host-file-result, or
- * /v1/host-cu-result after completing the operation, get a 404, and the
- * proxy timer would fire with a spurious timeout error.
+ * client would POST to /v1/host-bash-result or /v1/host-file-result after
+ * completing the operation, get a 404, and the proxy timer would fire with
+ * a spurious timeout error.
+ *
+ * host_cu is also skipped for the same reason (proxy endpoint coming in a
+ * follow-up PR).
  */
 export function removeBySession(session: Session): void {
   for (const [requestId, interaction] of pending) {


### PR DESCRIPTION
## Summary
- Updated `pending-interactions.ts` comments to clarify that `host_cu_request` registration and `/v1/host-cu-result` endpoint don't exist yet (coming in a follow-up PR)
- Added `Host CU` section to `assistant/src/runtime/AGENTS.md` following the host_bash/host_file pattern

Addresses review feedback from #15780.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
