### PR TITLE
fix(memory): fix no-op error-handling test in handleMemoryRecall

### DIFF
--- a/assistant/src/tools/memory/handlers.test.ts
+++ b/assistant/src/tools/memory/handlers.test.ts
@@ -492,28 +492,27 @@ describe("handleMemoryRecall", () => {
   // ── Error handling ────────────────────────────────────────────────
 
   test("retrieval failure returns error message, does not throw", async () => {
-    // Create a config that will cause the retrieval pipeline to throw
-    // by making memory disabled in a way that buildMemoryRecall breaks.
-    // We mock the retriever to throw an error.
-    const badConfig: AssistantConfig = {
-      ...TEST_CONFIG,
-      memory: {
-        ...TEST_CONFIG.memory,
-        // Force retrieval with impossible settings to trigger an error path
-        retrieval: {
-          ...TEST_CONFIG.memory.retrieval,
-        },
-      },
+    // Mock buildMemoryRecall to throw, simulating an internal retrieval failure
+    const retrieverModule = await import("../../memory/retriever.js");
+    const original = retrieverModule.buildMemoryRecall;
+    (retrieverModule as Record<string, unknown>).buildMemoryRecall = async () => {
+      throw new Error("Simulated retrieval failure");
     };
 
-    // Even if the query fails internally, the handler should catch and return
-    // an error result rather than throwing
-    const result = await handleMemoryRecall({ query: "test query" }, badConfig);
+    try {
+      const result = await handleMemoryRecall(
+        { query: "test query" },
+        TEST_CONFIG,
+      );
 
-    // The function should either succeed gracefully or return an error
-    // but never throw
-    expect(typeof result.content).toBe("string");
-    expect(typeof result.isError).toBe("boolean");
+      // The handler should catch the error and return an error result,
+      // never throw
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Simulated retrieval failure");
+    } finally {
+      // Restore original implementation
+      (retrieverModule as Record<string, unknown>).buildMemoryRecall = original;
+    }
   });
 
   test("result shape matches MemoryRecallToolResult when successful", async () => {


### PR DESCRIPTION
## Summary
- The error-handling test at handlers.test.ts:494 became a no-op after #15945 removed `lexicalTopK: -1` — the `badConfig` was identical to `TEST_CONFIG`.
- Replace the dead config override with a mock that makes `buildMemoryRecall` throw, so the test properly exercises the catch path.
- Addresses review feedback from #15945.

## Test plan
- [ ] CI passes — the test now asserts `isError: true` and checks the error message content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
