### PR TITLE
fix(memory): normalize RRF scores after post-query filtering

### DIFF
--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -154,27 +154,14 @@ export async function semanticSearch(
     for (const row of rows) mediaScopeMap.set(row.id, row.memoryScopeId);
   }
 
-  // For hybrid search (RRF fusion), Qdrant returns Reciprocal Rank Fusion
-  // scores (typically 0.01-0.033) which are incompatible with tier
-  // classification thresholds. Normalize relative to the batch maximum so the
-  // top result gets 1.0 and others are proportional.
-  // For dense-only search, scores are cosine similarities in [-1, 1] and
-  // mapCosineToUnit correctly maps them to [0, 1].
-  const maxRrfScore =
-    isHybrid && results.length > 0
-      ? Math.max(...results.map((r) => r.score))
-      : 0;
-
   const excludedSet =
     excludedMessageIds.length > 0 ? new Set(excludedMessageIds) : null;
 
   const candidates: Candidate[] = [];
   for (const result of results) {
     const { payload, score } = result;
-    const semantic =
-      isHybrid && maxRrfScore > 0
-        ? score / maxRrfScore
-        : mapCosineToUnit(score);
+    // Store raw score; hybrid RRF normalization happens after filtering
+    const semantic = isHybrid ? score : mapCosineToUnit(score);
     const createdAt = payload.created_at ?? Date.now();
 
     if (payload.target_type === "item") {
@@ -275,6 +262,19 @@ export async function semanticSearch(
     }
     if (candidates.length >= limit) break;
   }
+
+  // For hybrid search (RRF fusion), normalize semantic scores relative to
+  // the surviving candidates' maximum — not the raw Qdrant batch. Filtered-out
+  // high-scoring hits must not anchor normalization and deflate survivors.
+  if (isHybrid && candidates.length > 0) {
+    const maxScore = Math.max(...candidates.map((c) => c.semantic));
+    if (maxScore > 0) {
+      for (const c of candidates) {
+        c.semantic = c.semantic / maxScore;
+      }
+    }
+  }
+
   return candidates;
 }
 


### PR DESCRIPTION
## Summary
- Moves hybrid RRF score normalization from before post-query filtering to after, so only surviving candidates determine the max score
- Previously, a high-scoring hit filtered out by excluded sources, invalid item status, or scope mismatch would still anchor normalization, deflating all surviving candidates' semantic scores below tier thresholds
- Addresses Codex P2 feedback from #15936

## Test plan
- [ ] Verify tier classification works correctly when high-scoring results are filtered out
- [ ] Confirm dense-only (non-hybrid) search path is unaffected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
