### PR TITLE
fix(docs): address review feedback on memory architecture doc

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -86,22 +86,28 @@ graph TB
     WORKER --> CLEAN_SUPERSEDED
     WORKER --> BUILD_SUM
 
-    EMBED_SEG --> DENSE
-    EMBED_SEG --> SPARSE
-    EMBED_ITEM --> DENSE
-    EMBED_ITEM --> SPARSE
-    EMBED_SUM --> DENSE
-    EMBED_SUM --> SPARSE
+    EMBED_SEG --> LOCAL_EMB
+    EMBED_ITEM --> LOCAL_EMB
+    EMBED_SUM --> LOCAL_EMB
+    LOCAL_EMB --> DENSE
+    LOCAL_EMB --> SPARSE
+    OAI_EMB --> DENSE
+    OAI_EMB --> SPARSE
+    GEM_EMB --> DENSE
+    GEM_EMB --> SPARSE
+    OLL_EMB --> DENSE
+    OLL_EMB --> SPARSE
 
     NEEDS_MEM --> QUERY
     QUERY --> EMBED_Q
+    EMBED_Q --> LOCAL_EMB
     EMBED_Q --> HYBRID
     HYBRID --> RRF
     QUERY --> RECENCY
-    HYBRID --> MERGE
-    RECENCY --> MERGE
-    MERGE --> SCOPE
-    SCOPE --> TIER
+    HYBRID --> SCOPE
+    RECENCY --> SCOPE
+    SCOPE --> MERGE
+    MERGE --> TIER
     TIER --> STALE
     STALE --> DEMOTE
     BUDGET --> INJECT
@@ -145,7 +151,7 @@ The key distinction: normal compaction is a cost-optimized background process th
 | `memory.retrieval.dynamicBudget.minInjectTokens`      |    `1200` | Lower clamp for computed recall injection budget.                              |
 | `memory.retrieval.dynamicBudget.maxInjectTokens`      |   `10000` | Upper clamp for computed recall injection budget.                              |
 | `memory.retrieval.dynamicBudget.targetHeadroomTokens` |   `10000` | Reserved headroom to keep free for response generation/tool traces.            |
-| `memory.retrieval.maxInjectTokens`                    |    `4096` | Static fallback when dynamic budget is disabled.                               |
+| `memory.retrieval.maxInjectTokens`                    |   `10000` | Static fallback when dynamic budget is disabled.                               |
 | `memory.retrieval.scopePolicy`                        | `'allow_global_fallback'` | Scope filtering strategy: `'strict'` or `'allow_global_fallback'`. |
 
 ### Memory Recall Debugging Playbook


### PR DESCRIPTION
## Summary

Followup to #15928 addressing review feedback:

- **Codex P2**: Corrected `memory.retrieval.maxInjectTokens` default from `4096` to `10000` to match actual config schema default in `memory-retrieval.ts`
- **Devin**: Connected orphaned "Embedding Providers" subgraph — embedding jobs and read-path query embedding now route through provider nodes before reaching Qdrant vectors
- **Devin**: Fixed scope filtering order in Mermaid diagram — scope filtering is applied to both hybrid and recency search results *before* merge, matching the actual code in `retriever.ts` where `scopeIds` are passed into `semanticSearch()` and `recencySearch()`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
