### PR TITLE
fix(memory): tighten Tier type and clamp staleness reinforcement floor

### DIFF
--- a/assistant/src/memory/search/staleness.ts
+++ b/assistant/src/memory/search/staleness.ts
@@ -21,7 +21,7 @@ export function computeStaleness(
   now: number,
 ): { level: StalenessLevel; ratio: number } {
   const baseLifetime = BASE_LIFETIME_MS[item.kind] ?? DEFAULT_LIFETIME_MS;
-  const reinforcement = 1 + 0.3 * (item.sourceConversationCount - 1);
+  const reinforcement = Math.max(1, 1 + 0.3 * (item.sourceConversationCount - 1));
   const effectiveLifetime = baseLifetime * reinforcement;
   const age = now - item.firstSeenAt;
   const ratio = age / effectiveLifetime;

--- a/assistant/src/memory/search/tier-classifier.ts
+++ b/assistant/src/memory/search/tier-classifier.ts
@@ -1,6 +1,6 @@
 import type { Candidate } from "./types.js";
 
-export type Tier = 1 | 2 | null;
+export type Tier = 1 | 2;
 
 export interface TieredCandidate extends Candidate {
   tier: Tier;
@@ -8,7 +8,7 @@ export interface TieredCandidate extends Candidate {
   sourceLabel?: string;
 }
 
-export function classifyTier(score: number): Tier {
+export function classifyTier(score: number): Tier | null {
   if (score > 0.8) return 1;
   if (score > 0.6) return 2;
   return null;
@@ -17,5 +17,5 @@ export function classifyTier(score: number): Tier {
 export function classifyTiers(candidates: Candidate[]): TieredCandidate[] {
   return candidates
     .map((c) => ({ ...c, tier: classifyTier(c.finalScore) }))
-    .filter((c): c is TieredCandidate & { tier: 1 | 2 } => c.tier != null);
+    .filter((c): c is TieredCandidate => c.tier != null);
 }


### PR DESCRIPTION
## Summary
Followup to #15857 addressing review feedback:

- **Tier type narrowing**: `Tier` no longer includes `null` — it represents classified tiers (`1 | 2`) only. `classifyTier()` returns `Tier | null` to represent the unclassified case, and `classifyTiers()` filters nulls out. This eliminates the redundant `& { tier: 1 | 2 }` intersection in the type guard.
- **Staleness reinforcement floor**: Added `Math.max(1, ...)` clamp so items with `sourceConversationCount < 1` (orphaned rows, data corruption) never reduce effective lifetime below the base value. Prevents division-by-zero or negative ratios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
