### PR TITLE
fix(macos): exact Cmd+F modifier match and transient error toast colors

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -176,6 +176,8 @@ struct ChatSessionErrorToast: View {
             return VColor.systemPositiveStrong
         case .contextTooLarge:
             return VColor.systemMidStrong
+        case .providerOrdering, .providerWebSearch:
+            return VColor.systemMidStrong
         default:
             return VColor.systemNegativeStrong
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -305,7 +305,7 @@ struct ChatView: View {
             return .ignored
         }
         .onKeyPress("f", phases: .down) { press in
-            guard press.modifiers.contains(.command) else { return .ignored }
+            guard press.modifiers == .command else { return .ignored }
             activateSearch()
             return .handled
         }


### PR DESCRIPTION
## Summary
- Fix `onKeyPress` Cmd+F handler to use exact modifier match (`== .command`) instead of superset check (`.contains(.command)`), preventing it from swallowing Cmd+Shift+F and other combos
- Add explicit `VColor.systemMidStrong` (amber) accent color for `.providerOrdering` and `.providerWebSearch` error categories, which are transient/retryable — previously fell through to red `default` case

Followup to #15889
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
