### PR TITLE
fix(macos): address Cmd+F search review feedback from #15868

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -399,7 +399,7 @@ extension AppDelegate {
     }
 
     @objc func activateChatSearch() {
-        NotificationCenter.default.post(name: .activateChatSearch, object: nil)
+        NotificationCenter.default.post(name: .activateChatSearch, object: mainWindow?.threadManager.activeThreadId)
     }
 
     @objc func openAppCollection() {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -67,3 +67,34 @@ struct ChatSearchBar: View {
         }
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+struct ChatSearchBar_Preview: PreviewProvider {
+    static var previews: some View {
+        ChatSearchBarPreviewWrapper()
+            .frame(width: 400)
+            .previewDisplayName("ChatSearchBar")
+    }
+}
+
+private struct ChatSearchBarPreviewWrapper: View {
+    @State private var text = "hello"
+
+    var body: some View {
+        ZStack {
+            VColor.background.ignoresSafeArea()
+            ChatSearchBar(
+                searchText: $text,
+                matchCount: 5,
+                currentMatchIndex: 2,
+                onPrevious: {},
+                onNext: {},
+                onDismiss: {}
+            )
+            .padding()
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -330,7 +330,19 @@ struct ChatView: View {
             currentMatchIndex = 0
             scrollToCurrentMatch()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { _ in
+        .onChange(of: messages.count) {
+            // Clamp currentMatchIndex when messages change (e.g. streaming, deletion)
+            // to avoid "4 of 2" display or broken navigation.
+            let count = searchMatches.count
+            if currentMatchIndex >= count {
+                currentMatchIndex = max(count - 1, 0)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { notification in
+            // Scope to the active thread so only the visible ChatView activates.
+            if let targetId = notification.object as? UUID, targetId != threadId {
+                return
+            }
             activateSearch()
         }
     }


### PR DESCRIPTION
## Summary
Follow-up fixes for the Cmd+F in-chat search feature (#15868):

- **Clamp stale `currentMatchIndex`**: Added `.onChange(of: messages.count)` handler to clamp `currentMatchIndex` when the match count shrinks (e.g. during streaming or message deletion), preventing nonsensical "4 of 2" display and broken navigation.
- **Scope search notification**: Pass `activeThreadId` as the notification object so only the visible ChatView activates search when triggered from the menu bar, avoiding phantom search bars in background tabs.
- **Add `#Preview` block**: Added required `PreviewProvider` to `ChatSearchBar.swift` per `clients/macos/CLAUDE.md` mandate.

Addresses review feedback from #15868.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
