### PR TITLE
fix: defer CU preactivation to dequeue time for queued desktop messages

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -284,6 +284,7 @@ export async function drainQueue(
     const sourceInterface = interfaceCtx?.userMessageInterface;
     if (sourceInterface === "macos" || sourceInterface === "ios") {
       session.restoreProxyAvailability();
+      session.addPreactivatedSkillId("computer-use");
     }
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -653,7 +653,12 @@ export async function handleSendMessage(
       });
       session.setHostCuProxy(cuProxy);
     }
-    session.addPreactivatedSkillId("computer-use");
+    // Only preactivate CU when the session is idle — if the session is
+    // processing, this message will be queued and preactivation is deferred
+    // to dequeue time in drainQueueImpl to avoid mutating in-flight turn state.
+    if (!session.isProcessing()) {
+      session.addPreactivatedSkillId("computer-use");
+    }
   } else if (!session.isProcessing()) {
     session.setHostBashProxy(undefined);
     session.setHostFileProxy(undefined);


### PR DESCRIPTION
## Summary
- Guard `addPreactivatedSkillId('computer-use')` in `conversation-routes.ts` so it only runs when `!session.isProcessing()`
- Add `addPreactivatedSkillId('computer-use')` at dequeue time in `session-process.ts` for macos/ios queued messages, alongside the existing `restoreProxyAvailability()` call

Followup to #15841 addressing review feedback from Codex and Devin.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
