### PR TITLE
fix: cache catalog lookups during skill include auto-install

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -320,26 +320,39 @@ export async function installSkillLocally(
 // ─── Auto-install (for skill_load) ──────────────────────────────────────────
 
 /**
+ * Resolve the catalog skill list, checking local (dev mode) first, then remote.
+ * Callers that install multiple skills in a loop should call this once and pass
+ * the result to `autoInstallFromCatalog` to avoid redundant network requests.
+ */
+export async function resolveCatalog(): Promise<CatalogSkill[]> {
+  const repoSkillsDir = getRepoSkillsDir();
+  if (repoSkillsDir) {
+    const local = readLocalCatalog(repoSkillsDir);
+    if (local.length > 0) return local;
+  }
+
+  return fetchCatalog();
+}
+
+/**
  * Attempt to find and install a skill from the first-party catalog.
  * Returns true if the skill was installed, false if not found in catalog.
  * Throws on install failures (network, filesystem, etc).
+ *
+ * When `catalog` is provided it is used directly, avoiding a redundant
+ * network fetch — pass a pre-resolved catalog when calling in a loop.
  */
 export async function autoInstallFromCatalog(
   skillId: string,
+  catalog?: CatalogSkill[],
 ): Promise<boolean> {
-  // Check local catalog first (dev mode), then remote
-  const repoSkillsDir = getRepoSkillsDir();
-  let entry: CatalogSkill | undefined;
+  let skills: CatalogSkill[];
 
-  if (repoSkillsDir) {
-    const localCatalog = readLocalCatalog(repoSkillsDir);
-    entry = localCatalog.find((s) => s.id === skillId);
-  }
-
-  if (!entry) {
+  if (catalog) {
+    skills = catalog;
+  } else {
     try {
-      const remoteCatalog = await fetchCatalog();
-      entry = remoteCatalog.find((s) => s.id === skillId);
+      skills = await resolveCatalog();
     } catch (err) {
       log.warn(
         { err, skillId },
@@ -349,6 +362,7 @@ export async function autoInstallFromCatalog(
     }
   }
 
+  const entry = skills.find((s) => s.id === skillId);
   if (!entry) {
     return false;
   }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -8,7 +8,10 @@ import type { SkillSummary, SkillToolManifest } from "../../config/skills.js";
 import { loadSkillBySelector, loadSkillCatalog } from "../../config/skills.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
-import { autoInstallFromCatalog } from "../../skills/catalog-install.js";
+import {
+  autoInstallFromCatalog,
+  resolveCatalog,
+} from "../../skills/catalog-install.js";
 import {
   collectAllMissing,
   indexCatalogById,
@@ -191,6 +194,14 @@ export class SkillLoadTool implements Tool {
       catalogIndex = indexCatalogById(catalog);
 
       // Auto-install missing includes before validation (max 5 rounds for transitive deps)
+      // Pre-fetch catalog once to avoid redundant network requests per dependency
+      let remoteCatalog: Awaited<ReturnType<typeof resolveCatalog>> | undefined;
+      try {
+        remoteCatalog = await resolveCatalog();
+      } catch (err) {
+        log.warn({ err, skillId: skill.id }, "Failed to resolve catalog for include auto-install");
+      }
+
       const MAX_INSTALL_ROUNDS = 5;
       for (let round = 0; round < MAX_INSTALL_ROUNDS; round++) {
         const missing = collectAllMissing(skill.id, catalogIndex);
@@ -199,7 +210,7 @@ export class SkillLoadTool implements Tool {
         let installedAny = false;
         for (const missingId of missing) {
           try {
-            const installed = await autoInstallFromCatalog(missingId);
+            const installed = await autoInstallFromCatalog(missingId, remoteCatalog);
             if (installed) {
               log.info(
                 { skillId: missingId, parentSkillId: skill.id },


### PR DESCRIPTION
## Summary
- Adds `resolveCatalog()` helper that fetches the catalog once (local dev or remote).
- `autoInstallFromCatalog()` accepts an optional pre-resolved `catalog` parameter to skip redundant fetches.
- The missing-includes install loop in `skill_load` now pre-fetches the catalog once and passes it to each call.

Addresses review feedback from #15795 — the loop was calling `fetchCatalog()` per missing dependency, causing redundant network requests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
