### PR TITLE
fix: enforce type-matched pairing and correct error format in history repair

### DIFF
--- a/assistant/src/__tests__/history-repair.test.ts
+++ b/assistant/src/__tests__/history-repair.test.ts
@@ -498,6 +498,7 @@ describe("repairHistory", () => {
     expect(wsBlocks[0]).toMatchObject({
       type: "web_search_tool_result",
       tool_use_id: "stu_1",
+      content: { type: "web_search_tool_result_error", error_code: "unavailable" },
     });
   });
 
@@ -571,6 +572,94 @@ describe("repairHistory", () => {
     expect(repaired[2].content[0]).toMatchObject({
       type: "web_search_tool_result",
       tool_use_id: "stu_1",
+      content: { type: "web_search_tool_result_error", error_code: "unavailable" },
+    });
+  });
+
+  test("downgrades type-mismatched tool_result for server_tool_use", () => {
+    // A tool_result paired with a server_tool_use ID is a type mismatch —
+    // the provider requires web_search_tool_result for server_tool_use
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Search" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "server_tool_use",
+            id: "stu_1",
+            name: "web_search",
+            input: { query: "test" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "stu_1", content: "wrong type" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    // The mismatched tool_result should be downgraded and a synthetic web_search_tool_result inserted
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(1);
+
+    const userMsg = repaired[2];
+    const wsBlocks = userMsg.content.filter(
+      (b) => b.type === "web_search_tool_result",
+    );
+    expect(wsBlocks).toHaveLength(1);
+    expect(wsBlocks[0]).toMatchObject({
+      type: "web_search_tool_result",
+      tool_use_id: "stu_1",
+      content: { type: "web_search_tool_result_error", error_code: "unavailable" },
+    });
+  });
+
+  test("downgrades type-mismatched web_search_tool_result for tool_use", () => {
+    // A web_search_tool_result paired with a regular tool_use ID is a type mismatch
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "Go" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "bash", input: { cmd: "ls" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "tu_1",
+            content: [{ type: "web_search_result", url: "https://example.com" }],
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    ];
+
+    const { messages: repaired, stats } = repairHistory(messages);
+
+    expect(stats.orphanToolResultsDowngraded).toBe(1);
+    expect(stats.missingToolResultsInserted).toBe(1);
+
+    const userMsg = repaired[2];
+    const trBlocks = userMsg.content.filter((b) => b.type === "tool_result");
+    expect(trBlocks).toHaveLength(1);
+    expect(trBlocks[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tu_1",
+      is_error: true,
     });
   });
 });

--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -22,6 +22,11 @@ export interface RepairResult {
 const SYNTHETIC_RESULT =
   "<synthesized_result>tool result missing from history</synthesized_result>";
 
+const SYNTHETIC_WEB_SEARCH_ERROR = {
+  type: "web_search_tool_result_error",
+  error_code: "unavailable",
+};
+
 export function repairHistory(messages: Message[]): RepairResult {
   const stats: RepairStats = {
     assistantToolResultsMigrated: 0,
@@ -109,7 +114,9 @@ export function repairHistory(messages: Message[]): RepairResult {
             block.type === "web_search_tool_result"
           ) {
             const tr = block as ToolResultContent | WebSearchToolResultContent;
-            if (pendingToolUseIds.has(tr.tool_use_id)) {
+            const isTypeMatch = pendingToolUseIds.has(tr.tool_use_id) &&
+              (block.type === "web_search_tool_result") === serverToolUseIds.has(tr.tool_use_id);
+            if (isTypeMatch) {
               matchedIds.add(tr.tool_use_id);
               newContent.push(block);
             } else {
@@ -134,7 +141,7 @@ export function repairHistory(messages: Message[]): RepairResult {
                 newContent.push({
                   type: "web_search_tool_result",
                   tool_use_id: id,
-                  content: [],
+                  content: SYNTHETIC_WEB_SEARCH_ERROR,
                 });
               } else {
                 newContent.push({
@@ -223,7 +230,7 @@ function buildResultMessage(
         return {
           type: "web_search_tool_result" as const,
           tool_use_id: id,
-          content: [],
+          content: SYNTHETIC_WEB_SEARCH_ERROR,
         };
       }
       return {


### PR DESCRIPTION
## Summary
- Enforce type-specific result matching in `repairHistory`: a `tool_result` only matches `tool_use` IDs and `web_search_tool_result` only matches `server_tool_use` IDs. Previously, matching keyed only on `tool_use_id`, allowing cross-type mismatches that would still cause provider 400s.
- Use the Anthropic-compatible `{ type: 'web_search_tool_result_error', error_code: 'unavailable' }` format for synthetic `web_search_tool_result` content instead of `content: []`. Matches the format in `buildSyntheticWebSearchToolResult` from the Anthropic client.
- Added tests for both type-mismatch scenarios.

Followup to #15911
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
