### PR TITLE
fix: handle timeout case in git hooks trust deny and preserve session guard on abort

### DIFF
--- a/assistant/src/daemon/git-hooks-approval.ts
+++ b/assistant/src/daemon/git-hooks-approval.ts
@@ -9,8 +9,8 @@ import { isAllowDecision } from "../permissions/types.js";
 export const GIT_HOOKS_TRUST_TOOL_NAME = "__internal:git-hooks-trust";
 
 export type GitHooksTrustApprovalResult =
-  | { approved: true }
-  | { approved: false };
+  | { approved: true; timedOut?: false }
+  | { approved: false; timedOut?: boolean };
 
 /**
  * Prompts the user to decide whether to trust the project's git hooks
@@ -44,5 +44,7 @@ export async function requestGitHooksTrustApproval(
     opts?.signal,
   );
 
-  return { approved: isAllowDecision(result.decision) };
+  const approved = isAllowDecision(result.decision);
+  const timedOut = !approved && result.decisionContext?.includes("timed out");
+  return { approved, timedOut };
 }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -424,12 +424,12 @@ export async function runAgentLoopImpl(
             const approval = await requestGitHooksTrustApproval(ctx.prompter, {
               signal: abortController.signal,
             });
-            // If the session was aborted mid-prompt, do not persist any
-            // decision — the prompter resolves with "deny" on abort but that
-            // is an infrastructure event, not a real user choice.  Reset the
-            // guard so the user is re-prompted in the next session.
-            if (abortController.signal.aborted) {
-              ctx.gitHooksTrustPromptIssuedForWorkspace = undefined;
+            // If the session was aborted mid-prompt or the prompt timed
+            // out, do not persist any decision — these are infrastructure
+            // events, not real user choices.  Leave the session guard set so
+            // we don't re-prompt on subsequent turns; the guard resets
+            // naturally when the session ends.
+            if (abortController.signal.aborted || approval.timedOut) {
               return;
             }
             setGitHooksTrustDecision(
@@ -437,24 +437,23 @@ export async function runAgentLoopImpl(
               approval.approved ? "allow" : "deny",
             );
           } catch (err) {
-            // Infrastructure errors (disposed prompter, timeout, etc.) should
-            // not permanently silence the trust prompt.  Reset the guard so
-            // the user is re-prompted next session.
+            // Infrastructure errors (disposed prompter, etc.) should not
+            // permanently silence the trust prompt.  Leave the session guard
+            // set to prevent re-prompt spam within this session; the guard
+            // resets naturally when the session ends.
             rlog.warn(
               { err },
               "Git hooks trust prompt failed (non-fatal); will re-prompt next session",
             );
-            ctx.gitHooksTrustPromptIssuedForWorkspace = undefined;
           }
         })
         .catch((err) => {
+          // Detection failure — leave the session guard set to avoid
+          // retrying on every turn.  Will re-prompt next session.
           rlog.warn(
             { err },
             "Git hooks trust hook detection failed (non-fatal); will re-prompt next session",
           );
-          // Reset the guard so a transient detection failure doesn't
-          // permanently silence the trust prompt for this session.
-          ctx.gitHooksTrustPromptIssuedForWorkspace = undefined;
         });
     }
   }


### PR DESCRIPTION
## Summary
- Fix timeout case: prompter timeout resolves as deny (not reject), bypassing the catch block and persisting deny permanently. Now detect timeout via decisionContext and skip persist, matching abort behavior.
- Preserve session guard: don't clear gitHooksTrustPromptIssuedForWorkspace on abort/error/timeout to prevent re-prompting spam within the same session. The guard resets naturally when the session ends.

Addresses feedback from #15895
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
