### PR TITLE
fix(memory): only report sparseVectorUsed after hybrid search succeeds

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -285,7 +285,7 @@ export async function buildMemoryRecall(
 
   // Generate sparse embedding for the query text (TF-IDF based)
   const sparseVector = generateSparseEmbedding(query);
-  const sparseVectorUsed = sparseVector.indices.length > 0;
+  const sparseVectorAvailable = sparseVector.indices.length > 0;
 
   // ── Step 3: Hybrid search on Qdrant ─────────────────────────────
   const scopePolicy = config.memory.retrieval.scopePolicy;
@@ -299,6 +299,7 @@ export async function buildMemoryRecall(
 
   let hybridCandidates: Candidate[] = [];
   let semanticSearchFailed = false;
+  let sparseVectorUsed = false;
   const hybridSearchStart = Date.now();
 
   if (queryVector && !isQdrantBreakerOpen()) {
@@ -310,8 +311,9 @@ export async function buildMemoryRecall(
         HYBRID_LIMIT,
         excludeMessageIds,
         scopeIds,
-        sparseVectorUsed ? sparseVector : undefined,
+        sparseVectorAvailable ? sparseVector : undefined,
       );
+      sparseVectorUsed = sparseVectorAvailable;
     } catch (err) {
       semanticSearchFailed = true;
       if (isQdrantConnectionError(err)) {


### PR DESCRIPTION
## Summary
- Fixes telemetry mislabeling where `sparseVectorUsed` could be `true` even when hybrid search was skipped (embedding failure, open Qdrant breaker, or search exception).
- `sparseVectorUsed` is now only set to `true` after `semanticSearch` completes successfully.

Follow-up to #15926 addressing Codex P2 feedback.

## Test plan
- [x] Verify `sparseVectorUsed` is `false` when `queryVector` is null (embedding failure)
- [x] Verify `sparseVectorUsed` is `false` when Qdrant breaker is open
- [x] Verify `sparseVectorUsed` is `false` when `semanticSearch` throws
- [x] Verify `sparseVectorUsed` reflects actual sparse vector usage on success path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
