### PR TITLE
fix(memory): correct FNV-1a hash and remove dead sparseModel field

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -637,7 +637,7 @@ function tokenHash(token: string, vocabSize: number): number {
   let hash = 0x811c9dc5;
   for (let i = 0; i < token.length; i++) {
     hash ^= token.charCodeAt(i);
-    hash = (hash * 0x01000193) >>> 0;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
   }
   return hash % vocabSize;
 }

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -17,7 +17,6 @@ export interface QdrantClientConfig {
   onDisk: boolean;
   quantization: "scalar" | "none";
   embeddingModel?: string;
-  sparseModel?: string;
 }
 
 export interface QdrantPointPayload {
@@ -68,7 +67,6 @@ export class VellumQdrantClient {
   private readonly onDisk: boolean;
   private readonly quantization: "scalar" | "none";
   private readonly embeddingModel?: string;
-  private readonly sparseModel?: string;
   private collectionReady = false;
 
   private readonly SENTINEL_ID = "00000000-0000-0000-0000-000000000000";
@@ -83,7 +81,6 @@ export class VellumQdrantClient {
     this.onDisk = config.onDisk;
     this.quantization = config.quantization;
     this.embeddingModel = config.embeddingModel;
-    this.sparseModel = config.sparseModel;
   }
 
   async ensureCollection(): Promise<{ migrated: boolean }> {


### PR DESCRIPTION
## Summary
- Fix FNV-1a hash in `tokenHash()` to use `Math.imul()` instead of regular `*` — regular multiplication overflows `Number.MAX_SAFE_INTEGER` producing incorrect hash values and ~25% more collisions
- Remove unused `sparseModel` field from `QdrantClientConfig` interface and `VellumQdrantClient` class (dead code per AGENTS.md)

Followup to #15859.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
