### PR TITLE
fix: block __internal: tool names in updateRule and HTTP update handler

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -395,6 +395,8 @@ export function addRule(
     executionTarget?: string;
   },
 ): TrustRule {
+  if (tool.startsWith("__internal:"))
+    throw new Error(`Cannot create internal pseudo-rule via addRule: ${tool}`);
   // Re-read from disk to avoid lost updates if another call modified rules
   // between our last read and now (e.g. two rapid trust rule additions).
   cachedRules = null;
@@ -437,6 +439,10 @@ export function updateRule(
   const defaultIds = new Set(getDefaultRuleTemplates().map((t) => t.id));
   if (defaultIds.has(id))
     throw new Error(`Cannot modify default trust rule: ${id}`);
+  if (updates.tool?.startsWith("__internal:"))
+    throw new Error(
+      `Cannot update tool to internal pseudo-rule: ${updates.tool}`,
+    );
 
   // Re-read from disk to avoid lost updates from concurrent modifications.
   cachedRules = null;

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -48,6 +48,13 @@ export async function handleAddTrustRuleManage(
   if (!toolName || typeof toolName !== "string") {
     return httpError("BAD_REQUEST", "toolName is required", 400);
   }
+  if (toolName.startsWith("__internal:")) {
+    return httpError(
+      "BAD_REQUEST",
+      "toolName must not start with __internal:",
+      400,
+    );
+  }
   if (!pattern || typeof pattern !== "string") {
     return httpError("BAD_REQUEST", "pattern is required", 400);
   }
@@ -124,6 +131,13 @@ export async function handleUpdateTrustRuleManage(
     priority?: number;
   };
 
+  if (body.tool?.startsWith("__internal:")) {
+    return httpError(
+      "BAD_REQUEST",
+      "tool must not start with __internal:",
+      400,
+    );
+  }
   if (body.decision !== undefined) {
     const validDecisions = ["allow", "deny", "ask"] as const;
     if (


### PR DESCRIPTION
## Summary
- Add guard to `addRule()` to reject tool names starting with `__internal:` (from #15908, not yet on main)
- Add validation in HTTP POST handler to reject `__internal:` tool names (from #15908, not yet on main)
- Add guard to `updateRule()` to reject `updates.tool` starting with `__internal:`
- Add validation in HTTP PATCH handler to reject `__internal:` tool names

Addresses feedback from #15908: `updateRule` allowed changing a rule's `tool` field to `__internal:*`, bypassing the guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
