### PR TITLE
fix(macos): use VColor.surfaceBase in ChatSearchBar preview

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -84,7 +84,7 @@ private struct ChatSearchBarPreviewWrapper: View {
 
     var body: some View {
         ZStack {
-            VColor.background.ignoresSafeArea()
+            VColor.surfaceBase.ignoresSafeArea()
             ChatSearchBar(
                 searchText: $text,
                 matchCount: 5,


### PR DESCRIPTION
## Summary
- Fix build failure: `VColor.background` was removed during the design token migration but the `ChatSearchBar` preview wrapper still referenced it
- Replace with `VColor.surfaceBase`, the correct semantic background token

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23025484540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
