### PR TITLE
fix(memory): broaden sparse embedding tokenizer to support non-Latin text

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -626,9 +626,9 @@ function isOllamaConfigured(config: AssistantConfig): boolean {
 
 const SPARSE_VOCAB_SIZE = 30_000;
 
-/** Tokenize text into lowercase alphanumeric tokens. */
+/** Tokenize text into lowercase alphanumeric tokens (Unicode-aware). */
 function tokenize(text: string): string[] {
-  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
 }
 
 /** Hash a token to a stable index in [0, vocabSize). */


### PR DESCRIPTION
## Summary
- Broadens the sparse embedding tokenizer regex from `/[a-z0-9]+/g` to `/[\p{L}\p{N}]+/gu` (Unicode property escapes)
- Non-Latin text (CJK, Arabic, Cyrillic, etc.) now produces meaningful sparse vectors for hybrid search instead of empty ones
- Addresses review feedback from #15861

## Test plan
- [x] Verify regex compiles and matches Unicode text
- [ ] Existing embedding tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
