### PR TITLE
fix(security): harden extractTarToDir against ZipSlip path traversal

### DIFF
--- a/assistant/src/__tests__/skills-install-extract.test.ts
+++ b/assistant/src/__tests__/skills-install-extract.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { extractTarToDir } from "../skills/catalog-install.js";
+
+let tempDir: string;
+
+function makeTarEntry(name: string, content: string): Buffer {
+  const header = Buffer.alloc(512, 0);
+  const nameBuffer = Buffer.from(name, "utf-8");
+  nameBuffer.copy(header, 0, 0, Math.min(nameBuffer.length, 100));
+
+  const mode = Buffer.from("0000644\0", "ascii");
+  mode.copy(header, 100);
+  Buffer.from("0000000\0", "ascii").copy(header, 108); // uid
+  Buffer.from("0000000\0", "ascii").copy(header, 116); // gid
+
+  const sizeOct = content.length.toString(8).padStart(11, "0") + "\0";
+  Buffer.from(sizeOct, "ascii").copy(header, 124);
+
+  Buffer.from("00000000000\0", "ascii").copy(header, 136); // mtime
+  Buffer.from("        ", "ascii").copy(header, 148); // checksum placeholder
+  header[156] = "0".charCodeAt(0);
+  Buffer.from("ustar\0", "ascii").copy(header, 257);
+  Buffer.from("00", "ascii").copy(header, 263);
+
+  let sum = 0;
+  for (let i = 0; i < 512; i += 1) sum += header[i] ?? 0;
+  const checksum = sum.toString(8).padStart(6, "0");
+  Buffer.from(`${checksum}\0 `, "ascii").copy(header, 148);
+
+  const data = Buffer.from(content, "utf-8");
+  const paddedSize = Math.ceil(data.length / 512) * 512;
+  const padded = Buffer.alloc(paddedSize, 0);
+  data.copy(padded);
+
+  return Buffer.concat([header, padded]);
+}
+
+function makeTar(entries: Array<{ name: string; content: string }>): Buffer {
+  const body = entries.map((entry) => makeTarEntry(entry.name, entry.content));
+  return Buffer.concat([...body, Buffer.alloc(1024, 0)]);
+}
+
+beforeEach(() => {
+  tempDir = join(
+    tmpdir(),
+    `skills-extract-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tempDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("extractTarToDir", () => {
+  test("extracts valid files and detects SKILL.md", () => {
+    const tar = makeTar([
+      { name: "SKILL.md", content: "# demo\n" },
+      { name: "scripts/run.sh", content: "echo ok\n" },
+    ]);
+
+    const foundSkillMd = extractTarToDir(tar, tempDir);
+
+    expect(foundSkillMd).toBe(true);
+    expect(readFileSync(join(tempDir, "SKILL.md"), "utf-8")).toBe("# demo\n");
+    expect(readFileSync(join(tempDir, "scripts", "run.sh"), "utf-8")).toBe(
+      "echo ok\n",
+    );
+  });
+
+  test("rejects traversal and absolute archive paths", () => {
+    const tar = makeTar([
+      { name: "SKILL.md", content: "# demo\n" },
+      { name: "../../escape.txt", content: "nope\n" },
+      { name: "..\\..\\win-escape.txt", content: "nope\n" },
+      { name: "/absolute.txt", content: "nope\n" },
+      { name: "C:/windows.txt", content: "nope\n" },
+    ]);
+
+    const foundSkillMd = extractTarToDir(tar, tempDir);
+
+    expect(foundSkillMd).toBe(true);
+    expect(existsSync(join(tempDir, "escape.txt"))).toBe(false);
+    expect(existsSync(join(tempDir, "win-escape.txt"))).toBe(false);
+    expect(existsSync(join(tempDir, "absolute.txt"))).toBe(false);
+    expect(existsSync(join(tempDir, "windows.txt"))).toBe(false);
+    expect(readFileSync(join(tempDir, "SKILL.md"), "utf-8")).toBe("# demo\n");
+  });
+});

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, posix, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import { getLogger } from "../util/logger.js";
@@ -160,16 +160,35 @@ export function extractTarToDir(tarBuffer: Buffer, destDir: string): boolean {
 
     // Skip directories and empty names
     if (name && typeFlag !== 53 /* '5' */) {
-      // Prevent path traversal
-      const normalizedName = name.replace(/^\.\//, "");
-      if (!normalizedName.startsWith("..") && !normalizedName.includes("/..")) {
-        const destPath = join(destDir, normalizedName);
+      // Prevent path traversal and absolute path writes
+      const normalizedName = name.replace(/\\/g, "/").replace(/^\.\/+/, "");
+      const normalizedPath = posix.normalize(normalizedName);
+      const hasWindowsDrivePrefix = /^[a-zA-Z]:\//.test(normalizedPath);
+      const isTraversal =
+        normalizedPath === ".." || normalizedPath.startsWith("../");
+
+      if (
+        normalizedPath &&
+        normalizedPath !== "." &&
+        !normalizedPath.startsWith("/") &&
+        !hasWindowsDrivePrefix &&
+        !isTraversal
+      ) {
+        const destRoot = resolve(destDir);
+        const destPath = resolve(destRoot, normalizedPath);
+        const insideDestination =
+          destPath === destRoot || destPath.startsWith(destRoot + sep);
+        if (!insideDestination) {
+          offset += Math.ceil(size / 512) * 512;
+          continue;
+        }
+
         mkdirSync(dirname(destPath), { recursive: true });
         writeFileSync(destPath, tarBuffer.subarray(offset, offset + size));
 
         if (
-          normalizedName === "SKILL.md" ||
-          normalizedName.endsWith("/SKILL.md")
+          normalizedPath === "SKILL.md" ||
+          normalizedPath.endsWith("/SKILL.md")
         ) {
           foundSkillMd = true;
         }


### PR DESCRIPTION
## Summary
- Normalize Windows-style backslashes and use `posix.normalize` before extraction to prevent backslash-based traversal on Windows
- Add a `resolve`-based containment check as defense-in-depth to guarantee extracted paths stay within the destination directory
- Add tests covering the happy path and all traversal/absolute-path attack vectors

## Original prompt
Codex security finding 31e92beb2e448191bb293db68091a543: ZipSlip-style path traversal in `extractTarToDir` via Windows backslash separators and insufficient guard logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
