### PR TITLE
fix(macos): remove dead formatter methods from DebugPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -150,29 +150,6 @@ struct DebugPanel: View {
         return String(format: "%.0fms", ms)
     }
 
-    private func formatWhole(_ value: Int) -> String {
-        "\(value)"
-    }
-
-    private func formatWhole(_ value: Double) -> String {
-        "\(Int(value.rounded()))"
-    }
-
-    private func formatDurationMs(_ value: Int?) -> String {
-        guard let value else { return "n/a" }
-        return formatDurationMs(Double(value))
-    }
-
-    private func formatDurationMs(_ value: Double?) -> String {
-        guard let value else { return "n/a" }
-        if value < 60_000 {
-            return String(format: "%.0fs", value / 1000)
-        }
-        if value < 3_600_000 {
-            return String(format: "%.0fm", value / 60_000)
-        }
-        return String(format: "%.1fh", value / 3_600_000)
-    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- Remove unused `formatWhole` (Int and Double overloads) and `formatDurationMs` (Int? and Double? overloads) from DebugPanel.swift
- These became dead code when #15881 removed the cleanup/conflict metrics that were the only call sites

Followup to #15881
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
