### PR TITLE
fix(gateway): reject ephemeral Slack messages with attachments

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -671,6 +671,40 @@ describe("slack-deliver endpoint", () => {
     expect(body.error).toContain("user is required");
   });
 
+  test("returns 400 when ephemeral message includes attachments", async () => {
+    const handler = createSlackDeliverHandler(
+      makeConfig(),
+      undefined,
+      makeCaches(),
+    );
+    const req = makeRequest({
+      chatId: "C123",
+      text: "secret info",
+      ephemeral: true,
+      user: "U456",
+      attachments: [
+        {
+          id: "att-img",
+          filename: "photo.png",
+          mimeType: "image/png",
+          sizeBytes: 100,
+        },
+      ],
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe(
+      "attachments are not supported for ephemeral messages",
+    );
+
+    const uploadCall = fetchCalls.find((c) =>
+      c.url.includes("files.completeUploadExternal"),
+    );
+    expect(uploadCall).toBeUndefined();
+  });
+
   test("ephemeral message includes thread_ts when threadTs query param is set", async () => {
     const handler = createSlackDeliverHandler(
       makeConfig(),

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -460,6 +460,12 @@ export function createSlackDeliverHandler(
         { status: 400 },
       );
     }
+    if (isEphemeral && attachments && attachments.length > 0) {
+      return Response.json(
+        { error: "attachments are not supported for ephemeral messages" },
+        { status: 400 },
+      );
+    }
 
     // Validate approval payload shape
     if (body.approval) {


### PR DESCRIPTION
## Summary
- Slack's `files.completeUploadExternal` API always requires `channel_id` and has no concept of user-scoped/ephemeral delivery; combining `ephemeral=true` with attachments silently leaked the file to the entire channel
- Added a 400 guard that rejects requests with `ephemeral=true` and non-empty `attachments` array before any Slack API calls are made
- Added a corresponding test case verifying the 400 response and that no upload API call is made

## Original prompt
Fix security finding: Slack ephemeral messages leak attachments to the channel (Codex finding 2317886bee448191b7c5c9ef89e82146, medium severity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
