### PR TITLE
fix(memory): remove hardcoded content-length heuristic from needsMemory gate

### DIFF
--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -43,16 +43,18 @@ function isToolResultOnlyUserTurn(message: Message | undefined): boolean {
 
 /**
  * Fast gate that determines whether the current turn warrants memory
- * retrieval. Returns `false` for low-value turns (empty, very short,
+ * retrieval. Returns `false` for mechanical no-ops (empty content,
  * tool-result-only) so the full memory pipeline can be skipped.
- * Runs in microseconds — string length checks only, no external calls.
+ * Runs in microseconds — no external calls.
+ *
+ * Note: We intentionally avoid character-length heuristics here.
+ * Short messages like "What did I say?" or "My preferences?" are
+ * legitimate memory queries. Per AGENTS.md, judgement calls about
+ * message value should be routed through the daemon, not hardcoded.
  */
 export function needsMemory(messages: Message[], content: string): boolean {
-  // Empty or whitespace-only content
+  // Empty or whitespace-only content — mechanical validation, nothing to query
   if (!content || content.trim().length === 0) return false;
-
-  // Very short messages like "ok", "thanks", "yes"
-  if (content.length < 20) return false;
 
   // Tool-result-only turns (assistant tool loop)
   const latestMessage = messages[messages.length - 1];
@@ -104,8 +106,8 @@ export async function prepareMemoryContext(
     return noopResult();
   }
 
-  // Gate: skip the entire memory pipeline for low-value turns (empty,
-  // very short messages, tool-result-only turns).
+  // Gate: skip the entire memory pipeline for mechanical no-ops (empty
+  // content, tool-result-only turns).
   if (!needsMemory(ctx.messages, content)) {
     return noopResult();
   }


### PR DESCRIPTION
## Summary
- Removes the `content.length < 20` gate from `needsMemory()` that was silently skipping memory recall for short but meaningful queries (e.g. "What did I say?", "My preferences?", "Recall my plan")
- Retains the empty/whitespace-only and tool-result-only gates which are mechanical validations
- Addresses the Assistant-Driven Judgement violation flagged in review: character-length scoring is exactly the kind of heuristic that should be routed through the daemon

Followup to #15856

## Test plan
- [ ] Verify short queries like "What did I say?" now trigger memory recall
- [ ] Verify empty/whitespace-only turns still skip the pipeline
- [ ] Verify tool-result-only turns still skip the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
