### PR TITLE
fix: enforce guardian-only access on schedule tools to prevent privilege escalation

### DIFF
--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -61,6 +61,11 @@ const ctx: ToolContext = {
   trustClass: "guardian",
 };
 
+const trustedCtx: ToolContext = {
+  ...ctx,
+  trustClass: "trusted_contact",
+};
+
 // ── schedule_create ─────────────────────────────────────────────────
 
 describe("schedule_create tool", () => {
@@ -168,6 +173,20 @@ describe("schedule_create tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Invalid cron expression");
+  });
+
+  test("rejects non-guardian actors", async () => {
+    const result = await executeScheduleCreate(
+      {
+        name: "Blocked schedule",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      trustedCtx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("restricted to guardian actors");
   });
 });
 
@@ -679,6 +698,19 @@ describe("schedule_update tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Invalid cron expression");
+  });
+
+  test("rejects non-guardian actors", async () => {
+    const result = await executeScheduleUpdate(
+      {
+        job_id: "nonexistent-id",
+        message: "injected",
+      },
+      trustedCtx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("restricted to guardian actors");
   });
 });
 

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -22,8 +22,15 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
 
 export async function executeScheduleCreate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (context.trustClass !== "guardian") {
+    return {
+      content:
+        "Error: schedule_create is restricted to guardian actors because schedules execute with elevated privileges.",
+      isError: true,
+    };
+  }
   const name = input.name as string;
   const timezone = (input.timezone as string) ?? null;
   const message = input.message as string;

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -25,8 +25,15 @@ const VALID_ROUTING_INTENTS: RoutingIntent[] = [
 
 export async function executeScheduleUpdate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (context.trustClass !== "guardian") {
+    return {
+      content:
+        "Error: schedule_update is restricted to guardian actors because schedules execute with elevated privileges.",
+      isError: true,
+    };
+  }
   const jobId = input.job_id as string;
   if (!jobId || typeof jobId !== "string") {
     return { content: "Error: job_id is required", isError: true };


### PR DESCRIPTION
## Summary

- Scheduled job executions always run with `trustClass: "guardian"` but `schedule_create` and `schedule_update` never validated the caller's trust class, allowing non-guardian actors with a one-time approval to create/modify schedules that later execute with elevated privileges
- Add guardian-only enforcement as the first check in both `executeScheduleCreate` and `executeScheduleUpdate`; closes the privilege escalation path identified in Codex finding 6956423023d0819195543e79d3b79172
- Add regression tests confirming non-guardian actors are rejected for both tools

## Original prompt
Fix privilege escalation: enforce guardian-only access on schedule_create and schedule_update tools. Scheduled job executions always run with trustClass: 'guardian' (hardcoded in scheduler.ts), but schedule creation and update tools don't check the caller's trust class. Codex finding 6956423023d0819195543e79d3b79172 (medium severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
