### PR TITLE
fix(macos): guard dismissHostCuOverlay against disrupting foreground CU sessions

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Sessions.swift
@@ -243,6 +243,12 @@ extension AppDelegate {
         hostCuOverlayCleanupTask = nil
         hostCuOverlayCancellables.removeAll()
 
+        // Only affect overlay/ambient/window state if a host CU proxy is active.
+        // The overlayWindow is shared with foreground CU sessions — without this
+        // guard we'd close an unrelated overlay, resume ambient prematurely, and
+        // steal focus by showing the main window.
+        guard activeHostCuProxy != nil else { return }
+
         overlayWindow?.close()
         overlayWindow = nil
         activeHostCuProxy = nil


### PR DESCRIPTION
Followup to #15801 — addresses review feedback from Codex and Devin.

`dismissHostCuOverlay()` unconditionally closed the shared `overlayWindow`, resumed `ambientAgent`, and showed `mainWindow` even when no host CU overlay was active. This could disrupt active foreground CU sessions by closing their overlay, resuming ambient monitoring prematurely, and stealing focus.

Fix: gate overlay/ambient/window cleanup on `activeHostCuProxy != nil`, while keeping task/cancellable cleanup unconditional (idempotent).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
