### PR TITLE
fix(cu): address review feedback from HostCuProxy PR

### DIFF
--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -370,6 +370,60 @@ describe("HostCuProxy", () => {
       );
     });
 
+    test("does not emit spurious warning on first observation", async () => {
+      setup();
+
+      // First ever request — no previous AX tree exists
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.resolve(sent1.requestId as string, {
+        axTree: "Button [1]",
+        // No axDiff on first observation — this is normal, not unchanged
+      });
+      const result1 = await p1;
+      expect(result1.content).not.toContain("NO VISIBLE EFFECT");
+    });
+
+    test("skips unchanged warning after computer_use_wait", async () => {
+      setup();
+
+      // Establish previous AX tree
+      const p1 = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+      proxy.recordAction("computer_use_click", { element_id: 1 });
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy.resolve(sent1.requestId as string, {
+        axTree: "Button [1]",
+      });
+      await p1;
+
+      // Wait action with unchanged screen — should NOT warn
+      const p2 = proxy.request(
+        "computer_use_wait",
+        { duration_ms: 2000 },
+        "session-1",
+        2,
+      );
+      proxy.recordAction("computer_use_wait", { duration_ms: 2000 });
+      const sent2 = sentMessages[1] as Record<string, unknown>;
+      proxy.resolve(sent2.requestId as string, {
+        axTree: "Button [1]",
+        // No axDiff — screen unchanged, but that's expected after wait
+      });
+      const result2 = await p2;
+      expect(result2.content).not.toContain("NO VISIBLE EFFECT");
+    });
+
     test("resets consecutive count when diff is present", async () => {
       setup();
 
@@ -628,7 +682,7 @@ describe("HostCuProxy", () => {
       proxy.dispose();
 
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
-      expect(resultPromise).rejects.toThrow("Host CU proxy disposed");
+      await expect(resultPromise).rejects.toThrow("Host CU proxy disposed");
     });
   });
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -197,10 +197,13 @@ export class HostCuProxy {
     clearTimeout(entry.timer);
     this.pending.delete(requestId);
 
+    // Capture pre-update state so formatObservation sees the correct previous AX tree
+    const prevAXTree = this._previousAXTree;
+
     // Update CU state from observation
     this.updateStateFromObservation(observation);
 
-    const result = this.formatObservation(observation);
+    const result = this.formatObservation(observation, prevAXTree);
     entry.resolve(result);
   }
 
@@ -255,7 +258,11 @@ export class HostCuProxy {
    * (AX tree wrapped in markers, diff, warnings) and optional screenshot
    * as an image content block.
    */
-  formatObservation(obs: CuObservationResult): ToolExecutionResult {
+  formatObservation(
+    obs: CuObservationResult,
+    previousAXTree?: string,
+  ): ToolExecutionResult {
+    const prevTree = previousAXTree ?? this._previousAXTree;
     const parts: string[] = [];
 
     // Surface user guidance prominently so the model sees it first
@@ -273,21 +280,30 @@ export class HostCuProxy {
     if (obs.axDiff) {
       parts.push(obs.axDiff);
       parts.push("");
-    } else if (this._previousAXTree != null && obs.axTree != null) {
-      // No diff means the screen didn't change
-      if (
-        this._consecutiveUnchangedSteps >=
-        CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD
-      ) {
-        parts.push(
-          `WARNING: ${this._consecutiveUnchangedSteps} consecutive actions had NO VISIBLE EFFECT on the UI. You MUST try a completely different approach.`,
-        );
-      } else {
-        parts.push(
-          "Your last action had NO VISIBLE EFFECT on the UI. Try something different.",
-        );
+    } else if (prevTree != null && obs.axTree != null) {
+      // Skip unchanged warning after wait actions — they intentionally yield no immediate change
+      const lastAction =
+        this._actionHistory.length > 0
+          ? this._actionHistory[this._actionHistory.length - 1]
+          : undefined;
+      const isWaitAction = lastAction?.toolName === "computer_use_wait";
+
+      if (!isWaitAction) {
+        // No diff means the screen didn't change
+        if (
+          this._consecutiveUnchangedSteps >=
+          CONSECUTIVE_UNCHANGED_WARNING_THRESHOLD
+        ) {
+          parts.push(
+            `WARNING: ${this._consecutiveUnchangedSteps} consecutive actions had NO VISIBLE EFFECT on the UI. You MUST try a completely different approach.`,
+          );
+        } else {
+          parts.push(
+            "Your last action had NO VISIBLE EFFECT on the UI. Try something different.",
+          );
+        }
+        parts.push("");
       }
-      parts.push("");
     }
 
     // Loop detection: identical actions repeated


### PR DESCRIPTION
## Summary
- Fix spurious 'NO VISIBLE EFFECT' warning on the first observation by capturing the previous AX tree state before mutation
- Skip unchanged-screen warning after `computer_use_wait` actions which intentionally yield no immediate UI change
- Add missing `await` on `expect().rejects` assertion in dispose test
- Add tests covering the first-observation and wait-action edge cases

Follow-up to #15786
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
