### PR TITLE
fix: count AX tree compaction per-block instead of per-message

### DIFF
--- a/assistant/src/agent/ax-tree-compaction.test.ts
+++ b/assistant/src/agent/ax-tree-compaction.test.ts
@@ -182,6 +182,57 @@ describe("compactAxTreeHistory", () => {
     expect(result).toEqual([]);
   });
 
+  test("counts AX trees per block, not per message", () => {
+    // One message has two AX tree blocks — they should count as 2 trees
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1a",
+            content: "<ax-tree>\ntree-1a\n</ax-tree>",
+            is_error: false,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "t1b",
+            content: "<ax-tree>\ntree-1b\n</ax-tree>",
+            is_error: false,
+          },
+        ],
+      },
+      assistantText("ok"),
+      axTreeToolResult("t2", "tree-2"),
+    ];
+
+    const result = compactAxTreeHistory(messages);
+
+    // 3 total AX tree blocks, keep last 2 → strip only first block (t1a)
+    const msg0 = result[0];
+    const block0 = msg0.content[0];
+    expect(block0.type).toBe("tool_result");
+    if (block0.type === "tool_result") {
+      expect(block0.content).toContain("<ax_tree_omitted />");
+      expect(block0.content).not.toContain("<ax-tree>");
+    }
+
+    // Second block in same message (t1b) should be kept
+    const block1 = msg0.content[1];
+    expect(block1.type).toBe("tool_result");
+    if (block1.type === "tool_result") {
+      expect(block1.content).toContain("<ax-tree>");
+      expect(block1.content).not.toContain("<ax_tree_omitted />");
+    }
+
+    // Last message (t2) should also be kept
+    const lastBlock = result[2].content[0];
+    expect(lastBlock.type).toBe("tool_result");
+    if (lastBlock.type === "tool_result") {
+      expect(lastBlock.content).toContain("<ax-tree>");
+    }
+  });
+
   test("is pure — does not mutate input messages", () => {
     const messages: Message[] = [
       axTreeToolResult("t1", "tree-1"),

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -624,40 +624,53 @@ export function escapeAxTreeContent(content: string): string {
  * `MAX_AX_TREES_IN_HISTORY` `<ax-tree>` blocks have been replaced with a
  * short placeholder.  This keeps the conversation context small so that
  * TTFT does not grow linearly with step count in computer-use sessions.
+ *
+ * Counting is per-block, not per-message — a single user message can
+ * contain multiple tool_result blocks each with their own AX tree snapshot.
  */
 export function compactAxTreeHistory(messages: Message[]): Message[] {
-  // Collect indices of user messages that contain an <ax-tree> block
-  const indicesWithAxTree: number[] = [];
+  // Collect (messageIndex, blockIndex) for every tool_result block with <ax-tree>
+  const axBlocks: Array<{ msgIdx: number; blockIdx: number }> = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (msg.role !== "user") continue;
-    for (const block of msg.content) {
+    for (let j = 0; j < msg.content.length; j++) {
+      const block = msg.content[j];
       if (
         block.type === "tool_result" &&
         typeof block.content === "string" &&
         block.content.includes("<ax-tree>")
       ) {
-        indicesWithAxTree.push(i);
-        break;
+        axBlocks.push({ msgIdx: i, blockIdx: j });
       }
     }
   }
 
-  if (indicesWithAxTree.length <= MAX_AX_TREES_IN_HISTORY) {
+  if (axBlocks.length <= MAX_AX_TREES_IN_HISTORY) {
     return messages;
   }
 
-  const toStrip = new Set(indicesWithAxTree.slice(0, -MAX_AX_TREES_IN_HISTORY));
+  // Build a set of "msgIdx:blockIdx" keys for blocks that should be stripped
+  const toStrip = new Set(
+    axBlocks
+      .slice(0, -MAX_AX_TREES_IN_HISTORY)
+      .map((b) => `${b.msgIdx}:${b.blockIdx}`),
+  );
 
   return messages.map((msg, idx) => {
-    if (!toStrip.has(idx)) return msg;
+    // Quick check: does this message have any blocks to strip?
+    const hasStripTarget = msg.content.some((_, j) =>
+      toStrip.has(`${idx}:${j}`),
+    );
+    if (!hasStripTarget) return msg;
+
     return {
       ...msg,
-      content: msg.content.map((block) => {
+      content: msg.content.map((block, j) => {
         if (
+          toStrip.has(`${idx}:${j}`) &&
           block.type === "tool_result" &&
-          typeof block.content === "string" &&
-          block.content.includes("<ax-tree>")
+          typeof block.content === "string"
         ) {
           return {
             ...block,


### PR DESCRIPTION
## Summary
- Fixes AX tree compaction to count individual `<ax-tree>` blocks rather than messages, so a single user message with multiple tool results containing AX trees doesn't bypass the retention limit
- Adds test case covering multi-block-per-message counting

Addresses review feedback from #15799.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
