### PR TITLE
fix: guard against empty rev-parse output in git-hooks-trust

### DIFF
--- a/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
+++ b/assistant/src/__tests__/workspace-git-hooks-trust.test.ts
@@ -288,6 +288,38 @@ describe("detectConfiguredHooks", () => {
     expect(result.hasHooks).toBe(false);
   });
 
+  test("falls back to .git/hooks when rev-parse returns empty output", async () => {
+    const defaultHooksDir = join(workspaceDir, ".git", "hooks");
+    mkdirSync(defaultHooksDir, { recursive: true });
+    writeHook(defaultHooksDir, "pre-commit");
+
+    // GitService that returns empty stdout for rev-parse --git-path hooks
+    const emptyRevParseService: GitServiceLike = {
+      async runReadOnlyGit(args: string[]) {
+        if (args[0] === "rev-parse" && args[1] === "--git-path") {
+          return { stdout: "", stderr: "" };
+        }
+        if (
+          args.length >= 3 &&
+          args[0] === "config" &&
+          args[2] === "core.hooksPath"
+        ) {
+          throw new Error("git config: not found");
+        }
+        return { stdout: "", stderr: "" };
+      },
+    };
+
+    const result = await detectConfiguredHooks(
+      workspaceDir,
+      emptyRevParseService,
+    );
+
+    // Empty rev-parse output should fall back to .git/hooks, not workspaceDir
+    expect(result.hooksDir).toBe(defaultHooksDir);
+    expect(result.hasHooks).toBe(true);
+  });
+
   test("multiple hooks are all returned in hookFiles", async () => {
     const hooksDir = join(workspaceDir, ".git", "hooks");
     mkdirSync(hooksDir, { recursive: true });

--- a/assistant/src/workspace/git-hooks-trust.ts
+++ b/assistant/src/workspace/git-hooks-trust.ts
@@ -159,6 +159,9 @@ export async function detectConfiguredHooks(
       "hooks",
     ]);
     const resolvedPath = gitPathStdout.trim();
+    if (!resolvedPath) {
+      throw new Error("git rev-parse --git-path hooks returned empty output");
+    }
     hooksDir = resolvedPath.startsWith("/")
       ? resolvedPath
       : join(workspaceDir, resolvedPath);


### PR DESCRIPTION
## Summary

Addresses review feedback from #15898:

- **Empty-string guard**: When `git rev-parse --git-path hooks` returns empty/whitespace-only output, `join(workspaceDir, "")` incorrectly resolves to `workspaceDir` instead of `.git/hooks`. Added an empty check that throws to trigger the existing catch fallback.
- **Test coverage**: Added a dedicated test that verifies the empty rev-parse output scenario correctly falls back to `.git/hooks`.

## Test plan

- [ ] New test: "falls back to .git/hooks when rev-parse returns empty output"
- [ ] Existing tests continue to pass (mock already handles rev-parse correctly on feature branch)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
