### PR TITLE
fix: add missing async to dispose test in host-cu-proxy

### DIFF
--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -665,7 +665,7 @@ describe("HostCuProxy", () => {
   // -------------------------------------------------------------------------
 
   describe("dispose", () => {
-    test("rejects all pending requests", () => {
+    test("rejects all pending requests", async () => {
       setup();
 
       const resultPromise = proxy.request(


### PR DESCRIPTION
## Summary
- Add missing `async` keyword to the "rejects all pending requests" test callback in `host-cu-proxy.test.ts` — it uses `await` but was declared as a sync function, causing a TS1308 type-check error in CI.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23025847972/job/66873365044

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
