### PR TITLE
test: strengthen memory test assertions per PR #15916 review

### DIFF
--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -50,6 +50,37 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Stub the local embedding backend so the real ONNX model never loads.
+mock.module("../memory/embedding-local.js", () => ({
+  LocalEmbeddingBackend: class {
+    readonly provider = "local" as const;
+    readonly model: string;
+    constructor(model: string) {
+      this.model = model;
+    }
+    async embed(texts: string[]): Promise<number[][]> {
+      return texts.map(() => new Array(384).fill(0));
+    }
+  },
+}));
+
+// Dynamic Qdrant mock so the benchmark can inject high-scoring results
+let mockQdrantResults: Array<{
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}> = [];
+
+mock.module("../memory/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => mockQdrantResults,
+    hybridSearch: async () => mockQdrantResults,
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+}));
+
 function makeLongMessages(turns: number): Message[] {
   const rows: Message[] = [];
   const userTail =
@@ -169,6 +200,7 @@ describe("Memory context benchmark", () => {
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM memory_jobs");
     db.run("DELETE FROM memory_checkpoints");
+    mockQdrantResults = [];
   });
 
   afterAll(() => {
@@ -247,6 +279,24 @@ describe("Memory context benchmark", () => {
         recallConfig.memory.retrieval.dynamicBudget.maxInjectTokens,
     });
 
+    // Seed Qdrant mock with a representative decision segment so
+    // the benchmark validates content quality, not just pipeline completion.
+    const now = 1_700_500_000_000;
+    mockQdrantResults = [
+      {
+        id: "emb-bench-decision",
+        score: 0.9,
+        payload: {
+          target_type: "segment",
+          target_id: "seg-bench-0",
+          text: "Decision 0: use Bun test fixtures for memory regressions and recall ranking checks.",
+          kind: "segment",
+          created_at: now,
+          last_seen_at: now,
+        },
+      },
+    ];
+
     const recall = await buildMemoryRecall(
       "What decisions did we make about Bun tests and retrieval diagnostics?",
       conversationId,
@@ -254,16 +304,13 @@ describe("Memory context benchmark", () => {
       { maxInjectTokensOverride: recallBudget },
     );
 
-    // In CI, Qdrant/embedding providers are unavailable, so semantic search
-    // fails and the retriever marks the result as degraded.  The benchmark
-    // cares about compaction and recall pipeline completion, not embedding
-    // availability, so we do not assert on `recall.degraded`.
     // Recency search finds conversation-scoped segments.
     expect(recall.recencyHits).toBeGreaterThan(0);
     expect(recall.enabled).toBe(true);
-    // With Qdrant/embeddings unavailable, recency-only candidates have
-    // low finalScore and are filtered by tier classification, so
-    // injectedTokens may be 0. Verify budget cap is respected.
+    // With Qdrant mock returning a high-scoring result, content should be injected.
+    expect(recall.selectedCount).toBeGreaterThan(0);
+    expect(recall.injectedText).toContain("Bun test fixtures");
+    expect(recall.injectedTokens).toBeGreaterThan(0);
     expect(recall.injectedTokens).toBeLessThanOrEqual(recallBudget);
     expect(recallBudget).toBeGreaterThanOrEqual(
       recallConfig.memory.retrieval.dynamicBudget.minInjectTokens,

--- a/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
+++ b/assistant/src/__tests__/memory-lifecycle-e2e.test.ts
@@ -333,7 +333,10 @@ describe("Memory lifecycle E2E regression", () => {
         conversationId,
         role: "user",
         content: JSON.stringify([
-          { type: "text", text: "My preferred timezone is America/Los_Angeles." },
+          {
+            type: "text",
+            text: "My preferred timezone is America/Los_Angeles.",
+          },
         ]),
         createdAt: now + 10,
       })
@@ -355,11 +358,12 @@ describe("Memory lifecycle E2E regression", () => {
       TEST_CONFIG,
     );
 
-    if (recall.injectedText.length > 0) {
-      // The new pipeline uses <memory_context> format when items exist
-      // or the old <memory> format for segments. Either way, verify structure.
-      expect(recall.injectedTokens).toBeGreaterThan(0);
-    }
+    // Recency search finds segments but their finalScore (semantic*0.7 +
+    // recency*0.2 + confidence*0.1) is too low to pass tier classification
+    // (threshold > 0.6) because semantic=0 with Qdrant mocked empty.
+    // Verify the pipeline ran and recency candidates were found.
+    expect(recall.recencyHits).toBeGreaterThan(0);
+    expect(recall.enabled).toBe(true);
   });
 
   test("stripping removes <memory_context> tags from injected recall", () => {

--- a/assistant/src/__tests__/memory-recall-quality.test.ts
+++ b/assistant/src/__tests__/memory-recall-quality.test.ts
@@ -54,13 +54,17 @@ mock.module("../memory/embedding-local.js", () => ({
   },
 }));
 
-// Mock Qdrant client so semantic search returns empty results instead of
-// throwing "Qdrant client not initialized" (which would discard lexical results
-// due to the single try-catch in buildMemoryRecall).
+// Dynamic Qdrant mock: tests can push results to be returned by searchWithFilter/hybridSearch
+let mockQdrantResults: Array<{
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}> = [];
+
 mock.module("../memory/qdrant-client.js", () => ({
   getQdrantClient: () => ({
-    searchWithFilter: async () => [],
-    hybridSearch: async () => [],
+    searchWithFilter: async () => mockQdrantResults,
+    hybridSearch: async () => mockQdrantResults,
     upsertPoints: async () => {},
     deletePoints: async () => {},
   }),
@@ -262,6 +266,7 @@ describe("Memory Recall Quality", () => {
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM memory_jobs");
     db.run("DELETE FROM memory_checkpoints");
+    mockQdrantResults = [];
   });
 
   afterAll(() => {
@@ -335,18 +340,68 @@ describe("Memory Recall Quality", () => {
         now + 2000,
       );
 
+      // Also insert items so the pipeline has structured data to inject
+      insertItem(db, {
+        id: "item-pref-dark",
+        kind: "preference",
+        subject: "display preference",
+        statement: "User prefers dark mode and concise answers",
+        importance: 0.8,
+        firstSeenAt: now,
+      });
+      insertItemSource(db, "item-pref-dark", "msg-pref-1", now);
+      insertItem(db, {
+        id: "item-pref-editor",
+        kind: "preference",
+        subject: "editor preference",
+        statement: "User favorite editor is Neovim",
+        importance: 0.8,
+        firstSeenAt: now + 1000,
+      });
+      insertItemSource(db, "item-pref-editor", "msg-pref-2", now + 1000);
+
+      // Mock Qdrant to return both preference items as high-scoring results
+      mockQdrantResults = [
+        {
+          id: "emb-pref-dark",
+          score: 0.92,
+          payload: {
+            target_type: "item",
+            target_id: "item-pref-dark",
+            text: "User prefers dark mode and concise answers",
+            kind: "preference",
+            status: "active",
+            created_at: now,
+            last_seen_at: now,
+          },
+        },
+        {
+          id: "emb-pref-editor",
+          score: 0.88,
+          payload: {
+            target_type: "item",
+            target_id: "item-pref-editor",
+            text: "User favorite editor is Neovim",
+            kind: "preference",
+            status: "active",
+            created_at: now + 1000,
+            last_seen_at: now + 1000,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "what are my preferences",
         "conv-pref",
         TEST_CONFIG,
       );
 
-      // With Qdrant mocked empty, the only retrieval path is recency search.
-      // Recency candidates score below the tier-2 threshold (finalScore =
-      // semantic*0.7 + recency*0.2 + confidence*0.1 ≈ 0.25 max) so they
-      // don't pass tier classification. Verify recency search ran correctly.
       expect(recall.recencyHits).toBeGreaterThan(0);
       expect(recall.enabled).toBe(true);
+      // With high-scoring Qdrant results, items should be injected
+      expect(recall.semanticHits).toBeGreaterThan(0);
+      expect(recall.injectedText).toContain("dark mode");
+      expect(recall.injectedText).toContain("Neovim");
     });
 
     test("high-importance preferences outrank low-importance facts in recall", async () => {
@@ -410,16 +465,46 @@ describe("Memory Recall Quality", () => {
       });
       insertItemSource(db, "item-lo-fact", "msg-lo", now + 1000);
 
+      // Mock Qdrant to return both items — the high-importance one with a higher score
+      mockQdrantResults = [
+        {
+          id: "emb-hi-pref",
+          score: 0.95,
+          payload: {
+            target_type: "item",
+            target_id: "item-hi-pref",
+            text: "User strongly prefers TypeScript over JavaScript",
+            kind: "preference",
+            status: "active",
+            created_at: now,
+            last_seen_at: now,
+          },
+        },
+        {
+          id: "emb-lo-fact",
+          score: 0.7,
+          payload: {
+            target_type: "item",
+            target_id: "item-lo-fact",
+            text: "The default port is 8080",
+            kind: "project",
+            status: "active",
+            created_at: now + 1000,
+            last_seen_at: now + 1000,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "TypeScript preference language",
         "conv-rank",
         TEST_CONFIG,
       );
 
-      // Recency search finds segments but they don't pass tier classification
-      // (see threshold explanation above). Verify the pipeline ran without error.
       expect(recall.recencyHits).toBeGreaterThan(0);
       expect(recall.enabled).toBe(true);
+      // High-importance preference should be injected
+      expect(recall.injectedText).toContain("TypeScript");
     });
   });
 
@@ -633,16 +718,43 @@ describe("Memory Recall Quality", () => {
         oneMonthAgo,
       );
 
+      // Add items and mock Qdrant with the recent item scoring higher
+      insertItem(db, {
+        id: "item-bun-runtime",
+        kind: "project",
+        subject: "runtime environment",
+        statement: "We are using Bun as our runtime environment",
+        importance: 0.7,
+        firstSeenAt: now - 1000,
+      });
+      insertItemSource(db, "item-bun-runtime", "msg-recent", now - 1000);
+
+      mockQdrantResults = [
+        {
+          id: "emb-bun-runtime",
+          score: 0.9,
+          payload: {
+            target_type: "item",
+            target_id: "item-bun-runtime",
+            text: "We are using Bun as our runtime environment",
+            kind: "project",
+            status: "active",
+            created_at: now - 1000,
+            last_seen_at: now - 1000,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "runtime environment",
         "conv-stale",
         TEST_CONFIG,
       );
 
-      // Recency search finds segments but tier classification filters them.
-      // Verify recency search ran and the pipeline completed without error.
       expect(recall.recencyHits).toBeGreaterThan(0);
       expect(recall.enabled).toBe(true);
+      // Recent Bun item should be injected, old Node reference should not
+      expect(recall.injectedText).toContain("Bun");
     });
 
     test("frequently accessed items surface via recency search when seeded with segments", async () => {
@@ -708,15 +820,46 @@ describe("Memory Recall Quality", () => {
       });
       insertItemSource(db, "item-rare", "msg-rare", now + 1000);
 
+      // Mock Qdrant with the frequently accessed item scoring higher
+      mockQdrantResults = [
+        {
+          id: "emb-freq",
+          score: 0.92,
+          payload: {
+            target_type: "item",
+            target_id: "item-freq",
+            text: "User timezone is America/Los_Angeles",
+            kind: "identity",
+            status: "active",
+            created_at: now,
+            last_seen_at: now,
+          },
+        },
+        {
+          id: "emb-rare",
+          score: 0.75,
+          payload: {
+            target_type: "item",
+            target_id: "item-rare",
+            text: "User timezone offset is UTC-8",
+            kind: "identity",
+            status: "active",
+            created_at: now + 1000,
+            last_seen_at: now + 1000,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "timezone",
         "conv-access",
         TEST_CONFIG,
       );
 
-      // Recency search finds segments but tier classification filters them.
       expect(recall.recencyHits).toBeGreaterThan(0);
       expect(recall.enabled).toBe(true);
+      // Frequently accessed timezone item should be in injected text
+      expect(recall.injectedText).toContain("America/Los_Angeles");
     });
   });
 
@@ -760,16 +903,33 @@ describe("Memory Recall Quality", () => {
       });
       insertItemSource(db, "item-deploy-rule", "msg-seg", now);
 
+      // Mock Qdrant to return the deployment rule item
+      mockQdrantResults = [
+        {
+          id: "emb-deploy-rule",
+          score: 0.91,
+          payload: {
+            target_type: "item",
+            target_id: "item-deploy-rule",
+            text: "Always deploy to staging before production",
+            kind: "constraint",
+            status: "active",
+            created_at: now,
+            last_seen_at: now,
+          },
+        },
+      ];
+
       const recall = await buildMemoryRecall(
         "deployment staging production",
         "conv-multi",
         TEST_CONFIG,
       );
 
-      // Recency search finds segments but tier classification filters them
-      // (score below 0.6 threshold).
       expect(recall.recencyHits).toBeGreaterThan(0);
       expect(recall.enabled).toBe(true);
+      // Deployment rule should be injected
+      expect(recall.injectedText).toContain("staging");
     });
 
     test("recall with no matching content returns empty injection", async () => {

--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -32,7 +32,11 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Dynamic Qdrant mock: tests can push results to be returned by searchWithFilter/hybridSearch
-let mockQdrantResults: Array<{ id: string; score: number; payload: Record<string, unknown> }> = [];
+let mockQdrantResults: Array<{
+  id: string;
+  score: number;
+  payload: Record<string, unknown>;
+}> = [];
 
 mock.module("../memory/qdrant-client.js", () => ({
   getQdrantClient: () => ({
@@ -96,6 +100,7 @@ describe("Memory regressions (experimental)", () => {
     db.run("DELETE FROM memory_items");
 
     db.run("DELETE FROM memory_segments");
+    db.run("DELETE FROM memory_summaries");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM memory_jobs");
@@ -354,7 +359,7 @@ describe("Memory regressions (experimental)", () => {
       },
       {
         id: "emb-semantic-orphan",
-        score: 0.90,
+        score: 0.9,
         payload: {
           target_type: "item",
           target_id: "item-semantic-orphan",
@@ -453,7 +458,7 @@ describe("Memory regressions (experimental)", () => {
       },
       {
         id: "emb-summary-semantic-weekly",
-        score: 0.90,
+        score: 0.9,
         payload: {
           target_type: "summary",
           target_id: "summary-semantic-weekly",

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -103,10 +103,7 @@ import {
 import { extractAndUpsertMemoryItemsForMessage } from "../memory/items-extractor.js";
 import { backfillJob } from "../memory/job-handlers/backfill.js";
 import { buildConversationSummaryJob } from "../memory/job-handlers/summarization.js";
-import {
-  claimMemoryJobs,
-  enqueueMemoryJob,
-} from "../memory/jobs-store.js";
+import { claimMemoryJobs, enqueueMemoryJob } from "../memory/jobs-store.js";
 import {
   maybeEnqueueScheduledCleanupJobs,
   resetCleanupScheduleThrottle,
@@ -1867,6 +1864,10 @@ describe("Memory regressions", () => {
     // With strict policy, only "strict-project" scope segments should be found.
     // The default scope segment should be excluded.
     expect(result.recencyHits).toBe(1);
+    // Assert the returned candidate is specifically from the strict-project scope,
+    // not the default scope segment (privacy boundary check).
+    expect(result.topCandidates.length).toBe(1);
+    expect(result.topCandidates[0].key).toBe("segment:seg-strict-custom");
   });
 
   test("scope columns: summaries default to scope_id=default", () => {

--- a/assistant/src/tools/memory/handlers.test.ts
+++ b/assistant/src/tools/memory/handlers.test.ts
@@ -94,7 +94,8 @@ import {
   memoryItemSources,
   messages,
 } from "../../memory/schema.js";
-import { handleMemoryRecall, type MemoryRecallToolResult } from "./handlers.js";
+import type { MemoryRecallToolResult } from "./handlers.js";
+import { handleMemoryRecall } from "./handlers.js";
 
 function clearTables() {
   const db = getDb();
@@ -436,31 +437,46 @@ describe("handleMemoryRecall", () => {
   // ── Scope filtering ───────────────────────────────────────────────
 
   test("scope 'conversation' passes scope policy override to retriever", async () => {
-    // With Qdrant mocked empty and no conversation segments, the retriever
-    // returns empty results. This test verifies the handler invocation path
-    // does not error when scope="conversation" is specified.
     const db = getDb();
     const now = Date.now();
+    const convId = "conv-scope-a";
 
-    insertItem(db, {
-      id: "item-scope-a",
-      kind: "identity",
-      subject: "scoped data",
-      statement: "This item is scoped to conversation A",
-      firstSeenAt: now - 10_000,
-      scopeId: "conv-scope-a",
-    });
+    insertConversation(db, convId, now - 10_000);
+    insertMessage(
+      db,
+      "msg-scope-a",
+      convId,
+      "user",
+      "scoped data for conversation A",
+      now - 5_000,
+    );
+
+    // Insert a segment scoped to this conversation's scope
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-scope-a', 'msg-scope-a', '${convId}', 'user', 0, 'scoped data for conversation A', 8, '${convId}', ${
+        now - 5_000
+      }, ${now - 5_000})
+    `);
+
+    // Insert an out-of-scope segment that should NOT be returned
+    db.run(`
+      INSERT INTO memory_segments (id, message_id, conversation_id, role, segment_index, text, token_estimate, scope_id, created_at, updated_at)
+      VALUES ('seg-scope-other', 'msg-scope-a', '${convId}', 'user', 1, 'data from a different scope', 8, 'other-scope', ${
+        now - 5_000
+      }, ${now - 5_000})
+    `);
 
     const result = await handleMemoryRecall(
       { query: "scoped data", scope: "conversation" },
       TEST_CONFIG,
-      "conv-scope-a",
+      convId,
     );
 
     expect(result.isError).toBe(false);
     const parsed = parseResult(result.content);
-    // Handler should return a valid result shape (empty with Qdrant mocked)
-    expect(typeof parsed.resultCount).toBe("number");
+    // Verify recency search found the conversation-scoped segment
+    expect(parsed.sources.recency).toBeGreaterThan(0);
   });
 
   test("default scope handler invocation does not error", async () => {
@@ -495,9 +511,10 @@ describe("handleMemoryRecall", () => {
     // Mock buildMemoryRecall to throw, simulating an internal retrieval failure
     const retrieverModule = await import("../../memory/retriever.js");
     const original = retrieverModule.buildMemoryRecall;
-    (retrieverModule as Record<string, unknown>).buildMemoryRecall = async () => {
-      throw new Error("Simulated retrieval failure");
-    };
+    (retrieverModule as Record<string, unknown>).buildMemoryRecall =
+      async () => {
+        throw new Error("Simulated retrieval failure");
+      };
 
     try {
       const result = await handleMemoryRecall(


### PR DESCRIPTION
## Summary
Addresses review feedback from #15916 (merged). The original PR weakened several memory test assertions when updating for the new pipeline. This PR restores meaningful assertions:

- **Privacy boundary (memory-regressions.test.ts)**: Assert `topCandidates[0].key` matches the strict-scope segment ID, not just `recencyHits === 1`
- **Scope filtering (handlers.test.ts)**: Add real segments with different scopes and verify `sources.recency > 0` instead of just checking `typeof resultCount`
- **XML format (memory-lifecycle-e2e.test.ts)**: Replace vacuous `if (injectedText.length > 0)` conditional with unconditional `recencyHits > 0` assertion
- **Recall quality (memory-recall-quality.test.ts)**: Convert static empty Qdrant mock to dynamic `mockQdrantResults` pattern; inject high-scoring results so tests validate content (`injectedText.toContain(...)`) not just pipeline completion
- **Test isolation (memory-regressions.experimental.test.ts)**: Restore `DELETE FROM memory_summaries` in `beforeEach` — the test still inserts summaries
- **Benchmark quality (memory-context-benchmark.test.ts)**: Add Qdrant/embedding mocks with seeded results; assert `selectedCount > 0`, `injectedText.toContain("Bun test fixtures")`, and `injectedTokens > 0`
- **Pre-existing fix (handlers.test.ts)**: Split inline `type` import that caused Prettier parse error

## Test plan
- [ ] All modified test files pass: `bun test` on each file
- [ ] No type errors: `bunx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
