### PR TITLE
fix: add missing conditional View modifier for macOS build

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/ConditionalModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/ConditionalModifier.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public extension View {
+    /// Conditionally applies a transformation to a view.
+    ///
+    /// When the condition is `true`, the `transform` closure is applied;
+    /// otherwise the view is returned unchanged.
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `ConditionalModifier.swift` in `clients/shared/DesignSystem/Modifiers/` with a `.if(_:transform:)` View extension
- This modifier was referenced by `ConstellationView.swift:342` and `InterviewChatView.swift:136` but never defined, causing the macOS CI build to fail

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23025967261/job/66873742469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
