### PR TITLE
fix(memory): restore timezone extraction from V2 recall for temporal context

### DIFF
--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildTemporalContext } from "../daemon/date-context.js";
+import {
+  buildTemporalContext,
+  extractUserTimeZoneFromRecall,
+} from "../daemon/date-context.js";
 
 // Fixed timestamps for deterministic assertions (all UTC midday to avoid DST edge cases).
 
@@ -534,5 +537,97 @@ describe("trip-planning: timezone-shifted weekend anchors", () => {
     });
     expect(result).toContain("Today: 2026-02-27 (Friday)");
     expect(result).toContain("Next weekend: 2026-02-28 – 2026-03-01");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUserTimeZoneFromRecall
+// ---------------------------------------------------------------------------
+
+describe("extractUserTimeZoneFromRecall", () => {
+  test("returns null for empty input", () => {
+    expect(extractUserTimeZoneFromRecall("")).toBeNull();
+    expect(extractUserTimeZoneFromRecall("  ")).toBeNull();
+  });
+
+  test("extracts IANA timezone from user_identity section", () => {
+    const text = `<memory_context>
+
+<user_identity>
+User's timezone is America/New_York
+User works as a software engineer
+</user_identity>
+
+</memory_context>`;
+    expect(extractUserTimeZoneFromRecall(text)).toBe("America/New_York");
+  });
+
+  test("extracts timezone from 'timezone: ...' line in identity", () => {
+    const text = `<memory_context>
+
+<user_identity>
+- name: Alice
+- timezone: Europe/London
+- role: designer
+</user_identity>
+
+</memory_context>`;
+    expect(extractUserTimeZoneFromRecall(text)).toBe("Europe/London");
+  });
+
+  test("extracts UTC offset timezone", () => {
+    const text = `<memory_context>
+
+<user_identity>
+User's time zone is UTC+5:30
+</user_identity>
+
+</memory_context>`;
+    const result = extractUserTimeZoneFromRecall(text);
+    expect(result).not.toBeNull();
+    // UTC+5:30 should canonicalize to +05:30
+    expect(result).toBe("+05:30");
+  });
+
+  test("falls back to scanning full text when no identity section", () => {
+    const text = `<memory_context>
+
+<relevant_context>
+<episode source="Mar 5">
+User mentioned their timezone is Asia/Tokyo
+</episode>
+</relevant_context>
+
+</memory_context>`;
+    expect(extractUserTimeZoneFromRecall(text)).toBe("Asia/Tokyo");
+  });
+
+  test("returns null when no timezone info present", () => {
+    const text = `<memory_context>
+
+<user_identity>
+User's name is Bob
+User works at Acme Corp
+</user_identity>
+
+</memory_context>`;
+    expect(extractUserTimeZoneFromRecall(text)).toBeNull();
+  });
+
+  test("prefers identity section over other sections", () => {
+    const text = `<memory_context>
+
+<user_identity>
+User's timezone is America/Chicago
+</user_identity>
+
+<relevant_context>
+<episode source="Mar 5">
+Discussed timezone America/Los_Angeles for the deployment
+</episode>
+</relevant_context>
+
+</memory_context>`;
+    expect(extractUserTimeZoneFromRecall(text)).toBe("America/Chicago");
   });
 });

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -117,6 +117,69 @@ function canonicalizeTimeZone(timeZone: string): string | null {
 }
 
 /**
+ * Regex matching IANA timezone identifiers (e.g. "America/New_York") and
+ * UTC/GMT offset tokens (e.g. "UTC+5", "GMT-8:30").
+ */
+const TIMEZONE_TOKEN_RE =
+  /\b(?:[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)+|(?:UTC|GMT)(?:[+-]\d{1,2}(?::?\d{2})?)?)\b/gi;
+
+/**
+ * Extract the user's timezone from V2 memory recall injected text.
+ *
+ * Scans the `<user_identity>` section (if present) for lines containing
+ * "timezone" and tries to resolve an IANA identifier. Falls back to
+ * scanning the full text body.
+ */
+export function extractUserTimeZoneFromRecall(
+  injectedText: string,
+): string | null {
+  if (!injectedText || injectedText.trim().length === 0) return null;
+
+  // Prefer lines inside <user_identity> that mention "timezone"
+  const identityMatch = injectedText.match(
+    /<user_identity>([\s\S]*?)<\/user_identity>/,
+  );
+  if (identityMatch) {
+    const identityBlock = identityMatch[1];
+    for (const line of identityBlock.split("\n")) {
+      if (/time\s*zone/i.test(line)) {
+        for (const token of extractTimeZoneCandidates(line)) {
+          const canonical = canonicalizeTimeZone(token);
+          if (canonical) return canonical;
+        }
+      }
+    }
+    // Scan full identity block for any timezone token
+    for (const token of extractTimeZoneCandidates(identityBlock)) {
+      const canonical = canonicalizeTimeZone(token);
+      if (canonical) return canonical;
+    }
+  }
+
+  // Fallback: scan entire injected text for timezone tokens in
+  // lines that mention "timezone"
+  for (const line of injectedText.split("\n")) {
+    if (/time\s*zone/i.test(line)) {
+      for (const token of extractTimeZoneCandidates(line)) {
+        const canonical = canonicalizeTimeZone(token);
+        if (canonical) return canonical;
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractTimeZoneCandidates(text: string): string[] {
+  const matches = (text.match(TIMEZONE_TOKEN_RE) ?? [])
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+  const ianaTokens = matches.filter((token) => token.includes("/"));
+  const offsetTokens = matches.filter((token) => !token.includes("/"));
+  return [...ianaTokens, ...offsetTokens];
+}
+
+/**
  * Get the local date parts for a given instant in the specified timezone.
  */
 function localDateParts(

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -71,7 +71,10 @@ import {
   reduceContextOverflow,
   type ReducerState,
 } from "./context-overflow-reducer.js";
-import { buildTemporalContext } from "./date-context.js";
+import {
+  buildTemporalContext,
+  extractUserTimeZoneFromRecall,
+} from "./date-context.js";
 import { deepRepairHistory, repairHistory } from "./history-repair.js";
 import type {
   DynamicPageSurfaceData,
@@ -616,13 +619,16 @@ export async function runAgentLoopImpl(
 
     // Compute fresh temporal context each turn for date grounding.
     // Absolute "now" is always anchored to assistant host clock, while local
-    // date semantics prefer configured user timezone, then profile memory.
+    // date semantics prefer configured user timezone, then recalled memory.
     const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const configuredUserTimeZone = getConfig().ui.userTimezone ?? null;
+    const recalledUserTimeZone = extractUserTimeZoneFromRecall(
+      recall.injectedText,
+    );
     const temporalContext = buildTemporalContext({
       hostTimeZone,
       configuredUserTimeZone,
-      userTimeZone: null,
+      userTimeZone: recalledUserTimeZone,
     });
 
     // Use the channel/interface context captured at the top of this function


### PR DESCRIPTION
## Summary
- Restores the timezone fallback from recalled memory that was lost in the session-memory V2 rewiring (#15873)
- Adds `extractUserTimeZoneFromRecall()` in `date-context.ts` that parses IANA timezone identifiers from V2 recall injected text (prefers `<user_identity>` section, falls back to full text scan)
- Wires it into temporal context building so the resolution chain is restored: explicit override > user settings > recalled memory > host fallback
- Updates stale comment referencing "profile memory" to "recalled memory"

## Test plan
- [x] Added 7 tests for `extractUserTimeZoneFromRecall`: empty input, IANA timezone from identity, `timezone:` line format, UTC offset, fallback to full text, no timezone present, identity preference over other sections
- [x] All 56 date-context tests pass

Addresses review feedback from #15873
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
