### PR TITLE
fix(macos): fix build failure from deleted TextResponseView/BouncingDots refs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/WorkspaceActivityFeed.swift
@@ -40,7 +40,7 @@ struct WorkspaceActivityFeed: View {
                     HStack(alignment: .top, spacing: VSpacing.sm) {
                         assistantAvatar
 
-                        Text(TextResponseView.markdownString(streamingText))
+                        Text(MessageBubbleView.markdownString(streamingText))
                             .font(VFont.body)
                             .foregroundColor(VColor.contentDefault)
                             .textSelection(.enabled)
@@ -59,7 +59,8 @@ struct WorkspaceActivityFeed: View {
                     HStack(alignment: .top, spacing: VSpacing.sm) {
                         assistantAvatar
 
-                        BouncingDots()
+                        ProgressView()
+                            .controlSize(.small)
                             .padding(.horizontal, VSpacing.lg)
                             .padding(.vertical, VSpacing.md)
                             .background(


### PR DESCRIPTION
## Summary
- `WorkspaceActivityFeed.swift` referenced `TextResponseView.markdownString()` and `BouncingDots()`, which were deleted in PR #15990 (dead code cleanup)
- Replace `TextResponseView.markdownString()` with `MessageBubbleView.markdownString()` (exists in shared module)
- Replace `BouncingDots()` with `ProgressView().controlSize(.small)` (native SwiftUI equivalent)

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23026123967

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/15998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
