### PR TITLE
fix(macos): use search match count for search index clamp trigger

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -330,8 +330,8 @@ struct ChatView: View {
             currentMatchIndex = 0
             scrollToCurrentMatch()
         }
-        .onChange(of: messages.count) {
-            // Clamp currentMatchIndex when messages change (e.g. streaming, deletion)
+        .onChange(of: searchMatches.count) {
+            // Clamp currentMatchIndex when matches change (e.g. streaming, deletion)
             // to avoid "4 of 2" display or broken navigation.
             let count = searchMatches.count
             if currentMatchIndex >= count {


### PR DESCRIPTION
## Summary
- Fix search index clamp to trigger on search match changes, not message count
- messages.count doesn't change during streaming (text is mutated in-place)
- Addresses Codex and Devin review feedback from #15967

## Test plan
- [ ] Verify search navigation clamps correctly during streaming
- [ ] Verify search index stays valid when matches change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
