### PR TITLE
fix: reset CU preactivation per queued item in drain loop

### DIFF
--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -227,6 +227,11 @@ export async function drainQueue(
   const next = session.queue.shift();
   if (!next) return;
 
+  // Reset per-turn preactivation so a prior iteration (e.g. an unknown-slash
+  // from a desktop source that skips runAgentLoop) can't leak CU preactivation
+  // into the next queued message.
+  session.preactivatedSkillIds = undefined;
+
   log.info(
     {
       conversationId: session.conversationId,


### PR DESCRIPTION
## Summary
- Clear preactivatedSkillIds at the start of each drain iteration
- Prevents CU preactivation from leaking between queued messages of different source interfaces
- Addresses Codex review feedback from #15968

## Test plan
- [ ] Verify CU preactivation is scoped to desktop messages only
- [ ] Verify non-desktop queued messages don't inherit CU preactivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
