### PR TITLE
fix: apply type-match check to recovered results in history repair

### DIFF
--- a/assistant/src/daemon/history-repair.ts
+++ b/assistant/src/daemon/history-repair.ts
@@ -114,8 +114,10 @@ export function repairHistory(messages: Message[]): RepairResult {
             block.type === "web_search_tool_result"
           ) {
             const tr = block as ToolResultContent | WebSearchToolResultContent;
-            const isTypeMatch = pendingToolUseIds.has(tr.tool_use_id) &&
-              (block.type === "web_search_tool_result") === serverToolUseIds.has(tr.tool_use_id);
+            const isTypeMatch =
+              pendingToolUseIds.has(tr.tool_use_id) &&
+              (block.type === "web_search_tool_result") ===
+                serverToolUseIds.has(tr.tool_use_id);
             if (isTypeMatch) {
               matchedIds.add(tr.tool_use_id);
               newContent.push(block);
@@ -132,7 +134,11 @@ export function repairHistory(messages: Message[]): RepairResult {
         for (const id of pendingToolUseIds) {
           if (!matchedIds.has(id)) {
             const recovered = recoveredResults.get(id);
-            if (recovered) {
+            const isRecoveredTypeMatch =
+              recovered &&
+              (recovered.type === "web_search_tool_result") ===
+                serverToolUseIds.has(id);
+            if (isRecoveredTypeMatch) {
               newContent.push(recovered);
               // Already counted in assistantToolResultsMigrated
             } else {
@@ -221,7 +227,9 @@ function buildResultMessage(
     role: "user",
     content: Array.from(ids).map((id) => {
       const rec = recovered.get(id);
-      if (rec) {
+      const isRecTypeMatch =
+        rec && (rec.type === "web_search_tool_result") === serverIds.has(id);
+      if (isRecTypeMatch) {
         // Already counted in assistantToolResultsMigrated
         return rec;
       }


### PR DESCRIPTION
## Summary
- Apply type-match validation when inserting recovered results from assistant messages
- Ensures tool_result only pairs with tool_use and web_search_tool_result only with server_tool_use
- Addresses Devin review feedback from #15970

## Test plan
- [ ] Verify recovered results are type-checked before insertion
- [ ] Verify mismatched recovered results are dropped, not inserted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
