### PR TITLE
fix: restore per-skill catalog fallback and defer resolution

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -328,7 +328,18 @@ export async function resolveCatalog(): Promise<CatalogSkill[]> {
   const repoSkillsDir = getRepoSkillsDir();
   if (repoSkillsDir) {
     const local = readLocalCatalog(repoSkillsDir);
-    if (local.length > 0) return local;
+    if (local.length > 0) {
+      // Merge with remote catalog so skills not in local catalog.json
+      // can still be found. Local entries take precedence by id.
+      try {
+        const remote = await fetchCatalog();
+        const localIds = new Set(local.map((s) => s.id));
+        return [...local, ...remote.filter((s) => !localIds.has(s.id))];
+      } catch {
+        // If remote fetch fails, fall back to local-only
+        return local;
+      }
+    }
   }
 
   return fetchCatalog();

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -194,23 +194,35 @@ export class SkillLoadTool implements Tool {
       catalogIndex = indexCatalogById(catalog);
 
       // Auto-install missing includes before validation (max 5 rounds for transitive deps)
-      // Pre-fetch catalog once to avoid redundant network requests per dependency
+      // Defer catalog resolution until we confirm there are missing includes,
+      // then cache the result to avoid redundant network requests per dependency.
       let remoteCatalog: Awaited<ReturnType<typeof resolveCatalog>> | undefined;
-      try {
-        remoteCatalog = await resolveCatalog();
-      } catch (err) {
-        log.warn({ err, skillId: skill.id }, "Failed to resolve catalog for include auto-install");
-      }
 
       const MAX_INSTALL_ROUNDS = 5;
       for (let round = 0; round < MAX_INSTALL_ROUNDS; round++) {
         const missing = collectAllMissing(skill.id, catalogIndex);
         if (missing.size === 0) break;
 
+        // Lazily resolve catalog on first round with missing includes
+        if (!remoteCatalog) {
+          try {
+            remoteCatalog = await resolveCatalog();
+          } catch (err) {
+            log.warn(
+              { err, skillId: skill.id },
+              "Failed to resolve catalog for include auto-install",
+            );
+            break;
+          }
+        }
+
         let installedAny = false;
         for (const missingId of missing) {
           try {
-            const installed = await autoInstallFromCatalog(missingId, remoteCatalog);
+            const installed = await autoInstallFromCatalog(
+              missingId,
+              remoteCatalog,
+            );
             if (installed) {
               log.info(
                 { skillId: missingId, parentSkillId: skill.id },


### PR DESCRIPTION
## Summary
- Restore per-skill local→remote fallback in dev mode for resolveCatalog()
- Defer catalog resolution until after confirming there are missing includes
- Addresses Codex and Devin review feedback from #15969

## Test plan
- [ ] Verify skills in remote but not local catalog are still found in dev mode
- [ ] Verify no network calls when all includes are already installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
