### PR TITLE
fix(docs): update CLAUDE.md VColor token reference to surfaceBase

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -168,7 +168,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 <summary><strong>Token reference</strong></summary>
 
 **VColor** — Semantic color tokens mapped to Tailwind-style scales (Slate, Violet, Emerald, Rose, Amber, Indigo):
-- Backgrounds: `background` (Slate._950), `backgroundSubtle` (Slate._800), `surface` (Slate._800), `surfaceBorder` (Slate._700)
+- Backgrounds: `surfaceBase` (Slate._950), `backgroundSubtle` (Slate._800), `surface` (Slate._800), `surfaceBorder` (Slate._700)
 - Text: `textPrimary` (Slate._50), `textSecondary` (Slate._400), `textMuted` (Slate._500)
 - Accent: `accent` (Violet._600), `accentSubtle` (Violet._100)
 - Status: `success` (Emerald._600), `error` (Rose._600), `warning` (Amber._600)


### PR DESCRIPTION
## Summary
- Replace stale VColor.background reference with VColor.surfaceBase in macOS CLAUDE.md
- VColor.background was removed during design token migration
- Addresses Devin review feedback from #15977

## Test plan
- [ ] Verify CLAUDE.md VColor section matches actual available tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
