### PR TITLE
fix: add type guard for tool field and sanitize __internal: rules on load

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -283,12 +283,28 @@ function loadFromDisk(): TrustRule[] {
       // Restore persisted starter bundle flag
       cachedStarterBundleAccepted = data.starterBundleAccepted === true;
 
+      // Defense-in-depth: strip any __internal: prefixed rules that may have
+      // been hand-edited into trust.json.
+      const sanitizedRules = rawRules.filter((r) => {
+        if (typeof r.tool === "string" && r.tool.startsWith("__internal:")) {
+          log.warn(
+            { ruleId: r.id, tool: r.tool },
+            "Stripping __internal: rule from trust file on load",
+          );
+          return false;
+        }
+        return true;
+      });
+
       if (
         data.version === TRUST_FILE_VERSION ||
         data.version === 1 ||
         data.version === 2
       ) {
-        rules = rawRules;
+        rules = sanitizedRules;
+        if (sanitizedRules.length < rawRules.length) {
+          needsSave = true;
+        }
         if (data.version !== TRUST_FILE_VERSION) {
           needsSave = true;
           log.info(

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -131,7 +131,7 @@ export async function handleUpdateTrustRuleManage(
     priority?: number;
   };
 
-  if (body.tool?.startsWith("__internal:")) {
+  if (typeof body.tool === "string" && body.tool.startsWith("__internal:")) {
     return httpError(
       "BAD_REQUEST",
       "tool must not start with __internal:",


### PR DESCRIPTION
## Summary
- Add typeof check before startsWith in PATCH handler to prevent TypeError on non-string tool values
- Filter out __internal: prefixed rules in loadFromDisk for defense-in-depth
- Addresses Codex and Devin review feedback from #15975

## Test plan
- [ ] Verify non-string tool values don't throw in PATCH handler
- [ ] Verify __internal: rules in trust.json are stripped on load
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
