### PR TITLE
fix(test): remove duplicate const now in memory benchmark test

### DIFF
--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -281,7 +281,6 @@ describe("Memory context benchmark", () => {
 
     // Seed Qdrant mock with a representative decision segment so
     // the benchmark validates content quality, not just pipeline completion.
-    const now = 1_700_500_000_000;
     mockQdrantResults = [
       {
         id: "emb-bench-decision",


### PR DESCRIPTION
## Summary
- Remove duplicate `const now` declaration in memory-context-benchmark.benchmark.test.ts
- The duplicate caused a SyntaxError at runtime
- Addresses Devin review feedback from #15992

## Test plan
- [x] Verify test file parses without SyntaxError
- [x] Verify benchmark test runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
