### PR TITLE
fix(macos): add .if() modifier to design system gallery catalog

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -174,6 +174,42 @@ struct ModifiersGallerySection: View {
                     )
                 }
             }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+            // MARK: - .if()
+            GallerySectionHeader(
+                title: ".if(_:transform:)",
+                description: "Conditionally applies a transformation to a view. When the condition is true, the transform closure is applied; otherwise the view is returned unchanged."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("condition = true (bold applied)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+
+                    Text("Hello, world!")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                        .if(true) { view in
+                            view.bold()
+                        }
+
+                    Divider().background(VColor.borderBase)
+
+                    Text("condition = false (no change)")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+
+                    Text("Hello, world!")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                        .if(false) { view in
+                            view.bold()
+                        }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add .if() conditional modifier to ModifiersGallerySection.swift
- Follows mandatory gallery catalog rule for new design system modifiers
- Addresses Devin review feedback from #15993

## Test plan
- [ ] Verify gallery section renders the new modifier entry
- [ ] Verify the gallery catalog includes all design system modifiers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
