### PR TITLE
fix(test): remove duplicate DELETE FROM memory_summaries in beforeEach

### DIFF
--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -101,7 +101,6 @@ describe("Memory regressions (experimental)", () => {
 
     db.run("DELETE FROM memory_summaries");
     db.run("DELETE FROM memory_segments");
-    db.run("DELETE FROM memory_summaries");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     db.run("DELETE FROM memory_jobs");


### PR DESCRIPTION
## Summary
- Remove duplicate DELETE FROM memory_summaries in test beforeEach cleanup
- The PR added one occurrence but the second already existed
- Addresses Devin review feedback from #15995

## Test plan
- [ ] Verify test cleanup still works with single DELETE statement
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
