### PR TITLE
fix(memory): bump sparse embedding version to trigger re-indexing

### DIFF
--- a/assistant/src/cli/commands/sessions.ts
+++ b/assistant/src/cli/commands/sessions.ts
@@ -12,7 +12,10 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { listConversations } from "../../memory/conversation-queries.js";
-import { selectEmbeddingBackend } from "../../memory/embedding-backend.js";
+import {
+  selectEmbeddingBackend,
+  SPARSE_EMBEDDING_VERSION,
+} from "../../memory/embedding-backend.js";
 import { initQdrantClient } from "../../memory/qdrant-client.js";
 import { timeAgo } from "../../util/time.js";
 import { initializeDb } from "../db.js";
@@ -226,7 +229,7 @@ Examples:
       const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
       const embeddingSelection = selectEmbeddingBackend(config);
       const embeddingModel = embeddingSelection.backend
-        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
+        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
         : undefined;
       const qdrant = initQdrantClient({
         url: qdrantUrl,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -33,7 +33,10 @@ import {
   getMessages,
 } from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db.js";
-import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
+import {
+  selectEmbeddingBackend,
+  SPARSE_EMBEDDING_VERSION,
+} from "../memory/embedding-backend.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
@@ -319,7 +322,7 @@ export async function runDaemon(): Promise<void> {
       await qdrantManager.start();
       const embeddingSelection = selectEmbeddingBackend(config);
       const embeddingModel = embeddingSelection.backend
-        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
+        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
         : undefined;
       const qdrantClient = initQdrantClient({
         url: qdrantUrl,
@@ -337,9 +340,7 @@ export async function runDaemon(): Promise<void> {
       const { migrated } = await qdrantClient.ensureCollection();
       if (migrated) {
         enqueueMemoryJob("rebuild_index", {});
-        log.info(
-          "Qdrant collection was migrated — enqueued rebuild_index job",
-        );
+        log.info("Qdrant collection was migrated — enqueued rebuild_index job");
       }
 
       log.info("Qdrant vector store initialized");

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -626,6 +626,13 @@ function isOllamaConfigured(config: AssistantConfig): boolean {
 
 const SPARSE_VOCAB_SIZE = 30_000;
 
+/**
+ * Bump this version whenever the sparse embedding algorithm changes
+ * (e.g. hash function fix, tokenizer change) to trigger re-indexing
+ * of existing sparse vectors via the sentinel mismatch mechanism.
+ */
+export const SPARSE_EMBEDDING_VERSION = 2;
+
 /** Tokenize text into lowercase alphanumeric tokens (Unicode-aware). */
 function tokenize(text: string): string[] {
   return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];


### PR DESCRIPTION
## Summary
- Add `SPARSE_EMBEDDING_VERSION` constant (set to 2) to `embedding-backend.ts`
- Append `:sparse-v{N}` to the embedding model sentinel string in both `lifecycle.ts` and `sessions.ts`
- On next startup, the sentinel mismatch triggers collection recreation and `rebuild_index` job, re-embedding all memory items with the corrected FNV-1a hash
- Addresses Devin review feedback from #15973

## Test plan
- [ ] Verify version bump triggers re-indexing of existing sparse vectors on daemon startup
- [ ] Verify new sparse vectors use correct FNV-1a hash indices
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
