### PR TITLE
fix(memory): restore top-candidate cap in recall debug output

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -460,14 +460,16 @@ export async function buildMemoryRecall(
       .length,
   };
 
-  const topCandidates: MemoryRecallCandiateDebug[] = afterDemotion.map((c) => ({
-    key: c.key,
-    type: c.type,
-    kind: c.kind,
-    finalScore: c.finalScore,
-    semantic: c.semantic,
-    recency: c.recency,
-  }));
+  const topCandidates: MemoryRecallCandiateDebug[] = afterDemotion
+    .slice(0, 10)
+    .map((c) => ({
+      key: c.key,
+      type: c.type,
+      kind: c.kind,
+      finalScore: c.finalScore,
+      semantic: c.semantic,
+      recency: c.recency,
+    }));
 
   const latencyMs = Date.now() - start;
 


### PR DESCRIPTION
## Summary
- Restore .slice(0, 10) cap on topCandidates debug array in retriever.ts
- Prevents oversized debug payloads in large recall sets
- Addresses Codex review feedback from #15996

## Test plan
- [ ] Verify topCandidates is capped at 10 entries in debug output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
