### PR TITLE
fix: prevent preflight bypass via empty required_tools snapshot

### DIFF
--- a/assistant/src/runtime/routes/work-items-routes.test.ts
+++ b/assistant/src/runtime/routes/work-items-routes.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for work-items-routes security fix:
+ * empty `required_tools` snapshot must fall back to task template tools,
+ * not bypass the preflight approval dialog.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "work-items-routes-test-"));
+
+mock.module("../../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../permissions/checker.js", () => ({
+  check: async () => ({ decision: "prompt" }),
+  classifyRisk: async () => "medium",
+}));
+
+import { getDb, initializeDb, resetDb } from "../../memory/db.js";
+import { createTask } from "../../tasks/task-store.js";
+import { createWorkItem } from "../../work-items/work-item-store.js";
+import type { RouteContext } from "../http-router.js";
+import {
+  preflightWorkItem,
+  workItemRouteDefinitions,
+} from "./work-items-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+beforeEach(() => {
+  const db = (getDb() as unknown as { $client: { run: (sql: string) => void } })
+    .$client;
+  db.run("DELETE FROM work_items");
+  db.run("DELETE FROM tasks");
+});
+
+// ── resolveRequiredTools via preflightWorkItem ───────────────────────────────
+
+describe("preflight: empty snapshot falls back to task required tools", () => {
+  test("returns the task's required tools when work-item snapshot is empty []", async () => {
+    const task = createTask({
+      title: "Test task",
+      template: "Do something",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Test work item",
+      // Empty array snapshot — the bug: this used to short-circuit to []
+      requiredTools: JSON.stringify([]),
+    });
+
+    const result = await preflightWorkItem(workItem.id);
+
+    expect(result.success).toBe(true);
+    expect(result.permissions).toBeDefined();
+    expect(result.permissions!.length).toBe(1);
+    expect(result.permissions![0].tool).toBe("host_bash");
+  });
+});
+
+// ── run handler: 403 when snapshot is empty and task tools unapproved ────────
+
+describe("run handler: 403 when empty snapshot and task tools unapproved", () => {
+  test("returns 403 FORBIDDEN when work-item has empty required_tools and no approvals", async () => {
+    const task = createTask({
+      title: "Test task",
+      template: "Do something",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Test work item",
+      requiredTools: JSON.stringify([]),
+    });
+
+    const routes = workItemRouteDefinitions();
+    const runRoute = routes.find(
+      (r) => r.endpoint === "work-items/:id/run" && r.method === "POST",
+    );
+
+    expect(runRoute).toBeDefined();
+
+    const mockReq = new Request(
+      "http://localhost/v1/work-items/" + workItem.id + "/run",
+      {
+        method: "POST",
+      },
+    );
+
+    const response = await runRoute!.handler({
+      req: mockReq,
+      params: { id: workItem.id },
+      url: new URL(mockReq.url),
+    } as unknown as RouteContext);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -24,6 +24,7 @@ import {
   getWorkItem,
   listWorkItems,
   updateWorkItem,
+  type WorkItem,
   type WorkItemStatus,
 } from "../../work-items/work-item-store.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -61,6 +62,24 @@ function broadcastWorkItemStatus(id: string): void {
       },
     });
   }
+}
+
+function resolveRequiredTools(
+  workItem: WorkItem,
+  taskRequiredTools: string[],
+): string[] {
+  if (workItem.requiredTools == null) {
+    return taskRequiredTools;
+  }
+
+  const snapshotTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+  if (snapshotTools.length > 0) {
+    return snapshotTools;
+  }
+
+  // Empty snapshot falls back to task template — an explicit [] does not
+  // mean "no tools"; it means the snapshot hasn't constrained the tool set.
+  return taskRequiredTools;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,21 +340,18 @@ export async function preflightWorkItem(
     return { success: false, error: "Work item not found" };
   }
 
-  let requiredTools: string[];
-  if (workItem.requiredTools != null) {
-    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-  } else {
-    const task = getTask(workItem.taskId);
-    if (!task) {
-      return {
-        success: false,
-        error: `Associated task not found: ${workItem.taskId}`,
-      };
-    }
-    requiredTools = task.requiredTools
-      ? sanitizeToolList(JSON.parse(task.requiredTools))
-      : getRegisteredToolNames();
+  const task = getTask(workItem.taskId);
+  if (!task) {
+    return {
+      success: false,
+      error: `Associated task not found: ${workItem.taskId}`,
+    };
   }
+
+  const taskRequiredTools = task.requiredTools
+    ? sanitizeToolList(JSON.parse(task.requiredTools))
+    : getRegisteredToolNames();
+  let requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
   if (requiredTools.length === 0) {
     return { success: true, permissions: [] };
@@ -648,15 +664,11 @@ export function workItemRouteDefinitions(
           );
         }
 
-        // Compute required tools
-        let requiredTools: string[];
-        if (workItem.requiredTools != null) {
-          requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-        } else {
-          requiredTools = task.requiredTools
-            ? sanitizeToolList(JSON.parse(task.requiredTools))
-            : getRegisteredToolNames();
-        }
+        // Compute required tools — empty snapshot falls back to task template
+        const taskRequiredTools = task.requiredTools
+          ? sanitizeToolList(JSON.parse(task.requiredTools))
+          : getRegisteredToolNames();
+        const requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
         // Permission checkpoint
         let approvedTools: string[] | undefined;

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -117,14 +117,19 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
     };
   }
 
-  // Resolve required tools
+  // Resolve required tools — empty snapshot falls back to task template.
+  // An explicit [] does not mean "no tools"; it means the snapshot hasn't
+  // constrained the tool set, so we fall back to the task template's tools.
+  const taskRequiredTools = task.requiredTools
+    ? sanitizeToolList(JSON.parse(task.requiredTools))
+    : getRegisteredToolNames();
   let requiredTools: string[];
-  if (workItem.requiredTools != null) {
-    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+  if (workItem.requiredTools == null) {
+    requiredTools = taskRequiredTools;
   } else {
-    requiredTools = task.requiredTools
-      ? sanitizeToolList(JSON.parse(task.requiredTools))
-      : getRegisteredToolNames();
+    const snapshotTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+    requiredTools =
+      snapshotTools.length > 0 ? snapshotTools : taskRequiredTools;
   }
 
   // Auto-approve all required tools for chat-initiated runs.


### PR DESCRIPTION
## Summary

- An explicit `required_tools: []` on a work item caused preflight to skip the approval dialog entirely, then runTask fell back to the task template's required tools and built ephemeral allow rules the user never approved (Codex finding 92d2aa34cd908191a30e0b593891162e)
- Add `resolveRequiredTools` helper that treats an empty snapshot the same as a null snapshot — both fall back to the task template's required tools, ensuring preflight always surfaces the correct tools for approval
- Update both `preflightWorkItem` and the run handler's permission checkpoint to use the new helper consistently

## Original prompt
Fix privilege escalation: empty required_tools snapshot bypasses work item preflight approval. Codex finding 92d2aa34cd908191a30e0b593891162e (high severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
