### PR TITLE
fix(security): add diagnostic logging for broker set failures

### DIFF
--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -264,7 +264,7 @@ describe("keychain-broker-client", () => {
 
       const client = createBrokerClient();
       const result = await client.set("my-key", "new-value");
-      expect(result).toBe(true);
+      expect(result).toEqual({ status: "ok" });
     });
 
     test("del returns true on success", async () => {
@@ -434,11 +434,11 @@ describe("keychain-broker-client", () => {
       expect(result).toBeNull();
     });
 
-    test("set returns false when socket file does not exist", async () => {
+    test("set returns unreachable when socket file does not exist", async () => {
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.set("test-key", "value");
-      expect(result).toBe(false);
+      expect(result).toEqual({ status: "unreachable" });
     });
 
     test("del returns false when socket file does not exist", async () => {
@@ -470,7 +470,7 @@ describe("keychain-broker-client", () => {
       }
       const client = createBrokerClient();
       expect(await client.get("key")).toBeNull();
-      expect(await client.set("key", "val")).toBe(false);
+      expect(await client.set("key", "val")).toEqual({ status: "unreachable" });
       expect(await client.del("key")).toBe(false);
       expect(await client.list()).toEqual([]);
       expect(await client.ping()).toBeNull();

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -46,9 +46,14 @@ mock.module("../security/keychain-broker-client.js", () => ({
       return { found: false };
     },
     set: async (account: string, value: string) => {
-      if (mockBrokerSetError) return false;
+      if (mockBrokerSetError)
+        return {
+          status: "rejected" as const,
+          code: "KEYCHAIN_ERROR",
+          message: "mock error",
+        };
       mockBrokerStore.set(account, value);
-      return true;
+      return { status: "ok" as const };
     },
     del: async (account: string) => {
       if (mockBrokerDelError) return false;

--- a/assistant/src/security/keychain-broker-client.ts
+++ b/assistant/src/security/keychain-broker-client.ts
@@ -33,11 +33,18 @@ const REQUEST_TIMEOUT_MS = 5_000;
  *  back); `{ found: false }` means the key doesn't exist in the keychain. */
 export type BrokerGetResult = { found: boolean; value?: string } | null;
 
+/** Result of a `set()` call — distinguishes broker-unreachable from an active
+ *  rejection so callers can log meaningful diagnostics. */
+export type BrokerSetResult =
+  | { status: "ok" }
+  | { status: "unreachable" }
+  | { status: "rejected"; code: string; message: string };
+
 export interface KeychainBrokerClient {
   isAvailable(): boolean;
   ping(): Promise<{ pong: boolean } | null>;
   get(account: string): Promise<BrokerGetResult>;
-  set(account: string, value: string): Promise<boolean>;
+  set(account: string, value: string): Promise<BrokerSetResult>;
   del(account: string): Promise<boolean>;
   list(): Promise<string[]>;
 }
@@ -360,12 +367,18 @@ export function createBrokerClient(): KeychainBrokerClient {
       }
     },
 
-    async set(account: string, value: string): Promise<boolean> {
+    async set(account: string, value: string): Promise<BrokerSetResult> {
       try {
         const response = await doRequest("key.set", { account, value });
-        return response?.ok === true;
+        if (!response) return { status: "unreachable" };
+        if (response.ok) return { status: "ok" };
+        return {
+          status: "rejected",
+          code: response.error?.code ?? "UNKNOWN",
+          message: response.error?.message ?? "unknown error",
+        };
       } catch {
-        return false;
+        return { status: "unreachable" };
       }
     },
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -7,9 +7,12 @@
  * encrypted store (startup code paths cannot do async I/O).
  */
 
+import { getLogger } from "../util/logger.js";
 import * as encryptedStore from "./encrypted-store.js";
 import type { KeychainBrokerClient } from "./keychain-broker-client.js";
 import { createBrokerClient } from "./keychain-broker-client.js";
+
+const log = getLogger("secure-keys");
 
 let _broker: KeychainBrokerClient | undefined;
 
@@ -120,13 +123,32 @@ export async function setSecureKeyAsync(
 ): Promise<boolean> {
   const broker = getBroker();
   if (broker.isAvailable()) {
-    const brokerOk = await broker.set(account, value);
-    if (!brokerOk) return false;
+    const result = await broker.set(account, value);
+    if (result.status !== "ok") {
+      log.warn(
+        {
+          account,
+          brokerStatus: result.status,
+          ...(result.status === "rejected"
+            ? { brokerCode: result.code, brokerMessage: result.message }
+            : {}),
+        },
+        "Broker set failed for secure key",
+      );
+      return false;
+    }
     // Broker succeeded — also persist to encrypted store for sync callers.
     const encOk = encryptedStore.setKey(account, value);
+    if (!encOk) {
+      log.warn({ account }, "Encrypted store set failed after broker success");
+    }
     return encOk;
   }
-  return encryptedStore.setKey(account, value);
+  const encOk = encryptedStore.setKey(account, value);
+  if (!encOk) {
+    log.warn({ account }, "Encrypted store set failed (broker unavailable)");
+  }
+  return encOk;
 }
 
 /**

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
@@ -293,10 +293,11 @@ final class KeychainBrokerServer {
                 sendError(id: request.id, code: "INVALID_REQUEST", message: "Missing 'account' or 'value' param", on: conn)
                 return
             }
-            if KeychainBrokerService.set(account: account, value: value) {
+            let setStatus = KeychainBrokerService.set(account: account, value: value)
+            if setStatus == errSecSuccess {
                 sendSuccess(id: request.id, result: SetResult(stored: true), on: conn)
             } else {
-                sendError(id: request.id, code: "KEYCHAIN_ERROR", message: "SecItemAdd failed", on: conn)
+                sendError(id: request.id, code: "KEYCHAIN_ERROR", message: "Keychain set failed (OSStatus \(setStatus))", on: conn)
             }
 
         case "key.delete":

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
@@ -1,6 +1,12 @@
 #if os(macOS)
 import Foundation
+import os
 import Security
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "KeychainBrokerService"
+)
 
 /// SecItem wrapper that performs keychain CRUD operations scoped to the
 /// `vellum-assistant` service. All methods are synchronous and thread-safe
@@ -40,9 +46,11 @@ enum KeychainBrokerService {
     /// Store a UTF-8 string value for a given account. Uses update-first
     /// with add-fallback so a transient add failure never erases an existing
     /// secret (unlike the previous delete-then-add approach).
+    ///
+    /// Returns `errSecSuccess` on success, or the failing `OSStatus` code.
     @discardableResult
-    static func set(account: String, value: String) -> Bool {
-        guard let data = value.data(using: .utf8) else { return false }
+    static func set(account: String, value: String) -> OSStatus {
+        guard let data = value.data(using: .utf8) else { return errSecParam }
 
         // Try to update an existing item first.
         let query: [String: Any] = [
@@ -57,7 +65,7 @@ enum KeychainBrokerService {
         let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
 
         if updateStatus == errSecSuccess {
-            return true
+            return errSecSuccess
         }
 
         // Item doesn't exist yet — add it.
@@ -70,10 +78,14 @@ enum KeychainBrokerService {
                 kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             ]
             let addStatus = SecItemAdd(addAttributes as CFDictionary, nil)
-            return addStatus == errSecSuccess
+            if addStatus != errSecSuccess {
+                log.error("SecItemAdd failed for account \(account, privacy: .public): OSStatus \(addStatus)")
+            }
+            return addStatus
         }
 
-        return false
+        log.error("SecItemUpdate failed for account \(account, privacy: .public): OSStatus \(updateStatus)")
+        return updateStatus
     }
 
     // MARK: - Delete

--- a/clients/macos/vellum-assistant/Security/KeychainCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainCredentialStorage.swift
@@ -9,7 +9,7 @@ struct KeychainCredentialStorage: CredentialStorage {
         KeychainBrokerService.get(account: account)
     }
     func set(account: String, value: String) -> Bool {
-        KeychainBrokerService.set(account: account, value: value)
+        KeychainBrokerService.set(account: account, value: value) == errSecSuccess
     }
     func delete(account: String) -> Bool {
         KeychainBrokerService.delete(account: account)


### PR DESCRIPTION
## Summary
- Changed `broker.set()` return type from `boolean` to a discriminated `BrokerSetResult` union (`ok` | `unreachable` | `rejected`) so callers can distinguish socket-dead from keychain-rejected failures
- Added warn-level logging in `setSecureKeyAsync` for both broker and encrypted store failure paths, including the broker error code/message when available
- Changed Swift `KeychainBrokerService.set()` to return raw `OSStatus` instead of `Bool`, and the broker server now includes the status code in error responses (e.g. `"Keychain set failed (OSStatus -25293)"` instead of generic `"SecItemAdd failed"`)

## Original prompt
Improve broker.set() error reporting and add diagnostic logging for secure key storage failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
