### PR TITLE
fix: use localhost for Docker hatch runtimeUrl instead of mDNS hostname

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -7,7 +7,6 @@ import { saveAssistantEntry, setActiveAssistant } from "./assistant-config";
 import type { AssistantEntry } from "./assistant-config";
 import { DEFAULT_GATEWAY_PORT } from "./constants";
 import type { Species } from "./constants";
-import { discoverPublicUrl } from "./local";
 import { generateRandomSuffix } from "./random-name";
 import { exec, execOutput } from "./step-runner";
 import {
@@ -326,8 +325,10 @@ export async function hatchDocker(
     );
   }
 
-  const publicUrl = await discoverPublicUrl(gatewayPort);
-  const runtimeUrl = publicUrl || `http://localhost:${gatewayPort}`;
+  // Docker containers bind to 0.0.0.0 so localhost always works. Skip
+  // mDNS/LAN discovery — the .local hostname often fails to resolve on the
+  // host machine itself (mDNS is designed for cross-device discovery).
+  const runtimeUrl = `http://localhost:${gatewayPort}`;
   const dockerEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,


### PR DESCRIPTION
## Summary

- Docker hatches previously used `discoverPublicUrl()` which on macOS returns a `.local` mDNS hostname (e.g. `Harrisons-MacBook-Pro.local`). This hostname often fails to resolve on the host machine itself, causing the app and `vellum ps` health checks to time out even though the container is running fine.
- Docker containers bind to `0.0.0.0`, so `localhost` is always correct. Skips mDNS/LAN discovery entirely for Docker hatches.

## Test plan

- [ ] `vellum hatch --remote docker` and verify `~/.vellum.lock.json` has `runtimeUrl: "http://localhost:<port>"` instead of a `.local` hostname
- [ ] `vellum ps` shows the Docker assistant as healthy
- [ ] macOS app connects successfully to the Docker-hatched assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
