### PR TITLE
feat(oauth): add client-id filtering to connection commands and invert connect defaults

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -114,6 +114,12 @@ mock.module("../oauth/oauth-store.js", () => {
   return {
     disconnectOAuthProvider: mockDisconnectOAuthProvider,
     getConnectionByProvider: (service: string) => mockConnections.get(service),
+    getConnection: (id: string) => {
+      for (const conn of mockConnections.values()) {
+        if (conn.id === id) return conn;
+      }
+      return undefined;
+    },
     getApp: (id: string) => mockApps.get(id),
     getProvider: (key: string) => mockProviders.get(key),
     updateConnection: () => {},

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -728,7 +728,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     });
   });
 
-  test("returns auth URL in url-only mode (JSON)", async () => {
+  test("returns auth URL in default (non-interactive) mode (JSON)", async () => {
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: true,
@@ -743,7 +743,6 @@ describe("assistant oauth connections connect <provider-key>", () => {
       "integration:gmail",
       "--client-id",
       "test-id",
-      "--url-only",
       "--json",
     ]);
     expect(exitCode).toBe(0);

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -86,10 +86,14 @@ token expiry, refresh token availability, account info, and status.
 Examples:
   $ assistant oauth connections list
   $ assistant oauth connections list --provider integration:gmail
+  $ assistant oauth connections list --client-id abc123
   $ assistant oauth connections get --id <uuid>
   $ assistant oauth connections get --provider integration:gmail
+  $ assistant oauth connections get --provider integration:gmail --client-id abc123
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections ping integration:gmail`,
+  $ assistant oauth connections ping integration:gmail
+  $ assistant oauth connections connect integration:gmail
+  $ assistant oauth connections connect integration:gmail --open-browser`,
   );
 
   // ---------------------------------------------------------------------------
@@ -103,21 +107,25 @@ Examples:
       "--provider <key>",
       "Filter by provider key (e.g. integration:gmail)",
     )
+    .option("--client-id <id>", "Filter by OAuth client ID")
     .addHelpText(
       "after",
       `
-Lists all OAuth connections, optionally filtered by provider key.
+Lists all OAuth connections, optionally filtered by provider key and/or client ID.
 
 Each connection shows its ID, provider, account info, granted scopes, token
 expiry, refresh token availability, and status.
 
 Examples:
   $ assistant oauth connections list
-  $ assistant oauth connections list --provider integration:gmail`,
+  $ assistant oauth connections list --provider integration:gmail
+  $ assistant oauth connections list --client-id abc123`,
     )
-    .action((opts: { provider?: string }, cmd: Command) => {
+    .action((opts: { provider?: string; clientId?: string }, cmd: Command) => {
       try {
-        const rows = listConnections(opts.provider).map(formatConnectionRow);
+        const rows = listConnections(opts.provider, opts.clientId).map(
+          formatConnectionRow,
+        );
 
         if (!shouldOutputJson(cmd)) {
           log.info(`Found ${rows.length} connection(s)`);
@@ -143,6 +151,10 @@ Examples:
       "--provider <key>",
       "Provider key (returns most recent active connection)",
     )
+    .option(
+      "--client-id <id>",
+      "Filter by OAuth client ID (used with --provider)",
+    )
     .addHelpText(
       "after",
       `
@@ -153,39 +165,45 @@ Two lookup modes are supported:
 
   2. By provider (returns the most recent active connection):
      $ assistant oauth connections get --provider integration:gmail
+     $ assistant oauth connections get --provider integration:gmail --client-id abc123
 
 At least --id or --provider must be specified.`,
     )
-    .action((opts: { id?: string; provider?: string }, cmd: Command) => {
-      try {
-        let row;
+    .action(
+      (
+        opts: { id?: string; provider?: string; clientId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          let row;
 
-        if (opts.id) {
-          row = getConnection(opts.id);
-        } else if (opts.provider) {
-          row = getConnectionByProvider(opts.provider);
-        } else {
-          writeOutput(cmd, {
-            ok: false,
-            error: "Provide --id or --provider",
-          });
+          if (opts.id) {
+            row = getConnection(opts.id);
+          } else if (opts.provider) {
+            row = getConnectionByProvider(opts.provider, opts.clientId);
+          } else {
+            writeOutput(cmd, {
+              ok: false,
+              error: "Provide --id or --provider",
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          if (!row) {
+            writeOutput(cmd, { ok: false, error: "Connection not found" });
+            process.exitCode = 1;
+            return;
+          }
+
+          writeOutput(cmd, formatConnectionRow(row));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
           process.exitCode = 1;
-          return;
         }
-
-        if (!row) {
-          writeOutput(cmd, { ok: false, error: "Connection not found" });
-          process.exitCode = 1;
-          return;
-        }
-
-        writeOutput(cmd, formatConnectionRow(row));
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // connections token <provider-key>
@@ -195,6 +213,10 @@ At least --id or --provider must be specified.`,
     .command("token <provider-key>")
     .description(
       "Print a valid OAuth access token for a provider, refreshing if expired",
+    )
+    .option(
+      "--client-id <id>",
+      "Filter by OAuth client ID when multiple apps exist for the provider",
     )
     .addHelpText(
       "after",
@@ -212,22 +234,33 @@ Exits with code 1 if no access token exists or refresh fails.
 
 Examples:
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections token integration:gmail --json`,
+  $ assistant oauth connections token integration:gmail --json
+  $ assistant oauth connections token integration:gmail --client-id abc123`,
     )
-    .action(async (providerKey: string, _opts: unknown, cmd: Command) => {
-      try {
-        const token = await withValidToken(providerKey, async (t) => t);
-        if (shouldOutputJson(cmd)) {
-          writeOutput(cmd, { ok: true, token });
-        } else {
-          process.stdout.write(token + "\n");
+    .action(
+      async (
+        providerKey: string,
+        opts: { clientId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          const token = await withValidToken(
+            providerKey,
+            async (t) => t,
+            opts.clientId,
+          );
+          if (shouldOutputJson(cmd)) {
+            writeOutput(cmd, { ok: true, token });
+          } else {
+            process.stdout.write(token + "\n");
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // connections ping <provider-key>
@@ -237,6 +270,10 @@ Examples:
     .command("ping <provider-key>")
     .description(
       "Verify that a stored OAuth token is still valid by hitting the provider's health-check endpoint",
+    )
+    .option(
+      "--client-id <id>",
+      "Filter by OAuth client ID when multiple apps exist for the provider",
     )
     .addHelpText(
       "after",
@@ -252,69 +289,80 @@ If no ping URL is configured for the provider, exits with an error.
 
 Examples:
   $ assistant oauth connections ping integration:gmail
-  $ assistant oauth connections ping integration:twitter --json`,
+  $ assistant oauth connections ping integration:twitter --json
+  $ assistant oauth connections ping integration:gmail --client-id abc123`,
     )
-    .action(async (providerKey: string, _opts: unknown, cmd: Command) => {
-      try {
-        const provider = getProvider(providerKey);
-        if (!provider) {
-          writeOutput(cmd, {
-            ok: false,
-            error: `Provider not found: ${providerKey}`,
-          });
-          process.exitCode = 1;
-          return;
-        }
-
-        if (!provider.pingUrl) {
-          writeOutput(cmd, {
-            ok: false,
-            error: `No ping URL configured for "${providerKey}"`,
-          });
-          process.exitCode = 1;
-          return;
-        }
-
-        const pingUrl = provider.pingUrl;
-
-        const result = await withValidToken(providerKey, async (token) => {
-          const res = await fetch(pingUrl, {
-            method: "GET",
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          return { status: res.status, ok: res.ok };
-        });
-
-        if (result.ok) {
-          if (shouldOutputJson(cmd)) {
+    .action(
+      async (
+        providerKey: string,
+        opts: { clientId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          const provider = getProvider(providerKey);
+          if (!provider) {
             writeOutput(cmd, {
-              ok: true,
-              provider: providerKey,
-              status: result.status,
+              ok: false,
+              error: `Provider not found: ${providerKey}`,
             });
-          } else {
-            log.info(`${providerKey}: OK (HTTP ${result.status})`);
-            writeOutput(cmd, {
-              ok: true,
-              provider: providerKey,
-              status: result.status,
-            });
+            process.exitCode = 1;
+            return;
           }
-        } else {
-          writeOutput(cmd, {
-            ok: false,
-            provider: providerKey,
-            status: result.status,
-            error: `Ping failed with HTTP ${result.status}`,
-          });
+
+          if (!provider.pingUrl) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `No ping URL configured for "${providerKey}"`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          const pingUrl = provider.pingUrl;
+
+          const result = await withValidToken(
+            providerKey,
+            async (token) => {
+              const res = await fetch(pingUrl, {
+                method: "GET",
+                headers: { Authorization: `Bearer ${token}` },
+              });
+              return { status: res.status, ok: res.ok };
+            },
+            opts.clientId,
+          );
+
+          if (result.ok) {
+            if (shouldOutputJson(cmd)) {
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                status: result.status,
+              });
+            } else {
+              log.info(`${providerKey}: OK (HTTP ${result.status})`);
+              writeOutput(cmd, {
+                ok: true,
+                provider: providerKey,
+                status: result.status,
+              });
+            }
+          } else {
+            writeOutput(cmd, {
+              ok: false,
+              provider: providerKey,
+              status: result.status,
+              error: `Ping failed with HTTP ${result.status}`,
+            });
+            process.exitCode = 1;
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
           process.exitCode = 1;
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // connections disconnect <provider-key>
@@ -324,6 +372,10 @@ Examples:
     .command("disconnect <provider-key>")
     .description(
       "Disconnect an OAuth integration and remove all associated credentials",
+    )
+    .option(
+      "--client-id <id>",
+      "Filter by OAuth client ID when multiple apps exist for the provider",
     )
     .addHelpText(
       "after",
@@ -340,62 +392,72 @@ client_id, client_secret) are also cleaned up if present.
 
 Examples:
   $ assistant oauth connections disconnect integration:gmail
-  $ assistant oauth connections disconnect integration:slack`,
+  $ assistant oauth connections disconnect integration:slack
+  $ assistant oauth connections disconnect integration:gmail --client-id abc123`,
     )
-    .action(async (providerKey: string, _opts: unknown, cmd: Command) => {
-      try {
-        assertMetadataWritable();
+    .action(
+      async (
+        providerKey: string,
+        opts: { clientId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          assertMetadataWritable();
 
-        let cleanedUp = false;
+          let cleanedUp = false;
 
-        // 1. Disconnect the OAuth connection (new-format keys + connection row)
-        const oauthResult = await disconnectOAuthProvider(providerKey);
-        if (oauthResult === "error") {
-          writeOutput(cmd, {
-            ok: false,
-            error: `Failed to disconnect OAuth provider "${providerKey}" — please try again`,
-          });
+          // 1. Disconnect the OAuth connection (new-format keys + connection row)
+          const oauthResult = await disconnectOAuthProvider(
+            providerKey,
+            opts.clientId,
+          );
+          if (oauthResult === "error") {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Failed to disconnect OAuth provider "${providerKey}" — please try again`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+          if (oauthResult === "disconnected") cleanedUp = true;
+
+          // 2. Clean up legacy credential keys for common fields
+          const legacyFields = [
+            "access_token",
+            "refresh_token",
+            "client_id",
+            "client_secret",
+          ];
+          for (const field of legacyFields) {
+            const key = credentialKey(providerKey, field);
+            const result = await deleteSecureKeyAsync(key);
+            if (result === "deleted") cleanedUp = true;
+
+            const metaDeleted = deleteCredentialMetadata(providerKey, field);
+            if (metaDeleted) cleanedUp = true;
+          }
+
+          if (!cleanedUp) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `No OAuth connection or credentials found for "${providerKey}"`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          writeOutput(cmd, { ok: true, service: providerKey });
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(`Disconnected ${providerKey}`);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
           process.exitCode = 1;
-          return;
         }
-        if (oauthResult === "disconnected") cleanedUp = true;
-
-        // 2. Clean up legacy credential keys for common fields
-        const legacyFields = [
-          "access_token",
-          "refresh_token",
-          "client_id",
-          "client_secret",
-        ];
-        for (const field of legacyFields) {
-          const key = credentialKey(providerKey, field);
-          const result = await deleteSecureKeyAsync(key);
-          if (result === "deleted") cleanedUp = true;
-
-          const metaDeleted = deleteCredentialMetadata(providerKey, field);
-          if (metaDeleted) cleanedUp = true;
-        }
-
-        if (!cleanedUp) {
-          writeOutput(cmd, {
-            ok: false,
-            error: `No OAuth connection or credentials found for "${providerKey}"`,
-          });
-          process.exitCode = 1;
-          return;
-        }
-
-        writeOutput(cmd, { ok: true, service: providerKey });
-
-        if (!shouldOutputJson(cmd)) {
-          log.info(`Disconnected ${providerKey}`);
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // connections connect <provider-key>
@@ -404,13 +466,18 @@ Examples:
   connections
     .command("connect <provider-key>")
     .description("Initiate an OAuth2 authorization flow for a provider")
-    .option("--client-id <id>", "Override the OAuth client ID")
-    .option("--client-secret <secret>", "Override the OAuth client secret")
+    .option(
+      "--client-id <id>",
+      "Filter by OAuth client ID when multiple apps exist for the provider",
+    )
     .option(
       "--scopes <scopes...>",
       "Additional scopes beyond the provider's defaults",
     )
-    .option("--url-only", "Print the auth URL instead of opening the browser")
+    .option(
+      "--open-browser",
+      "Open the auth URL in the browser and wait for completion",
+    )
     .addHelpText(
       "after",
       `
@@ -418,19 +485,19 @@ Arguments:
   provider-key   Provider key (e.g. integration:gmail) or alias (e.g. gmail)
 
 Initiates an OAuth2 authorization flow for the given provider. By default,
-opens the authorization URL in your browser and waits for completion.
+prints the authorization URL to stdout — useful for headless/remote sessions.
+The token exchange completes in the background when the user authorizes.
 
-With --url-only, prints the auth URL instead — useful for headless/remote
-sessions. The token exchange completes in the background when the user
-authorizes.
+With --open-browser, opens the authorization URL in your browser and waits
+for completion.
 
-Client credentials are resolved from the OAuth app store unless overridden
-with --client-id and --client-secret.
+Client credentials are resolved from the OAuth app store. Use --client-id
+to select a specific app when multiple apps exist for the same provider.
 
 Examples:
   $ assistant oauth connections connect integration:gmail
-  $ assistant oauth connections connect gmail --url-only
-  $ assistant oauth connections connect integration:slack --client-id abc --client-secret s3cret
+  $ assistant oauth connections connect gmail --open-browser
+  $ assistant oauth connections connect integration:slack --client-id abc123
   $ assistant oauth connections connect integration:gmail --scopes calendar.readonly --json`,
     )
     .action(
@@ -438,9 +505,8 @@ Examples:
         providerKey: string,
         opts: {
           clientId?: string;
-          clientSecret?: string;
           scopes?: string[];
-          urlOnly?: boolean;
+          openBrowser?: boolean;
         },
         cmd: Command,
       ) => {
@@ -448,24 +514,18 @@ Examples:
           // a. Resolve service alias
           const resolvedServiceKey = resolveService(providerKey);
 
-          // b. Resolve client credentials
+          // b. Resolve client credentials from the DB
+          const dbApp = opts.clientId
+            ? getAppByProviderAndClientId(resolvedServiceKey, opts.clientId)
+            : getMostRecentAppByProvider(resolvedServiceKey);
+
           let clientId = opts.clientId;
-          let clientSecret = opts.clientSecret;
+          let clientSecret: string | undefined;
 
-          if (!clientId || !clientSecret) {
-            const dbApp = clientId
-              ? getAppByProviderAndClientId(resolvedServiceKey, clientId)
-              : getMostRecentAppByProvider(resolvedServiceKey);
-
-            if (dbApp) {
-              if (!clientId) clientId = dbApp.clientId;
-              if (!clientSecret) {
-                const storedSecret = getSecureKey(
-                  dbApp.clientSecretCredentialPath,
-                );
-                if (storedSecret) clientSecret = storedSecret;
-              }
-            }
+          if (dbApp) {
+            if (!clientId) clientId = dbApp.clientId;
+            const storedSecret = getSecureKey(dbApp.clientSecretCredentialPath);
+            if (storedSecret) clientSecret = storedSecret;
           }
 
           // c. Validate client_id
@@ -493,7 +553,7 @@ Examples:
             if (requiresSecret) {
               writeOutput(cmd, {
                 ok: false,
-                error: `client_secret is required for ${resolvedServiceKey} but not found. Provide --client-secret or store it first with 'assistant oauth apps upsert --client-secret'.`,
+                error: `client_secret is required for ${resolvedServiceKey} but not found. Store it first with 'assistant oauth apps upsert --client-secret'.`,
               });
               process.exitCode = 1;
               return;
@@ -505,8 +565,8 @@ Examples:
             service: providerKey,
             clientId,
             clientSecret,
-            isInteractive: !opts.urlOnly,
-            openUrl: !opts.urlOnly
+            isInteractive: !!opts.openBrowser,
+            openUrl: opts.openBrowser
               ? (url) => {
                   if (isMacOS()) {
                     Bun.spawn(["open", url], {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -400,12 +400,33 @@ export function getConnection(id: string): OAuthConnectionRow | undefined {
 
 /**
  * Get the most recent active connection for a provider.
+ * When `clientId` is provided, only connections linked to the matching app are considered.
  * Returns undefined if no active connection exists.
  */
 export function getConnectionByProvider(
   providerKey: string,
+  clientId?: string,
 ): OAuthConnectionRow | undefined {
   const db = getDb();
+
+  if (clientId) {
+    const app = getAppByProviderAndClientId(providerKey, clientId);
+    if (!app) return undefined;
+    return db
+      .select()
+      .from(oauthConnections)
+      .where(
+        and(
+          eq(oauthConnections.providerKey, providerKey),
+          eq(oauthConnections.oauthAppId, app.id),
+          eq(oauthConnections.status, "active"),
+        ),
+      )
+      .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
+      .limit(1)
+      .get();
+  }
+
   return db
     .select()
     .from(oauthConnections)
@@ -475,19 +496,37 @@ export function updateConnection(
   return rawChanges() > 0;
 }
 
-/** List connections, optionally filtered by provider key. */
-export function listConnections(providerKey?: string): OAuthConnectionRow[] {
+/** List connections, optionally filtered by provider key and/or client ID. */
+export function listConnections(
+  providerKey?: string,
+  clientId?: string,
+): OAuthConnectionRow[] {
   const db = getDb();
 
+  let rows: OAuthConnectionRow[];
   if (providerKey) {
-    return db
+    rows = db
       .select()
       .from(oauthConnections)
       .where(eq(oauthConnections.providerKey, providerKey))
       .all();
+  } else {
+    rows = db.select().from(oauthConnections).all();
   }
 
-  return db.select().from(oauthConnections).all();
+  if (clientId) {
+    const matchingAppIds = new Set(
+      db
+        .select({ id: oauthApps.id })
+        .from(oauthApps)
+        .where(eq(oauthApps.clientId, clientId))
+        .all()
+        .map((a) => a.id),
+    );
+    return rows.filter((r) => matchingAppIds.has(r.oauthAppId));
+  }
+
+  return rows;
 }
 
 /** Delete a connection by ID. Returns true if a row was deleted. */
@@ -512,8 +551,9 @@ export function deleteConnection(id: string): boolean {
  */
 export async function disconnectOAuthProvider(
   providerKey: string,
+  clientId?: string,
 ): Promise<"disconnected" | "not-found" | "error"> {
-  const conn = getConnectionByProvider(providerKey);
+  const conn = getConnectionByProvider(providerKey, clientId);
   if (!conn) return "not-found";
 
   const r1 = await deleteSecureKeyAsync(

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -9,6 +9,7 @@
 
 import {
   getApp,
+  getConnection,
   getConnectionByProvider,
   getProvider,
   updateConnection,
@@ -116,14 +117,14 @@ function recordRefreshFailure(service: string): void {
 
 const inflightRefreshes = new Map<string, Promise<string>>();
 
-function deduplicatedRefresh(service: string): Promise<string> {
-  const existing = inflightRefreshes.get(service);
+function deduplicatedRefresh(service: string, connId: string): Promise<string> {
+  const existing = inflightRefreshes.get(connId);
   if (existing) return existing;
 
-  const promise = doRefresh(service).finally(() => {
-    inflightRefreshes.delete(service);
+  const promise = doRefresh(service, connId).finally(() => {
+    inflightRefreshes.delete(connId);
   });
-  inflightRefreshes.set(service, promise);
+  inflightRefreshes.set(connId, promise);
   return promise;
 }
 
@@ -157,18 +158,11 @@ export class TokenExpiredError extends Error {
 }
 
 /**
- * Check whether the access token for a service is expired or will expire
- * within the buffer window, based on the `expiresAt` field in the
- * oauth_connection row.
+ * Check whether a token is expired or will expire within the buffer window.
  */
-function isTokenExpired(service: string): boolean {
-  try {
-    const conn = getConnectionByProvider(service);
-    if (!conn?.expiresAt) return false;
-    return Date.now() >= conn.expiresAt - EXPIRY_BUFFER_MS;
-  } catch {
-    return false;
-  }
+function isTokenExpired(expiresAt: number | null): boolean {
+  if (!expiresAt) return false;
+  return Date.now() >= expiresAt - EXPIRY_BUFFER_MS;
 }
 
 // ── Refresh config resolution ─────────────────────────────────────────
@@ -191,8 +185,8 @@ interface RefreshConfig {
  * authMethod. Throws `TokenExpiredError` if the connection is not found
  * or incomplete.
  */
-function resolveRefreshConfig(service: string): RefreshConfig {
-  const conn = getConnectionByProvider(service);
+function resolveRefreshConfig(service: string, connId: string): RefreshConfig {
+  const conn = getConnection(connId);
   if (!conn) {
     throw new TokenExpiredError(
       service,
@@ -217,8 +211,8 @@ function resolveRefreshConfig(service: string): RefreshConfig {
   }
 
   const tokenUrl = provider.tokenUrl;
-  const clientId = app.clientId;
-  if (!tokenUrl || !clientId) {
+  const resolvedClientId = app.clientId;
+  if (!tokenUrl || !resolvedClientId) {
     throw new TokenExpiredError(
       service,
       `Missing OAuth2 refresh config for "${service}".${recoveryHint(service)}`,
@@ -238,7 +232,7 @@ function resolveRefreshConfig(service: string): RefreshConfig {
   return {
     connId: conn.id,
     tokenUrl,
-    clientId,
+    clientId: resolvedClientId,
     secret,
     refreshToken,
     authMethod,
@@ -254,10 +248,15 @@ function resolveRefreshConfig(service: string): RefreshConfig {
  * Returns the new access token on success.
  * Throws `TokenExpiredError` if refresh is not possible.
  */
-async function doRefresh(service: string): Promise<string> {
-  const refreshConfig = resolveRefreshConfig(service);
-  const { tokenUrl, clientId, secret, authMethod, connId, refreshToken } =
-    refreshConfig;
+async function doRefresh(service: string, connId: string): Promise<string> {
+  const refreshConfig = resolveRefreshConfig(service, connId);
+  const {
+    tokenUrl,
+    clientId: resolvedClientId,
+    secret,
+    authMethod,
+    refreshToken,
+  } = refreshConfig;
 
   if (!refreshToken) {
     throw new TokenExpiredError(
@@ -266,8 +265,8 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  if (isRefreshBreakerOpen(service)) {
-    const state = refreshBreakers.get(service)!;
+  if (isRefreshBreakerOpen(connId)) {
+    const state = refreshBreakers.get(connId)!;
     const remainingMs = state.cooldownMs - (Date.now() - state.openedAt);
     throw new TokenExpiredError(
       service,
@@ -282,13 +281,13 @@ async function doRefresh(service: string): Promise<string> {
   try {
     result = await refreshOAuth2Token(
       tokenUrl,
-      clientId,
+      resolvedClientId,
       refreshToken,
       secret,
       authMethod,
     );
   } catch (err) {
-    recordRefreshFailure(service);
+    recordRefreshFailure(connId);
     if (isCredentialError(err)) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new TokenExpiredError(
@@ -349,7 +348,7 @@ async function doRefresh(service: string): Promise<string> {
     );
   }
 
-  recordRefreshSuccess(service);
+  recordRefreshSuccess(connId);
   log.info({ service }, "OAuth2 access token refreshed successfully");
   return result.accessToken;
 }
@@ -368,12 +367,13 @@ async function doRefresh(service: string): Promise<string> {
 export async function withValidToken<T>(
   service: string,
   callback: (token: string) => Promise<T>,
+  clientId?: string,
 ): Promise<T> {
-  const conn = getConnectionByProvider(service);
+  const conn = getConnectionByProvider(service, clientId);
   let token = conn
     ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
     : undefined;
-  if (!token) {
+  if (!token || !conn) {
     throw new TokenExpiredError(
       service,
       `No access token found for "${service}". Authorization required.${recoveryHint(service)}`,
@@ -381,15 +381,15 @@ export async function withValidToken<T>(
   }
 
   // Proactively refresh if expired or about to expire.
-  if (isTokenExpired(service)) {
-    token = await deduplicatedRefresh(service);
+  if (isTokenExpired(conn.expiresAt)) {
+    token = await deduplicatedRefresh(service, conn.id);
   }
 
   try {
     return await callback(token);
   } catch (err: unknown) {
     if (is401Error(err)) {
-      token = await deduplicatedRefresh(service);
+      token = await deduplicatedRefresh(service, conn.id);
       return callback(token);
     }
     throw err;

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -103,12 +103,14 @@ Every step follows this rhythm:
 Before beginning, look up information about the google oauth app, which we'll need later.
 
 Find the gmail or google oauth provider
+
 ```
 bash:
   command: assistant oauth providers list --provider-key "gmail, google" --json
 ```
 
 If one doesn't yet exist, then register a new one with a provider key of "integration:google"
+
 ```
 bash:
   command: assistant oauth providers register --help
@@ -350,7 +352,6 @@ Wait for the user to confirm the dialog is showing.
 This value is not secret and can safely be provided conversationally.
 
 > Copy the Client ID from the Google Cloud dialog and paste it here in the chat. This is not a secret value and can be safely provided here.
-
 
 ### 7b: Client Secret
 

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -374,7 +374,7 @@ Now register the OAuth app with the collected Client ID and Client Secret.
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path <provider-key>
+    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>/client_secret"
 ```
 
 Do not navigate away from the credential dialog until both values are provided. After both are stored and the app is registered, tell the user they can close the dialog.
@@ -398,7 +398,7 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth connections connect <provider-key> --client-id <client-id> --url-only
+    assistant oauth connections connect <provider-key> --client-id <client-id>
 ```
 
 The command prints an authorization URL. Send it to the user and encourage them to open it. Wait for the user to complete authorization in the browser. The token exchange completes in the background.


### PR DESCRIPTION
## Summary
- Add `--client-id` filtering to `connections list`, `get`, `token`, `ping`, and `disconnect` subcommands so callers can target a specific OAuth app when multiple exist for the same provider
- Change `connections connect` to print the auth URL by default (replacing `--url-only` with `--open-browser` to opt into interactive mode) and remove `--client-secret` CLI override — credentials are always resolved from the DB
- Thread `clientId` through `oauth-store` and `token-manager`, keying dedup/breaker maps on the resolved connection ID rather than a synthetic composite key

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] `oauth-cli.test.ts` — 35 pass
- [x] `oauth-store.test.ts` — 50 pass
- [x] `credential-vault.test.ts` — 45 pass (added `getConnection` mock for new `resolveRefreshConfig` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
