### PR TITLE
fix: remove extra channels rendering and stale comments

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -292,7 +292,6 @@ struct ContactDetailView: View {
                 grouping: displayContact.channels,
                 by: { $0.type }
             )
-            let extraChannels = displayContact.channels.filter { !Self.allChannelTypes.contains($0.type) }
 
             let visibleTypes = Self.allChannelTypes.filter { type in
                 // Always show channels the contact already has configured
@@ -301,7 +300,6 @@ struct ContactDetailView: View {
                     || channelReadiness[type]?.ready == true
             }
             let lastVisibleType = visibleTypes.last
-            let hasExtraChannels = !extraChannels.isEmpty
 
             ForEach(Array(Self.allChannelTypes.enumerated()), id: \.element) { _, type in
                 if let channels = channelsByType[type] {
@@ -314,24 +312,16 @@ struct ContactDetailView: View {
                         }
                     }
 
-                    if type != lastVisibleType || hasExtraChannels {
+                    if type != lastVisibleType {
                         Divider().background(VColor.borderBase)
                     }
                 } else if channelReadiness[type]?.ready == true {
                     // Unconfigured but assistant has this channel set up — show
                     unconfiguredChannelRow(type: type)
 
-                    if type != lastVisibleType || hasExtraChannels {
+                    if type != lastVisibleType {
                         Divider().background(VColor.borderBase)
                     }
-                }
-            }
-
-            ForEach(Array(extraChannels.enumerated()), id: \.element.id) { index, channel in
-                channelRow(channel)
-
-                if index < extraChannels.count - 1 {
-                    Divider().background(VColor.borderBase)
                 }
             }
 
@@ -532,7 +522,7 @@ struct ContactDetailView: View {
                         }
                     }
                 } else if let channelHandle = result.channelHandle {
-                    // For channels without a share URL (email, WhatsApp),
+                    // For channels without a share URL,
                     // show the assistant's channel handle so it can be copied.
                     HStack(spacing: VSpacing.sm) {
                         Text(channelHandle)


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for contacts-channel-filter.md.

**Gap 1:** Remove `extraChannels` rendering so email/whatsapp/other non-supported channel types never appear on the Contacts page, even if a contact has them configured.

**Gap 2:** Update stale comment that referenced email and WhatsApp as examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
