### PR TITLE
refactor: simplify VButton to 4 styles, remove size variants

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -104,7 +104,7 @@ struct ChannelVerificationFlowView: View {
                 }
                 Spacer()
             }
-            VButton(label: "Revoke", style: .secondary) {
+            VButton(label: "Revoke", style: .outlined) {
                 onRevoke()
             }
         }
@@ -230,13 +230,13 @@ struct ChannelVerificationFlowView: View {
                 // Disable resend during bootstrap: when bootstrapUrl is set the session is
                 // in pending_bootstrap state and the daemon rejects resend attempts.
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: resendCooldownText ?? "Resend", style: .secondary, isFullWidth: true) {
+                    VButton(label: resendCooldownText ?? "Resend", style: .outlined, isFullWidth: true) {
                         onResend()
                     }
                     .disabled(!canResend)
                     .frame(width: 160)
 
-                    VButton(label: "Cancel", style: .tertiary) {
+                    VButton(label: "Cancel", style: .outlined) {
                         onCancelOutbound()
                     }
                 }
@@ -355,7 +355,7 @@ struct ChannelVerificationFlowView: View {
                     .padding(.leading, leadingPadding)
             }
 
-            VButton(label: "Cancel", style: .tertiary) {
+            VButton(label: "Cancel", style: .outlined) {
                 onCancelSession()
             }
         }
@@ -402,7 +402,7 @@ struct ChannelVerificationFlowView: View {
                     .foregroundColor(VColor.contentTertiary)
             }
 
-            VButton(label: "Send", style: .secondary) {
+            VButton(label: "Send", style: .outlined) {
                 onStartOutbound(destination)
             }
             .disabled(destination.isEmpty)
@@ -420,7 +420,7 @@ struct ChannelVerificationFlowView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.systemNegativeStrong)
             if state.alreadyBound {
-                VButton(label: "Replace", style: .secondary) {
+                VButton(label: "Replace", style: .outlined) {
                     onStartSession(true)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/BootstrapInterstitialView.swift
@@ -32,8 +32,7 @@ struct BootstrapInterstitialView: View {
                 VButton(
                     label: "Try Again",
                     icon: "arrow.clockwise",
-                    style: .tertiary,
-                    size: .medium,
+                    style: .outlined,
                     isDisabled: isRetrying
                 ) {
                     onRetry()

--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -159,8 +159,8 @@ struct AssistantChannelsDetailView: View {
         return SettingsCard(title: "Telegram", subtitle: "Message your assistant from Telegram") {
             if status == "ready" {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.telegramSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
@@ -170,7 +170,7 @@ struct AssistantChannelsDetailView: View {
             } else if (status == "incomplete" && store.telegramHasBotToken) || telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .outlined) {
                     telegramSetupExpanded = true
                 }
             }
@@ -230,7 +230,7 @@ struct AssistantChannelsDetailView: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .secondary, size: .medium, isDisabled: store.telegramRevokingMemberIds.contains(member.id)) {
+                        VButton(label: "Revoke", style: .outlined, isDisabled: store.telegramRevokingMemberIds.contains(member.id)) {
                             store.revokeTelegramApprovedMember(memberId: member.id)
                         }
                     }
@@ -272,11 +272,11 @@ struct AssistantChannelsDetailView: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                    VButton(label: "Connect", style: .outlined, isDisabled: telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                         store.saveTelegramToken(botToken: telegramBotTokenText)
                         telegramBotTokenText = ""
                     }
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .outlined) {
                         telegramSetupExpanded = false
                         telegramBotTokenText = ""
                     }
@@ -292,8 +292,8 @@ struct AssistantChannelsDetailView: View {
         return SettingsCard(title: "Slack", subtitle: "Message your assistant from Slack") {
             if status == "ready" {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.slackChannelSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
                         store.clearSlackChannelConfig()
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -304,7 +304,7 @@ struct AssistantChannelsDetailView: View {
             } else if (status == "incomplete" && (store.slackChannelHasBotToken || store.slackChannelHasAppToken)) || slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .outlined) {
                     slackChannelSetupExpanded = true
                 }
             }
@@ -362,7 +362,7 @@ struct AssistantChannelsDetailView: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .secondary, size: .medium, isDisabled: store.slackRevokingMemberIds.contains(member.id)) {
+                        VButton(label: "Revoke", style: .outlined, isDisabled: store.slackRevokingMemberIds.contains(member.id)) {
                             store.revokeSlackApprovedMember(memberId: member.id)
                         }
                     }
@@ -411,8 +411,7 @@ struct AssistantChannelsDetailView: View {
                 HStack(spacing: VSpacing.sm) {
                     VButton(
                         label: "Connect",
-                        style: .secondary,
-                        size: .medium,
+                        style: .outlined,
                         isDisabled: slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                             || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ) {
@@ -423,7 +422,7 @@ struct AssistantChannelsDetailView: View {
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
                     }
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .outlined) {
                         slackChannelSetupExpanded = false
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -440,8 +439,8 @@ struct AssistantChannelsDetailView: View {
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio") {
             if status == "ready" {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                         store.channelSetupStatus["phone"] = "not_configured"
                     }
@@ -449,7 +448,7 @@ struct AssistantChannelsDetailView: View {
             } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .outlined) {
                     voiceSetupExpanded = true
                 }
             }
@@ -525,8 +524,7 @@ struct AssistantChannelsDetailView: View {
                 HStack(spacing: VSpacing.sm) {
                     VButton(
                         label: "Connect",
-                        style: .secondary,
-                        size: .medium,
+                        style: .outlined,
                         isDisabled: voiceAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                             voiceAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     ) {
@@ -537,7 +535,7 @@ struct AssistantChannelsDetailView: View {
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
                     }
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .outlined) {
                         voiceSetupExpanded = false
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
@@ -109,14 +109,13 @@ struct ContactCreateView: View {
 
     private var actionButtons: some View {
         HStack(spacing: VSpacing.md) {
-            VButton(label: "Cancel", style: .tertiary, size: .medium) {
+            VButton(label: "Cancel", style: .outlined) {
                 isPresented = false
             }
             Spacer()
             VButton(
                 label: isSubmitting ? "Creating..." : "Create",
                 style: .primary,
-                size: .medium,
                 isDisabled: !canSubmit
             ) {
                 submit()

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -145,7 +145,7 @@ struct ContactDetailView: View {
 
                 if isEditing {
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Save", style: .primary, size: .medium, isDisabled: isSaving) {
+                        VButton(label: "Save", style: .primary, isDisabled: isSaving) {
                             Task { await saveCardEdits() }
                         }
                         Button {
@@ -488,8 +488,7 @@ struct ContactDetailView: View {
                 } else {
                     VButton(
                         label: "Invite",
-                        style: .secondary,
-                        size: .medium,
+                        style: .outlined,
                         isDisabled: inviteInProgress != nil
                     ) {
                         createInviteForChannel(type: type)
@@ -559,8 +558,7 @@ struct ContactDetailView: View {
                         VButton(
                             label: inviteCopiedType == "\(type)-link" ? "Copied!" : "Copy Link",
                             icon: VIcon.copy.rawValue,
-                            style: .secondary,
-                            size: .medium
+                            style: .outlined
                         ) {
                             NSPasteboard.general.clearContents()
                             NSPasteboard.general.setString(shareUrl, forType: .string)
@@ -585,8 +583,7 @@ struct ContactDetailView: View {
                         VButton(
                             label: inviteCopiedType == "\(type)-handle" ? "Copied!" : "Copy Address",
                             icon: VIcon.copy.rawValue,
-                            style: .secondary,
-                            size: .medium
+                            style: .outlined
                         ) {
                             NSPasteboard.general.clearContents()
                             NSPasteboard.general.setString(channelHandle, forType: .string)
@@ -612,8 +609,7 @@ struct ContactDetailView: View {
                 VButton(
                     label: inviteCopiedType == type ? "Copied!" : "Copy Code",
                     icon: VIcon.copy.rawValue,
-                    style: (result.shareUrl != nil || result.channelHandle != nil) ? .tertiary : .secondary,
-                    size: .medium
+                    style: .outlined
                 ) {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(inviteCode, forType: .string)
@@ -641,8 +637,7 @@ struct ContactDetailView: View {
                 VButton(
                     label: inviteCopiedType == type ? "Copied!" : "Copy",
                     icon: VIcon.copy.rawValue,
-                    style: .tertiary,
-                    size: .medium
+                    style: .outlined
                 ) {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(shareableText, forType: .string)
@@ -672,8 +667,7 @@ struct ContactDetailView: View {
                 case "revoked":
                     VButton(
                         label: "Restore Access",
-                        style: .secondary,
-                        size: .medium,
+                        style: .outlined,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "active")
@@ -681,8 +675,7 @@ struct ContactDetailView: View {
                 case "blocked":
                     VButton(
                         label: "Restore Access",
-                        style: .secondary,
-                        size: .medium,
+                        style: .outlined,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "active")
@@ -691,7 +684,6 @@ struct ContactDetailView: View {
                     VButton(
                         label: "Send Verification",
                         style: .primary,
-                        size: .medium,
                         isDisabled: anyActionInFlight
                     ) {
                         initiateVerification(for: channel)
@@ -699,7 +691,6 @@ struct ContactDetailView: View {
                     VButton(
                         label: "Revoke Access",
                         style: .danger,
-                        size: .medium,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "revoked")
@@ -708,7 +699,6 @@ struct ContactDetailView: View {
                     VButton(
                         label: "Revoke Access",
                         style: .danger,
-                        size: .medium,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "revoked")
@@ -716,7 +706,6 @@ struct ContactDetailView: View {
                     VButton(
                         label: "Block",
                         style: .danger,
-                        size: .medium,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "blocked")

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -323,7 +323,7 @@ struct ContactsListView: View {
                 .foregroundColor(VColor.contentTertiary)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: 300)
-            VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary, size: .medium) {
+            VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary) {
                 viewModel.isCreatingContact = true
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -786,11 +786,11 @@ struct DynamicWorkspaceWrapper: View {
             HStack {
                 // Left: Close Chat primary CTA in edit mode, Edit primary button otherwise
                 if case .appEditing = windowState.selection {
-                    VButton(label: "Close chat", icon: VIcon.x.rawValue, style: .primary, size: .medium) {
+                    VButton(label: "Close chat", icon: VIcon.x.rawValue, style: .primary) {
                         onToggleChatDock()
                     }
                 } else {
-                    VButton(label: "Edit", icon: VIcon.pencil.rawValue, style: .primary, size: .medium) {
+                    VButton(label: "Edit", icon: VIcon.pencil.rawValue, style: .primary) {
                         if !isChatDockOpen {
                             windowState.workspaceComposerExpanded = false
                         }
@@ -1125,13 +1125,13 @@ private struct AppLoadingView: View {
                     .frame(maxWidth: 280)
                 HStack(spacing: VSpacing.sm) {
                     if let appId {
-                        VButton(label: "Retry", icon: "arrow.clockwise", style: .secondary) {
+                        VButton(label: "Retry", icon: "arrow.clockwise", style: .outlined) {
                             timedOut = false
                             onRetry(appId)
                         }
                         .controlSize(.small)
                     }
-                    VButton(label: "Close", style: .tertiary) {
+                    VButton(label: "Close", style: .outlined) {
                         onClose()
                     }
                     .controlSize(.small)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -649,7 +649,6 @@ struct AgentPanelContent: View {
                 label: isSuccess ? "Installed!" : (isInstalling ? "Installing..." : "Install"),
                 icon: isSuccess ? "checkmark.circle.fill" : (isInstalling ? nil : "arrow.down.circle.fill"),
                 style: .primary,
-                size: .small,
                 isFullWidth: false,
                 isDisabled: isInstalling || isSuccess
             ) {
@@ -876,8 +875,7 @@ struct AgentPanelContent: View {
                 VButton(
                     label: "Details",
                     rightIcon: isExpanded ? "chevron.up" : "chevron.down",
-                    style: .ghost,
-                    size: .small
+                    style: .outlined
                 ) {
                     withAnimation(VAnimation.fast) {
                         if isExpanded {
@@ -967,7 +965,7 @@ struct AgentPanelContent: View {
                 Spacer()
 
                 if skill.source == "managed" {
-                    VButton(label: "Remove", icon: VIcon.trash.rawValue, style: .danger, size: .small) {
+                    VButton(label: "Remove", icon: VIcon.trash.rawValue, style: .danger) {
                         skillToDelete = skill
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -24,7 +24,7 @@ struct AppVersionHistoryPanel: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack {
-                VButton(label: "Back", icon: "chevron.left", style: .tertiary) {
+                VButton(label: "Back", icon: "chevron.left", style: .outlined) {
                     onClose()
                 }
                 .controlSize(.small)
@@ -195,7 +195,7 @@ struct AppVersionHistoryPanel: View {
                 Spacer()
 
                 if !isRestoring && version.commitHash != versions.first?.commitHash {
-                    VButton(label: "Restore", icon: "arrow.counterclockwise", style: .tertiary) {
+                    VButton(label: "Restore", icon: "arrow.counterclockwise", style: .outlined) {
                         restoreConfirmVersion = version
                     }
                     .controlSize(.small)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -57,7 +57,7 @@ struct IdentityPanel: View {
                                 .frame(maxWidth: .infinity, alignment: .center)
 
                             // Update Avatar button
-                            VButton(label: "Update Avatar", style: .secondary) { showAvatarSheet = true }
+                            VButton(label: "Update Avatar", style: .outlined) { showAvatarSheet = true }
                                 .padding(.top, VSpacing.md)
 
                             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/NewSkillSheet.swift
@@ -252,7 +252,6 @@ struct NewSkillSheet: View {
                     label: skillsManager.isDrafting ? "Generating..." : "Generate Draft",
                     leftIcon: skillsManager.isDrafting ? nil : "wand.and.stars",
                     style: .primary,
-                    size: .medium,
                     isDisabled: sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || skillsManager.isDrafting
                 ) {
                     skillsManager.draftSkill(sourceText: sourceText)
@@ -262,7 +261,6 @@ struct NewSkillSheet: View {
                     label: skillsManager.isCreating ? "Creating..." : "Create Skill",
                     leftIcon: skillsManager.isCreating ? nil : "plus.circle.fill",
                     style: .primary,
-                    size: .medium,
                     isDisabled: !isFormValid || skillsManager.isCreating
                 ) {
                     skillsManager.createSkillFromDraft(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -483,7 +483,7 @@ struct SettingsPanel: View {
                             .font(VFont.sectionDescription)
                             .foregroundColor(VColor.contentTertiary)
                     }
-                    VButton(label: "Manage", style: .secondary, size: .medium) {
+                    VButton(label: "Manage", style: .outlined) {
                         daemonClient?.isTrustRulesSheetOpen = true
                         showingTrustRules = true
                     }
@@ -638,7 +638,7 @@ struct SettingsPanelEnvVarsSheet: View {
                     .font(VFont.headline)
                     .foregroundColor(VColor.contentDefault)
                 Spacer()
-                VButton(label: "Done", style: .tertiary) { dismiss() }
+                VButton(label: "Done", style: .outlined) { dismiss() }
             }
             .padding(VSpacing.lg)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -138,7 +138,7 @@ struct SidebarThreadItem: View {
         }
         .overlay(alignment: .trailing) {
             if sidebar.threadPendingDeletion == thread.id {
-                VButton(label: "Confirm", style: .danger, size: .small) {
+                VButton(label: "Confirm", style: .danger) {
                     threadManager.archiveThread(id: thread.id)
                     sidebar.threadPendingDeletion = nil
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -75,12 +75,12 @@ struct AssistantBackupsSection: View {
         }
 
         HStack(spacing: VSpacing.md) {
-            VButton(label: isExporting ? "Exporting..." : "Create Backup", style: .secondary) {
+            VButton(label: isExporting ? "Exporting..." : "Create Backup", style: .outlined) {
                 Task { await exportLocalBackup() }
             }
             .disabled(isExporting || isImporting)
 
-            VButton(label: isImporting ? "Restoring..." : "Restore from Backup", style: .secondary) {
+            VButton(label: isImporting ? "Restoring..." : "Restore from Backup", style: .outlined) {
                 selectAndRestoreLocalBackup()
             }
             .disabled(isExporting || isImporting)
@@ -108,12 +108,12 @@ struct AssistantBackupsSection: View {
         }
 
         HStack(spacing: VSpacing.md) {
-            VButton(label: isCreatingBackup ? "Creating..." : "Create Backup", style: .secondary) {
+            VButton(label: isCreatingBackup ? "Creating..." : "Create Backup", style: .outlined) {
                 Task { await createManagedBackup() }
             }
             .disabled(isCreatingBackup || isLoadingBackups)
 
-            VButton(label: isLoadingBackups ? "Loading..." : "Refresh", style: .secondary) {
+            VButton(label: isLoadingBackups ? "Loading..." : "Refresh", style: .outlined) {
                 Task { await loadManagedBackups() }
             }
             .disabled(isLoadingBackups || isCreatingBackup)
@@ -154,7 +154,7 @@ struct AssistantBackupsSection: View {
                     }
                     Spacer()
                     if backup.readyToUse {
-                        VButton(label: "Restore", style: .secondary) {
+                        VButton(label: "Restore", style: .outlined) {
                             pendingManagedRestore = backup
                             showingManagedRestoreConfirmation = true
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -75,7 +75,7 @@ struct AssistantUpgradeSection: View {
 
                 VButton(
                     label: isLoadingReleases ? "Checking..." : "Check for Updates",
-                    style: .secondary
+                    style: .outlined
                 ) {
                     Task { await loadReleases() }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -74,7 +74,7 @@ struct GatewaySettingsCard: View {
 
                 // Running badge — only shown when gateway is reachable
                 if store.gatewayReachable == true {
-                    VButton(label: "Running", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
+                    VButton(label: "Running", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
                 }
 
                 Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
@@ -123,7 +123,7 @@ struct GatewaySettingsCard: View {
 
                 // Save button at the bottom
                 HStack {
-                    VButton(label: "Save", style: .primary, size: .medium) {
+                    VButton(label: "Save", style: .primary) {
                         store.saveIngressPublicBaseUrl(gatewayUrlText)
                         isGatewayUrlFocused = false
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -101,14 +101,13 @@ struct LogReportFormView: View {
     private var actionRow: some View {
         HStack {
             Spacer()
-            VButton(label: "Cancel", style: .secondary, size: .medium) {
+            VButton(label: "Cancel", style: .outlined) {
                 onCancel()
             }
             VButton(
                 label: "Send Logs",
                 leftIcon: VIcon.send.rawValue,
                 style: .primary,
-                size: .medium,
                 isDisabled: !canSend
             ) {
                 guard let reason = selectedReason else { return }

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
@@ -73,11 +73,11 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
 
             // Action buttons
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Save", style: .primary, size: .medium, isDisabled: !isSaveEnabled) {
+                VButton(label: "Save", style: .primary, isDisabled: !isSaveEnabled) {
                     onSave()
                 }
                 if isConnected {
-                    VButton(label: "Reset (disconnect)", style: .danger, size: .medium) {
+                    VButton(label: "Reset (disconnect)", style: .danger) {
                         onReset()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -196,16 +196,16 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingGlobalHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
+                        VButton(label: "Press shortcut...", style: .outlined) {
                             stopRecording()
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined, size: .medium) {
+                            VButton(label: "Record", style: .outlined) {
                                 startRecording()
                             }
                             if !store.globalHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined, size: .medium) {
+                                VButton(label: "Unbind", style: .outlined) {
                                     store.globalHotkeyShortcut = ""
                                 }
                             }
@@ -236,16 +236,16 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingQuickInputHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
+                        VButton(label: "Press shortcut...", style: .outlined) {
                             stopRecording()
                         }
                     } else {
                         HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined, size: .medium) {
+                            VButton(label: "Record", style: .outlined) {
                                 startRecordingQuickInput()
                             }
                             if !store.quickInputHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined, size: .medium) {
+                                VButton(label: "Unbind", style: .outlined) {
                                     store.quickInputHotkeyShortcut = ""
                                     store.quickInputHotkeyKeyCode = 0
                                 }
@@ -307,7 +307,7 @@ struct SettingsAppearanceTab: View {
                                     addAllowlistDomain()
                                 }
 
-                            VButton(label: "Add", style: .primary, size: .medium, isDisabled: newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                            VButton(label: "Add", style: .primary, isDisabled: newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                                 addAllowlistDomain()
                             }
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedThreadsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedThreadsTab.swift
@@ -61,7 +61,7 @@ private struct ArchivedThreadRow: View {
 
             Spacer()
 
-            VButton(label: "Unarchive", style: .secondary, size: .small) {
+            VButton(label: "Unarchive", style: .outlined) {
                 onUnarchive()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -214,7 +214,7 @@ struct SettingsDeveloperTab: View {
                     .foregroundColor(VColor.contentDefault)
                     .focused($isPlatformUrlFocused)
 
-                VButton(label: "Save", style: .primary, size: .medium, isDisabled: platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                VButton(label: "Save", style: .primary, isDisabled: platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                     store.savePlatformBaseUrl(platformUrlText)
                     isPlatformUrlFocused = false
                 }
@@ -531,7 +531,7 @@ struct SettingsDeveloperTab: View {
             title: "Restart Assistant",
             subtitle: "The assistant will be briefly unavailable during restart."
         ) {
-            VButton(label: "Restart", style: .secondary, size: .medium) {
+            VButton(label: "Restart", style: .outlined) {
                 showingRestartConfirmation = true
             }
         }
@@ -583,7 +583,7 @@ struct SettingsDeveloperTab: View {
             title: "SSH Terminal",
             subtitle: "Open a terminal session to the assistant's host machine."
         ) {
-            VButton(label: "Open Terminal", style: .secondary, size: .medium) {
+            VButton(label: "Open Terminal", style: .outlined) {
                 openTerminalWindow()
             }
         }
@@ -616,7 +616,7 @@ struct SettingsDeveloperTab: View {
                 ? "Stops the current assistant and switches to another."
                 : "Stops the daemon, removes local data, and returns to initial setup."
         ) {
-            VButton(label: "Retire", style: .danger, size: .medium) {
+            VButton(label: "Retire", style: .danger) {
                 showingRetireConfirmation = true
             }
         }
@@ -652,7 +652,7 @@ struct SettingsDeveloperTab: View {
     private var hatchNewAssistantSection: some View {
         if isHatchFlagEnabled {
             SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
-                VButton(label: "Hatch...", style: .primary, size: .medium) {
+                VButton(label: "Hatch...", style: .primary) {
                     showingHatchConfirmation = true
                 }
                 .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
@@ -828,7 +828,7 @@ struct SettingsDeveloperTab: View {
     private var environmentVariablesSection: some View {
         if daemonClient != nil {
             SettingsCard(title: "Environment Variables", subtitle: "View env vars for both the app and daemon processes") {
-                VButton(label: "View", style: .secondary, size: .medium) {
+                VButton(label: "View", style: .outlined) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
                             .map { ($0.key, $0.value) }
@@ -874,7 +874,7 @@ struct SettingsDeveloperTab: View {
 
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Trigger Fatal Crash", style: .danger, size: .medium) {
+                    VButton(label: "Trigger Fatal Crash", style: .danger) {
                         fatalError("Sentry test crash")
                     }
                     Text("Calls fatalError() — will terminate the app immediately.")
@@ -885,7 +885,7 @@ struct SettingsDeveloperTab: View {
                 SettingsDivider()
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Error", style: .secondary, size: .medium) {
+                    VButton(label: "Send Test Error", style: .outlined) {
                         sendSentryTestEvent(level: .error, label: "error")
                     }
                     Text("Captures a Sentry event with level .error")
@@ -896,7 +896,7 @@ struct SettingsDeveloperTab: View {
                 SettingsDivider()
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Warning", style: .secondary, size: .medium) {
+                    VButton(label: "Send Test Warning", style: .outlined) {
                         sendSentryTestEvent(level: .warning, label: "warning")
                     }
                     Text("Captures a Sentry event with level .warning")
@@ -907,7 +907,7 @@ struct SettingsDeveloperTab: View {
                 SettingsDivider()
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Send Test Message", style: .secondary, size: .medium) {
+                    VButton(label: "Send Test Message", style: .outlined) {
                         sendSentryTestEvent(level: .info, label: "info message")
                     }
                     Text("Captures a Sentry event with level .info")
@@ -918,7 +918,7 @@ struct SettingsDeveloperTab: View {
                 SettingsDivider()
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    VButton(label: "Test Performance Transaction", style: .secondary, size: .medium) {
+                    VButton(label: "Test Performance Transaction", style: .outlined) {
                         guard isSentryEnabled else {
                             showSentryStatus("Sentry is disabled — transaction not sent.")
                             return

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -63,7 +63,7 @@ struct SettingsGeneralTab: View {
                         .foregroundColor(VColor.systemNegativeHover)
                 }
             } else {
-                VButton(label: "Pair Device", leftIcon: VIcon.qrCode.rawValue, style: .primary, size: .medium) {
+                VButton(label: "Pair Device", leftIcon: VIcon.qrCode.rawValue, style: .primary) {
                     showingPairingQR = true
                 }
             }
@@ -83,14 +83,13 @@ struct SettingsGeneralTab: View {
                         .foregroundColor(VColor.contentSecondary)
                 }
             } else if authManager.currentUser != nil {
-                VButton(label: "Log Out", style: .danger, size: .medium) {
+                VButton(label: "Log Out", style: .danger) {
                     Task { await authManager.logout() }
                 }
             } else {
                 VButton(
                     label: authManager.isSubmitting ? "Signing in..." : "Sign In",
                     style: .primary,
-                    size: .medium,
                     isDisabled: authManager.isSubmitting
                 ) {
                     Task { await authManager.startWorkOSLogin() }

--- a/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SkillDeleteConfirmView.swift
@@ -20,11 +20,11 @@ struct SkillDeleteConfirmView: View {
             }
 
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                VButton(label: "Cancel", style: .outlined) {
                     onCancel()
                 }
 
-                VButton(label: "Delete", style: .danger, size: .medium) {
+                VButton(label: "Delete", style: .danger) {
                     onDelete()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -180,7 +180,7 @@ struct ToolPermissionTesterView: View {
     @ViewBuilder
     private var simulateButton: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary, size: .medium, isDisabled: !model.canSimulate) {
+            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary, isDisabled: !model.canSimulate) {
                 model.simulate()
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -275,8 +275,8 @@ struct VoiceSettingsView: View {
         SettingsCard(title: "Text-to-Speech", subtitle: "ElevenLabs provides high-quality voice responses during voice conversations. An API key is required.") {
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger) {
                         store.clearElevenLabsKey()
                         elevenLabsKeyText = ""
                         ttsSetupExpanded = false
@@ -302,19 +302,19 @@ struct VoiceSettingsView: View {
                     }
 
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                        VButton(label: "Connect", style: .outlined, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                             store.saveElevenLabsKey(elevenLabsKeyText)
                             elevenLabsKeyText = ""
                             ttsSetupExpanded = false
                         }
-                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        VButton(label: "Cancel", style: .outlined) {
                             ttsSetupExpanded = false
                             elevenLabsKeyText = ""
                         }
                     }
                 }
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .outlined) {
                     ttsSetupExpanded = true
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -217,7 +217,7 @@ struct BundleConfirmationView: View {
 
     private var footerSection: some View {
         HStack(spacing: VSpacing.md) {
-            VButton(label: "Cancel", style: .ghost, size: .medium) {
+            VButton(label: "Cancel", style: .outlined) {
                 viewModel.cancel()
             }
 
@@ -226,7 +226,7 @@ struct BundleConfirmationView: View {
             if viewModel.isTampered {
                 tamperedInstallButton
             } else {
-                VButton(label: "Install", style: .primary, size: .medium) {
+                VButton(label: "Install", style: .primary) {
                     viewModel.confirm()
                 }
                 .disabled(viewModel.isInstalling)
@@ -243,13 +243,13 @@ struct BundleConfirmationView: View {
                 Text("This app may have been modified.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.systemNegativeStrong)
-                VButton(label: "Install Anyway", style: .danger, size: .medium) {
+                VButton(label: "Install Anyway", style: .danger) {
                     viewModel.confirm()
                 }
                 .disabled(viewModel.isInstalling)
             }
         } else {
-            VButton(label: "Install", style: .ghost, size: .medium) {
+            VButton(label: "Install", style: .outlined) {
                 withAnimation(VAnimation.standard) {
                     viewModel.showTamperedWarning = true
                 }
@@ -295,7 +295,7 @@ struct BundleConfirmationView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, VSpacing.xxl)
 
-            VButton(label: "Dismiss", style: .ghost, size: .medium) {
+            VButton(label: "Dismiss", style: .outlined) {
                 viewModel.cancel()
             }
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -222,7 +222,7 @@ struct SecretPromptView: View {
                     // Buttons
                     HStack(spacing: VSpacing.lg) {
                         Spacer()
-                        VButton(label: "Cancel", style: .tertiary, accessibilityID: "secure-credential-cancel") {
+                        VButton(label: "Cancel", style: .outlined, accessibilityID: "secure-credential-cancel") {
                             onCancel()
                         }
                         .accessibilityLabel("Cancel")
@@ -241,7 +241,7 @@ struct SecretPromptView: View {
                         HStack(spacing: VSpacing.xs) {
                             VIconView(.triangleAlert, size: 10)
                                 .foregroundColor(VColor.systemNegativeHover)
-                            VButton(label: "Send Once (not saved)", style: .tertiary) {
+                            VButton(label: "Send Once (not saved)", style: .outlined) {
                                 let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
                                 guard !trimmed.isEmpty else { return }
                                 _ = onSendOnce(trimmed)

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -137,7 +137,7 @@ struct SurfaceContainerView: View {
     private func buttonStyle(for style: SurfaceActionStyle) -> VButton.Style {
         switch style {
         case .primary: return .primary
-        case .secondary: return .tertiary
+        case .secondary: return .outlined
         case .destructive: return .danger
         }
     }

--- a/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/SSHTerminalWindow.swift
@@ -118,19 +118,19 @@ private struct SSHTerminalContentView: View {
             Spacer()
 
             if case .error = sessionManager.status {
-                VButton(label: "Reconnect", style: .secondary, size: .small) {
+                VButton(label: "Reconnect", style: .outlined) {
                     sessionManager.reconnect()
                 }
             }
 
             if case .connected = sessionManager.status {
-                VButton(label: "Disconnect", style: .secondary, size: .small) {
+                VButton(label: "Disconnect", style: .outlined) {
                     sessionManager.close()
                 }
             }
 
             if case .closed = sessionManager.status {
-                VButton(label: "Connect", style: .primary, size: .small) {
+                VButton(label: "Connect", style: .primary) {
                     sessionManager.connect()
                 }
             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -325,11 +325,11 @@ struct RecordingSourcePickerView: View {
 
             // Buttons
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                VButton(label: "Cancel", style: .outlined) {
                     onCancel()
                 }
                 Spacer()
-                VButton(label: "Start Recording", style: .primary, size: .medium, isDisabled: !viewModel.canStart) {
+                VButton(label: "Start Recording", style: .primary, isDisabled: !viewModel.canStart) {
                     onStart(viewModel.selectedRecordingOptions)
                 }
             }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -1,14 +1,12 @@
 import SwiftUI
 
 public struct VButton: View {
-    public enum Style: Hashable { case primary, secondary, tertiary, danger, ghost, outlined, success }
-    public enum Size: Hashable { case small, medium, large }
+    public enum Style: Hashable { case primary, danger, dangerOutline, outlined }
 
     public let label: String
     public var leftIcon: String? = nil
     public var rightIcon: String? = nil
     public var style: Style = .primary
-    public var size: Size = .small
     public var isFullWidth: Bool = false
     public var isDisabled: Bool = false
     public var accessibilityID: String? = nil
@@ -16,12 +14,11 @@ public struct VButton: View {
 
     @State private var isHovered = false
 
-    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, style: Style = .primary, size: Size = .small, isFullWidth: Bool = false, isDisabled: Bool = false, accessibilityID: String? = nil, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, style: Style = .primary, isFullWidth: Bool = false, isDisabled: Bool = false, accessibilityID: String? = nil, action: @escaping () -> Void) {
         self.label = label
         self.leftIcon = leftIcon ?? icon
         self.rightIcon = rightIcon
         self.style = style
-        self.size = size
         self.isFullWidth = isFullWidth
         self.isDisabled = isDisabled
         self.accessibilityID = accessibilityID
@@ -35,8 +32,7 @@ public struct VButton: View {
                     VIconView(.resolve(leftIcon), size: iconSize)
                 }
                 Text(label)
-                    .font(labelFont)
-                    .fontWeight(style == .ghost || style == .tertiary ? .medium : .regular)
+                    .font(VFont.bodyMedium)
                 if isFullWidth && (leftIcon != nil || rightIcon != nil) {
                     Spacer(minLength: 0)
                 }
@@ -45,7 +41,7 @@ public struct VButton: View {
                 }
             }
         }
-        .buttonStyle(VButtonStyle(style: style, size: size, isHovered: isHovered, isFullWidth: isFullWidth))
+        .buttonStyle(VButtonStyle(style: style, isHovered: isHovered, isFullWidth: isFullWidth))
         .onHover { hovering in
             isHovered = isDisabled ? false : hovering
         }
@@ -56,82 +52,36 @@ public struct VButton: View {
     }
 
     private var iconSize: CGFloat { 13 }
-
-    private var labelFont: Font {
-        switch size {
-        case .small: return VFont.caption
-        case .medium: return VFont.bodyMedium
-        case .large: return VFont.buttonLarge
-        }
-    }
 }
 
 private struct VButtonStyle: ButtonStyle {
     let style: VButton.Style
-    let size: VButton.Size
     let isHovered: Bool
     let isFullWidth: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundColor(foregroundColor)
-            .padding(.horizontal, horizontalPadding)
+            .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.buttonV)
-            .frame(height: height)
+            .frame(height: 28)
             .frame(maxWidth: isFullWidth ? .infinity : nil)
             .background(backgroundColor(isPressed: configuration.isPressed))
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
+                RoundedRectangle(cornerRadius: VRadius.md)
                     .strokeBorder(borderColor(isPressed: configuration.isPressed), lineWidth: borderLineWidth)
             )
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .shadow(color: configuration.isPressed ? .clear : shadowColor, radius: 0, x: 0, y: 2)
+            .contentShape(RoundedRectangle(cornerRadius: VRadius.md))
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
             .animation(VAnimation.fast, value: configuration.isPressed)
             .animation(VAnimation.fast, value: isHovered)
     }
 
-    private var cornerRadius: CGFloat {
-        return VRadius.md
-    }
-
     private var borderLineWidth: CGFloat {
         switch style {
-        case .tertiary: return 2
-        case .outlined: return 2.5
+        case .outlined, .dangerOutline: return 2
         default: return 0
-        }
-    }
-
-    private var height: CGFloat {
-        switch size {
-        case .small: return 24
-        case .medium: return 28
-        case .large: return 32
-        }
-    }
-
-    private var horizontalPadding: CGFloat {
-        switch size {
-        case .small: return VSpacing.md
-        case .medium: return VSpacing.md
-        case .large: return VSpacing.lg
-        }
-    }
-
-    private var shadowColor: Color {
-        switch style {
-        case .primary:
-            return .clear
-        case .danger:
-            return .clear
-        case .tertiary, .ghost:
-            return .clear
-        case .secondary:
-            return .clear
-        case .outlined, .success:
-            return .clear
         }
     }
 
@@ -144,31 +94,13 @@ private struct VButtonStyle: ButtonStyle {
             if isPressed { return VColor.primaryActive }
             if isHovered { return VColor.primaryHover }
             return VColor.primaryBase
-        case .secondary:
-            guard isEnabled else { return VColor.surfaceBase }
-            if isPressed { return VColor.surfaceActive }
-            if isHovered { return VColor.surfaceActive }
-            return VColor.surfaceBase
         case .danger:
             guard isEnabled else { return VColor.primaryDisabled }
             if isPressed { return VColor.systemNegativeHover }
             if isHovered { return VColor.systemNegativeHover }
             return VColor.systemNegativeStrong
-        case .tertiary:
-            if isPressed { return VColor.surfaceActive }
-            if isHovered { return VColor.surfaceBase }
+        case .outlined, .dangerOutline:
             return .clear
-        case .ghost:
-            if isPressed { return VColor.surfaceActive }
-            if isHovered { return VColor.surfaceBase }
-            return .clear
-        case .outlined:
-            return .clear
-        case .success:
-            guard isEnabled else { return VColor.primaryDisabled }
-            if isPressed { return VColor.primaryBase }
-            if isHovered { return VColor.primaryHover }
-            return VColor.systemPositiveWeak
         }
     }
 
@@ -176,25 +108,24 @@ private struct VButtonStyle: ButtonStyle {
         guard isEnabled else { return VColor.contentDisabled }
         switch style {
         case .primary: return VColor.auxWhite
-        case .tertiary: return VColor.primaryBase
-        case .secondary: return VColor.primaryBase
         case .danger: return VColor.auxWhite
-        case .ghost: return VColor.primaryBase
-        case .outlined: return VColor.primaryBase
-        case .success: return VColor.primaryActive
+        case .outlined: return isHovered ? VColor.primaryHover : VColor.primaryBase
+        case .dangerOutline: return isHovered ? VColor.systemNegativeHover : VColor.systemNegativeStrong
         }
     }
 
     private func borderColor(isPressed: Bool) -> Color {
         switch style {
-        case .tertiary:
-            if isPressed { return VColor.surfaceActive }
-            return VColor.borderActive
         case .outlined:
-            if isPressed { return VColor.borderActive.opacity(0.7) }
-            return VColor.borderActive
-        case .secondary, .ghost, .success:
-            return .clear
+            guard isEnabled else { return VColor.primaryDisabled }
+            if isPressed { return VColor.primaryActive }
+            if isHovered { return VColor.primaryHover }
+            return VColor.primaryBase
+        case .dangerOutline:
+            guard isEnabled else { return VColor.primaryDisabled }
+            if isPressed { return VColor.systemNegativeHover }
+            if isHovered { return VColor.systemNegativeHover }
+            return VColor.systemNegativeStrong
         default:
             return .clear
         }
@@ -211,4 +142,3 @@ private extension View {
         }
     }
 }
-

--- a/clients/shared/DesignSystem/Core/Feedback/VToast.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VToast.swift
@@ -52,7 +52,7 @@ public struct VToast: View {
             if primaryAction != nil || secondaryAction != nil || onDismiss != nil {
                 HStack(spacing: VSpacing.sm) {
                     if let secondary = secondaryAction {
-                        VButton(label: secondary.label, style: .tertiary, action: secondary.action)
+                        VButton(label: secondary.label, style: .outlined, action: secondary.action)
                     }
                     if let primary = primaryAction {
                         VButton(label: primary.label, style: actionButtonStyle, action: primary.action)

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -23,14 +23,14 @@ struct ButtonsGallerySection: View {
                         VSegmentedControl(
                             items: [
                                 (label: "Primary", tag: VButton.Style.primary),
-                                (label: "Tertiary", tag: VButton.Style.tertiary),
-                                (label: "Secondary", tag: VButton.Style.secondary),
+                                (label: "Outlined", tag: VButton.Style.outlined),
                                 (label: "Danger", tag: VButton.Style.danger),
+                                (label: "Danger Outline", tag: VButton.Style.dangerOutline),
                             ],
                             selection: $selectedStyle,
                             style: .pill
                         )
-                        .frame(maxWidth: 300)
+                        .frame(maxWidth: 500)
 
                         Toggle("Full Width", isOn: $isFullWidth)
                         Toggle("Disabled", isOn: $isDisabled)
@@ -39,12 +39,29 @@ struct ButtonsGallerySection: View {
                     Divider().background(VColor.borderBase)
 
                     // Live preview
-                    VButton(
-                        label: "Click Me",
-                        style: selectedStyle,
-                        isFullWidth: isFullWidth,
-                        isDisabled: isDisabled
-                    ) {}
+                    HStack(spacing: VSpacing.lg) {
+                        VButton(
+                            label: "With Icons",
+                            leftIcon: VIcon.zap.rawValue,
+                            rightIcon: VIcon.arrowUpRight.rawValue,
+                            style: selectedStyle,
+                            isFullWidth: isFullWidth,
+                            isDisabled: isDisabled
+                        ) {}
+                        VButton(
+                            label: "Left Icon",
+                            leftIcon: VIcon.zap.rawValue,
+                            style: selectedStyle,
+                            isFullWidth: isFullWidth,
+                            isDisabled: isDisabled
+                        ) {}
+                        VButton(
+                            label: "Text Only",
+                            style: selectedStyle,
+                            isFullWidth: isFullWidth,
+                            isDisabled: isDisabled
+                        ) {}
+                    }
                 }
             }
 
@@ -55,33 +72,11 @@ struct ButtonsGallerySection: View {
 
             VCard {
                 HStack(spacing: VSpacing.xl) {
-                    ForEach([VButton.Style.primary, .tertiary, .secondary, .danger], id: \.self) { style in
+                    ForEach([VButton.Style.primary, .outlined, .danger, .dangerOutline], id: \.self) { style in
                         VStack(spacing: VSpacing.md) {
                             VButton(label: styleName(style), style: style) {}
                             VButton(label: "Disabled", style: style, isDisabled: true) {}
                             VButton(label: "Full Width", style: style, isFullWidth: true) {}
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
-                }
-            }
-
-            // All Sizes
-            Text("All Sizes")
-                .font(VFont.headline)
-                .foregroundColor(VColor.contentSecondary)
-
-            VCard {
-                HStack(spacing: VSpacing.xl) {
-                    ForEach([VButton.Size.small, .medium, .large], id: \.self) { size in
-                        VStack(spacing: VSpacing.md) {
-                            Text(sizeName(size))
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentTertiary)
-                            VButton(label: sizeName(size), style: .primary, size: size) {}
-                            VButton(label: sizeName(size), style: .secondary, size: size) {}
-                            VButton(label: sizeName(size), style: .tertiary, size: size) {}
-                            VButton(label: sizeName(size), style: .danger, size: size) {}
                         }
                         .frame(maxWidth: .infinity)
                     }
@@ -227,20 +222,9 @@ struct ButtonsGallerySection: View {
     private func styleName(_ style: VButton.Style) -> String {
         switch style {
         case .primary: return "Primary"
-        case .tertiary: return "Tertiary"
-        case .secondary: return "Secondary"
         case .danger: return "Danger"
-        case .ghost: return "Ghost"
         case .outlined: return "Outlined"
-        case .success: return "Success"
-        }
-    }
-
-    private func sizeName(_ size: VButton.Size) -> String {
-        switch size {
-        case .small: return "Small"
-        case .medium: return "Medium"
-        case .large: return "Large"
+        case .dangerOutline: return "Danger Outline"
         }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -47,7 +47,7 @@ struct InlineAppCreatedCard: View {
 
             // Action buttons
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Open App", leftIcon: VIcon.arrowUpRight.rawValue, style: .primary, size: .small) {
+                VButton(label: "Open App", leftIcon: VIcon.arrowUpRight.rawValue, style: .primary) {
                     onOpenApp()
                 }
 
@@ -55,8 +55,7 @@ struct InlineAppCreatedCard: View {
                     VButton(
                         label: isPinned ? "Unpin" : "Pin to Nav",
                         leftIcon: isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
-                        style: .tertiary,
-                        size: .small
+                        style: .outlined
                     ) {
                         onTogglePin(isPinned)
                     }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -148,11 +148,11 @@ public struct ToolConfirmationBubble: View {
                     #endif
                 }
 
-                VButton(label: "I\u{2019}ve granted it", style: .tertiary) {
+                VButton(label: "I\u{2019}ve granted it", style: .outlined) {
                     onAllow()
                 }
 
-                VButton(label: "Skip", style: .tertiary) {
+                VButton(label: "Skip", style: .outlined) {
                     onDeny()
                 }
             }

--- a/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/ConfirmationSurfaceView.swift
@@ -89,7 +89,7 @@ public struct ConfirmationSurfaceView: View {
 
                 VButton(
                     label: data.cancelLabel ?? "Cancel",
-                    style: .tertiary
+                    style: .outlined
                 ) {
                     selectedAction = .cancelled
                     onAction(cancelActionId)

--- a/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FileUploadSurfaceView.swift
@@ -48,7 +48,7 @@ public struct FileUploadSurfaceView: View {
             HStack(spacing: VSpacing.lg) {
                 Spacer()
 
-                VButton(label: "Cancel", style: .tertiary) {
+                VButton(label: "Cancel", style: .outlined) {
                     onCancel()
                 }
 

--- a/clients/shared/Features/Surfaces/FormSurfaceView.swift
+++ b/clients/shared/Features/Surfaces/FormSurfaceView.swift
@@ -107,7 +107,7 @@ public struct FormSurfaceView: View {
             if currentPage > 0 {
                 VButton(
                     label: data.pageLabels?.back ?? "Back",
-                    style: .tertiary
+                    style: .outlined
                 ) {
                     withAnimation(VAnimation.fast) {
                         currentPageIndex -= 1


### PR DESCRIPTION
## Summary
- Remove `.secondary`, `.tertiary`, `.ghost`, and `.success` styles from `VButton.Style`, leaving only `.primary`, `.danger`, `.dangerOutline`, and `.outlined`
- Remove the `Size` enum entirely (`.small`/`.medium`/`.large`) — all buttons use a single fixed size
- Migrate ~70 call sites across 38 files to use the remaining styles

## Test plan
- [ ] Open component gallery → Buttons section, verify 4 styles render correctly
- [ ] Check settings panels (Developer, Backups, Voice) for correct button styling
- [ ] Check channel verification and contact detail flows
- [ ] Verify disabled and full-width states still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
