### PR TITLE
fix: render server-side web search as tool chips on desktop

### DIFF
--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -431,6 +431,7 @@ describe("Native Web Search — Streaming Events", () => {
       type: "server_tool_start",
       name: "web_search",
       toolUseId: "stu_stream123",
+      input: {},
     });
   });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -72,7 +72,13 @@ export type AgentEvent =
       toolUseId: string;
       accumulatedJson: string;
     }
-  | { type: "server_tool_start"; name: string; toolUseId: string }
+  | {
+      type: "server_tool_start";
+      name: string;
+      toolUseId: string;
+      input: Record<string, unknown>;
+    }
+  | { type: "server_tool_complete"; toolUseId: string }
   | { type: "error"; error: Error }
   | {
       type: "usage";
@@ -305,6 +311,12 @@ export class AgentLoop {
                 onEvent({
                   type: "server_tool_start",
                   name: event.name,
+                  toolUseId: event.toolUseId,
+                  input: event.input,
+                });
+              } else if (event.type === "server_tool_complete") {
+                onEvent({
+                  type: "server_tool_complete",
                   toolUseId: event.toolUseId,
                 });
               }

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -844,6 +844,31 @@ export async function dispatchAgentEvent(
         deps.reqId,
         statusText,
       );
+      // Emit tool_use_start so the client renders a tool chip (like other tools)
+      deps.onEvent({
+        type: "tool_use_start",
+        toolName: event.name,
+        input: event.input,
+        sessionId: deps.ctx.conversationId,
+        toolUseId: event.toolUseId,
+      });
+      break;
+    }
+    case "server_tool_complete": {
+      deps.ctx.emitActivityState(
+        "streaming",
+        "tool_result_received",
+        "assistant_turn",
+        deps.reqId,
+      );
+      deps.onEvent({
+        type: "tool_result",
+        toolName: "",
+        result: "",
+        isError: false,
+        sessionId: deps.ctx.conversationId,
+        toolUseId: event.toolUseId,
+      });
       break;
     }
     case "error":

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -680,10 +680,14 @@ export class AnthropicProvider implements Provider {
               onEvent?.({ type: "text_delta", text: " " });
             }
             hasSeenTextBlock = true;
-          } else if (event.type === "content_block_start") {
-            // Reset on non-text blocks so that text separated by tool_use
-            // (text -> tool_use -> text) doesn't get a spurious leading space
-            // in the second text segment.
+          } else if (
+            event.type === "content_block_start" &&
+            event.content_block.type === "tool_use"
+          ) {
+            // Reset only for client-side tool_use blocks, which create visual
+            // separators in the UI. Server-side tool blocks (server_tool_use,
+            // web_search_tool_result) are transparent in the text stream and
+            // need the space preserved between surrounding text blocks.
             hasSeenTextBlock = false;
           }
           if (
@@ -708,6 +712,20 @@ export class AnthropicProvider implements Provider {
               type: "server_tool_start",
               name: event.content_block.name,
               toolUseId: event.content_block.id,
+              input: (
+                event.content_block as { input?: Record<string, unknown> }
+              ).input ?? {},
+            });
+          }
+          if (
+            event.type === "content_block_start" &&
+            event.content_block.type === "web_search_tool_result"
+          ) {
+            onEvent?.({
+              type: "server_tool_complete",
+              toolUseId: (
+                event.content_block as { tool_use_id: string }
+              ).tool_use_id,
             });
           }
           if (event.type === "content_block_stop") {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -117,7 +117,13 @@ export type ProviderEvent =
       toolUseId: string;
       accumulatedJson: string;
     }
-  | { type: "server_tool_start"; name: string; toolUseId: string };
+  | {
+      type: "server_tool_start";
+      name: string;
+      toolUseId: string;
+      input: Record<string, unknown>;
+    }
+  | { type: "server_tool_complete"; toolUseId: string };
 
 export interface SendMessageConfig {
   model?: string;


### PR DESCRIPTION
## Summary

- **Text spacing fix**: Server-side tool blocks (web_search) no longer eat the space between surrounding text blocks. Previously `hasSeenTextBlock` was reset for all non-text blocks; now only client-side `tool_use` blocks reset it.
- **Tool chip rendering**: Server-side tools now emit `tool_use_start`/`tool_result` events so the desktop client renders them as proper tool chips in the "Completed N steps" dropdown, instead of showing "Searching the web" in the Thinking indicator.
- Added `server_tool_complete` provider event emitted when `web_search_tool_result` content block arrives, piped through the agent loop to the session handler.

## Original prompt
Fix web search progress indicators on desktop: (1) Missing space between text blocks around server-side tool use - "web search.Step 2 done." runs together without space. Fix: only reset hasSeenTextBlock for client-side tool_use blocks, not server-side blocks. (2) "Searching the web" shows in Thinking UI instead of tool chip dropdown. Fix: emit tool_use_start/tool_result events for server-side tools so they appear as proper tool chips in the "Completed N steps" UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
