### PR TITLE
feat: add startInviteCall for outbound voice invite delivery

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -1017,3 +1017,139 @@ export async function startVerificationCall(
     };
   }
 }
+
+// ── Invite call ───────────────────────────────────────────────────────
+
+export type StartInviteCallInput = {
+  phoneNumber: string;
+  friendName: string;
+  guardianName: string;
+  assistantId?: string;
+  originConversationId?: string;
+};
+
+export type StartInviteCallResult = { ok: true; callSid: string } | CallError;
+
+/**
+ * Initiate an outbound call to deliver a voice invite to a contact.
+ *
+ * Creates a minimal call session with a voice channel binding and
+ * passes invite-specific custom parameters so the relay server can
+ * detect this is an invite redemption call.
+ */
+export async function startInviteCall(
+  input: StartInviteCallInput,
+): Promise<StartInviteCallResult> {
+  const { phoneNumber, friendName, guardianName, originConversationId } = input;
+
+  if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {
+    return {
+      ok: false,
+      error: "phone_number must be in E.164 format",
+      status: 400,
+    };
+  }
+
+  let sessionId: string | null = null;
+
+  try {
+    const config = loadConfig();
+    const provider = new TwilioConversationRelayProvider();
+
+    // Resolve the assistant's Twilio number as the caller ID
+    const identityResult = await resolveCallerIdentity(config);
+    if (!identityResult.ok) {
+      return { ok: false, error: identityResult.error, status: 400 };
+    }
+
+    const preflightResult = await preflightVoiceIngress();
+    if (!preflightResult.ok) {
+      return preflightResult;
+    }
+    const ingressConfig = preflightResult.ingressConfig;
+
+    // Create a minimal conversation so the call session has a valid FK,
+    // and bind it to the voice channel so it never appears as an unbound
+    // desktop thread.
+    const timestamp = Date.now();
+    const convKey = `invite-call:${phoneNumber}:${timestamp}`;
+    const { conversationId } = getOrCreateConversation(convKey);
+
+    upsertBinding({
+      conversationId,
+      sourceChannel: "phone",
+      externalChatId: `invite-call:${phoneNumber}:${timestamp}`,
+    });
+
+    const session = createCallSession({
+      conversationId,
+      provider: "twilio",
+      fromNumber: identityResult.fromNumber,
+      toNumber: phoneNumber,
+      initiatedFromConversationId: originConversationId,
+    });
+    sessionId = session.id;
+
+    const webhookUrl = await resolveCallbackUrl(
+      () => getTwilioVoiceWebhookUrl(ingressConfig, session.id),
+      "webhooks/twilio/voice",
+      "twilio_voice",
+      { callSessionId: session.id },
+    );
+    const statusCallbackUrl = await resolveCallbackUrl(
+      () => getTwilioStatusCallbackUrl(ingressConfig),
+      "webhooks/twilio/status",
+      "twilio_status",
+    );
+
+    upsertActiveCallLease({ callSessionId: session.id });
+
+    const { callSid } = await provider.initiateCall({
+      from: identityResult.fromNumber,
+      to: phoneNumber,
+      webhookUrl,
+      statusCallbackUrl,
+      customParams: {
+        inviteRedemptionMode: "true",
+        inviteRedemptionFromNumber: phoneNumber,
+        inviteRedemptionFriendName: friendName,
+        inviteRedemptionGuardianName: guardianName,
+      },
+    });
+
+    updateCallSession(session.id, { providerCallSid: callSid });
+
+    log.info(
+      {
+        callSessionId: session.id,
+        callSid,
+        to: phoneNumber,
+        friendName,
+        guardianName,
+      },
+      "Invite call initiated",
+    );
+
+    return { ok: true, callSid };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(
+      { err, phoneNumber, friendName, guardianName },
+      "Failed to initiate invite call",
+    );
+
+    if (sessionId) {
+      updateCallSession(sessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: msg,
+      });
+    }
+
+    return {
+      ok: false,
+      error: `Error initiating invite call: ${msg}`,
+      status: 500,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `StartInviteCallInput` type and `startInviteCall()` function to call-domain.ts
- Creates outbound Twilio calls with invite-specific custom parameters for relay routing
- Creates voice-bound conversations that don't appear in desktop threads
- Validates E.164 phone format and Twilio provider availability

Part of plan: voice-code-invites.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
