### PR TITLE
fix: make entire composer area show IBeam cursor and accept clicks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -412,6 +412,9 @@ struct ComposerView: View {
                 .stroke(VColor.borderBase.opacity(isComposerFocused ? 0.12 : 0), lineWidth: 3)
         )
         .shadow(color: .clear, radius: 0)
+        .contentShape(Rectangle())
+        .onTapGesture { composerFocus = true }
+        .iBeamCursor()
     }
 
     @ViewBuilder

--- a/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ModifiersGallerySection.swift
@@ -129,6 +129,51 @@ struct ModifiersGallerySection: View {
 
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
+            // MARK: - .iBeamCursor()
+            GallerySectionHeader(
+                title: ".iBeamCursor()",
+                description: "Shows an I-beam (text) cursor on hover. Useful for making non-TextField areas feel like clickable text-input zones."
+            )
+
+            VCard {
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    Text("Hover over the items below to see the I-beam cursor:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+
+                    HStack(spacing: VSpacing.lg) {
+                        Text("Text input area")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .padding(VSpacing.md)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .stroke(VColor.borderBase, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                            .iBeamCursor()
+
+                        Text("Disabled")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentSecondary)
+                            .padding(VSpacing.md)
+                            .background(VColor.surfaceBase)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.sm)
+                                    .stroke(VColor.borderBase, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                            .iBeamCursor()
+                            .disabled(true)
+                    }
+                }
+            }
+
+            Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
             // MARK: - .vPanelBackground()
             GallerySectionHeader(
                 title: ".vPanelBackground()",

--- a/clients/shared/DesignSystem/Modifiers/IBeamCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/IBeamCursorModifier.swift
@@ -6,9 +6,10 @@ import AppKit
 
 /// A view modifier that shows an I-beam (text) cursor on hover.
 ///
-/// On macOS 15+ this uses the native `.pointerStyle(.horizontalBeamResize)` workaround
-/// since there is no `.iBeam` pointer style. On macOS 14 it falls back to
-/// `NSCursor.iBeam.push()` / `NSCursor.pop()`.
+/// On macOS this uses `NSCursor.iBeam.push()` / `NSCursor.pop()` with cleanup
+/// in `onChange(of: isEnabled)` and `onDisappear` to avoid cursor stack leaks.
+/// There is no `.pointerStyle` equivalent for I-beam, so the NSCursor approach
+/// is used unconditionally across all macOS versions.
 struct IBeamCursorModifier: ViewModifier {
     @Environment(\.isEnabled) private var isEnabled
 

--- a/clients/shared/DesignSystem/Modifiers/IBeamCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/IBeamCursorModifier.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+#endif
+
+/// A view modifier that shows an I-beam (text) cursor on hover.
+///
+/// On macOS 15+ this uses the native `.pointerStyle(.horizontalBeamResize)` workaround
+/// since there is no `.iBeam` pointer style. On macOS 14 it falls back to
+/// `NSCursor.iBeam.push()` / `NSCursor.pop()`.
+struct IBeamCursorModifier: ViewModifier {
+    @Environment(\.isEnabled) private var isEnabled
+
+    #if os(macOS)
+    @State private var didPushCursor = false
+    #endif
+
+    func body(content: Content) -> some View {
+        #if os(macOS)
+        content
+            .onHover { hovering in
+                if hovering && isEnabled {
+                    NSCursor.iBeam.push()
+                    didPushCursor = true
+                } else if didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+            .onChange(of: isEnabled) { _, enabled in
+                if !enabled && didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+            .onDisappear {
+                if didPushCursor {
+                    NSCursor.pop()
+                    didPushCursor = false
+                }
+            }
+        #else
+        content
+        #endif
+    }
+}
+
+extension View {
+    /// Applies an I-beam (text) cursor when the user hovers over this view.
+    func iBeamCursor() -> some View {
+        modifier(IBeamCursorModifier())
+    }
+}


### PR DESCRIPTION
## Summary
- Added `IBeamCursorModifier` (mirrors existing `PointerCursorModifier` but uses `NSCursor.iBeam`)
- Applied `.contentShape(Rectangle())`, `.onTapGesture { composerFocus = true }`, and `.iBeamCursor()` to `standardComposerShell` so the full padded area responds to hover and clicks

## Original prompt
roughly only the area i highlighted in our text input is clickable. i want it to show my "insert text" style cursor whenever i hover over upper/lower region above my red highlight too, and it should be clickable to focus. know what i mean?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
