### PR TITLE
feat: add assistant skills search command with security audits

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  AuditResponse,
+  SkillAuditData,
+  SkillsShSearchResult,
+} from "../skills/skillssh-registry.js";
+import {
+  fetchSkillAudits,
+  formatAuditBadges,
+  providerDisplayName,
+  riskToDisplay,
+  searchSkillsRegistry,
+} from "../skills/skillssh-registry.js";
+
+// ─── Fetch mock helpers ──────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+let mockFetchImpl: (url: string | URL | Request) => Promise<Response>;
+
+beforeEach(() => {
+  mockFetchImpl = () =>
+    Promise.resolve(new Response("not mocked", { status: 500 }));
+  globalThis.fetch = mock((input: string | URL | Request) =>
+    mockFetchImpl(typeof input === "string" ? input : input.toString()),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ─── searchSkillsRegistry ────────────────────────────────────────────────────
+
+describe("searchSkillsRegistry", () => {
+  test("sends correct query parameters and returns results", async () => {
+    const mockResults: SkillsShSearchResult[] = [
+      {
+        id: "vercel-labs/agent-skills/vercel-react-best-practices",
+        skillId: "vercel-react-best-practices",
+        name: "Vercel React Best Practices",
+        installs: 1200,
+        source: "vercel-labs/agent-skills",
+      },
+    ];
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).toContain("skills.sh/api/search");
+      expect(urlStr).toContain("q=react");
+      expect(urlStr).toContain("limit=5");
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResults), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const results = await searchSkillsRegistry("react", 5);
+    expect(results).toEqual(mockResults);
+  });
+
+  test("omits limit parameter when not provided", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).not.toContain("limit=");
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const results = await searchSkillsRegistry("test");
+    expect(results).toEqual([]);
+  });
+
+  test("throws on non-OK response", async () => {
+    mockFetchImpl = () =>
+      Promise.resolve(new Response("Not Found", { status: 404 }));
+
+    await expect(searchSkillsRegistry("bad-query")).rejects.toThrow(
+      "skills.sh search failed: HTTP 404",
+    );
+  });
+});
+
+// ─── fetchSkillAudits ────────────────────────────────────────────────────────
+
+describe("fetchSkillAudits", () => {
+  test("sends correct parameters and returns audit data", async () => {
+    const mockAudits: AuditResponse = {
+      "vercel-react-best-practices": {
+        ath: {
+          risk: "safe",
+          alerts: 0,
+          score: 100,
+          analyzedAt: "2025-01-15T00:00:00Z",
+        },
+        socket: {
+          risk: "low",
+          alerts: 1,
+          score: 95,
+          analyzedAt: "2025-01-15T00:00:00Z",
+        },
+      },
+    };
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).toContain("add-skill.vercel.sh/audit");
+      expect(urlStr).toContain("source=vercel-labs%2Fagent-skills");
+      expect(urlStr).toContain(
+        "skills=vercel-react-best-practices%2Canother-skill",
+      );
+      return Promise.resolve(
+        new Response(JSON.stringify(mockAudits), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const audits = await fetchSkillAudits("vercel-labs/agent-skills", [
+      "vercel-react-best-practices",
+      "another-skill",
+    ]);
+    expect(audits).toEqual(mockAudits);
+  });
+
+  test("returns empty object for empty slugs list", async () => {
+    const audits = await fetchSkillAudits("some/source", []);
+    expect(audits).toEqual({});
+    // fetch should not have been called
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("throws on non-OK response", async () => {
+    mockFetchImpl = () =>
+      Promise.resolve(
+        new Response("Internal Server Error", { status: 500 }),
+      );
+
+    await expect(
+      fetchSkillAudits("some/source", ["slug"]),
+    ).rejects.toThrow("Audit fetch failed: HTTP 500");
+  });
+});
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+describe("riskToDisplay", () => {
+  test("maps risk levels correctly", () => {
+    expect(riskToDisplay("safe")).toBe("PASS");
+    expect(riskToDisplay("low")).toBe("PASS");
+    expect(riskToDisplay("medium")).toBe("WARN");
+    expect(riskToDisplay("high")).toBe("FAIL");
+    expect(riskToDisplay("critical")).toBe("FAIL");
+    expect(riskToDisplay("unknown")).toBe("?");
+  });
+});
+
+describe("providerDisplayName", () => {
+  test("maps known providers", () => {
+    expect(providerDisplayName("ath")).toBe("ATH");
+    expect(providerDisplayName("socket")).toBe("Socket");
+    expect(providerDisplayName("snyk")).toBe("Snyk");
+  });
+
+  test("returns raw name for unknown providers", () => {
+    expect(providerDisplayName("custom-auditor")).toBe("custom-auditor");
+  });
+});
+
+describe("formatAuditBadges", () => {
+  test("formats multiple providers as badges", () => {
+    const auditData: SkillAuditData = {
+      ath: { risk: "safe", analyzedAt: "2025-01-15T00:00:00Z" },
+      socket: { risk: "safe", analyzedAt: "2025-01-15T00:00:00Z" },
+      snyk: { risk: "medium", analyzedAt: "2025-01-15T00:00:00Z" },
+    };
+    expect(formatAuditBadges(auditData)).toBe(
+      "Security: [ATH:PASS] [Socket:PASS] [Snyk:WARN]",
+    );
+  });
+
+  test("returns fallback message when no providers present", () => {
+    expect(formatAuditBadges({})).toBe("Security: no audit data");
+  });
+
+  test("handles single provider", () => {
+    const auditData: SkillAuditData = {
+      ath: { risk: "critical", analyzedAt: "2025-01-15T00:00:00Z" },
+    };
+    expect(formatAuditBadges(auditData)).toBe("Security: [ATH:FAIL]");
+  });
+});

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -8,6 +8,12 @@ import {
   readLocalCatalog,
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
+import {
+  fetchSkillAudits,
+  formatAuditBadges,
+  searchSkillsRegistry,
+} from "../../skills/skillssh-registry.js";
+import type { AuditResponse } from "../../skills/skillssh-registry.js";
 import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
@@ -28,6 +34,8 @@ capabilities with pre-built workflows and tools.
 Examples:
   $ assistant skills list
   $ assistant skills list --json
+  $ assistant skills search react
+  $ assistant skills search react --limit 5 --json
   $ assistant skills install weather
   $ assistant skills install weather --overwrite
   $ assistant skills uninstall weather`,
@@ -78,6 +86,86 @@ Examples:
         process.exitCode = 1;
       }
     });
+
+  skills
+    .command("search <query>")
+    .description("Search the skills.sh community registry")
+    .option("--limit <n>", "Maximum number of results", "10")
+    .option("--json", "Machine-readable JSON output")
+    .action(
+      async (query: string, opts: { limit: string; json?: boolean }) => {
+        const json = opts.json ?? false;
+        const limit = parseInt(opts.limit, 10) || 10;
+
+        try {
+          const results = await searchSkillsRegistry(query, limit);
+
+          if (results.length === 0) {
+            if (json) {
+              console.log(
+                JSON.stringify({ ok: true, results: [], audits: {} }),
+              );
+            } else {
+              log.info(`No skills found for "${query}".`);
+            }
+            return;
+          }
+
+          // Group skill slugs by source for batch audit lookups
+          const sourceToSlugs = new Map<string, string[]>();
+          for (const r of results) {
+            const slugs = sourceToSlugs.get(r.source) ?? [];
+            slugs.push(r.skillId);
+            sourceToSlugs.set(r.source, slugs);
+          }
+
+          // Fetch audits for each unique source
+          const allAudits: AuditResponse = {};
+          for (const [source, slugs] of sourceToSlugs) {
+            try {
+              const audits = await fetchSkillAudits(source, slugs);
+              Object.assign(allAudits, audits);
+            } catch {
+              // Audit fetch failures are non-fatal; display results without audits
+            }
+          }
+
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                results,
+                audits: allAudits,
+              }),
+            );
+            return;
+          }
+
+          log.info(`Search results for "${query}" (${results.length}):\n`);
+          for (const r of results) {
+            log.info(`  ${r.name}`);
+            log.info(`    ID: ${r.skillId}`);
+            log.info(`    Source: ${r.source}`);
+            log.info(`    Installs: ${r.installs}`);
+            const auditData = allAudits[r.skillId];
+            if (auditData) {
+              log.info(`    ${formatAuditBadges(auditData)}`);
+            } else {
+              log.info("    Security: no audit data");
+            }
+            log.info("");
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (json) {
+            console.log(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
 
   skills
     .command("install <skill-id>")

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -92,6 +92,23 @@ Examples:
     .description("Search the skills.sh community registry")
     .option("--limit <n>", "Maximum number of results", "10")
     .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  query    Free-text search term matched against skill names, descriptions,
+           and tags in the skills.sh registry.
+
+Searches the skills.sh community registry and displays matching skills
+with install counts and security audit badges (ATH, Socket, Snyk).
+Audit fetch failures are non-fatal — results are still shown without
+security data.
+
+Examples:
+  $ assistant skills search react
+  $ assistant skills search "file management" --limit 3
+  $ assistant skills search deploy --json`,
+    )
     .action(
       async (query: string, opts: { limit: string; json?: boolean }) => {
         const json = opts.json ?? false;
@@ -119,12 +136,15 @@ Examples:
             sourceToSlugs.set(r.source, slugs);
           }
 
-          // Fetch audits for each unique source
+          // Fetch audits for each unique source, keyed by source/skillId
+          // to avoid collisions when different sources share the same slug.
           const allAudits: AuditResponse = {};
           for (const [source, slugs] of sourceToSlugs) {
             try {
               const audits = await fetchSkillAudits(source, slugs);
-              Object.assign(allAudits, audits);
+              for (const [skillId, auditData] of Object.entries(audits)) {
+                allAudits[`${source}/${skillId}`] = auditData;
+              }
             } catch {
               // Audit fetch failures are non-fatal; display results without audits
             }
@@ -147,7 +167,7 @@ Examples:
             log.info(`    ID: ${r.skillId}`);
             log.info(`    Source: ${r.source}`);
             log.info(`    Installs: ${r.installs}`);
-            const auditData = allAudits[r.skillId];
+            const auditData = allAudits[`${r.source}/${r.skillId}`];
             if (auditData) {
               log.info(`    ${formatAuditBadges(auditData)}`);
             } else {

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,0 +1,119 @@
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SkillsShSearchResult {
+  id: string; // e.g. "vercel-labs/agent-skills/vercel-react-best-practices"
+  skillId: string; // e.g. "vercel-react-best-practices"
+  name: string;
+  installs: number;
+  source: string; // e.g. "vercel-labs/agent-skills"
+}
+
+export type RiskLevel =
+  | "safe"
+  | "low"
+  | "medium"
+  | "high"
+  | "critical"
+  | "unknown";
+
+export interface PartnerAudit {
+  risk: RiskLevel;
+  alerts?: number;
+  score?: number;
+  analyzedAt: string;
+}
+
+/** Map from audit provider name (e.g. "ath", "socket", "snyk") to audit data */
+export type SkillAuditData = Record<string, PartnerAudit>;
+
+/** Map from skill slug to per-provider audit data */
+export type AuditResponse = Record<string, SkillAuditData>;
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+const RISK_DISPLAY: Record<RiskLevel, string> = {
+  safe: "PASS",
+  low: "PASS",
+  medium: "WARN",
+  high: "FAIL",
+  critical: "FAIL",
+  unknown: "?",
+};
+
+const PROVIDER_DISPLAY: Record<string, string> = {
+  ath: "ATH",
+  socket: "Socket",
+  snyk: "Snyk",
+};
+
+export function riskToDisplay(risk: RiskLevel): string {
+  return RISK_DISPLAY[risk] ?? "?";
+}
+
+export function providerDisplayName(provider: string): string {
+  return PROVIDER_DISPLAY[provider] ?? provider;
+}
+
+export function formatAuditBadges(auditData: SkillAuditData): string {
+  const providers = Object.keys(auditData);
+  if (providers.length === 0) return "Security: no audit data";
+
+  const badges = providers.map((provider) => {
+    const audit = auditData[provider]!;
+    const display = riskToDisplay(audit.risk);
+    const name = providerDisplayName(provider);
+    return `[${name}:${display}]`;
+  });
+
+  return `Security: ${badges.join(" ")}`;
+}
+
+// ─── API clients ─────────────────────────────────────────────────────────────
+
+export async function searchSkillsRegistry(
+  query: string,
+  limit?: number,
+): Promise<SkillsShSearchResult[]> {
+  const params = new URLSearchParams({ q: query });
+  if (limit != null) {
+    params.set("limit", String(limit));
+  }
+
+  const url = `https://skills.sh/api/search?${params.toString()}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `skills.sh search failed: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as SkillsShSearchResult[];
+}
+
+export async function fetchSkillAudits(
+  source: string,
+  skillSlugs: string[],
+): Promise<AuditResponse> {
+  if (skillSlugs.length === 0) return {};
+
+  const params = new URLSearchParams({
+    source,
+    skills: skillSlugs.join(","),
+  });
+
+  const url = `https://add-skill.vercel.sh/audit?${params.toString()}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Audit fetch failed: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as AuditResponse;
+}


### PR DESCRIPTION
## Summary
- Adds `assistant skills search <query>` CLI command that searches the skills.sh community registry
- Fetches and displays security audit data (ATH, Socket, Snyk) as concise badges
- Supports `--limit` and `--json` flags
- Creates `skillssh-registry.ts` module with typed API clients

## Original prompt
M1 of skills.sh registry search & install feature (#16037)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
