### PR TITLE
feat: route outbound invite calls to invite redemption flow

### DIFF
--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -99,6 +99,26 @@ export function routeSetup(ctx: SetupContext): {
     actorTrust,
   };
 
+  // ── Outbound invite redemption ────────────────────────────────────
+  if (!isInbound && ctx.customParameters?.inviteRedemptionMode === "true") {
+    const fromNumber = ctx.customParameters
+      .inviteRedemptionFromNumber as string;
+    const friendName = ctx.customParameters
+      .inviteRedemptionFriendName as string;
+    const guardianName = ctx.customParameters
+      .inviteRedemptionGuardianName as string;
+    return {
+      outcome: {
+        action: "invite_redemption" as const,
+        assistantId,
+        fromNumber,
+        friendName,
+        guardianName,
+      },
+      resolved,
+    };
+  }
+
   // ── Outbound guardian verification (persisted mode) ──────────────
   const persistedMode = ctx.session?.callMode;
   const persistedVsId = ctx.session?.verificationSessionId;


### PR DESCRIPTION
## Summary
- Add early check in relay-setup-router for outbound calls with `inviteRedemptionMode` custom param
- Route these calls to the existing `invite_redemption` action, reusing relay-server's `startInviteRedemption()` flow
- Normal outbound calls are unaffected

Part of plan: voice-code-invites.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
