### PR TITLE
feat: initiate outbound call to contact after voice invite creation

### DIFF
--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -8,6 +8,7 @@
  * /v1/contacts/channels endpoints.
  */
 
+import { startInviteCall } from "../calls/call-domain.js";
 import { isChannelId } from "../channels/types.js";
 import {
   createInvite,
@@ -23,6 +24,7 @@ import {
   DEFAULT_USER_REFERENCE,
   resolveGuardianName,
 } from "../prompts/user-reference.js";
+import { getLogger } from "../util/logger.js";
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import {
@@ -36,6 +38,8 @@ import {
   redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
   type VoiceRedemptionOutcome,
 } from "./invite-redemption-service.js";
+
+const log = getLogger("invite-service");
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and message handlers
@@ -247,6 +251,27 @@ export async function createIngressInvite(params: {
       channelHandle,
       hasShareUrl: !!share?.url,
       shareUrl: share?.url,
+    });
+  }
+
+  // For voice invites with a known phone number, initiate an outbound call
+  // so the contact is prompted to enter their code immediately.
+  if (
+    params.sourceChannel === "phone" &&
+    params.expectedExternalUserId &&
+    params.friendName &&
+    effectiveGuardianName
+  ) {
+    // Fire-and-forget: don't block invite creation on call initiation
+    startInviteCall({
+      phoneNumber: params.expectedExternalUserId,
+      friendName: params.friendName,
+      guardianName: effectiveGuardianName,
+    }).catch((err) => {
+      log.warn(
+        { err, inviteId: invite.id },
+        "Failed to initiate outbound invite call",
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- After creating a voice invite with phone number and names, fire-and-forget an outbound call to the contact
- Uses `startInviteCall()` from call-domain to initiate the Twilio call
- Call failure does not block invite creation; guardian can still share the code manually

Part of plan: voice-code-invites.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
