### PR TITLE
feat: enable voice channel invites on Contacts page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -10,14 +10,14 @@ struct ContactDetailView: View {
 
     private static let verificationSupportedChannels: Set<String> = ["telegram", "phone", "slack"]
 
-    /// Channels that support 6-digit code invites from this view. Voice invites
-    /// require additional fields not available here, so they are excluded.
-    private static let codeInviteChannels: Set<String> = ["telegram", "slack"]
+    /// Channels that support 6-digit code invites from this view.
+    private static let codeInviteChannels: Set<String> = ["telegram", "slack", "phone"]
 
     let contact: ContactPayload
     var daemonClient: DaemonClient?
     var store: SettingsStore?
     var onDelete: (() -> Void)?
+    var guardianName: String?
 
     @State var currentContact: ContactPayload?
     @State private var showDeleteConfirmation = false
@@ -33,6 +33,7 @@ struct ContactDetailView: View {
     @State private var verificationSuccessChannelId: String?
     @State private var telegramBootstrapUrl: String?
     @State private var telegramBootstrapChannelId: String?
+    @State private var invitePhoneNumber = ""
     @State private var inviteInProgress: String?
     @State private var inviteResult: (
         type: String,
@@ -454,21 +455,26 @@ struct ContactDetailView: View {
                     )
                 }
             } else if Self.codeInviteChannels.contains(type) {
-                // Channels that support 6-digit code invites can be invited directly
-                // from this view. Voice invites require additional fields (phone number,
-                // friend/guardian names) that aren't available in this context.
-                // Row visibility is already gated on channelReadiness[type]?.ready == true,
-                // so no additional readiness check is needed here.
                 if inviteInProgress == type {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    VButton(
-                        label: "Invite",
-                        style: .outlined,
-                        isDisabled: inviteInProgress != nil
-                    ) {
-                        createInviteForChannel(type: type)
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        if type == "phone" {
+                            TextField("+1234567890", text: $invitePhoneNumber)
+                                .font(VFont.mono)
+                                .textFieldStyle(.plain)
+                                .padding(VSpacing.sm)
+                                .background(VColor.surfaceActive)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                        }
+                        VButton(
+                            label: "Invite",
+                            style: .outlined,
+                            isDisabled: inviteInProgress != nil || (type == "phone" && invitePhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty)
+                        ) {
+                            createInviteForChannel(type: type)
+                        }
                     }
                 }
             }
@@ -970,10 +976,16 @@ struct ContactDetailView: View {
         inviteResult = nil
         Task {
             do {
+                let phoneNumber = type == "phone" ? invitePhoneNumber.trimmingCharacters(in: .whitespaces) : nil
+                let resolvedGuardianName = type == "phone" ? (guardianName ?? "your guardian") : nil
+
                 if let result = try await daemonClient.createInvite(
                     sourceChannel: type,
                     note: "Invite for \(displayContact.displayName)",
-                    contactName: displayContact.displayName
+                    contactName: displayContact.displayName,
+                    expectedExternalUserId: phoneNumber,
+                    friendName: type == "phone" ? displayContact.displayName : nil,
+                    guardianName: resolvedGuardianName
                 ) {
                     inviteResult = (
                         type: type,

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -82,7 +82,8 @@ struct ContactsContainerView: View {
                             onDelete: {
                                 selection = .assistant
                                 viewModel.loadContacts()
-                            }
+                            },
+                            guardianName: viewModel.guardianContact?.displayName
                         )
                         .id(contactId)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## Summary
- Add `"phone"` to `codeInviteChannels` to enable voice channel invites from Contact detail view
- Show phone number input field for voice channel invites
- Pass `expectedExternalUserId`, `friendName`, and `guardianName` to the backend when creating voice invites
- Telegram and Slack invite flows continue unchanged

Part of plan: voice-code-invites.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
