### PR TITLE
feat: add assistant skills add command for external skill installation

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -12,6 +12,7 @@ import {
   resolveSkillSource,
   riskToDisplay,
   searchSkillsRegistry,
+  validateSkillSlug,
 } from "../skills/skillssh-registry.js";
 
 // ─── Fetch mock helpers ──────────────────────────────────────────────────────
@@ -229,6 +230,7 @@ describe("resolveSkillSource", () => {
       owner: "vercel-labs",
       repo: "skills",
       skillSlug: "find-skills",
+      ref: "main",
     });
   });
 
@@ -240,6 +242,7 @@ describe("resolveSkillSource", () => {
       owner: "some-org",
       repo: "repo",
       skillSlug: "my-skill",
+      ref: "develop",
     });
   });
 
@@ -251,6 +254,7 @@ describe("resolveSkillSource", () => {
       owner: "owner",
       repo: "repo",
       skillSlug: "skill-name",
+      ref: "main",
     });
   });
 
@@ -274,5 +278,45 @@ describe("resolveSkillSource", () => {
     expect(() => resolveSkillSource("vercel-labs/skills")).toThrow(
       'Invalid skill source "vercel-labs/skills"',
     );
+  });
+
+  test("rejects path traversal in @ format slug", () => {
+    expect(() =>
+      resolveSkillSource("owner/repo@../../malicious"),
+    ).toThrow('Invalid skill source "owner/repo@../../malicious"');
+  });
+
+  test("rejects uppercase slug in @ format", () => {
+    expect(() => resolveSkillSource("owner/repo@BadSlug")).toThrow(
+      'Invalid skill source "owner/repo@BadSlug"',
+    );
+  });
+});
+
+// ─── validateSkillSlug ──────────────────────────────────────────────────────
+
+describe("validateSkillSlug", () => {
+  test("accepts valid slugs", () => {
+    expect(() => validateSkillSlug("my-skill")).not.toThrow();
+    expect(() => validateSkillSlug("skill123")).not.toThrow();
+    expect(() => validateSkillSlug("my.skill")).not.toThrow();
+    expect(() => validateSkillSlug("my_skill")).not.toThrow();
+  });
+
+  test("rejects path traversal characters", () => {
+    expect(() => validateSkillSlug("../../malicious")).toThrow(
+      "path traversal",
+    );
+    expect(() => validateSkillSlug("foo/bar")).toThrow("path traversal");
+    expect(() => validateSkillSlug("foo\\bar")).toThrow("path traversal");
+  });
+
+  test("rejects slugs starting with special chars", () => {
+    expect(() => validateSkillSlug(".hidden")).toThrow();
+    expect(() => validateSkillSlug("-dash")).toThrow();
+  });
+
+  test("rejects empty input", () => {
+    expect(() => validateSkillSlug("")).toThrow("Skill slug is required");
   });
 });

--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -9,6 +9,7 @@ import {
   fetchSkillAudits,
   formatAuditBadges,
   providerDisplayName,
+  resolveSkillSource,
   riskToDisplay,
   searchSkillsRegistry,
 } from "../skills/skillssh-registry.js";
@@ -196,5 +197,82 @@ describe("formatAuditBadges", () => {
       ath: { risk: "critical", analyzedAt: "2025-01-15T00:00:00Z" },
     };
     expect(formatAuditBadges(auditData)).toBe("Security: [ATH:FAIL]");
+  });
+});
+
+// ─── resolveSkillSource ─────────────────────────────────────────────────────
+
+describe("resolveSkillSource", () => {
+  test("parses owner/repo@skill-name format", () => {
+    const result = resolveSkillSource("vercel-labs/skills@find-skills");
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+    });
+  });
+
+  test("parses owner/repo/skill-name format", () => {
+    const result = resolveSkillSource("vercel-labs/skills/find-skills");
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+    });
+  });
+
+  test("parses full GitHub URL with main branch", () => {
+    const result = resolveSkillSource(
+      "https://github.com/vercel-labs/skills/tree/main/skills/find-skills",
+    );
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+    });
+  });
+
+  test("parses full GitHub URL with non-main branch", () => {
+    const result = resolveSkillSource(
+      "https://github.com/some-org/repo/tree/develop/skills/my-skill",
+    );
+    expect(result).toEqual({
+      owner: "some-org",
+      repo: "repo",
+      skillSlug: "my-skill",
+    });
+  });
+
+  test("parses GitHub URL with trailing slash", () => {
+    const result = resolveSkillSource(
+      "https://github.com/owner/repo/tree/main/skills/skill-name/",
+    );
+    expect(result).toEqual({
+      owner: "owner",
+      repo: "repo",
+      skillSlug: "skill-name",
+    });
+  });
+
+  test("throws on bare skill name (no owner/repo)", () => {
+    expect(() => resolveSkillSource("find-skills")).toThrow(
+      'Invalid skill source "find-skills"',
+    );
+  });
+
+  test("throws on empty string", () => {
+    expect(() => resolveSkillSource("")).toThrow('Invalid skill source ""');
+  });
+
+  test("throws on owner-only format", () => {
+    expect(() => resolveSkillSource("vercel-labs")).toThrow(
+      'Invalid skill source "vercel-labs"',
+    );
+  });
+
+  test("throws on owner/repo without skill", () => {
+    expect(() => resolveSkillSource("vercel-labs/skills")).toThrow(
+      'Invalid skill source "vercel-labs/skills"',
+    );
   });
 });

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -304,13 +304,14 @@ Examples:
         const json = opts.json ?? false;
 
         try {
-          const { owner, repo, skillSlug } = resolveSkillSource(source);
+          const { owner, repo, skillSlug, ref } = resolveSkillSource(source);
 
           await installExternalSkill(
             owner,
             repo,
             skillSlug,
             opts.overwrite ?? false,
+            ref,
           );
 
           if (json) {

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -11,6 +11,8 @@ import {
 import {
   fetchSkillAudits,
   formatAuditBadges,
+  installExternalSkill,
+  resolveSkillSource,
   searchSkillsRegistry,
 } from "../../skills/skillssh-registry.js";
 import type { AuditResponse } from "../../skills/skillssh-registry.js";
@@ -38,7 +40,9 @@ Examples:
   $ assistant skills search react --limit 5 --json
   $ assistant skills install weather
   $ assistant skills install weather --overwrite
-  $ assistant skills uninstall weather`,
+  $ assistant skills uninstall weather
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills --overwrite`,
   );
 
   skills
@@ -265,4 +269,72 @@ Examples:
         process.exitCode = 1;
       }
     });
+
+  skills
+    .command("add <source>")
+    .description(
+      "Install a community skill from the skills.sh registry (GitHub)",
+    )
+    .option("--overwrite", "Replace an already installed skill")
+    .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  source   Skill source in one of these formats:
+             owner/repo@skill-name
+             owner/repo/skill-name
+             https://github.com/owner/repo/tree/<branch>/skills/skill-name
+
+Notes:
+  Fetches the skill's SKILL.md and supporting files from the specified GitHub
+  repository and installs them into the workspace skills directory. A
+  version.json file is written with origin metadata for provenance tracking.
+
+Examples:
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills
+  $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
+    )
+    .action(
+      async (
+        source: string,
+        opts: { overwrite?: boolean; json?: boolean },
+      ) => {
+        const json = opts.json ?? false;
+
+        try {
+          const { owner, repo, skillSlug } = resolveSkillSource(source);
+
+          await installExternalSkill(
+            owner,
+            repo,
+            skillSlug,
+            opts.overwrite ?? false,
+          );
+
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                skillSlug,
+                source: `${owner}/${repo}`,
+              }),
+            );
+          } else {
+            log.info(
+              `Installed skill "${skillSlug}" from ${owner}/${repo}.`,
+            );
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (json) {
+            console.log(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
 }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 
 import { upsertSkillsIndex } from "./catalog-install.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
@@ -41,6 +41,7 @@ export interface ResolvedSkillSource {
   owner: string;
   repo: string;
   skillSlug: string;
+  ref?: string;
 }
 
 /** Map of relative file paths to their string contents */
@@ -146,16 +147,21 @@ export async function fetchSkillAudits(
  *   - `https://github.com/owner/repo/tree/<branch>/skills/skill-name`
  */
 export function resolveSkillSource(source: string): ResolvedSkillSource {
-  // Full GitHub URL
+  // Full GitHub URL — capture the branch for ref passthrough
   const urlMatch = source.match(
-    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/[^/]+\/skills\/([^/]+)\/?$/,
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/skills\/([^/]+)\/?$/,
   );
   if (urlMatch) {
-    return { owner: urlMatch[1]!, repo: urlMatch[2]!, skillSlug: urlMatch[3]! };
+    return {
+      owner: urlMatch[1]!,
+      repo: urlMatch[2]!,
+      skillSlug: urlMatch[4]!,
+      ref: urlMatch[3]!,
+    };
   }
 
-  // owner/repo@skill-name
-  const atMatch = source.match(/^([^/]+)\/([^/@]+)@(.+)$/);
+  // owner/repo@skill-name — restrict slug to safe characters
+  const atMatch = source.match(/^([^/]+)\/([^/@]+)@([a-z0-9][a-z0-9._-]*)$/);
   if (atMatch) {
     return { owner: atMatch[1]!, repo: atMatch[2]!, skillSlug: atMatch[3]! };
   }
@@ -186,55 +192,93 @@ interface GitHubContentsEntry {
   download_url: string | null;
 }
 
+/** Build common headers for GitHub API requests (User-Agent + optional auth). */
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "vellum-assistant",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers["Authorization"] = `token ${token}`;
+  }
+  return headers;
+}
+
 /**
  * Fetch SKILL.md and supporting files from a GitHub-hosted skills directory.
  *
  * Uses the GitHub Contents API: `GET /repos/:owner/:repo/contents/skills/:slug`
  * and follows each file's `download_url` to retrieve content.
+ * Recursively fetches subdirectories (e.g. scripts/, references/).
  */
 export async function fetchSkillFromGitHub(
   owner: string,
   repo: string,
   skillSlug: string,
+  ref?: string,
 ): Promise<SkillFiles> {
-  const apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/skills/${encodeURIComponent(skillSlug)}`;
-  const response = await fetch(apiUrl, {
-    headers: { Accept: "application/vnd.github.v3+json" },
-    signal: AbortSignal.timeout(15_000),
-  });
+  const headers = githubHeaders();
 
-  if (!response.ok) {
-    if (response.status === 404) {
-      throw new Error(
-        `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
-          `Looked in skills/${skillSlug}/`,
-      );
+  async function fetchDir(subpath: string, prefix: string): Promise<SkillFiles> {
+    let apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${subpath}`;
+    if (ref) {
+      apiUrl += `?ref=${encodeURIComponent(ref)}`;
     }
-    throw new Error(
-      `GitHub API error: HTTP ${response.status} ${response.statusText}`,
-    );
-  }
 
-  const entries = (await response.json()) as GitHubContentsEntry[];
-  if (!Array.isArray(entries)) {
-    throw new Error(
-      `Expected a directory listing for skills/${skillSlug}/ but got a single file`,
-    );
-  }
-
-  const files: SkillFiles = {};
-  for (const entry of entries) {
-    if (entry.type !== "file" || !entry.download_url) continue;
-    const fileResponse = await fetch(entry.download_url, {
-      signal: AbortSignal.timeout(10_000),
+    const response = await fetch(apiUrl, {
+      headers,
+      signal: AbortSignal.timeout(15_000),
     });
-    if (!fileResponse.ok) {
+
+    if (!response.ok) {
+      if (response.status === 404 && prefix === "") {
+        throw new Error(
+          `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
+            `Looked in skills/${skillSlug}/`,
+        );
+      }
       throw new Error(
-        `Failed to download ${entry.name}: HTTP ${fileResponse.status}`,
+        `GitHub API error: HTTP ${response.status} ${response.statusText}`,
       );
     }
-    files[entry.name] = await fileResponse.text();
+
+    const entries = (await response.json()) as GitHubContentsEntry[];
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `Expected a directory listing for ${subpath}/ but got a single file`,
+      );
+    }
+
+    const files: SkillFiles = {};
+    for (const entry of entries) {
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      if (entry.type === "dir") {
+        // Recursively fetch subdirectory contents
+        const subFiles = await fetchDir(`${subpath}/${entry.name}`, relativePath);
+        Object.assign(files, subFiles);
+        continue;
+      }
+
+      if (entry.type !== "file" || !entry.download_url) continue;
+      const fileResponse = await fetch(entry.download_url, {
+        headers: { "User-Agent": "vellum-assistant" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!fileResponse.ok) {
+        throw new Error(
+          `Failed to download ${relativePath}: HTTP ${fileResponse.status}`,
+        );
+      }
+      files[relativePath] = await fileResponse.text();
+    }
+
+    return files;
   }
+
+  const rootPath = `skills/${encodeURIComponent(skillSlug)}`;
+  const files = await fetchDir(rootPath, "");
 
   if (!files["SKILL.md"]) {
     throw new Error(
@@ -247,21 +291,50 @@ export async function fetchSkillFromGitHub(
 
 // ─── External skill installation ────────────────────────────────────────────
 
+// ─── Slug validation ────────────────────────────────────────────────────────
+
+const VALID_SKILL_SLUG = /^[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * Validate that a skill slug is safe for use in filesystem paths.
+ * Follows the same pattern as `validateManagedSkillId` in managed-store.ts.
+ */
+export function validateSkillSlug(slug: string): void {
+  if (!slug || typeof slug !== "string") {
+    throw new Error("Skill slug is required");
+  }
+  if (slug.includes("..") || slug.includes("/") || slug.includes("\\")) {
+    throw new Error(
+      `Invalid skill slug "${slug}": must not contain path traversal characters`,
+    );
+  }
+  if (!VALID_SKILL_SLUG.test(slug)) {
+    throw new Error(
+      `Invalid skill slug "${slug}": must start with a lowercase letter or digit and contain only lowercase letters, digits, dots, hyphens, and underscores`,
+    );
+  }
+}
+
 /**
  * Install a community skill from a GitHub-hosted skills.sh registry repo.
  *
- * 1. Fetches all files from `skills/<skillSlug>/` in the source repo
- * 2. Writes them to `<workspace>/skills/<skillSlug>/`
- * 3. Writes `version.json` with origin metadata
- * 4. Registers the skill in SKILLS.md
+ * 1. Validates the skill slug for path safety
+ * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
+ * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
+ * 4. Writes `version.json` with origin metadata
  * 5. Runs `bun install` if a `package.json` is present
+ * 6. Registers the skill in SKILLS.md only after all steps succeed
  */
 export async function installExternalSkill(
   owner: string,
   repo: string,
   skillSlug: string,
   overwrite: boolean,
+  ref?: string,
 ): Promise<void> {
+  // Validate slug before using in filesystem paths
+  validateSkillSlug(skillSlug);
+
   const skillDir = join(getWorkspaceSkillsDir(), skillSlug);
   const skillFilePath = join(skillDir, "SKILL.md");
 
@@ -271,12 +344,23 @@ export async function installExternalSkill(
     );
   }
 
-  const files = await fetchSkillFromGitHub(owner, repo, skillSlug);
+  const files = await fetchSkillFromGitHub(owner, repo, skillSlug, ref);
 
   mkdirSync(skillDir, { recursive: true });
 
+  // Write files with path traversal protection (follows extractTarToDir pattern)
   for (const [filename, content] of Object.entries(files)) {
-    writeFileSync(join(skillDir, filename), content, "utf-8");
+    const normalized = filename.replace(/\\/g, "/").replace(/^\.\/+/g, "");
+    if (!normalized || normalized.includes("..") || normalized.startsWith("/"))
+      continue;
+    const destPath = resolve(skillDir, normalized);
+    if (
+      !destPath.startsWith(resolve(skillDir) + sep) &&
+      destPath !== resolve(skillDir)
+    )
+      continue;
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, content, "utf-8");
   }
 
   // Write origin metadata
@@ -292,9 +376,6 @@ export async function installExternalSkill(
     "utf-8",
   );
 
-  // Register in SKILLS.md only after files are written
-  upsertSkillsIndex(skillSlug);
-
   // Install npm dependencies if the skill ships a package.json
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;
@@ -304,4 +385,7 @@ export async function installExternalSkill(
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
   }
+
+  // Register in SKILLS.md only after files are written and deps installed
+  upsertSkillsIndex(skillSlug);
 }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,3 +1,11 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { upsertSkillsIndex } from "./catalog-install.js";
+import { getWorkspaceSkillsDir } from "../util/platform.js";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface SkillsShSearchResult {
@@ -28,6 +36,15 @@ export type SkillAuditData = Record<string, PartnerAudit>;
 
 /** Map from skill slug to per-provider audit data */
 export type AuditResponse = Record<string, SkillAuditData>;
+
+export interface ResolvedSkillSource {
+  owner: string;
+  repo: string;
+  skillSlug: string;
+}
+
+/** Map of relative file paths to their string contents */
+export type SkillFiles = Record<string, string>;
 
 // ─── Display helpers ─────────────────────────────────────────────────────────
 
@@ -116,4 +133,175 @@ export async function fetchSkillAudits(
   }
 
   return (await response.json()) as AuditResponse;
+}
+
+// ─── Source resolution ──────────────────────────────────────────────────────
+
+/**
+ * Parse a skill source string into owner, repo, and skill slug.
+ *
+ * Supported formats:
+ *   - `owner/repo@skill-name`
+ *   - `owner/repo/skill-name`
+ *   - `https://github.com/owner/repo/tree/<branch>/skills/skill-name`
+ */
+export function resolveSkillSource(source: string): ResolvedSkillSource {
+  // Full GitHub URL
+  const urlMatch = source.match(
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/[^/]+\/skills\/([^/]+)\/?$/,
+  );
+  if (urlMatch) {
+    return { owner: urlMatch[1]!, repo: urlMatch[2]!, skillSlug: urlMatch[3]! };
+  }
+
+  // owner/repo@skill-name
+  const atMatch = source.match(/^([^/]+)\/([^/@]+)@(.+)$/);
+  if (atMatch) {
+    return { owner: atMatch[1]!, repo: atMatch[2]!, skillSlug: atMatch[3]! };
+  }
+
+  // owner/repo/skill-name (exactly 3 segments)
+  const slashMatch = source.match(/^([^/]+)\/([^/]+)\/([^/]+)$/);
+  if (slashMatch) {
+    return {
+      owner: slashMatch[1]!,
+      repo: slashMatch[2]!,
+      skillSlug: slashMatch[3]!,
+    };
+  }
+
+  throw new Error(
+    `Invalid skill source "${source}". Expected one of:\n` +
+      `  owner/repo@skill-name\n` +
+      `  owner/repo/skill-name\n` +
+      `  https://github.com/owner/repo/tree/<branch>/skills/skill-name`,
+  );
+}
+
+// ─── GitHub fetch ───────────────────────────────────────────────────────────
+
+interface GitHubContentsEntry {
+  name: string;
+  type: "file" | "dir";
+  download_url: string | null;
+}
+
+/**
+ * Fetch SKILL.md and supporting files from a GitHub-hosted skills directory.
+ *
+ * Uses the GitHub Contents API: `GET /repos/:owner/:repo/contents/skills/:slug`
+ * and follows each file's `download_url` to retrieve content.
+ */
+export async function fetchSkillFromGitHub(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+): Promise<SkillFiles> {
+  const apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/skills/${encodeURIComponent(skillSlug)}`;
+  const response = await fetch(apiUrl, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
+          `Looked in skills/${skillSlug}/`,
+      );
+    }
+    throw new Error(
+      `GitHub API error: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const entries = (await response.json()) as GitHubContentsEntry[];
+  if (!Array.isArray(entries)) {
+    throw new Error(
+      `Expected a directory listing for skills/${skillSlug}/ but got a single file`,
+    );
+  }
+
+  const files: SkillFiles = {};
+  for (const entry of entries) {
+    if (entry.type !== "file" || !entry.download_url) continue;
+    const fileResponse = await fetch(entry.download_url, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!fileResponse.ok) {
+      throw new Error(
+        `Failed to download ${entry.name}: HTTP ${fileResponse.status}`,
+      );
+    }
+    files[entry.name] = await fileResponse.text();
+  }
+
+  if (!files["SKILL.md"]) {
+    throw new Error(
+      `SKILL.md not found in ${owner}/${repo}/skills/${skillSlug}/`,
+    );
+  }
+
+  return files;
+}
+
+// ─── External skill installation ────────────────────────────────────────────
+
+/**
+ * Install a community skill from a GitHub-hosted skills.sh registry repo.
+ *
+ * 1. Fetches all files from `skills/<skillSlug>/` in the source repo
+ * 2. Writes them to `<workspace>/skills/<skillSlug>/`
+ * 3. Writes `version.json` with origin metadata
+ * 4. Registers the skill in SKILLS.md
+ * 5. Runs `bun install` if a `package.json` is present
+ */
+export async function installExternalSkill(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  overwrite: boolean,
+): Promise<void> {
+  const skillDir = join(getWorkspaceSkillsDir(), skillSlug);
+  const skillFilePath = join(skillDir, "SKILL.md");
+
+  if (existsSync(skillFilePath) && !overwrite) {
+    throw new Error(
+      `Skill "${skillSlug}" is already installed. Use --overwrite to replace it.`,
+    );
+  }
+
+  const files = await fetchSkillFromGitHub(owner, repo, skillSlug);
+
+  mkdirSync(skillDir, { recursive: true });
+
+  for (const [filename, content] of Object.entries(files)) {
+    writeFileSync(join(skillDir, filename), content, "utf-8");
+  }
+
+  // Write origin metadata
+  const meta = {
+    origin: "skills.sh",
+    source: `${owner}/${repo}`,
+    skillSlug,
+    installedAt: new Date().toISOString(),
+  };
+  writeFileSync(
+    join(skillDir, "version.json"),
+    JSON.stringify(meta, null, 2) + "\n",
+    "utf-8",
+  );
+
+  // Register in SKILLS.md only after files are written
+  upsertSkillsIndex(skillSlug);
+
+  // Install npm dependencies if the skill ships a package.json
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `assistant skills add <source>` CLI command to install skills from the skills.sh community registry
- Supports `owner/repo@skill`, `owner/repo/skill`, and full GitHub URL source formats
- Fetches SKILL.md and supporting files from GitHub, installs to workspace skills directory
- Writes version.json with origin metadata, registers in SKILLS.md index
- Includes source parser tests

## Original prompt
M2 of skills.sh registry search & install feature (#16037)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
