### PR TITLE
fix: use unfiltered contacts array for guardian lookup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -56,8 +56,10 @@ final class ContactsViewModel: ObservableObject {
     }
 
     /// The guardian contact, if present.
+    /// Uses the unfiltered contacts array so the guardian is always found
+    /// regardless of the active search query.
     var guardianContact: ContactPayload? {
-        filteredContacts.first { $0.role == "guardian" }
+        contacts.first { $0.role == "guardian" }
     }
 
     /// All non-guardian contacts from the filtered set.


### PR DESCRIPTION
## Summary
Fixes guardianName becoming nil when a search query is active by using the unfiltered contacts array instead of filteredContacts for the guardian contact lookup.

Part of plan: voice-code-invites.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
