### PR TITLE
fix: route outbound invite calls using persisted callMode

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -1025,7 +1025,6 @@ export type StartInviteCallInput = {
   friendName: string;
   guardianName: string;
   assistantId?: string;
-  originConversationId?: string;
 };
 
 export type StartInviteCallResult = { ok: true; callSid: string } | CallError;
@@ -1040,7 +1039,7 @@ export type StartInviteCallResult = { ok: true; callSid: string } | CallError;
 export async function startInviteCall(
   input: StartInviteCallInput,
 ): Promise<StartInviteCallResult> {
-  const { phoneNumber, friendName, guardianName, originConversationId } = input;
+  const { phoneNumber, friendName, guardianName } = input;
 
   if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {
     return {
@@ -1086,7 +1085,10 @@ export async function startInviteCall(
       provider: "twilio",
       fromNumber: identityResult.fromNumber,
       toNumber: phoneNumber,
-      initiatedFromConversationId: originConversationId,
+      callMode: "invite",
+      inviteFriendName: friendName,
+      inviteGuardianName: guardianName,
+      initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
 
@@ -1109,12 +1111,6 @@ export async function startInviteCall(
       to: phoneNumber,
       webhookUrl,
       statusCallbackUrl,
-      customParams: {
-        inviteRedemptionMode: "true",
-        inviteRedemptionFromNumber: phoneNumber,
-        inviteRedemptionFriendName: friendName,
-        inviteRedemptionGuardianName: guardianName,
-      },
     });
 
     updateCallSession(session.id, { providerCallSid: callSid });

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -37,6 +37,8 @@ const parseCallSession = createRowMapper<
   status: { from: "status", transform: cast<CallSession["status"]>() },
   callMode: { from: "callMode", transform: cast<CallSession["callMode"]>() },
   verificationSessionId: "verificationSessionId",
+  inviteFriendName: "inviteFriendName",
+  inviteGuardianName: "inviteGuardianName",
   callerIdentityMode: "callerIdentityMode",
   callerIdentitySource: "callerIdentitySource",
   initiatedFromConversationId: "initiatedFromConversationId",
@@ -81,6 +83,8 @@ export function createCallSession(opts: {
   task?: string;
   callMode?: string;
   verificationSessionId?: string;
+  inviteFriendName?: string;
+  inviteGuardianName?: string;
   callerIdentityMode?: string;
   callerIdentitySource?: string;
   initiatedFromConversationId?: string;
@@ -98,6 +102,8 @@ export function createCallSession(opts: {
     status: "initiated" as const,
     callMode: (opts.callMode ?? null) as CallSession["callMode"],
     verificationSessionId: opts.verificationSessionId ?? null,
+    inviteFriendName: opts.inviteFriendName ?? null,
+    inviteGuardianName: opts.inviteGuardianName ?? null,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
     initiatedFromConversationId: opts.initiatedFromConversationId ?? null,

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -99,28 +99,24 @@ export function routeSetup(ctx: SetupContext): {
     actorTrust,
   };
 
-  // ── Outbound invite redemption ────────────────────────────────────
-  if (!isInbound && ctx.customParameters?.inviteRedemptionMode === "true") {
-    const fromNumber = ctx.customParameters
-      .inviteRedemptionFromNumber as string;
-    const friendName = ctx.customParameters
-      .inviteRedemptionFriendName as string;
-    const guardianName = ctx.customParameters
-      .inviteRedemptionGuardianName as string;
+  // ── Outbound flow selection based on persisted call mode ──────────
+  const persistedMode = ctx.session?.callMode;
+
+  // ── Outbound invite redemption (persisted mode) ─────────────────
+  if (persistedMode === "invite") {
     return {
       outcome: {
         action: "invite_redemption" as const,
         assistantId,
-        fromNumber,
-        friendName,
-        guardianName,
+        fromNumber: ctx.to,
+        friendName: ctx.session?.inviteFriendName ?? null,
+        guardianName: ctx.session?.inviteGuardianName ?? null,
       },
       resolved,
     };
   }
 
   // ── Outbound guardian verification (persisted mode) ──────────────
-  const persistedMode = ctx.session?.callMode;
   const persistedVsId = ctx.session?.verificationSessionId;
   const customParamVsId = ctx.customParameters?.verificationSessionId;
   const verificationSessionId = persistedVsId ?? customParamVsId;

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -58,7 +58,7 @@ export type PendingQuestionStatus =
  * uses this as the primary signal for deterministic flow selection,
  * with Twilio setup custom parameters as a secondary/observability signal.
  */
-export type CallMode = "normal" | "verification";
+export type CallMode = "normal" | "verification" | "invite";
 
 export interface CallSession {
   id: string;
@@ -71,6 +71,8 @@ export interface CallSession {
   status: CallStatus;
   callMode: CallMode | null;
   verificationSessionId: string | null;
+  inviteFriendName: string | null;
+  inviteGuardianName: string | null;
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
   initiatedFromConversationId?: string | null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
   migrateBackfillUsageCacheAccounting,
+  migrateCallSessionInviteMetadata,
   migrateCallSessionMode,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
@@ -367,6 +368,9 @@ export function initializeDb(): void {
 
   // 58. Drop memory_item_conflicts table (conflict resolution system removed)
   migrateDropConflicts(database);
+
+  // 59. Add invite metadata columns to call_sessions for outbound invite call routing
+  migrateCallSessionInviteMetadata(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/156-call-session-invite-metadata.ts
+++ b/assistant/src/memory/migrations/156-call-session-invite-metadata.ts
@@ -1,0 +1,24 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Add invite metadata columns to call_sessions so outbound invite calls
+ * can persist friend/guardian names for deterministic routing in the
+ * relay setup router (mirroring how verification_session_id works for
+ * guardian verification calls).
+ */
+export function migrateCallSessionInviteMetadata(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE call_sessions ADD COLUMN invite_friend_name TEXT`,
+    );
+  } catch {
+    /* already exists */
+  }
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE call_sessions ADD COLUMN invite_guardian_name TEXT`,
+    );
+  } catch {
+    /* already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -97,6 +97,7 @@ export { migrateMemoryItemSupersession } from "./152-memory-item-supersession.js
 export { migrateDropEntityTables } from "./153-drop-entity-tables.js";
 export { migrateDropMemorySegmentFts } from "./154-drop-fts.js";
 export { migrateDropConflicts } from "./155-drop-conflicts.js";
+export { migrateCallSessionInviteMetadata } from "./156-call-session-invite-metadata.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -23,6 +23,8 @@ export const callSessions = sqliteTable(
     status: text("status").notNull().default("initiated"),
     callMode: text("call_mode"),
     verificationSessionId: text("verification_session_id"),
+    inviteFriendName: text("invite_friend_name"),
+    inviteGuardianName: text("invite_guardian_name"),
     callerIdentityMode: text("caller_identity_mode"),
     callerIdentitySource: text("caller_identity_source"),
     initiatedFromConversationId: text("initiated_from_conversation_id"),


### PR DESCRIPTION
## Summary
Fixes a bug where outbound invite calls never reached the invite_redemption flow because:
1. Custom params passed to Twilio REST API don't propagate as TwiML Parameters
2. initiatedFromConversationId was null, causing calls to be classified as inbound

Follows the established verification call pattern: adds "invite" to CallMode, stores invite metadata on the call session, and routes based on persisted callMode in relay-setup-router.

Part of plan: voice-code-invites.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
