### PR TITLE
fix: handle voice invite response in Swift client

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -37,9 +37,10 @@ struct ContactDetailView: View {
     @State private var inviteInProgress: String?
     @State private var inviteResult: (
         type: String,
-        token: String,
+        token: String?,
         shareUrl: String?,
         inviteCode: String?,
+        voiceCode: String?,
         guardianInstruction: String?,
         channelHandle: String?
     )?
@@ -489,7 +490,7 @@ struct ContactDetailView: View {
     private func inviteResultDisplay(for type: String) -> some View {
         let result = inviteResult!
 
-        if let inviteCode = result.inviteCode {
+        if let inviteCode = result.inviteCode ?? result.voiceCode {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 if let instruction = result.guardianInstruction {
                     Text(instruction)
@@ -576,10 +577,9 @@ struct ContactDetailView: View {
                     }
                 }
             }
-        } else {
+        } else if let shareableText = result.shareUrl ?? result.token {
             // Fallback: no invite code available, show raw token
             HStack(spacing: VSpacing.sm) {
-                let shareableText = result.shareUrl ?? result.token
                 let truncated = shareableText.count > 20
                     ? String(shareableText.prefix(20)) + "..."
                     : shareableText
@@ -992,6 +992,7 @@ struct ContactDetailView: View {
                         token: result.token,
                         shareUrl: result.shareUrl,
                         inviteCode: result.inviteCode,
+                        voiceCode: result.voiceCode,
                         guardianInstruction: result.guardianInstruction,
                         channelHandle: result.channelHandle
                     )

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2044,7 +2044,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         expectedExternalUserId: String? = nil,
         friendName: String? = nil,
         guardianName: String? = nil
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?, channelHandle: String?)? {
+    ) async throws -> (inviteId: String, token: String?, shareUrl: String?, inviteCode: String?, voiceCode: String?, guardianInstruction: String?, channelHandle: String?)? {
         if let httpTransport {
             return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, expectedExternalUserId: expectedExternalUserId, friendName: friendName, guardianName: guardianName)
         }
@@ -2075,6 +2075,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 let token: String?
                 let share: ShareData?
                 let inviteCode: String?
+                let voiceCode: String?
                 let guardianInstruction: String?
                 let channelHandle: String?
             }
@@ -2084,8 +2085,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             }
         }
         let decoded = try JSONDecoder().decode(CreateInviteResponse.self, from: data)
-        guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
+        guard let invite = decoded.invite else { return nil }
+        return (inviteId: invite.id, token: invite.token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, voiceCode: invite.voiceCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
         #else
         return nil
         #endif

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2350,6 +2350,7 @@ public final class HTTPTransport {
             let share: SharePayload?
             let status: String
             let inviteCode: String?
+            let voiceCode: String?
             let guardianInstruction: String?
             let channelHandle: String?
         }
@@ -2473,7 +2474,7 @@ public final class HTTPTransport {
         friendName: String? = nil,
         guardianName: String? = nil,
         isRetry: Bool = false
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?, channelHandle: String?)? {
+    ) async throws -> (inviteId: String, token: String?, shareUrl: String?, inviteCode: String?, voiceCode: String?, guardianInstruction: String?, channelHandle: String?)? {
         guard let url = buildURL(for: .contactsInvitesCreate) else { return nil }
 
         var request = URLRequest(url: url)
@@ -2504,8 +2505,8 @@ public final class HTTPTransport {
         }
 
         let decoded = try decoder.decode(HTTPCreateInviteResponse.self, from: data)
-        guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
+        guard let invite = decoded.invite else { return nil }
+        return (inviteId: invite.id, token: invite.token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, voiceCode: invite.voiceCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
     }
 
     // MARK: - Channel Readiness


### PR DESCRIPTION
## Summary
Fixes two related bugs:
1. Voice invite creation returned nil because the guard required a non-nil token, but backend omits token for voice invites
2. voiceCode field was not decoded from the backend response, so the 6-digit code was never available in the UI

Makes token optional in createInvite response, adds voiceCode to response structs, and updates ContactDetailView to display voiceCode for phone invites.

Part of plan: voice-code-invites.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
