### PR TITLE
fix: remap eye coordinates between viewBox spaces in AvatarCompositor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
@@ -39,10 +39,28 @@ enum AvatarCompositor {
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
 
-        // Draw eyes
+        // Draw eyes — remap from eye sourceViewBox to body viewBox before applying canvas transform.
+        // This aspect-fit centers the eye paths within the body's coordinate space so that
+        // eye styles designed for one body shape render correctly on any other body shape.
+        let srcVB = eyeStyle.sourceViewBox
+        var eyeTransform: CGAffineTransform
+        if srcVB.width == viewBox.width && srcVB.height == viewBox.height {
+            // Same coordinate space — no remapping needed.
+            eyeTransform = transform
+        } else {
+            let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
+            let remapTx = (viewBox.width - srcVB.width * remapScale) / 2
+            let remapTy = (viewBox.height - srcVB.height * remapScale) / 2
+            // Remap: translate + scale within body viewBox, then apply the canvas transform.
+            eyeTransform = CGAffineTransform(translationX: remapTx, y: remapTy)
+                .scaledBy(x: remapScale, y: remapScale)
+            eyeTransform = eyeTransform.concatenating(transform)
+        }
+
         for eyePath in eyeStyle.paths {
             let parsed = parseSVGPath(eyePath.svgPath)
-            let transformed = parsed.copy(using: &transform)!
+            var mutableEyeTransform = eyeTransform
+            let transformed = parsed.copy(using: &mutableEyeTransform)!
             context.addPath(transformed)
             context.setFillColor(eyePath.color.cgColor)
             context.fillPath()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-compositing.md.

**Gap:** Eye coordinate remapping not implemented — sourceViewBox is dead code
**What was expected:** The compositor should remap eye paths from their source coordinate space to the body shape's coordinate space
**What was found:** A single transform from bodyShape.viewBox was applied to both body and eye paths, ignoring AvatarEyeStyle.sourceViewBox entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
