### PR TITLE
fix: rename Voice to Phone and auto-prepend +1 for phone invites

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -829,7 +829,7 @@ struct ContactDetailView: View {
         case "telegram": return "Telegram"
         case "email": return "Email"
         case "whatsapp": return "WhatsApp"
-        case "phone": return "Voice"
+        case "phone": return "Phone"
         case "slack": return "Slack"
         default: return type.capitalized
         }
@@ -976,7 +976,11 @@ struct ContactDetailView: View {
         inviteResult = nil
         Task {
             do {
-                let phoneNumber = type == "phone" ? invitePhoneNumber.trimmingCharacters(in: .whitespaces) : nil
+                var phoneNumber: String? = nil
+                if type == "phone" {
+                    let trimmed = invitePhoneNumber.trimmingCharacters(in: .whitespaces)
+                    phoneNumber = trimmed.hasPrefix("+") ? trimmed : "+1\(trimmed)"
+                }
                 let resolvedGuardianName = type == "phone" ? (guardianName ?? "your guardian") : nil
 
                 if let result = try await daemonClient.createInvite(

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -136,7 +136,7 @@ struct ContactsListView: View {
         var channels: [String] = []
         if store?.telegramHasBotToken == true { channels.append("Telegram") }
         if store?.slackChannelHasBotToken == true && store?.slackChannelHasAppToken == true { channels.append("Slack") }
-        if store?.twilioHasCredentials == true { channels.append("Voice") }
+        if store?.twilioHasCredentials == true { channels.append("Phone") }
         if store?.assistantEmail != nil { channels.append("Email") }
         return channels.isEmpty ? "No channels configured" : channels.joined(separator: ", ")
     }
@@ -354,7 +354,7 @@ struct ContactsListView: View {
     private func channelLabel(for type: String) -> String {
         switch type {
         case "telegram": return "Telegram"
-        case "phone": return "Voice"
+        case "phone": return "Phone"
         case "email": return "Email"
         case "slack": return "Slack"
         default: return type.capitalized


### PR DESCRIPTION
## Summary
- Renames "Voice" to "Phone" in channel display labels on the Contacts page
- Auto-prepends `+1` when the user enters a phone number without the `+` prefix, fixing E.164 validation failures that caused "Failed to create invite"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
