### PR TITLE
feat(avatar): add "Generate Random" option to avatar management sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -89,6 +89,22 @@ struct AvatarManagementSheet: View {
                     .padding(.horizontal, VSpacing.xl)
 
                 actionRow(
+                    icon: "dice",
+                    label: "Generate Random",
+                    subtitle: "Random body, eyes, and color combo"
+                ) {
+                    let body = AvatarBodyShape.allCases.randomElement()!
+                    let eyes = AvatarEyeStyle.allCases.randomElement()!
+                    let color = AvatarColor.allCases.randomElement()! // color-literal-ok
+                    let image = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
+                    appearance.setCustomAvatar(image)
+                    onClose()
+                }
+
+                Divider().background(VColor.borderBase)
+                    .padding(.horizontal, VSpacing.xl)
+
+                actionRow(
                     icon: "photo",
                     label: "Upload Image",
                     subtitle: "Choose a PNG or JPEG from your Mac"


### PR DESCRIPTION
## Summary
- Adds a "Generate Random" action row to AvatarManagementSheet between "Choose from Presets" and "Upload Image"
- Composes a random body shape, eye style, and color using AvatarCompositor
- Sets the generated avatar and closes the sheet

Part of plan: avatar-random-edit.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
