### PR TITLE
fix: correct eye remap transform order and add @MainActor to AvatarCompositor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
@@ -1,5 +1,6 @@
 import AppKit
 
+@MainActor
 enum AvatarCompositor {
     /// Renders a composite avatar from body shape + eye style + color into an NSImage.
     static func render(
@@ -51,10 +52,10 @@ enum AvatarCompositor {
             let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
             let remapTx = (viewBox.width - srcVB.width * remapScale) / 2
             let remapTy = (viewBox.height - srcVB.height * remapScale) / 2
-            // Remap: translate + scale within body viewBox, then apply the canvas transform.
-            eyeTransform = CGAffineTransform(translationX: remapTx, y: remapTy)
-                .scaledBy(x: remapScale, y: remapScale)
-            eyeTransform = eyeTransform.concatenating(transform)
+            // Remap: scale within body viewBox, then translate to center, then apply the canvas transform.
+            let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
+                .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
+            eyeTransform = remapT.concatenating(transform)
         }
 
         for eyePath in eyeStyle.paths {


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for avatar-compositing.md.

**Gap 1:** Eye remapping transform used translate-then-scale, causing centering offset to be multiplied by scale factor (~0.7px error for yellow-ninja, would grow for future mix-and-match)
**Gap 2:** Static cache dictionary lacked @MainActor isolation for strict concurrency safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
