### PR TITLE
feat: skills.sh registry search & install

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  AuditResponse,
+  SkillAuditData,
+  SkillsShSearchResult,
+} from "../skills/skillssh-registry.js";
+import {
+  fetchSkillAudits,
+  formatAuditBadges,
+  providerDisplayName,
+  riskToDisplay,
+  searchSkillsRegistry,
+} from "../skills/skillssh-registry.js";
+
+// ─── Fetch mock helpers ──────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+let mockFetchImpl: (url: string | URL | Request) => Promise<Response>;
+
+beforeEach(() => {
+  mockFetchImpl = () =>
+    Promise.resolve(new Response("not mocked", { status: 500 }));
+  globalThis.fetch = mock((input: string | URL | Request) =>
+    mockFetchImpl(typeof input === "string" ? input : input.toString()),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ─── searchSkillsRegistry ────────────────────────────────────────────────────
+
+describe("searchSkillsRegistry", () => {
+  test("sends correct query parameters and returns results", async () => {
+    const mockResults: SkillsShSearchResult[] = [
+      {
+        id: "vercel-labs/agent-skills/vercel-react-best-practices",
+        skillId: "vercel-react-best-practices",
+        name: "Vercel React Best Practices",
+        installs: 1200,
+        source: "vercel-labs/agent-skills",
+      },
+    ];
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).toContain("skills.sh/api/search");
+      expect(urlStr).toContain("q=react");
+      expect(urlStr).toContain("limit=5");
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResults), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const results = await searchSkillsRegistry("react", 5);
+    expect(results).toEqual(mockResults);
+  });
+
+  test("omits limit parameter when not provided", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).not.toContain("limit=");
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const results = await searchSkillsRegistry("test");
+    expect(results).toEqual([]);
+  });
+
+  test("throws on non-OK response", async () => {
+    mockFetchImpl = () =>
+      Promise.resolve(new Response("Not Found", { status: 404 }));
+
+    await expect(searchSkillsRegistry("bad-query")).rejects.toThrow(
+      "skills.sh search failed: HTTP 404",
+    );
+  });
+});
+
+// ─── fetchSkillAudits ────────────────────────────────────────────────────────
+
+describe("fetchSkillAudits", () => {
+  test("sends correct parameters and returns audit data", async () => {
+    const mockAudits: AuditResponse = {
+      "vercel-react-best-practices": {
+        ath: {
+          risk: "safe",
+          alerts: 0,
+          score: 100,
+          analyzedAt: "2025-01-15T00:00:00Z",
+        },
+        socket: {
+          risk: "low",
+          alerts: 1,
+          score: 95,
+          analyzedAt: "2025-01-15T00:00:00Z",
+        },
+      },
+    };
+
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      expect(urlStr).toContain("add-skill.vercel.sh/audit");
+      expect(urlStr).toContain("source=vercel-labs%2Fagent-skills");
+      expect(urlStr).toContain(
+        "skills=vercel-react-best-practices%2Canother-skill",
+      );
+      return Promise.resolve(
+        new Response(JSON.stringify(mockAudits), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const audits = await fetchSkillAudits("vercel-labs/agent-skills", [
+      "vercel-react-best-practices",
+      "another-skill",
+    ]);
+    expect(audits).toEqual(mockAudits);
+  });
+
+  test("returns empty object for empty slugs list", async () => {
+    const audits = await fetchSkillAudits("some/source", []);
+    expect(audits).toEqual({});
+    // fetch should not have been called
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("throws on non-OK response", async () => {
+    mockFetchImpl = () =>
+      Promise.resolve(
+        new Response("Internal Server Error", { status: 500 }),
+      );
+
+    await expect(
+      fetchSkillAudits("some/source", ["slug"]),
+    ).rejects.toThrow("Audit fetch failed: HTTP 500");
+  });
+});
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+describe("riskToDisplay", () => {
+  test("maps risk levels correctly", () => {
+    expect(riskToDisplay("safe")).toBe("PASS");
+    expect(riskToDisplay("low")).toBe("PASS");
+    expect(riskToDisplay("medium")).toBe("WARN");
+    expect(riskToDisplay("high")).toBe("FAIL");
+    expect(riskToDisplay("critical")).toBe("FAIL");
+    expect(riskToDisplay("unknown")).toBe("?");
+  });
+});
+
+describe("providerDisplayName", () => {
+  test("maps known providers", () => {
+    expect(providerDisplayName("ath")).toBe("ATH");
+    expect(providerDisplayName("socket")).toBe("Socket");
+    expect(providerDisplayName("snyk")).toBe("Snyk");
+  });
+
+  test("returns raw name for unknown providers", () => {
+    expect(providerDisplayName("custom-auditor")).toBe("custom-auditor");
+  });
+});
+
+describe("formatAuditBadges", () => {
+  test("formats multiple providers as badges", () => {
+    const auditData: SkillAuditData = {
+      ath: { risk: "safe", analyzedAt: "2025-01-15T00:00:00Z" },
+      socket: { risk: "safe", analyzedAt: "2025-01-15T00:00:00Z" },
+      snyk: { risk: "medium", analyzedAt: "2025-01-15T00:00:00Z" },
+    };
+    expect(formatAuditBadges(auditData)).toBe(
+      "Security: [ATH:PASS] [Socket:PASS] [Snyk:WARN]",
+    );
+  });
+
+  test("returns fallback message when no providers present", () => {
+    expect(formatAuditBadges({})).toBe("Security: no audit data");
+  });
+
+  test("handles single provider", () => {
+    const auditData: SkillAuditData = {
+      ath: { risk: "critical", analyzedAt: "2025-01-15T00:00:00Z" },
+    };
+    expect(formatAuditBadges(auditData)).toBe("Security: [ATH:FAIL]");
+  });
+});

--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -9,8 +9,10 @@ import {
   fetchSkillAudits,
   formatAuditBadges,
   providerDisplayName,
+  resolveSkillSource,
   riskToDisplay,
   searchSkillsRegistry,
+  validateSkillSlug,
 } from "../skills/skillssh-registry.js";
 
 // ─── Fetch mock helpers ──────────────────────────────────────────────────────
@@ -196,5 +198,125 @@ describe("formatAuditBadges", () => {
       ath: { risk: "critical", analyzedAt: "2025-01-15T00:00:00Z" },
     };
     expect(formatAuditBadges(auditData)).toBe("Security: [ATH:FAIL]");
+  });
+});
+
+// ─── resolveSkillSource ─────────────────────────────────────────────────────
+
+describe("resolveSkillSource", () => {
+  test("parses owner/repo@skill-name format", () => {
+    const result = resolveSkillSource("vercel-labs/skills@find-skills");
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+    });
+  });
+
+  test("parses owner/repo/skill-name format", () => {
+    const result = resolveSkillSource("vercel-labs/skills/find-skills");
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+    });
+  });
+
+  test("parses full GitHub URL with main branch", () => {
+    const result = resolveSkillSource(
+      "https://github.com/vercel-labs/skills/tree/main/skills/find-skills",
+    );
+    expect(result).toEqual({
+      owner: "vercel-labs",
+      repo: "skills",
+      skillSlug: "find-skills",
+      ref: "main",
+    });
+  });
+
+  test("parses full GitHub URL with non-main branch", () => {
+    const result = resolveSkillSource(
+      "https://github.com/some-org/repo/tree/develop/skills/my-skill",
+    );
+    expect(result).toEqual({
+      owner: "some-org",
+      repo: "repo",
+      skillSlug: "my-skill",
+      ref: "develop",
+    });
+  });
+
+  test("parses GitHub URL with trailing slash", () => {
+    const result = resolveSkillSource(
+      "https://github.com/owner/repo/tree/main/skills/skill-name/",
+    );
+    expect(result).toEqual({
+      owner: "owner",
+      repo: "repo",
+      skillSlug: "skill-name",
+      ref: "main",
+    });
+  });
+
+  test("throws on bare skill name (no owner/repo)", () => {
+    expect(() => resolveSkillSource("find-skills")).toThrow(
+      'Invalid skill source "find-skills"',
+    );
+  });
+
+  test("throws on empty string", () => {
+    expect(() => resolveSkillSource("")).toThrow('Invalid skill source ""');
+  });
+
+  test("throws on owner-only format", () => {
+    expect(() => resolveSkillSource("vercel-labs")).toThrow(
+      'Invalid skill source "vercel-labs"',
+    );
+  });
+
+  test("throws on owner/repo without skill", () => {
+    expect(() => resolveSkillSource("vercel-labs/skills")).toThrow(
+      'Invalid skill source "vercel-labs/skills"',
+    );
+  });
+
+  test("rejects path traversal in @ format slug", () => {
+    expect(() =>
+      resolveSkillSource("owner/repo@../../malicious"),
+    ).toThrow('Invalid skill source "owner/repo@../../malicious"');
+  });
+
+  test("rejects uppercase slug in @ format", () => {
+    expect(() => resolveSkillSource("owner/repo@BadSlug")).toThrow(
+      'Invalid skill source "owner/repo@BadSlug"',
+    );
+  });
+});
+
+// ─── validateSkillSlug ──────────────────────────────────────────────────────
+
+describe("validateSkillSlug", () => {
+  test("accepts valid slugs", () => {
+    expect(() => validateSkillSlug("my-skill")).not.toThrow();
+    expect(() => validateSkillSlug("skill123")).not.toThrow();
+    expect(() => validateSkillSlug("my.skill")).not.toThrow();
+    expect(() => validateSkillSlug("my_skill")).not.toThrow();
+  });
+
+  test("rejects path traversal characters", () => {
+    expect(() => validateSkillSlug("../../malicious")).toThrow(
+      "path traversal",
+    );
+    expect(() => validateSkillSlug("foo/bar")).toThrow("path traversal");
+    expect(() => validateSkillSlug("foo\\bar")).toThrow("path traversal");
+  });
+
+  test("rejects slugs starting with special chars", () => {
+    expect(() => validateSkillSlug(".hidden")).toThrow();
+    expect(() => validateSkillSlug("-dash")).toThrow();
+  });
+
+  test("rejects empty input", () => {
+    expect(() => validateSkillSlug("")).toThrow("Skill slug is required");
   });
 });

--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
     Promise.resolve(new Response("not mocked", { status: 500 }));
   globalThis.fetch = mock((input: string | URL | Request) =>
     mockFetchImpl(typeof input === "string" ? input : input.toString()),
-  ) as typeof fetch;
+  ) as unknown as typeof fetch;
 });
 
 afterEach(() => {
@@ -53,7 +53,7 @@ describe("searchSkillsRegistry", () => {
       expect(urlStr).toContain("q=react");
       expect(urlStr).toContain("limit=5");
       return Promise.resolve(
-        new Response(JSON.stringify(mockResults), {
+        new Response(JSON.stringify({ skills: mockResults }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -69,7 +69,7 @@ describe("searchSkillsRegistry", () => {
       const urlStr = url.toString();
       expect(urlStr).not.toContain("limit=");
       return Promise.resolve(
-        new Response(JSON.stringify([]), {
+        new Response(JSON.stringify({ skills: [] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -142,13 +142,11 @@ describe("fetchSkillAudits", () => {
 
   test("throws on non-OK response", async () => {
     mockFetchImpl = () =>
-      Promise.resolve(
-        new Response("Internal Server Error", { status: 500 }),
-      );
+      Promise.resolve(new Response("Internal Server Error", { status: 500 }));
 
-    await expect(
-      fetchSkillAudits("some/source", ["slug"]),
-    ).rejects.toThrow("Audit fetch failed: HTTP 500");
+    await expect(fetchSkillAudits("some/source", ["slug"])).rejects.toThrow(
+      "Audit fetch failed: HTTP 500",
+    );
   });
 });
 
@@ -281,9 +279,9 @@ describe("resolveSkillSource", () => {
   });
 
   test("rejects path traversal in @ format slug", () => {
-    expect(() =>
-      resolveSkillSource("owner/repo@../../malicious"),
-    ).toThrow('Invalid skill source "owner/repo@../../malicious"');
+    expect(() => resolveSkillSource("owner/repo@../../malicious")).toThrow(
+      'Invalid skill source "owner/repo@../../malicious"',
+    );
   });
 
   test("rejects uppercase slug in @ format", () => {

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -11,6 +11,8 @@ import {
 import {
   fetchSkillAudits,
   formatAuditBadges,
+  installExternalSkill,
+  resolveSkillSource,
   searchSkillsRegistry,
 } from "../../skills/skillssh-registry.js";
 import type { AuditResponse } from "../../skills/skillssh-registry.js";
@@ -38,7 +40,9 @@ Examples:
   $ assistant skills search react --limit 5 --json
   $ assistant skills install weather
   $ assistant skills install weather --overwrite
-  $ assistant skills uninstall weather`,
+  $ assistant skills uninstall weather
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills --overwrite`,
   );
 
   skills
@@ -265,4 +269,73 @@ Examples:
         process.exitCode = 1;
       }
     });
+
+  skills
+    .command("add <source>")
+    .description(
+      "Install a community skill from the skills.sh registry (GitHub)",
+    )
+    .option("--overwrite", "Replace an already installed skill")
+    .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  source   Skill source in one of these formats:
+             owner/repo@skill-name
+             owner/repo/skill-name
+             https://github.com/owner/repo/tree/<branch>/skills/skill-name
+
+Notes:
+  Fetches the skill's SKILL.md and supporting files from the specified GitHub
+  repository and installs them into the workspace skills directory. A
+  version.json file is written with origin metadata for provenance tracking.
+
+Examples:
+  $ assistant skills add vercel-labs/skills@find-skills
+  $ assistant skills add vercel-labs/skills/find-skills
+  $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
+    )
+    .action(
+      async (
+        source: string,
+        opts: { overwrite?: boolean; json?: boolean },
+      ) => {
+        const json = opts.json ?? false;
+
+        try {
+          const { owner, repo, skillSlug, ref } = resolveSkillSource(source);
+
+          await installExternalSkill(
+            owner,
+            repo,
+            skillSlug,
+            opts.overwrite ?? false,
+            ref,
+          );
+
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                skillSlug,
+                source: `${owner}/${repo}`,
+              }),
+            );
+          } else {
+            log.info(
+              `Installed skill "${skillSlug}" from ${owner}/${repo}.`,
+            );
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (json) {
+            console.log(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
 }

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -8,6 +8,12 @@ import {
   readLocalCatalog,
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
+import {
+  fetchSkillAudits,
+  formatAuditBadges,
+  searchSkillsRegistry,
+} from "../../skills/skillssh-registry.js";
+import type { AuditResponse } from "../../skills/skillssh-registry.js";
 import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
@@ -28,6 +34,8 @@ capabilities with pre-built workflows and tools.
 Examples:
   $ assistant skills list
   $ assistant skills list --json
+  $ assistant skills search react
+  $ assistant skills search react --limit 5 --json
   $ assistant skills install weather
   $ assistant skills install weather --overwrite
   $ assistant skills uninstall weather`,
@@ -78,6 +86,106 @@ Examples:
         process.exitCode = 1;
       }
     });
+
+  skills
+    .command("search <query>")
+    .description("Search the skills.sh community registry")
+    .option("--limit <n>", "Maximum number of results", "10")
+    .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  query    Free-text search term matched against skill names, descriptions,
+           and tags in the skills.sh registry.
+
+Searches the skills.sh community registry and displays matching skills
+with install counts and security audit badges (ATH, Socket, Snyk).
+Audit fetch failures are non-fatal — results are still shown without
+security data.
+
+Examples:
+  $ assistant skills search react
+  $ assistant skills search "file management" --limit 3
+  $ assistant skills search deploy --json`,
+    )
+    .action(
+      async (query: string, opts: { limit: string; json?: boolean }) => {
+        const json = opts.json ?? false;
+        const limit = parseInt(opts.limit, 10) || 10;
+
+        try {
+          const results = await searchSkillsRegistry(query, limit);
+
+          if (results.length === 0) {
+            if (json) {
+              console.log(
+                JSON.stringify({ ok: true, results: [], audits: {} }),
+              );
+            } else {
+              log.info(`No skills found for "${query}".`);
+            }
+            return;
+          }
+
+          // Group skill slugs by source for batch audit lookups
+          const sourceToSlugs = new Map<string, string[]>();
+          for (const r of results) {
+            const slugs = sourceToSlugs.get(r.source) ?? [];
+            slugs.push(r.skillId);
+            sourceToSlugs.set(r.source, slugs);
+          }
+
+          // Fetch audits for each unique source, keyed by source/skillId
+          // to avoid collisions when different sources share the same slug.
+          const allAudits: AuditResponse = {};
+          for (const [source, slugs] of sourceToSlugs) {
+            try {
+              const audits = await fetchSkillAudits(source, slugs);
+              for (const [skillId, auditData] of Object.entries(audits)) {
+                allAudits[`${source}/${skillId}`] = auditData;
+              }
+            } catch {
+              // Audit fetch failures are non-fatal; display results without audits
+            }
+          }
+
+          if (json) {
+            console.log(
+              JSON.stringify({
+                ok: true,
+                results,
+                audits: allAudits,
+              }),
+            );
+            return;
+          }
+
+          log.info(`Search results for "${query}" (${results.length}):\n`);
+          for (const r of results) {
+            log.info(`  ${r.name}`);
+            log.info(`    ID: ${r.skillId}`);
+            log.info(`    Source: ${r.source}`);
+            log.info(`    Installs: ${r.installs}`);
+            const auditData = allAudits[`${r.source}/${r.skillId}`];
+            if (auditData) {
+              log.info(`    ${formatAuditBadges(auditData)}`);
+            } else {
+              log.info("    Security: no audit data");
+            }
+            log.info("");
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (json) {
+            console.log(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+        }
+      },
+    );
 
   skills
     .command("install <skill-id>")

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -960,6 +960,20 @@ function buildDynamicSkillWorkflowSection(
     );
   }
 
+  lines.push(
+    "",
+    "### Community Skills Discovery",
+    "",
+    "When no built-in skill satisfies a request, search the community skills.sh registry:",
+    "1. Run `assistant skills search <query>` to find community skills. Results include install counts and security audit badges (ATH, Socket, Snyk).",
+    "2. Present the search results to the user, highlighting the security audit status. ATH is Gen Agent Trust Hub. Audits show PASS (safe/low risk), WARN (medium risk), or FAIL (high/critical risk) for each provider.",
+    '3. **Always ask the user for permission before installing a community skill.** Say something like: "I found a skill that could help with this. Would you like me to install it?" — share the skill name, source, and audit results.',
+    "4. After user consent, install with `assistant skills add <owner>/<repo>@<skill-name>` (e.g., `assistant skills add vercel-labs/skills@find-skills`).",
+    "5. After installation, load the skill with `skill_load` as usual.",
+    "",
+    "**Never install community skills without explicit user confirmation.** The user should always see the security audit information and make an informed choice.",
+  );
+
   return lines.join("\n");
 }
 

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -3,8 +3,8 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
-import { upsertSkillsIndex } from "./catalog-install.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { upsertSkillsIndex } from "./catalog-install.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -108,7 +108,8 @@ export async function searchSkillsRegistry(
     );
   }
 
-  return (await response.json()) as SkillsShSearchResult[];
+  const data = (await response.json()) as { skills: SkillsShSearchResult[] };
+  return data.skills ?? [];
 }
 
 export async function fetchSkillAudits(
@@ -221,7 +222,10 @@ export async function fetchSkillFromGitHub(
 ): Promise<SkillFiles> {
   const headers = githubHeaders();
 
-  async function fetchDir(subpath: string, prefix: string): Promise<SkillFiles> {
+  async function fetchDir(
+    subpath: string,
+    prefix: string,
+  ): Promise<SkillFiles> {
     let apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${subpath}`;
     if (ref) {
       apiUrl += `?ref=${encodeURIComponent(ref)}`;
@@ -257,7 +261,10 @@ export async function fetchSkillFromGitHub(
 
       if (entry.type === "dir") {
         // Recursively fetch subdirectory contents
-        const subFiles = await fetchDir(`${subpath}/${entry.name}`, relativePath);
+        const subFiles = await fetchDir(
+          `${subpath}/${entry.name}`,
+          relativePath,
+        );
         Object.assign(files, subFiles);
         continue;
       }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,3 +1,11 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+
+import { upsertSkillsIndex } from "./catalog-install.js";
+import { getWorkspaceSkillsDir } from "../util/platform.js";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface SkillsShSearchResult {
@@ -28,6 +36,16 @@ export type SkillAuditData = Record<string, PartnerAudit>;
 
 /** Map from skill slug to per-provider audit data */
 export type AuditResponse = Record<string, SkillAuditData>;
+
+export interface ResolvedSkillSource {
+  owner: string;
+  repo: string;
+  skillSlug: string;
+  ref?: string;
+}
+
+/** Map of relative file paths to their string contents */
+export type SkillFiles = Record<string, string>;
 
 // ─── Display helpers ─────────────────────────────────────────────────────────
 
@@ -116,4 +134,258 @@ export async function fetchSkillAudits(
   }
 
   return (await response.json()) as AuditResponse;
+}
+
+// ─── Source resolution ──────────────────────────────────────────────────────
+
+/**
+ * Parse a skill source string into owner, repo, and skill slug.
+ *
+ * Supported formats:
+ *   - `owner/repo@skill-name`
+ *   - `owner/repo/skill-name`
+ *   - `https://github.com/owner/repo/tree/<branch>/skills/skill-name`
+ */
+export function resolveSkillSource(source: string): ResolvedSkillSource {
+  // Full GitHub URL — capture the branch for ref passthrough
+  const urlMatch = source.match(
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/skills\/([^/]+)\/?$/,
+  );
+  if (urlMatch) {
+    return {
+      owner: urlMatch[1]!,
+      repo: urlMatch[2]!,
+      skillSlug: urlMatch[4]!,
+      ref: urlMatch[3]!,
+    };
+  }
+
+  // owner/repo@skill-name — restrict slug to safe characters
+  const atMatch = source.match(/^([^/]+)\/([^/@]+)@([a-z0-9][a-z0-9._-]*)$/);
+  if (atMatch) {
+    return { owner: atMatch[1]!, repo: atMatch[2]!, skillSlug: atMatch[3]! };
+  }
+
+  // owner/repo/skill-name (exactly 3 segments)
+  const slashMatch = source.match(/^([^/]+)\/([^/]+)\/([^/]+)$/);
+  if (slashMatch) {
+    return {
+      owner: slashMatch[1]!,
+      repo: slashMatch[2]!,
+      skillSlug: slashMatch[3]!,
+    };
+  }
+
+  throw new Error(
+    `Invalid skill source "${source}". Expected one of:\n` +
+      `  owner/repo@skill-name\n` +
+      `  owner/repo/skill-name\n` +
+      `  https://github.com/owner/repo/tree/<branch>/skills/skill-name`,
+  );
+}
+
+// ─── GitHub fetch ───────────────────────────────────────────────────────────
+
+interface GitHubContentsEntry {
+  name: string;
+  type: "file" | "dir";
+  download_url: string | null;
+}
+
+/** Build common headers for GitHub API requests (User-Agent + optional auth). */
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "vellum-assistant",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers["Authorization"] = `token ${token}`;
+  }
+  return headers;
+}
+
+/**
+ * Fetch SKILL.md and supporting files from a GitHub-hosted skills directory.
+ *
+ * Uses the GitHub Contents API: `GET /repos/:owner/:repo/contents/skills/:slug`
+ * and follows each file's `download_url` to retrieve content.
+ * Recursively fetches subdirectories (e.g. scripts/, references/).
+ */
+export async function fetchSkillFromGitHub(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  ref?: string,
+): Promise<SkillFiles> {
+  const headers = githubHeaders();
+
+  async function fetchDir(subpath: string, prefix: string): Promise<SkillFiles> {
+    let apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${subpath}`;
+    if (ref) {
+      apiUrl += `?ref=${encodeURIComponent(ref)}`;
+    }
+
+    const response = await fetch(apiUrl, {
+      headers,
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404 && prefix === "") {
+        throw new Error(
+          `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
+            `Looked in skills/${skillSlug}/`,
+        );
+      }
+      throw new Error(
+        `GitHub API error: HTTP ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const entries = (await response.json()) as GitHubContentsEntry[];
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `Expected a directory listing for ${subpath}/ but got a single file`,
+      );
+    }
+
+    const files: SkillFiles = {};
+    for (const entry of entries) {
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      if (entry.type === "dir") {
+        // Recursively fetch subdirectory contents
+        const subFiles = await fetchDir(`${subpath}/${entry.name}`, relativePath);
+        Object.assign(files, subFiles);
+        continue;
+      }
+
+      if (entry.type !== "file" || !entry.download_url) continue;
+      const fileResponse = await fetch(entry.download_url, {
+        headers: { "User-Agent": "vellum-assistant" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!fileResponse.ok) {
+        throw new Error(
+          `Failed to download ${relativePath}: HTTP ${fileResponse.status}`,
+        );
+      }
+      files[relativePath] = await fileResponse.text();
+    }
+
+    return files;
+  }
+
+  const rootPath = `skills/${encodeURIComponent(skillSlug)}`;
+  const files = await fetchDir(rootPath, "");
+
+  if (!files["SKILL.md"]) {
+    throw new Error(
+      `SKILL.md not found in ${owner}/${repo}/skills/${skillSlug}/`,
+    );
+  }
+
+  return files;
+}
+
+// ─── External skill installation ────────────────────────────────────────────
+
+// ─── Slug validation ────────────────────────────────────────────────────────
+
+const VALID_SKILL_SLUG = /^[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * Validate that a skill slug is safe for use in filesystem paths.
+ * Follows the same pattern as `validateManagedSkillId` in managed-store.ts.
+ */
+export function validateSkillSlug(slug: string): void {
+  if (!slug || typeof slug !== "string") {
+    throw new Error("Skill slug is required");
+  }
+  if (slug.includes("..") || slug.includes("/") || slug.includes("\\")) {
+    throw new Error(
+      `Invalid skill slug "${slug}": must not contain path traversal characters`,
+    );
+  }
+  if (!VALID_SKILL_SLUG.test(slug)) {
+    throw new Error(
+      `Invalid skill slug "${slug}": must start with a lowercase letter or digit and contain only lowercase letters, digits, dots, hyphens, and underscores`,
+    );
+  }
+}
+
+/**
+ * Install a community skill from a GitHub-hosted skills.sh registry repo.
+ *
+ * 1. Validates the skill slug for path safety
+ * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
+ * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
+ * 4. Writes `version.json` with origin metadata
+ * 5. Runs `bun install` if a `package.json` is present
+ * 6. Registers the skill in SKILLS.md only after all steps succeed
+ */
+export async function installExternalSkill(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  overwrite: boolean,
+  ref?: string,
+): Promise<void> {
+  // Validate slug before using in filesystem paths
+  validateSkillSlug(skillSlug);
+
+  const skillDir = join(getWorkspaceSkillsDir(), skillSlug);
+  const skillFilePath = join(skillDir, "SKILL.md");
+
+  if (existsSync(skillFilePath) && !overwrite) {
+    throw new Error(
+      `Skill "${skillSlug}" is already installed. Use --overwrite to replace it.`,
+    );
+  }
+
+  const files = await fetchSkillFromGitHub(owner, repo, skillSlug, ref);
+
+  mkdirSync(skillDir, { recursive: true });
+
+  // Write files with path traversal protection (follows extractTarToDir pattern)
+  for (const [filename, content] of Object.entries(files)) {
+    const normalized = filename.replace(/\\/g, "/").replace(/^\.\/+/g, "");
+    if (!normalized || normalized.includes("..") || normalized.startsWith("/"))
+      continue;
+    const destPath = resolve(skillDir, normalized);
+    if (
+      !destPath.startsWith(resolve(skillDir) + sep) &&
+      destPath !== resolve(skillDir)
+    )
+      continue;
+    mkdirSync(dirname(destPath), { recursive: true });
+    writeFileSync(destPath, content, "utf-8");
+  }
+
+  // Write origin metadata
+  const meta = {
+    origin: "skills.sh",
+    source: `${owner}/${repo}`,
+    skillSlug,
+    installedAt: new Date().toISOString(),
+  };
+  writeFileSync(
+    join(skillDir, "version.json"),
+    JSON.stringify(meta, null, 2) + "\n",
+    "utf-8",
+  );
+
+  // Install npm dependencies if the skill ships a package.json
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+
+  // Register in SKILLS.md only after files are written and deps installed
+  upsertSkillsIndex(skillSlug);
 }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
@@ -148,8 +148,9 @@ export async function fetchSkillAudits(
  */
 export function resolveSkillSource(source: string): ResolvedSkillSource {
   // Full GitHub URL — capture the branch for ref passthrough
+  // Branch capture uses non-greedy `.+?` to handle branch names with slashes (e.g. feature/new-flow)
   const urlMatch = source.match(
-    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/skills\/([^/]+)\/?$/,
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/(.+?)\/skills\/([a-z0-9][a-z0-9._-]*)\/?$/,
   );
   if (urlMatch) {
     return {
@@ -166,8 +167,8 @@ export function resolveSkillSource(source: string): ResolvedSkillSource {
     return { owner: atMatch[1]!, repo: atMatch[2]!, skillSlug: atMatch[3]! };
   }
 
-  // owner/repo/skill-name (exactly 3 segments)
-  const slashMatch = source.match(/^([^/]+)\/([^/]+)\/([^/]+)$/);
+  // owner/repo/skill-name (exactly 3 segments) — restrict slug to safe characters
+  const slashMatch = source.match(/^([^/]+)\/([^/]+)\/([a-z0-9][a-z0-9._-]*)$/);
   if (slashMatch) {
     return {
       owner: slashMatch[1]!,
@@ -263,7 +264,7 @@ export async function fetchSkillFromGitHub(
 
       if (entry.type !== "file" || !entry.download_url) continue;
       const fileResponse = await fetch(entry.download_url, {
-        headers: { "User-Agent": "vellum-assistant" },
+        headers,
         signal: AbortSignal.timeout(10_000),
       });
       if (!fileResponse.ok) {
@@ -346,6 +347,10 @@ export async function installExternalSkill(
 
   const files = await fetchSkillFromGitHub(owner, repo, skillSlug, ref);
 
+  // Clear existing directory on overwrite to remove stale files
+  if (overwrite && existsSync(skillDir)) {
+    rmSync(skillDir, { recursive: true, force: true });
+  }
   mkdirSync(skillDir, { recursive: true });
 
   // Write files with path traversal protection (follows extractTarToDir pattern)

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,0 +1,119 @@
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SkillsShSearchResult {
+  id: string; // e.g. "vercel-labs/agent-skills/vercel-react-best-practices"
+  skillId: string; // e.g. "vercel-react-best-practices"
+  name: string;
+  installs: number;
+  source: string; // e.g. "vercel-labs/agent-skills"
+}
+
+export type RiskLevel =
+  | "safe"
+  | "low"
+  | "medium"
+  | "high"
+  | "critical"
+  | "unknown";
+
+export interface PartnerAudit {
+  risk: RiskLevel;
+  alerts?: number;
+  score?: number;
+  analyzedAt: string;
+}
+
+/** Map from audit provider name (e.g. "ath", "socket", "snyk") to audit data */
+export type SkillAuditData = Record<string, PartnerAudit>;
+
+/** Map from skill slug to per-provider audit data */
+export type AuditResponse = Record<string, SkillAuditData>;
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+const RISK_DISPLAY: Record<RiskLevel, string> = {
+  safe: "PASS",
+  low: "PASS",
+  medium: "WARN",
+  high: "FAIL",
+  critical: "FAIL",
+  unknown: "?",
+};
+
+const PROVIDER_DISPLAY: Record<string, string> = {
+  ath: "ATH",
+  socket: "Socket",
+  snyk: "Snyk",
+};
+
+export function riskToDisplay(risk: RiskLevel): string {
+  return RISK_DISPLAY[risk] ?? "?";
+}
+
+export function providerDisplayName(provider: string): string {
+  return PROVIDER_DISPLAY[provider] ?? provider;
+}
+
+export function formatAuditBadges(auditData: SkillAuditData): string {
+  const providers = Object.keys(auditData);
+  if (providers.length === 0) return "Security: no audit data";
+
+  const badges = providers.map((provider) => {
+    const audit = auditData[provider]!;
+    const display = riskToDisplay(audit.risk);
+    const name = providerDisplayName(provider);
+    return `[${name}:${display}]`;
+  });
+
+  return `Security: ${badges.join(" ")}`;
+}
+
+// ─── API clients ─────────────────────────────────────────────────────────────
+
+export async function searchSkillsRegistry(
+  query: string,
+  limit?: number,
+): Promise<SkillsShSearchResult[]> {
+  const params = new URLSearchParams({ q: query });
+  if (limit != null) {
+    params.set("limit", String(limit));
+  }
+
+  const url = `https://skills.sh/api/search?${params.toString()}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `skills.sh search failed: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as SkillsShSearchResult[];
+}
+
+export async function fetchSkillAudits(
+  source: string,
+  skillSlugs: string[],
+): Promise<AuditResponse> {
+  if (skillSlugs.length === 0) return {};
+
+  const params = new URLSearchParams({
+    source,
+    skills: skillSlugs.join(","),
+  });
+
+  const url = `https://add-skill.vercel.sh/audit?${params.toString()}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Audit fetch failed: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as AuditResponse;
+}


### PR DESCRIPTION
## Summary
Extends the `assistant skills` CLI with community skills discovery, security audit inspection, and installation from the Vercel skills.sh open registry. Users can search for skills, see security audit badges (ATH, Socket, Snyk), and install them into their workspace. The system prompt now guides the LLM to use this workflow when built-in skills don't satisfy a request.

## Changes
- `assistant skills search <query>` — searches the skills.sh registry, displays results with install counts and security audit badges
- `assistant skills add <source>` — installs skills from GitHub repos into the workspace (supports `owner/repo@skill`, `owner/repo/skill`, and full URL formats)
- System prompt teaches the LLM the search → present → confirm → install → load workflow
- Security: skill slug validation, path traversal protection on GitHub API filenames, recursive subdirectory fetching
- GitHub API integration with User-Agent header and optional GITHUB_TOKEN authentication

## Milestone PRs (merged into feature branch)
- #16045: M1 — Add assistant skills search CLI command with security audits
- #16051: M2 — Add assistant skills add command for external skill installation
- #16056: M3 — Update system prompt with skills discovery guidance

## Project issue
Closes #16037

## Test plan
- [ ] Run `assistant skills search react` and verify results with audit badges
- [ ] Run `assistant skills add vercel-labs/skills@find-skills` and verify skill appears in workspace
- [ ] Run `assistant skills search deploy --json` and verify JSON output includes audit data
- [ ] Verify system prompt includes Community Skills Discovery section
- [ ] Verify path traversal protection rejects malicious slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
