### PR TITLE
refactor(avatar): remove "Edit in Chat" option from avatar management

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -2,10 +2,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
-/// Modal overlay for managing the avatar: upload, choose from presets, edit in chat, or delete.
+/// Modal overlay for managing the avatar: upload, choose from presets, or delete.
 struct AvatarManagementSheet: View {
     let onClose: () -> Void
-    let onEditAvatar: () -> Void
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var showingPresets = false
@@ -94,17 +93,6 @@ struct AvatarManagementSheet: View {
                     subtitle: "Choose a PNG or JPEG from your Mac"
                 ) {
                     pickImage()
-                }
-
-                Divider().background(VColor.borderBase)
-                    .padding(.horizontal, VSpacing.xl)
-
-                actionRow(
-                    icon: "bubble.left.and.text.bubble.right",
-                    label: "Edit in Chat",
-                    subtitle: "Describe changes and let AI generate it"
-                ) {
-                    onEditAvatar()
                 }
 
                 if appearance.customAvatarImage != nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -76,15 +76,6 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.selection = nil },
-                onEditAvatar: {
-                    if threadManager.activeViewModel == nil {
-                        threadManager.createThread()
-                    }
-                    if let viewModel = threadManager.activeViewModel {
-                        viewModel.inputText = "I want to edit my avatar's looks"
-                    }
-                    windowState.selection = nil
-                },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
                         threadManager.createThread()
@@ -455,15 +446,6 @@ extension MainWindowView {
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
-                onEditAvatar: {
-                    if threadManager.activeViewModel == nil {
-                        threadManager.createThread()
-                    }
-                    if let viewModel = threadManager.activeViewModel {
-                        viewModel.inputText = "I want to edit my avatar's looks"
-                    }
-                    windowState.dismissOverlay()
-                },
                 onInvokeSkill: { skill in
                     if threadManager.activeViewModel == nil {
                         threadManager.createThread()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -3,7 +3,6 @@ import VellumAssistantShared
 
 struct IdentityPanel: View {
     let onClose: () -> Void
-    let onEditAvatar: () -> Void
     let daemonClient: DaemonClient
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -131,11 +130,7 @@ struct IdentityPanel: View {
 
                 if showAvatarSheet {
                     AvatarManagementSheet(
-                        onClose: { showAvatarSheet = false },
-                        onEditAvatar: {
-                            showAvatarSheet = false
-                            onEditAvatar()
-                        }
+                        onClose: { showAvatarSheet = false }
                     )
                     .frame(width: 360)
                     .fixedSize(horizontal: false, vertical: true)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -5,7 +5,6 @@ import VellumAssistantShared
 
 struct IntelligencePanel: View {
     var onClose: () -> Void
-    var onEditAvatar: () -> Void
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
 
@@ -84,7 +83,6 @@ struct IntelligencePanel: View {
         case .identity:
             IdentityPanel(
                 onClose: onClose,
-                onEditAvatar: onEditAvatar,
                 daemonClient: daemonClient
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
@@ -114,5 +112,5 @@ struct IntelligencePanel: View {
 }
 
 #Preview {
-    IntelligencePanel(onClose: {}, onEditAvatar: {}, daemonClient: DaemonClient())
+    IntelligencePanel(onClose: {}, daemonClient: DaemonClient())
 }

--- a/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowAvatarRoutingTests.swift
@@ -7,26 +7,6 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
     // MARK: - Callback Wiring Tests
 
-    /// Constructs an IdentityPanel with the same closure pattern used in IntelligencePanel,
-    /// then invokes the panel's onEditAvatar callback and verifies it clears selection
-    /// (navigating back to chat).
-    func testIdentityPanelOnEditAvatarClearsSelection() {
-        let state = MainWindowState(hasAPIKey: false)
-        state.selection = .panel(.intelligence)
-        let daemonClient = DaemonClient()
-
-        let panel = IdentityPanel(
-            onClose: { state.selection = nil },
-            onEditAvatar: { state.selection = nil },
-            daemonClient: daemonClient
-        )
-
-        panel.onEditAvatar()
-
-        XCTAssertNil(state.selection)
-        daemonClient.disconnect()
-    }
-
     /// Constructs an IdentityPanel and verifies the onClose callback clears selection.
     func testIdentityPanelOnCloseCallback() {
         let state = MainWindowState(hasAPIKey: false)
@@ -35,37 +15,12 @@ final class MainWindowAvatarRoutingTests: XCTestCase {
 
         let panel = IdentityPanel(
             onClose: { state.selection = nil },
-            onEditAvatar: { state.selection = nil },
             daemonClient: daemonClient
         )
 
         panel.onClose()
 
         XCTAssertNil(state.selection)
-        daemonClient.disconnect()
-    }
-
-    // MARK: - Callback Contract Tests
-
-    /// Verifies that IdentityPanel's init signature requires an onEditAvatar callback.
-    /// Instantiates a real IdentityPanel so the test fails to compile if the parameter is removed.
-    func testIdentityPanelRequiresEditAvatarCallback() {
-        var editCalled = false
-        var closeCalled = false
-        let daemonClient = DaemonClient()
-
-        let panel = IdentityPanel(
-            onClose: { closeCalled = true },
-            onEditAvatar: { editCalled = true },
-            daemonClient: daemonClient
-        )
-
-        // Verify callbacks are wired — invoke them directly to confirm the closures passed through
-        panel.onClose()
-        panel.onEditAvatar()
-
-        XCTAssertTrue(closeCalled)
-        XCTAssertTrue(editCalled)
         daemonClient.disconnect()
     }
 


### PR DESCRIPTION
## Summary
- Removes the "Edit in Chat" action row from AvatarManagementSheet
- Removes onEditAvatar callback plumbing from AvatarManagementSheet, IdentityPanel, IntelligencePanel, and PanelCoordinator
- Removes associated tests for the deleted callback

Part of plan: avatar-random-edit.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
