### PR TITLE
fix: reorder settings tabs and move contacts search bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -20,7 +20,6 @@ struct ContactsListView: View {
             } else if viewModel.contacts.isEmpty {
                 emptyState
             } else {
-                searchBar
                 contactsList
             }
         }
@@ -209,6 +208,10 @@ struct ContactsListView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Add contact")
+            }
+
+            if viewModel.hasNonGuardianContacts {
+                searchBar
             }
 
             if !viewModel.hasNonGuardianContacts {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,14 +12,14 @@ enum SettingsTab: String {
 
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
     static func primaryTabs(contactsEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [
-            .general, .modelsAndServices, .voice,
-            .permissionsAndPrivacy
-        ]
+        var tabs: [SettingsTab] = [.general]
         if contactsEnabled {
             tabs.append(.contacts)
         }
-        tabs.append(.archivedThreads)
+        tabs.append(contentsOf: [
+            .voice, .modelsAndServices,
+            .permissionsAndPrivacy, .archivedThreads
+        ])
         return tabs
     }
 


### PR DESCRIPTION
## Summary
- Reorders settings sidebar: General → Contacts → Voice → Models & Services → Permissions & Privacy → Archived Threads
- Moves contacts search bar below the "Contacts" sub-header (was at the top of the list)
- Hides search bar when there are no contacts yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
