### PR TITLE
security: scope bun run allowlist keys to script basename

### DIFF
--- a/assistant/src/__tests__/shell-identity.test.ts
+++ b/assistant/src/__tests__/shell-identity.test.ts
@@ -170,6 +170,16 @@ describe("deriveShellActionKeys", () => {
       { key: "action:gh", depth: 1 },
     ]);
   });
+
+  test("bun run script derives script-specific key and excludes broad bun run", async () => {
+    const analysis = await analyzeShellCommand(
+      "bun run /tmp/skills/amazon/scripts/amazon.ts fresh delivery-slots --json",
+    );
+    const result = deriveShellActionKeys(analysis);
+
+    expect(result.isSimpleAction).toBe(true);
+    expect(result.keys).toEqual([{ key: "action:bun run amazon", depth: 3 }]);
+  });
 });
 
 describe("buildShellCommandCandidates", () => {
@@ -276,5 +286,16 @@ describe("buildShellAllowlistOptions — complex command restrictions", () => {
     expect(options[0].pattern).toBe("npm install express");
     expect(options.some((o) => o.pattern === "action:npm install")).toBe(true);
     expect(options.some((o) => o.pattern === "action:npm")).toBe(true);
+  });
+
+  test("bun run script allowlist options are script-specific", async () => {
+    const options = await buildShellAllowlistOptions(
+      "bun run /tmp/skills/amazon/scripts/amazon.ts fresh checkout",
+    );
+
+    expect(options.some((o) => o.pattern === "action:bun run amazon")).toBe(
+      true,
+    );
+    expect(options.some((o) => o.pattern === "action:bun run")).toBe(false);
   });
 });

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -76,6 +76,37 @@ const SETUP_PREFIX_PROGRAMS = new Set([
 
 const MAX_ACTION_KEY_DEPTH = 3;
 
+const SCRIPT_RUNNERS = new Set(["bun", "node", "python", "python3"]);
+
+function getScriptIdentityToken(
+  program: string,
+  args: string[],
+): string | null {
+  if (!SCRIPT_RUNNERS.has(program) || args[0] !== "run") {
+    return null;
+  }
+
+  const scriptArg = args.find(
+    (arg) => arg.includes("/") || arg.startsWith("."),
+  );
+  if (!scriptArg) {
+    return null;
+  }
+
+  const normalized = scriptArg.replace(/^['"]|['"]$/g, "");
+  const baseName =
+    normalized
+      .split("/")
+      .pop()
+      ?.replace(/\.[^.]+$/, "") ?? "";
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(baseName)) {
+    return null;
+  }
+
+  return baseName;
+}
+
 /**
  * Analyze a shell command using the tree-sitter parser to extract
  * identity information for permission decisions.
@@ -166,6 +197,10 @@ export function deriveShellActionKeys(
 
   const primarySegment = actionSegments[0];
   const tokens: string[] = [primarySegment.program];
+  const scriptIdentityToken = getScriptIdentityToken(
+    primarySegment.program,
+    primarySegment.args,
+  );
 
   // Add non-flag, non-path stable subcommand tokens (up to MAX_ACTION_KEY_DEPTH)
   for (const arg of primarySegment.args) {
@@ -177,9 +212,18 @@ export function deriveShellActionKeys(
     tokens.push(arg);
   }
 
+  if (scriptIdentityToken && !tokens.includes(scriptIdentityToken)) {
+    if (tokens.length < MAX_ACTION_KEY_DEPTH) {
+      tokens.push(scriptIdentityToken);
+    } else {
+      tokens[tokens.length - 1] = scriptIdentityToken;
+    }
+  }
+
   // Build action keys from narrowest to broadest
   const keys: ShellActionKey[] = [];
-  for (let depth = tokens.length; depth >= 1; depth--) {
+  const minDepth = scriptIdentityToken ? tokens.length : 1;
+  for (let depth = tokens.length; depth >= minDepth; depth--) {
     keys.push({
       key: `action:${tokens.slice(0, depth).join(" ")}`,
       depth,

--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -86,10 +86,12 @@ function getScriptIdentityToken(
     return null;
   }
 
-  const scriptArg = args.find(
-    (arg) => arg.includes("/") || arg.startsWith("."),
-  );
-  if (!scriptArg) {
+  // Only use args[1] (the direct run target) as the script identity.
+  // Scanning later args risks deriving identity from ancillary path arguments
+  // (e.g. `bun run lint ./src/index.ts` would otherwise key on `index` instead
+  // of `lint`, allowing unrelated commands to share the same allowlist entry).
+  const scriptArg = args[1];
+  if (!scriptArg || (!scriptArg.includes("/") && !scriptArg.startsWith("."))) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Adds `getScriptIdentityToken` to `shell-identity.ts` that extracts the basename of a script path argument (e.g. `amazon` from `/path/to/amazon.ts`) for known script runners (`bun run`, `node run`, etc.)
- When a script path is detected, injects the basename as the final action-key token and suppresses broader keys (e.g. `action:bun run`), so an always-allow for Amazon commands produces `action:bun run amazon` rather than a catch-all `action:bun run`
- Fixes a permission-scope regression introduced when the Amazon skill switched from `assistant amazon` to `bun run {baseDir}/scripts/amazon.ts`: without this fix, a user accepting the always-allow prompt for Amazon commands would silently authorize any other `bun run` script

## Original prompt
Security finding 3c46620e7b90819196eff6f682c91fd2 (medium severity): Amazon skill's switch to `bun run {baseDir}/scripts/amazon.ts` combined with the shell action-key derivation skipping path args caused always-allow rules to broaden to `action:bun run *`, enabling prompt-injection attacks to run arbitrary bun scripts under the same approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
