### PR TITLE
fix: add @MainActor to PresetAvatar.image

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/PresetAvatarManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/PresetAvatarManager.swift
@@ -8,7 +8,7 @@ struct PresetAvatar: Identifiable, Equatable {
 
     var id: String { name }
 
-    var image: NSImage? {
+    @MainActor var image: NSImage? {
         AvatarCompositor.render(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color)
     }
 


### PR DESCRIPTION
## Summary
- Add `@MainActor` annotation to `PresetAvatar.image` computed property to fix Swift strict concurrency error when calling `@MainActor`-isolated `AvatarCompositor.render()` from a non-isolated context
- Fixes macOS app build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
