### PR TITLE
fix: remove misleading 'Not set up' label from contact channel rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -426,10 +426,6 @@ struct ContactDetailView: View {
                 }
 
                 Spacer()
-
-                Text("Not set up")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
             }
 
             // Guardian contacts get the full channel verification flow; others get invite button


### PR DESCRIPTION
## Summary
- Remove the "Not set up" status label from unconfigured channel rows on contact/guardian cards
- The label was misleading: it appeared next to channels the assistant HAS set up (e.g., Telegram with @bot_handle), making it look like the channel infrastructure was broken rather than indicating the contact simply hasn't been connected via that channel yet
- The invite/verification UI below each channel already communicates the state clearly without the ambiguous label

## Original prompt
--safe Ship the removal of the misleading "Not set up" label from unconfigured channel rows on contact/guardian cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
