### PR TITLE
fix(security): prevent arbitrary file reads in sequence_import / parseContactFile

### DIFF
--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
@@ -8,7 +8,7 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const filePath = input.file_path as string;
   const sequenceId = input.sequence_id as string;
@@ -21,7 +21,7 @@ export async function run(
     const seq = getSequence(sequenceId);
     if (!seq) return err(`Sequence not found: ${sequenceId}`);
 
-    const parsed = parseContactFile(filePath);
+    const parsed = parseContactFile(filePath, context.workingDir);
 
     if (parsed.contacts.length === 0 && parsed.errors.length > 0) {
       return err(

--- a/assistant/src/sequence/importer.test.ts
+++ b/assistant/src/sequence/importer.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { parseContactFile } from "./importer.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseContactFile", () => {
+  test("rejects files outside the current workspace", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "sequence-workspace-"));
+    const external = mkdtempSync(join(tmpdir(), "sequence-external-"));
+    tempDirs.push(workspace, external);
+
+    const current = process.cwd();
+    process.chdir(workspace);
+
+    try {
+      const externalPath = join(external, "contacts.csv");
+      writeFileSync(externalPath, "email,name\nuser@example.com,User\n");
+
+      expect(() => parseContactFile(externalPath)).toThrow(
+        "file_path must be inside the current workspace.",
+      );
+    } finally {
+      process.chdir(current);
+    }
+  });
+
+  test("rejects non-csv/tsv file extensions", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "sequence-workspace-"));
+    tempDirs.push(workspace);
+
+    const current = process.cwd();
+    process.chdir(workspace);
+
+    try {
+      const filePath = join(workspace, "secrets.txt");
+      writeFileSync(filePath, "root:x:0:0:root:/root:/bin/bash\n");
+
+      expect(() => parseContactFile(filePath)).toThrow(
+        "file_path must be a .csv or .tsv file.",
+      );
+    } finally {
+      process.chdir(current);
+    }
+  });
+
+  test("does not echo raw input values in invalid email errors", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "sequence-workspace-"));
+    tempDirs.push(workspace);
+
+    const current = process.cwd();
+    process.chdir(workspace);
+
+    try {
+      const filePath = join(workspace, "contacts.csv");
+      writeFileSync(filePath, "email\nroot:x:0:0:root:/root:/bin/bash\n");
+
+      const result = parseContactFile(filePath);
+
+      expect(result.errors).toEqual([
+        { row: 2, reason: "Invalid email format" },
+      ]);
+    } finally {
+      process.chdir(current);
+    }
+  });
+});

--- a/assistant/src/sequence/importer.test.ts
+++ b/assistant/src/sequence/importer.test.ts
@@ -19,58 +19,35 @@ describe("parseContactFile", () => {
     const external = mkdtempSync(join(tmpdir(), "sequence-external-"));
     tempDirs.push(workspace, external);
 
-    const current = process.cwd();
-    process.chdir(workspace);
+    const externalPath = join(external, "contacts.csv");
+    writeFileSync(externalPath, "email,name\nuser@example.com,User\n");
 
-    try {
-      const externalPath = join(external, "contacts.csv");
-      writeFileSync(externalPath, "email,name\nuser@example.com,User\n");
-
-      expect(() => parseContactFile(externalPath)).toThrow(
-        "file_path must be inside the current workspace.",
-      );
-    } finally {
-      process.chdir(current);
-    }
+    expect(() => parseContactFile(externalPath, workspace)).toThrow(
+      "file_path must be inside the current workspace.",
+    );
   });
 
   test("rejects non-csv/tsv file extensions", () => {
     const workspace = mkdtempSync(join(tmpdir(), "sequence-workspace-"));
     tempDirs.push(workspace);
 
-    const current = process.cwd();
-    process.chdir(workspace);
+    const filePath = join(workspace, "secrets.txt");
+    writeFileSync(filePath, "root:x:0:0:root:/root:/bin/bash\n");
 
-    try {
-      const filePath = join(workspace, "secrets.txt");
-      writeFileSync(filePath, "root:x:0:0:root:/root:/bin/bash\n");
-
-      expect(() => parseContactFile(filePath)).toThrow(
-        "file_path must be a .csv or .tsv file.",
-      );
-    } finally {
-      process.chdir(current);
-    }
+    expect(() => parseContactFile(filePath, workspace)).toThrow(
+      "file_path must be a .csv or .tsv file.",
+    );
   });
 
   test("does not echo raw input values in invalid email errors", () => {
     const workspace = mkdtempSync(join(tmpdir(), "sequence-workspace-"));
     tempDirs.push(workspace);
 
-    const current = process.cwd();
-    process.chdir(workspace);
+    const filePath = join(workspace, "contacts.csv");
+    writeFileSync(filePath, "email\nroot:x:0:0:root:/root:/bin/bash\n");
 
-    try {
-      const filePath = join(workspace, "contacts.csv");
-      writeFileSync(filePath, "email\nroot:x:0:0:root:/root:/bin/bash\n");
+    const result = parseContactFile(filePath, workspace);
 
-      const result = parseContactFile(filePath);
-
-      expect(result.errors).toEqual([
-        { row: 2, reason: "Invalid email format" },
-      ]);
-    } finally {
-      process.chdir(current);
-    }
+    expect(result.errors).toEqual([{ row: 2, reason: "Invalid email format" }]);
   });
 });

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -74,9 +74,16 @@ function validateImportPath(filePath: string, workspaceRoot?: string): string {
   const normalizedPath = normalizeForPathCheck(realPath);
   const normalizedWorkspace = normalizeForPathCheck(realWorkspace);
 
+  // Build the prefix used for the startsWith check. When the workspace root is
+  // the filesystem root (e.g. "/" on Unix or "C:\" on Windows) it already ends
+  // with a separator, so avoid producing a double-separator like "//".
+  const workspacePrefix = normalizedWorkspace.endsWith(sep)
+    ? normalizedWorkspace
+    : `${normalizedWorkspace}${sep}`;
+
   if (
     normalizedPath !== normalizedWorkspace &&
-    !normalizedPath.startsWith(`${normalizedWorkspace}${sep}`)
+    !normalizedPath.startsWith(workspacePrefix)
   ) {
     throw new Error("file_path must be inside the current workspace.");
   }

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -5,7 +5,7 @@
  * and bulk-enrolls contacts into a sequence.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { extname, resolve, sep } from "node:path";
 
 import { getLogger } from "../util/logger.js";
@@ -48,9 +48,26 @@ function normalizeForPathCheck(path: string): string {
 
 function validateImportPath(filePath: string): string {
   const resolvedPath = resolve(filePath);
-  const workspaceRoot = resolve(process.cwd());
-  const normalizedPath = normalizeForPathCheck(resolvedPath);
-  const normalizedWorkspace = normalizeForPathCheck(workspaceRoot);
+
+  // Resolve symlinks to prevent symlink-based escapes (e.g. workspace/evil.csv -> /etc/shadow).
+  // Fall back to the resolve()-d path if the file doesn't exist yet.
+  let realPath: string;
+  try {
+    realPath = realpathSync(resolvedPath);
+  } catch {
+    realPath = resolvedPath;
+  }
+
+  // Also resolve the workspace root's real path (e.g. /tmp -> /private/tmp on macOS).
+  let realWorkspace: string;
+  try {
+    realWorkspace = realpathSync(resolve(process.cwd()));
+  } catch {
+    realWorkspace = resolve(process.cwd());
+  }
+
+  const normalizedPath = normalizeForPathCheck(realPath);
+  const normalizedWorkspace = normalizeForPathCheck(realWorkspace);
 
   if (
     normalizedPath !== normalizedWorkspace &&
@@ -64,7 +81,7 @@ function validateImportPath(filePath: string): string {
     throw new Error("file_path must be a .csv or .tsv file.");
   }
 
-  return resolvedPath;
+  return realPath;
 }
 
 // ── Email validation ────────────────────────────────────────────────

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -47,7 +47,13 @@ function normalizeForPathCheck(path: string): string {
 }
 
 function validateImportPath(filePath: string, workspaceRoot?: string): string {
-  const resolvedPath = resolve(filePath);
+  // Use the caller-supplied workspace root (e.g. ToolContext.workingDir) so that validation
+  // is anchored to the same directory the tool operates in, not process.cwd() which may
+  // differ when the daemon is launched without forcing cwd.
+  // Also use root as the base for resolve() so that relative paths (e.g. "contacts.csv")
+  // are interpreted relative to the workspace, not process.cwd().
+  const root = workspaceRoot ?? process.cwd();
+  const resolvedPath = resolve(root, filePath);
 
   // Resolve symlinks to prevent symlink-based escapes (e.g. workspace/evil.csv -> /etc/shadow).
   // Fall back to the resolve()-d path if the file doesn't exist yet.
@@ -57,11 +63,6 @@ function validateImportPath(filePath: string, workspaceRoot?: string): string {
   } catch {
     realPath = resolvedPath;
   }
-
-  // Use the caller-supplied workspace root (e.g. ToolContext.workingDir) so that validation
-  // is anchored to the same directory the tool operates in, not process.cwd() which may
-  // differ when the daemon is launched without forcing cwd.
-  const root = workspaceRoot ?? process.cwd();
 
   // Also resolve the workspace root's real path (e.g. /tmp -> /private/tmp on macOS).
   let realWorkspace: string;

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -46,7 +46,7 @@ function normalizeForPathCheck(path: string): string {
   return process.platform === "win32" ? path.toLowerCase() : path;
 }
 
-function validateImportPath(filePath: string): string {
+function validateImportPath(filePath: string, workspaceRoot?: string): string {
   const resolvedPath = resolve(filePath);
 
   // Resolve symlinks to prevent symlink-based escapes (e.g. workspace/evil.csv -> /etc/shadow).
@@ -58,12 +58,17 @@ function validateImportPath(filePath: string): string {
     realPath = resolvedPath;
   }
 
+  // Use the caller-supplied workspace root (e.g. ToolContext.workingDir) so that validation
+  // is anchored to the same directory the tool operates in, not process.cwd() which may
+  // differ when the daemon is launched without forcing cwd.
+  const root = workspaceRoot ?? process.cwd();
+
   // Also resolve the workspace root's real path (e.g. /tmp -> /private/tmp on macOS).
   let realWorkspace: string;
   try {
-    realWorkspace = realpathSync(resolve(process.cwd()));
+    realWorkspace = realpathSync(resolve(root));
   } catch {
-    realWorkspace = resolve(process.cwd());
+    realWorkspace = resolve(root);
   }
 
   const normalizedPath = normalizeForPathCheck(realPath);
@@ -236,8 +241,11 @@ function splitCSVRows(content: string): string[] {
 /**
  * Parse a CSV/TSV file into structured contacts.
  */
-export function parseContactFile(filePath: string): ParseResult {
-  const validatedPath = validateImportPath(filePath);
+export function parseContactFile(
+  filePath: string,
+  workspaceRoot?: string,
+): ParseResult {
+  const validatedPath = validateImportPath(filePath, workspaceRoot);
   const content = readFileSync(validatedPath, "utf-8");
   const lines = splitCSVRows(content);
 

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { extname, resolve, sep } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import {
@@ -35,6 +36,35 @@ export interface EnrollResult {
   enrolled: string[];
   skipped: Array<{ email: string; reason: string }>;
   failed: Array<{ email: string; reason: string }>;
+}
+
+// ── Path validation ─────────────────────────────────────────────────
+
+const ALLOWED_IMPORT_EXTENSIONS = new Set([".csv", ".tsv"]);
+
+function normalizeForPathCheck(path: string): string {
+  return process.platform === "win32" ? path.toLowerCase() : path;
+}
+
+function validateImportPath(filePath: string): string {
+  const resolvedPath = resolve(filePath);
+  const workspaceRoot = resolve(process.cwd());
+  const normalizedPath = normalizeForPathCheck(resolvedPath);
+  const normalizedWorkspace = normalizeForPathCheck(workspaceRoot);
+
+  if (
+    normalizedPath !== normalizedWorkspace &&
+    !normalizedPath.startsWith(`${normalizedWorkspace}${sep}`)
+  ) {
+    throw new Error("file_path must be inside the current workspace.");
+  }
+
+  const extension = extname(resolvedPath).toLowerCase();
+  if (!ALLOWED_IMPORT_EXTENSIONS.has(extension)) {
+    throw new Error("file_path must be a .csv or .tsv file.");
+  }
+
+  return resolvedPath;
 }
 
 // ── Email validation ────────────────────────────────────────────────
@@ -190,7 +220,8 @@ function splitCSVRows(content: string): string[] {
  * Parse a CSV/TSV file into structured contacts.
  */
 export function parseContactFile(filePath: string): ParseResult {
-  const content = readFileSync(filePath, "utf-8");
+  const validatedPath = validateImportPath(filePath);
+  const content = readFileSync(validatedPath, "utf-8");
   const lines = splitCSVRows(content);
 
   if (lines.length === 0) {
@@ -245,7 +276,7 @@ export function parseContactFile(filePath: string): ParseResult {
 
     const email = rawEmail.toLowerCase();
     if (!isValidEmail(email)) {
-      errors.push({ row: rowNum, reason: `Invalid email: ${rawEmail}` });
+      errors.push({ row: rowNum, reason: "Invalid email format" });
       continue;
     }
 

--- a/assistant/src/sequence/importer.ts
+++ b/assistant/src/sequence/importer.ts
@@ -76,7 +76,7 @@ function validateImportPath(filePath: string): string {
     throw new Error("file_path must be inside the current workspace.");
   }
 
-  const extension = extname(resolvedPath).toLowerCase();
+  const extension = extname(realPath).toLowerCase();
   if (!ALLOWED_IMPORT_EXTENSIONS.has(extension)) {
     throw new Error("file_path must be a .csv or .tsv file.");
   }


### PR DESCRIPTION
## Summary
- Adds `validateImportPath()` to `importer.ts` that resolves the caller-supplied path, checks it is contained within `process.cwd()`, and validates the extension is `.csv` or `.tsv` — blocks path traversal to `/etc/passwd` and similar host files
- Replaces the `Invalid email: ${rawEmail}` error message with `"Invalid email format"` to stop raw file content from being echoed back to the caller via parse errors
- Adds `importer.test.ts` with three regression tests: path-traversal rejection, extension rejection, and sanitized error messages

Fixes Codex security finding [5c52503559cc81919adaa3f864e0684e](https://chatgpt.com/codex/security/findings/5c52503559cc81919adaa3f864e0684e?sev=&page=5) (medium severity).

## Original prompt
Fix arbitrary file read vulnerability in sequence_import / parseContactFile: `parseContactFile` in `assistant/src/sequence/importer.ts` accepts an arbitrary `filePath`, reads it with `readFileSync` without any path or extension validation, and includes raw field values in error messages (`Invalid email: ${rawEmail}`). The `sequence_import` tool surfaces these errors to the caller, making it possible to read any host file by supplying a path like `/etc/passwd` and triggering parse errors that echo file content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
