### PR TITLE
fix(security): restrict DoorDash session file permissions to owner-only (0600/0700)

### DIFF
--- a/skills/doordash/scripts/__tests__/doordash-session.test.ts
+++ b/skills/doordash/scripts/__tests__/doordash-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -60,6 +60,31 @@ describe("DoorDash session helpers", () => {
         expect(statSync(sessionDir).mode & 0o777).toBe(0o700);
         expect(statSync(sessionPath).mode & 0o777).toBe(0o600);
         expect(loadSession()).not.toBeNull();
+      } finally {
+        if (previousDataDir === undefined) delete process.env.VELLUM_DATA_DIR;
+        else process.env.VELLUM_DATA_DIR = previousDataDir;
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("enforces restrictive permissions when overwriting an existing world-readable file", () => {
+      const tempDir = mkdtempSync(
+        join(tmpdir(), "doordash-session-overwrite-"),
+      );
+      const previousDataDir = process.env.VELLUM_DATA_DIR;
+      process.env.VELLUM_DATA_DIR = tempDir;
+
+      try {
+        // First save creates the file correctly
+        saveSession(makeSession());
+        // Simulate a pre-existing file with insecure permissions (e.g. created before this fix)
+        const sessionPath = join(tempDir, "doordash", "session.json");
+        chmodSync(sessionPath, 0o644);
+        expect(statSync(sessionPath).mode & 0o777).toBe(0o644);
+
+        // Second save must re-enforce permissions even on overwrite
+        saveSession(makeSession());
+        expect(statSync(sessionPath).mode & 0o777).toBe(0o600);
       } finally {
         if (previousDataDir === undefined) delete process.env.VELLUM_DATA_DIR;
         else process.env.VELLUM_DATA_DIR = previousDataDir;

--- a/skills/doordash/scripts/__tests__/doordash-session.test.ts
+++ b/skills/doordash/scripts/__tests__/doordash-session.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import {
   type DoorDashSession,
   getCookieHeader,
   getCsrfToken,
+  loadSession,
+  saveSession,
 } from "../lib/session.js";
 
 function makeCookie(
@@ -40,6 +45,29 @@ function makeSession(overrides?: Partial<DoorDashSession>): DoorDashSession {
 }
 
 describe("DoorDash session helpers", () => {
+  describe("session persistence", () => {
+    it("writes session directory and file with restrictive permissions", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "doordash-session-"));
+      const previousDataDir = process.env.VELLUM_DATA_DIR;
+      process.env.VELLUM_DATA_DIR = tempDir;
+
+      try {
+        saveSession(makeSession());
+
+        const sessionDir = join(tempDir, "doordash");
+        const sessionPath = join(sessionDir, "session.json");
+
+        expect(statSync(sessionDir).mode & 0o777).toBe(0o700);
+        expect(statSync(sessionPath).mode & 0o777).toBe(0o600);
+        expect(loadSession()).not.toBeNull();
+      } finally {
+        if (previousDataDir === undefined) delete process.env.VELLUM_DATA_DIR;
+        else process.env.VELLUM_DATA_DIR = previousDataDir;
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe("getCookieHeader", () => {
     it("joins all cookies into a single header string", () => {
       const session = makeSession();

--- a/skills/doordash/scripts/lib/session.ts
+++ b/skills/doordash/scripts/lib/session.ts
@@ -5,6 +5,7 @@
 
 import { execFile } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -18,6 +19,8 @@ import { ConfigError } from "./shared/errors.js";
 import type { ExtractedCredential } from "./shared/recording-types.js";
 
 const execFileAsync = promisify(execFile);
+const SESSION_DIR_MODE = 0o700;
+const SESSION_FILE_MODE = 0o600;
 
 export interface DoorDashSession {
   cookies: ExtractedCredential[];
@@ -37,6 +40,7 @@ export function loadSession(): DoorDashSession | null {
   const path = getSessionPath();
   if (!existsSync(path)) return null;
   try {
+    chmodSync(path, SESSION_FILE_MODE);
     return JSON.parse(readFileSync(path, "utf-8")) as DoorDashSession;
   } catch {
     return null;
@@ -45,8 +49,11 @@ export function loadSession(): DoorDashSession | null {
 
 export function saveSession(session: DoorDashSession): void {
   const dir = getSessionDir();
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(getSessionPath(), JSON.stringify(session, null, 2));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: SESSION_DIR_MODE });
+  else chmodSync(dir, SESSION_DIR_MODE);
+  writeFileSync(getSessionPath(), JSON.stringify(session, null, 2), {
+    mode: SESSION_FILE_MODE,
+  });
 }
 
 export function clearSession(): void {

--- a/skills/doordash/scripts/lib/session.ts
+++ b/skills/doordash/scripts/lib/session.ts
@@ -49,7 +49,8 @@ export function loadSession(): DoorDashSession | null {
 
 export function saveSession(session: DoorDashSession): void {
   const dir = getSessionDir();
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: SESSION_DIR_MODE });
+  if (!existsSync(dir))
+    mkdirSync(dir, { recursive: true, mode: SESSION_DIR_MODE });
   else chmodSync(dir, SESSION_DIR_MODE);
   writeFileSync(getSessionPath(), JSON.stringify(session, null, 2), {
     mode: SESSION_FILE_MODE,

--- a/skills/doordash/scripts/lib/session.ts
+++ b/skills/doordash/scripts/lib/session.ts
@@ -55,6 +55,7 @@ export function saveSession(session: DoorDashSession): void {
   writeFileSync(getSessionPath(), JSON.stringify(session, null, 2), {
     mode: SESSION_FILE_MODE,
   });
+  chmodSync(getSessionPath(), SESSION_FILE_MODE);
 }
 
 export function clearSession(): void {


### PR DESCRIPTION
## Summary

- DoorDash session cookies were written to `session.json` with default umask permissions (644 — world-readable), exposing plaintext auth credentials to any local user or process
- `saveSession()` now creates the directory with mode `0o700` and writes the file with mode `0o600`; `loadSession()` applies `chmodSync` to remediate existing over-permissive files
- Added a permission-assertion test verifying both the directory (0o700) and file (0o600) modes after `saveSession()`

## Original prompt

fix(security): restrict doordash session file permissions to owner-only (0600/0700)

Fixes Codex security finding 1b490c5052108191a287c9c3dc2841b9 (medium severity): DoorDash CLI persists auth cookies in plaintext session file without restrictive permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
