### PR TITLE
fix: require approval prompt for computer_use_observe

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -895,6 +895,19 @@ describe("Permission Checker", () => {
       );
     });
 
+    test("computer_use_observe prompts by default via computer-use ask rule", async () => {
+      const result = await check(
+        "computer_use_observe",
+        { reason: "Check current screen state before acting" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("prompt");
+      expect(result.reason).toContain("ask rule");
+      expect(result.matchedRule?.id).toBe(
+        "default:ask-computer_use_observe-global",
+      );
+    });
+
     test("higher-priority allow rule can override default computer-use ask rule", async () => {
       addRule(
         "computer_use_click",

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -900,6 +900,20 @@ describe("Trust Store", () => {
       );
     });
 
+    test("findHighestPriorityRule matches default ask for computer_use_observe", () => {
+      const match = findHighestPriorityRule(
+        "computer_use_observe",
+        ["computer_use_observe:"],
+        "/tmp",
+      );
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe("default:ask-computer_use_observe-global");
+      expect(match!.decision).toBe("ask");
+      expect(match!.priority).toBe(
+        DEFAULT_PRIORITY_BY_ID.get("default:ask-computer_use_observe-global")!,
+      );
+    });
+
     test("bootstrap delete rule matches only when workingDir is the workspace dir", () => {
       const workspaceDir = join(testDir, "workspace");
       // Should match when workingDir is the workspace directory — the bootstrap

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -20,6 +20,7 @@ const HOST_FILE_TOOLS = [
   "host_file_edit",
 ] as const;
 const COMPUTER_USE_TOOLS = [
+  "computer_use_observe",
   "computer_use_click",
   "computer_use_type_text",
   "computer_use_key",


### PR DESCRIPTION
## Summary
- Add \`computer_use_observe\` to \`COMPUTER_USE_TOOLS\` in \`defaults.ts\` so it receives a default \`ask\` trust rule (priority 1000), matching every other computer-use action tool
- Without this rule the permission checker's bundled-skill auto-allow path silently allowed the tool, enabling silent screen capture (AX tree + screenshots) on macOS/iOS desktop sessions without any user approval prompt
- Add tests in \`checker.test.ts\` and \`trust-store.test.ts\` verifying \`computer_use_observe\` now prompts by default

## Original prompt
Fix security vulnerability: computer_use_observe can capture the user's screen without any approval prompt. The COMPUTER_USE_TOOLS array in defaults.ts was missing computer_use_observe, causing it to be auto-allowed as a low-risk bundled skill tool instead of requiring user approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
