### PR TITLE
fix: hide header card for guardian contact on contacts page

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -77,7 +77,9 @@ struct ContactDetailView: View {
 
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                headerSection
+                if displayContact.role != "guardian" {
+                    headerSection
+                }
                 channelsSection
             }
             .padding(VSpacing.xl)


### PR DESCRIPTION
## Summary
- Hide the header card (name, role badges, interaction count, notes) when the guardian's contact is selected on the Contacts page
- Matches the existing behavior for the assistant contact, which also omits this card
- Only non-guardian contacts now show the header card

## Original prompt
we do not need to show this card for the Guardian's contact card on the contact page (just like its absent when the assistant's card is selected.. We only need to show it for non-guardian contacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
