### PR TITLE
Register missing route policy for /v1/export

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -403,6 +403,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "schedules/cancel", scopes: ["settings.write"] },
 
   // Diagnostics
+  { endpoint: "export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/export", scopes: ["settings.read"] },
   { endpoint: "diagnostics/env-vars", scopes: ["settings.read"] },
 


### PR DESCRIPTION
### Motivation
- The `POST /v1/export` route returns audit rows and daemon logs and declared `policyKey: "export"`, but no corresponding policy was registered, leaving the endpoint effectively unprotected and able to expose sensitive data to any valid bearer token.

### Description
- Add a policy registration for the `export` route by inserting `{ endpoint: "export", scopes: ["settings.read"] }` into `ACTOR_ENDPOINTS` in `assistant/src/runtime/auth/route-policy.ts` so that `enforcePolicy` requires the `settings.read` scope for this endpoint.

### Testing
- Attempted to run the relevant auth tests (`src/runtime/auth/__tests__/route-policy.test.ts` and `src/runtime/auth/__tests__/guard-tests.test.ts`) but the `bun` test runner is unavailable in this environment so the test run failed; the change was verified via `git diff` and file inspection to ensure the `export` policy is now present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1568e0b708323ae76157fa733a435)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
