### PR TITLE
fix: harden verification control-plane shell fragment detection

### DIFF
--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -436,6 +436,15 @@ describe("isVerificationControlPlaneInvocation", () => {
       ).toBe(true);
     });
 
+    test("detects endpoint when path fragments are split across variables", () => {
+      expect(
+        isVerificationControlPlaneInvocation("bash", {
+          command:
+            'part1=channel-verification; part2=sessions; curl "http://localhost:3000/v1/${part1}-${part2}"',
+        }),
+      ).toBe(true);
+    });
+
     test("detects endpoint via heredoc-style construction", () => {
       expect(
         isVerificationControlPlaneInvocation("bash", {

--- a/assistant/src/tools/verification-control-plane-policy.ts
+++ b/assistant/src/tools/verification-control-plane-policy.ts
@@ -84,7 +84,19 @@ function containsVerificationEndpointPath(value: string): boolean {
  */
 function containsVerificationFragments(command: string): boolean {
   const lower = command.toLowerCase();
-  return lower.includes("channel-verification-sessions");
+
+  // Match contiguous endpoint assignment first.
+  if (lower.includes("channel-verification-sessions")) {
+    return true;
+  }
+
+  // Catch shell-built variants where `channel-verification` and `sessions`
+  // are assembled through variable expansion and are not contiguous.
+  const hasChannelVerification =
+    lower.includes("channel-verification") ||
+    (lower.includes("channel") && lower.includes("verification"));
+
+  return hasChannelVerification && lower.includes("sessions");
 }
 
 /**


### PR DESCRIPTION
### Motivation

- The shell-tool fallback previously only checked for the contiguous substring `channel-verification-sessions`, which allowed commands that build the path across variables (e.g. `part1=channel-verification; part2=sessions; ...`) to bypass the guardian-only gate.
- Harden detection so untrusted channels cannot invoke guardian/verification control-plane endpoints via crafted shell commands while preserving existing normalized/regex matching.

### Description

- Update `containsVerificationFragments` in `assistant/src/tools/verification-control-plane-policy.ts` to first match the contiguous endpoint and then detect shell-built variants by checking for `channel-verification` (or `channel` + `verification`) together with `sessions` so split-fragment constructions are caught.
- Preserve existing behavior of `containsVerificationEndpointPath` which performs normalization and regex matching for structured URLs and contiguous paths.
- Add a focused regression test in `assistant/src/__tests__/verification-control-plane-policy.test.ts` that asserts a split-variable construction (`part1=channel-verification; part2=sessions; ...`) is detected by `isVerificationControlPlaneInvocation`.

### Testing

- A targeted test was added: run `cd assistant && bun test src/__tests__/verification-control-plane-policy.test.ts` in CI or a local environment with Bun to validate the regression case.
- Automated tests could not be executed in this environment because Bun is not available, so the new test was not run here and should be validated by CI.
- The change is minimal and preserves existing normalized/path-regex matching, so existing verification-control-plane tests should continue to pass when run in the project CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae03df2cc88323bb1e542d378592fc)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
