### PR TITLE
feat(contacts): improve empty state with prominent Add Contact button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -202,12 +202,14 @@ struct ContactsListView: View {
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.contentDefault)
                 Spacer()
-                Button { viewModel.isCreatingContact = true } label: {
-                    VIconView(.plus, size: 14)
-                        .foregroundColor(VColor.primaryBase)
+                if viewModel.hasNonGuardianContacts {
+                    Button { viewModel.isCreatingContact = true } label: {
+                        VIconView(.plus, size: 14)
+                            .foregroundColor(VColor.primaryBase)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Add contact")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Add contact")
             }
 
             if viewModel.hasNonGuardianContacts {
@@ -215,12 +217,19 @@ struct ContactsListView: View {
             }
 
             if !viewModel.hasNonGuardianContacts {
-                Text("No contacts yet. Tap + to add one.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-                    .padding(VSpacing.lg)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .vCard(background: VColor.surfaceOverlay)
+                VStack(spacing: VSpacing.md) {
+                    VIconView(.users, size: 24)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text("No contacts yet")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                    VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary) {
+                        viewModel.isCreatingContact = true
+                    }
+                }
+                .padding(.vertical, VSpacing.lg)
+                .frame(maxWidth: .infinity)
+                .vCard(background: VColor.surfaceOverlay)
             } else if !viewModel.otherContacts.isEmpty {
                 VStack(spacing: 0) {
                     ForEach(Array(viewModel.otherContacts.enumerated()), id: \.element.id) { index, contact in


### PR DESCRIPTION
## Summary
- Hide the small '+' header button in the Contacts section when no non-guardian contacts exist
- Replace plain text empty state with a prominent card containing users icon, 'No contacts yet' text, and a primary 'Add Contact' button
- The Add Contact button opens the same ContactCreateView sheet as the previous '+' button

Part of plan: contacts-empty-state.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
