### PR TITLE
feat: add header and subtitle to assistant channels detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -32,6 +32,15 @@ struct AssistantChannelsDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Assistant Channels")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Once set up, you and others you trust can talk to your assistant in these channels.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+
                 telegramCard
                 slackChannelCard
                 voiceCard


### PR DESCRIPTION
## Summary
- Add "Assistant Channels" header and subtitle text above the Telegram/Slack/Phone channel cards when the assistant contact is selected
- Subtitle reads: "Once set up, you and others you trust can talk to your assistant in these channels."

## Original prompt
Lets add a header and subheader text above the three channel cards when the Assistant contact card is selected. It should say: Assistant Channels / Once set up, you and others you trust can talk to your assistant in these channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
