### PR TITLE
fix: treat revoked contact channels as uninvited in UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -619,14 +619,6 @@ struct ContactDetailView: View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
                 switch channel.status {
-                case "revoked":
-                    VButton(
-                        label: "Restore Access",
-                        style: .outlined,
-                        isDisabled: anyActionInFlight
-                    ) {
-                        updateChannelStatus(channelId: channel.id, status: "active")
-                    }
                 case "blocked":
                     VButton(
                         label: "Restore Access",

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -293,7 +293,7 @@ struct ContactDetailView: View {
                 .foregroundColor(VColor.contentDefault)
 
             let channelsByType = Dictionary(
-                grouping: displayContact.channels,
+                grouping: displayContact.channels.filter { $0.status != "revoked" },
                 by: { $0.type }
             )
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -168,8 +168,9 @@ struct ContactsListView: View {
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
                         }
 
-                        if !contact.channels.isEmpty {
-                            Text(channelSummary(contact.channels))
+                        let summary = channelSummary(contact.channels)
+                        if !summary.isEmpty {
+                            Text(summary)
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.contentSecondary)
                                 .lineLimit(1)
@@ -279,7 +280,7 @@ struct ContactsListView: View {
 
     private func channelIconsRow(_ channels: [ContactChannelPayload]) -> some View {
         HStack(spacing: VSpacing.sm) {
-            let channelTypes = Set(channels.map(\.type))
+            let channelTypes = Set(channels.filter { $0.status != "revoked" }.map(\.type))
             ForEach(Array(channelTypes.sorted()), id: \.self) { type in
                 VIconView(channelIcon(for: type), size: 11)
                     .foregroundColor(VColor.contentTertiary)
@@ -338,7 +339,7 @@ struct ContactsListView: View {
 
     /// Summarizes channel types into a human-readable string (e.g. "Telegram, Voice").
     private func channelSummary(_ channels: [ContactChannelPayload]) -> String {
-        let types = Set(channels.map(\.type))
+        let types = Set(channels.filter { $0.status != "revoked" }.map(\.type))
         return types.sorted().map { channelLabel(for: $0) }.joined(separator: ", ")
     }
 
@@ -365,17 +366,19 @@ struct ContactsListView: View {
     }
 
     /// Aggregates channel statuses into a single status indicator.
-    /// Green = all active/verified, Yellow = some pending, Red = any blocked/revoked.
+    /// Green = all active/verified, Yellow = some pending, Red = any blocked.
+    /// Revoked channels are treated as uninvited and excluded from aggregation.
     private func aggregateChannelStatus(_ channels: [ContactChannelPayload]) -> (color: Color, label: String) {
-        guard !channels.isEmpty else {
+        let active = channels.filter { $0.status != "revoked" }
+        guard !active.isEmpty else {
             return (VColor.contentTertiary, "No channels")
         }
 
-        let hasBlocked = channels.contains { $0.status == "blocked" || $0.status == "revoked" }
-        let hasPending = channels.contains { $0.status == "pending" || $0.status == "unverified" }
+        let hasBlocked = active.contains { $0.status == "blocked" }
+        let hasPending = active.contains { $0.status == "pending" || $0.status == "unverified" }
 
         if hasBlocked {
-            return (VColor.systemNegativeStrong, "Some channels blocked or revoked")
+            return (VColor.systemNegativeStrong, "Some channels blocked")
         } else if hasPending {
             return (VColor.systemNegativeHover, "Some channels pending verification")
         } else {


### PR DESCRIPTION
## Summary
- Filter revoked channels out of the detail view's configured channels list so the invite/verification flow is shown instead of the revoked badge and "Restore Access" button
- Exclude revoked channels from the sidebar status dot indicator, channel icons, and channel summary text — a contact with only revoked channels now shows a gray "No channels" dot instead of a red dot
- Revoked channels are treated as if the contact was never invited, allowing a fresh setup flow

## Original prompt
Treat revoked contact channels as uninvited — filter them from the detail view (showing invite/verification flow instead), sidebar status dot, channel summary, and channel icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
