### PR TITLE
fix(avatar): center eyes on body shapes using eye-center → face-center alignment

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarBodyShapes.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarBodyShapes.swift
@@ -30,6 +30,23 @@ enum AvatarBodyShape: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Point within the viewBox where eyes should be centered — derived from each body's
+    /// native eye style placement. Ninja has no native eye style so uses a manual estimate.
+    var faceCenter: CGPoint {
+        switch self {
+        case .blob:    return CGPoint(x: 300, y: 273)
+        case .cloud:   return CGPoint(x: 350, y: 380)
+        case .sprout:  return CGPoint(x: 264, y: 415)
+        case .star:    return CGPoint(x: 325, y: 390)
+        case .ghost:   return CGPoint(x: 321, y: 167)
+        case .urchin:  return CGPoint(x: 397, y: 338)
+        case .stack:   return CGPoint(x: 304, y: 358)
+        case .flower:  return CGPoint(x: 335, y: 352)
+        case .burst:   return CGPoint(x: 345, y: 305)
+        case .ninja:   return CGPoint(x: 395, y: 387)
+        }
+    }
+
     // swiftlint:disable line_length
     var svgPath: String {
         switch self {

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
@@ -40,23 +40,21 @@ enum AvatarCompositor {
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
 
-        // Draw eyes — remap from eye sourceViewBox to body viewBox before applying canvas transform.
-        // This aspect-fit centers the eye paths within the body's coordinate space so that
-        // eye styles designed for one body shape render correctly on any other body shape.
+        // Draw eyes — remap from eye sourceViewBox to body viewBox using eye-center → face-center
+        // alignment.  Each eye style's paths are designed around a center point within their source
+        // coordinate space; each body shape defines a face-center where eyes should land.
+        // Aspect-fit scaling sizes the eyes appropriately, then translation aligns the centers.
+        // Per-combo overrides allow specific eye+body pairs to use a custom face center.
         let srcVB = eyeStyle.sourceViewBox
-        var eyeTransform: CGAffineTransform
-        if srcVB.width == viewBox.width && srcVB.height == viewBox.height {
-            // Same coordinate space — no remapping needed.
-            eyeTransform = transform
-        } else {
-            let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
-            let remapTx = (viewBox.width - srcVB.width * remapScale) / 2
-            let remapTy = (viewBox.height - srcVB.height * remapScale) / 2
-            // Remap: scale within body viewBox, then translate to center, then apply the canvas transform.
-            let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
-                .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
-            eyeTransform = remapT.concatenating(transform)
-        }
+        let eyeCenter = eyeStyle.eyeCenter
+        let overrideKey = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)"
+        let faceCenter = faceCenterOverrides[overrideKey] ?? bodyShape.faceCenter
+        let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
+        let remapTx = faceCenter.x - eyeCenter.x * remapScale
+        let remapTy = faceCenter.y - eyeCenter.y * remapScale
+        let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
+            .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
+        let eyeTransform = remapT.concatenating(transform)
 
         for eyePath in eyeStyle.paths {
             let parsed = parseSVGPath(eyePath.svgPath)
@@ -72,6 +70,35 @@ enum AvatarCompositor {
         cache[cacheKey] = image
         return image
     }
+
+    /// Per-combo face-center overrides for when the default body faceCenter doesn't produce
+    /// the best result for a specific eye style.  Key format: "bodyRawValue-eyeRawValue".
+    ///
+    /// Ghost (native faceCenter y=167, 28%) — non-native eyes pulled slightly lower to ~34%
+    /// so they sit better within the ghost's rounded head rather than at the very top.
+    ///
+    /// Sprout (native faceCenter y=415, 66%) — non-native eyes pulled slightly higher to ~61%
+    /// so they sit better within the sprout's leaf area rather than at the very bottom.
+    private static let faceCenterOverrides: [String: CGPoint] = [
+        // Ghost body — shift non-native eyes from y=167 → y=200
+        "ghost-grumpy":  CGPoint(x: 321, y: 200),
+        "ghost-angry":   CGPoint(x: 321, y: 200),
+        "ghost-curious":  CGPoint(x: 321, y: 200),
+        "ghost-goofy":   CGPoint(x: 321, y: 200),
+        "ghost-bashful":  CGPoint(x: 321, y: 200),
+        "ghost-gentle":  CGPoint(x: 321, y: 200),
+        "ghost-quirky":  CGPoint(x: 321, y: 200),
+        "ghost-dazed":   CGPoint(x: 321, y: 200),
+        // Sprout body — shift non-native eyes from y=415 → y=385
+        "sprout-grumpy":   CGPoint(x: 264, y: 385),
+        "sprout-angry":    CGPoint(x: 264, y: 385),
+        "sprout-goofy":    CGPoint(x: 264, y: 385),
+        "sprout-surprised": CGPoint(x: 264, y: 385),
+        "sprout-bashful":  CGPoint(x: 264, y: 385),
+        "sprout-gentle":   CGPoint(x: 264, y: 385),
+        "sprout-quirky":   CGPoint(x: 264, y: 385),
+        "sprout-dazed":    CGPoint(x: 264, y: 385),
+    ]
 
     private static var cache: [String: NSImage] = [:]
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarEyeStyles.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarEyeStyles.swift
@@ -33,6 +33,22 @@ enum AvatarEyeStyle: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Approximate center of the combined eye paths' bounding box within sourceViewBox coordinates.
+    /// Used by AvatarCompositor to align eyes to each body shape's face center.
+    var eyeCenter: CGPoint {
+        switch self {
+        case .grumpy:   return CGPoint(x: 300, y: 273)
+        case .angry:    return CGPoint(x: 350, y: 380)
+        case .curious:  return CGPoint(x: 264, y: 415)
+        case .goofy:    return CGPoint(x: 325, y: 390)
+        case .surprised: return CGPoint(x: 321, y: 167)
+        case .bashful:  return CGPoint(x: 397, y: 338)
+        case .gentle:   return CGPoint(x: 304, y: 358)
+        case .quirky:   return CGPoint(x: 335, y: 352)
+        case .dazed:    return CGPoint(x: 345, y: 305)
+        }
+    }
+
     private static let scleraColor = NSColor(srgbRed: 0xF2 / 255.0, green: 0xF2 / 255.0, blue: 0xF2 / 255.0, alpha: 1)
     private static let pupilColor = NSColor(srgbRed: 0x1A / 255.0, green: 0x1A / 255.0, blue: 0x1A / 255.0, alpha: 1)
 


### PR DESCRIPTION
## Summary
- Adds `eyeCenter` property to `AvatarEyeStyle` — the bounding box midpoint of all eye paths in sourceViewBox coordinates
- Adds `faceCenter` property to `AvatarBodyShape` — where eyes should land, derived from each body's native eye style
- Updates `AvatarCompositor` to align eye centers to face centers instead of centering viewBoxes, fixing offset eyes (especially `surprised` at 28% and `curious` at 66%) on non-native body shapes
- Adds per-combo `faceCenterOverrides` for ghost and sprout bodies that pull non-native eyes toward more moderate vertical positions

## Test plan
- [ ] Open avatar presets — all 10 native pairings should look identical to before
- [ ] Use "Generate Random" repeatedly — surprised and curious eyes should now appear centered on all body shapes instead of floating high/low
- [ ] Check ghost body with various eye styles — eyes should sit slightly lower than the native surprised position
- [ ] Check sprout body with various eye styles — eyes should sit slightly higher than the native curious position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
