### PR TITLE
fix(contacts): update stale comment and add accessibility hidden to decorative icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -62,7 +62,7 @@ struct ContactsListView: View {
                 guardianSection(guardian)
             }
 
-            // Other contacts section (always show header + "+" button)
+            // Other contacts section
             otherContactsSection
 
             // Filtered-empty state (contacts exist but search yields nothing)
@@ -220,6 +220,7 @@ struct ContactsListView: View {
                 VStack(spacing: VSpacing.md) {
                     VIconView(.users, size: 24)
                         .foregroundColor(VColor.contentTertiary)
+                        .accessibilityHidden(true)
                     Text("No contacts yet")
                         .font(VFont.body)
                         .foregroundColor(VColor.contentSecondary)


### PR DESCRIPTION
## Summary
- Update stale comment on line 65 that incorrectly stated the '+' button is always shown
- Add .accessibilityHidden(true) to decorative users icon in the contacts empty state per project accessibility guidelines

Review fix for plan: contacts-empty-state.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
