### PR TITLE
Use VAvatarImage for avatar previews in AvatarManagementSheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -67,11 +67,7 @@ struct AvatarManagementSheet: View {
     private var actionList: some View {
         Group {
             // Avatar preview
-            Image(nsImage: appearance.fullAvatarImage)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 120, height: 120)
-                .clipShape(Circle())
+            VAvatarImage(image: appearance.fullAvatarImage, size: 120, showBorder: false)
                 .padding(.bottom, VSpacing.xl)
 
             Divider().background(VColor.borderBase)
@@ -125,11 +121,7 @@ struct AvatarManagementSheet: View {
     private var characterBuilder: some View {
         VStack(spacing: 0) {
             // Draft avatar preview
-            Image(nsImage: draftImage ?? appearance.fullAvatarImage)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 120, height: 120)
-                .clipShape(Circle())
+            VAvatarImage(image: draftImage ?? appearance.fullAvatarImage, size: 120, showBorder: false)
                 .padding(.bottom, VSpacing.lg)
 
             // Generate Random button


### PR DESCRIPTION
## Summary
- Replace hardcoded `.clipShape(Circle())` with `VAvatarImage` for both avatar previews in the management sheet
- Compositor-generated characters now display their full silhouette instead of being circle-clipped
- Uploaded photos and initial-letter fallbacks continue to be circle-clipped via VAvatarImage's transparency detection

Part of plan: avatar-clip-centralize.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
