### PR TITLE
Use VAvatarImage for avatar previews in AvatarCustomizationPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -36,11 +36,7 @@ struct AvatarCustomizationPanel: View {
                     // Avatar preview
                     HStack {
                         Spacer()
-                        Image(nsImage: appearance.fullAvatarImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 120, height: 120)
-                            .clipShape(Circle())
+                        VAvatarImage(image: appearance.fullAvatarImage, size: 120, showBorder: false)
                         Spacer()
                     }
 
@@ -68,11 +64,7 @@ struct AvatarCustomizationPanel: View {
 
             if let customImage = appearance.customAvatarImage {
                 HStack(spacing: VSpacing.md) {
-                    Image(nsImage: customImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 48, height: 48)
-                        .clipShape(Circle())
+                    VAvatarImage(image: customImage, size: 48, showBorder: false)
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         Button("Change") { pickImage() }


### PR DESCRIPTION
## Summary
- Replace hardcoded `.clipShape(Circle())` with `VAvatarImage` for both avatar previews in the customization panel
- Compositor-generated characters now display their full silhouette instead of being circle-clipped
- Uploaded photos continue to be circle-clipped via VAvatarImage's transparency detection

Part of plan: avatar-clip-centralize.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
