### PR TITLE
Use VAvatarImage for avatar display in onboarding views

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
@@ -46,11 +46,7 @@ struct ComingAliveOverlay: View {
                 .allowsHitTesting(false)
 
             // Avatar image
-            Image(nsImage: appearance.fullAvatarImage)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 200, height: 200)
-                .clipShape(Circle())
+            VAvatarImage(image: appearance.fullAvatarImage, size: 200, showBorder: false)
                 .shadow(color: Meadow.avatarGradientStart.opacity(0.3), radius: 12)
                 .scaleEffect(avatarScale)
                 .opacity(avatarOpacity)

--- a/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
@@ -128,11 +128,7 @@ struct AvatarRevealStepView: View {
     private var revealedAvatar: some View {
         Group {
             if let image = avatarImage {
-                Image(nsImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 160, height: 160)
-                    .clipShape(Circle())
+                VAvatarImage(image: image, size: 160, showBorder: false)
                     .shadow(color: VColor.primaryBase.opacity(0.3), radius: 12, y: 4)
                     .scaleEffect(showAvatar ? 1.0 : 0.8)
                     .opacity(showAvatar ? 1 : 0)

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -50,11 +50,7 @@ struct CreatureView: View {
     }
 
     private var avatarImage: some View {
-        Image(nsImage: appearance.fullAvatarImage)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: 200, height: 200)
-            .clipShape(Circle())
+        VAvatarImage(image: appearance.fullAvatarImage, size: 200, showBorder: false)
             .shadow(radius: 8)
     }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `.clipShape(Circle())` with `VAvatarImage` in AvatarRevealStepView, CreatureView, and ComingAliveOverlay
- Compositor-generated characters now display their full silhouette instead of being circle-clipped
- Shadow effects, scale animations, and breathing animations are preserved

Part of plan: avatar-clip-centralize.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
