### PR TITLE
feat(avatar): generate fully random avatar at hatch instead of picking from presets

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -12,7 +12,9 @@ struct HatchingStepView: View {
     @State private var showCharacter = true
     @State private var hatchStarted = false
     @State private var failureReason: String?
-    @State private var selectedPreset = PresetAvatar.random()
+    @State private var hatchBody = AvatarBodyShape.allCases.randomElement()!
+    @State private var hatchEyes = AvatarEyeStyle.allCases.randomElement()!
+    @State private var hatchColor = AvatarColor.allCases.randomElement()! // color-literal-ok
     @State private var completionTask: Task<Void, Never>?
 
     var body: some View {
@@ -61,11 +63,17 @@ struct HatchingStepView: View {
         }
     }
 
+    // MARK: - Avatar
+
+    private var hatchAvatarImage: NSImage? {
+        AvatarCompositor.render(bodyShape: hatchBody, eyeStyle: hatchEyes, color: hatchColor)
+    }
+
     // MARK: - Character Animation
 
     private var characterAnimation: some View {
         ZStack {
-            if let image = selectedPreset.image {
+            if let image = hatchAvatarImage {
                 Image(nsImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -154,15 +162,15 @@ struct HatchingStepView: View {
         state.resetForRetry()
     }
 
-    /// Called when the CLI process finishes successfully. Saves the preset avatar
+    /// Called when the CLI process finishes successfully. Saves the random avatar
     /// (for non-pairing flows) then signals completion after a brief delay.
     private func handleHatchSuccess() {
-        // Save the randomly-assigned preset as the user's avatar, but only for
+        // Save the randomly-generated avatar as the user's avatar, but only for
         // non-pairing flows and only if one hasn't already been uploaded/generated
         // (preserves existing avatars when replaying onboarding during development).
         if !isCustomHardware,
            AvatarAppearanceManager.shared.customAvatarImage == nil,
-           let image = selectedPreset.image {
+           let image = hatchAvatarImage {
             AvatarAppearanceManager.shared.setCustomAvatar(image)
         }
 


### PR DESCRIPTION
## Summary
- Replace `PresetAvatar.random()` in HatchingStepView with independent random selection of body shape, eye style, and color
- This expands the hatch avatar space from 10 presets to 540 possible combinations (10 bodies × 9 eyes × 6 colors)

Part of plan: avatar-builder-cycle-buttons.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
