### PR TITLE
refactor(contacts): simplify assistant and guardian list cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Displays the list of contacts, with an assistant section at the top,
-/// a guardian ("Me") section, search, channel icons, and status indicators.
+/// a guardian section, search, channel icons, and status indicators.
 @MainActor
 struct ContactsListView: View {
     @ObservedObject var viewModel: ContactsViewModel
@@ -57,7 +57,7 @@ struct ContactsListView: View {
             // Assistant section (always visible, unaffected by search)
             assistantSection
 
-            // Guardian ("Me") section
+            // Guardian section
             if let guardian = viewModel.guardianContact {
                 guardianSection(guardian)
             }
@@ -93,27 +93,10 @@ struct ContactsListView: View {
                 selection = .assistant
             } label: {
                 HStack(spacing: VSpacing.md) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(cachedAssistantDisplayName)
-                                .font(VFont.bodyBold)
-                                .foregroundColor(VColor.contentDefault)
-                                .lineLimit(1)
-
-                            Text("Assistant")
-                                .font(VFont.small)
-                                .foregroundColor(VColor.auxWhite)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, VSpacing.xxs)
-                                .background(VColor.primaryBase)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
-                        }
-
-                        Text(assistantChannelSummary)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentSecondary)
-                            .lineLimit(1)
-                    }
+                    Text(cachedAssistantDisplayName)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(1)
 
                     Spacer()
                 }
@@ -130,21 +113,11 @@ struct ContactsListView: View {
         }
     }
 
-    /// Summarizes which assistant channels are configured.
-    private var assistantChannelSummary: String {
-        var channels: [String] = []
-        if store?.telegramHasBotToken == true { channels.append("Telegram") }
-        if store?.slackChannelHasBotToken == true && store?.slackChannelHasAppToken == true { channels.append("Slack") }
-        if store?.twilioHasCredentials == true { channels.append("Phone") }
-        if store?.assistantEmail != nil { channels.append("Email") }
-        return channels.isEmpty ? "No channels configured" : channels.joined(separator: ", ")
-    }
-
     // MARK: - Guardian Section
 
     private func guardianSection(_ contact: ContactPayload) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Me")
+            Text("Guardian (You)")
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.contentDefault)
 
@@ -152,34 +125,12 @@ struct ContactsListView: View {
                 selection = .contact(contact.id)
             } label: {
                 HStack(spacing: VSpacing.md) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(contact.displayName)
-                                .font(VFont.bodyBold)
-                                .foregroundColor(VColor.contentDefault)
-                                .lineLimit(1)
-
-                            Text("Guardian")
-                                .font(VFont.small)
-                                .foregroundColor(VColor.auxWhite)
-                                .padding(.horizontal, VSpacing.sm)
-                                .padding(.vertical, VSpacing.xxs)
-                                .background(VColor.primaryBase)
-                                .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
-                        }
-
-                        let summary = channelSummary(contact.channels)
-                        if !summary.isEmpty {
-                            Text(summary)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.contentSecondary)
-                                .lineLimit(1)
-                        }
-                    }
+                    Text(contact.displayName)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(1)
 
                     Spacer()
-
-                    statusIndicator(for: contact)
                 }
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -346,12 +297,6 @@ struct ContactsListView: View {
     }
 
     // MARK: - Helpers
-
-    /// Summarizes channel types into a human-readable string (e.g. "Telegram, Voice").
-    private func channelSummary(_ channels: [ContactChannelPayload]) -> String {
-        let types = Set(channels.filter { $0.status != "revoked" }.map(\.type))
-        return types.sorted().map { channelLabel(for: $0) }.joined(separator: ", ")
-    }
 
     /// Maps channel type to a VIcon.
     private func channelIcon(for type: String) -> VIcon {


### PR DESCRIPTION
## Summary
- Rename 'Me' section label to 'Guardian (You)'
- Remove 'Assistant' and 'Guardian' badge chips from contact cards
- Remove channel summary text and status indicator from assistant and guardian cards
- Remove dead code: `assistantChannelSummary` computed property and `channelSummary` function

Part of plan: guardian-channel-cards.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
