### PR TITLE
feat(avatar): add left/right cycle buttons for body, eyes, and color in character builder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -140,6 +140,11 @@ struct AvatarManagementSheet: View {
             }
             .padding(.bottom, VSpacing.lg)
 
+            // Cycle controls for body, eyes, and color
+            cycleControls
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.bottom, VSpacing.lg)
+
             // Preset grid
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), spacing: VSpacing.sm), count: 5),
@@ -195,6 +200,119 @@ struct AvatarManagementSheet: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.lg)
+        }
+    }
+
+    // MARK: - Cycle Helpers
+
+    private func cycleForward<T: CaseIterable & Equatable>(_ current: T?) -> T where T.AllCases.Index == Int {
+        let all = Array(T.allCases)
+        guard let current, let idx = all.firstIndex(of: current) else { return all[0] }
+        return all[(idx + 1) % all.count]
+    }
+
+    private func cycleBackward<T: CaseIterable & Equatable>(_ current: T?) -> T where T.AllCases.Index == Int {
+        let all = Array(T.allCases)
+        guard let current, let idx = all.firstIndex(of: current) else { return all[0] }
+        return all[(idx - 1 + all.count) % all.count]
+    }
+
+    private func ensureDraftsInitialized() {
+        if draftBody == nil && draftEyes == nil && draftColor == nil {
+            draftBody = AvatarBodyShape.allCases.first
+            draftEyes = AvatarEyeStyle.allCases.first
+            draftColor = AvatarColor.allCases.first
+        }
+    }
+
+    // MARK: - Cycle Controls
+
+    @ViewBuilder
+    private var cycleControls: some View {
+        VStack(spacing: VSpacing.sm) {
+            cycleRow(
+                label: "Body",
+                value: draftBody?.rawValue.capitalized ?? "\u{2014}",
+                onLeft: {
+                    ensureDraftsInitialized()
+                    draftBody = cycleBackward(draftBody)
+                    selectedPresetID = nil
+                    renderDraft()
+                },
+                onRight: {
+                    ensureDraftsInitialized()
+                    draftBody = cycleForward(draftBody)
+                    selectedPresetID = nil
+                    renderDraft()
+                }
+            )
+            cycleRow(
+                label: "Eyes",
+                value: draftEyes?.rawValue.capitalized ?? "\u{2014}",
+                onLeft: {
+                    ensureDraftsInitialized()
+                    draftEyes = cycleBackward(draftEyes)
+                    selectedPresetID = nil
+                    renderDraft()
+                },
+                onRight: {
+                    ensureDraftsInitialized()
+                    draftEyes = cycleForward(draftEyes)
+                    selectedPresetID = nil
+                    renderDraft()
+                }
+            )
+            cycleRow(
+                label: "Color",
+                value: draftColor?.rawValue.capitalized ?? "\u{2014}",
+                onLeft: {
+                    ensureDraftsInitialized()
+                    draftColor = cycleBackward(draftColor)
+                    selectedPresetID = nil
+                    renderDraft()
+                },
+                onRight: {
+                    ensureDraftsInitialized()
+                    draftColor = cycleForward(draftColor)
+                    selectedPresetID = nil
+                    renderDraft()
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func cycleRow(
+        label: String,
+        value: String,
+        onLeft: @escaping () -> Void,
+        onRight: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 0) {
+            Button(action: onLeft) {
+                VIconView(.chevronLeft, size: 10)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel("Previous \(label.lowercased())")
+
+            Text("\(label): \(value)")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.contentSecondary)
+                .frame(width: 120)
+
+            Button(action: onRight) {
+                VIconView(.chevronRight, size: 10)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel("Next \(label.lowercased())")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add three rows of left/right chevron buttons between "Generate Random" and the preset grid
- Each row cycles through body shape, eye style, or color independently with live preview updates
- Users can now build custom avatars by mixing and matching any body + eyes + color combination

Part of plan: avatar-builder-cycle-buttons.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
