### PR TITLE
fix: use VAvatarImage in FirstMeetingIntroductionView for pattern consistency

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/FirstMeeting/FirstMeetingIntroductionView.swift
@@ -39,13 +39,14 @@ struct FirstMeetingIntroductionView: View {
             // Main content: evolving avatar left, chat panel right
             HStack(alignment: .center, spacing: VSpacing.xxxl) {
                 // Avatar placeholder
-                Image(nsImage: AvatarAppearanceManager.buildInitialLetterAvatar(
-                    name: state.assistantName,
-                    size: 128
-                ))
-                    .resizable()
-                    .frame(width: 128, height: 128)
-                    .clipShape(Circle())
+                VAvatarImage(
+                    image: AvatarAppearanceManager.buildInitialLetterAvatar(
+                        name: state.assistantName,
+                        size: 128
+                    ),
+                    size: 128,
+                    showBorder: false
+                )
 
                 // Chat messages + input in panel
                 OnboardingPanel {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-clip-centralize.md.

**Gap:** FirstMeetingIntroductionView still uses hardcoded `.clipShape(Circle())` instead of `VAvatarImage`
**What was expected:** All avatar display locations should use `VAvatarImage` for consistency
**What was found:** The file was excluded from the original migration but should have been included for pattern consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
