### PR TITLE
feat(contacts): add card-per-channel guardian detail view with verification flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 import VellumAssistantShared
 
@@ -7,8 +6,6 @@ import VellumAssistantShared
 @MainActor
 struct ContactDetailView: View {
     private static let allChannelTypes = ["telegram", "phone", "slack"]
-
-    private static let verificationSupportedChannels: Set<String> = ["telegram", "phone", "slack"]
 
     /// Channels that support 6-digit code invites from this view.
     private static let codeInviteChannels: Set<String> = ["telegram", "slack", "phone"]
@@ -48,12 +45,6 @@ struct ContactDetailView: View {
     @State private var inviteCopiedType: String?
     @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
     @State private var readinessFetchFailed = false
-    @State private var verificationDestinationTexts: [String: String] = [:]
-    @State private var verificationCountdownNow: Date = Date()
-    @State private var verificationCountdownTimer: Timer?
-    /// Incremented whenever SettingsStore publishes a change, forcing SwiftUI to
-    /// re-evaluate channel verification state derived from the store.
-    @State private var verificationStoreRevision: Int = 0
     /// Monotonically increasing counter that correlates a verification attempt
     /// with its one-shot response / timeout so stale callbacks are ignored.
     @State private var verificationAttempt: UInt64 = 0
@@ -70,16 +61,9 @@ struct ContactDetailView: View {
     }
 
     var body: some View {
-        // Read verificationStoreRevision so SwiftUI tracks it; the .onReceive
-        // below increments it whenever SettingsStore publishes, forcing
-        // re-evaluation of channel verification state.
-        let _ = verificationStoreRevision
-
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                if displayContact.role != "guardian" {
-                    headerSection
-                }
+                headerSection
                 channelsSection
             }
             .padding(VSpacing.xl)
@@ -99,18 +83,8 @@ struct ContactDetailView: View {
         }
         .onAppear {
             currentContact = contact
-            if contact.role == "guardian" {
-                startVerificationCountdownTimer()
-                // Refresh channel verification state for all supported channels
-                // so the view shows current status even if the user hasn't visited
-                // the Channels settings tab yet.
-                for channel in Self.verificationSupportedChannels {
-                    store?.refreshChannelVerificationStatus(channel: channel)
-                }
-            }
         }
         .onDisappear {
-            stopVerificationCountdownTimer()
             verificationTimeoutTask?.cancel()
             verificationTimeoutTask = nil
             verificationSuccessAnimationTask?.cancel()
@@ -123,9 +97,6 @@ struct ContactDetailView: View {
                 verificationInProgress = nil
             }
         }
-        .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            verificationStoreRevision += 1
-        }
     }
 
     // MARK: - Header Section
@@ -133,7 +104,7 @@ struct ContactDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack {
-                if isEditing && displayContact.role != "guardian" {
+                if isEditing {
                     TextField("Display name", text: $editedName)
                         .font(VFont.largeTitle)
                         .foregroundColor(VColor.contentDefault)
@@ -176,23 +147,21 @@ struct ContactDetailView: View {
                     .animation(VAnimation.fast, value: isHoveringHeader)
                     .accessibilityLabel("Edit contact")
 
-                    if displayContact.role != "guardian" {
-                        Button(action: { showDeleteConfirmation = true }) {
-                            if isDeleting {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                VIconView(.trash, size: 14)
-                                    .foregroundColor(VColor.systemNegativeStrong)
-                            }
+                    Button(action: { showDeleteConfirmation = true }) {
+                        if isDeleting {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            VIconView(.trash, size: 14)
+                                .foregroundColor(VColor.systemNegativeStrong)
                         }
-                        .buttonStyle(.plain)
-                        .disabled(isDeleting || actionInProgress != nil || verificationInProgress != nil)
-                        .help("Delete contact")
-                        .opacity(isHoveringHeader ? 1 : 0)
-                        .animation(VAnimation.fast, value: isHoveringHeader)
-                        .accessibilityLabel("Delete contact")
                     }
+                    .buttonStyle(.plain)
+                    .disabled(isDeleting || actionInProgress != nil || verificationInProgress != nil)
+                    .help("Delete contact")
+                    .opacity(isHoveringHeader ? 1 : 0)
+                    .animation(VAnimation.fast, value: isHoveringHeader)
+                    .accessibilityLabel("Delete contact")
                 }
             }
 
@@ -399,12 +368,7 @@ struct ContactDetailView: View {
                 Spacer()
             }
 
-            // Guardian contacts get the full channel verification flow; others get standard actions
-            if displayContact.role == "guardian" {
-                channelVerificationActions(for: channel)
-            } else {
-                channelActions(for: channel)
-            }
+            channelActions(for: channel)
         }
     }
 
@@ -430,30 +394,7 @@ struct ContactDetailView: View {
                 Spacer()
             }
 
-            // Guardian contacts get the full channel verification flow; others get invite button
-            if displayContact.role == "guardian" {
-                if Self.verificationSupportedChannels.contains(type), let store {
-                    let state = store.channelVerificationState(for: type)
-                    let destinationBinding = Binding<String>(
-                        get: { verificationDestinationTexts[type] ?? "" },
-                        set: { verificationDestinationTexts[type] = $0 }
-                    )
-                    ChannelVerificationFlowView(
-                        state: state,
-                        countdownNow: $verificationCountdownNow,
-                        destinationText: destinationBinding,
-                        onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
-                        onResend: { store.resendOutboundVerification(channel: type) },
-                        onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
-                        onRevoke: { store.revokeChannelVerification(channel: type) },
-                        onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
-                        onCancelSession: { store.cancelVerificationSession(channel: type) },
-                        botUsername: store.telegramBotUsername,
-                        phoneNumber: store.twilioPhoneNumber,
-                        showLabel: false
-                    )
-                }
-            } else if Self.codeInviteChannels.contains(type) {
+            if Self.codeInviteChannels.contains(type) {
                 if inviteInProgress == type {
                     ProgressView()
                         .controlSize(.small)
@@ -707,52 +648,6 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Channel Verification Actions
-
-    @ViewBuilder
-    private func channelVerificationActions(for channel: ContactChannelPayload) -> some View {
-        if Self.verificationSupportedChannels.contains(channel.type), let store {
-            let state = store.channelVerificationState(for: channel.type)
-            let destinationBinding = Binding<String>(
-                get: { verificationDestinationTexts[channel.type] ?? "" },
-                set: { verificationDestinationTexts[channel.type] = $0 }
-            )
-
-            ChannelVerificationFlowView(
-                state: state,
-                countdownNow: $verificationCountdownNow,
-                destinationText: destinationBinding,
-                onStartOutbound: { dest in store.startOutboundVerification(channel: channel.type, destination: dest) },
-                onResend: { store.resendOutboundVerification(channel: channel.type) },
-                onCancelOutbound: { store.cancelOutboundVerification(channel: channel.type) },
-                onRevoke: { store.revokeChannelVerification(channel: channel.type) },
-                onStartSession: { rebind in store.startChannelVerification(channel: channel.type, rebind: rebind) },
-                onCancelSession: { store.cancelVerificationSession(channel: channel.type) },
-                botUsername: store.telegramBotUsername,
-                phoneNumber: store.twilioPhoneNumber,
-                showLabel: false
-            )
-        }
-        // Email and other unsupported channel types: show nothing (display-only)
-    }
-
-    // MARK: - Verification Countdown Timer
-
-    private func startVerificationCountdownTimer() {
-        guard verificationCountdownTimer == nil else { return }
-        verificationCountdownNow = Date()
-        verificationCountdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            Task { @MainActor in
-                verificationCountdownNow = Date()
-            }
-        }
-    }
-
-    private func stopVerificationCountdownTimer() {
-        verificationCountdownTimer?.invalidate()
-        verificationCountdownTimer = nil
-    }
-
     // MARK: - Status Badge
 
     @ViewBuilder
@@ -843,8 +738,7 @@ struct ContactDetailView: View {
     // MARK: - Actions
 
     private func saveCardEdits() async {
-        let isGuardian = displayContact.role == "guardian"
-        let trimmedName = isGuardian ? displayContact.displayName : editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedName = editedName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
         let trimmedNotes = editedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -75,18 +75,28 @@ struct ContactsContainerView: View {
                     }
                 case .contact(let contactId):
                     if let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
-                        ContactDetailView(
-                            contact: contact,
-                            daemonClient: daemonClient,
-                            store: store,
-                            onDelete: {
-                                selection = .assistant
-                                viewModel.loadContacts()
-                            },
-                            guardianName: viewModel.guardianContact?.displayName
-                        )
-                        .id(contactId)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        if contact.role == "guardian" {
+                            GuardianChannelsDetailView(
+                                contact: contact,
+                                daemonClient: daemonClient,
+                                store: store
+                            )
+                            .id(contactId)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        } else {
+                            ContactDetailView(
+                                contact: contact,
+                                daemonClient: daemonClient,
+                                store: store,
+                                onDelete: {
+                                    selection = .assistant
+                                    viewModel.loadContacts()
+                                },
+                                guardianName: viewModel.guardianContact?.displayName
+                            )
+                            .id(contactId)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        }
                     }
                 case nil:
                     // True empty state — contacts loaded but none selected

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -1,0 +1,252 @@
+import Combine
+import SwiftUI
+import VellumAssistantShared
+
+/// Right-pane detail view that shows the guardian's channel verification cards
+/// (Telegram, Phone, Slack) when the guardian row is selected in the Contacts list.
+/// Mirrors the card-per-channel layout of AssistantChannelsDetailView.
+@MainActor
+struct GuardianChannelsDetailView: View {
+    private static let allChannelTypes = ["telegram", "phone", "slack"]
+    private static let verificationSupportedChannels: Set<String> = ["telegram", "phone", "slack"]
+
+    let contact: ContactPayload
+    var daemonClient: DaemonClient?
+    var store: SettingsStore?
+
+    @State var currentContact: ContactPayload?
+    @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
+    @State private var verificationDestinationTexts: [String: String] = [:]
+    @State private var verificationCountdownNow: Date = Date()
+    @State private var verificationCountdownTimer: Timer?
+    @State private var verificationStoreRevision: Int = 0
+    @State private var errorMessage: String?
+
+    var displayContact: ContactPayload {
+        currentContact ?? contact
+    }
+
+    var body: some View {
+        let _ = verificationStoreRevision
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Header
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Your Channels")
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.contentDefault)
+                    Text("Once verified, your assistant will recognize you when you message from these channels.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+
+                // One card per channel type
+                ForEach(Self.allChannelTypes, id: \.self) { type in
+                    channelCard(for: type)
+                }
+            }
+            .padding(VSpacing.lg)
+        }
+        .onAppear {
+            currentContact = contact
+            startVerificationCountdownTimer()
+            for channel in Self.verificationSupportedChannels {
+                store?.refreshChannelVerificationStatus(channel: channel)
+            }
+            Task {
+                channelReadiness = (try? await daemonClient?.fetchChannelReadiness()) ?? [:]
+            }
+        }
+        .onDisappear {
+            stopVerificationCountdownTimer()
+        }
+        .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
+            verificationStoreRevision += 1
+        }
+    }
+
+    // MARK: - Channel Card
+
+    @ViewBuilder
+    private func channelCard(for type: String) -> some View {
+        SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type)) {
+            let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
+
+            if let channel = existingChannels.first, channel.status == "active", channel.verifiedAt != nil {
+                // Verified channel — show verified badge row with revoke option
+                verifiedChannelContent(channel: channel, type: type)
+            } else if !existingChannels.isEmpty || channelReadiness[type]?.ready == true {
+                // Unverified/pending channel or no channel but assistant has this channel ready
+                verificationFlowContent(for: type)
+            } else {
+                // Channel not configured on the assistant
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.triangleAlert, size: 12)
+                        .foregroundColor(VColor.systemNegativeHover)
+                    Text("Set up this channel on your assistant first")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    // MARK: - Verified Channel Content
+
+    @ViewBuilder
+    private func verifiedChannelContent(channel: ContactChannelPayload, type: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(channelIcon(for: type), size: 14)
+                    .foregroundColor(VColor.contentSecondary)
+                    .frame(width: 20, alignment: .center)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(channel.address)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .lineLimit(1)
+
+                        Text("Verified")
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xxs)
+                            .background(VColor.systemPositiveWeak)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+                    }
+
+                    if let verifiedAt = channel.verifiedAt, verifiedAt > 0 {
+                        let dateStr = formatDate(epochMs: verifiedAt)
+                        let via = channel.verifiedVia ?? "unknown"
+                        Text("Verified via \(via) on \(dateStr)")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+                }
+
+                Spacer()
+            }
+
+            // Revoke via ChannelVerificationFlowView
+            if let store {
+                let state = store.channelVerificationState(for: type)
+                let destinationBinding = Binding<String>(
+                    get: { verificationDestinationTexts[type] ?? "" },
+                    set: { verificationDestinationTexts[type] = $0 }
+                )
+                ChannelVerificationFlowView(
+                    state: state,
+                    countdownNow: $verificationCountdownNow,
+                    destinationText: destinationBinding,
+                    onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
+                    onResend: { store.resendOutboundVerification(channel: type) },
+                    onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
+                    onRevoke: { store.revokeChannelVerification(channel: type) },
+                    onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
+                    onCancelSession: { store.cancelVerificationSession(channel: type) },
+                    botUsername: store.telegramBotUsername,
+                    phoneNumber: store.twilioPhoneNumber,
+                    showLabel: false
+                )
+            }
+        }
+    }
+
+    // MARK: - Verification Flow Content
+
+    @ViewBuilder
+    private func verificationFlowContent(for type: String) -> some View {
+        if Self.verificationSupportedChannels.contains(type), let store {
+            let state = store.channelVerificationState(for: type)
+            let destinationBinding = Binding<String>(
+                get: { verificationDestinationTexts[type] ?? "" },
+                set: { verificationDestinationTexts[type] = $0 }
+            )
+            ChannelVerificationFlowView(
+                state: state,
+                countdownNow: $verificationCountdownNow,
+                destinationText: destinationBinding,
+                onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
+                onResend: { store.resendOutboundVerification(channel: type) },
+                onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
+                onRevoke: { store.revokeChannelVerification(channel: type) },
+                onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
+                onCancelSession: { store.cancelVerificationSession(channel: type) },
+                botUsername: store.telegramBotUsername,
+                phoneNumber: store.twilioPhoneNumber,
+                showLabel: false
+            )
+        }
+    }
+
+    // MARK: - Verification Countdown Timer
+
+    private func startVerificationCountdownTimer() {
+        guard verificationCountdownTimer == nil else { return }
+        verificationCountdownNow = Date()
+        verificationCountdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            Task { @MainActor in
+                verificationCountdownNow = Date()
+            }
+        }
+    }
+
+    private func stopVerificationCountdownTimer() {
+        verificationCountdownTimer?.invalidate()
+        verificationCountdownTimer = nil
+    }
+
+    // MARK: - Helpers
+
+    private func channelIcon(for type: String) -> VIcon {
+        switch type {
+        case "telegram":
+            return .send
+        case "phone":
+            return .phoneCall
+        case "email":
+            return .mail
+        case "whatsapp", "slack":
+            return .messageCircle
+        default:
+            return .globe
+        }
+    }
+
+    private func channelLabel(for type: String) -> String {
+        switch type {
+        case "telegram": return "Telegram"
+        case "email": return "Email"
+        case "whatsapp": return "WhatsApp"
+        case "phone": return "Phone"
+        case "slack": return "Slack"
+        default: return type.capitalized
+        }
+    }
+
+    private func channelSubtitle(for type: String) -> String {
+        switch type {
+        case "telegram": return "Message your assistant from Telegram"
+        case "phone": return "Call or text your assistant via phone"
+        case "slack": return "Message your assistant from Slack"
+        default: return "Connect via \(type.capitalized)"
+        }
+    }
+
+    private func formatDate(epochMs: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(epochMs) / 1000)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}


### PR DESCRIPTION
## Summary
- Create GuardianChannelsDetailView with 'Your Channels' header and one SettingsCard per channel type
- Embed ChannelVerificationFlowView for Set Up / verified states per channel
- Route guardian selection in ContactsContainerView to new detail view
- Remove dead guardian-specific code from ContactDetailView

Part of plan: guardian-channel-cards.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
