### PR TITLE
feat(calls): differentiate handoff message for invite vs approval vs verification flows

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -4055,7 +4055,7 @@ describe("relay-server", () => {
       .filter((m) => m.type === "text");
     expect(
       textMessages.some((m) =>
-        (m.token ?? "").includes("said I can speak with you"),
+        (m.token ?? "").includes("verified that you are Eve"),
       ),
     ).toBe(true);
 

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -772,6 +772,12 @@ export class RelayConnection {
     fromNumber: string;
     callerName?: string;
     skipMemberActivation?: boolean;
+    activationReason?:
+      | "invite_redeemed"
+      | "access_approved"
+      | "trusted_contact_verified";
+    friendName?: string;
+    guardianName?: string;
   }): void {
     const { assistantId, fromNumber, callerName } = params;
 
@@ -808,7 +814,25 @@ export class RelayConnection {
     updateCallSession(this.callSessionId, { status: "in_progress" });
 
     const guardianLabel = this.resolveGuardianLabel();
-    const handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
+    let handoffText: string;
+
+    if (params.activationReason === "invite_redeemed") {
+      const name = params.friendName;
+      const assistantName = this.resolveAssistantLabel();
+      const gLabel = params.guardianName || guardianLabel;
+      if (name) {
+        handoffText = assistantName
+          ? `Great, I've verified that you are ${name}. It's nice to meet you! I'm ${assistantName}, ${gLabel}'s assistant. How can I help?`
+          : `Great, I've verified that you are ${name}. It's nice to meet you! How can I help?`;
+      } else {
+        handoffText = assistantName
+          ? `Great, I've verified your identity. It's nice to meet you! I'm ${assistantName}, ${gLabel}'s assistant. How can I help?`
+          : `Great, I've verified your identity. It's nice to meet you! How can I help?`;
+      }
+    } else {
+      handoffText = `Great! ${guardianLabel} said I can speak with you. How can I help?`;
+    }
+
     this.sendTextToken(handoffText, true);
 
     recordCallEvent(this.callSessionId, "assistant_spoke", {
@@ -1000,6 +1024,7 @@ export class RelayConnection {
         this.continueCallAfterTrustedContactActivation({
           assistantId,
           fromNumber,
+          activationReason: "trusted_contact_verified",
         });
       } else {
         // Inbound guardian verification: binding already handled above,
@@ -1358,6 +1383,7 @@ export class RelayConnection {
       assistantId,
       fromNumber,
       callerName: callerName ?? undefined,
+      activationReason: "access_approved",
     });
 
     recordCallEvent(
@@ -1541,6 +1567,9 @@ export class RelayConnection {
         fromNumber: this.inviteRedemptionFromNumber,
         callerName: this.inviteRedemptionFriendName ?? undefined,
         skipMemberActivation: true,
+        activationReason: "invite_redeemed",
+        friendName: this.inviteRedemptionFriendName ?? undefined,
+        guardianName: this.inviteRedemptionGuardianName ?? undefined,
       });
     } else {
       this.inviteRedemptionActive = false;


### PR DESCRIPTION
## Summary
- Add `activationReason` discriminator to `continueCallAfterTrustedContactActivation()` to distinguish invite redemption, access approval, and trusted contact verification flows
- Invite redemption now says "Great, I've verified that you are {name}..." instead of the generic "Great! {guardian} said I can speak with you..."
- Access-approved and trusted-contact-verified flows keep existing wording

Part of plan: invite-flow-transition-msgs.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
