### PR TITLE
feat(calls): use assistant introduction in outbound invite prompt

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -4079,6 +4079,51 @@ describe("relay-server", () => {
     relay.destroy();
   });
 
+  test("outbound invite prompt uses assistant introduction", async () => {
+    ensureConversation("conv-outbound-invite-origin");
+    ensureConversation("conv-outbound-invite");
+    const session = createCallSession({
+      conversationId: "conv-outbound-invite",
+      provider: "twilio",
+      fromNumber: "+15551111111",
+      toNumber: "+15558887777",
+      callMode: "invite",
+      inviteFriendName: "Grace",
+      inviteGuardianName: "Hank",
+      initiatedFromConversationId: "conv-outbound-invite-origin",
+    });
+
+    mockAssistantName = "Vellum";
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_outbound_invite",
+        from: "+15551111111",
+        to: "+15558887777",
+      }),
+    );
+
+    // Should be in verification-pending for invite redemption
+    expect(relay.getConnectionState()).toBe("verification_pending");
+
+    // The prompt should use the outbound assistant introduction
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some(
+        (m) =>
+          (m.token ?? "").includes("this is Vellum") &&
+          (m.token ?? "").includes("Hank's assistant"),
+      ),
+    ).toBe(true);
+
+    relay.destroy();
+  });
+
   // ── resolveGuardianLabel resolution priority ─────────────────────────
 
   test("guardian label: USER.md name takes precedence over Contact.displayName", async () => {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -575,6 +575,7 @@ export class RelayConnection {
           outcome.fromNumber,
           outcome.friendName,
           outcome.guardianName,
+          !resolved.isInbound,
         );
         return;
       case "name_capture":
@@ -1096,6 +1097,7 @@ export class RelayConnection {
     fromNumber: string,
     friendName: string | null,
     guardianName: string | null,
+    isOutbound: boolean,
   ): void {
     this.inviteRedemptionActive = true;
     this.inviteRedemptionAssistantId = assistantId;
@@ -1116,10 +1118,17 @@ export class RelayConnection {
 
     const displayFriend = friendName ?? "there";
     const displayGuardian = guardianName ?? "your contact";
-    this.sendTextToken(
-      `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`,
-      true,
-    );
+
+    let promptText: string;
+    if (isOutbound) {
+      const assistantName = this.resolveAssistantLabel();
+      promptText = assistantName
+        ? `Hi ${displayFriend}, this is ${assistantName}, ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`
+        : `Hi ${displayFriend}, this is ${displayGuardian}'s assistant. To get started, please enter the 6-digit code that ${displayGuardian} shared with you.`;
+    } else {
+      promptText = `Welcome ${displayFriend}. Please enter the 6-digit code that ${displayGuardian} provided you to verify your identity.`;
+    }
+    this.sendTextToken(promptText, true);
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },


### PR DESCRIPTION
## Summary
- Add `isOutbound` parameter to `startInviteRedemption()` to differentiate inbound vs outbound invite flows
- Outbound invite calls now introduce the assistant: "Hi {friend}, this is {assistant}, {guardian}'s assistant. To get started, please enter the 6-digit code..."
- Inbound invite calls keep the existing "Welcome {friend}..." prompt

Part of plan: invite-flow-transition-msgs.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
