### PR TITLE
fix(avatar): initialize draft state on builder open and reorder cycle rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -10,6 +10,11 @@ final class AvatarAppearanceManager {
     /// User-uploaded custom avatar image, persisted to disk.
     private(set) var customAvatarImage: NSImage?
 
+    /// The avatar component choices used to build the current character avatar (nil if uploaded image).
+    private(set) var characterBodyShape: AvatarBodyShape?
+    private(set) var characterEyeStyle: AvatarEyeStyle?
+    private(set) var characterColor: AvatarColor?
+
     /// Cached fallback avatar to avoid rebuilding on every access.
     /// @ObservationIgnored so that populating the cache inside a computed getter
     /// doesn't fire an observation notification and trigger another SwiftUI
@@ -111,6 +116,7 @@ final class AvatarAppearanceManager {
             fallback: "V"
         )
         loadCustomAvatar()
+        loadAvatarComponents()
         watchAvatarFile()
 
         // Refresh assistantName and invalidate cached fallback avatars when
@@ -172,7 +178,7 @@ final class AvatarAppearanceManager {
         customAvatarImage = NSImage(contentsOf: url)
     }
 
-    func setCustomAvatar(_ image: NSImage) {
+    func saveAvatar(_ image: NSImage, bodyShape: AvatarBodyShape? = nil, eyeStyle: AvatarEyeStyle? = nil, color: AvatarColor? = nil) {
         let url = customAvatarURL
         let dir = url.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -184,6 +190,12 @@ final class AvatarAppearanceManager {
         try? pngData.write(to: url)
         cachedChatAvatar = nil
         customAvatarImage = image
+
+        // Persist component choices (nil clears them for uploaded images)
+        characterBodyShape = bodyShape
+        characterEyeStyle = eyeStyle
+        characterColor = color
+        saveAvatarComponents()
     }
 
     /// Reloads the custom avatar from disk. Called when the daemon notifies
@@ -199,10 +211,49 @@ final class AvatarAppearanceManager {
     func clearCustomAvatar() {
         try? FileManager.default.removeItem(at: customAvatarURL)
         try? FileManager.default.removeItem(at: Self.legacyAppSupportCustomAvatarURL())
+        try? FileManager.default.removeItem(at: avatarComponentsURL)
         customAvatarImage = nil
+        characterBodyShape = nil
+        characterEyeStyle = nil
+        characterColor = nil
         cachedChatAvatar = nil
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
+    }
+
+    // MARK: - Avatar Components Persistence
+
+    private var avatarComponentsURL: URL {
+        customAvatarURL.deletingLastPathComponent().appendingPathComponent("avatar-components.json")
+    }
+
+    private struct AvatarComponents: Codable {
+        let bodyShape: String
+        let eyeStyle: String
+        let color: String
+    }
+
+    private func saveAvatarComponents() {
+        guard let body = characterBodyShape, let eyes = characterEyeStyle, let color = characterColor else {
+            try? FileManager.default.removeItem(at: avatarComponentsURL)
+            return
+        }
+        let components = AvatarComponents(bodyShape: body.rawValue, eyeStyle: eyes.rawValue, color: color.rawValue)
+        guard let data = try? JSONEncoder().encode(components) else { return }
+        try? data.write(to: avatarComponentsURL)
+    }
+
+    private func loadAvatarComponents() {
+        guard let data = try? Data(contentsOf: avatarComponentsURL),
+              let components = try? JSONDecoder().decode(AvatarComponents.self, from: data) else {
+            characterBodyShape = nil
+            characterEyeStyle = nil
+            characterColor = nil
+            return
+        }
+        characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
+        characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
+        characterColor = AvatarColor(rawValue: components.color)
     }
 
     // MARK: - File Watching

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCustomizationPanel.swift
@@ -109,6 +109,6 @@ struct AvatarCustomizationPanel: View {
 
         guard panel.runModal() == .OK, let url = panel.url,
               let image = NSImage(contentsOf: url) else { return }
-        appearance.setCustomAvatar(image)
+        appearance.saveAvatar(image)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -84,7 +84,10 @@ struct AvatarManagementSheet: View {
                     subtitle: "Build your own character"
                 ) {
                     withAnimation(VAnimation.fast) {
-                        draftImage = nil
+                        draftBody = AvatarBodyShape.allCases.randomElement()!
+                        draftEyes = AvatarEyeStyle.allCases.randomElement()!
+                        draftColor = AvatarColor.allCases.randomElement()! // color-literal-ok
+                        renderDraft()
                         showingCharacterBuilder = true
                     }
                 }
@@ -186,6 +189,23 @@ struct AvatarManagementSheet: View {
     private var cycleControls: some View {
         VStack(spacing: VSpacing.sm) {
             cycleRow(
+                label: "Color",
+                onLeft: {
+                    ensureDraftsInitialized()
+                    draftColor = cycleBackward(draftColor)
+                    renderDraft()
+                },
+                onRight: {
+                    ensureDraftsInitialized()
+                    draftColor = cycleForward(draftColor)
+                    renderDraft()
+                }
+            ) {
+                Circle()
+                    .fill(draftColor.map { Color(nsColor: $0.nsColor) } ?? VColor.contentTertiary)
+                    .frame(width: 20, height: 20)
+            }
+            cycleRow(
                 label: "Body",
                 onLeft: {
                     ensureDraftsInitialized()
@@ -224,23 +244,6 @@ struct AvatarManagementSheet: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 32, height: 32)
                 }
-            }
-            cycleRow(
-                label: "Color",
-                onLeft: {
-                    ensureDraftsInitialized()
-                    draftColor = cycleBackward(draftColor)
-                    renderDraft()
-                },
-                onRight: {
-                    ensureDraftsInitialized()
-                    draftColor = cycleForward(draftColor)
-                    renderDraft()
-                }
-            ) {
-                Circle()
-                    .fill(draftColor.map { Color(nsColor: $0.nsColor) } ?? VColor.contentTertiary)
-                    .frame(width: 20, height: 20)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -84,9 +84,17 @@ struct AvatarManagementSheet: View {
                     subtitle: "Build your own character"
                 ) {
                     withAnimation(VAnimation.fast) {
-                        draftBody = AvatarBodyShape.allCases.randomElement()!
-                        draftEyes = AvatarEyeStyle.allCases.randomElement()!
-                        draftColor = AvatarColor.allCases.randomElement()! // color-literal-ok
+                        if let body = appearance.characterBodyShape,
+                           let eyes = appearance.characterEyeStyle,
+                           let color = appearance.characterColor {
+                            draftBody = body
+                            draftEyes = eyes
+                            draftColor = color
+                        } else {
+                            draftBody = AvatarBodyShape.allCases.randomElement()!
+                            draftEyes = AvatarEyeStyle.allCases.randomElement()!
+                            draftColor = AvatarColor.allCases.randomElement()! // color-literal-ok
+                        }
                         renderDraft()
                         showingCharacterBuilder = true
                     }
@@ -151,7 +159,7 @@ struct AvatarManagementSheet: View {
                 }
                 VButton(label: "Confirm", style: .primary, isDisabled: draftImage == nil) {
                     if let draftImage {
-                        appearance.setCustomAvatar(draftImage)
+                        appearance.saveAvatar(draftImage, bodyShape: draftBody, eyeStyle: draftEyes, color: draftColor)
                     }
                     onClose()
                 }
@@ -350,7 +358,7 @@ struct AvatarManagementSheet: View {
 
         guard panel.runModal() == .OK, let url = panel.url,
               let image = NSImage(contentsOf: url) else { return }
-        appearance.setCustomAvatar(image)
+        appearance.saveAvatar(image)
         onClose()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -171,7 +171,7 @@ struct HatchingStepView: View {
         if !isCustomHardware,
            AvatarAppearanceManager.shared.customAvatarImage == nil,
            let image = hatchAvatarImage {
-            AvatarAppearanceManager.shared.setCustomAvatar(image)
+            AvatarAppearanceManager.shared.saveAvatar(image, bodyShape: hatchBody, eyeStyle: hatchEyes, color: hatchColor)
         }
 
         // Brief delay so the user sees the waking animation before transition.


### PR DESCRIPTION
## Summary
- Initialize draft body/eyes/color with random values when entering the character builder so cycle rows show visual previews immediately instead of being empty
- Reorder cycle rows to Color, Body, Eyes (color first)

## Original prompt
Ship the two changes already made to AvatarManagementSheet.swift: (1) initialize draft state with random values when entering the character builder, and (2) reorder cycle rows to Color, Body, Eyes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
