### PR TITLE
fix(constellation): check character components to distinguish native vs custom avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -755,8 +755,13 @@ struct ConstellationView: View {
     }
 
     /// Whether the user has uploaded a custom avatar image (vs. the bundled native character).
+    /// Native characters set characterBodyShape/eyeStyle/color when saved, so if any
+    /// component is present the avatar is a built character, not a custom upload.
     private var hasCustomAvatar: Bool {
         appearance.customAvatarImage != nil
+            && appearance.characterBodyShape == nil
+            && appearance.characterEyeStyle == nil
+            && appearance.characterColor == nil
     }
 
     /// Computes tree layout synchronously and populates all state vars.


### PR DESCRIPTION
## Summary
- Fix `hasCustomAvatar` in ConstellationView to correctly distinguish native character avatars from custom uploads
- Native characters (built from body shape + eye style + color) were incorrectly treated as custom uploads because both paths set `customAvatarImage`
- Now checks that all character component properties (`characterBodyShape`, `characterEyeStyle`, `characterColor`) are nil before treating an avatar as a custom upload

## Original prompt
implement the fix. Maybe check for character eye and color too

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
