### PR TITLE
fix(settings): dismiss timezone dropdown on click-away and Escape key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -95,7 +95,14 @@ struct SettingsAppearanceTab: View {
                         if focused && timezoneSearchText.isEmpty {
                             // Show all when focused with empty search
                             isTimezoneDropdownOpen = true
+                        } else if !focused {
+                            isTimezoneDropdownOpen = false
                         }
+                    }
+                    .onExitCommand {
+                        isTimezoneDropdownOpen = false
+                        isTimezoneSearchFocused = false
+                        timezoneSearchText = ""
                     }
 
                     if isTimezoneDropdownOpen {


### PR DESCRIPTION
## Summary
- Close the timezone search dropdown when focus leaves the text field (clicking elsewhere)
- Close the dropdown and clear search text when the user presses Escape
- Previously the only way to dismiss the dropdown was to make a selection or clear the search text

## Original prompt
when I click into the timezone search bar (where it says "Search city or country...") there is no way to exit the dropdown other than make a selection. It should go away if I click elsewhere or press esc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
