### PR TITLE
fix: update Things empty state copy to say "your assistant"

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -137,7 +137,7 @@ struct AppsGridView: View {
                     .font(VFont.bodyBold)
                     .foregroundColor(VColor.contentSecondary)
 
-                Text("Ask the assistant to build something")
+                Text("Ask your assistant to build something")
                     .font(VFont.body)
                     .foregroundColor(VColor.contentTertiary)
             }


### PR DESCRIPTION
## Summary
- Change "Ask the assistant to build something" → "Ask your assistant to build something" on the Things page empty state

## Original prompt
On the Things page empty state where it says "Ask the assistant to build something" It should say "Ask your assistant to build something"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
