### PR TITLE
feat(contacts): show "Set Up" button in Guardian channel cards for unverified channels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -20,6 +20,7 @@ struct GuardianChannelsDetailView: View {
     @State private var verificationDestinationTexts: [String: String] = [:]
     @State private var verificationCountdownNow: Date = Date()
     @State private var verificationCountdownTimer: Timer?
+    @State private var setupExpanded: Set<String> = []
     @State private var verificationStoreRevision: Int = 0
 
     var displayContact: ContactPayload {
@@ -100,9 +101,14 @@ struct GuardianChannelsDetailView: View {
             if let channel = existingChannels.first, channel.status == "active", channel.verifiedAt != nil {
                 // Verified channel — delegate to ChannelVerificationFlowView
                 verifiedChannelContent(channel: channel, type: type)
-            } else if !existingChannels.isEmpty || channelReadiness[type]?.ready == true {
-                // Unverified/pending channel or no channel but assistant has this channel ready
+            } else if !existingChannels.isEmpty || setupExpanded.contains(type) {
+                // Existing unverified channel or user clicked "Set Up" — show verification flow
                 verificationFlowContent(for: type)
+            } else {
+                // Channel ready on assistant but not yet started — show "Set Up"
+                VButton(label: "Set Up", style: .outlined) {
+                    setupExpanded.insert(type)
+                }
             }
 
         }


### PR DESCRIPTION
## Summary
- Add setupExpanded state to track which Guardian channel cards have been expanded
- Show a 'Set Up' button instead of the full verification form for unconfigured channels
- Clicking 'Set Up' expands to reveal the verification flow (destination input)
- Channels with existing entries still show the verification flow directly

Part of plan: guardian-contact-card-selection.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
