### PR TITLE
fix(constellation): render center avatar above edges for all avatar types

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -1106,12 +1106,7 @@ struct ConstellationView: View {
                 endRadius: min(size.width, size.height) * 0.5
             )
 
-            // Native character avatar rendered BEHIND edges (no glow)
-            if !hasCustomAvatar {
-                centerAvatarView(showGlow: false)
-            }
-
-            // Edge lines (behind nodes, on top of native avatar)
+            // Edge lines (behind nodes)
             // Uses SwiftUI Path shapes instead of Canvas so edges are never clipped
             // to the view bounds — they extend as far as the nodes go.
             ForEach(treeEdges) { edge in
@@ -1191,10 +1186,8 @@ struct ConstellationView: View {
                 }
             }
 
-            // Custom avatar rendered ON TOP of everything with glow
-            if hasCustomAvatar {
-                centerAvatarView(showGlow: true)
-            }
+            // Center avatar on top of edges/nodes; glow only for custom uploads
+            centerAvatarView(showGlow: hasCustomAvatar)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Always render the center avatar on top of edges and nodes in the constellation mind map
- Native character avatars render without glow; custom uploads retain the glow circle
- Removes the incorrect z-ordering from #16091 that placed native avatars behind edge lines

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
