### PR TITLE
fix(contacts): remove duplicate channel label from unconfigured channel rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -362,25 +362,6 @@ struct ContactDetailView: View {
     @ViewBuilder
     private func unconfiguredChannelRow(type: String) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
-                VIconView(channelIcon(for: type), size: 14)
-                    .foregroundColor(VColor.contentSecondary)
-                    .frame(width: 20, alignment: .center)
-
-                Text(channelLabel(for: type))
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentDefault)
-
-                if let handle = channelReadiness[type]?.channelHandle {
-                    Text(handle)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.contentTertiary)
-                        .lineLimit(1)
-                }
-
-                Spacer()
-            }
-
             if Self.codeInviteChannels.contains(type) {
                 if inviteInProgress == type {
                     ProgressView()


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-contact-card-selection.md.

**Gap:** Duplicate channel label in ContactDetailView unconfigured channel rows
**What was expected:** Each channel's name should appear once — as the SettingsCard title
**What was found:** unconfiguredChannelRow renders icon + channel name inside the card body, duplicating the SettingsCard title

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
