### PR TITLE
feat(constellation): make native character avatar 25% larger in mind map

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -473,11 +473,10 @@ private func resolveOverlap(
 /// Each category's subtree stays within its angular sector to prevent cross-category overlap.
 /// Skills are placed in compact grids extending outward from their parent.
 /// Every node is checked against all previously-placed nodes to prevent overlap.
-private func buildTree(center: CGPoint, groups: [CategoryGroup]) -> (nodes: [TreeNode], edges: [EdgeLine]) {
+private func buildTree(center: CGPoint, groups: [CategoryGroup], centerSize: CGFloat = 90) -> (nodes: [TreeNode], edges: [EdgeLine]) {
     var nodes: [TreeNode] = []
     var edges: [EdgeLine] = []
 
-    let centerSize: CGFloat = 90
     let catSize: CGFloat = 80
     let subCatSize: CGFloat = 56
     let skillSize: CGFloat = 64
@@ -700,8 +699,13 @@ struct ConstellationView: View {
     // Node sizes
     private let categoryNodeSize: CGFloat = 80
     private let skillNodeSize: CGFloat = 64
-    private let centerAvatarSize: CGFloat = 90
+    private let customAvatarSize: CGFloat = 90
+    private let nativeCharacterAvatarSize: CGFloat = 112
     private let subCatNodeSize: CGFloat = 56
+
+    private var centerAvatarSize: CGFloat {
+        hasCustomAvatar ? customAvatarSize : nativeCharacterAvatarSize
+    }
 
     /// Tree layout positions, keyed by node ID.
     @State private var treePositions: [String: CGPoint] = [:]
@@ -766,7 +770,7 @@ struct ConstellationView: View {
 
     /// Computes tree layout synchronously and populates all state vars.
     private func computeLayout(center: CGPoint) {
-        let result = buildTree(center: center, groups: groups)
+        let result = buildTree(center: center, groups: groups, centerSize: centerAvatarSize)
         treeNodes = result.nodes
         treeEdges = result.edges
         var positions: [String: CGPoint] = [:]


### PR DESCRIPTION
## Summary
- Increase the center avatar from 90pt to 112pt (25% larger) for native character avatars in the constellation mind map
- Custom uploaded avatars remain at 90pt with their glow effect unchanged
- Pass dynamic center size into `buildTree()` so layout overlap detection uses the correct radius

## Original prompt
Make the avatar 25% larger in the mind map on the Intelligence page when it is a native character

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
