### PR TITLE
feat(contacts): rename Revoke to Disconnect and fix Telegram hyperlink in verified state

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -77,17 +77,10 @@ struct ChannelVerificationFlowView: View {
                     verificationLabel
                 }
                 VStack(alignment: .leading, spacing: 2) {
-                    if let telegramProfileURL {
-                        Link(primaryIdentity ?? "Verified", destination: telegramProfileURL)
-                            .font(VFont.body)
-                            .lineLimit(1)
-                            .pointerCursor()
-                    } else {
-                        Text(primaryIdentity ?? "Verified")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.contentSecondary)
-                            .lineLimit(1)
-                    }
+                    Text(primaryIdentity ?? "Verified")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentDefault)
+                        .lineLimit(1)
                     if let secondaryIdentity {
                         if let telegramProfileURL {
                             Link(secondaryIdentity, destination: telegramProfileURL)
@@ -104,7 +97,7 @@ struct ChannelVerificationFlowView: View {
                 }
                 Spacer()
             }
-            VButton(label: "Revoke", style: .outlined) {
+            VButton(label: "Disconnect", style: .danger) {
                 onRevoke()
             }
         }


### PR DESCRIPTION
## Summary
- Change 'Revoke' button to 'Disconnect' with danger style in verified channel view
- Make primary identity (display name) always plain text, not a hyperlink
- Keep secondary identity (Telegram ID) as a clickable hyperlink

Part of plan: contacts-card-ux-polish.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
