### PR TITLE
feat(contacts): add Cancel button to Guardian verification destination input

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -19,6 +19,7 @@ struct ChannelVerificationFlowView: View {
     let onRevoke: () -> Void
     let onStartSession: (Bool) -> Void
     let onCancelSession: () -> Void
+    var onCancel: (() -> Void)?
 
     // Optional layout/display parameters
     var botUsername: String?
@@ -402,10 +403,18 @@ struct ChannelVerificationFlowView: View {
                     .foregroundColor(VColor.contentTertiary)
             }
 
-            VButton(label: "Send", style: .outlined) {
-                onStartOutbound(destination)
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Send", style: .outlined) {
+                    onStartOutbound(destination)
+                }
+                .disabled(destination.isEmpty)
+
+                if let onCancel {
+                    VButton(label: "Cancel", style: .outlined) {
+                        onCancel()
+                    }
+                }
             }
-            .disabled(destination.isEmpty)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -163,6 +163,7 @@ struct GuardianChannelsDetailView: View {
                 onRevoke: { store.revokeChannelVerification(channel: type) },
                 onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
                 onCancelSession: { store.cancelVerificationSession(channel: type) },
+                onCancel: { setupExpanded.remove(type) },
                 botUsername: store.telegramBotUsername,
                 phoneNumber: store.twilioPhoneNumber,
                 showLabel: false


### PR DESCRIPTION
## Summary
- Add optional onCancel closure to ChannelVerificationFlowView
- Show Cancel button next to Send in the destination input view when onCancel is provided
- Wire onCancel in GuardianChannelsDetailView to collapse the card back to Set Up state

Part of plan: contacts-card-ux-polish.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
