### PR TITLE
fix(trust): add computer_use_observe to default tools test

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -777,6 +777,7 @@ describe("Trust Store", () => {
         "computer_use_click",
         "computer_use_drag",
         "computer_use_key",
+        "computer_use_observe",
         "computer_use_open_app",
         "computer_use_run_applescript",
         "computer_use_scroll",


### PR DESCRIPTION
## Summary
- Add `computer_use_observe` to the expected default tools list in `trust-store.test.ts`
- The tool was added to the default trust rules but the test's expected list wasn't updated, causing CI failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23035518637/job/66902530177

🤖 Generated with [Claude Code](https://claude.com/claude-code)