### PR TITLE
fix(memory): use selectedCount for recall tool result instead of capped topCandidates length

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -331,7 +331,7 @@ export async function handleMemoryRecall(
 
     const result: MemoryRecallToolResult = {
       text: recall.injectedText,
-      resultCount: recall.topCandidates.length,
+      resultCount: recall.selectedCount,
       degraded,
       items: recall.topCandidates.map((c) => ({
         id: c.key,


### PR DESCRIPTION
Addresses feedback from PR #16011. The topCandidates array is capped at 10 for debug output, but resultCount in the tool result was derived from its length, causing undercount. Now uses the correct total selected count.

Part of #16011
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
