### PR TITLE
fix(memory): remove ambiguous timezone abbreviations from recall parsing

### DIFF
--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -135,16 +135,12 @@ const TIMEZONE_ABBREVIATIONS: Record<string, string> = {
   // North America
   PST: "America/Los_Angeles",
   PDT: "America/Los_Angeles",
-  PT: "America/Los_Angeles",
   MST: "America/Denver",
   MDT: "America/Denver",
-  MT: "America/Denver",
   CST: "America/Chicago",
   CDT: "America/Chicago",
-  CT: "America/Chicago",
   EST: "America/New_York",
   EDT: "America/New_York",
-  ET: "America/New_York",
   AKST: "America/Anchorage",
   AKDT: "America/Anchorage",
   HST: "Pacific/Honolulu",
@@ -157,16 +153,13 @@ const TIMEZONE_ABBREVIATIONS: Record<string, string> = {
   CEST: "Europe/Paris",
   EET: "Europe/Athens",
   EEST: "Europe/Athens",
-  WET: "Europe/Lisbon",
   WEST: "Europe/Lisbon",
   MSK: "Europe/Moscow",
-  IST: "Europe/Dublin",
   // Asia / Oceania
   JST: "Asia/Tokyo",
   KST: "Asia/Seoul",
   HKT: "Asia/Hong_Kong",
   SGT: "Asia/Singapore",
-  ICT: "Asia/Bangkok",
   WIB: "Asia/Jakarta",
   PHT: "Asia/Manila",
   PKT: "Asia/Karachi",
@@ -180,7 +173,6 @@ const TIMEZONE_ABBREVIATIONS: Record<string, string> = {
   NZDT: "Pacific/Auckland",
   // South America
   BRT: "America/Sao_Paulo",
-  ART: "America/Argentina/Buenos_Aires",
 };
 
 /**


### PR DESCRIPTION
Addresses feedback from PR #16013. Removes short/ambiguous timezone abbreviations (PT, MT, CT, ET, ART, WET, ICT, IST) that match common English words or have multiple conflicting meanings. Keeps only unambiguous abbreviations (PST, PDT, MST, MDT, CST, CDT, EST, EDT, etc.).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
