### PR TITLE
feat: auto-allow assistant CLI commands on host_bash

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1097,6 +1097,39 @@ describe("Trust Store", () => {
       expect(match!.decision).toBe("allow");
     });
 
+    // ── default allow: assistant CLI on host_bash ──────────────
+
+    test("assistant CLI default allow rule exists in templates", () => {
+      const templates = getDefaultRuleTemplates();
+      const rule = templates.find(
+        (t) => t.id === "default:allow-host_bash-assistant-cli",
+      );
+      expect(rule).toBeDefined();
+      expect(rule!.tool).toBe("host_bash");
+      expect(rule!.pattern).toBe("action:assistant");
+      expect(rule!.decision).toBe("allow");
+      expect(rule!.scope).toBe("everywhere");
+      expect(rule!.priority).toBe(60);
+    });
+
+    test("assistant CLI allow rule beats host_bash global ask rule", () => {
+      // The action key "action:assistant" should match the allow rule (priority 60)
+      // instead of the host_bash global ask rule (priority 50).
+      const match = findHighestPriorityRule(
+        "host_bash",
+        [
+          "assistant skills search react",
+          "action:assistant skills search",
+          "action:assistant skills",
+          "action:assistant",
+        ],
+        "/tmp",
+      );
+      expect(match).not.toBeNull();
+      expect(match!.id).toBe("default:allow-host_bash-assistant-cli");
+      expect(match!.decision).toBe("allow");
+    });
+
     // ── default allow: browser tools ────────────────────────────
 
     test("all 10 browser tools have default allow rules", () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -274,6 +274,20 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     }),
   );
 
+  // The `assistant` CLI is first-party trusted code.  Auto-allow all
+  // `assistant` subcommands on the host shell so the LLM can run
+  // `assistant skills search`, `assistant skills add`, etc. without
+  // triggering permission prompts.  Priority 60 beats the host_bash
+  // global ask rule (priority 50).
+  const assistantCliRule: DefaultRuleTemplate = {
+    id: "default:allow-host_bash-assistant-cli",
+    tool: "host_bash",
+    pattern: "action:assistant",
+    scope: "everywhere",
+    decision: "allow",
+    priority: 60,
+  };
+
   // memory_recall is a read-only tool — always allow without prompting.
   const memoryRecallRule: DefaultRuleTemplate = {
     id: "default:allow-memory_recall-global",
@@ -300,5 +314,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...browserToolRules,
     ...uiSurfaceRules,
     memoryRecallRule,
+    assistantCliRule,
   ];
 }


### PR DESCRIPTION
## Summary
- Adds a default `allow` trust rule for `action:assistant` on `host_bash` (priority 60), so the LLM can run `assistant skills search`, `assistant skills add`, and other assistant CLI subcommands without triggering a permission prompt
- Priority 60 beats the existing `default:ask-host_bash-global` rule (priority 50)
- Adds tests verifying the rule exists and beats the global ask rule

## Original prompt
Add a default allow rule for `assistant` CLI commands on `host_bash` so the LLM doesn't trigger a permission prompt when running `assistant skills search` or `assistant skills add`. The `assistant` binary is first-party trusted code. In `assistant/src/permissions/defaults.ts`, add a new `DefaultRuleTemplate` with `tool: "host_bash"`, `pattern: "action:assistant"`, `decision: "allow"`, `scope: "everywhere"`, and `priority: 60` (higher than the default ask rule at 50). Add it to the returned array. Also add a test in the relevant test file verifying that `assistant skills search` commands via `host_bash` get auto-allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
