### PR TITLE
fix: revert host_bash allow rule, enforce bash for assistant CLI

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1097,39 +1097,6 @@ describe("Trust Store", () => {
       expect(match!.decision).toBe("allow");
     });
 
-    // ── default allow: assistant CLI on host_bash ──────────────
-
-    test("assistant CLI default allow rule exists in templates", () => {
-      const templates = getDefaultRuleTemplates();
-      const rule = templates.find(
-        (t) => t.id === "default:allow-host_bash-assistant-cli",
-      );
-      expect(rule).toBeDefined();
-      expect(rule!.tool).toBe("host_bash");
-      expect(rule!.pattern).toBe("action:assistant");
-      expect(rule!.decision).toBe("allow");
-      expect(rule!.scope).toBe("everywhere");
-      expect(rule!.priority).toBe(60);
-    });
-
-    test("assistant CLI allow rule beats host_bash global ask rule", () => {
-      // The action key "action:assistant" should match the allow rule (priority 60)
-      // instead of the host_bash global ask rule (priority 50).
-      const match = findHighestPriorityRule(
-        "host_bash",
-        [
-          "assistant skills search react",
-          "action:assistant skills search",
-          "action:assistant skills",
-          "action:assistant",
-        ],
-        "/tmp",
-      );
-      expect(match).not.toBeNull();
-      expect(match!.id).toBe("default:allow-host_bash-assistant-cli");
-      expect(match!.decision).toBe("allow");
-    });
-
     // ── default allow: browser tools ────────────────────────────
 
     test("all 10 browser tools have default allow rules", () => {

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -274,20 +274,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     }),
   );
 
-  // The `assistant` CLI is first-party trusted code.  Auto-allow all
-  // `assistant` subcommands on the host shell so the LLM can run
-  // `assistant skills search`, `assistant skills add`, etc. without
-  // triggering permission prompts.  Priority 60 beats the host_bash
-  // global ask rule (priority 50).
-  const assistantCliRule: DefaultRuleTemplate = {
-    id: "default:allow-host_bash-assistant-cli",
-    tool: "host_bash",
-    pattern: "action:assistant",
-    scope: "everywhere",
-    decision: "allow",
-    priority: 60,
-  };
-
   // memory_recall is a read-only tool — always allow without prompting.
   const memoryRecallRule: DefaultRuleTemplate = {
     id: "default:allow-memory_recall-global",
@@ -314,6 +300,5 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...browserToolRules,
     ...uiSurfaceRules,
     memoryRecallRule,
-    assistantCliRule,
   ];
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -845,7 +845,7 @@ export function buildCliReferenceSection(): string {
   return [
     "## Assistant CLI",
     "",
-    "The `assistant` CLI is installed on the user's machine and available via `bash`.",
+    "The `assistant` CLI is available in the sandbox. Always use the `bash` tool (never `host_bash`) when running `assistant` commands.",
     "For account and authentication work, prefer real `assistant` CLI workflows over any legacy account-record abstraction.",
     "- Use `assistant credentials ...` for stored secrets and credential metadata.",
     "- Use `assistant oauth connections token <provider-key>` for connected integration tokens.",


### PR DESCRIPTION
## Summary
- Reverts the `default:allow-host_bash-assistant-cli` trust rule and its tests from #16115 — assistant CLI commands should never use `host_bash`
- Strengthens system prompt from "available via `bash`" to "Always use the `bash` tool (never `host_bash`) when running `assistant` commands" to prevent the LLM from routing to `host_bash`
- Consistent with the existing `CLI_RETRIEVAL_PATTERN.md` guidance

## Original prompt
Revert the `assistantCliRule` added in PR #16115 (the `default:allow-host_bash-assistant-cli` rule in `assistant/src/permissions/defaults.ts` and its test in `assistant/src/__tests__/trust-store.test.ts`). Then strengthen the system prompt in `assistant/src/prompts/system-prompt.ts` where it mentions the `assistant` CLI — make the guidance explicit and unambiguous that `assistant` commands MUST always use the `bash` tool (sandboxed), never `host_bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
