### PR TITLE
fix: fall back to repo tree search for non-standard skill paths

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "../skills/skillssh-registry.js";
 import {
   fetchSkillAudits,
+  fetchSkillFromGitHub,
   formatAuditBadges,
   providerDisplayName,
   resolveSkillSource,
@@ -316,5 +317,134 @@ describe("validateSkillSlug", () => {
 
   test("rejects empty input", () => {
     expect(() => validateSkillSlug("")).toThrow("Skill slug is required");
+  });
+});
+
+// ─── fetchSkillFromGitHub ───────────────────────────────────────────────────
+
+describe("fetchSkillFromGitHub", () => {
+  test("fetches from conventional skills/<slug>/ path", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      // Probe request for skills/my-skill
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      // File download
+      if (urlStr.includes("raw.example.com/SKILL.md")) {
+        return Promise.resolve(new Response("# My Skill", { status: 200 }));
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const files = await fetchSkillFromGitHub("owner", "repo", "my-skill");
+    expect(files["SKILL.md"]).toBe("# My Skill");
+  });
+
+  test("falls back to tree search when skills/<slug>/ returns 404", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      // Probe for conventional path returns 404
+      if (urlStr.includes("/contents/skills/csv")) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+      // Tree search returns the skill at a non-standard path
+      if (urlStr.includes("/git/trees/")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              tree: [
+                { path: "examples/skills/csv/SKILL.md", type: "blob" },
+                { path: "examples/skills/csv/scripts/filter.sh", type: "blob" },
+                { path: "README.md", type: "blob" },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      // Contents API for the discovered path
+      if (urlStr.includes("/contents/examples/skills/csv")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "SKILL.md",
+                type: "file",
+                download_url: "https://raw.example.com/SKILL.md",
+              },
+              {
+                name: "scripts",
+                type: "dir",
+                download_url: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      // Subdirectory listing
+      if (urlStr.includes("/contents/examples/skills/csv/scripts")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "filter.sh",
+                type: "file",
+                download_url: "https://raw.example.com/filter.sh",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      // File downloads
+      if (urlStr.includes("raw.example.com/SKILL.md")) {
+        return Promise.resolve(new Response("# CSV Skill", { status: 200 }));
+      }
+      if (urlStr.includes("raw.example.com/filter.sh")) {
+        return Promise.resolve(
+          new Response("#!/bin/bash\necho filter", { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    const files = await fetchSkillFromGitHub("vercel-labs", "bash-tool", "csv");
+    expect(files["SKILL.md"]).toBe("# CSV Skill");
+    expect(files["scripts/filter.sh"]).toBe("#!/bin/bash\necho filter");
+  });
+
+  test("throws when skill not found in tree either", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      if (urlStr.includes("/contents/skills/missing")) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+      if (urlStr.includes("/git/trees/")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ tree: [{ path: "README.md", type: "blob" }] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    await expect(
+      fetchSkillFromGitHub("owner", "repo", "missing"),
+    ).rejects.toThrow("Searched skills/missing/ and the full repo tree");
   });
 });

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -207,11 +207,51 @@ function githubHeaders(): Record<string, string> {
   return headers;
 }
 
+interface GitHubTreeEntry {
+  path: string;
+  type: "blob" | "tree";
+}
+
+/**
+ * Search the repo tree for a directory containing `<slug>/SKILL.md`.
+ * Returns the directory path (e.g. "examples/skills-tool/skills/csv") or null.
+ */
+async function findSkillDirInTree(
+  owner: string,
+  repo: string,
+  skillSlug: string,
+  ref: string,
+  headers: Record<string, string>,
+): Promise<string | null> {
+  const treeUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+  const response = await fetch(treeUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) return null;
+
+  const data = (await response.json()) as { tree: GitHubTreeEntry[] };
+  const suffix = `${skillSlug}/SKILL.md`;
+  const match = data.tree.find(
+    (entry) =>
+      entry.type === "blob" &&
+      (entry.path === suffix || entry.path.endsWith(`/${suffix}`)),
+  );
+  if (!match) return null;
+
+  // Return the directory containing SKILL.md (strip the trailing /SKILL.md)
+  return match.path.slice(0, -"/SKILL.md".length);
+}
+
 /**
  * Fetch SKILL.md and supporting files from a GitHub-hosted skills directory.
  *
- * Uses the GitHub Contents API: `GET /repos/:owner/:repo/contents/skills/:slug`
- * and follows each file's `download_url` to retrieve content.
+ * First tries the conventional `skills/<slug>/` path. If that returns a 404,
+ * falls back to searching the full repo tree for `<slug>/SKILL.md` at any
+ * depth (handles repos like `vercel-labs/bash-tool` where skills live at
+ * non-standard paths like `examples/skills-tool/skills/csv/`).
+ *
+ * Uses the GitHub Contents API for directory listing and file downloads.
  * Recursively fetches subdirectories (e.g. scripts/, references/).
  */
 export async function fetchSkillFromGitHub(
@@ -237,12 +277,6 @@ export async function fetchSkillFromGitHub(
     });
 
     if (!response.ok) {
-      if (response.status === 404 && prefix === "") {
-        throw new Error(
-          `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
-            `Looked in skills/${skillSlug}/`,
-        );
-      }
       throw new Error(
         `GitHub API error: HTTP ${response.status} ${response.statusText}`,
       );
@@ -285,13 +319,79 @@ export async function fetchSkillFromGitHub(
     return files;
   }
 
-  const rootPath = `skills/${encodeURIComponent(skillSlug)}`;
-  const files = await fetchDir(rootPath, "");
+  // Try the conventional skills/<slug>/ path first
+  const conventionalPath = `skills/${encodeURIComponent(skillSlug)}`;
+  let skillDirPath = conventionalPath;
+
+  const probeUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${conventionalPath}${ref ? `?ref=${encodeURIComponent(ref)}` : ""}`;
+  const probeResponse = await fetch(probeUrl, {
+    headers,
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (probeResponse.status === 404) {
+    // Fall back to searching the repo tree for <slug>/SKILL.md at any path
+    const treeRef = ref ?? "HEAD";
+    const foundPath = await findSkillDirInTree(
+      owner,
+      repo,
+      skillSlug,
+      treeRef,
+      headers,
+    );
+    if (!foundPath) {
+      throw new Error(
+        `Skill "${skillSlug}" not found in ${owner}/${repo}. ` +
+          `Searched skills/${skillSlug}/ and the full repo tree.`,
+      );
+    }
+    skillDirPath = foundPath;
+  } else if (!probeResponse.ok) {
+    throw new Error(
+      `GitHub API error: HTTP ${probeResponse.status} ${probeResponse.statusText}`,
+    );
+  }
+
+  // If we already have the probe response for the conventional path and it was
+  // successful, we can use it directly instead of re-fetching.
+  let files: SkillFiles;
+  if (skillDirPath === conventionalPath && probeResponse.ok) {
+    const entries = (await probeResponse.json()) as GitHubContentsEntry[];
+    if (!Array.isArray(entries)) {
+      throw new Error(
+        `Expected a directory listing for ${conventionalPath}/ but got a single file`,
+      );
+    }
+    // Fetch the directory contents from the already-parsed probe response
+    const result: SkillFiles = {};
+    for (const entry of entries) {
+      if (entry.type === "dir") {
+        const subFiles = await fetchDir(
+          `${conventionalPath}/${entry.name}`,
+          entry.name,
+        );
+        Object.assign(result, subFiles);
+        continue;
+      }
+      if (entry.type !== "file" || !entry.download_url) continue;
+      const fileResponse = await fetch(entry.download_url, {
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!fileResponse.ok) {
+        throw new Error(
+          `Failed to download ${entry.name}: HTTP ${fileResponse.status}`,
+        );
+      }
+      result[entry.name] = await fileResponse.text();
+    }
+    files = result;
+  } else {
+    files = await fetchDir(skillDirPath, "");
+  }
 
   if (!files["SKILL.md"]) {
-    throw new Error(
-      `SKILL.md not found in ${owner}/${repo}/skills/${skillSlug}/`,
-    );
+    throw new Error(`SKILL.md not found in ${owner}/${repo}/${skillDirPath}/`);
   }
 
   return files;


### PR DESCRIPTION
## Summary
- When `fetchSkillFromGitHub` gets a 404 from the conventional `skills/<slug>/` path, it now falls back to searching the repo tree (via `GET /repos/:owner/:repo/git/trees/:ref?recursive=1`) for `<slug>/SKILL.md` at any depth
- Fixes install failures for repos like `vercel-labs/bash-tool` where the `csv` skill lives at `examples/skills-tool/skills/csv/` instead of `skills/csv/`
- Adds tests for both the conventional path and the tree-search fallback

## Original prompt
Fix `fetchSkillFromGitHub` to handle repos where skills aren't at the standard `skills/<slug>/` path. When the initial lookup returns a 404, fall back to searching the repo tree using the GitHub Trees API for any path matching `<slug>/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
