### PR TITLE
fix(lint): sort imports in skills CLI command

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -8,6 +8,7 @@ import {
   readLocalCatalog,
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
+import type { AuditResponse } from "../../skills/skillssh-registry.js";
 import {
   fetchSkillAudits,
   formatAuditBadges,
@@ -15,7 +16,6 @@ import {
   resolveSkillSource,
   searchSkillsRegistry,
 } from "../../skills/skillssh-registry.js";
-import type { AuditResponse } from "../../skills/skillssh-registry.js";
 import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
@@ -113,83 +113,79 @@ Examples:
   $ assistant skills search "file management" --limit 3
   $ assistant skills search deploy --json`,
     )
-    .action(
-      async (query: string, opts: { limit: string; json?: boolean }) => {
-        const json = opts.json ?? false;
-        const limit = parseInt(opts.limit, 10) || 10;
+    .action(async (query: string, opts: { limit: string; json?: boolean }) => {
+      const json = opts.json ?? false;
+      const limit = parseInt(opts.limit, 10) || 10;
 
-        try {
-          const results = await searchSkillsRegistry(query, limit);
+      try {
+        const results = await searchSkillsRegistry(query, limit);
 
-          if (results.length === 0) {
-            if (json) {
-              console.log(
-                JSON.stringify({ ok: true, results: [], audits: {} }),
-              );
-            } else {
-              log.info(`No skills found for "${query}".`);
-            }
-            return;
-          }
-
-          // Group skill slugs by source for batch audit lookups
-          const sourceToSlugs = new Map<string, string[]>();
-          for (const r of results) {
-            const slugs = sourceToSlugs.get(r.source) ?? [];
-            slugs.push(r.skillId);
-            sourceToSlugs.set(r.source, slugs);
-          }
-
-          // Fetch audits for each unique source, keyed by source/skillId
-          // to avoid collisions when different sources share the same slug.
-          const allAudits: AuditResponse = {};
-          for (const [source, slugs] of sourceToSlugs) {
-            try {
-              const audits = await fetchSkillAudits(source, slugs);
-              for (const [skillId, auditData] of Object.entries(audits)) {
-                allAudits[`${source}/${skillId}`] = auditData;
-              }
-            } catch {
-              // Audit fetch failures are non-fatal; display results without audits
-            }
-          }
-
+        if (results.length === 0) {
           if (json) {
-            console.log(
-              JSON.stringify({
-                ok: true,
-                results,
-                audits: allAudits,
-              }),
-            );
-            return;
-          }
-
-          log.info(`Search results for "${query}" (${results.length}):\n`);
-          for (const r of results) {
-            log.info(`  ${r.name}`);
-            log.info(`    ID: ${r.skillId}`);
-            log.info(`    Source: ${r.source}`);
-            log.info(`    Installs: ${r.installs}`);
-            const auditData = allAudits[`${r.source}/${r.skillId}`];
-            if (auditData) {
-              log.info(`    ${formatAuditBadges(auditData)}`);
-            } else {
-              log.info("    Security: no audit data");
-            }
-            log.info("");
-          }
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (json) {
-            console.log(JSON.stringify({ ok: false, error: msg }));
+            console.log(JSON.stringify({ ok: true, results: [], audits: {} }));
           } else {
-            log.error(`Error: ${msg}`);
+            log.info(`No skills found for "${query}".`);
           }
-          process.exitCode = 1;
+          return;
         }
-      },
-    );
+
+        // Group skill slugs by source for batch audit lookups
+        const sourceToSlugs = new Map<string, string[]>();
+        for (const r of results) {
+          const slugs = sourceToSlugs.get(r.source) ?? [];
+          slugs.push(r.skillId);
+          sourceToSlugs.set(r.source, slugs);
+        }
+
+        // Fetch audits for each unique source, keyed by source/skillId
+        // to avoid collisions when different sources share the same slug.
+        const allAudits: AuditResponse = {};
+        for (const [source, slugs] of sourceToSlugs) {
+          try {
+            const audits = await fetchSkillAudits(source, slugs);
+            for (const [skillId, auditData] of Object.entries(audits)) {
+              allAudits[`${source}/${skillId}`] = auditData;
+            }
+          } catch {
+            // Audit fetch failures are non-fatal; display results without audits
+          }
+        }
+
+        if (json) {
+          console.log(
+            JSON.stringify({
+              ok: true,
+              results,
+              audits: allAudits,
+            }),
+          );
+          return;
+        }
+
+        log.info(`Search results for "${query}" (${results.length}):\n`);
+        for (const r of results) {
+          log.info(`  ${r.name}`);
+          log.info(`    ID: ${r.skillId}`);
+          log.info(`    Source: ${r.source}`);
+          log.info(`    Installs: ${r.installs}`);
+          const auditData = allAudits[`${r.source}/${r.skillId}`];
+          if (auditData) {
+            log.info(`    ${formatAuditBadges(auditData)}`);
+          } else {
+            log.info("    Security: no audit data");
+          }
+          log.info("");
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (json) {
+          console.log(JSON.stringify({ ok: false, error: msg }));
+        } else {
+          log.error(`Error: ${msg}`);
+        }
+        process.exitCode = 1;
+      }
+    });
 
   skills
     .command("install <skill-id>")
@@ -297,10 +293,7 @@ Examples:
   $ assistant skills add vercel-labs/skills@find-skills --overwrite`,
     )
     .action(
-      async (
-        source: string,
-        opts: { overwrite?: boolean; json?: boolean },
-      ) => {
+      async (source: string, opts: { overwrite?: boolean; json?: boolean }) => {
         const json = opts.json ?? false;
 
         try {
@@ -323,9 +316,7 @@ Examples:
               }),
             );
           } else {
-            log.info(
-              `Installed skill "${skillSlug}" from ${owner}/${repo}.`,
-            );
+            log.info(`Installed skill "${skillSlug}" from ${owner}/${repo}.`);
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/cli/commands/skills.ts` by reordering the type import from `skillssh-registry.js` above the value import from the same module

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23037481667/job/66908688656

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
