### PR TITLE
fix: reorder mock URL checks in skillssh-registry test to prevent hang

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -374,6 +374,22 @@ describe("fetchSkillFromGitHub", () => {
           ),
         );
       }
+      // Subdirectory listing (must precede parent path check — both use
+      // .includes() and the parent path is a prefix of this one)
+      if (urlStr.includes("/contents/examples/skills/csv/scripts")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                name: "filter.sh",
+                type: "file",
+                download_url: "https://raw.example.com/filter.sh",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
       // Contents API for the discovered path
       if (urlStr.includes("/contents/examples/skills/csv")) {
         return Promise.resolve(
@@ -388,21 +404,6 @@ describe("fetchSkillFromGitHub", () => {
                 name: "scripts",
                 type: "dir",
                 download_url: null,
-              },
-            ]),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-        );
-      }
-      // Subdirectory listing
-      if (urlStr.includes("/contents/examples/skills/csv/scripts")) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify([
-              {
-                name: "filter.sh",
-                type: "file",
-                download_url: "https://raw.example.com/filter.sh",
               },
             ]),
             { status: 200, headers: { "Content-Type": "application/json" } },


### PR DESCRIPTION
## Summary
- The `skillssh-registry.test.ts` "falls back to tree search" test had a mock URL matching bug: `.includes("/contents/examples/skills/csv")` matched both the parent directory URL and the `/scripts` subdirectory URL, since the former is a substring of the latter
- Because the parent check came first, the subdirectory fetch always got the parent listing back, causing infinite async recursion on the "scripts" dir entry
- Fix: reorder the mock checks so the more-specific `/scripts` path is matched before the parent path

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23037776015/job/66909547333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
