### PR TITLE
fix: defer remote catalog fetch until specific skill miss in dev mode

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -340,22 +340,34 @@ export async function installSkillLocally(
 
 /**
  * Resolve the catalog skill list, checking local (dev mode) first, then remote.
+ *
+ * In dev mode with a local catalog, returns local entries immediately to avoid
+ * unnecessary network latency.  Pass `skillId` to trigger a deferred remote
+ * fetch only when the requested skill is not found locally — this preserves the
+ * ability to discover remote-only skills without penalising every call with a
+ * 10s timeout on flaky networks.
+ *
  * Callers that install multiple skills in a loop should call this once and pass
  * the result to `autoInstallFromCatalog` to avoid redundant network requests.
  */
-export async function resolveCatalog(): Promise<CatalogSkill[]> {
+export async function resolveCatalog(
+  skillId?: string,
+): Promise<CatalogSkill[]> {
   const repoSkillsDir = getRepoSkillsDir();
   if (repoSkillsDir) {
     const local = readLocalCatalog(repoSkillsDir);
     if (local.length > 0) {
-      // Merge with remote catalog so skills not in local catalog.json
-      // can still be found. Local entries take precedence by id.
+      // If no specific skill requested, or it exists locally, skip remote fetch
+      if (!skillId || local.some((s) => s.id === skillId)) {
+        return local;
+      }
+      // Skill not found locally — merge with remote so remote-only skills
+      // can still be discovered. Local entries take precedence by id.
       try {
         const remote = await fetchCatalog();
         const localIds = new Set(local.map((s) => s.id));
         return [...local, ...remote.filter((s) => !localIds.has(s.id))];
       } catch {
-        // If remote fetch fails, fall back to local-only
         return local;
       }
     }
@@ -382,7 +394,7 @@ export async function autoInstallFromCatalog(
     skills = catalog;
   } else {
     try {
-      skills = await resolveCatalog();
+      skills = await resolveCatalog(skillId);
     } catch (err) {
       log.warn(
         { err, skillId },

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -206,7 +206,7 @@ export class SkillLoadTool implements Tool {
         // Lazily resolve catalog on first round with missing includes
         if (!remoteCatalog) {
           try {
-            remoteCatalog = await resolveCatalog();
+            remoteCatalog = await resolveCatalog([...missing][0]);
           } catch (err) {
             log.warn(
               { err, skillId: skill.id },


### PR DESCRIPTION
Addresses review feedback from #16004. In dev mode, `resolveCatalog()` now returns local catalog entries immediately and only fetches the remote catalog when a specific skill is not found locally, avoiding unnecessary 10s timeout latency on flaky/offline networks.

Changes:
- `resolveCatalog()` accepts an optional `skillId` parameter. When in dev mode with local entries: if no `skillId` is given or the skill exists locally, returns local-only. Only hits remote when the specific skill is missing from local catalog.
- `autoInstallFromCatalog()` passes `skillId` through to `resolveCatalog()` so single-skill lookups benefit from the deferred fetch.
- The include resolution loop in `load.ts` passes the first missing include ID to trigger remote fetch only when needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
