### PR TITLE
feat: add memory items CRUD API routes

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -135,6 +135,7 @@ import { telegramRouteDefinitions } from "./routes/integrations/telegram.js";
 import { twilioRouteDefinitions } from "./routes/integrations/twilio.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { logExportRouteDefinitions } from "./routes/log-export-routes.js";
+import { memoryItemRouteDefinitions } from "./routes/memory-item-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 import {
@@ -724,6 +725,7 @@ export class RuntimeHttpServer {
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...workspaceRouteDefinitions(),
+      ...memoryItemRouteDefinitions(),
       ...settingsRouteDefinitions(),
       ...scheduleRouteDefinitions({
         sendMessageDeps: this.sendMessageDeps,

--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -1,0 +1,725 @@
+/**
+ * Tests for memory item CRUD HTTP endpoints.
+ *
+ * Covers: list with filters, get by ID, create + duplicate rejection,
+ * update + fingerprint collision, delete + 404.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "memory-item-routes-test-"));
+
+mock.module("../../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Stub config loader
+mock.module("../../config/loader.js", () => ({
+  loadConfig: () => ({}),
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+}));
+
+import { and, eq } from "drizzle-orm";
+
+import { getDb, initializeDb, resetDb } from "../../memory/db.js";
+import {
+  memoryEmbeddings,
+  memoryItems,
+  memoryJobs,
+} from "../../memory/schema.js";
+import type { RouteContext } from "../http-router.js";
+import { memoryItemRouteDefinitions } from "./memory-item-routes.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getHandler(endpoint: string, method: string) {
+  const routes = memoryItemRouteDefinitions();
+  const route = routes.find(
+    (r) => r.endpoint === endpoint && r.method === method,
+  );
+  if (!route) throw new Error(`No route: ${method} ${endpoint}`);
+  return route.handler;
+}
+
+function makeCtx(
+  searchParams: Record<string, string> = {},
+  params: Record<string, string> = {},
+): RouteContext {
+  const url = new URL("http://localhost/v1/memory-items");
+  for (const [k, v] of Object.entries(searchParams)) {
+    url.searchParams.set(k, v);
+  }
+  return {
+    url,
+    req: new Request(url),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params,
+  };
+}
+
+function makeJsonCtx(
+  endpoint: string,
+  method: string,
+  body: unknown,
+  params: Record<string, string> = {},
+): RouteContext {
+  const url = new URL(`http://localhost/v1/${endpoint}`);
+  return {
+    url,
+    req: new Request(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params,
+  };
+}
+
+function insertItem(opts: {
+  id: string;
+  kind: string;
+  subject: string;
+  statement: string;
+  status?: string;
+  importance?: number;
+  firstSeenAt?: number;
+  lastSeenAt?: number;
+  supersedes?: string;
+  supersededBy?: string;
+}) {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(memoryItems)
+    .values({
+      id: opts.id,
+      kind: opts.kind,
+      subject: opts.subject,
+      statement: opts.statement,
+      status: opts.status ?? "active",
+      confidence: 0.95,
+      importance: opts.importance ?? 0.8,
+      fingerprint: `fp-${opts.id}`,
+      verificationState: "user_confirmed",
+      scopeId: "default",
+      firstSeenAt: opts.firstSeenAt ?? now,
+      lastSeenAt: opts.lastSeenAt ?? now,
+      lastUsedAt: null,
+    })
+    .run();
+
+  if (opts.supersedes || opts.supersededBy) {
+    const set: Record<string, unknown> = {};
+    if (opts.supersedes) set.supersedes = opts.supersedes;
+    if (opts.supersededBy) set.supersededBy = opts.supersededBy;
+    db.update(memoryItems).set(set).where(eq(memoryItems.id, opts.id)).run();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("Memory Item Routes", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM memory_embeddings");
+    db.run("DELETE FROM memory_item_sources");
+    db.run("DELETE FROM memory_items");
+    db.run("DELETE FROM memory_jobs");
+  });
+
+  afterAll(() => {
+    resetDb();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // GET /v1/memory-items (list)
+  // =========================================================================
+
+  describe("GET /v1/memory-items", () => {
+    const handler = getHandler("memory-items", "GET");
+
+    test("returns empty list when no items", async () => {
+      const ctx = makeCtx();
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { items: unknown[]; total: number };
+      expect(body.items).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    test("returns all active items by default", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "s2",
+        statement: "st2",
+        status: "deleted",
+      });
+
+      const ctx = makeCtx();
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(1);
+      expect(body.items.length).toBe(1);
+      expect(body.items[0].id).toBe("i1");
+    });
+
+    test("filters by kind", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "s2",
+        statement: "st2",
+      });
+
+      const ctx = makeCtx({ kind: "preference" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(1);
+      expect(body.items[0].id).toBe("i1");
+    });
+
+    test("filters by search on subject and statement", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "name",
+        statement: "User name is Alice",
+      });
+
+      const ctx = makeCtx({ search: "dark" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(1);
+      expect(body.items[0].id).toBe("i1");
+    });
+
+    test("supports pagination with limit and offset", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+        lastSeenAt: 1000,
+      });
+      insertItem({
+        id: "i2",
+        kind: "preference",
+        subject: "s2",
+        statement: "st2",
+        lastSeenAt: 2000,
+      });
+      insertItem({
+        id: "i3",
+        kind: "preference",
+        subject: "s3",
+        statement: "st3",
+        lastSeenAt: 3000,
+      });
+
+      const ctx = makeCtx({ limit: "1", offset: "1" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(3);
+      expect(body.items.length).toBe(1);
+      // Default sort is lastSeenAt desc, so offset 1 should be i2
+      expect(body.items[0].id).toBe("i2");
+    });
+
+    test("supports sort by firstSeenAt ascending", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+        firstSeenAt: 3000,
+      });
+      insertItem({
+        id: "i2",
+        kind: "preference",
+        subject: "s2",
+        statement: "st2",
+        firstSeenAt: 1000,
+      });
+
+      const ctx = makeCtx({ sort: "firstSeenAt", order: "asc" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+      };
+      expect(body.items[0].id).toBe("i2");
+      expect(body.items[1].id).toBe("i1");
+    });
+
+    test("rejects invalid kind filter", async () => {
+      const ctx = makeCtx({ kind: "bogus" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects invalid sort field", async () => {
+      const ctx = makeCtx({ sort: "bogus" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // =========================================================================
+  // GET /v1/memory-items/:id
+  // =========================================================================
+
+  describe("GET /v1/memory-items/:id", () => {
+    const handler = getHandler("memory-items/:id", "GET");
+
+    test("returns item by ID", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "dark mode",
+        statement: "Prefers dark mode",
+      });
+
+      const ctx = makeCtx({}, { id: "i1" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        item: { id: string; subject: string };
+      };
+      expect(body.item.id).toBe("i1");
+      expect(body.item.subject).toBe("dark mode");
+    });
+
+    test("returns 404 for non-existent item", async () => {
+      const ctx = makeCtx({}, { id: "nonexistent" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(404);
+    });
+
+    test("includes supersedesSubject when supersedes is set", async () => {
+      insertItem({
+        id: "old",
+        kind: "preference",
+        subject: "old pref",
+        statement: "old",
+      });
+      insertItem({
+        id: "new",
+        kind: "preference",
+        subject: "new pref",
+        statement: "new",
+      });
+
+      // Set supersedes relationship manually
+      getDb()
+        .update(memoryItems)
+        .set({ supersedes: "old" })
+        .where(eq(memoryItems.id, "new"))
+        .run();
+
+      const ctx = makeCtx({}, { id: "new" });
+      const res = await handler(ctx);
+      const body = (await res.json()) as {
+        item: { supersedesSubject?: string };
+      };
+      expect(body.item.supersedesSubject).toBe("old pref");
+    });
+  });
+
+  // =========================================================================
+  // POST /v1/memory-items
+  // =========================================================================
+
+  describe("POST /v1/memory-items", () => {
+    const handler = getHandler("memory-items", "POST");
+
+    test("creates a new memory item", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        item: { id: string; kind: string; subject: string; statement: string };
+      };
+      expect(body.item.kind).toBe("preference");
+      expect(body.item.subject).toBe("dark mode");
+      expect(body.item.statement).toBe("User prefers dark mode");
+    });
+
+    test("uses custom importance when provided", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: "importance test",
+        statement: "Testing custom importance",
+        importance: 0.5,
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        item: { importance: number };
+      };
+      expect(body.item.importance).toBe(0.5);
+    });
+
+    test("rejects duplicate fingerprint", async () => {
+      const payload = {
+        kind: "preference",
+        subject: "dark mode",
+        statement: "User prefers dark mode",
+      };
+      const ctx1 = makeJsonCtx("memory-items", "POST", payload);
+      const res1 = await handler(ctx1);
+      expect(res1.status).toBe(201);
+
+      const ctx2 = makeJsonCtx("memory-items", "POST", payload);
+      const res2 = await handler(ctx2);
+      expect(res2.status).toBe(409);
+    });
+
+    test("rejects invalid kind", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "bogus",
+        subject: "test",
+        statement: "test",
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects missing subject", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        statement: "test",
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects missing statement", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: "test",
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+
+    test("truncates long subject and statement", async () => {
+      const longSubject = "a".repeat(200);
+      const longStatement = "b".repeat(1000);
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: longSubject,
+        statement: longStatement,
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        item: { subject: string; statement: string };
+      };
+      expect(body.item.subject.length).toBeLessThanOrEqual(80);
+      expect(body.item.statement.length).toBeLessThanOrEqual(500);
+    });
+
+    test("enqueues embed job on create", async () => {
+      const ctx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: "embed test",
+        statement: "Should enqueue embed job",
+      });
+      await handler(ctx);
+
+      // Verify a memory job was enqueued
+      const db = getDb();
+      const jobs = db.select().from(memoryJobs).all();
+      const embedJobs = jobs.filter(
+        (j) => j.type === "embed_item" && j.status === "pending",
+      );
+      expect(embedJobs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // =========================================================================
+  // PATCH /v1/memory-items/:id
+  // =========================================================================
+
+  describe("PATCH /v1/memory-items/:id", () => {
+    const handler = getHandler("memory-items/:id", "PATCH");
+
+    test("updates subject and statement", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "old subject",
+        statement: "old statement",
+      });
+
+      const ctx = makeJsonCtx(
+        "memory-items/i1",
+        "PATCH",
+        { subject: "new subject", statement: "new statement" },
+        { id: "i1" },
+      );
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        item: { subject: string; statement: string };
+      };
+      expect(body.item.subject).toBe("new subject");
+      expect(body.item.statement).toBe("new statement");
+    });
+
+    test("returns 404 for non-existent item", async () => {
+      const ctx = makeJsonCtx(
+        "memory-items/nonexistent",
+        "PATCH",
+        { subject: "test" },
+        { id: "nonexistent" },
+      );
+      const res = await handler(ctx);
+      expect(res.status).toBe(404);
+    });
+
+    test("detects fingerprint collision on update", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "first",
+        statement: "first statement",
+      });
+      // Insert a second item using the create handler to get a real fingerprint
+      const createHandler = getHandler("memory-items", "POST");
+      const createCtx = makeJsonCtx("memory-items", "POST", {
+        kind: "preference",
+        subject: "second",
+        statement: "second statement",
+      });
+      await createHandler(createCtx);
+
+      // Now try to update i1 to match the second item's content
+      // This should produce the same fingerprint as the second item
+      const ctx = makeJsonCtx(
+        "memory-items/i1",
+        "PATCH",
+        { subject: "second", statement: "second statement" },
+        { id: "i1" },
+      );
+      const res = await handler(ctx);
+      expect(res.status).toBe(409);
+    });
+
+    test("allows updating kind", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "test",
+        statement: "test",
+      });
+
+      const ctx = makeJsonCtx(
+        "memory-items/i1",
+        "PATCH",
+        { kind: "identity" },
+        { id: "i1" },
+      );
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { item: { kind: string } };
+      expect(body.item.kind).toBe("identity");
+    });
+
+    test("rejects invalid kind on update", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "test",
+        statement: "test",
+      });
+
+      const ctx = makeJsonCtx(
+        "memory-items/i1",
+        "PATCH",
+        { kind: "bogus" },
+        { id: "i1" },
+      );
+      const res = await handler(ctx);
+      expect(res.status).toBe(400);
+    });
+
+    test("enqueues embed job when statement changes", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "test",
+        statement: "old statement",
+      });
+
+      // Clear jobs first
+      getDb().run("DELETE FROM memory_jobs");
+
+      const ctx = makeJsonCtx(
+        "memory-items/i1",
+        "PATCH",
+        { statement: "new statement" },
+        { id: "i1" },
+      );
+      await handler(ctx);
+
+      const db = getDb();
+      const jobs = db.select().from(memoryJobs).all();
+      const embedJobs = jobs.filter(
+        (j) => j.type === "embed_item" && j.status === "pending",
+      );
+      expect(embedJobs.length).toBe(1);
+    });
+  });
+
+  // =========================================================================
+  // DELETE /v1/memory-items/:id
+  // =========================================================================
+
+  describe("DELETE /v1/memory-items/:id", () => {
+    const handler = getHandler("memory-items/:id", "DELETE");
+
+    test("deletes item and returns 204", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "test",
+        statement: "test",
+      });
+
+      const ctx = makeJsonCtx("memory-items/i1", "DELETE", null, { id: "i1" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(204);
+
+      // Verify the item is gone
+      const db = getDb();
+      const item = db
+        .select()
+        .from(memoryItems)
+        .where(eq(memoryItems.id, "i1"))
+        .get();
+      expect(item).toBeUndefined();
+    });
+
+    test("returns 404 for non-existent item", async () => {
+      const ctx = makeJsonCtx("memory-items/nonexistent", "DELETE", null, {
+        id: "nonexistent",
+      });
+      const res = await handler(ctx);
+      expect(res.status).toBe(404);
+    });
+
+    test("also deletes associated embeddings", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "test",
+        statement: "test",
+      });
+
+      // Insert an embedding for this item
+      const db = getDb();
+      db.insert(memoryEmbeddings)
+        .values({
+          id: "emb-1",
+          targetType: "item",
+          targetId: "i1",
+          provider: "test",
+          model: "test-model",
+          dimensions: 384,
+          vectorJson: "[]",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        })
+        .run();
+
+      const ctx = makeJsonCtx("memory-items/i1", "DELETE", null, { id: "i1" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(204);
+
+      // Verify embedding is also gone
+      const emb = db
+        .select()
+        .from(memoryEmbeddings)
+        .where(
+          and(
+            eq(memoryEmbeddings.targetType, "item"),
+            eq(memoryEmbeddings.targetId, "i1"),
+          ),
+        )
+        .get();
+      expect(emb).toBeUndefined();
+    });
+  });
+});

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -1,0 +1,497 @@
+/**
+ * Route handlers for memory item CRUD endpoints.
+ *
+ * GET    /v1/memory-items        — list memory items (with filtering, search, sort, pagination)
+ * GET    /v1/memory-items/:id    — get a single memory item
+ * POST   /v1/memory-items        — create a new memory item
+ * PATCH  /v1/memory-items/:id    — update an existing memory item
+ * DELETE /v1/memory-items/:id    — delete a memory item and its embeddings
+ */
+
+import { and, asc, count, desc, eq, like, ne, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../../memory/db.js";
+import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
+import { enqueueMemoryJob } from "../../memory/jobs-store.js";
+import { memoryEmbeddings, memoryItems } from "../../memory/schema.js";
+import { truncate } from "../../util/truncate.js";
+import { httpError } from "../http-errors.js";
+import type { RouteContext, RouteDefinition } from "../http-router.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALID_KINDS = [
+  "identity",
+  "preference",
+  "project",
+  "decision",
+  "constraint",
+  "event",
+] as const;
+
+type MemoryItemKind = (typeof VALID_KINDS)[number];
+
+const VALID_SORT_FIELDS = [
+  "lastSeenAt",
+  "importance",
+  "kind",
+  "firstSeenAt",
+] as const;
+
+type SortField = (typeof VALID_SORT_FIELDS)[number];
+
+const SORT_COLUMN_MAP = {
+  lastSeenAt: memoryItems.lastSeenAt,
+  importance: memoryItems.importance,
+  kind: memoryItems.kind,
+  firstSeenAt: memoryItems.firstSeenAt,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isValidKind(value: string): value is MemoryItemKind {
+  return (VALID_KINDS as readonly string[]).includes(value);
+}
+
+function isValidSortField(value: string): value is SortField {
+  return (VALID_SORT_FIELDS as readonly string[]).includes(value);
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/memory-items
+// ---------------------------------------------------------------------------
+
+export function handleListMemoryItems(url: URL): Response {
+  const kindParam = url.searchParams.get("kind");
+  const statusParam = url.searchParams.get("status") ?? "active";
+  const searchParam = url.searchParams.get("search");
+  const sortParam = url.searchParams.get("sort") ?? "lastSeenAt";
+  const orderParam = url.searchParams.get("order") ?? "desc";
+  const limitParam = Number(url.searchParams.get("limit") ?? 100);
+  const offsetParam = Number(url.searchParams.get("offset") ?? 0);
+
+  if (kindParam && !isValidKind(kindParam)) {
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid kind "${kindParam}". Must be one of: ${VALID_KINDS.join(", ")}`,
+      400,
+    );
+  }
+
+  if (!isValidSortField(sortParam)) {
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid sort "${sortParam}". Must be one of: ${VALID_SORT_FIELDS.join(", ")}`,
+      400,
+    );
+  }
+
+  if (orderParam !== "asc" && orderParam !== "desc") {
+    return httpError(
+      "BAD_REQUEST",
+      `Invalid order "${orderParam}". Must be "asc" or "desc"`,
+      400,
+    );
+  }
+
+  const db = getDb();
+
+  // Build WHERE conditions
+  const conditions = [];
+  if (statusParam) {
+    conditions.push(eq(memoryItems.status, statusParam));
+  }
+  if (kindParam) {
+    conditions.push(eq(memoryItems.kind, kindParam));
+  }
+  if (searchParam) {
+    conditions.push(
+      or(
+        like(memoryItems.subject, `%${searchParam}%`),
+        like(memoryItems.statement, `%${searchParam}%`),
+      )!,
+    );
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // Count query
+  const countResult = db
+    .select({ count: count() })
+    .from(memoryItems)
+    .where(whereClause)
+    .get();
+  const total = countResult?.count ?? 0;
+
+  // Data query
+  const sortColumn = SORT_COLUMN_MAP[sortParam];
+  const orderFn = orderParam === "asc" ? asc : desc;
+
+  const items = db
+    .select()
+    .from(memoryItems)
+    .where(whereClause)
+    .orderBy(orderFn(sortColumn))
+    .limit(limitParam)
+    .offset(offsetParam)
+    .all();
+
+  return Response.json({ items, total });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/memory-items/:id
+// ---------------------------------------------------------------------------
+
+export function handleGetMemoryItem(ctx: RouteContext): Response {
+  const { id } = ctx.params;
+  const db = getDb();
+
+  const item = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, id))
+    .get();
+
+  if (!item) {
+    return httpError("NOT_FOUND", "Memory item not found", 404);
+  }
+
+  let supersedesSubject: string | undefined;
+  let supersededBySubject: string | undefined;
+
+  if (item.supersedes) {
+    const superseded = db
+      .select({ subject: memoryItems.subject })
+      .from(memoryItems)
+      .where(eq(memoryItems.id, item.supersedes))
+      .get();
+    supersedesSubject = superseded?.subject;
+  }
+
+  if (item.supersededBy) {
+    const superseding = db
+      .select({ subject: memoryItems.subject })
+      .from(memoryItems)
+      .where(eq(memoryItems.id, item.supersededBy))
+      .get();
+    supersededBySubject = superseding?.subject;
+  }
+
+  return Response.json({
+    item: {
+      ...item,
+      ...(supersedesSubject !== undefined ? { supersedesSubject } : {}),
+      ...(supersededBySubject !== undefined ? { supersededBySubject } : {}),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/memory-items
+// ---------------------------------------------------------------------------
+
+export async function handleCreateMemoryItem(
+  ctx: RouteContext,
+): Promise<Response> {
+  const body = (await ctx.req.json()) as {
+    kind?: string;
+    subject?: string;
+    statement?: string;
+    importance?: number;
+  };
+
+  const { kind, subject, statement, importance } = body;
+
+  // Validate kind
+  if (typeof kind !== "string" || !isValidKind(kind)) {
+    return httpError(
+      "BAD_REQUEST",
+      `kind is required and must be one of: ${VALID_KINDS.join(", ")}`,
+      400,
+    );
+  }
+
+  // Validate subject
+  if (typeof subject !== "string" || subject.trim().length === 0) {
+    return httpError(
+      "BAD_REQUEST",
+      "subject is required and must be a non-empty string",
+      400,
+    );
+  }
+
+  // Validate statement
+  if (typeof statement !== "string" || statement.trim().length === 0) {
+    return httpError(
+      "BAD_REQUEST",
+      "statement is required and must be a non-empty string",
+      400,
+    );
+  }
+
+  const trimmedSubject = truncate(subject.trim(), 80, "");
+  const trimmedStatement = truncate(statement.trim(), 500, "");
+
+  const scopeId = "default";
+  const fingerprint = computeMemoryFingerprint(
+    scopeId,
+    kind,
+    trimmedSubject,
+    trimmedStatement,
+  );
+
+  const db = getDb();
+
+  // Check for existing item with same fingerprint + scopeId
+  const existing = db
+    .select()
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.fingerprint, fingerprint),
+        eq(memoryItems.scopeId, scopeId),
+      ),
+    )
+    .get();
+
+  if (existing) {
+    return httpError(
+      "CONFLICT",
+      "A memory with this content already exists",
+      409,
+    );
+  }
+
+  const id = uuid();
+  const now = Date.now();
+
+  db.insert(memoryItems)
+    .values({
+      id,
+      kind,
+      subject: trimmedSubject,
+      statement: trimmedStatement,
+      status: "active",
+      confidence: 0.95,
+      importance: importance ?? 0.8,
+      fingerprint,
+      verificationState: "user_confirmed",
+      scopeId,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastUsedAt: null,
+      overrideConfidence: "explicit",
+    })
+    .run();
+
+  enqueueMemoryJob("embed_item", { itemId: id });
+
+  // Fetch the inserted row to return it
+  const insertedRow = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, id))
+    .get();
+
+  return Response.json({ item: insertedRow }, { status: 201 });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/memory-items/:id
+// ---------------------------------------------------------------------------
+
+export async function handleUpdateMemoryItem(
+  ctx: RouteContext,
+): Promise<Response> {
+  const { id } = ctx.params;
+  const body = (await ctx.req.json()) as {
+    subject?: string;
+    statement?: string;
+    kind?: string;
+    status?: string;
+    importance?: number;
+    verificationState?: string;
+  };
+
+  const db = getDb();
+
+  const existing = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, id))
+    .get();
+
+  if (!existing) {
+    return httpError("NOT_FOUND", "Memory item not found", 404);
+  }
+
+  // Build the update set with only provided fields
+  const set: Record<string, unknown> = {
+    lastSeenAt: Date.now(),
+  };
+
+  if (body.subject !== undefined) {
+    set.subject = truncate(body.subject.trim(), 80, "");
+  }
+  if (body.statement !== undefined) {
+    set.statement = truncate(body.statement.trim(), 500, "");
+  }
+  if (body.kind !== undefined) {
+    if (!isValidKind(body.kind)) {
+      return httpError(
+        "BAD_REQUEST",
+        `Invalid kind "${body.kind}". Must be one of: ${VALID_KINDS.join(", ")}`,
+        400,
+      );
+    }
+    set.kind = body.kind;
+  }
+  if (body.status !== undefined) {
+    set.status = body.status;
+  }
+  if (body.importance !== undefined) {
+    set.importance = body.importance;
+  }
+  if (body.verificationState !== undefined) {
+    set.verificationState = body.verificationState;
+  }
+
+  // If subject, statement, or kind changed, recompute fingerprint
+  const contentChanged =
+    body.subject !== undefined ||
+    body.statement !== undefined ||
+    body.kind !== undefined;
+
+  if (contentChanged) {
+    const newSubject = (set.subject as string | undefined) ?? existing.subject;
+    const newStatement =
+      (set.statement as string | undefined) ?? existing.statement;
+    const newKind = (set.kind as string | undefined) ?? existing.kind;
+    const scopeId = existing.scopeId;
+
+    const fingerprint = computeMemoryFingerprint(
+      scopeId,
+      newKind,
+      newSubject,
+      newStatement,
+    );
+
+    // Check for collision (exclude self)
+    const collision = db
+      .select({ id: memoryItems.id })
+      .from(memoryItems)
+      .where(
+        and(
+          eq(memoryItems.fingerprint, fingerprint),
+          eq(memoryItems.scopeId, scopeId),
+          ne(memoryItems.id, id),
+        ),
+      )
+      .get();
+
+    if (collision) {
+      return httpError(
+        "CONFLICT",
+        "Another memory item with this content already exists",
+        409,
+      );
+    }
+
+    set.fingerprint = fingerprint;
+  }
+
+  db.update(memoryItems).set(set).where(eq(memoryItems.id, id)).run();
+
+  // If statement changed, enqueue embed job
+  if (body.statement !== undefined) {
+    enqueueMemoryJob("embed_item", { itemId: id });
+  }
+
+  // Fetch and return the updated row
+  const updatedRow = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, id))
+    .get();
+
+  return Response.json({ item: updatedRow });
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/memory-items/:id
+// ---------------------------------------------------------------------------
+
+export async function handleDeleteMemoryItem(
+  ctx: RouteContext,
+): Promise<Response> {
+  const { id } = ctx.params;
+  const db = getDb();
+
+  const existing = db
+    .select()
+    .from(memoryItems)
+    .where(eq(memoryItems.id, id))
+    .get();
+
+  if (!existing) {
+    return httpError("NOT_FOUND", "Memory item not found", 404);
+  }
+
+  // Delete embeddings for this item
+  db.delete(memoryEmbeddings)
+    .where(
+      and(
+        eq(memoryEmbeddings.targetType, "item"),
+        eq(memoryEmbeddings.targetId, id),
+      ),
+    )
+    .run();
+
+  // Delete the item (cascades memoryItemSources)
+  db.delete(memoryItems).where(eq(memoryItems.id, id)).run();
+
+  return new Response(null, { status: 204 });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function memoryItemRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "memory-items",
+      method: "GET",
+      handler: (ctx) => handleListMemoryItems(ctx.url),
+    },
+    {
+      endpoint: "memory-items/:id",
+      method: "GET",
+      policyKey: "memory-items",
+      handler: (ctx) => handleGetMemoryItem(ctx),
+    },
+    {
+      endpoint: "memory-items",
+      method: "POST",
+      handler: (ctx) => handleCreateMemoryItem(ctx),
+    },
+    {
+      endpoint: "memory-items/:id",
+      method: "PATCH",
+      policyKey: "memory-items",
+      handler: (ctx) => handleUpdateMemoryItem(ctx),
+    },
+    {
+      endpoint: "memory-items/:id",
+      method: "DELETE",
+      policyKey: "memory-items",
+      handler: (ctx) => handleDeleteMemoryItem(ctx),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds 5 new HTTP API routes for memory item CRUD operations (list, get, create, update, delete)
- Supports filtering by kind/status, text search, sorting, and pagination
- Reuses existing fingerprint computation and embedding job infrastructure

Part of plan: memories-tab.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
