### PR TITLE
feat: add shared MemoryItemPayload and MemoryKindStyle types

### DIFF
--- a/clients/shared/Features/Memory/MemoryItemPayload.swift
+++ b/clients/shared/Features/Memory/MemoryItemPayload.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// A single memory item returned by the assistant's memory API.
+public struct MemoryItemPayload: Codable, Identifiable, Hashable, Sendable {
+    public let id: String
+    public let kind: String
+    public let subject: String
+    public let statement: String
+    public let status: String
+    public let confidence: Double
+    public let importance: Double?
+    public let accessCount: Int
+    public let verificationState: String
+    public let scopeId: String
+    public let firstSeenAt: Int      // epoch ms
+    public let lastSeenAt: Int       // epoch ms
+    public let lastUsedAt: Int?      // epoch ms
+    public let supersedes: String?
+    public let supersededBy: String?
+    public let supersedesSubject: String?    // populated by GET detail
+    public let supersededBySubject: String?  // populated by GET detail
+
+    enum CodingKeys: String, CodingKey {
+        case id, kind, subject, statement, status, confidence, importance
+        case accessCount, verificationState, scopeId
+        case firstSeenAt, lastSeenAt, lastUsedAt
+        case supersedes, supersededBy
+        case supersedesSubject, supersededBySubject
+    }
+
+    // MARK: - Date Helpers
+
+    /// Converts `firstSeenAt` (epoch milliseconds) to a `Date`.
+    public var firstSeenDate: Date {
+        Date(timeIntervalSince1970: Double(firstSeenAt) / 1000.0)
+    }
+
+    /// Converts `lastSeenAt` (epoch milliseconds) to a `Date`.
+    public var lastSeenDate: Date {
+        Date(timeIntervalSince1970: Double(lastSeenAt) / 1000.0)
+    }
+
+    /// Converts `lastUsedAt` (epoch milliseconds) to a `Date`, if present.
+    public var lastUsedDate: Date? {
+        guard let ms = lastUsedAt else { return nil }
+        return Date(timeIntervalSince1970: Double(ms) / 1000.0)
+    }
+
+    /// Human-readable relative time for `lastSeenAt` (e.g. "2 hours ago").
+    public var relativeLastSeen: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: lastSeenDate, relativeTo: Date())
+    }
+
+    // MARK: - Status Helpers
+
+    /// Whether this memory has been superseded by another.
+    public var isSuperseded: Bool {
+        supersededBy != nil
+    }
+
+    /// Whether the user has explicitly confirmed this memory.
+    public var isUserConfirmed: Bool {
+        verificationState == "user_confirmed"
+    }
+}
+
+/// Response shape for the memory items list endpoint.
+public struct MemoryItemsListResponse: Codable, Sendable {
+    public let items: [MemoryItemPayload]
+    public let total: Int
+}

--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// The six memory kinds with display metadata (label, color, icon).
+public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
+    case identity
+    case preference
+    case project
+    case decision
+    case constraint
+    case event
+
+    public var id: String { rawValue }
+
+    /// Capitalised display label for the kind.
+    public var label: String { rawValue.capitalized }
+
+    /// Distinct fun-palette color for each kind.
+    public var color: Color {
+        switch self {
+        case .identity:   return VColor.funTeal
+        case .preference: return VColor.funPurple
+        case .project:    return VColor.funGreen
+        case .decision:   return VColor.funYellow
+        case .constraint: return VColor.funCoral
+        case .event:      return VColor.funPink
+        }
+    }
+
+    /// Lucide icon raw value matching `VIcon` cases.
+    public var icon: String {
+        switch self {
+        case .identity:   return VIcon.user.rawValue
+        case .preference: return VIcon.heart.rawValue
+        case .project:    return VIcon.folder.rawValue
+        case .decision:   return VIcon.gitBranch.rawValue
+        case .constraint: return VIcon.shield.rawValue
+        case .event:      return VIcon.calendar.rawValue
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MemoryItemPayload` Codable struct with computed date helpers and status checks
- Adds `MemoryItemsListResponse` for list endpoint decoding
- Adds `MemoryKind` enum mapping 6 kinds to distinct colors and icons from the design system

Part of plan: memories-tab.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
