### PR TITLE
feat: add memory items network endpoints and shared store

### DIFF
--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Shared store for memory item CRUD operations with filter state.
+/// Used by both macOS and iOS memory list views.
+@MainActor
+public final class MemoryItemsStore: ObservableObject {
+    @Published public var items: [MemoryItemPayload] = []
+    @Published public var total: Int = 0
+    @Published public var isLoading = false
+
+    // Filter state
+    @Published public var kindFilter: String? = nil
+    @Published public var statusFilter: String? = "active"
+    @Published public var searchText: String = ""
+    @Published public var sortField: String = "lastSeenAt"
+    @Published public var sortOrder: String = "desc"
+
+    private let daemonClient: DaemonClient
+
+    public init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    /// Load memory items using the current filter state.
+    public func loadItems() async {
+        isLoading = true
+        let response = await daemonClient.fetchMemoryItems(
+            kind: kindFilter,
+            status: statusFilter,
+            search: searchText.isEmpty ? nil : searchText,
+            sort: sortField,
+            order: sortOrder
+        )
+        items = response?.items ?? []
+        total = response?.total ?? 0
+        isLoading = false
+    }
+
+    /// Create a new memory item and refresh the list on success.
+    public func createItem(
+        kind: String,
+        subject: String,
+        statement: String,
+        importance: Double? = nil
+    ) async -> MemoryItemPayload? {
+        let item = await daemonClient.createMemoryItem(
+            kind: kind,
+            subject: subject,
+            statement: statement,
+            importance: importance
+        )
+        if item != nil { await loadItems() }
+        return item
+    }
+
+    /// Update an existing memory item and refresh the list on success.
+    public func updateItem(
+        id: String,
+        subject: String? = nil,
+        statement: String? = nil,
+        kind: String? = nil,
+        status: String? = nil,
+        importance: Double? = nil,
+        verificationState: String? = nil
+    ) async -> MemoryItemPayload? {
+        let item = await daemonClient.updateMemoryItem(
+            id: id,
+            subject: subject,
+            statement: statement,
+            kind: kind,
+            status: status,
+            importance: importance,
+            verificationState: verificationState
+        )
+        if item != nil { await loadItems() }
+        return item
+    }
+
+    /// Delete a memory item and refresh the list on success.
+    public func deleteItem(id: String) async -> Bool {
+        let success = await daemonClient.deleteMemoryItem(id: id)
+        if success { await loadItems() }
+        return success
+    }
+}

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2422,6 +2422,137 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
+    // MARK: - Memory Items
+
+    /// Fetch a paginated list of memory items with optional filters.
+    public func fetchMemoryItems(
+        kind: String? = nil,
+        status: String? = "active",
+        search: String? = nil,
+        sort: String? = "lastSeenAt",
+        order: String? = "desc",
+        limit: Int = 100,
+        offset: Int = 0
+    ) async -> MemoryItemsListResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchMemoryItems(
+                kind: kind, status: status, search: search,
+                sort: sort, order: order, limit: limit, offset: offset
+            )
+        }
+
+        var queryParts = ["limit=\(limit)", "offset=\(offset)"]
+        if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+        if let status { queryParts.append("status=\(status)") }
+        if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+        if let sort { queryParts.append("sort=\(sort)") }
+        if let order { queryParts.append("order=\(order)") }
+        let qs = queryParts.joined(separator: "&")
+        return await executeLocalRequest(path: "v1/memory-items?\(qs)")
+    }
+
+    /// Fetch a single memory item by ID.
+    public func fetchMemoryItem(id: String) async -> MemoryItemPayload? {
+        if let httpTransport {
+            return await httpTransport.fetchMemoryItem(id: id)
+        }
+
+        struct Wrapper: Decodable { let item: MemoryItemPayload }
+        let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        guard let wrapper: Wrapper = await executeLocalRequest(path: "v1/memory-items/\(encoded)") else { return nil }
+        return wrapper.item
+    }
+
+    /// Create a new memory item.
+    public func createMemoryItem(
+        kind: String,
+        subject: String,
+        statement: String,
+        importance: Double? = nil
+    ) async -> MemoryItemPayload? {
+        if let httpTransport {
+            return await httpTransport.createMemoryItem(
+                kind: kind, subject: subject, statement: statement, importance: importance
+            )
+        }
+
+        var body: [String: Any] = [
+            "kind": kind,
+            "subject": subject,
+            "statement": statement
+        ]
+        if let importance { body["importance"] = importance }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+
+        struct Wrapper: Decodable { let item: MemoryItemPayload }
+        guard let wrapper: Wrapper = await executeLocalRequest(path: "v1/memory-items", method: "POST", body: bodyData) else { return nil }
+        return wrapper.item
+    }
+
+    /// Update an existing memory item.
+    public func updateMemoryItem(
+        id: String,
+        subject: String? = nil,
+        statement: String? = nil,
+        kind: String? = nil,
+        status: String? = nil,
+        importance: Double? = nil,
+        verificationState: String? = nil
+    ) async -> MemoryItemPayload? {
+        if let httpTransport {
+            return await httpTransport.updateMemoryItem(
+                id: id, subject: subject, statement: statement,
+                kind: kind, status: status, importance: importance,
+                verificationState: verificationState
+            )
+        }
+
+        var body: [String: Any] = [:]
+        if let subject { body["subject"] = subject }
+        if let statement { body["statement"] = statement }
+        if let kind { body["kind"] = kind }
+        if let status { body["status"] = status }
+        if let importance { body["importance"] = importance }
+        if let verificationState { body["verificationState"] = verificationState }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+
+        let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        struct Wrapper: Decodable { let item: MemoryItemPayload }
+        guard let wrapper: Wrapper = await executeLocalRequest(path: "v1/memory-items/\(encoded)", method: "PATCH", body: bodyData) else { return nil }
+        return wrapper.item
+    }
+
+    /// Delete a memory item by ID.
+    public func deleteMemoryItem(id: String) async -> Bool {
+        if let httpTransport {
+            return await httpTransport.deleteMemoryItem(id: id)
+        }
+
+        let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        guard var request = buildLocalRequest(target: .daemon, path: "v1/memory-items/\(encoded)", method: "DELETE") else { return false }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else { return false }
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else { return false }
+
+                guard let retryRequest = buildLocalRequest(target: .daemon, path: "v1/memory-items/\(encoded)", method: "DELETE") else { return false }
+                let (_, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse else { return false }
+                return retryHttp.statusCode == 204
+            }
+
+            return http.statusCode == 204
+        } catch {
+            log.error("deleteMemoryItem failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     // MARK: - Actor Token Bootstrap
 
     /// Response from `POST /v1/guardian/init`.

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -429,6 +429,13 @@ public final class HTTPTransport {
         case channelVerificationSessionsResend
         case channelVerificationSessionsRevoke
         case registerDeviceToken
+
+        // Memory Items
+        case memoryItemsList(kind: String?, status: String?, search: String?, sort: String?, order: String?, limit: Int, offset: Int)
+        case memoryItemGet(id: String)
+        case memoryItemCreate
+        case memoryItemUpdate(id: String)
+        case memoryItemDelete(id: String)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -829,6 +836,26 @@ public final class HTTPTransport {
             return ("/v1/channel-verification-sessions/revoke", nil)
         case .registerDeviceToken:
             return ("/v1/device-token", nil)
+        // Memory Items
+        case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
+            var queryParts = ["limit=\(limit)", "offset=\(offset)"]
+            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+            if let status { queryParts.append("status=\(status)") }
+            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+            if let sort { queryParts.append("sort=\(sort)") }
+            if let order { queryParts.append("order=\(order)") }
+            return ("/v1/memory-items", queryParts.joined(separator: "&"))
+        case .memoryItemGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/memory-items/\(encoded)", nil)
+        case .memoryItemCreate:
+            return ("/v1/memory-items", nil)
+        case .memoryItemUpdate(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/memory-items/\(encoded)", nil)
+        case .memoryItemDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/memory-items/\(encoded)", nil)
         }
     }
 
@@ -1210,6 +1237,26 @@ public final class HTTPTransport {
             return ("\(prefix)/channel-verification-sessions/revoke/", nil)
         case .registerDeviceToken:
             return ("\(prefix)/device-token/", nil)
+        // Memory Items
+        case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
+            var queryParts = ["limit=\(limit)", "offset=\(offset)"]
+            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+            if let status { queryParts.append("status=\(status)") }
+            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+            if let sort { queryParts.append("sort=\(sort)") }
+            if let order { queryParts.append("order=\(order)") }
+            return ("\(prefix)/memory-items/", queryParts.joined(separator: "&"))
+        case .memoryItemGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/memory-items/\(encoded)/", nil)
+        case .memoryItemCreate:
+            return ("\(prefix)/memory-items/", nil)
+        case .memoryItemUpdate(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/memory-items/\(encoded)/", nil)
+        case .memoryItemDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/memory-items/\(encoded)/", nil)
         }
     }
 
@@ -4490,6 +4537,190 @@ public final class HTTPTransport {
             if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
                 request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
             }
+        }
+    }
+
+    // MARK: - Memory Items
+
+    /// Fetch a paginated list of memory items with optional filters.
+    func fetchMemoryItems(
+        kind: String? = nil,
+        status: String? = "active",
+        search: String? = nil,
+        sort: String? = "lastSeenAt",
+        order: String? = "desc",
+        limit: Int = 100,
+        offset: Int = 0,
+        isRetry: Bool = false
+    ) async -> MemoryItemsListResponse? {
+        guard let url = buildURL(for: .memoryItemsList(
+            kind: kind, status: status, search: search,
+            sort: sort, order: order, limit: limit, offset: offset
+        )) else { return nil }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchMemoryItems(kind: kind, status: status, search: search, sort: sort, order: order, limit: limit, offset: offset, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(MemoryItemsListResponse.self, from: data)
+        } catch {
+            log.error("fetchMemoryItems failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch a single memory item by ID.
+    func fetchMemoryItem(id: String, isRetry: Bool = false) async -> MemoryItemPayload? {
+        guard let url = buildURL(for: .memoryItemGet(id: id)) else { return nil }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchMemoryItem(id: id, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            struct Wrapper: Decodable { let item: MemoryItemPayload }
+            return try decoder.decode(Wrapper.self, from: data).item
+        } catch {
+            log.error("fetchMemoryItem failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Create a new memory item.
+    func createMemoryItem(
+        kind: String,
+        subject: String,
+        statement: String,
+        importance: Double? = nil,
+        isRetry: Bool = false
+    ) async -> MemoryItemPayload? {
+        guard let url = buildURL(for: .memoryItemCreate) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "kind": kind,
+            "subject": subject,
+            "statement": statement
+        ]
+        if let importance { body["importance"] = importance }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await createMemoryItem(kind: kind, subject: subject, statement: statement, importance: importance, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...201).contains(http.statusCode) else { return nil }
+            }
+            struct Wrapper: Decodable { let item: MemoryItemPayload }
+            return try decoder.decode(Wrapper.self, from: data).item
+        } catch {
+            log.error("createMemoryItem failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Update an existing memory item.
+    func updateMemoryItem(
+        id: String,
+        subject: String? = nil,
+        statement: String? = nil,
+        kind: String? = nil,
+        status: String? = nil,
+        importance: Double? = nil,
+        verificationState: String? = nil,
+        isRetry: Bool = false
+    ) async -> MemoryItemPayload? {
+        guard let url = buildURL(for: .memoryItemUpdate(id: id)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [:]
+        if let subject { body["subject"] = subject }
+        if let statement { body["statement"] = statement }
+        if let kind { body["kind"] = kind }
+        if let status { body["status"] = status }
+        if let importance { body["importance"] = importance }
+        if let verificationState { body["verificationState"] = verificationState }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await updateMemoryItem(id: id, subject: subject, statement: statement, kind: kind, status: status, importance: importance, verificationState: verificationState, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            struct Wrapper: Decodable { let item: MemoryItemPayload }
+            return try decoder.decode(Wrapper.self, from: data).item
+        } catch {
+            log.error("updateMemoryItem failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Delete a memory item by ID.
+    func deleteMemoryItem(id: String, isRetry: Bool = false) async -> Bool {
+        guard let url = buildURL(for: .memoryItemDelete(id: id)) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await deleteMemoryItem(id: id, isRetry: true)
+                    }
+                    return false
+                }
+                return http.statusCode == 204
+            }
+            return false
+        } catch {
+            log.error("deleteMemoryItem failed: \(error.localizedDescription)")
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds 5 `Endpoint` enum cases for memory item CRUD in `HTTPDaemonClient`
- Adds runtime flat and platform proxy path builders for all memory item endpoints
- Adds typed async methods: `fetchMemoryItems`, `fetchMemoryItem`, `createMemoryItem`, `updateMemoryItem`, `deleteMemoryItem` in both `HTTPDaemonClient` and `DaemonClient`
- Adds `MemoryItemsStore` ObservableObject with filter state, load, create, update, delete

Part of plan: memories-tab.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)