### PR TITLE
feat(ios): add Memories section to Intelligence tab

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -12,10 +12,12 @@ final class IdentityViewModel {
 
     var skillsStore: SkillsStore?
     var contactsStore: ContactsStore?
+    var memoriesStore: MemoryItemsStore?
 
     // Cached counts — updated via Combine when the stores' @Published properties change.
     var installedSkillsCount: Int = 0
     var contactsCount: Int = 0
+    var memoriesCount: Int = 0
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -39,16 +41,27 @@ final class IdentityViewModel {
             .sink { [weak self] count in self?.contactsCount = count }
             .store(in: &cancellables)
 
+        let memories = MemoryItemsStore(daemonClient: daemonClient)
+        memoriesStore = memories
+        memories.$items
+            .map(\.count)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] count in self?.memoriesCount = count }
+            .store(in: &cancellables)
+
         skills.fetchSkills(force: true)
         contacts.loadContacts()
+        Task { await memories.loadItems() }
     }
 
     func tearDown() {
         cancellables.removeAll()
         skillsStore = nil
         contactsStore = nil
+        memoriesStore = nil
         installedSkillsCount = 0
         contactsCount = 0
+        memoriesCount = 0
     }
 
     func fetchIdentity(client: any DaemonClientProtocol) async {
@@ -178,6 +191,35 @@ struct IdentityView: View {
                     }
                 }
                 .disabled(viewModel.contactsStore == nil)
+
+                // Memories
+                NavigationLink {
+                    if let store = viewModel.memoriesStore {
+                        MemoriesListView(store: store)
+                    }
+                } label: {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.bookOpen, size: 16)
+                            .foregroundColor(VColor.primaryBase)
+                            .frame(width: 24)
+                        Text("Memories")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                        Spacer()
+                        if viewModel.memoriesCount > 0 {
+                            Text("\(viewModel.memoriesCount)")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule()
+                                        .fill(VColor.borderBase)
+                                )
+                        }
+                    }
+                }
+                .disabled(viewModel.memoriesStore == nil)
             }
 
             // Workspace section
@@ -199,6 +241,9 @@ struct IdentityView: View {
         .refreshable {
             viewModel.skillsStore?.fetchSkills(force: true)
             viewModel.contactsStore?.loadContacts()
+            if let memoriesStore = viewModel.memoriesStore {
+                await memoriesStore.loadItems()
+            }
             await viewModel.fetchIdentity(client: clientProvider.client)
         }
     }

--- a/clients/ios/Views/Intelligence/MemoriesListView.swift
+++ b/clients/ios/Views/Intelligence/MemoriesListView.swift
@@ -1,0 +1,159 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+struct MemoriesListView: View {
+    @ObservedObject var store: MemoryItemsStore
+    @State private var searchText = ""
+    @State private var selectedKind: String? = nil
+    @State private var showCreateSheet = false
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.items.isEmpty {
+                loadingState
+            } else if store.items.isEmpty {
+                emptyState
+            } else {
+                memoriesList
+            }
+        }
+        .searchable(text: $searchText, prompt: "Search memories...")
+        .onChange(of: searchText) { _, newValue in
+            store.searchText = newValue
+            Task { await store.loadItems() }
+        }
+        .navigationTitle("Memories")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showCreateSheet = true
+                } label: {
+                    VIconView(.plus, size: 16)
+                }
+            }
+        }
+        .refreshable { await store.loadItems() }
+        .task { await store.loadItems() }
+    }
+
+    // MARK: - Memories List
+
+    private var memoriesList: some View {
+        List {
+            // Kind filter chips
+            Section {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: VSpacing.sm) {
+                        kindFilterChip("All", kind: nil)
+                        ForEach(MemoryKind.allCases) { kind in
+                            kindFilterChip(kind.label, kind: kind.rawValue)
+                        }
+                    }
+                }
+            }
+
+            // Memory items
+            Section {
+                ForEach(store.items) { item in
+                    memoryRow(item)
+                }
+            }
+        }
+    }
+
+    // MARK: - Kind Filter Chip
+
+    private func kindFilterChip(_ label: String, kind: String?) -> some View {
+        let isSelected = selectedKind == kind
+        return Button {
+            selectedKind = kind
+            store.kindFilter = kind
+            Task { await store.loadItems() }
+        } label: {
+            Text(label)
+                .font(VFont.caption)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? VColor.primaryBase : VColor.surfaceActive)
+                )
+                .foregroundColor(isSelected ? .white : VColor.contentSecondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) filter\(isSelected ? ", selected" : "")")
+    }
+
+    // MARK: - Memory Row
+
+    private func memoryRow(_ item: MemoryItemPayload) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            // Kind color indicator
+            Circle()
+                .fill(MemoryKind(rawValue: item.kind)?.color ?? VColor.contentTertiary)
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.subject)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.contentDefault)
+                    .lineLimit(1)
+
+                Text(item.statement)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Text(item.relativeLastSeen)
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+        }
+        .padding(.vertical, 2)
+        .swipeActions(edge: .trailing) {
+            Button("Delete", role: .destructive) {
+                Task { await store.deleteItem(id: item.id) }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Memory: \(item.subject). \(item.statement). \(item.relativeLastSeen)")
+    }
+
+    // MARK: - Empty States
+
+    private var emptyState: some View {
+        VStack(spacing: VSpacing.lg) {
+            VIconView(.bookOpen, size: 48)
+                .foregroundColor(VColor.contentTertiary)
+                .accessibilityHidden(true)
+
+            Text("No Memories Yet")
+                .font(VFont.title)
+                .foregroundColor(VColor.contentDefault)
+
+            Text("Your assistant learns from conversations.")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xl)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No memories yet. Your assistant learns from conversations.")
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: VSpacing.md) {
+            ProgressView()
+            Text("Loading memories...")
+                .font(VFont.body)
+                .foregroundColor(VColor.contentSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds Memories NavigationLink with count badge to IdentityView (between Contacts and Browse Workspace)
- Creates MemoriesListView with kind filter chips, search, pull-to-refresh, empty state
- Memory rows show kind indicator, subject, statement preview, timestamp, swipe-to-delete

Part of plan: memories-tab.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
