### PR TITLE
feat(macos): add Memories tab to Intelligence panel with list view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -15,6 +15,7 @@ struct IntelligencePanel: View {
         case installedSkills = "Installed Skills"
         case communitySkills = "Community Skills"
         case workspace = "Workspace"
+        case memories = "Memories"
     }
 
     private let maxContentWidth: CGFloat = 1100
@@ -106,6 +107,10 @@ struct IntelligencePanel: View {
 
         case .workspace:
             WorkspacePanel(daemonClient: daemonClient)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+
+        case .memories:
+            MemoriesPanel(daemonClient: daemonClient)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Sort Options
+
+private enum MemorySortOption: String, CaseIterable {
+    case newest = "Newest"
+    case oldest = "Oldest"
+    case importance = "Importance"
+    case kind = "Kind"
+
+    var sortField: String {
+        switch self {
+        case .newest, .oldest: return "lastSeenAt"
+        case .importance: return "importance"
+        case .kind: return "kind"
+        }
+    }
+
+    var sortOrder: String {
+        switch self {
+        case .newest, .importance: return "desc"
+        case .oldest, .kind: return "asc"
+        }
+    }
+}
+
+private enum MemoryStatusFilter: String, CaseIterable {
+    case active = "Active"
+    case inactive = "Inactive"
+    case all = "All"
+
+    /// API value: nil means no filter (all).
+    var apiValue: String? {
+        switch self {
+        case .active: return "active"
+        case .inactive: return "inactive"
+        case .all: return nil
+        }
+    }
+}
+
+// MARK: - Memories Panel
+
+struct MemoriesPanel: View {
+    let daemonClient: DaemonClient
+    @StateObject private var store: MemoryItemsStore
+    @State private var showCreateSheet = false
+    @State private var selectedItem: MemoryItemPayload?
+    @State private var selectedKind: MemoryKind?
+    @State private var statusFilter: MemoryStatusFilter = .active
+    @State private var sortOption: MemorySortOption = .newest
+    @State private var searchDebounceTask: Task<Void, Never>?
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+        _store = StateObject(wrappedValue: MemoryItemsStore(daemonClient: daemonClient))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            filterBar
+            Divider().background(VColor.borderDisabled)
+            contentView
+        }
+        .task { await store.loadItems() }
+    }
+
+    // MARK: - Filter Bar
+
+    @ViewBuilder
+    private var filterBar: some View {
+        VStack(spacing: VSpacing.sm) {
+            // Row 1: Kind filter chips
+            kindChips
+
+            // Row 2: Status, Search, Sort, New button
+            HStack(spacing: VSpacing.sm) {
+                VDropdown(
+                    placeholder: "Status",
+                    selection: $statusFilter,
+                    options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
+                )
+                .frame(width: 100)
+                .onChange(of: statusFilter) {
+                    store.statusFilter = statusFilter.apiValue
+                    Task { await store.loadItems() }
+                }
+
+                VSearchBar(placeholder: "Search memories...", text: $store.searchText)
+                    .onChange(of: store.searchText) {
+                        searchDebounceTask?.cancel()
+                        searchDebounceTask = Task {
+                            try? await Task.sleep(nanoseconds: 300_000_000)
+                            guard !Task.isCancelled else { return }
+                            await store.loadItems()
+                        }
+                    }
+
+                VDropdown(
+                    placeholder: "Sort",
+                    selection: $sortOption,
+                    options: MemorySortOption.allCases.map { ($0.rawValue, $0) }
+                )
+                .frame(width: 120)
+                .onChange(of: sortOption) {
+                    store.sortField = sortOption.sortField
+                    store.sortOrder = sortOption.sortOrder
+                    Task { await store.loadItems() }
+                }
+
+                VButton(label: "New", icon: VIcon.plus.rawValue, style: .outlined) {
+                    showCreateSheet = true
+                }
+                .accessibilityLabel("Create new memory")
+            }
+        }
+        .padding(VSpacing.md)
+    }
+
+    @ViewBuilder
+    private var kindChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: VSpacing.xs) {
+                kindChip(label: "All", kind: nil)
+                ForEach(MemoryKind.allCases) { kind in
+                    kindChip(label: kind.label, kind: kind)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func kindChip(label: String, kind: MemoryKind?) -> some View {
+        let isSelected = selectedKind == kind
+        Button {
+            selectedKind = kind
+            store.kindFilter = kind?.rawValue
+            Task { await store.loadItems() }
+        } label: {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(isSelected ? VColor.auxWhite : VColor.contentDefault)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.xxs)
+                .background(isSelected ? VColor.primaryBase : VColor.surfaceActive)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) filter")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Content View
+
+    @ViewBuilder
+    private var contentView: some View {
+        if store.isLoading && store.items.isEmpty {
+            VStack {
+                Spacer()
+                VLoadingIndicator()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if store.items.isEmpty {
+            VEmptyState(
+                title: "No Memories Yet",
+                subtitle: "Your assistant learns and remembers things from your conversations. Memories will appear here as they're created.",
+                icon: VIcon.bookOpen.rawValue
+            )
+        } else {
+            ScrollView {
+                LazyVStack(spacing: VSpacing.xs) {
+                    ForEach(store.items) { item in
+                        MemoryItemRow(
+                            item: item,
+                            onSelect: { selectedItem = item },
+                            onDelete: {
+                                Task { _ = await store.deleteItem(id: item.id) }
+                            }
+                        )
+                    }
+                }
+                .padding(VSpacing.md)
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MemoryItemRow: View {
+    let item: MemoryItemPayload
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                kindBadge
+
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    HStack {
+                        Text(item.subject)
+                            .font(VFont.bodyBold)
+                            .foregroundColor(VColor.contentDefault)
+
+                        Spacer()
+
+                        if item.isUserConfirmed {
+                            VIconView(.circleCheck, size: 12)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                                .accessibilityLabel("User confirmed")
+                        }
+
+                        Text(item.relativeLastSeen)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+
+                    Text(item.statement)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentSecondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+            }
+            .padding(VSpacing.md)
+            .background(isHovered ? VColor.surfaceActive : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .contextMenu {
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Kind Badge
+
+    @ViewBuilder
+    private var kindBadge: some View {
+        let memoryKind = MemoryKind(rawValue: item.kind)
+        let color = memoryKind?.color ?? VColor.contentTertiary
+        let label = memoryKind?.label ?? item.kind.capitalized
+
+        VBadge(style: .label(label), color: color)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Memories` tab to IntelligencePanel tab bar
- Creates MemoriesPanel with filter bar (kind chips, status, search, sort) and scrollable list
- Creates MemoryItemRow with kind badge, subject, statement preview, timestamp, hover state, context menu

Part of plan: memories-tab.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
