### PR TITLE
feat(macos): add memory item detail/edit and create sheets

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -64,6 +64,19 @@ struct MemoriesPanel: View {
             contentView
         }
         .task { await store.loadItems() }
+        .sheet(item: $selectedItem) { item in
+            MemoryItemDetailSheet(
+                item: item,
+                store: store,
+                onDismiss: { selectedItem = nil }
+            )
+        }
+        .sheet(isPresented: $showCreateSheet) {
+            MemoryItemCreateSheet(
+                store: store,
+                onDismiss: { showCreateSheet = false }
+            )
+        }
     }
 
     // MARK: - Filter Bar

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MemoryItemCreateSheet: View {
+    let store: MemoryItemsStore
+    let onDismiss: () -> Void
+
+    @State private var kind: String = "identity"
+    @State private var subject: String = ""
+    @State private var statement: String = ""
+    @State private var importance: Double = 0.8
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().background(VColor.borderBase)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    // Kind picker
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Kind")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        VDropdown(
+                            placeholder: "Kind",
+                            selection: $kind,
+                            options: MemoryKind.allCases.map { ($0.label, $0.rawValue) }
+                        )
+                    }
+
+                    // Subject
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Subject")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        VTextField(placeholder: "Brief topic or label", text: $subject)
+                    }
+
+                    // Statement
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        Text("Statement")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                        TextEditor(text: $statement)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .scrollContentBackground(.hidden)
+                            .padding(VSpacing.sm)
+                            .background(VColor.surfaceActive)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .stroke(VColor.borderBase, lineWidth: 1)
+                            )
+                            .frame(minHeight: 100)
+                            .overlay(alignment: .topLeading) {
+                                if statement.isEmpty {
+                                    Text("What should the assistant remember?")
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.contentTertiary)
+                                        .padding(VSpacing.sm)
+                                        .padding(.top, 1)
+                                        .allowsHitTesting(false)
+                                }
+                            }
+                    }
+
+                    // Importance slider
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack {
+                            Text("Importance")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            Spacer()
+                            Text("\(Int(importance * 100))%")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentSecondary)
+                        }
+                        Slider(value: $importance, in: 0...1, step: 0.1)
+                            .tint(VColor.primaryBase)
+                    }
+
+                    if let errorMessage {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.circleAlert, size: 11)
+                                .foregroundColor(VColor.systemNegativeStrong)
+                            Text(errorMessage)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.systemNegativeStrong)
+                        }
+                    }
+                }
+                .padding(VSpacing.xl)
+            }
+
+            Divider().background(VColor.borderBase)
+            footer
+        }
+        .frame(width: 480, height: 460)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(.plus, size: 14)
+                .foregroundColor(VColor.primaryBase)
+            Text("New Memory")
+                .font(VFont.display)
+                .foregroundColor(VColor.contentDefault)
+            Spacer()
+            Button {
+                onDismiss()
+            } label: {
+                VIconView(.x, size: 11)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 24, height: 24)
+                    .background(VColor.surfaceBase)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            Button {
+                onDismiss()
+            } label: {
+                Text("Cancel")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            VButton(
+                label: isCreating ? "Creating..." : "Create",
+                leftIcon: isCreating ? nil : VIcon.plus.rawValue,
+                style: .primary,
+                isDisabled: !isFormValid || isCreating
+            ) {
+                create()
+            }
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Validation
+
+    private var isFormValid: Bool {
+        !subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !statement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Actions
+
+    private func create() {
+        isCreating = true
+        errorMessage = nil
+        Task {
+            let result = await store.createItem(
+                kind: kind,
+                subject: subject.trimmingCharacters(in: .whitespacesAndNewlines),
+                statement: statement.trimmingCharacters(in: .whitespacesAndNewlines),
+                importance: importance
+            )
+            isCreating = false
+            if result != nil {
+                onDismiss()
+            } else {
+                errorMessage = "Failed to create memory. Please try again."
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -1,0 +1,364 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct MemoryItemDetailSheet: View {
+    let item: MemoryItemPayload
+    let store: MemoryItemsStore
+    let onDismiss: () -> Void
+
+    @State private var isEditing = false
+    @State private var editSubject: String
+    @State private var editStatement: String
+    @State private var editKind: String
+    @State private var editStatus: String
+    @State private var editImportance: Double
+    @State private var isSaving = false
+    @State private var showDeleteConfirm = false
+    @State private var errorMessage: String?
+
+    init(item: MemoryItemPayload, store: MemoryItemsStore, onDismiss: @escaping () -> Void) {
+        self.item = item
+        self.store = store
+        self.onDismiss = onDismiss
+        _editSubject = State(initialValue: item.subject)
+        _editStatement = State(initialValue: item.statement)
+        _editKind = State(initialValue: item.kind)
+        _editStatus = State(initialValue: item.status)
+        _editImportance = State(initialValue: item.importance ?? 0.5)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().background(VColor.borderBase)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: VSpacing.xl) {
+                    if isEditing {
+                        editModeContent
+                    } else {
+                        viewModeContent
+                    }
+                }
+                .padding(VSpacing.xl)
+            }
+
+            if let errorMessage {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleAlert, size: 11)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                    Text(errorMessage)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .padding(.bottom, VSpacing.sm)
+            }
+
+            Divider().background(VColor.borderBase)
+            footer
+        }
+        .frame(width: 480, height: 520)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .alert("Delete this memory?", isPresented: $showDeleteConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                Task {
+                    _ = await store.deleteItem(id: item.id)
+                    onDismiss()
+                }
+            }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: VSpacing.sm) {
+            kindBadge
+            Text(item.subject)
+                .font(VFont.headline)
+                .foregroundColor(VColor.contentDefault)
+                .lineLimit(1)
+            Spacer()
+
+            if !isEditing {
+                VIconButton(
+                    label: "Edit",
+                    icon: VIcon.pencil.rawValue,
+                    iconOnly: true,
+                    tooltip: "Edit memory"
+                ) {
+                    isEditing = true
+                }
+
+                VIconButton(
+                    label: "Delete",
+                    icon: VIcon.trash.rawValue,
+                    iconOnly: true,
+                    variant: .danger,
+                    tooltip: "Delete memory"
+                ) {
+                    showDeleteConfirm = true
+                }
+            }
+
+            Button {
+                onDismiss()
+            } label: {
+                VIconView(.x, size: 11)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 24, height: 24)
+                    .background(VColor.surfaceBase)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - View Mode
+
+    @ViewBuilder
+    private var viewModeContent: some View {
+        // Statement
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("Statement")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+            Text(item.statement)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .textSelection(.enabled)
+        }
+
+        // Metadata
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Details")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+
+            metadataRow(label: "Kind", value: memoryKind?.label ?? item.kind.capitalized)
+            metadataRow(label: "Status", value: item.status.capitalized)
+            metadataRow(label: "Confidence", value: "\(Int(item.confidence * 100))%")
+            if let importance = item.importance {
+                metadataRow(label: "Importance", value: "\(Int(importance * 100))%")
+            }
+
+            // Verification state
+            HStack(spacing: VSpacing.xs) {
+                Text("Verification")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 100, alignment: .leading)
+                if item.isUserConfirmed {
+                    VIconView(.circleCheck, size: 12)
+                        .foregroundColor(VColor.systemPositiveStrong)
+                    Text("Confirmed by you")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                } else {
+                    VIconView(.sparkles, size: 12)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text("Inferred by assistant")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+            }
+
+            metadataRow(label: "First seen", value: formattedDate(item.firstSeenDate))
+            metadataRow(label: "Last seen", value: formattedDate(item.lastSeenDate))
+            if let lastUsedDate = item.lastUsedDate {
+                metadataRow(label: "Last used", value: formattedDate(lastUsedDate))
+            }
+            metadataRow(label: "Access count", value: "\(item.accessCount)")
+
+            // Supersession
+            if let supersededBySubject = item.supersededBySubject {
+                metadataRow(label: "Superseded by", value: supersededBySubject)
+            }
+            if let supersedesSubject = item.supersedesSubject {
+                metadataRow(label: "Supersedes", value: supersedesSubject)
+            }
+        }
+    }
+
+    // MARK: - Edit Mode
+
+    @ViewBuilder
+    private var editModeContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Subject
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Subject")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VTextField(placeholder: "Brief topic or label", text: $editSubject)
+            }
+
+            // Statement
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Statement")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                TextEditor(text: $editStatement)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                    .scrollContentBackground(.hidden)
+                    .padding(VSpacing.sm)
+                    .background(VColor.surfaceActive)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .stroke(VColor.borderBase, lineWidth: 1)
+                    )
+                    .frame(minHeight: 100)
+            }
+
+            // Kind picker
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Kind")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VDropdown(
+                    placeholder: "Kind",
+                    selection: $editKind,
+                    options: MemoryKind.allCases.map { ($0.label, $0.rawValue) }
+                )
+            }
+
+            // Status picker
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Status")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VDropdown(
+                    placeholder: "Status",
+                    selection: $editStatus,
+                    options: [("Active", "active"), ("Inactive", "inactive")]
+                )
+            }
+
+            // Importance slider
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack {
+                    Text("Importance")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Spacer()
+                    Text("\(Int(editImportance * 100))%")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+                Slider(value: $editImportance, in: 0...1, step: 0.1)
+                    .tint(VColor.primaryBase)
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            if isEditing {
+                Button {
+                    isEditing = false
+                    errorMessage = nil
+                    // Reset to original values
+                    editSubject = item.subject
+                    editStatement = item.statement
+                    editKind = item.kind
+                    editStatus = item.status
+                    editImportance = item.importance ?? 0.5
+                } label: {
+                    Text("Cancel")
+                        .font(VFont.bodyMedium)
+                        .foregroundColor(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                VButton(
+                    label: isSaving ? "Saving..." : "Save",
+                    style: .primary,
+                    isDisabled: isSaving
+                ) {
+                    save()
+                }
+            } else {
+                Spacer()
+            }
+        }
+        .padding(.horizontal, VSpacing.xl)
+        .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Actions
+
+    private func save() {
+        isSaving = true
+        errorMessage = nil
+        Task {
+            // Only send changed fields
+            let newSubject = editSubject != item.subject ? editSubject : nil
+            let newStatement = editStatement != item.statement ? editStatement : nil
+            let newKind = editKind != item.kind ? editKind : nil
+            let newStatus = editStatus != item.status ? editStatus : nil
+            let newImportance = editImportance != (item.importance ?? 0.5) ? editImportance : nil
+
+            let result = await store.updateItem(
+                id: item.id,
+                subject: newSubject,
+                statement: newStatement,
+                kind: newKind,
+                status: newStatus,
+                importance: newImportance
+            )
+
+            isSaving = false
+            if result != nil {
+                onDismiss()
+            } else {
+                errorMessage = "Failed to save changes. Please try again."
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var memoryKind: MemoryKind? {
+        MemoryKind(rawValue: item.kind)
+    }
+
+    @ViewBuilder
+    private var kindBadge: some View {
+        let color = memoryKind?.color ?? VColor.contentTertiary
+        let label = memoryKind?.label ?? item.kind.capitalized
+        VBadge(style: .label(label), color: color)
+    }
+
+    private func metadataRow(label: String, value: String) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(width: 100, alignment: .leading)
+            Text(value)
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds MemoryItemDetailSheet with view mode (all fields) and edit mode (subject, statement, kind, status, importance)
- Adds MemoryItemCreateSheet with kind picker, subject, statement, importance
- Wires both sheets into MemoriesPanel via selectedItem and showCreateSheet state

Part of plan: memories-tab.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
