### PR TITLE
fix: add route policy, PATCH validation, and status filter for memory items

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -347,6 +347,12 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "skills:DELETE", scopes: ["settings.write"] },
   { endpoint: "skills:PATCH", scopes: ["settings.write"] },
 
+  // Memory items
+  { endpoint: "memory-items:GET", scopes: ["settings.read"] },
+  { endpoint: "memory-items:POST", scopes: ["settings.write"] },
+  { endpoint: "memory-items:PATCH", scopes: ["settings.write"] },
+  { endpoint: "memory-items:DELETE", scopes: ["settings.write"] },
+
   // Trust rule CRUD management
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },
   { endpoint: "trust-rules/manage:POST", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -103,7 +103,7 @@ export function handleListMemoryItems(url: URL): Response {
 
   // Build WHERE conditions
   const conditions = [];
-  if (statusParam) {
+  if (statusParam && statusParam !== "all") {
     conditions.push(eq(memoryItems.status, statusParam));
   }
   if (kindParam) {
@@ -337,9 +337,15 @@ export async function handleUpdateMemoryItem(
   };
 
   if (body.subject !== undefined) {
+    if (typeof body.subject !== "string") {
+      return httpError("BAD_REQUEST", "subject must be a string", 400);
+    }
     set.subject = truncate(body.subject.trim(), 80, "");
   }
   if (body.statement !== undefined) {
+    if (typeof body.statement !== "string") {
+      return httpError("BAD_REQUEST", "statement must be a string", 400);
+    }
     set.statement = truncate(body.statement.trim(), 500, "");
   }
   if (body.kind !== undefined) {


### PR DESCRIPTION
## Summary
- Add route policy entries for memory-items endpoints (read → settings.read, write → settings.write)
- Add type validation in PATCH handler before calling .trim() on subject/statement
- Support `status=all` query param to return items of any status

Fixes gaps from memories-tab.md plan review (round 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
