### PR TITLE
fix(macos): status filter sends 'all' sentinel and cancel task on disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -30,12 +30,12 @@ private enum MemoryStatusFilter: String, CaseIterable {
     case inactive = "Inactive"
     case all = "All"
 
-    /// API value: nil means no filter (all).
-    var apiValue: String? {
+    /// API value sent as the `status` query parameter.
+    var apiValue: String {
         switch self {
         case .active: return "active"
         case .inactive: return "inactive"
-        case .all: return nil
+        case .all: return "all"
         }
     }
 }
@@ -64,6 +64,10 @@ struct MemoriesPanel: View {
             contentView
         }
         .task { await store.loadItems() }
+        .onDisappear {
+            searchDebounceTask?.cancel()
+            searchDebounceTask = nil
+        }
         .sheet(item: $selectedItem) { item in
             MemoryItemDetailSheet(
                 item: item,


### PR DESCRIPTION
## Summary
- Change MemoryStatusFilter.all to send `status=all` instead of omitting the param
- Add .onDisappear to cancel searchDebounceTask

Fixes gaps from memories-tab.md plan review (round 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
