### PR TITLE
fix: suppress unused variable warning in DaemonClient.deleteMemoryItem

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2532,7 +2532,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard var request = buildLocalRequest(target: .daemon, path: "v1/memory-items/\(encoded)", method: "DELETE") else { return false }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else { return false }
 
             if http.statusCode == 401 {


### PR DESCRIPTION
## Summary
- Change `let (data, response)` to `let (_, response)` in deleteMemoryItem to match existing DELETE endpoint pattern

Fixes gap from memories-tab.md plan review (round 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)