### PR TITLE
fix(ios): only dismiss create view on success, show error on failure

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemCreateView.swift
@@ -11,6 +11,7 @@ struct MemoryItemCreateView: View {
     @State private var statement: String = ""
     @State private var importance: Double = 0.8
     @State private var isCreating = false
+    @State private var errorMessage: String?
 
     private var canCreate: Bool {
         !subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -61,6 +62,14 @@ struct MemoryItemCreateView: View {
                     Slider(value: $importance, in: 0...1, step: 0.1)
                 }
             }
+
+            if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
+            }
         }
         .navigationTitle("New Memory")
         .navigationBarTitleDisplayMode(.inline)
@@ -82,14 +91,20 @@ struct MemoryItemCreateView: View {
 
     private func createMemory() {
         isCreating = true
+        errorMessage = nil
         Task {
-            _ = await store.createItem(
+            let result = await store.createItem(
                 kind: kind,
                 subject: subject.trimmingCharacters(in: .whitespacesAndNewlines),
                 statement: statement.trimmingCharacters(in: .whitespacesAndNewlines),
                 importance: importance
             )
-            dismiss()
+            isCreating = false
+            if result != nil {
+                dismiss()
+            } else {
+                errorMessage = "Failed to create memory. Please try again."
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Check createItem() return value before dismissing
- Show error message on creation failure instead of silently dismissing
- Matches macOS MemoryItemCreateSheet error handling pattern

Fixes gap from memories-tab.md plan review (round 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
