### PR TITLE
test: add coverage for status=all sentinel in memory items list

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -210,6 +210,35 @@ describe("Memory Item Routes", () => {
       expect(body.items[0].id).toBe("i1");
     });
 
+    test("returns items of all statuses when status=all", async () => {
+      insertItem({
+        id: "i1",
+        kind: "preference",
+        subject: "s1",
+        statement: "st1",
+        status: "active",
+      });
+      insertItem({
+        id: "i2",
+        kind: "identity",
+        subject: "s2",
+        statement: "st2",
+        status: "deleted",
+      });
+
+      const ctx = makeCtx({ status: "all" });
+      const res = await handler(ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        items: Array<{ id: string }>;
+        total: number;
+      };
+      expect(body.total).toBe(2);
+      expect(body.items.length).toBe(2);
+      const ids = body.items.map((i) => i.id).sort();
+      expect(ids).toEqual(["i1", "i2"]);
+    });
+
     test("filters by kind", async () => {
       insertItem({
         id: "i1",


### PR DESCRIPTION
## Summary
- Add test verifying `status=all` returns items of all statuses
- Ensures the sentinel value introduced in #16129 doesn't regress

Fixes gap from memories-tab.md plan review (round 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
