### PR TITLE
fix(ios): dismiss detail view only after successful delete

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -15,6 +15,7 @@ struct MemoryItemDetailView: View {
     @State private var editImportance: Double
     @State private var showDeleteConfirm = false
     @State private var showSaveError = false
+    @State private var showDeleteError = false
 
     /// Live item data from store (updates after save).
     private var liveItem: MemoryItemPayload {
@@ -72,8 +73,14 @@ struct MemoryItemDetailView: View {
         .alert("Delete Memory?", isPresented: $showDeleteConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
-                Task { await store.deleteItem(id: liveItem.id) }
-                dismiss()
+                Task {
+                    let success = await store.deleteItem(id: liveItem.id)
+                    if success {
+                        dismiss()
+                    } else {
+                        showDeleteError = true
+                    }
+                }
             }
         } message: {
             Text("Are you sure you want to delete this memory? This action cannot be undone.")
@@ -82,6 +89,11 @@ struct MemoryItemDetailView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Unable to save changes. Please try again.")
+        }
+        .alert("Delete Failed", isPresented: $showDeleteError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Unable to delete memory. Please try again.")
         }
         .task {
             await store.fetchDetail(id: item.id)


### PR DESCRIPTION
## Summary
- Move dismiss() inside Task, gated on delete success
- Show error alert if delete fails
- Matches macOS detail sheet pattern and iOS save/create patterns

Fixes gap from memories-tab.md plan review (round 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
