### PR TITLE
feat(cli): smart default when running vellum with no args

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
   getActiveAssistant,
   findAssistantByName,
   loadLatestAssistant,
+  setActiveAssistant,
 } from "./lib/assistant-config";
 import { checkHealth } from "./lib/health-check";
 
@@ -84,6 +85,10 @@ async function tryLaunchClient(): Promise<boolean> {
 
   const result = await checkHealth(url, entry.bearerToken);
   if (result.status !== "healthy") return false;
+
+  // Ensure the resolved assistant is active so client() can find it
+  // (client() independently reads the active assistant from config).
+  setActiveAssistant(String(entry.assistantId));
 
   await client();
   return true;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,12 @@ import { ssh } from "./commands/ssh";
 import { tunnel } from "./commands/tunnel";
 import { use } from "./commands/use";
 import { wake } from "./commands/wake";
+import {
+  getActiveAssistant,
+  findAssistantByName,
+  loadLatestAssistant,
+} from "./lib/assistant-config";
+import { checkHealth } from "./lib/health-check";
 
 const commands = {
   clean,
@@ -37,6 +43,52 @@ const commands = {
 
 type CommandName = keyof typeof commands;
 
+function printHelp(): void {
+  console.log("Usage: vellum <command> [options]");
+  console.log("");
+  console.log("Commands:");
+  console.log("  clean    Kill orphaned vellum processes");
+  console.log("  client   Connect to a hatched assistant");
+  console.log("  hatch    Create a new assistant instance");
+  console.log("  login    Log in to the Vellum platform");
+  console.log("  logout   Log out of the Vellum platform");
+  console.log("  pair     Pair with a remote assistant via QR code");
+  console.log(
+    "  ps       List assistants (or processes for a specific assistant)",
+  );
+  console.log("  recover  Restore a previously retired local assistant");
+  console.log("  retire   Delete an assistant instance");
+  console.log("  setup    Configure API keys interactively");
+  console.log("  sleep    Stop the assistant process");
+  console.log("  ssh      SSH into a remote assistant instance");
+  console.log("  tunnel   Create a tunnel for a locally hosted assistant");
+  console.log("  use      Set the active assistant for commands");
+  console.log("  wake     Start the assistant and gateway");
+  console.log("  whoami   Show current logged-in user");
+}
+
+/**
+ * If a running assistant is detected, launch the TUI client and return true.
+ * Otherwise return false so the caller can fall back to help text.
+ */
+async function tryLaunchClient(): Promise<boolean> {
+  const activeName = getActiveAssistant();
+  const entry = activeName
+    ? findAssistantByName(activeName)
+    : loadLatestAssistant();
+
+  if (!entry) return false;
+
+  const url = entry.localUrl || entry.runtimeUrl;
+  if (!url) return false;
+
+  const result = await checkHealth(url, entry.bearerToken);
+  if (result.status !== "healthy") return false;
+
+  await client();
+  return true;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const commandName = args[0];
@@ -46,28 +98,16 @@ async function main() {
     process.exit(0);
   }
 
-  if (!commandName || commandName === "--help" || commandName === "-h") {
-    console.log("Usage: vellum <command> [options]");
-    console.log("");
-    console.log("Commands:");
-    console.log("  clean    Kill orphaned vellum processes");
-    console.log("  client   Connect to a hatched assistant");
-    console.log("  hatch    Create a new assistant instance");
-    console.log("  login    Log in to the Vellum platform");
-    console.log("  logout   Log out of the Vellum platform");
-    console.log("  pair     Pair with a remote assistant via QR code");
-    console.log(
-      "  ps       List assistants (or processes for a specific assistant)",
-    );
-    console.log("  recover  Restore a previously retired local assistant");
-    console.log("  retire   Delete an assistant instance");
-    console.log("  setup    Configure API keys interactively");
-    console.log("  sleep    Stop the assistant process");
-    console.log("  ssh      SSH into a remote assistant instance");
-    console.log("  tunnel   Create a tunnel for a locally hosted assistant");
-    console.log("  use      Set the active assistant for commands");
-    console.log("  wake     Start the assistant and gateway");
-    console.log("  whoami   Show current logged-in user");
+  if (commandName === "--help" || commandName === "-h") {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!commandName) {
+    const launched = await tryLaunchClient();
+    if (!launched) {
+      printHelp();
+    }
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary
- When `vellum` is run with no arguments, check if a running assistant is detected via health check
- If a healthy assistant is found (active or latest from lockfile), launch the TUI client automatically
- If no running assistant is detected, fall back to showing help text as before

Closes #15759

## Test plan
- [ ] Run `vellum` with a healthy assistant running -- should launch TUI client
- [ ] Run `vellum` with no assistant running -- should show help text
- [ ] Run `vellum` with assistant in lockfile but not running -- should show help text
- [ ] Run `vellum --help` -- should always show help text
- [ ] Run `vellum client` -- should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
