### PR TITLE
feat(cli): ring terminal bell on response completion

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1440,6 +1440,7 @@ function ChatApp({
     if (!busy) {
       setSpinnerText(null);
       setInputFocused(true);
+      process.stdout.write("\x07");
     }
   }, []);
 

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -1440,7 +1440,6 @@ function ChatApp({
     if (!busy) {
       setSpinnerText(null);
       setInputFocused(true);
-      process.stdout.write("\x07");
     }
   }, []);
 
@@ -2066,6 +2065,7 @@ function ChatApp({
                     role: "assistant",
                     content: msg.content,
                   });
+                  process.stdout.write("\x07");
                   h.setBusy(false);
                   h.hideSpinner();
                   return;


### PR DESCRIPTION
## Summary
- Send BEL character (`\x07`) to stdout when the assistant finishes responding, providing an audible notification in terminals that support it
- Useful for SSH/tmux workflows where the user switches to another pane while waiting

## Test plan
- [ ] Run the CLI, send a message, and verify the terminal bell rings when the response completes
- [ ] Verify behavior in tmux (bell should propagate to the status bar or trigger a visual/audible alert)

Closes #15765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
