### PR TITLE
feat(cli): add --no-color and --plain flags

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -124,6 +124,11 @@ async function main() {
   const GLOBAL_FLAGS = new Set(["--no-color", "--plain"]);
   const commandName = args.find((a) => !GLOBAL_FLAGS.has(a));
 
+  // Strip global flags from process.argv so subcommands that parse
+  // process.argv.slice(3) don't see them as positional arguments.
+  const filteredArgs = args.filter((a) => !GLOBAL_FLAGS.has(a));
+  process.argv = [...process.argv.slice(0, 2), ...filteredArgs];
+
   if (commandName === "--version" || commandName === "-v") {
     console.log(`@vellumai/cli v${cliPkg.version}`);
     process.exit(0);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -66,6 +66,26 @@ function printHelp(): void {
   console.log("  use      Set the active assistant for commands");
   console.log("  wake     Start the assistant and gateway");
   console.log("  whoami   Show current logged-in user");
+  console.log("");
+  console.log("Options:");
+  console.log(
+    "  --no-color, --plain   Disable colored output (honors NO_COLOR env)",
+  );
+  console.log("  --version, -v         Show version");
+  console.log("  --help, -h            Show this help");
+}
+
+/**
+ * Check for --no-color / --plain flags and set NO_COLOR env var
+ * before any terminal capability detection runs.
+ *
+ * Per https://no-color.org/, setting NO_COLOR to any non-empty value
+ * signals that color output should be suppressed.
+ */
+function applyNoColorFlags(argv: string[]): void {
+  if (argv.includes("--no-color") || argv.includes("--plain")) {
+    process.env.NO_COLOR = "1";
+  }
 }
 
 /**
@@ -96,7 +116,13 @@ async function tryLaunchClient(): Promise<boolean> {
 
 async function main() {
   const args = process.argv.slice(2);
-  const commandName = args[0];
+
+  // Must run before any command or terminal-capabilities usage
+  applyNoColorFlags(args);
+
+  // Global flags that are not command names
+  const GLOBAL_FLAGS = new Set(["--no-color", "--plain"]);
+  const commandName = args.find((a) => !GLOBAL_FLAGS.has(a));
 
   if (commandName === "--version" || commandName === "-v") {
     console.log(`@vellumai/cli v${cliPkg.version}`);

--- a/cli/src/lib/terminal-capabilities.ts
+++ b/cli/src/lib/terminal-capabilities.ts
@@ -107,6 +107,15 @@ export function getTerminalCapabilities(): TerminalCapabilities {
   return _cached;
 }
 
+/**
+ * Clear the cached capabilities so the next `getTerminalCapabilities()`
+ * call re-detects from the current environment. Useful after modifying
+ * `process.env.NO_COLOR` at startup or in tests.
+ */
+export function resetCapabilitiesCache(): void {
+  _cached = undefined;
+}
+
 // ── Convenience helpers ──────────────────────────────────────
 
 /** True when colors should be used (any level above "none"). */


### PR DESCRIPTION
## Summary
- Add `--no-color` and `--plain` global CLI flags that disable colored output by setting `NO_COLOR=1` in the process environment
- Integrates with the existing `terminal-capabilities.ts` module which already respects the `NO_COLOR` env var per https://no-color.org/
- Add `resetCapabilitiesCache()` export for testability when env vars change at runtime
- Document the new flags in `--help` output

Closes #15762

## Test plan
- [ ] Run `vellum --help` and verify the new Options section appears
- [ ] Run `vellum --no-color client` and verify no ANSI color codes in output
- [ ] Run `vellum --plain client` and verify same behavior as `--no-color`
- [ ] Run `NO_COLOR=1 vellum client` and verify colors are disabled (existing behavior)
- [ ] Verify `vellum client` still has colors when no flag is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
