### PR TITLE
fix: match settings panel colors to Figma design

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -75,20 +75,20 @@ struct SettingsPanel: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(VColor.contentSecondary)
+                .foregroundStyle(VColor.primaryBase)
                 .pointerCursor()
                 .accessibilityLabel("Back")
 
                 Text("Settings")
                     .font(VFont.panelTitle)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundColor(VColor.contentEmphasized)
 
                 Spacer()
             }
             .padding(.trailing, VSpacing.xl)
             .padding(.bottom, VSpacing.md)
 
-            VColor.borderBase.frame(height: 1)
+            VColor.borderDisabled.frame(height: 1)
                 .padding(.trailing, VSpacing.xl)
 
             // Body: nav pinned left + centered content with max width
@@ -118,7 +118,7 @@ struct SettingsPanel: View {
         }
         .padding(.top, VSpacing.xl)
         .padding(.leading, VSpacing.xl)
-        .background(VColor.surfaceBase)
+        .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .task {
             // Refresh permission status and feature flags when the view appears
@@ -600,7 +600,7 @@ private struct SettingsNavRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .font(VFont.body)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundColor(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                 Spacer()
             }
             .padding(.leading, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -13,7 +13,7 @@ struct SettingsCard<Content: View>: View {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text(title)
                     .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.contentDefault)
+                    .foregroundColor(VColor.contentEmphasized)
                 if let subtitle {
                     Text(subtitle)
                         .font(VFont.sectionDescription)
@@ -32,7 +32,7 @@ struct SettingsCard<Content: View>: View {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderBase)
+            .fill(VColor.borderDisabled)
             .frame(height: 1)
     }
 }

--- a/clients/shared/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/CardModifier.swift
@@ -17,7 +17,7 @@ public struct CardModifier: ViewModifier {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
-                    .strokeBorder(VColor.borderBase, lineWidth: 2)
+                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
                     .allowsHitTesting(false)
             )
     }


### PR DESCRIPTION
## Summary
- Update settings panel background from `surfaceBase` to `surfaceOverlay` to match Figma
- Change card borders globally from `borderBase` (#BDB9A9) to `borderDisabled` (#D4D1C1)
- Update settings nav text to use `contentSecondary`/`contentEmphasized` hierarchy
- Change back button icon to `primaryBase` and title to `contentEmphasized`

## Test plan
- [ ] Open Settings panel — verify lighter background and border colors
- [ ] Check nav sidebar — unselected items should be lighter, selected darker
- [ ] Verify cards across the app still look correct with the lighter border

🤖 Generated with [Claude Code](https://claude.com/claude-code)