### PR TITLE
fix: rename neutral → contrast button, fix disabled state

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -187,7 +187,7 @@ struct InputBarView: View {
                 VButton(
                     label: "Stop generation",
                     iconOnly: VIcon.square.rawValue,
-                    style: .neutral,
+                    style: .contrast,
                     action: onStop
                 )
             } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -432,7 +432,7 @@ struct ComposerView: View {
                 VButton(
                     label: "Stop generation",
                     iconOnly: VIcon.square.rawValue,
-                    style: .neutral,
+                    style: .contrast,
                     iconSize: composerActionButtonSize,
                     action: onStop
                 )
@@ -573,7 +573,7 @@ VStreamingWaveform(
                     VButton(
                         label: manager.state == .listening ? "Mute" : "Unmute",
                         iconOnly: manager.state == .listening ? VIcon.mic.rawValue : VIcon.micOff.rawValue,
-                        style: .neutral,
+                        style: .contrast,
                         iconSize: composerActionButtonSize,
                         action: { manager.toggleListening() }
                     )

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public struct VButton: View {
-    public enum Style: Hashable { case primary, danger, dangerOutline, outlined, ghost, neutral }
+    public enum Style: Hashable { case primary, danger, dangerOutline, outlined, ghost, contrast }
 
     public let label: String
     public var leftIcon: String? = nil
@@ -83,8 +83,10 @@ public struct VButton: View {
 
     private var iconOnlyForegroundColor: Color {
         switch style {
-        case .primary, .danger, .neutral:
+        case .primary, .danger:
             return VColor.auxWhite
+        case .contrast:
+            return VColor.contentInset
         case .ghost, .outlined, .dangerOutline:
             if isActive { return VColor.primaryActive }
             return VColor.primaryBase
@@ -184,8 +186,8 @@ public struct VButtonStyle: ButtonStyle {
                 if isHovered { return VColor.surfaceBase }
                 return .clear
             }
-        case .neutral:
-            guard isEnabled else { return VColor.contentDisabled }
+        case .contrast:
+            guard isEnabled else { return VColor.primaryDisabled }
             if isPressed { return VColor.contentEmphasized }
             if isHovered { return VColor.contentSecondary }
             return VColor.contentDefault
@@ -197,7 +199,7 @@ public struct VButtonStyle: ButtonStyle {
         switch style {
         case .primary: return VColor.auxWhite
         case .danger: return VColor.auxWhite
-        case .neutral: return VColor.auxWhite
+        case .contrast: return VColor.contentInset
         case .outlined: return isHovered ? VColor.primaryHover : VColor.primaryBase
         case .dangerOutline: return isHovered ? VColor.systemNegativeHover : VColor.systemNegativeStrong
         case .ghost:

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -26,7 +26,7 @@ struct ButtonsGallerySection: View {
                                 (label: "Danger", tag: VButton.Style.danger),
                                 (label: "Danger Outline", tag: VButton.Style.dangerOutline),
                                 (label: "Ghost", tag: VButton.Style.ghost),
-                                (label: "Neutral", tag: VButton.Style.neutral),
+                                (label: "Contrast", tag: VButton.Style.contrast),
                             ],
                             selection: $selectedStyle,
                             style: .pill
@@ -73,7 +73,7 @@ struct ButtonsGallerySection: View {
 
             VCard {
                 HStack(spacing: VSpacing.xl) {
-                    ForEach([VButton.Style.primary, .outlined, .danger, .dangerOutline, .ghost, .neutral], id: \.self) { style in
+                    ForEach([VButton.Style.primary, .outlined, .danger, .dangerOutline, .ghost, .contrast], id: \.self) { style in
                         VStack(spacing: VSpacing.md) {
                             VButton(label: styleName(style), style: style) {}
                             VButton(label: "Disabled", style: style, isDisabled: true) {}
@@ -153,8 +153,8 @@ struct ButtonsGallerySection: View {
                         VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .danger) {}
                     }
                     VStack(alignment: .leading, spacing: VSpacing.md) {
-                        Text("Neutral").font(VFont.caption).foregroundColor(VColor.contentTertiary)
-                        VButton(label: "Stop", iconOnly: VIcon.square.rawValue, style: .neutral) {}
+                        Text("Contrast").font(VFont.caption).foregroundColor(VColor.contentTertiary)
+                        VButton(label: "Stop", iconOnly: VIcon.square.rawValue, style: .contrast) {}
                     }
                 }
             }
@@ -222,7 +222,7 @@ struct ButtonsGallerySection: View {
         case .outlined: return "Outlined"
         case .dangerOutline: return "Danger Outline"
         case .ghost: return "Ghost"
-        case .neutral: return "Neutral"
+        case .contrast: return "Contrast"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Renames `.neutral` button style to `.contrast` to match Figma naming
- Fixes disabled background from `contentDisabled` to `primaryDisabled` (matching primary/danger styles)
- Changes foreground color to `contentInset` semantic token

## Test plan
- [x] Build succeeds
- [ ] Verify contrast button disabled state matches primary disabled state visually
- [ ] Check stop/mute buttons in composer still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
