### PR TITLE
Reorder Phone card to show Phone Number dropdown above connection buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -409,25 +409,8 @@ struct AssistantChannelsDetailView: View {
     private var voiceCard: some View {
         let status = store.channelSetupStatus["phone"]
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio") {
-            if status == "ready" {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
-                        store.clearTwilioCredentials()
-                        store.channelSetupStatus["phone"] = "not_configured"
-                    }
-                }
-            } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
-                voiceCredentialEntry
-            } else {
-                VButton(label: "Set Up", style: .outlined) {
-                    voiceSetupExpanded = true
-                }
-            }
-
             // Phone number dropdown: show when credentials are configured
             if (status == "ready" || status == "incomplete") && store.twilioHasCredentials {
-                SettingsDivider()
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("Phone Number")
                         .font(VFont.inputLabel)
@@ -444,6 +427,22 @@ struct AssistantChannelsDetailView: View {
                         emptyValue: ""
                     )
                     .frame(maxWidth: 360)
+                }
+            }
+
+            if status == "ready" {
+                HStack(spacing: VSpacing.sm) {
+                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
+                        store.clearTwilioCredentials()
+                        store.channelSetupStatus["phone"] = "not_configured"
+                    }
+                }
+            } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
+                voiceCredentialEntry
+            } else {
+                VButton(label: "Set Up", style: .outlined) {
+                    voiceSetupExpanded = true
                 }
             }
 


### PR DESCRIPTION
## Summary
- Move the Phone Number label and dropdown to appear above the Connected/Disconnect buttons
- Remove the horizontal divider that previously separated them
- Warning/error messages remain at the bottom of the card

Part of plan: contact-select-ui-improvements.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
