### PR TITLE
feat(macos): add Cmd+N shortcut to create a new thread

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -68,6 +68,7 @@ extension AppDelegate {
         registerQuickInputMonitor()
         registerFnVMonitor()
         registerCmdKMonitor()
+        registerCmdNMonitor()
 
         globalHotkeyObserver = Publishers.Merge3(
             UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
@@ -159,6 +160,10 @@ extension AppDelegate {
             NSEvent.removeMonitor(monitor)
             cmdKLocalMonitor = nil
         }
+        if let monitor = cmdNLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdNLocalMonitor = nil
+        }
         if let monitor = navLocalMonitor {
             NSEvent.removeMonitor(monitor)
             navLocalMonitor = nil
@@ -190,6 +195,23 @@ extension AppDelegate {
             _ = handler(event)
         }
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers Cmd+N as a local shortcut to create a new thread.
+    func registerCmdNMonitor() {
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard event.keyCode == 45, // kVK_ANSI_N
+                  mods == [.command] else {
+                return event
+            }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.createNewThread()
+            }
+            return nil
+        }
+        cmdNLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
     /// Registers Cmd+K as a local shortcut to open the command palette.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -45,6 +45,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var quickInputEventHandlerRef: EventHandlerRef?
     var commandPaletteWindow: CommandPaletteWindow?
     var cmdKLocalMonitor: Any?
+    var cmdNLocalMonitor: Any?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
     public let services = AppServices()
@@ -428,5 +429,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     public func performZoomIn() { zoomManager.zoomIn() }
     public func performZoomOut() { zoomManager.zoomOut() }
     public func performZoomReset() { zoomManager.resetZoom() }
+
+    public func createNewThread() {
+        showMainWindow()
+        mainWindow?.threadManager.createThread()
+    }
 
 }


### PR DESCRIPTION
## Summary
- Adds Cmd+N keyboard shortcut to create a new thread in the macOS app
- Uses a local NSEvent monitor (same pattern as Cmd+K for command palette) since the app is an LSUIElement without a standard menu bar

## Test plan
- [ ] Open the macOS app and press Cmd+N — a new thread should be created and focused
- [ ] Verify the shortcut works from any view (chat, settings panel, etc.)
- [ ] Verify the command palette still shows ⌘N hint for "New Conversation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
