### PR TITLE
fix: clarify handle input purpose in Telegram/Slack invite flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -492,6 +492,11 @@ struct ContactDetailView: View {
             }
 
             // Handle input section
+            // NOTE: The handle input is informational for this iteration. It lets the
+            // guardian note which user they're inviting, but the value is not yet sent
+            // to the backend. The invite is already created when the card expands (with
+            // the shareable URL/code). Backend integration to proactively message the
+            // contact via their handle is deferred to a future iteration.
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 Text("Or enter their \(channelLabel(for: type)) handle:")
                     .font(VFont.caption)
@@ -504,7 +509,8 @@ struct ContactDetailView: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             }
 
-            // Buttons: Send + Cancel
+            // Buttons: Send reveals the already-generated invite code (the invite
+            // was created when the card expanded). Cancel collapses the section.
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Send", style: .outlined) {
                     inviteCodeRevealed = true


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-select-ui-improvements.md.

**Gap:** Handle input is collected but never used by the Send action
**What was expected:** Handle input should serve a purpose or be documented
**What was found:** inviteHandleInput is bound to a TextField but never consumed

Adds a comment explaining the handle input is informational for this iteration. The invite is created on expand (with the URL), and the "Send" button reveals the code. Backend integration to proactively message the contact via their handle is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
