### PR TITLE
fix: remove misleading codeInviteChannels set

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -7,9 +7,6 @@ import VellumAssistantShared
 struct ContactDetailView: View {
     private static let allChannelTypes = ["telegram", "phone", "slack"]
 
-    /// Channels that support 6-digit code invites from this view.
-    private static let codeInviteChannels: Set<String> = ["telegram", "slack", "phone"]
-
     let contact: ContactPayload
     var daemonClient: DaemonClient?
     var store: SettingsStore?
@@ -403,8 +400,8 @@ struct ContactDetailView: View {
                         }
                     }
                 }
-            } else if Self.codeInviteChannels.contains(type) {
-                // Phone and other channels: keep existing behavior
+            } else if type == "phone" {
+                // Phone channel: code-based invite flow
                 if inviteInProgress == type {
                     ProgressView()
                         .controlSize(.small)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-select-ui-improvements.md.

**Gap:** codeInviteChannels set is misleading after Telegram/Slack got their own branch
**What was expected:** The set should accurately represent channels it gates
**What was found:** Only "phone" reaches the codeInviteChannels check; "telegram" and "slack" are dead entries

Removes the codeInviteChannels static property and replaces the check with a direct `type == "phone"` condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
