### PR TITLE
fix: show invite error inline in Telegram/Slack invite flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -400,6 +400,13 @@ struct ContactDetailView: View {
                         }
                     }
                 }
+
+                // Inline error display so the message appears inside the channel card
+                if let inviteError {
+                    Text(inviteError)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
+                }
             } else if type == "phone" {
                 // Phone channel: code-based invite flow
                 if inviteInProgress == type {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-select-ui-improvements.md.

**Gap:** Invite error display disconnected from Telegram/Slack invite flow
**What was expected:** Error should appear contextually near the invite UI
**What was found:** inviteError renders outside the channel cards, visually disconnected

Adds inline inviteError display within the Telegram/Slack branch of unconfiguredChannelContent so errors appear right in the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
