### PR TITLE
fix: remove duplicate inviteError display for Telegram/Slack

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -309,12 +309,6 @@ struct ContactDetailView: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.systemNegativeStrong)
             }
-
-            if let inviteError {
-                Text(inviteError)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemNegativeStrong)
-            }
         }
         .task {
             do {
@@ -441,6 +435,13 @@ struct ContactDetailView: View {
 
                 if inviteResult?.type == type {
                     inviteResultDisplay(for: type)
+                }
+
+                // Inline error display so the message appears inside the channel card
+                if let inviteError {
+                    Text(inviteError)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.systemNegativeStrong)
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes duplicate error display identified during plan review round 2.

**Gap:** inviteError shows twice for Telegram/Slack — inline in the card AND at the outer section level
**Fix:** Remove the outer inviteError display from channelsSection and add inline error display to the phone branch, so all channels consistently show errors inline within their cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
