### PR TITLE
fix: update contact detail layout for trusted contacts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -173,11 +173,7 @@ struct ContactDetailView: View {
             }
 
             HStack(spacing: VSpacing.sm) {
-                roleBadge
                 contactTypeBadge
-            }
-
-            HStack(spacing: VSpacing.sm) {
                 Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
                     .font(VFont.caption)
                     .foregroundColor(VColor.contentTertiary)
@@ -227,18 +223,6 @@ struct ContactDetailView: View {
         .onHover { hovering in
             isHoveringHeader = hovering
         }
-    }
-
-    private var roleBadge: some View {
-        // Guardians route to GuardianChannelsDetailView, so this view only
-        // renders non-guardian contacts.
-        Text("Contact")
-            .font(VFont.captionMedium)
-            .foregroundColor(VColor.contentSecondary)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xxs)
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
     }
 
     private var contactTypeBadge: some View {


### PR DESCRIPTION
## Summary
- Removed the "Contact" role badge from beneath the contact name in the detail view
- Moved the "Human" contact type chip to the interactions line, to the left of the interaction count
- Removed the now-unused `roleBadge` computed property

## Original prompt
let's update the selection state of trusted contacts such that:
- We do not have the word "Contact" beneath their name
- We put the "Human" chip on the same line as the number of interactions (to the left of interaction count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
