### PR TITLE
fix: rename Reset (disconnect) button to Clear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceCredentialCard.swift
@@ -77,7 +77,7 @@ struct ServiceCredentialCard<ExtraContent: View>: View {
                     onSave()
                 }
                 if isConnected {
-                    VButton(label: "Reset (disconnect)", style: .danger) {
+                    VButton(label: "Clear", style: .danger) {
                         onReset()
                     }
                 }


### PR DESCRIPTION
## Summary
- Renamed the "Reset (disconnect)" button to "Clear" on service credential cards in the Models & Services settings page for clarity

## Original prompt
lets update this "Reset (disconnect)" button to just say "Clear" here on the Anthropic card on the Models & Services page in macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
