### PR TITLE
fix: make chatbar attach button use inline sheet instead of blocking modal

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -72,6 +72,22 @@ struct ComposerFocusBridge: NSViewRepresentable {
             candidate = view.superview
         }
         window.composerContainerView = container
+
+        // Prevent the internal NSTextView from intercepting file drops.
+        // SwiftUI's TextField wraps an NSTextView that registers for file URL
+        // drag types by default, causing it to insert file paths as text.
+        // Re-register with only text types so file drops fall through to the
+        // SwiftUI .onDrop handler on the parent ScrollView.
+        Self.unregisterFileDragTypes(in: container)
+    }
+
+    private static func unregisterFileDragTypes(in view: NSView) {
+        if view is NSTextView {
+            view.registerForDraggedTypes([.string, .rtf, .rtfd])
+        }
+        for subview in view.subviews {
+            unregisterFileDragTypes(in: subview)
+        }
     }
 
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -78,6 +78,7 @@ struct ComposerView: View {
     @State private var preDictationText: String = ""
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
     @State private var liveAmplitude: Float = 0
+    @State private var isComposerDropTargeted = false
 
     /// The portion of the suggestion that extends beyond the current input.
     private var ghostSuffix: String? {
@@ -277,7 +278,7 @@ struct ComposerView: View {
                 updateSlashState()
             }
         }
-        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: nil) { providers in
+        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isComposerDropTargeted) { providers in
             let group = DispatchGroup()
             // Collect URLs on the main queue to avoid concurrent Array mutation
             // from loadObject callbacks that may fire on different threads.
@@ -397,6 +398,26 @@ struct ComposerView: View {
                 .fill(VColor.surfaceLift)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay {
+            if isComposerDropTargeted {
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .strokeBorder(VColor.primaryBase, style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .fill(VColor.primaryBase.opacity(0.08))
+                    )
+                    .overlay {
+                        VStack(spacing: VSpacing.xs) {
+                            VIconView(.paperclip, size: 20)
+                                .foregroundColor(VColor.primaryBase)
+                            Text("Drop files to attach")
+                                .font(VFont.bodyMedium)
+                                .foregroundColor(VColor.primaryBase)
+                        }
+                    }
+                    .allowsHitTesting(false)
+            }
+        }
         .shadow(color: VColor.auxBlack.opacity(0.05), radius: 2, x: 0, y: 2)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -401,18 +401,14 @@ struct ComposerView: View {
         .overlay {
             if isComposerDropTargeted {
                 RoundedRectangle(cornerRadius: VRadius.lg)
-                    .strokeBorder(VColor.primaryBase, style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.lg)
-                            .fill(VColor.primaryBase.opacity(0.08))
-                    )
+                    .fill(VColor.surfaceActive)
                     .overlay {
-                        VStack(spacing: VSpacing.xs) {
-                            VIconView(.paperclip, size: 20)
-                                .foregroundColor(VColor.primaryBase)
+                        HStack(spacing: VSpacing.sm) {
+                            VIconView(.paperclip, size: 16)
+                                .foregroundColor(VColor.contentSecondary)
                             Text("Drop files to attach")
-                                .font(VFont.bodyMedium)
-                                .foregroundColor(VColor.primaryBase)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.contentSecondary)
                         }
                     }
                     .allowsHitTesting(false)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -538,9 +538,21 @@ func openFilePicker(viewModel: ChatViewModel) {
         .movie, .mpeg4Movie, .quickTimeMovie, .avi,
         .mp3, .wav, .aiff, .audio,
     ]
-    guard panel.runModal() == .OK else { return }
-    for url in panel.urls {
-        viewModel.addAttachment(url: url)
+    // Present as a window sheet instead of a blocking app-modal dialog
+    // so the user can still see the chat while picking files.
+    guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
+        // Fallback to modal if no window is available.
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            viewModel.addAttachment(url: url)
+        }
+        return
+    }
+    panel.beginSheetModal(for: window) { response in
+        guard response == .OK else { return }
+        for url in panel.urls {
+            viewModel.addAttachment(url: url)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Changed `openFilePicker` from `NSOpenPanel.runModal()` (blocking app-modal) to `beginSheetModal(for:)` (non-blocking window sheet)
- The file picker now appears as a sheet attached to the window, so users can still see the chat while picking files
- Falls back to modal dialog if no window is available

## Original prompt
--safe https://linear.app/vellum/issue/LUM-168/attachment-button-polish-attach-from-chatbar-should-work-inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
