### PR TITLE
fix: prevent invite redemption from reactivating guardian channels

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -23,7 +23,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { findContactChannel } from "../contacts/contact-store.js";
+import {
+  findContactChannel,
+  upsertContact,
+} from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
@@ -273,6 +276,67 @@ describe("invite-redemption-service", () => {
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  test("returns invalid_token for a revoked guardian to prevent invite-based reactivation", () => {
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      maxUses: 5,
+    });
+
+    // Pre-create a guardian contact with a revoked telegram channel
+    upsertContact({
+      displayName: "Guardian",
+      role: "guardian",
+      channels: [
+        {
+          type: "telegram",
+          address: "guardian-tg-id",
+          externalUserId: "guardian-tg-id",
+          status: "revoked",
+        },
+      ],
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "guardian-tg-id",
+    });
+
+    // Must reject — guardian channels are managed via the binding flow, not invites
+    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+  });
+
+  test("returns invalid_token for a revoked guardian via 6-digit invite code", () => {
+    const code = "123456";
+    const inviteCodeHash = hashVoiceCode(code);
+    createInvite({
+      sourceChannel: "telegram",
+      maxUses: 5,
+      inviteCodeHash,
+    });
+
+    upsertContact({
+      displayName: "Guardian",
+      role: "guardian",
+      channels: [
+        {
+          type: "telegram",
+          address: "guardian-code-id",
+          externalUserId: "guardian-code-id",
+          status: "revoked",
+        },
+      ],
+    });
+
+    const outcome = redeemInviteByCode({
+      code,
+      sourceChannel: "telegram",
+      externalUserId: "guardian-code-id",
     });
 
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -146,6 +146,12 @@ export function redeemInvite(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
+  // Guardian channels must not be reactivated via regular invite redemption —
+  // their lifecycle is managed exclusively through the guardian binding flow.
+  if (existingContact && existingContact.role === "guardian") {
+    return { ok: false, reason: "invalid_token" };
+  }
+
   // Inactive member reactivation: when the user already has a member record
   // in a non-active state (revoked/pending), reactivate it via upsertContactChannel
   // and consume an invite use atomically. The fresh-member path below also
@@ -338,6 +344,7 @@ export function redeemVoiceInviteCode(params: {
     externalUserId: canonicalCallerId,
   });
   const existingVoiceChannel = voiceContactResult?.channel ?? null;
+  const voiceContact = voiceContactResult?.contact ?? null;
 
   if (existingVoiceChannel && existingVoiceChannel.status === "active") {
     return {
@@ -352,13 +359,18 @@ export function redeemVoiceInviteCode(params: {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
+  // Guardian channels must not be reactivated via regular invite redemption —
+  // their lifecycle is managed exclusively through the guardian binding flow.
+  if (voiceContact && voiceContact.role === "guardian") {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+
   // Atomic redemption: upsert member + consume invite use in a transaction
   const STALE_INVITE = Symbol("stale_invite");
   let memberId: string | undefined;
 
   // Reactivation should not overwrite a guardian-managed nickname (same
   // protection as the token-based redemption path above).
-  const voiceContact = voiceContactResult?.contact ?? null;
   const preservedDisplayName = voiceContact?.displayName?.trim().length
     ? voiceContact.displayName
     : (invite.friendName ?? undefined);
@@ -484,6 +496,12 @@ export function redeemInviteByCode(params: {
   // codes. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
   if (existingChannel && existingChannel.status === "blocked") {
+    return { ok: false, reason: "invalid_token" };
+  }
+
+  // Guardian channels must not be reactivated via regular invite redemption —
+  // their lifecycle is managed exclusively through the guardian binding flow.
+  if (existingContact && existingContact.role === "guardian") {
     return { ok: false, reason: "invalid_token" };
   }
 


### PR DESCRIPTION
## Summary
- Add guardian role check to all three invite redemption functions (redeemInvite, redeemVoiceInviteCode, redeemInviteByCode) to prevent reactivation of revoked guardian channels via invite links
- Guardian channels can only be managed through the guardian binding/verification flow
- Add test coverage for the guardian guard in both token-based and code-based redemption paths

Part of plan: guardian-invite-reactivate.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
