### PR TITLE
feat: add showHidden query param to workspace tree endpoint

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -33,6 +33,7 @@ interface TreeEntry {
 
 function handleWorkspaceTree(ctx: RouteContext): Response {
   const requestedPath = ctx.url.searchParams.get("path") ?? "";
+  const showHidden = ctx.url.searchParams.get("showHidden") === "true";
   const resolved = resolveWorkspacePath(requestedPath);
   if (resolved === undefined) {
     return httpError("BAD_REQUEST", "Invalid path", 400);
@@ -45,7 +46,7 @@ function handleWorkspaceTree(ctx: RouteContext): Response {
     const entries: TreeEntry[] = [];
     for (const entry of dirents) {
       // Filter out dotfiles/directories (.env, .git, .private, etc.)
-      if (entry.name.startsWith(".")) continue;
+      if (!showHidden && entry.name.startsWith(".")) continue;
 
       const fullPath = join(resolved, entry.name);
 


### PR DESCRIPTION
## Summary
- Add `showHidden=true` query parameter to `GET /v1/workspace/tree` to optionally include dotfiles/dotdirectories in the response
- Default behavior unchanged: dotfiles are still hidden when param is absent or false
- Security layer (`resolveWorkspacePath`) remains untouched — write/delete/rename still reject dot-prefixed paths

Part of plan: show-hidden-files-toggle.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
