### PR TITLE
test: add guardian guard test for redeemVoiceInviteCode

### DIFF
--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -23,7 +23,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { findContactChannel } from "../contacts/contact-store.js";
+import {
+  findContactChannel,
+  upsertContact,
+} from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
@@ -352,6 +355,34 @@ describe("redeemVoiceInviteCode", () => {
       code: "123456",
     });
 
+    expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
+  });
+
+  test("returns invalid_or_expired for a revoked guardian to prevent invite-based reactivation", () => {
+    const phone = "+15559998888";
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    // Pre-create a guardian contact with a revoked phone channel
+    upsertContact({
+      displayName: "Guardian",
+      role: "guardian",
+      channels: [
+        {
+          type: "phone",
+          address: phone,
+          externalUserId: phone,
+          status: "revoked",
+        },
+      ],
+    });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "phone",
+      code,
+    });
+
+    // Must reject — guardian channels are managed via the binding flow, not invites
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-invite-reactivate.md.

**Gap:** Missing test for redeemVoiceInviteCode guardian guard
**What was expected:** All three redemption functions should have test coverage for the guardian guard
**What was found:** Only redeemInvite and redeemInviteByCode had guardian tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
