### PR TITLE
docs: add keyboard shortcut configurability note to macOS AGENTS.md

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -1,0 +1,5 @@
+# macOS Client — Agent Guidance
+
+## Keyboard Shortcuts
+
+When adding a new keyboard shortcut to the macOS app, you **must** also add a corresponding configurable key binding in the "Keyboard Shortcuts" section of the Settings/General page. Users should be able to customize every shortcut — do not hard-code key bindings without a matching settings entry.


### PR DESCRIPTION
## Summary
- Creates `clients/macos/AGENTS.md` with guidance that every new keyboard shortcut must also have a configurable key binding in the Settings/General "Keyboard Shortcuts" section
- Ensures agents and contributors don't hard-code shortcuts without corresponding settings entries

## Original prompt
add a note to clients/macos/AGNTS.md – whenever someone adds a new keyboard shortcut, they should also update the "Keyboard Shortcuts" section under the Settings/General page such that the key binding is configurable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
