### PR TITLE
fix: allow read-only workspace endpoints to access hidden files when showHidden=true

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -34,7 +34,9 @@ interface TreeEntry {
 function handleWorkspaceTree(ctx: RouteContext): Response {
   const requestedPath = ctx.url.searchParams.get("path") ?? "";
   const showHidden = ctx.url.searchParams.get("showHidden") === "true";
-  const resolved = resolveWorkspacePath(requestedPath);
+  const resolved = resolveWorkspacePath(requestedPath, {
+    allowHidden: showHidden,
+  });
   if (resolved === undefined) {
     return httpError("BAD_REQUEST", "Invalid path", 400);
   }
@@ -96,7 +98,8 @@ function handleWorkspaceFile(ctx: RouteContext): Response {
     return httpError("BAD_REQUEST", "path query parameter is required", 400);
   }
 
-  const resolved = resolveWorkspacePath(path);
+  const showHidden = ctx.url.searchParams.get("showHidden") === "true";
+  const resolved = resolveWorkspacePath(path, { allowHidden: showHidden });
   if (resolved === undefined) {
     return httpError("BAD_REQUEST", "Invalid path", 400);
   }
@@ -146,7 +149,8 @@ function handleWorkspaceFileContent(ctx: RouteContext): Response {
     );
   }
 
-  const resolved = resolveWorkspacePath(path);
+  const showHidden = ctx.url.searchParams.get("showHidden") === "true";
+  const resolved = resolveWorkspacePath(path, { allowHidden: showHidden });
   if (resolved === undefined) {
     return httpError("BAD_REQUEST", "Invalid path", 400);
   }

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -7,10 +7,16 @@ import { getWorkspaceDir } from "../../util/platform.js";
  * Resolves a user-provided relative path to an absolute path within the workspace.
  * Returns the resolved absolute path, or undefined if the path escapes the workspace root.
  */
-export function resolveWorkspacePath(relativePath: string): string | undefined {
+export function resolveWorkspacePath(
+  relativePath: string,
+  options?: { allowHidden?: boolean },
+): string | undefined {
   // Reject paths containing hidden (dot-prefixed) segments like .env, .git, .hidden/foo
   const segments = relativePath.split(/[/\\]/);
-  if (segments.some((s) => s.startsWith(".") && s !== "." && s !== "..")) {
+  if (
+    !options?.allowHidden &&
+    segments.some((s) => s.startsWith(".") && s !== "." && s !== "..")
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
Fixes gap where hidden files/directories were visible in the workspace tree but inaccessible via file read and subdirectory expansion endpoints.

- Add `allowHidden` option to `resolveWorkspacePath` to conditionally skip dot-prefix segment rejection
- Thread `showHidden` query param through `handleWorkspaceFile` and `handleWorkspaceFileContent`
- Pass `{ allowHidden: showHidden }` from all three read-only handlers
- Write/delete/rename endpoints remain unchanged — they still reject dot-prefixed paths

Fixes gap identified during plan review for show-hidden-files-toggle.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
