### PR TITLE
refactor: extract avatar body and eye transform math from AvatarCompositor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
@@ -16,16 +16,7 @@ enum AvatarCompositor {
         }
 
         let viewBox = bodyShape.viewBox
-        let scale = min(size / viewBox.width, size / viewBox.height)
-        let tx = (size - viewBox.width * scale) / 2
-        let ty = (size - viewBox.height * scale) / 2
-
-        // Flip Y: Core Graphics has y=0 at bottom, SVG has y=0 at top.
-        // Translate up by size, then scale y by -1, then apply the aspect-fit transform.
-        var transform = CGAffineTransform(translationX: 0, y: size)
-            .scaledBy(x: 1, y: -1)
-            .translatedBy(x: tx, y: ty)
-            .scaledBy(x: scale, y: scale)
+        let transform = AvatarTransforms.bodyTransform(viewBox: viewBox, outputSize: size)
 
         let image = NSImage(size: NSSize(width: size, height: size))
         image.lockFocus()
@@ -36,7 +27,8 @@ enum AvatarCompositor {
 
         // Draw body
         let bodyPath = parseSVGPath(bodyShape.svgPath)
-        let transformedBody = bodyPath.copy(using: &transform)!
+        var mutableTransform = transform
+        let transformedBody = bodyPath.copy(using: &mutableTransform)!
         context.addPath(transformedBody)
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
@@ -46,16 +38,14 @@ enum AvatarCompositor {
         // coordinate space; each body shape defines a face-center where eyes should land.
         // Aspect-fit scaling sizes the eyes appropriately, then translation aligns the centers.
         // Per-combo overrides allow specific eye+body pairs to use a custom face center.
-        let srcVB = eyeStyle.sourceViewBox
-        let eyeCenter = eyeStyle.eyeCenter
-        let overrideKey = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)"
-        let faceCenter = faceCenterOverrides[overrideKey] ?? bodyShape.faceCenter
-        let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
-        let remapTx = faceCenter.x - eyeCenter.x * remapScale
-        let remapTy = faceCenter.y - eyeCenter.y * remapScale
-        let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
-            .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
-        let eyeTransform = remapT.concatenating(transform)
+        let faceCenter = AvatarTransforms.resolveFaceCenter(bodyShape: bodyShape, eyeStyle: eyeStyle)
+        let eyeTransform = AvatarTransforms.eyeTransform(
+            eyeSourceViewBox: eyeStyle.sourceViewBox,
+            eyeCenter: eyeStyle.eyeCenter,
+            bodyViewBox: viewBox,
+            faceCenter: faceCenter,
+            bodyTransform: transform
+        )
 
         for eyePath in eyeStyle.paths {
             let parsed = parseSVGPath(eyePath.svgPath)
@@ -84,14 +74,7 @@ enum AvatarCompositor {
         }
 
         let viewBox = bodyShape.viewBox
-        let scale = min(size / viewBox.width, size / viewBox.height)
-        let tx = (size - viewBox.width * scale) / 2
-        let ty = (size - viewBox.height * scale) / 2
-
-        var transform = CGAffineTransform(translationX: 0, y: size)
-            .scaledBy(x: 1, y: -1)
-            .translatedBy(x: tx, y: ty)
-            .scaledBy(x: scale, y: scale)
+        let transform = AvatarTransforms.bodyTransform(viewBox: viewBox, outputSize: size)
 
         let image = NSImage(size: NSSize(width: size, height: size))
         image.lockFocus()
@@ -101,7 +84,8 @@ enum AvatarCompositor {
         }
 
         let bodyPath = parseSVGPath(bodyShape.svgPath)
-        let transformedBody = bodyPath.copy(using: &transform)!
+        var mutableTransform = transform
+        let transformedBody = bodyPath.copy(using: &mutableTransform)!
         context.addPath(transformedBody)
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
@@ -202,35 +186,6 @@ enum AvatarCompositor {
         cache[cacheKey] = image
         return image
     }
-
-    /// Per-combo face-center overrides for when the default body faceCenter doesn't produce
-    /// the best result for a specific eye style.  Key format: "bodyRawValue-eyeRawValue".
-    ///
-    /// Ghost (native faceCenter y=167, 28%) — non-native eyes pulled slightly lower to ~34%
-    /// so they sit better within the ghost's rounded head rather than at the very top.
-    ///
-    /// Sprout (native faceCenter y=415, 66%) — non-native eyes pulled slightly higher to ~61%
-    /// so they sit better within the sprout's leaf area rather than at the very bottom.
-    private static let faceCenterOverrides: [String: CGPoint] = [
-        // Ghost body — shift non-native eyes from y=167 → y=200
-        "ghost-grumpy":  CGPoint(x: 321, y: 200),
-        "ghost-angry":   CGPoint(x: 321, y: 200),
-        "ghost-curious":  CGPoint(x: 321, y: 200),
-        "ghost-goofy":   CGPoint(x: 321, y: 200),
-        "ghost-bashful":  CGPoint(x: 321, y: 200),
-        "ghost-gentle":  CGPoint(x: 321, y: 200),
-        "ghost-quirky":  CGPoint(x: 321, y: 200),
-        "ghost-dazed":   CGPoint(x: 321, y: 200),
-        // Sprout body — shift non-native eyes from y=415 → y=385
-        "sprout-grumpy":   CGPoint(x: 264, y: 385),
-        "sprout-angry":    CGPoint(x: 264, y: 385),
-        "sprout-goofy":    CGPoint(x: 264, y: 385),
-        "sprout-surprised": CGPoint(x: 264, y: 385),
-        "sprout-bashful":  CGPoint(x: 264, y: 385),
-        "sprout-gentle":   CGPoint(x: 264, y: 385),
-        "sprout-quirky":   CGPoint(x: 264, y: 385),
-        "sprout-dazed":    CGPoint(x: 264, y: 385),
-    ]
 
     private static var cache: [String: NSImage] = [:]
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+
+/// Pure functions for computing the affine transforms used to render avatar
+/// body shapes and eye paths. Shared by both AvatarCompositor (static bitmap)
+/// and AnimatedAvatarView (live CAShapeLayer rendering).
+enum AvatarTransforms {
+    /// Computes the transform that maps an SVG viewBox to a square output of
+    /// the given size: Y-flip (SVG y=0 at top, CG y=0 at bottom) + aspect-fit
+    /// centering.
+    static func bodyTransform(viewBox: CGSize, outputSize: CGFloat) -> CGAffineTransform {
+        let scale = min(outputSize / viewBox.width, outputSize / viewBox.height)
+        let tx = (outputSize - viewBox.width * scale) / 2
+        let ty = (outputSize - viewBox.height * scale) / 2
+        return CGAffineTransform(translationX: 0, y: outputSize)
+            .scaledBy(x: 1, y: -1)
+            .translatedBy(x: tx, y: ty)
+            .scaledBy(x: scale, y: scale)
+    }
+
+    /// Computes the transform for eye paths: remaps from the eye's source
+    /// viewBox to the body's viewBox using eye-center -> face-center alignment,
+    /// then composes with the body transform.
+    static func eyeTransform(
+        eyeSourceViewBox: CGSize,
+        eyeCenter: CGPoint,
+        bodyViewBox: CGSize,
+        faceCenter: CGPoint,
+        bodyTransform: CGAffineTransform
+    ) -> CGAffineTransform {
+        let remapScale = min(bodyViewBox.width / eyeSourceViewBox.width,
+                             bodyViewBox.height / eyeSourceViewBox.height)
+        let remapTx = faceCenter.x - eyeCenter.x * remapScale
+        let remapTy = faceCenter.y - eyeCenter.y * remapScale
+        let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
+            .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
+        return remapT.concatenating(bodyTransform)
+    }
+
+    /// Resolves the face center for a body/eye combination, checking for
+    /// per-combo overrides before falling back to the body's default.
+    static func resolveFaceCenter(
+        bodyShape: AvatarBodyShape,
+        eyeStyle: AvatarEyeStyle
+    ) -> CGPoint {
+        let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)"
+        return faceCenterOverrides[key] ?? bodyShape.faceCenter
+    }
+
+    /// Per-combo face-center overrides for when the default body faceCenter doesn't produce
+    /// the best result for a specific eye style.  Key format: "bodyRawValue-eyeRawValue".
+    ///
+    /// Ghost (native faceCenter y=167, 28%) — non-native eyes pulled slightly lower to ~34%
+    /// so they sit better within the ghost's rounded head rather than at the very top.
+    ///
+    /// Sprout (native faceCenter y=415, 66%) — non-native eyes pulled slightly higher to ~61%
+    /// so they sit better within the sprout's leaf area rather than at the very bottom.
+    private static let faceCenterOverrides: [String: CGPoint] = [
+        // Ghost body — shift non-native eyes from y=167 -> y=200
+        "ghost-grumpy":  CGPoint(x: 321, y: 200),
+        "ghost-angry":   CGPoint(x: 321, y: 200),
+        "ghost-curious":  CGPoint(x: 321, y: 200),
+        "ghost-goofy":   CGPoint(x: 321, y: 200),
+        "ghost-bashful":  CGPoint(x: 321, y: 200),
+        "ghost-gentle":  CGPoint(x: 321, y: 200),
+        "ghost-quirky":  CGPoint(x: 321, y: 200),
+        "ghost-dazed":   CGPoint(x: 321, y: 200),
+        // Sprout body — shift non-native eyes from y=415 -> y=385
+        "sprout-grumpy":   CGPoint(x: 264, y: 385),
+        "sprout-angry":    CGPoint(x: 264, y: 385),
+        "sprout-goofy":    CGPoint(x: 264, y: 385),
+        "sprout-surprised": CGPoint(x: 264, y: 385),
+        "sprout-bashful":  CGPoint(x: 264, y: 385),
+        "sprout-gentle":   CGPoint(x: 264, y: 385),
+        "sprout-quirky":   CGPoint(x: 264, y: 385),
+        "sprout-dazed":    CGPoint(x: 264, y: 385),
+    ]
+}


### PR DESCRIPTION
## Summary
- Create AvatarTransforms utility enum with bodyTransform(), eyeTransform(), and resolveFaceCenter() pure functions
- Move faceCenterOverrides dictionary from AvatarCompositor to AvatarTransforms
- Refactor AvatarCompositor.render() and renderBodyOnly() to use the shared transform utilities

Part of plan: animated-avatar-foundation.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
