### PR TITLE
fix: thread showHidden through Swift client file endpoints and WorkspacePanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -40,7 +40,7 @@ final class WorkspaceBrowserState {
         }
     }
 
-    func loadFile(path targetPath: String, using daemonClient: DaemonClient) async {
+    func loadFile(path targetPath: String, using daemonClient: DaemonClient, showHidden: Bool = false) async {
         selectedFilePath = targetPath
         isLoadingFile = true
         selectedFileDetail = nil
@@ -48,7 +48,7 @@ final class WorkspaceBrowserState {
         editableContent = ""
         fileLoadTask?.cancel()
         let task = Task {
-            let detail = await daemonClient.fetchWorkspaceFile(path: targetPath)
+            let detail = await daemonClient.fetchWorkspaceFile(path: targetPath, showHidden: showHidden)
             guard !Task.isCancelled, selectedFilePath == targetPath else { return }
             selectedFileDetail = detail
             editableContent = detail?.content ?? ""
@@ -87,7 +87,7 @@ struct WorkspacePanel: View {
             Button("Discard", role: .destructive) {
                 guard let targetPath = state.pendingSwitchPath else { return }
                 state.pendingSwitchPath = nil
-                Task { await state.loadFile(path: targetPath, using: daemonClient) }
+                Task { await state.loadFile(path: targetPath, using: daemonClient, showHidden: state.showHiddenFiles) }
             }
             Button("Cancel", role: .cancel) {
                 state.pendingSwitchPath = nil
@@ -543,7 +543,7 @@ private struct WorkspaceTreeRow: View {
                 state.pendingSwitchPath = targetPath
                 state.showingDirtyAlert = true
             } else {
-                await state.loadFile(path: targetPath, using: daemonClient)
+                await state.loadFile(path: targetPath, using: daemonClient, showHidden: state.showHiddenFiles)
             }
         }
     }
@@ -686,7 +686,7 @@ private struct WorkspaceFileViewer: View {
 
     private func imageViewer(_ detail: WorkspaceFileResponse) -> some View {
         Group {
-            if let url = daemonClient.workspaceFileContentURL(path: detail.path) {
+            if let url = daemonClient.workspaceFileContentURL(path: detail.path, showHidden: state.showHiddenFiles) {
                 AuthenticatedImageView(url: url, daemonClient: daemonClient)
             } else {
                 Text("Unable to load image URL")
@@ -699,7 +699,7 @@ private struct WorkspaceFileViewer: View {
 
     private func videoViewer(_ detail: WorkspaceFileResponse) -> some View {
         Group {
-            if let url = daemonClient.workspaceFileContentURL(path: detail.path) {
+            if let url = daemonClient.workspaceFileContentURL(path: detail.path, showHidden: state.showHiddenFiles) {
                 WorkspaceVideoPlayer(url: url, daemonClient: daemonClient)
             } else {
                 Text("Unable to load video URL")

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -972,25 +972,29 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Fetch a single workspace file's metadata and optional content.
     /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
-    public func fetchWorkspaceFile(path: String) async -> WorkspaceFileResponse? {
+    public func fetchWorkspaceFile(path: String, showHidden: Bool = false) async -> WorkspaceFileResponse? {
         if let httpTransport {
-            return await httpTransport.fetchWorkspaceFile(path: path)
+            return await httpTransport.fetchWorkspaceFile(path: path, showHidden: showHidden)
         }
 
         let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
-        return await executeLocalRequest(path: "v1/workspace/file?path=\(encoded)", timeout: 10)
+        var query = "path=\(encoded)"
+        if showHidden { query += "&showHidden=true" }
+        return await executeLocalRequest(path: "v1/workspace/file?\(query)", timeout: 10)
     }
 
     /// Build a URL for streaming/downloading workspace file content.
     /// For remote connections, delegates to HTTPTransport. For local, builds against daemon HTTP port.
-    public func workspaceFileContentURL(path: String) -> URL? {
+    public func workspaceFileContentURL(path: String, showHidden: Bool = false) -> URL? {
         if let httpTransport {
-            return httpTransport.workspaceFileContentURL(path: path)
+            return httpTransport.workspaceFileContentURL(path: path, showHidden: showHidden)
         }
 
         let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
+        var query = "path=\(encoded)"
+        if showHidden { query += "&showHidden=true" }
         guard let port = httpPort else { return nil }
-        return URL(string: "http://localhost:\(port)/v1/workspace/file/content?path=\(encoded)")
+        return URL(string: "http://localhost:\(port)/v1/workspace/file/content?\(query)")
     }
 
     // MARK: - Workspace Write Operations

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -278,8 +278,8 @@ public final class HTTPTransport {
         case usageDaily(from: Int, to: Int)
         case usageBreakdown(from: Int, to: Int, groupBy: String)
         case workspaceTree(path: String, showHidden: Bool)
-        case workspaceFile(path: String)
-        case workspaceFileContent(path: String)
+        case workspaceFile(path: String, showHidden: Bool)
+        case workspaceFileContent(path: String, showHidden: Bool)
         case workspaceWrite
         case workspaceMkdir
         case workspaceRename
@@ -551,12 +551,16 @@ public final class HTTPTransport {
             if !path.isEmpty { params.append("path=\(encoded)") }
             if showHidden { params.append("showHidden=true") }
             return ("/v1/workspace/tree", params.isEmpty ? nil : params.joined(separator: "&"))
-        case .workspaceFile(let path):
+        case .workspaceFile(let path, let showHidden):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
-            return ("/v1/workspace/file", "path=\(encoded)")
-        case .workspaceFileContent(let path):
+            var query = "path=\(encoded)"
+            if showHidden { query += "&showHidden=true" }
+            return ("/v1/workspace/file", query)
+        case .workspaceFileContent(let path, let showHidden):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
-            return ("/v1/workspace/file/content", "path=\(encoded)")
+            var query = "path=\(encoded)"
+            if showHidden { query += "&showHidden=true" }
+            return ("/v1/workspace/file/content", query)
         case .workspaceWrite:
             return ("/v1/workspace/write", nil)
         case .workspaceMkdir:
@@ -955,12 +959,16 @@ public final class HTTPTransport {
             if !path.isEmpty { params.append("path=\(encoded)") }
             if showHidden { params.append("showHidden=true") }
             return ("\(prefix)/workspace/tree/", params.isEmpty ? nil : params.joined(separator: "&"))
-        case .workspaceFile(let path):
+        case .workspaceFile(let path, let showHidden):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
-            return ("\(prefix)/workspace/file/", "path=\(encoded)")
-        case .workspaceFileContent(let path):
+            var query = "path=\(encoded)"
+            if showHidden { query += "&showHidden=true" }
+            return ("\(prefix)/workspace/file/", query)
+        case .workspaceFileContent(let path, let showHidden):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
-            return ("\(prefix)/workspace/file/content/", "path=\(encoded)")
+            var query = "path=\(encoded)"
+            if showHidden { query += "&showHidden=true" }
+            return ("\(prefix)/workspace/file/content/", query)
         case .workspaceWrite:
             return ("\(prefix)/workspace/write/", nil)
         case .workspaceMkdir:
@@ -3213,8 +3221,8 @@ public final class HTTPTransport {
     }
 
     /// Fetch a single workspace file's metadata from `GET /v1/workspace/file`.
-    func fetchWorkspaceFile(path: String, isRetry: Bool = false) async -> WorkspaceFileResponse? {
-        guard let url = buildURL(for: .workspaceFile(path: path)) else { return nil }
+    func fetchWorkspaceFile(path: String, showHidden: Bool = false, isRetry: Bool = false) async -> WorkspaceFileResponse? {
+        guard let url = buildURL(for: .workspaceFile(path: path, showHidden: showHidden)) else { return nil }
 
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
@@ -3226,7 +3234,7 @@ public final class HTTPTransport {
                 if http.statusCode == 401 && !isRetry {
                     let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                     if case .success = refreshResult {
-                        return await fetchWorkspaceFile(path: path, isRetry: true)
+                        return await fetchWorkspaceFile(path: path, showHidden: showHidden, isRetry: true)
                     }
                     return nil
                 }
@@ -3240,8 +3248,8 @@ public final class HTTPTransport {
     }
 
     /// Build a URL for streaming/downloading workspace file content.
-    func workspaceFileContentURL(path: String) -> URL? {
-        return buildURL(for: .workspaceFileContent(path: path))
+    func workspaceFileContentURL(path: String, showHidden: Bool = false) -> URL? {
+        return buildURL(for: .workspaceFileContent(path: path, showHidden: showHidden))
     }
 
     /// Write (create or overwrite) a file in the workspace via `POST /v1/workspace/write`.


### PR DESCRIPTION
## Summary
Completes the hidden files feature by threading `showHidden` through the file access path:

- Add `showHidden: Bool` parameter to `Endpoint.workspaceFile` and `Endpoint.workspaceFileContent` enum cases
- Thread `showHidden` through `fetchWorkspaceFile` and `workspaceFileContentURL` in both `HTTPDaemonClient` and `DaemonClient`
- Pass `showHiddenFiles` through `loadFile`, image viewer URLs, and video viewer URLs in `WorkspacePanel`

Without this fix, hidden files appear in the tree when the toggle is on, but clicking them fails because the client doesn't pass `showHidden=true` to the file/content endpoints.

Fixes gap identified during plan review for show-hidden-files-toggle.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
