### PR TITLE
fix: make hidden workspace files read-only and disable mutating context menu items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -421,7 +421,8 @@ private struct WorkspaceTreeRow: View {
             }
         }
         .contextMenu {
-            if entry.isDirectory {
+            let hidden = isHiddenPath(entry.path)
+            if entry.isDirectory && !hidden {
                 Button {
                     state.newItemParentPath = entry.path
                     state.newItemName = ""
@@ -438,17 +439,19 @@ private struct WorkspaceTreeRow: View {
                 }
                 Divider()
             }
-            Button(role: .destructive) {
-                state.deleteConfirmPath = entry.path
-                state.deleteConfirmName = entry.name
-            } label: {
-                Label { Text("Delete") } icon: { VIconView(.trash, size: 12) }
-            }
-            Button {
-                state.renamingPath = entry.path
-                state.renamingText = entry.name
-            } label: {
-                Label { Text("Rename") } icon: { VIconView(.pencil, size: 12) }
+            if !hidden {
+                Button(role: .destructive) {
+                    state.deleteConfirmPath = entry.path
+                    state.deleteConfirmName = entry.name
+                } label: {
+                    Label { Text("Delete") } icon: { VIconView(.trash, size: 12) }
+                }
+                Button {
+                    state.renamingPath = entry.path
+                    state.renamingText = entry.name
+                } label: {
+                    Label { Text("Rename") } icon: { VIconView(.pencil, size: 12) }
+                }
             }
         }
     }
@@ -607,8 +610,18 @@ private struct WorkspaceFileViewer: View {
     }
 
     private func textViewer(_ detail: WorkspaceFileResponse) -> some View {
-        VStack(spacing: 0) {
-            if state.isDirty {
+        let readOnly = isHiddenPath(detail.path)
+        return VStack(spacing: 0) {
+            if readOnly {
+                HStack {
+                    Spacer()
+                    Text("Read-only")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                        .padding(.trailing, VSpacing.md)
+                        .padding(.vertical, VSpacing.xs)
+                }
+            } else if state.isDirty {
                 HStack {
                     Spacer()
                     Button {
@@ -629,15 +642,27 @@ private struct WorkspaceFileViewer: View {
                 }
             }
 
-            TextEditor(text: $state.editableContent)
-                .font(VFont.mono)
-                .foregroundColor(VColor.contentDefault)
-                .scrollContentBackground(.hidden)
-                .padding(VSpacing.md)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .onChange(of: state.editableContent) { _, newValue in
-                    state.isDirty = newValue != state.originalContent
+            if readOnly {
+                ScrollView {
+                    Text(detail.content ?? "")
+                        .font(VFont.mono)
+                        .foregroundColor(VColor.contentDefault)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(VSpacing.md)
+                        .textSelection(.enabled)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                TextEditor(text: $state.editableContent)
+                    .font(VFont.mono)
+                    .foregroundColor(VColor.contentDefault)
+                    .scrollContentBackground(.hidden)
+                    .padding(VSpacing.md)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .onChange(of: state.editableContent) { _, newValue in
+                        state.isDirty = newValue != state.originalContent
+                    }
+            }
         }
     }
 
@@ -746,6 +771,13 @@ private struct WorkspaceFileViewer: View {
         formatter.countStyle = .file
         return formatter.string(fromByteCount: Int64(bytes))
     }
+}
+
+// MARK: - Hidden Path Helper
+
+/// Returns true if any segment of the path starts with a dot (e.g. ".hidden/file.txt" or "dir/.env").
+private func isHiddenPath(_ path: String) -> Bool {
+    path.split(separator: "/").contains { $0.hasPrefix(".") }
 }
 
 // MARK: - Authenticated Image View


### PR DESCRIPTION
## Summary
Prevents misleading UX when interacting with hidden files in the workspace:

- Hidden text files are displayed in a read-only view (no Save button, non-editable)
- Delete and Rename context menu items are hidden for hidden entries
- New File and New Folder context menu items are hidden for hidden directories
- Non-hidden files are completely unaffected

This fixes silent failures where the backend rejects write/delete/rename operations on dot-prefixed paths while the UI appeared to allow them.

Fixes gap identified during plan review for show-hidden-files-toggle.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
