### PR TITLE
fix: downgrade guardian to contact on invite redemption instead of blocking

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -281,7 +281,7 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
   });
 
-  test("returns invalid_token for a revoked guardian to prevent invite-based reactivation", () => {
+  test("downgrades a revoked guardian to contact when they redeem an invite", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
       maxUses: 5,
@@ -307,11 +307,20 @@ describe("invite-redemption-service", () => {
       externalUserId: "guardian-tg-id",
     });
 
-    // Must reject — guardian channels are managed via the binding flow, not invites
-    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+    // Should succeed — guardian is downgraded to a regular contact
+    expect(outcome.ok).toBe(true);
+    expect((outcome as { type: string }).type).toBe("redeemed");
+
+    // Verify the contact was downgraded from guardian to contact
+    const result = findContactChannel({
+      channelType: "telegram",
+      externalUserId: "guardian-tg-id",
+    });
+    expect(result?.contact.role).toBe("contact");
+    expect(result?.channel.status).toBe("active");
   });
 
-  test("returns invalid_token for a revoked guardian via 6-digit invite code", () => {
+  test("downgrades a revoked guardian to contact via 6-digit invite code", () => {
     const code = "123456";
     const inviteCodeHash = hashVoiceCode(code);
     createInvite({
@@ -339,7 +348,17 @@ describe("invite-redemption-service", () => {
       externalUserId: "guardian-code-id",
     });
 
-    expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
+    // Should succeed — guardian is downgraded to a regular contact
+    expect(outcome.ok).toBe(true);
+    expect((outcome as { type: string }).type).toBe("redeemed");
+
+    // Verify the contact was downgraded from guardian to contact
+    const result = findContactChannel({
+      channelType: "telegram",
+      externalUserId: "guardian-code-id",
+    });
+    expect(result?.contact.role).toBe("contact");
+    expect(result?.channel.status).toBe("active");
   });
 
   test("does not return already_member for a revoked member", () => {

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -358,7 +358,7 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("returns invalid_or_expired for a revoked guardian to prevent invite-based reactivation", () => {
+  test("downgrades a revoked guardian to contact when they redeem a voice invite", () => {
     const phone = "+15559998888";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
@@ -382,7 +382,16 @@ describe("redeemVoiceInviteCode", () => {
       code,
     });
 
-    // Must reject — guardian channels are managed via the binding flow, not invites
-    expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
+    // Should succeed — guardian is downgraded to a regular contact
+    expect(result.ok).toBe(true);
+    expect((result as { type: string }).type).toBe("redeemed");
+
+    // Verify the contact was downgraded from guardian to contact
+    const contactResult = findContactChannel({
+      channelType: "phone",
+      externalUserId: phone,
+    });
+    expect(contactResult?.contact.role).toBe("contact");
+    expect(contactResult?.channel.status).toBe("active");
   });
 });

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -24,6 +24,7 @@ import {
 import type {
   ChannelPolicy,
   ChannelStatus,
+  ContactRole,
   ContactWriteResult,
 } from "./types.js";
 
@@ -146,6 +147,7 @@ export function upsertContactChannel(params: {
   createdBySessionId?: string;
   verifiedAt?: number;
   verifiedVia?: string;
+  role?: ContactRole;
 }): ContactWriteResult | null {
   let address: string;
 
@@ -174,6 +176,7 @@ export function upsertContactChannel(params: {
 
   upsertContact({
     displayName,
+    role: params.role,
     channels: [
       {
         type: params.sourceChannel,

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -146,11 +146,9 @@ export function redeemInvite(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
-  // Guardian channels must not be reactivated via regular invite redemption —
-  // their lifecycle is managed exclusively through the guardian binding flow.
-  if (existingContact && existingContact.role === "guardian") {
-    return { ok: false, reason: "invalid_token" };
-  }
+  // When a guardian redeems a regular invite, downgrade them to a normal
+  // contact — they are opting into the regular contact flow.
+  const isGuardianDowngrade = existingContact?.role === "guardian";
 
   // Inactive member reactivation: when the user already has a member record
   // in a non-active state (revoked/pending), reactivate it via upsertContactChannel
@@ -195,6 +193,7 @@ export function redeemInvite(params: {
             inviteId: invite.id,
             verifiedAt: Date.now(),
             verifiedVia: "invite",
+            ...(isGuardianDowngrade ? { role: "contact" as const } : {}),
           });
 
           const recorded = recordInviteUse({
@@ -359,11 +358,9 @@ export function redeemVoiceInviteCode(params: {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
-  // Guardian channels must not be reactivated via regular invite redemption —
-  // their lifecycle is managed exclusively through the guardian binding flow.
-  if (voiceContact && voiceContact.role === "guardian") {
-    return { ok: false, reason: "invalid_or_expired" };
-  }
+  // When a guardian redeems a regular invite, downgrade them to a normal
+  // contact — they are opting into the regular contact flow.
+  const isVoiceGuardianDowngrade = voiceContact?.role === "guardian";
 
   // Atomic redemption: upsert member + consume invite use in a transaction
   const STALE_INVITE = Symbol("stale_invite");
@@ -388,6 +385,7 @@ export function redeemVoiceInviteCode(params: {
           inviteId: invite.id,
           verifiedAt: Date.now(),
           verifiedVia: "invite",
+          ...(isVoiceGuardianDowngrade ? { role: "contact" as const } : {}),
         });
         memberId = writeResult!.channel.id;
 
@@ -499,11 +497,9 @@ export function redeemInviteByCode(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
-  // Guardian channels must not be reactivated via regular invite redemption —
-  // their lifecycle is managed exclusively through the guardian binding flow.
-  if (existingContact && existingContact.role === "guardian") {
-    return { ok: false, reason: "invalid_token" };
-  }
+  // When a guardian redeems a regular invite, downgrade them to a normal
+  // contact — they are opting into the regular contact flow.
+  const isCodeGuardianDowngrade = existingContact?.role === "guardian";
 
   // Inactive member reactivation: reactivate via upsertContactChannel and consume
   // an invite use atomically.
@@ -543,6 +539,7 @@ export function redeemInviteByCode(params: {
             inviteId: invite.id,
             verifiedAt: Date.now(),
             verifiedVia: "invite",
+            ...(isCodeGuardianDowngrade ? { role: "contact" as const } : {}),
           });
 
           const recorded = recordInviteUse({


### PR DESCRIPTION
## Summary
- When a guardian redeems a regular invite, downgrade their role from `guardian` to `contact` instead of rejecting with `invalid_token`
- Added optional `role` param to `upsertContactChannel` to support role changes during invite redemption
- Updated all three redemption functions (`redeemInvite`, `redeemVoiceInviteCode`, `redeemInviteByCode`) and their tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
