### PR TITLE
feat: animated avatar foundation — live CAShapeLayer rendering pipeline

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import AppKit
+
+/// Live-rendered avatar using CAShapeLayer, enabling future animations
+/// (blink, ripple, bounce). Renders identically to AvatarCompositor's
+/// static bitmap output for the same body/eyes/color combination.
+struct AnimatedAvatarView: View {
+    let bodyShape: AvatarBodyShape
+    let eyeStyle: AvatarEyeStyle
+    let color: AvatarColor
+    let size: CGFloat
+
+    var body: some View {
+        AvatarLayerRepresentable(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color, size: size)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct AvatarLayerRepresentable: NSViewRepresentable {
+    let bodyShape: AvatarBodyShape
+    let eyeStyle: AvatarEyeStyle
+    let color: AvatarColor
+    let size: CGFloat
+
+    func makeNSView(context: Context) -> AvatarLayerView {
+        let view = AvatarLayerView(frame: NSRect(x: 0, y: 0, width: size, height: size))
+        view.configure(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color, size: size)
+        return view
+    }
+
+    func updateNSView(_ nsView: AvatarLayerView, context: Context) {
+        nsView.configure(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color, size: size)
+    }
+}
+
+class AvatarLayerView: NSView {
+    private var bodyLayer = CAShapeLayer()
+    private var eyeLayers: [CAShapeLayer] = []
+
+    /// Track current configuration to skip redundant updates.
+    private var currentKey: String?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layer?.addSublayer(bodyLayer)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor, size: CGFloat) {
+        let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)-\(color.rawValue)-\(Int(size))"
+        guard key != currentKey else { return }
+        currentKey = key
+
+        // Update frame
+        frame = NSRect(x: 0, y: 0, width: size, height: size)
+
+        // Disable implicit CALayer animations during configuration
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        // --- Body layer ---
+        let bodyTransform = AvatarTransforms.bodyTransform(viewBox: bodyShape.viewBox, outputSize: size)
+        let bodyEditable = parseSVGPathToEditable(bodyShape.svgPath)
+        let bodyCGPath = bodyEditable.toCGPath()
+
+        var mutableTransform = bodyTransform
+        bodyLayer.path = bodyCGPath.copy(using: &mutableTransform)
+        bodyLayer.fillColor = color.nsColor.cgColor
+        bodyLayer.frame = CGRect(x: 0, y: 0, width: size, height: size)
+
+        // --- Eye layers ---
+        // Remove old eye layers
+        for layer in eyeLayers { layer.removeFromSuperlayer() }
+        eyeLayers.removeAll()
+
+        let faceCenter = AvatarTransforms.resolveFaceCenter(bodyShape: bodyShape, eyeStyle: eyeStyle)
+        let eyeXform = AvatarTransforms.eyeTransform(
+            eyeSourceViewBox: eyeStyle.sourceViewBox,
+            eyeCenter: eyeStyle.eyeCenter,
+            bodyViewBox: bodyShape.viewBox,
+            faceCenter: faceCenter,
+            bodyTransform: bodyTransform
+        )
+
+        for eyePath in eyeStyle.paths {
+            let eyeEditable = parseSVGPathToEditable(eyePath.svgPath)
+            let eyeCGPath = eyeEditable.toCGPath()
+            var mutableEyeTransform = eyeXform
+            let transformedEyePath = eyeCGPath.copy(using: &mutableEyeTransform)
+
+            let eyeLayer = CAShapeLayer()
+            eyeLayer.path = transformedEyePath
+            eyeLayer.fillColor = eyePath.color.cgColor
+            eyeLayer.frame = CGRect(x: 0, y: 0, width: size, height: size)
+            layer?.addSublayer(eyeLayer)
+            eyeLayers.append(eyeLayer)
+        }
+
+        CATransaction.commit()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarCompositor.swift
@@ -16,16 +16,7 @@ enum AvatarCompositor {
         }
 
         let viewBox = bodyShape.viewBox
-        let scale = min(size / viewBox.width, size / viewBox.height)
-        let tx = (size - viewBox.width * scale) / 2
-        let ty = (size - viewBox.height * scale) / 2
-
-        // Flip Y: Core Graphics has y=0 at bottom, SVG has y=0 at top.
-        // Translate up by size, then scale y by -1, then apply the aspect-fit transform.
-        var transform = CGAffineTransform(translationX: 0, y: size)
-            .scaledBy(x: 1, y: -1)
-            .translatedBy(x: tx, y: ty)
-            .scaledBy(x: scale, y: scale)
+        let transform = AvatarTransforms.bodyTransform(viewBox: viewBox, outputSize: size)
 
         let image = NSImage(size: NSSize(width: size, height: size))
         image.lockFocus()
@@ -36,7 +27,8 @@ enum AvatarCompositor {
 
         // Draw body
         let bodyPath = parseSVGPath(bodyShape.svgPath)
-        let transformedBody = bodyPath.copy(using: &transform)!
+        var mutableTransform = transform
+        let transformedBody = bodyPath.copy(using: &mutableTransform)!
         context.addPath(transformedBody)
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
@@ -46,16 +38,14 @@ enum AvatarCompositor {
         // coordinate space; each body shape defines a face-center where eyes should land.
         // Aspect-fit scaling sizes the eyes appropriately, then translation aligns the centers.
         // Per-combo overrides allow specific eye+body pairs to use a custom face center.
-        let srcVB = eyeStyle.sourceViewBox
-        let eyeCenter = eyeStyle.eyeCenter
-        let overrideKey = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)"
-        let faceCenter = faceCenterOverrides[overrideKey] ?? bodyShape.faceCenter
-        let remapScale = min(viewBox.width / srcVB.width, viewBox.height / srcVB.height)
-        let remapTx = faceCenter.x - eyeCenter.x * remapScale
-        let remapTy = faceCenter.y - eyeCenter.y * remapScale
-        let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
-            .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
-        let eyeTransform = remapT.concatenating(transform)
+        let faceCenter = AvatarTransforms.resolveFaceCenter(bodyShape: bodyShape, eyeStyle: eyeStyle)
+        let eyeTransform = AvatarTransforms.eyeTransform(
+            eyeSourceViewBox: eyeStyle.sourceViewBox,
+            eyeCenter: eyeStyle.eyeCenter,
+            bodyViewBox: viewBox,
+            faceCenter: faceCenter,
+            bodyTransform: transform
+        )
 
         for eyePath in eyeStyle.paths {
             let parsed = parseSVGPath(eyePath.svgPath)
@@ -84,14 +74,7 @@ enum AvatarCompositor {
         }
 
         let viewBox = bodyShape.viewBox
-        let scale = min(size / viewBox.width, size / viewBox.height)
-        let tx = (size - viewBox.width * scale) / 2
-        let ty = (size - viewBox.height * scale) / 2
-
-        var transform = CGAffineTransform(translationX: 0, y: size)
-            .scaledBy(x: 1, y: -1)
-            .translatedBy(x: tx, y: ty)
-            .scaledBy(x: scale, y: scale)
+        let transform = AvatarTransforms.bodyTransform(viewBox: viewBox, outputSize: size)
 
         let image = NSImage(size: NSSize(width: size, height: size))
         image.lockFocus()
@@ -101,7 +84,8 @@ enum AvatarCompositor {
         }
 
         let bodyPath = parseSVGPath(bodyShape.svgPath)
-        let transformedBody = bodyPath.copy(using: &transform)!
+        var mutableTransform = transform
+        let transformedBody = bodyPath.copy(using: &mutableTransform)!
         context.addPath(transformedBody)
         context.setFillColor(color.nsColor.cgColor)
         context.fillPath()
@@ -202,35 +186,6 @@ enum AvatarCompositor {
         cache[cacheKey] = image
         return image
     }
-
-    /// Per-combo face-center overrides for when the default body faceCenter doesn't produce
-    /// the best result for a specific eye style.  Key format: "bodyRawValue-eyeRawValue".
-    ///
-    /// Ghost (native faceCenter y=167, 28%) — non-native eyes pulled slightly lower to ~34%
-    /// so they sit better within the ghost's rounded head rather than at the very top.
-    ///
-    /// Sprout (native faceCenter y=415, 66%) — non-native eyes pulled slightly higher to ~61%
-    /// so they sit better within the sprout's leaf area rather than at the very bottom.
-    private static let faceCenterOverrides: [String: CGPoint] = [
-        // Ghost body — shift non-native eyes from y=167 → y=200
-        "ghost-grumpy":  CGPoint(x: 321, y: 200),
-        "ghost-angry":   CGPoint(x: 321, y: 200),
-        "ghost-curious":  CGPoint(x: 321, y: 200),
-        "ghost-goofy":   CGPoint(x: 321, y: 200),
-        "ghost-bashful":  CGPoint(x: 321, y: 200),
-        "ghost-gentle":  CGPoint(x: 321, y: 200),
-        "ghost-quirky":  CGPoint(x: 321, y: 200),
-        "ghost-dazed":   CGPoint(x: 321, y: 200),
-        // Sprout body — shift non-native eyes from y=415 → y=385
-        "sprout-grumpy":   CGPoint(x: 264, y: 385),
-        "sprout-angry":    CGPoint(x: 264, y: 385),
-        "sprout-goofy":    CGPoint(x: 264, y: 385),
-        "sprout-surprised": CGPoint(x: 264, y: 385),
-        "sprout-bashful":  CGPoint(x: 264, y: 385),
-        "sprout-gentle":   CGPoint(x: 264, y: 385),
-        "sprout-quirky":   CGPoint(x: 264, y: 385),
-        "sprout-dazed":    CGPoint(x: 264, y: 385),
-    ]
 
     private static var cache: [String: NSImage] = [:]
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarTransforms.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+
+/// Pure functions for computing the affine transforms used to render avatar
+/// body shapes and eye paths. Shared by both AvatarCompositor (static bitmap)
+/// and AnimatedAvatarView (live CAShapeLayer rendering).
+enum AvatarTransforms {
+    /// Computes the transform that maps an SVG viewBox to a square output of
+    /// the given size: Y-flip (SVG y=0 at top, CG y=0 at bottom) + aspect-fit
+    /// centering.
+    static func bodyTransform(viewBox: CGSize, outputSize: CGFloat) -> CGAffineTransform {
+        let scale = min(outputSize / viewBox.width, outputSize / viewBox.height)
+        let tx = (outputSize - viewBox.width * scale) / 2
+        let ty = (outputSize - viewBox.height * scale) / 2
+        return CGAffineTransform(translationX: 0, y: outputSize)
+            .scaledBy(x: 1, y: -1)
+            .translatedBy(x: tx, y: ty)
+            .scaledBy(x: scale, y: scale)
+    }
+
+    /// Computes the transform for eye paths: remaps from the eye's source
+    /// viewBox to the body's viewBox using eye-center -> face-center alignment,
+    /// then composes with the body transform.
+    static func eyeTransform(
+        eyeSourceViewBox: CGSize,
+        eyeCenter: CGPoint,
+        bodyViewBox: CGSize,
+        faceCenter: CGPoint,
+        bodyTransform: CGAffineTransform
+    ) -> CGAffineTransform {
+        let remapScale = min(bodyViewBox.width / eyeSourceViewBox.width,
+                             bodyViewBox.height / eyeSourceViewBox.height)
+        let remapTx = faceCenter.x - eyeCenter.x * remapScale
+        let remapTy = faceCenter.y - eyeCenter.y * remapScale
+        let remapT = CGAffineTransform(scaleX: remapScale, y: remapScale)
+            .concatenating(CGAffineTransform(translationX: remapTx, y: remapTy))
+        return remapT.concatenating(bodyTransform)
+    }
+
+    /// Resolves the face center for a body/eye combination, checking for
+    /// per-combo overrides before falling back to the body's default.
+    static func resolveFaceCenter(
+        bodyShape: AvatarBodyShape,
+        eyeStyle: AvatarEyeStyle
+    ) -> CGPoint {
+        let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)"
+        return faceCenterOverrides[key] ?? bodyShape.faceCenter
+    }
+
+    /// Per-combo face-center overrides for when the default body faceCenter doesn't produce
+    /// the best result for a specific eye style.  Key format: "bodyRawValue-eyeRawValue".
+    ///
+    /// Ghost (native faceCenter y=167, 28%) — non-native eyes pulled slightly lower to ~34%
+    /// so they sit better within the ghost's rounded head rather than at the very top.
+    ///
+    /// Sprout (native faceCenter y=415, 66%) — non-native eyes pulled slightly higher to ~61%
+    /// so they sit better within the sprout's leaf area rather than at the very bottom.
+    private static let faceCenterOverrides: [String: CGPoint] = [
+        // Ghost body — shift non-native eyes from y=167 -> y=200
+        "ghost-grumpy":  CGPoint(x: 321, y: 200),
+        "ghost-angry":   CGPoint(x: 321, y: 200),
+        "ghost-curious":  CGPoint(x: 321, y: 200),
+        "ghost-goofy":   CGPoint(x: 321, y: 200),
+        "ghost-bashful":  CGPoint(x: 321, y: 200),
+        "ghost-gentle":  CGPoint(x: 321, y: 200),
+        "ghost-quirky":  CGPoint(x: 321, y: 200),
+        "ghost-dazed":   CGPoint(x: 321, y: 200),
+        // Sprout body — shift non-native eyes from y=415 -> y=385
+        "sprout-grumpy":   CGPoint(x: 264, y: 385),
+        "sprout-angry":    CGPoint(x: 264, y: 385),
+        "sprout-goofy":    CGPoint(x: 264, y: 385),
+        "sprout-surprised": CGPoint(x: 264, y: 385),
+        "sprout-bashful":  CGPoint(x: 264, y: 385),
+        "sprout-gentle":   CGPoint(x: 264, y: 385),
+        "sprout-quirky":   CGPoint(x: 264, y: 385),
+        "sprout-dazed":    CGPoint(x: 264, y: 385),
+    ]
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/EditablePath.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/EditablePath.swift
@@ -1,0 +1,33 @@
+import CoreGraphics
+
+/// Mutable intermediate representation of an SVG path, preserving individual
+/// path elements so they can be manipulated programmatically (e.g., squishing
+/// Y coordinates for blink animations, perturbing control points for ripples).
+struct EditablePath {
+    var elements: [PathElement]
+
+    enum PathElement {
+        case moveTo(CGPoint)
+        case lineTo(CGPoint)
+        case curveTo(to: CGPoint, control1: CGPoint, control2: CGPoint)
+        case close
+    }
+
+    /// Convert to a Core Graphics path for rendering.
+    func toCGPath() -> CGPath {
+        let path = CGMutablePath()
+        for element in elements {
+            switch element {
+            case .moveTo(let point):
+                path.move(to: point)
+            case .lineTo(let point):
+                path.addLine(to: point)
+            case .curveTo(let to, let control1, let control2):
+                path.addCurve(to: to, control1: control1, control2: control2)
+            case .close:
+                path.closeSubpath()
+            }
+        }
+        return path
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Avatar/SVGPathParser.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/SVGPathParser.swift
@@ -16,8 +16,17 @@ import CoreGraphics
 /// - Scientific notation (e.g., `1e-4`)
 /// - Implicit repeated commands after the initial coordinate group
 func parseSVGPath(_ d: String) -> CGPath {
+    return parseSVGPathToEditable(d).toCGPath()
+}
+
+/// Parses an SVG path `d` attribute string into an `EditablePath`, preserving
+/// individual path elements for programmatic manipulation (animations, morphing).
+///
+/// Uses the same tokenizer and coordinate resolution logic as `parseSVGPath`,
+/// but builds an `EditablePath` instead of a `CGPath` directly.
+func parseSVGPathToEditable(_ d: String) -> EditablePath {
     let tokens = tokenize(d)
-    return buildPath(from: tokens)
+    return buildEditablePath(from: tokens)
 }
 
 // MARK: - Token Types
@@ -143,9 +152,9 @@ private func scanNumber(_ chars: [Character], from start: Int) -> (Double?, Int)
 
 // MARK: - Path Builder
 
-/// Processes the token stream and builds a CGMutablePath.
-private func buildPath(from tokens: [Token]) -> CGPath {
-    let path = CGMutablePath()
+/// Processes the token stream and builds an EditablePath with individual path elements.
+private func buildEditablePath(from tokens: [Token]) -> EditablePath {
+    var elements: [EditablePath.PathElement] = []
     var currentPoint = CGPoint.zero
     var startPoint = CGPoint.zero
     var currentCommand: Character = "M"
@@ -161,7 +170,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
 
             // Z/z takes no arguments
             if currentCommand == "Z" {
-                path.closeSubpath()
+                elements.append(.close)
                 currentPoint = startPoint
                 continue
             }
@@ -172,7 +181,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
         case "M":
             guard let (x, y, newI) = consumeCoordinatePair(tokens, from: i) else { break }
             let point = resolvePoint(x: x, y: y, relative: isRelative, current: currentPoint)
-            path.move(to: point)
+            elements.append(.moveTo(point))
             currentPoint = point
             startPoint = point
             i = newI
@@ -183,7 +192,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
         case "L":
             guard let (x, y, newI) = consumeCoordinatePair(tokens, from: i) else { break }
             let point = resolvePoint(x: x, y: y, relative: isRelative, current: currentPoint)
-            path.addLine(to: point)
+            elements.append(.lineTo(point))
             currentPoint = point
             i = newI
             continue
@@ -192,7 +201,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
             guard let (x, newI) = consumeNumber(tokens, from: i) else { break }
             let absX = isRelative ? currentPoint.x + x : x
             let point = CGPoint(x: absX, y: currentPoint.y)
-            path.addLine(to: point)
+            elements.append(.lineTo(point))
             currentPoint = point
             i = newI
             continue
@@ -201,7 +210,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
             guard let (y, newI) = consumeNumber(tokens, from: i) else { break }
             let absY = isRelative ? currentPoint.y + y : y
             let point = CGPoint(x: currentPoint.x, y: absY)
-            path.addLine(to: point)
+            elements.append(.lineTo(point))
             currentPoint = point
             i = newI
             continue
@@ -213,7 +222,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
             let control1 = resolvePoint(x: x1, y: y1, relative: isRelative, current: currentPoint)
             let control2 = resolvePoint(x: x2, y: y2, relative: isRelative, current: currentPoint)
             let endPoint = resolvePoint(x: x, y: y, relative: isRelative, current: currentPoint)
-            path.addCurve(to: endPoint, control1: control1, control2: control2)
+            elements.append(.curveTo(to: endPoint, control1: control1, control2: control2))
             currentPoint = endPoint
             i = newI3
             continue
@@ -227,7 +236,7 @@ private func buildPath(from tokens: [Token]) -> CGPath {
         i += 1
     }
 
-    return path
+    return EditablePath(elements: elements)
 }
 
 // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -52,8 +52,18 @@ struct IdentityPanel: View {
                             Spacer()
 
                             // Large centered avatar
-                            VAvatarImage(image: appearance.fullAvatarImage, size: avatarSize, showBorder: false)
-                                .frame(maxWidth: .infinity, alignment: .center)
+                            Group {
+                                if let body = appearance.characterBodyShape,
+                                   let eyes = appearance.characterEyeStyle,
+                                   let color = appearance.characterColor {
+                                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: avatarSize)
+                                        .frame(width: avatarSize, height: avatarSize)
+                                        .frame(maxWidth: .infinity, alignment: .center)
+                                } else {
+                                    VAvatarImage(image: appearance.fullAvatarImage, size: avatarSize, showBorder: false)
+                                        .frame(maxWidth: .infinity, alignment: .center)
+                                }
+                            }
 
                             // Update Avatar button
                             VButton(label: "Update Avatar", style: .outlined) { showAvatarSheet = true }


### PR DESCRIPTION
## Summary
Lays the foundation for animating avatar characters (eye blinks, body ripples, bounces) by introducing a live `CAShapeLayer`-based rendering pipeline alongside the existing static bitmap compositor.

- **EditablePath** — mutable intermediate representation for SVG paths, preserving individual path elements for future procedural animation transforms
- **AvatarTransforms** — extracted shared transform math (body transform, eye transform, face-center resolution) from `AvatarCompositor` into reusable pure functions
- **AnimatedAvatarView** — `NSViewRepresentable`-wrapped `NSView` with `CAShapeLayer` sublayers, rendering avatars identically to the static compositor but in a live layer tree ready for Core Animation
- **IdentityPanel integration** — swapped static `VAvatarImage` for `AnimatedAvatarView` when character components are available, with graceful fallback

No visual changes — this PR achieves pixel parity with the existing static rendering. The `AvatarCompositor` remains intact for static PNG generation (chat bubbles, activity feed, etc.).

## PRs included
- #16183 — refactor: extract avatar body and eye transform math from AvatarCompositor
- #16184 — feat: add EditablePath intermediate representation for SVG paths
- #16187 — feat: add CAShapeLayer-based AnimatedAvatarView for live avatar rendering
- #16190 — feat: use AnimatedAvatarView for character avatars in IdentityPanel

## Test plan
- [ ] Build and run macOS app
- [ ] Open Identity panel — avatar should render identically to before
- [ ] Cycle through body shapes, eye styles, and colors — all combos render correctly
- [ ] Verify static avatar images (chat bubbles, activity feed) still use AvatarCompositor and look correct
- [ ] Ghost and sprout body shapes with non-native eyes should have properly adjusted eye positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
