### PR TITLE
fix: remove apiKeys merge-on-read from loadRawConfig

### DIFF
--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -39,9 +39,12 @@ export function registerConfigCommand(program: Command): void {
     "after",
     `
 Configuration is stored in config.json in the assistant workspace directory.
-Keys support dotted paths for nested values (e.g. calls.enabled, apiKeys.anthropic).
+Keys support dotted paths for nested values (e.g. calls.enabled, twilio.accountSid).
 Values are auto-parsed as JSON (booleans, numbers, objects) with fallback to
 plain string if parsing fails.
+
+API keys are managed separately via secure storage. Use "assistant keys list"
+and "assistant keys set <provider> <key>" to view and manage API keys.
 
 Examples:
   $ assistant config list
@@ -53,14 +56,14 @@ Examples:
   config
     .command("set <key> <value>")
     .description(
-      "Set a config value (supports dotted paths like apiKeys.anthropic)",
+      "Set a config value (supports dotted paths like calls.enabled)",
     )
     .addHelpText(
       "after",
       `
 Arguments:
   key     Dotted path to the config key (e.g. provider, calls.enabled,
-          apiKeys.anthropic). Intermediate objects are created automatically.
+          twilio.accountSid). Intermediate objects are created automatically.
   value   The value to store. Parsed as JSON first (so "true" becomes boolean
           true, "42" becomes number 42). Falls back to plain string if JSON
           parsing fails.
@@ -68,10 +71,11 @@ Arguments:
 After writing the value to config.json, the lockfile is automatically synced
 to reflect the updated configuration.
 
+To manage API keys, use "assistant keys set <provider> <key>" instead.
+
 Examples:
   $ assistant config set provider anthropic
-  $ assistant config set calls.enabled true
-  $ assistant config set apiKeys.anthropic sk-ant-abc123`,
+  $ assistant config set calls.enabled true`,
     )
     .action((key: string, value: string) => {
       const raw = loadRawConfig();
@@ -100,10 +104,11 @@ Arguments:
 Prints the value at the given key path. If the key is not set, prints
 "(not set)". Object values are pretty-printed as indented JSON.
 
+To view API keys, use "assistant keys list" instead.
+
 Examples:
   $ assistant config get provider
-  $ assistant config get calls.enabled
-  $ assistant config get apiKeys`,
+  $ assistant config get calls.enabled`,
     )
     .action((key: string) => {
       const raw = loadRawConfig();
@@ -133,8 +138,8 @@ Dumps the full raw configuration from config.json as pretty-printed JSON.
 If no configuration has been set, prints "No configuration set".
 
 The --search flag filters results by case-insensitive substring match against
-flattened dotted key paths. For example, --search api matches apiKeys.anthropic,
-apiKeys.openai, and any other key containing "api".
+flattened dotted key paths. For example, --search calls matches calls.enabled,
+calls.recordingEnabled, and any other key containing "calls".
 
 Examples:
   $ assistant config list

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -7,6 +7,7 @@ import { getRuntimeHttpPort } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import { isHttpHealthy } from "../../daemon/daemon-control.js";
+import { getSecureKey } from "../../security/secure-keys.js";
 import {
   getDbPath,
   getLogPath,
@@ -83,9 +84,7 @@ Examples:
         fireworks: "FIREWORKS_API_KEY",
         openrouter: "OPENROUTER_API_KEY",
       };
-      const configKey = (raw.apiKeys as Record<string, string> | undefined)?.[
-        provider
-      ];
+      const configKey = getSecureKey(provider);
       const envVar = providerEnvVar[provider];
       const envKey = envVar ? process.env[envVar] : undefined;
 
@@ -97,7 +96,7 @@ Examples:
         fail(
           "API key configured",
           envVar
-            ? `set ${envVar} or run: assistant config set apiKeys.${provider} <key>`
+            ? `set ${envVar} or run: assistant keys set ${provider} <key>`
             : `set API key for provider "${provider}"`,
         );
       }

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -405,8 +405,9 @@ export function invalidateConfigCache(): void {
 }
 
 /**
- * Load the raw config from disk, merging API keys from secure storage.
+ * Load the raw config from disk without any secure-storage merging.
  * Used by CLI config commands to read/write the file directly.
+ * API keys in secure storage are managed via `assistant keys` commands.
  */
 export function loadRawConfig(): Record<string, unknown> {
   ensureMigratedDataDir();
@@ -418,25 +419,6 @@ export function loadRawConfig(): Record<string, unknown> {
     } catch (err) {
       throw new ConfigError(`Failed to parse config at ${configPath}: ${err}`);
     }
-  }
-
-  // Merge secure keys into apiKeys so `config get apiKeys.*` works
-  try {
-    const apiKeys =
-      raw.apiKeys &&
-      typeof raw.apiKeys === "object" &&
-      !Array.isArray(raw.apiKeys)
-        ? { ...(raw.apiKeys as Record<string, unknown>) }
-        : {};
-    for (const provider of API_KEY_PROVIDERS) {
-      const value = getSecureKey(provider);
-      if (value) apiKeys[provider] = value;
-    }
-    if (Object.keys(apiKeys).length > 0) {
-      raw.apiKeys = apiKeys;
-    }
-  } catch (err) {
-    log.debug({ err }, "Failed to merge secure keys into raw config");
   }
 
   return raw;


### PR DESCRIPTION
## Summary
- Remove the secure key merge block from `loadRawConfig()` that caused `config set` to fail when keychain is unavailable
- Fix `doctor.ts` to check API keys via `getSecureKey()` directly instead of relying on the removed merge
- Update `config.ts` help text to remove `apiKeys.*` examples and direct users to `assistant keys`

Part of plan: remove-apikeys-merge-on-read.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
