### PR TITLE
feat: add 14 OAuth integrations with collaborative guided flow

### DIFF
--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -39,6 +39,12 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
         headerName: "Authorization",
         valuePrefix: "Bearer ",
       },
+      {
+        hostPattern: "www.googleapis.com/drive",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
     ],
     setupSkillId: "google-oauth-applescript",
     setup: {
@@ -179,6 +185,396 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       return undefined;
     },
   },
+  "integration:github": {
+    service: "integration:github",
+    injectionTemplates: [
+      {
+        hostPattern: "api.github.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "github-oauth-setup",
+    setup: {
+      displayName: "GitHub",
+      dashboardUrl: "https://github.com/settings/developers",
+      appType: "OAuth App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.github.com/user", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as { login?: string };
+          return body.login ? `@${body.login}` : undefined;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:linear": {
+    service: "integration:linear",
+    injectionTemplates: [
+      {
+        hostPattern: "api.linear.app",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "linear-oauth-setup",
+    setup: {
+      displayName: "Linear",
+      dashboardUrl: "https://linear.app/settings/api",
+      appType: "OAuth application",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.linear.app/graphql", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ query: "{ viewer { email name } }" }),
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            data?: { viewer?: { email?: string; name?: string } };
+          };
+          return body.data?.viewer?.email ?? body.data?.viewer?.name;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:spotify": {
+    service: "integration:spotify",
+    injectionTemplates: [
+      {
+        hostPattern: "api.spotify.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "spotify-oauth-setup",
+    setup: {
+      displayName: "Spotify",
+      dashboardUrl: "https://developer.spotify.com/dashboard",
+      appType: "App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.spotify.com/v1/me", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            display_name?: string;
+            email?: string;
+          };
+          return body.display_name ?? body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:todoist": {
+    service: "integration:todoist",
+    injectionTemplates: [
+      {
+        hostPattern: "api.todoist.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "todoist-oauth-setup",
+    setup: {
+      displayName: "Todoist",
+      dashboardUrl: "https://developer.todoist.com/appconsole.html",
+      appType: "App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.todoist.com/sync/v9/sync", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: "sync_token=*&resource_types=[%22user%22]",
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            user?: { email?: string; full_name?: string };
+          };
+          return body.user?.full_name ?? body.user?.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:discord": {
+    service: "integration:discord",
+    injectionTemplates: [
+      {
+        hostPattern: "discord.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "discord-oauth-setup",
+    setup: {
+      displayName: "Discord",
+      dashboardUrl: "https://discord.com/developers/applications",
+      appType: "Application",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://discord.com/api/v10/users/@me", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            username?: string;
+            global_name?: string;
+          };
+          return body.global_name ?? body.username;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:dropbox": {
+    service: "integration:dropbox",
+    injectionTemplates: [
+      {
+        hostPattern: "api.dropboxapi.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+      {
+        hostPattern: "content.dropboxapi.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "dropbox-oauth-setup",
+    setup: {
+      displayName: "Dropbox",
+      dashboardUrl: "https://www.dropbox.com/developers/apps",
+      appType: "Scoped access app",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch(
+          "https://api.dropboxapi.com/2/users/get_current_account",
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        );
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            name?: { display_name?: string };
+            email?: string;
+          };
+          return body.name?.display_name ?? body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:asana": {
+    service: "integration:asana",
+    injectionTemplates: [
+      {
+        hostPattern: "app.asana.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "asana-oauth-setup",
+    setup: {
+      displayName: "Asana",
+      dashboardUrl: "https://app.asana.com/0/my-apps",
+      appType: "App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://app.asana.com/api/1.0/users/me", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            data?: { name?: string; email?: string };
+          };
+          return body.data?.name ?? body.data?.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:airtable": {
+    service: "integration:airtable",
+    injectionTemplates: [
+      {
+        hostPattern: "api.airtable.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "airtable-oauth-setup",
+    setup: {
+      displayName: "Airtable",
+      dashboardUrl: "https://airtable.com/create/oauth",
+      appType: "OAuth integration",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.airtable.com/v0/meta/whoami", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as { email?: string };
+          return body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:hubspot": {
+    service: "integration:hubspot",
+    injectionTemplates: [
+      {
+        hostPattern: "api.hubapi.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "hubspot-oauth-setup",
+    setup: {
+      displayName: "HubSpot",
+      dashboardUrl: "https://app.hubspot.com/developer",
+      appType: "App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch(
+          "https://api.hubapi.com/oauth/v1/access-tokens/" + accessToken,
+        );
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            user?: string;
+            hub_domain?: string;
+          };
+          return body.user ?? body.hub_domain;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
+
+  "integration:figma": {
+    service: "integration:figma",
+    injectionTemplates: [
+      {
+        hostPattern: "api.figma.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "figma-oauth-setup",
+    setup: {
+      displayName: "Figma",
+      dashboardUrl: "https://www.figma.com/developers/apps",
+      appType: "App",
+      requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.figma.com/v1/me", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            handle?: string;
+            email?: string;
+          };
+          return body.handle ?? body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -191,6 +587,16 @@ export const SERVICE_ALIASES: Record<string, string> = {
   slack: "integration:slack",
   notion: "integration:notion",
   twitter: "integration:twitter",
+  github: "integration:github",
+  linear: "integration:linear",
+  spotify: "integration:spotify",
+  todoist: "integration:todoist",
+  discord: "integration:discord",
+  dropbox: "integration:dropbox",
+  asana: "integration:asana",
+  airtable: "integration:airtable",
+  hubspot: "integration:hubspot",
+  figma: "integration:figma",
 };
 
 /**

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -47,6 +47,28 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       appType: "Desktop app",
       requiresClientSecret: true,
     },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch(
+          "https://www.googleapis.com/oauth2/v2/userinfo",
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        );
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            email?: string;
+            name?: string;
+          };
+          return body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
   },
 
   "integration:slack": {
@@ -65,6 +87,27 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       dashboardUrl: "https://api.slack.com/apps",
       appType: "Slack App",
       requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://slack.com/api/auth.test", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            ok: boolean;
+            user?: string;
+            team?: string;
+          };
+          if (body.user && body.team) return `@${body.user} (${body.team})`;
+          if (body.user) return `@${body.user}`;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
     },
   },
 
@@ -85,10 +128,34 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       appType: "Public integration",
       requiresClientSecret: true,
     },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.notion.com/v1/users/me", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Notion-Version": "2022-06-28",
+          },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            name?: string;
+            type?: string;
+            person?: { email?: string };
+          };
+          return body.name ?? body.person?.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
   },
 
   "integration:twitter": {
     service: "integration:twitter",
+    setupSkillId: "twitter-oauth-setup",
     setup: {
       displayName: "Twitter / X",
       dashboardUrl: "https://developer.x.com/en/portal/dashboard",

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -51,6 +51,21 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
   "integration:slack": {
     service: "integration:slack",
+    injectionTemplates: [
+      {
+        hostPattern: "slack.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "slack-oauth-setup",
+    setup: {
+      displayName: "Slack",
+      dashboardUrl: "https://api.slack.com/apps",
+      appType: "Slack App",
+      requiresClientSecret: true,
+    },
   },
 
   "integration:notion": {
@@ -63,6 +78,13 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
         valuePrefix: "Bearer ",
       },
     ],
+    setupSkillId: "notion-oauth-setup",
+    setup: {
+      displayName: "Notion",
+      dashboardUrl: "https://www.notion.so/my-integrations",
+      appType: "Public integration",
+      requiresClientSecret: true,
+    },
   },
 
   "integration:twitter": {

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -47,8 +47,11 @@ const PROVIDER_SEED_DATA: Record<
       "https://www.googleapis.com/auth/contacts.readonly",
     ],
     scopePolicy: {
-      allowAdditionalScopes: false,
-      allowedOptionalScopes: [],
+      allowAdditionalScopes: true,
+      allowedOptionalScopes: [
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+      ],
       forbiddenScopes: [],
     },
     extraParams: { access_type: "offline", prompt: "consent" },
@@ -124,6 +127,197 @@ const PROVIDER_SEED_DATA: Record<
     },
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "gateway",
+  },
+
+  "integration:github": {
+    providerKey: "integration:github",
+    authUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    pingUrl: "https://api.github.com/user",
+    baseUrl: "https://api.github.com",
+    defaultScopes: ["repo", "read:user", "notifications"],
+    scopePolicy: {
+      allowAdditionalScopes: true,
+      allowedOptionalScopes: [
+        "read:org",
+        "write:discussion",
+        "gist",
+        "project",
+      ],
+      forbiddenScopes: ["delete_repo", "admin:org"],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:linear": {
+    providerKey: "integration:linear",
+    authUrl: "https://linear.app/oauth/authorize",
+    tokenUrl: "https://api.linear.app/oauth/token",
+    pingUrl: "https://api.linear.app/graphql",
+    baseUrl: "https://api.linear.app",
+    defaultScopes: ["read", "write", "issues:create"],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    extraParams: { prompt: "consent" },
+    callbackTransport: "loopback",
+  },
+
+  "integration:spotify": {
+    providerKey: "integration:spotify",
+    authUrl: "https://accounts.spotify.com/authorize",
+    tokenUrl: "https://accounts.spotify.com/api/token",
+    pingUrl: "https://api.spotify.com/v1/me",
+    baseUrl: "https://api.spotify.com/v1",
+    defaultScopes: [
+      "user-read-playback-state",
+      "user-modify-playback-state",
+      "user-read-currently-playing",
+      "user-read-recently-played",
+      "playlist-read-private",
+      "playlist-modify-public",
+      "playlist-modify-private",
+      "user-library-read",
+      "user-library-modify",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:todoist": {
+    providerKey: "integration:todoist",
+    authUrl: "https://todoist.com/oauth/authorize",
+    tokenUrl: "https://todoist.com/oauth/access_token",
+    pingUrl: "https://api.todoist.com/rest/v2/projects",
+    baseUrl: "https://api.todoist.com/rest/v2",
+    defaultScopes: ["data:read_write"],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: ["data:delete"],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:discord": {
+    providerKey: "integration:discord",
+    authUrl: "https://discord.com/oauth2/authorize",
+    tokenUrl: "https://discord.com/api/v10/oauth2/token",
+    pingUrl: "https://discord.com/api/v10/users/@me",
+    baseUrl: "https://discord.com/api/v10",
+    defaultScopes: [
+      "identify",
+      "guilds",
+      "guilds.members.read",
+      "messages.read",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: ["bot"],
+      forbiddenScopes: [],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:dropbox": {
+    providerKey: "integration:dropbox",
+    authUrl: "https://www.dropbox.com/oauth2/authorize",
+    tokenUrl: "https://api.dropboxapi.com/oauth2/token",
+    pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
+    baseUrl: "https://api.dropboxapi.com/2",
+    defaultScopes: [
+      "files.metadata.read",
+      "files.content.read",
+      "files.content.write",
+      "sharing.read",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    extraParams: { token_access_type: "offline" },
+    callbackTransport: "loopback",
+  },
+
+  "integration:asana": {
+    providerKey: "integration:asana",
+    authUrl: "https://app.asana.com/-/oauth_authorize",
+    tokenUrl: "https://app.asana.com/-/oauth_token",
+    pingUrl: "https://app.asana.com/api/1.0/users/me",
+    baseUrl: "https://app.asana.com/api/1.0",
+    defaultScopes: ["default"],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:airtable": {
+    providerKey: "integration:airtable",
+    authUrl: "https://airtable.com/oauth2/v1/authorize",
+    tokenUrl: "https://airtable.com/oauth2/v1/token",
+    pingUrl: "https://api.airtable.com/v0/meta/whoami",
+    baseUrl: "https://api.airtable.com/v0",
+    defaultScopes: [
+      "data.records:read",
+      "data.records:write",
+      "schema.bases:read",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    tokenEndpointAuthMethod: "client_secret_post",
+    callbackTransport: "loopback",
+  },
+
+  "integration:hubspot": {
+    providerKey: "integration:hubspot",
+    authUrl: "https://app.hubspot.com/oauth/authorize",
+    tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+    pingUrl: "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
+    baseUrl: "https://api.hubapi.com",
+    defaultScopes: [
+      "crm.objects.contacts.read",
+      "crm.objects.contacts.write",
+      "crm.objects.deals.read",
+      "crm.objects.deals.write",
+      "crm.objects.companies.read",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: true,
+      allowedOptionalScopes: [
+        "crm.objects.companies.write",
+        "crm.objects.owners.read",
+      ],
+      forbiddenScopes: [],
+    },
+    callbackTransport: "loopback",
+  },
+
+  "integration:figma": {
+    providerKey: "integration:figma",
+    authUrl: "https://www.figma.com/oauth",
+    tokenUrl: "https://api.figma.com/v1/oauth/token",
+    pingUrl: "https://api.figma.com/v1/me",
+    baseUrl: "https://api.figma.com/v1",
+    defaultScopes: ["files:read", "file_comments:write"],
+    scopePolicy: {
+      allowAdditionalScopes: false,
+      allowedOptionalScopes: [],
+      forbiddenScopes: [],
+    },
+    callbackTransport: "loopback",
   },
 
   // Manual-token providers: these don't use OAuth2 flows but need provider

--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: airtable-oauth-setup
+description: Set up Airtable OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Airtable OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "airtable"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Airtable OAuth credentials so the Airtable integration can connect to their bases.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Airtable-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:airtable`
+- **Dashboard:** `https://airtable.com/create/oauth`
+- **Ping URL:** `https://api.airtable.com/v0/meta/whoami`
+- **Callback transport:** Loopback (port 17322)
+- **Token endpoint auth method:** secret via POST body
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Airtable-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have an Airtable account? You'll need one to create an OAuth integration.
+
+If no account, direct them to `https://airtable.com/signup` to create one first.
+
+---
+
+### Step 1: Open Airtable OAuth Page
+
+Open: `https://airtable.com/create/oauth`
+
+> I've opened the Airtable OAuth page. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Register a New OAuth Integration
+
+> Look for the **Register new OAuth integration** button and click it.
+
+Then:
+
+> Set the name to **Vellum Assistant**. Then click **Register integration**.
+
+**Known issues:**
+- If you don't see the registration option, make sure you're on a plan that supports OAuth integrations (most plans do)
+
+**Milestone (2 of 8):** "Integration registered — now let's configure the redirect URL."
+
+---
+
+### Step 3: Set Up Redirect URL
+
+Before this step, resolve the redirect URI:
+
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:airtable" --json
+```
+
+Check the `redirectUri` from `credential_store describe`:
+
+```
+credential_store describe:
+  service: "integration:airtable"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user to find the **OAuth redirect URL** field, paste the URI, and save.
+
+---
+
+### Step 4: Add Scopes
+
+> Now let's add the permissions this integration needs. Look for the **Scopes** section.
+>
+> You'll need to add each of these scopes:
+>
+> - `data.records:read` — read records from bases
+> - `data.records:write` — create and update records
+> - `schema.bases:read` — view base structure and field info
+>
+> Select each scope from the list and make sure all three are added.
+
+Wait for the user to confirm all 3 scopes are added.
+
+**Milestone (4 of 8):** "Scopes configured — now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and OAuth Secret
+
+> Now let's grab the credentials. You should see the **Client ID** on this page.
+
+> Also look for the **OAuth secret** — you may need to click a button to reveal or generate it.
+
+**Milestone (5 of 8):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the OAuth secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:airtable"
+  field: "oauth_secret"
+  label: "Airtable OAuth Secret"
+  description: "Copy the OAuth secret from the integration page (you may need to click Show or Generate first) and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:airtable --client-id <client-id> --client-secret-credential-path "integration:airtable:oauth_secret"
+```
+
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 7: Authorize
+
+> I'll start the Airtable authorization flow now. You should see a consent page asking you to allow **Vellum Assistant** to access your Airtable data.
+>
+> Review the permissions and click **Grant access**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:airtable --client-id <client-id>
+```
+
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:airtable --client-id <client-id>)" "https://api.airtable.com/v0/meta/whoami" | python3 -m json.tool
+```
+
+**On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Airtable-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under the OAuth redirect URL field on the integration page
+- Airtable OAuth secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,131 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Airtable from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. An Airtable account
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Register an OAuth Integration
+
+Tell the user:
+
+> **Step 1: Register an OAuth integration**
+>
+> Open this link:
+> `https://airtable.com/create/oauth`
+>
+> 1. Click **Register new OAuth integration**
+> 2. Set the name to **Vellum Assistant**
+> 3. Click **Register integration**
+>
+> Let me know when the integration is created.
+
+## Path B Step 4: Add Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> In the integration settings, find the **Scopes** section and add each of these scopes:
+>
+> `data.records:read`, `data.records:write`, `schema.bases:read`
+>
+> That's 3 scopes total.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> In the integration settings, find the **OAuth redirect URL** field.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Save the settings
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your integration credentials**
+>
+> On the integration settings page, find the **Client ID** and the **OAuth secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:airtable"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **OAuth secret**. You may need to click **Show** or **Generate** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:airtable"
+  field: "oauth_secret"
+  value: "<the oauth secret the user sent>"
+```
+
+Note: Airtable OAuth secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Airtable**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:airtable --client-id <client-id> --client-secret-credential-path "integration:airtable:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:airtable --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **Airtable is connected!** You can now ask me to read and update records in your Airtable bases.

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: asana-oauth-setup
+description: Set up Asana OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Asana OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "asana"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Asana OAuth credentials so the Asana integration can connect to their workspace.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Asana-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:asana`
+- **Dashboard:** `https://app.asana.com/0/my-apps`
+- **Ping URL:** `https://app.asana.com/api/1.0/users/me`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
+- **Scopes:** `default` (Asana uses a single default scope)
+
+## Asana-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have an Asana account? You'll need to be able to create developer apps in your Asana workspace.
+
+If no account, direct them to sign up at `https://asana.com`. If they're unsure about permissions, suggest proceeding — most Asana accounts allow creating personal apps.
+
+---
+
+### Step 1: Open Asana Developer Console
+
+Open: `https://app.asana.com/0/my-apps`
+
+> I've opened the Asana Developer Console (My Apps). If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create New App** button. Go ahead and click it.
+
+After the user clicks:
+
+> Set the app name to **Vellum Assistant**. You'll also need to select a purpose — pick whichever fits best (e.g., "Build an integration" or "Personal use"). Then click **Create app**.
+
+**Known issues:**
+- If the user is part of multiple workspaces, the app will be tied to their default workspace — that's fine for personal use
+
+**Milestone (2 of 7):** "App created — now let's set up the redirect URL."
+
+---
+
+### Step 3: Set Up Redirect URL
+
+Before this step, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:asana"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> In the app settings, look for the **OAuth** section or tab. Under **Redirect URLs**, click **Add redirect URL**, paste the URL I'll give you, and save.
+
+Provide the redirect URI from the `credential_store describe` output.
+
+**Milestone (3 of 7):** "Redirect URL is configured — now let's grab the credentials."
+
+---
+
+### Step 4: Get Client ID and App Secret
+
+> Now let's grab the credentials. In the app settings, look for the **OAuth** section. You should see the **Client ID** and the app **secret** listed there.
+
+> You may need to click a reveal or show button to see the secret.
+
+**Milestone (4 of 7):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 5: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:asana"
+  field: "oauth_secret"
+  label: "Asana OAuth App Secret"
+  description: "Copy the app secret from the OAuth section of your Asana app settings (you may need to click Show first) and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:asana --client-id <client-id> --client-secret-credential-path "integration:asana:oauth_secret"
+```
+
+**Milestone (5 of 7):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 6: Authorize
+
+> I'll start the Asana authorization flow now. You should see an Asana consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Allow**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:asana --client-id <client-id>
+```
+
+---
+
+### Step 7: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:asana --client-id <client-id>)" "https://app.asana.com/api/1.0/users/me" | python3 -m json.tool
+```
+
+**On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Asana-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under the **OAuth** section of the app settings
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,119 @@
+# Path B: Manual Channel Setup (Asana)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Asana from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. An Asana account with permission to create developer apps
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create an Asana App
+
+Tell the user:
+
+> **Step 1: Create an Asana App**
+>
+> Open this link:
+> `https://app.asana.com/0/my-apps`
+>
+> 1. Click **Create New App**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Select a purpose (e.g., "Build an integration")
+> 4. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Redirect URL
+
+Tell the user:
+
+> **Step 2: Add redirect URL**
+>
+> In the app settings, go to the **OAuth** section.
+>
+> 1. Under **Redirect URLs**, click **Add redirect URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Save the changes
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> In the **OAuth** section of your app settings, you should see the **Client ID** and the app **secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:asana"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **app secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:asana"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: Asana app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 4: Authorize Asana**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:asana --client-id <client-id> --client-secret-credential-path "integration:asana:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:asana --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Asana is connected!** You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work.

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: discord-oauth-setup
+description: Set up Discord OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Discord OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "discord"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Discord OAuth credentials so the Discord integration can connect to their account and servers.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Discord-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:discord`
+- **Dashboard:** `https://discord.com/developers/applications`
+- **Ping URL:** `https://discord.com/api/v10/users/@me`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Discord-Specific Flow
+
+The flow has 9 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Discord account? You don't need any special permissions; any Discord user can create applications in the Developer Portal.
+
+If no account, direct them to `https://discord.com/register` first.
+
+---
+
+### Step 1: Open Discord Developer Portal
+
+Open: `https://discord.com/developers/applications`
+
+> I've opened the Discord Developer Portal. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New Application
+
+> Look for the **New Application** button (top-right area). Go ahead and click it.
+
+After the user clicks:
+
+> Set the application name to **Vellum Assistant**, accept the Developer Terms of Service and Developer Policy, then click **Create**.
+
+**Known issues:**
+- If the user already has an application named "Vellum Assistant", they can either reuse it or pick a different name
+- Discord may show a CAPTCHA during creation
+
+**Milestone (2 of 9):** "Application created — now let's head to the OAuth2 settings."
+
+---
+
+### Step 3: Navigate to OAuth2
+
+> In the left sidebar, click **OAuth2**. This is where we'll configure the credentials and scopes.
+
+Open: the application's **OAuth2** page via the left sidebar.
+
+**Milestone (3 of 9):** "OAuth2 page open — let's grab the Client ID."
+
+---
+
+### Step 4: Copy Client ID
+
+> You should see the **Client ID** near the top of the OAuth2 page. Copy it and paste it here in the chat.
+
+Wait for the user to provide the Client ID.
+
+---
+
+### Step 5: Reset and Copy the App Secret
+
+> Now we need the app secret. Click the **Reset Secret** button. Discord will ask you to confirm — go ahead and confirm it.
+
+> **Important:** Once the secret is shown, you'll only be able to see it this once. I'll prompt you to paste it securely in a moment.
+
+**Known issues:**
+- If the user has 2FA enabled, Discord will ask for a 2FA code before revealing the secret
+- The old secret (if any) will stop working immediately after reset
+
+**Milestone (5 of 9):** "Credentials in hand — now let's set up the redirect URL."
+
+---
+
+### Step 6: Add Redirect URL
+
+Before this step, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:discord"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> Still on the **OAuth2** page, scroll down to the **Redirects** section. Click **Add Redirect**, paste this URL:
+>
+> `<redirect URI from credential_store>`
+>
+> Then click **Save Changes** at the bottom.
+
+**Milestone (6 of 9):** "Redirect URL is set — time to save the credentials."
+
+---
+
+### Step 7: Store Credentials
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:discord"
+  field: "oauth_secret"
+  label: "Discord OAuth App Secret"
+  description: "Paste the app secret you just copied from the OAuth2 page."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:discord --client-id <client-id> --client-secret-credential-path "integration:discord:oauth_secret"
+```
+
+**Milestone (7 of 9):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 8: Authorize
+
+> I'll start the Discord authorization flow now. You should see a Discord consent page asking you to authorize **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Authorize**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:discord --client-id <client-id> --scopes "identify guilds guilds.members.read messages.read"
+```
+
+---
+
+### Step 9: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:discord --client-id <client-id>)" "https://discord.com/api/v10/users/@me" | python3 -m json.tool
+```
+
+**On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Discord-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **Redirects** on the OAuth2 page
+- Discord app secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,129 @@
+# Path B: Manual Channel Setup (Discord)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Discord from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Discord account
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Discord Application
+
+Tell the user:
+
+> **Step 1: Create a Discord Application**
+>
+> Open this link:
+> `https://discord.com/developers/applications`
+>
+> 1. Click **New Application**
+> 2. Set the name to **Vellum Assistant**
+> 3. Accept the Developer Terms of Service and Developer Policy
+> 4. Click **Create**
+>
+> Let me know when the application is created.
+
+## Path B Step 4: Navigate to OAuth2
+
+Tell the user:
+
+> **Step 2: Open OAuth2 settings**
+>
+> In the left sidebar, click **OAuth2**.
+>
+> Let me know when you're on that page.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> On the **OAuth2** page, scroll down to the **Redirects** section.
+>
+> 1. Click **Add Redirect**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Save Changes** at the bottom of the page
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> On the **OAuth2** page, you should see the **Client ID** near the top.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:discord"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now click **Reset Secret** on the OAuth2 page. Confirm the reset when prompted. Copy the revealed secret and send it here as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:discord"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: Discord app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Discord**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:discord --client-id <client-id> --client-secret-credential-path "integration:discord:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:discord --client-id <client-id> --scopes "identify guilds guilds.members.read messages.read"
+```
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **Discord is connected!** You can now ask me to check your Discord servers, read messages, and look up server members.

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: dropbox-oauth-setup
+description: Set up Dropbox OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Dropbox OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "dropbox"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Dropbox OAuth credentials so the Dropbox integration can connect to their account.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Dropbox-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:dropbox`
+- **Dashboard:** `https://www.dropbox.com/developers/apps`
+- **Ping URL:** `https://api.dropboxapi.com/2/users/get_current_account` (POST, no body)
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+- **Extra params:** `token_access_type=offline`
+
+## Dropbox-Specific Flow
+
+The flow has 11 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Dropbox account? A free account works fine.
+
+If no account, direct them to `https://www.dropbox.com` to create one first.
+
+---
+
+### Step 1: Open Dropbox App Console
+
+Open: `https://www.dropbox.com/developers/apps`
+
+> I've opened the Dropbox App Console. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create app** button. Go ahead and click it.
+
+After the user clicks:
+
+> You should see a setup form. Choose these options:
+>
+> 1. **Choose an API:** Select **Scoped access**
+> 2. **Choose the type of access:** Select **Full Dropbox**
+> 3. **Name your app:** Enter **Vellum Assistant**
+
+Then:
+
+> Click **Create app** to finish.
+
+**Known issues:**
+- App names must be globally unique on Dropbox — if "Vellum Assistant" is taken, suggest adding a suffix like "Vellum Assistant - Personal"
+- If the user sees "You have reached the limit for the number of apps," they'll need to delete an unused app first
+
+**Milestone (2 of 11):** "App created — now let's set the permissions."
+
+---
+
+### Step 3: Set Permissions
+
+> Click the **Permissions** tab at the top of the app page.
+>
+> You'll need to check the boxes for each of these scopes:
+>
+> - `files.metadata.read` — view file and folder metadata
+> - `files.content.read` — read file content
+> - `files.content.write` — create and update files
+> - `sharing.read` — view shared files and folders
+>
+> Make sure each one is checked.
+
+Wait for the user to confirm all 4 scopes are enabled.
+
+---
+
+### Step 4: Save Permissions
+
+> Now click the **Submit** button at the bottom to save the permissions.
+
+**Important:** Permissions must be saved before the authorization step, otherwise the token will not include the requested scopes.
+
+**Milestone (4 of 11):** "Permissions saved — now let's set up the redirect URL."
+
+---
+
+### Step 5: Set Up Redirect URI
+
+Before this step, resolve the redirect URI:
+
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:dropbox" --json
+```
+
+Check the `redirectUri` from `credential_store describe`:
+
+```
+credential_store describe:
+  service: "integration:dropbox"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URI — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> Click the **Settings** tab. Scroll down to the **OAuth 2** section and find the **Redirect URIs** field.
+>
+> Paste this URI and click **Add**:
+>
+> `<redirect URI>`
+
+---
+
+### Step 6: Get App Key and App Secret
+
+> Stay on the **Settings** tab. Scroll up to the **App key** and **App secret** fields in the same OAuth 2 section.
+>
+> The App key is shown in plain text. The App secret is hidden — click **Show** to reveal it.
+
+**Milestone (6 of 11):** "Found the credentials — now let's save them."
+
+---
+
+### Step 7: Store App Key (Client ID)
+
+Collect the App key conversationally:
+
+> Copy the **App key** and paste it here in the chat.
+
+---
+
+### Step 8: Store App Secret
+
+Collect the App secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:dropbox"
+  field: "oauth_secret"
+  label: "Dropbox App Secret"
+  description: "Copy the App secret from the Settings page (click Show to reveal it) and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:dropbox --client-id <app-key> --client-secret-credential-path "integration:dropbox:oauth_secret" --extra-params "token_access_type=offline"
+```
+
+**Milestone (8 of 11):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 9: Authorize
+
+> I'll start the Dropbox authorization flow now. You should see a Dropbox consent page asking you to allow **Vellum Assistant** to access your Dropbox.
+>
+> Review the permissions and click **Allow**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:dropbox --client-id <app-key>
+```
+
+---
+
+### Step 10: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -X POST -H "Authorization: Bearer $(assistant oauth connections token integration:dropbox --client-id <app-key>)" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
+```
+
+**On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."
+
+---
+
+### Step 11: Done
+
+Summarize what was set up and remind the user:
+
+> Your Dropbox integration is ready. The token will refresh automatically, so you shouldn't need to repeat this process.
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Dropbox-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URIs** on the Settings tab
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,133 @@
+# Path B: Manual Channel Setup (Dropbox)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Dropbox from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Dropbox account (free is fine)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Dropbox App
+
+Tell the user:
+
+> **Step 1: Create a Dropbox App**
+>
+> Open this link:
+> `https://www.dropbox.com/developers/apps`
+>
+> 1. Click **Create app**
+> 2. Choose **Scoped access**
+> 3. Choose **Full Dropbox** access type
+> 4. Name it **Vellum Assistant**
+> 5. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Set Permissions
+
+Tell the user:
+
+> **Step 2: Set permissions**
+>
+> Click the **Permissions** tab at the top of the app page. Check the boxes for each of these scopes:
+>
+> `files.metadata.read`, `files.content.read`, `files.content.write`, `sharing.read`
+>
+> That's 4 scopes total. After checking all four, click **Submit** to save.
+>
+> Let me know when they're saved.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Click the **Settings** tab. Scroll down to the **OAuth 2** section and find **Redirect URIs**.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Click **Add**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> Still on the **Settings** tab, find the **App key** and **App secret** in the OAuth 2 section.
+>
+> Send me your **App key** first.
+
+Wait for the App key, then store it:
+
+```
+credential_store store:
+  service: "integration:dropbox"
+  field: "client_id"
+  value: "<the app key the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **App secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:dropbox"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: Dropbox app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Dropbox**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:dropbox --client-id <app-key> --client-secret-credential-path "integration:dropbox:oauth_secret" --extra-params "token_access_type=offline"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:dropbox --client-id <app-key>
+```
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **Dropbox is connected!** You can now ask me to read files, upload documents, and browse your Dropbox.

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: figma-oauth-setup
+description: Set up Figma OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Figma OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "figma"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Figma OAuth credentials so the Figma integration can access their design files and comments.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Figma-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:figma`
+- **Dashboard:** `https://www.figma.com/developers/apps`
+- **Ping URL:** `https://api.figma.com/v1/me`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Figma-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Figma account? You'll need one to create a Figma app for OAuth access.
+
+If the user doesn't have a Figma account, point them to `https://www.figma.com/signup` and wait for them to sign up.
+
+---
+
+### Step 1: Open Figma Developers Page
+
+Open: `https://www.figma.com/developers/apps`
+
+> I've opened the Figma developers page. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New Figma App
+
+> Look for the **Create a new app** button (or a **+** button). Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following details:
+>
+> - **App name:** Vellum Assistant
+> - **Website URL:** any URL is fine (e.g., `https://vellum.ai`)
+>
+> Then click **Save** or **Create**.
+
+**Known issues:**
+- If the page looks different or the button isn't visible, the user may need to scroll down or check that they're on the correct page at `https://www.figma.com/developers/apps`
+
+**Milestone (2 of 7):** "App created — now let's set up the callback URL."
+
+---
+
+### Step 3: Set Up Redirect URI
+
+Before this step, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:figma"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> On the app settings page, find the **Callback URL** or **Redirect URI** field. Paste in this URL:
+>
+> `<redirect URI from credential_store>`
+>
+> Then click **Save**.
+
+**Milestone (3 of 7):** "Callback URL is set — now let's configure the scopes."
+
+---
+
+### Step 4: Configure Scopes
+
+> Now let's make sure the right scopes are enabled. On the app settings page, look for a **Scopes** or **Permissions** section.
+>
+> Enable these scopes:
+>
+> - `files:read` — read access to files and projects
+> - `file_comments:write` — ability to post comments on files
+>
+> Save your changes if there's a save button.
+
+Wait for the user to confirm scopes are set.
+
+**Milestone (4 of 7):** "Scopes are configured — now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and App Secret
+
+> On the app settings page, you should see your **Client ID** and **App Secret** (sometimes called just "Secret"). These are the credentials we need.
+
+**Milestone (5 of 7):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:figma"
+  field: "oauth_secret"
+  label: "Figma OAuth App Secret"
+  description: "Copy the app secret from the Figma app settings page and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:figma --client-id <client-id> --client-secret-credential-path "integration:figma:oauth_secret"
+```
+
+**Milestone (6 of 7):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 7: Authorize and Verify
+
+> I'll start the Figma authorization flow now. You should see a Figma consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Allow access**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:figma --client-id <client-id>
+```
+
+After authorization completes, verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:figma --client-id <client-id>)" "https://api.figma.com/v1/me" | python3 -m json.tool
+```
+
+**On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Figma-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI in the **Callback URL** field on the app settings page
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,124 @@
+# Path B: Manual Channel Setup (Figma)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Figma from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Figma account
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Figma App
+
+Tell the user:
+
+> **Step 1: Create a Figma App**
+>
+> Open this link:
+> `https://www.figma.com/developers/apps`
+>
+> 1. Click **Create a new app** (or the **+** button)
+> 2. Set the app name to **Vellum Assistant**
+> 3. Set the website URL to any URL (e.g., `https://vellum.ai`)
+> 4. Click **Save** or **Create**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Configure Scopes and Callback URL
+
+Tell the user:
+
+> **Step 2: Set up scopes and callback URL**
+>
+> On the app settings page:
+>
+> 1. Find the **Scopes** section and enable:
+>    - `files:read`
+>    - `file_comments:write`
+>
+> 2. Find the **Callback URL** field and paste this exact URL:
+>    `OAUTH_CALLBACK_URL`
+>
+> 3. Click **Save**
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> On the app settings page, find the **Client ID** and **App Secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:figma"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **App Secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:figma"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: Figma app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 4: Authorize Figma**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:figma --client-id <client-id> --client-secret-credential-path "integration:figma:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:figma --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Figma is connected!** You can now ask me to browse your design files, inspect components, and post comments.

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: github-oauth-setup
+description: Set up GitHub OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "GitHub OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "github"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up GitHub OAuth credentials so the GitHub integration can connect to their account.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the GitHub-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:github`
+- **Dashboard:** `https://github.com/settings/developers`
+- **Ping URL:** `https://api.github.com/user`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## GitHub-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a GitHub account? You'll need one to create an OAuth App.
+
+If no account, direct them to `https://github.com/signup` and wait for them to finish before continuing.
+
+---
+
+### Step 1: Open GitHub Developer Settings
+
+Open: `https://github.com/settings/developers`
+
+> I've opened the GitHub Developer Settings page. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New OAuth App
+
+> Look for the **New OAuth App** button (top-right area of the OAuth Apps tab). Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following fields:
+>
+> - **Application name:** `Vellum Assistant`
+> - **Homepage URL:** `https://vellum.ai` (or any URL you prefer)
+> - **Authorization callback URL:** We need to look this up first — hold on.
+
+Resolve the callback URL:
+
+```
+credential_store describe:
+  service: "integration:github"
+```
+
+Use the `redirectUri` from the response. If it says **"automatic"** or the callback transport is loopback with no ingress requirement, tell the user:
+
+> For the **Authorization callback URL**, enter: `http://localhost:17322/oauth/callback`
+
+If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+
+Then:
+
+> Once all three fields are filled in, click **Register application**.
+
+**Milestone (2 of 8):** "App registered — now let's grab the credentials."
+
+---
+
+### Step 3: Copy Client ID
+
+> You should now be on the app's settings page. The **Client ID** is displayed near the top. Copy it — we'll need it in a moment.
+
+**Milestone (3 of 8):** "Client ID is ready — now we need the app secret."
+
+---
+
+### Step 4: Generate App Secret
+
+> Below the Client ID, you should see a **Generate a new client secret** button. Click it.
+>
+> GitHub will show the secret only once, so copy it right away before navigating away from the page.
+
+**Milestone (4 of 8):** "Secret generated — now let's store both credentials."
+
+---
+
+### Step 5: Store Credentials
+
+Collect Client ID conversationally:
+
+> Paste the **Client ID** here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:github"
+  field: <secret-field>
+  label: "GitHub OAuth App Secret"
+  description: "Paste the app secret you just generated from the GitHub OAuth App page."
+  placeholder: "..."
+```
+
+<!-- Note: <secret-field> maps to the provider's secret credential field name for the OAuth token exchange. -->
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:github --client-id <client-id> --secret-credential-path "integration:github:<secret-field>"
+```
+
+**Milestone (5 of 8):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 6: Add Scopes
+
+The GitHub integration requires these scopes:
+
+- `repo` — full access to repositories
+- `read:user` — read user profile info
+- `notifications` — access notifications
+
+These scopes are passed during the authorization step below.
+
+---
+
+### Step 7: Authorize
+
+> I'll start the GitHub authorization flow now. You should see a GitHub consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Authorize**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:github --client-id <client-id> --scopes "repo,read:user,notifications"
+```
+
+**Milestone (7 of 8):** "Authorization complete — let's verify it works."
+
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:github --client-id <client-id>)" "https://api.github.com/user" | python3 -m json.tool
+```
+
+**On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key GitHub-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Set the **Authorization callback URL** to the ingress-based OAuth callback URL when creating the app
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,110 @@
+# Path B: Manual Channel Setup (GitHub)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up GitHub from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A GitHub account
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a GitHub OAuth App
+
+Tell the user:
+
+> **Step 1: Create an OAuth App**
+>
+> Open this link:
+> `https://github.com/settings/developers`
+>
+> 1. Click the **OAuth Apps** tab if not already selected
+> 2. Click **New OAuth App**
+> 3. Fill in:
+>    - **Application name:** `Vellum Assistant`
+>    - **Homepage URL:** `https://vellum.ai`
+>    - **Authorization callback URL:** `OAUTH_CALLBACK_URL`
+> 4. Click **Register application**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> You should be on the app's settings page now. The **Client ID** is shown near the top.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:github"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now click **Generate a new client secret**. GitHub will show it only once, so copy it immediately. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:github"
+  field: <secret-field>
+  value: "<the app secret the user sent>"
+```
+
+<!-- Note: <secret-field> maps to the provider's secret credential field name for the OAuth token exchange. -->
+
+Note: GitHub app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 5: Authorize
+
+Tell the user:
+
+> **Step 3: Authorize GitHub**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:github --client-id <client-id> --secret-credential-path "integration:github:<secret-field>"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:github --client-id <client-id> --scopes "repo,read:user,notifications"
+```
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.
+
+## Path B Step 6: Done
+
+After authorization:
+
+> **GitHub is connected!** You can now ask me to check your repositories, notifications, pull requests, and issues.

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: hubspot-oauth-setup
+description: Set up HubSpot OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "HubSpot OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "hubspot"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up HubSpot OAuth credentials so the HubSpot CRM integration can connect to their account.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the HubSpot-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:hubspot`
+- **Dashboard:** `https://app.hubspot.com/developer`
+- **Ping URL:** `https://api.hubapi.com/crm/v3/objects/contacts?limit=1`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## HubSpot-Specific Flow
+
+The flow has 10 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a HubSpot account? You'll need one to create a developer app.
+
+If no account, direct them to sign up at `https://app.hubspot.com/signup/developers` and come back once they're logged in.
+
+---
+
+### Step 1: Open HubSpot Developer Portal
+
+Open: `https://app.hubspot.com/developer`
+
+> I've opened the HubSpot developer portal. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a Developer Account (if needed)
+
+> If this is your first time here, HubSpot may ask you to create a developer account. Go ahead and follow the prompts to set one up — it's free.
+
+If the user already has a developer account, skip to the next step.
+
+**Milestone (2 of 10):** "Developer account ready — now let's create an app."
+
+---
+
+### Step 3: Create a New App
+
+> Look for the **Create app** button. Go ahead and click it.
+
+**Known issues:**
+- If the user doesn't see a Create app button, they may need to navigate to **Apps** in the top navigation first
+- Some accounts may show "Create a public app" vs "Create a private app" — choose **public app** (required for OAuth)
+
+**Milestone (3 of 10):** "App created — now let's configure it."
+
+---
+
+### Step 4: Fill In App Details
+
+> Set the app name to **Vellum Assistant**. You can leave the other fields (description, logo, etc.) blank for now. Click **Save**.
+
+---
+
+### Step 5: Go to the Auth Tab
+
+> Now click on the **Auth** tab at the top of the app page. This is where we'll configure OAuth settings.
+
+**Milestone (5 of 10):** "Auth tab open — let's set up the redirect URL and scopes."
+
+---
+
+### Step 6: Add Redirect URL
+
+Before this step, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:hubspot"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> On the **Auth** tab, find the **Redirect URLs** section. Click **Add URL**, paste the redirect URI, and click **Save**.
+
+---
+
+### Step 7: Add Scopes
+
+> Still on the **Auth** tab, scroll down to the **Scopes** section. You'll need to add each of these scopes:
+>
+> - `crm.objects.contacts.read` — read contact records
+> - `crm.objects.contacts.write` — create and update contacts
+> - `crm.objects.deals.read` — read deal records
+> - `crm.objects.deals.write` — create and update deals
+> - `crm.objects.companies.read` — read company records
+>
+> Use the search box to find each scope, then check the box next to it. Click **Save** when all five are added.
+
+Wait for the user to confirm all 5 scopes are added.
+
+**Milestone (7 of 10):** "Scopes configured — now let's grab the credentials."
+
+---
+
+### Step 8: Get Client ID and App Secret
+
+> Still on the **Auth** tab, you should see the **Client ID** and **App Secret** near the top of the page.
+
+**Milestone (8 of 10):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 9: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:hubspot"
+  field: "oauth_secret"
+  label: "HubSpot OAuth App Secret"
+  description: "Copy the App Secret from the Auth tab and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:hubspot --client-id <client-id> --client-secret-credential-path "integration:hubspot:oauth_secret"
+```
+
+Then authorize:
+
+> I'll start the HubSpot authorization flow now. You should see a HubSpot consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Select the HubSpot account you want to connect, review the permissions, and click **Grant access**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:hubspot --client-id <client-id>
+```
+
+**Milestone (9 of 10):** "Credentials saved and authorized — let's verify."
+
+---
+
+### Step 10: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:hubspot --client-id <client-id>)" "https://api.hubapi.com/crm/v3/objects/contacts?limit=1" | python3 -m json.tool
+```
+
+**On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key HubSpot-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URLs** on the Auth tab
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,133 @@
+# Path B: Manual Channel Setup (HubSpot)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up HubSpot from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A HubSpot account (free tier works)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Developer Account and App
+
+Tell the user:
+
+> **Step 1: Create a HubSpot App**
+>
+> Open this link:
+> `https://app.hubspot.com/developer`
+>
+> 1. Sign in or create a free developer account if needed
+> 2. Click **Create app** (choose public app if prompted)
+> 3. Set the app name to **Vellum Assistant**
+> 4. Click **Save**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> Click on the **Auth** tab at the top of the app page. Scroll down to the **Scopes** section and add each of these scopes:
+>
+> `crm.objects.contacts.read`, `crm.objects.contacts.write`, `crm.objects.deals.read`, `crm.objects.deals.write`, `crm.objects.companies.read`
+>
+> That's 5 scopes total. Use the search box to find each one and check the box next to it. Click **Save** when done.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Still on the **Auth** tab, scroll to the **Redirect URLs** section.
+>
+> 1. Click **Add URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Save**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> Still on the **Auth** tab, look near the top for the **Client ID** and **App Secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:hubspot"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **App Secret**. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:hubspot"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: HubSpot app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize HubSpot**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:hubspot --client-id <client-id> --client-secret-credential-path "integration:hubspot:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:hubspot --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **HubSpot is connected!** You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM.

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: linear-oauth-setup
+description: Set up Linear OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Linear OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "linear"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Linear OAuth credentials so the Linear integration can connect to their workspace.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Linear-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:linear`
+- **Auth URL:** `https://linear.app/oauth/authorize`
+- **Token URL:** `https://api.linear.app/oauth/token`
+- **Ping URL:** `https://api.linear.app/graphql`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
+- **Extra params:** `prompt=consent`
+
+## Linear-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Linear account with access to a workspace?
+
+If no account, direct them to sign up at `https://linear.app`. If they have an account but aren't sure about permissions, explain that they'll need workspace access to create OAuth applications under Settings > API.
+
+---
+
+### Step 1: Open Linear API Settings
+
+Open: `https://linear.app/settings/api`
+
+> I've opened the Linear API settings page. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New OAuth Application
+
+> Scroll down to the **OAuth Applications** section. Click **Create new OAuth application**.
+
+After the user clicks:
+
+> Set the **Application name** to **Vellum Assistant**.
+
+Before filling in the redirect URL, resolve it:
+
+```
+credential_store describe:
+  service: "integration:linear"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, tell the user: "For the **Redirect URL**, enter `http://localhost:17322/oauth/callback`."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user to paste the resolved redirect URI.
+
+> Now click **Create**.
+
+**Known issues:**
+- If the user sees an error about duplicate application names, suggest a variant like "Vellum Assistant (Personal)"
+
+**Milestone (2 of 8):** "App created — now let's grab the credentials."
+
+---
+
+### Step 3: Copy the Client ID
+
+> You should now see the application details page. Look for the **Client ID** (sometimes labeled **Application ID**). Copy it and paste it here in the chat.
+
+Wait for the user to provide the Client ID.
+
+**Milestone (3 of 8):** "Got the Client ID — now let's grab the secret."
+
+---
+
+### Step 4: Copy the OAuth Secret
+
+> The app secret is shown **only once** right after creation. If you can still see it on the page, copy it now.
+
+If the user missed it:
+
+> If you navigated away and the secret is no longer visible, you'll need to generate a new one. Look for a **Regenerate** or **New secret** option on the application details page.
+
+Collect the secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:linear"
+  field: "oauth_secret"
+  label: "Linear OAuth App Secret"
+  description: "Copy the app secret from the Linear OAuth application page and paste it here."
+  placeholder: "lin_oauth_..."
+```
+
+**Milestone (4 of 8):** "Credentials captured — let's add the scopes next."
+
+---
+
+### Step 5: Configure Scopes
+
+> Now let's make sure the right scopes are requested. The Linear OAuth flow requests scopes at authorization time, so I'll handle that automatically. The scopes we'll request are:
+>
+> - `read` — read access to your Linear data
+> - `write` — write access to update issues, projects, etc.
+> - `issues:create` — create new issues
+>
+> You don't need to configure these in the Linear dashboard — I'll include them in the authorization request.
+
+**Milestone (5 of 8):** "Scopes are set — now let's save everything."
+
+---
+
+### Step 6: Store Credentials
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:linear --client-id <client-id> --client-secret-credential-path "integration:linear:oauth_secret"
+```
+
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 7: Authorize
+
+> I'll start the Linear authorization flow now. You should see a Linear consent page asking you to allow **Vellum Assistant** to access your workspace.
+>
+> Review the permissions and click **Authorize**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:linear --client-id <client-id> --extra-params "prompt=consent"
+```
+
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth connections token integration:linear --client-id <client-id>)" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
+```
+
+**On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Linear-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- The redirect URL must be set when creating the OAuth application (or updated afterwards in the app settings)
+- The app secret is shown only once at creation time — if the user misses it, they'll need to regenerate it

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,104 @@
+# Path B: Manual Channel Setup (Linear)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Linear from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Linear account with workspace access
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Linear OAuth Application
+
+Tell the user:
+
+> **Step 1: Create a Linear OAuth application**
+>
+> Open this link:
+> `https://linear.app/settings/api`
+>
+> 1. Scroll down to the **OAuth Applications** section
+> 2. Click **Create new OAuth application**
+> 3. Set the application name to **Vellum Assistant**
+> 4. Set the **Redirect URL** to `OAUTH_CALLBACK_URL`
+> 5. Click **Create**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> You should now see the application details. Send me the **Client ID** (also called **Application ID**) first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:linear"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **app secret**. It's shown only once right after creation. If you can still see it, copy and send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:linear"
+  field: "oauth_secret"
+  value: "<the secret the user sent>"
+```
+
+Note: If the user navigated away and can no longer see the secret, they'll need to regenerate it from the application settings page.
+
+## Path B Step 5: Authorize
+
+Tell the user:
+
+> **Step 3: Authorize Linear**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:linear --client-id <client-id> --client-secret-credential-path "integration:linear:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:linear --client-id <client-id> --extra-params "prompt=consent"
+```
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.
+
+## Path B Step 6: Done
+
+After authorization:
+
+> **Linear is connected!** You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow.

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -1,133 +1,154 @@
 ---
 name: notion-oauth-setup
-description: Create a Notion integration and OAuth credentials for Notion integration using browser automation
+description: Set up Notion OAuth credentials for Notion integration using a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "Notion OAuth Setup"
     user-invocable: true
-    includes: ["browser", "public-ingress"]
+    credential-setup-for: "notion"
+    includes: ["collaborative-oauth-flow"]
 ---
 
-You are helping your user create a Notion integration (OAuth app) so Vellum can connect to their Notion workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
+You are helping your user set up Notion OAuth credentials so the Notion integration can connect to their workspace.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Notion-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:notion`
+- **Credential type:** Public integration (OAuth)
+- **Token endpoint auth:** `client_secret_basic` (client secret always required)
+- **Scopes:** None (Notion does not use explicit OAuth scopes)
+- **Extra params:** `owner=user`
 
 ## Prerequisites
 
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
+Before beginning the user-facing flow, ensure **public ingress** is configured. Notion OAuth requires a publicly reachable redirect URI — there is no loopback/desktop-app alternative.
 
-## Before You Start
+Read the configured public gateway URL from `ingress.publicBaseUrl`. If it is missing, load and run the `public-ingress` skill first (`skill_load` with `skill: "public-ingress"`). Build the redirect URI as `<publicBaseUrl>/webhooks/oauth/callback`.
 
-Tell the user:
+## Notion-Specific Flow
 
-- "I'll walk you through creating a Notion integration so Vellum can read and write pages and databases in your workspace. The whole process takes a few minutes."
-- "I'll be automating the Notion integrations page in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
-- "No sensitive credentials will be shown in the conversation."
+The flow has 6 steps total, takes about 2-3 minutes.
 
-## Step 1: Navigate to Notion Integrations
+### Step 0: Prerequisite Check
 
-Tell the user: "First, let me open the Notion integrations page."
+> Before we start — do you have a Notion account and workspace you'd like to connect?
 
-Use `browser_navigate` to go to `https://www.notion.so/my-integrations`.
+If no Notion account, guide them to create one at `https://www.notion.so/signup` or defer.
 
-Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+---
 
-- **If a sign-in page appears:** Tell the user "Please sign in to your Notion account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
-- **If the integrations dashboard loads:** Tell the user "Notion integrations page is loaded. Let's create your integration!" and continue to Step 2.
+### Step 1: Open Notion Integrations
 
-## Step 2: Create a New Integration
+Open: `https://www.notion.so/profile/integrations`
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+> I've opened the Notion integrations page. If it's asking you to sign in, go ahead and do that first. Once you're in, you should see your list of integrations (it might be empty).
 
-> **Create a Notion Integration**
+---
+
+### Step 2: Create a New Public Integration
+
+> Look for the **"New integration"** button (or a **"+"** button) and click it.
 >
-> I'm about to create a new Notion integration called "Vellum Assistant". This integration will only have the capabilities you approve — it won't access any pages or databases until you explicitly share them with it or authorize it via OAuth.
+> On the creation form:
+> 1. Set the name to **Vellum Assistant**
+> 2. Select your workspace from the **Associated workspace** dropdown
+> 3. For the **Type**, select **Public** — this is required for OAuth
+> 4. Click **Submit**
 
-Wait for the user to approve. If they decline, explain that the integration is required for OAuth and offer to try again or cancel.
+**Known issues:**
+- If "Public" is not available as a type, the user may need to check their workspace settings or plan level
+- If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it — skip ahead to Step 3
 
-Once approved:
+**Milestone (2 of 6):** "Integration created — now we'll configure the OAuth redirect."
 
-1. Click "New integration" (or the "+" button)
-2. Select "Public" as the integration type (required for OAuth)
-3. Enter integration name: "Vellum Assistant"
-4. Select the user's workspace
-5. Click "Submit" or "Create"
+---
 
-Take a `browser_screenshot` to show the result.
+### Step 3: Configure OAuth Redirect URI
 
-Tell the user: "Integration created! Now let's configure the OAuth settings."
+The integration settings page should load after creation. Guide the user to the **Distribution** tab or section.
 
-## Step 3: Configure OAuth Settings
-
-Navigate to the integration's "Distribution" or "OAuth Domain & URIs" tab.
-
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
-
-> **Configure OAuth Redirect URI**
+> Now look for the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**). Click into it.
 >
-> I'm about to add the OAuth redirect URI to your Notion integration. This allows Notion to send the authorization code back to Vellum after you approve the connection.
+> You should see a field for **Redirect URIs**. Paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> Then scroll down and click **Save changes**.
 
-Wait for the user to approve.
+Replace `OAUTH_CALLBACK_URL` with the concrete redirect URI built from `ingress.publicBaseUrl`. Never send the placeholder literally.
 
-Once approved:
-
-1. Find the "Redirect URIs" field
-2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress).
-3. Save the settings
-
-Take a `browser_snapshot` to confirm.
-
-Tell the user: "Redirect URI configured. Now let's get your OAuth credentials."
-
-## Step 4: Extract Client ID and Client Secret
-
-Stay on the integration settings page and navigate to the "Secrets" or "OAuth Clients" section.
-
-Use `browser_extract` to read:
-
-1. **OAuth client_id** — this is the integration's OAuth client ID
-2. **OAuth client_secret** — click "Show" or "Reveal" first, then extract the value
-
-**Important:** Notion requires a client secret for the token exchange (sent via HTTP Basic Auth). Both values are needed.
-
-Tell the user: "Credentials extracted! Now let's connect your Notion workspace."
-
-## Step 5: Connect Notion
-
-Tell the user: "Opening Notion authorization so you can grant Vellum access to your workspace. You'll see a Notion consent page — just click 'Allow access'."
-
-Use the `credential_store` tool to connect Notion via OAuth2:
+Copy the redirect URI to the clipboard before navigating so the user can paste it:
 
 ```
-action: "oauth2_connect"
-service: "integration:notion"
-client_id: "<the extracted OAuth client_id>"
-client_secret: "<the extracted OAuth client_secret>"
-scopes: []
+host_bash:
+  command: |
+    echo -n "OAUTH_CALLBACK_URL" | pbcopy && /tmp/vellum-nav.sh "https://www.notion.so/profile/integrations"
 ```
 
-This will open the Notion authorization page in the user's browser. Wait for the flow to complete.
+**Known issues:**
+- Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use the base domain from `ingress.publicBaseUrl`
+- If the page shows "Internal integration" with no Distribution tab, the integration was created as Internal — they'll need to recreate it as Public
 
-## Step 6: Celebrate!
+---
 
-Once connected, tell the user:
+### Step 4: Copy Client ID and Client Secret
 
-"**Notion is connected!** You're all set. You can now read and write pages and databases in your Notion workspace through Vellum. Try asking me to list your databases or read a specific page!"
+> Now look for the **Secrets** section on the integration page. You should see:
+> - **OAuth client ID**
+> - **OAuth client secret** (you may need to click **Show** to reveal it)
+>
+> Copy the **Client ID** and paste it here in the chat.
 
-Summarize what was accomplished:
+After receiving the Client ID, collect the secret securely:
 
-- Created a Notion public integration called "Vellum Assistant"
-- Configured the OAuth redirect URI
-- Connected your Notion workspace with read and write access
+```
+credential_store prompt:
+  service: "integration:notion"
+  field: "client_secret"
+  label: "Notion OAuth Client Secret"
+  description: "Copy the Client Secret from the Notion integration page and paste it here."
+  placeholder: "secret_..."
+```
 
-## Error Handling
+**Milestone (4 of 6):** "Credentials collected — almost done."
 
-- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
-- **"Public" integration type not available:** The user may need to enable public integrations in their workspace settings. Guide them to Workspace Settings > Integrations.
-- **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. Notion's UI may have changed; adapt your selectors.
-- **User declines an approval gate:** Don't push back. Explain briefly why the step matters, offer to try again, or cancel gracefully.
-- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry. The integration is already created, so they only need to re-run the connect step.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance.
+---
+
+### Step 5: Store Credentials and Authorize
+
+Register the OAuth app and start the authorization flow. See the collaborative guided flow reference for the exact commands (`assistant oauth apps upsert` and `assistant oauth connections connect`).
+
+> I'll save your credentials and start the Notion authorization flow now.
+>
+> You should see a Notion consent page asking you to **select which pages** to share with Vellum Assistant. Pick the pages or databases you'd like to connect, then click **Allow access**.
+
+**Known issues:**
+- If the consent page shows an error about the redirect URI, double-check that the URI in Step 3 matches exactly
+- The user can always re-authorize later to share additional pages
+
+---
+
+### Step 6: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id <client-id>)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+```
+
+**On success:** "Notion is connected! You can now ask me to read and write pages and databases in your Notion workspace."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Notion-specific differences for Path B:
+- Still requires public ingress for the redirect URI (no loopback alternative)
+- Client Secret prefix is `secret_` — use `credential_store prompt` to collect it securely; split entry is not needed since this prefix doesn't trigger channel scanners

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,133 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The OAuth callback goes through the public gateway URL.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Notion integration from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Notion account with a workspace you want to connect
+> 2. About 3 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create a Public Integration
+
+Tell the user:
+
+> **Step 1: Create a Notion integration**
+>
+> Open this link to go to your Notion integrations page:
+> `https://www.notion.so/profile/integrations`
+>
+> If you need to sign in, do that first.
+>
+> Then:
+> 1. Click **"New integration"** (or the **"+"** button)
+> 2. Set the name to **Vellum Assistant**
+> 3. Select your workspace from the **Associated workspace** dropdown
+> 4. For the **Type**, select **Public** (this is required for OAuth)
+> 5. Click **Submit**
+>
+> Let me know when the integration is created.
+
+## Path B Step 3: Configure OAuth Redirect URI
+
+Before sending the next step, resolve the concrete callback URL:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+Tell the user:
+
+> **Step 2: Configure the redirect URI**
+>
+> In your integration settings, find the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**).
+>
+> In the **Redirect URIs** field, paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> Scroll down and click **Save changes**.
+>
+> Let me know when it's saved.
+
+## Path B Step 4: Copy Credentials
+
+Tell the user:
+
+> **Step 3: Copy your credentials**
+>
+> In your integration settings, find the **Secrets** section. You should see:
+> - **OAuth client ID**
+> - **OAuth client secret** (you may need to click **Show** to reveal it)
+>
+> Send me the **Client ID** first. It looks like a UUID or alphanumeric string.
+
+Wait for the user to send the Client ID.
+
+## Path B Step 5: Store Credentials
+
+### Path B Step 5a: Client ID
+
+After the user sends the Client ID:
+
+```
+credential_store store:
+  service: "integration:notion"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+### Path B Step 5b: Client Secret
+
+Tell the user:
+
+> **Step 4: Send your Client Secret**
+>
+> Now send me the **Client Secret** from the Secrets section. It starts with `secret_`.
+>
+> Send it as a standalone message with no other text.
+
+After the user sends it:
+
+```
+credential_store store:
+  service: "integration:notion"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Notion**
+>
+> I'll generate an authorization link for you now.
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:notion"
+```
+
+Send the returned auth URL to the user:
+
+> Open this link to authorize Vellum Assistant:
+> `<auth URL>`
+>
+> You'll see a Notion consent page. Select the pages and databases you'd like to share, then click **Allow access**.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Notion is connected!** You can now ask me to read and write pages and databases in your Notion workspace.

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: oauth-setup
-description: Connect any OAuth service — create app credentials and authorize via browser automation
+description: Connect any OAuth service — walk users through app setup via a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "OAuth Setup"
     user-invocable: true
-    includes: ["browser"]
+    includes: ["collaborative-oauth-flow"]
 ---
 
 You are helping the user connect an OAuth-based service to Vellum. This is a generic setup flow that works for any provider with a well-known OAuth config.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines the generic provider-agnostic steps.
 
 ## Input
 
@@ -36,17 +36,21 @@ It may also include a `setup` object with rich metadata:
 
 If no config is found, tell the user this service doesn't have a pre-configured setup and offer to help them configure it manually via `oauth2_connect`.
 
-## Step 2: Choose the flow based on setup metadata
+## Step 2: Check for a dedicated setup skill
 
-### If `setup` metadata is present (rich flow)
+If the `credential_store describe` response includes a `setupSkillId`, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
 
-Continue to Step 3 (Rich Flow).
+## Step 3: Choose the flow based on setup metadata
+
+### If `setup` metadata is present (guided flow)
+
+Continue to Step 4.
 
 ### If `setup` metadata is absent (manual flow)
 
-The provider has OAuth config (endpoints, scopes) but no setup automation metadata. Guide the user through a manual app creation:
+The provider has OAuth config (endpoints, scopes) but no setup guidance. Guide the user through a manual app creation:
 
-1. Tell the user: "I have the OAuth endpoints and scopes for this service, but I don't have developer dashboard automation for it. You'll need to create an OAuth app manually."
+1. Tell the user: "I have the OAuth endpoints and scopes for this service, but I don't have step-by-step guidance for its developer dashboard. You'll need to create an OAuth app manually."
 2. Provide the details they need:
    - **Scopes to request:** list the `scopes` from the config
    - **Redirect URI:** show the `redirectUri` value
@@ -57,92 +61,130 @@ The provider has OAuth config (endpoints, scopes) but no setup automation metada
    - Set the redirect URI
    - Configure the required scopes
    - Copy the Client ID (and Client Secret if required)
-4. Once they provide the credentials, skip to **Step 8: Connect**.
+4. Once they provide the credentials, skip to **Step 9: Store and Connect**.
 
 ---
 
-## Rich Flow (when `setup` is present)
+## Guided Flow (when `setup` is present)
 
-### Step 3: Tell the user what's happening
+### Step 4: Pre-Flow Setup
 
-Tell the user:
-- "I'll walk you through creating a {setup.appType} so Vellum can connect to {setup.displayName}. The whole process takes a few minutes."
-- "I'll be automating the {setup.displayName} developer dashboard in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
+> We're going to set up {setup.displayName} OAuth together. I'll open each page in your browser and tell you exactly what to do. You can pause anytime.
+>
+> Your Mac may ask for permissions along the way — if you see an option to allow for a longer duration (like 10 minutes), that'll save you from approving every single step.
 
-### Step 4: Navigate to the developer dashboard
+### Step 5: Open the developer dashboard
 
-Use `browser_navigate` to go to `setup.dashboardUrl`.
+Open: `{setup.dashboardUrl}`
 
-Take a `browser_screenshot` and `browser_snapshot`:
-- **If a sign-in page appears:** Tell the user to sign in and wait for confirmation.
-- **If the dashboard loads:** Continue to Step 5.
+> I've opened the {setup.displayName} developer dashboard. If it's asking you to sign in, go ahead and do that first.
 
-### Step 5: Create an app
+Wait for user confirmation before proceeding.
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` explaining what you're about to create.
+---
 
-Once approved:
-1. Find and click the "Create App" / "New Application" / "New Integration" button (adapt to the provider's UI)
-2. Name it "Vellum Assistant"
-3. Follow any guidance from `setup.notes`
-4. Complete the creation flow
+### Step 6: Create an app
 
-Take a `browser_screenshot` to confirm.
+> Look for a button to create a new app or integration — it might say "Create App", "New Application", or "New Integration". Go ahead and click it.
 
-### Step 6: Configure scopes/permissions
+Guide the user through the creation flow:
+1. Name it "Vellum Assistant"
+2. Follow any guidance from `setup.notes` (e.g., select "Public" for Notion, "From scratch" for Slack)
+3. Complete the creation
 
-**Ask for approval before proceeding.** List the `scopes` from the config and explain what each grants.
+Wait for confirmation.
 
-Once approved, navigate to the OAuth/permissions section and add each scope. Follow `setup.notes` for any provider-specific guidance (e.g., "User Token Scopes" vs "Bot Token Scopes").
+---
 
-Take a `browser_screenshot` after adding all scopes.
+### Step 7: Configure scopes/permissions (if any)
 
-### Step 7: Set redirect URL
+If scopes are non-empty, guide the user to the OAuth/permissions section:
+
+> Now we need to add the permissions {setup.displayName} needs. Look for an OAuth, Permissions, or Scopes section.
+
+List each scope and what it grants. Guide the user to add them one at a time or paste them.
+
+If scopes are empty (e.g. Notion), skip this step.
+
+---
+
+### Step 8: Set redirect URL
 
 Check the `redirectUri` from the config:
-- If it mentions "not currently configured" or `ingress.publicBaseUrl` — the user needs a public gateway URL configured. Check if one is set; if not, load the `public-ingress` skill first.
-- If it says "automatic" — skip this step entirely (no redirect URI needed).
-- Otherwise, enter the `redirectUri` exactly as provided.
+- If it says "automatic" — skip this step entirely (no redirect URI needed for loopback)
+- If it mentions `ingress.publicBaseUrl` — the user needs a public gateway URL. Check if one is configured; if not, load the `public-ingress` skill first
+- Otherwise, tell the user exactly where to add the redirect URI
 
-Take a `browser_snapshot` to confirm.
-
-### Step 7b: Extract credentials
-
-Navigate to the app's credentials/settings section.
-
-Use `browser_extract` to read:
-1. **Client ID** (or equivalent)
-2. **Client Secret** (if `requiresClientSecret` is true) — click "Show"/"Reveal" first if needed
+> Look for "Redirect URLs" or "OAuth Redirect URIs" in the settings. Add this URL: `{redirectUri}`
 
 ---
 
-## Step 8: Connect
+### Step 9: Store and Connect
 
-Tell the user you're opening the authorization page.
+#### Collect Client ID
 
-Use `credential_store` with:
+> Copy the Client ID from the app's credentials page and paste it here in the chat.
+
+#### Collect Client Secret (if required)
+
+Always use a secure prompt:
+
 ```
-action: "oauth2_connect"
-service: "<service name>"
-client_id: "<extracted client ID>"
-client_secret: "<extracted client secret>"  (if required)
+credential_store prompt:
+  service: "<provider-key>"
+  field: "client_secret"
+  label: "{setup.displayName} OAuth Client Secret"
+  description: "Copy the Client Secret from the credentials page and paste it here."
+  placeholder: "..."
 ```
 
-Everything else (endpoints, scopes, params) is auto-filled from the well-known config. Wait for the flow to complete.
+#### Register and authorize
 
-## Step 9: Celebrate!
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>:client_secret"
+```
 
-Once connected, tell the user:
-- If `setup` is present: "**{setup.displayName} is connected!** You're all set."
-- If `setup` is absent: "**{service} is connected!** You're all set."
+```
+bash:
+  command: |
+    assistant oauth connections connect <provider-key> --client-id <client-id>
+```
+
+If the service shows an "unverified app" or consent warning, tell the user how to proceed.
+
+---
+
+### Step 10: Verify Connection
+
+If a ping URL is available, verify:
+
+```
+bash:
+  command: |
+    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id <client-id>)" "<provider-ping-url>"
+```
+
+**On success:** "**{setup.displayName} is connected!** You're all set."
 
 Summarize what was accomplished.
 
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels (Telegram, Slack, etc.), provide all URLs and instructions as text messages. Key differences:
+
+- The user navigates on their own — give them the URLs to open
+- Use **Web application** credentials if the provider distinguishes (callback goes through public gateway)
+- Collect the Client Secret via `credential_store prompt` or split entry if the prefix could trigger channel scanners
+- Resolve the redirect URI from `ingress.publicBaseUrl` before sending instructions; if not configured, load the `public-ingress` skill first
+
 ## Error Handling
 
-- **Page load failures:** Retry once. If it still fails, ask the user to check their connection.
-- **Element not found:** Take a fresh `browser_snapshot`. The provider's UI may have changed — adapt dynamically.
-- **User declines an approval gate:** Don't push back. Explain why it matters, offer to retry or cancel.
+- **User lands on unexpected page:** Offer to screenshot, identify where they are, navigate back
+- **User not signed in:** Tell them to sign in, wait, continue
+- **Feature already configured:** "Looks like this is already set up — great, let's skip ahead."
+- **User is confused or frustrated:** Pause, acknowledge, simplify
 - **OAuth flow timeout or failure:** Offer to retry. The app is already created, so only the connect step needs to be re-run.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask for guidance.

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -1,166 +1,195 @@
 ---
 name: slack-oauth-setup
-description: Create Slack App and OAuth credentials for Slack integration using browser automation
+description: Set up Slack OAuth credentials for Slack integration using a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "Slack OAuth Setup"
     user-invocable: true
-    includes: ["browser"]
+    credential-setup-for: "slack"
+    includes: ["collaborative-oauth-flow"]
 ---
 
-You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
+You are helping your user set up Slack OAuth credentials so the Slack messaging integration can connect to their workspace.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Slack-specific steps.
 
-## Before You Start
+## Provider Details
 
-Tell the user:
+- **Provider key:** `integration:slack`
+- **Auth URL:** `https://slack.com/oauth/v2/authorize`
+- **Token URL:** `https://slack.com/api/oauth.v2.access`
+- **Ping URL:** `https://slack.com/api/auth.test`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
 
-- "I'll walk you through creating a Slack App so Vellum can connect to your workspace. The whole process takes a few minutes."
-- "I'll be automating the Slack API website in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
-- "No sensitive credentials will be shown in the conversation."
+## Slack-Specific Flow
 
-## Step 1: Navigate to Slack API
+The flow has 8 steps total, takes about 3-5 minutes.
 
-Tell the user: "First, let me open the Slack API dashboard."
+### Step 0: Prerequisite Check
 
-Use `browser_navigate` to go to `https://api.slack.com/apps`.
+> Before we start — do you have a Slack workspace where you have permission to install apps?
 
-Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+If no workspace or no admin access, explain that workspace admin approval may be needed and offer to proceed anyway (some workspaces allow member-installed apps).
 
-- **If a sign-in page appears:** Tell the user "Please sign in to your Slack account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
-- **If the apps dashboard loads:** Tell the user "Slack API dashboard is loaded. Let's create your app!" and continue to Step 2.
+---
 
-## Step 2: Create a Slack App
+### Step 1: Open Slack API Dashboard
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+Open: `https://api.slack.com/apps`
 
-> **Create a Slack App**
+> I've opened the Slack API dashboard. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New Slack App
+
+> Look for the **Create New App** button (usually green, top-right area). Go ahead and click it.
+
+After the user clicks:
+
+> You should see two options — **From scratch** and **From an app manifest**. Pick **From scratch**.
+
+Then:
+
+> Set the app name to **Vellum Assistant** and select your workspace from the dropdown. Then click **Create App**.
+
+**Known issues:**
+- If the workspace dropdown is empty, the user may need to sign in to a different workspace
+- Some workspaces require admin approval for new apps — if blocked, explain that they'll need an admin to approve the app
+
+**Milestone (2 of 8):** "App created — now let's add the permissions it needs."
+
+---
+
+### Step 3: Add User Token Scopes
+
+Open: the app's **OAuth & Permissions** page. Look for it in the left sidebar, or navigate directly if you have the app URL.
+
+> In the left sidebar, click **OAuth & Permissions**. Scroll down until you see **User Token Scopes**.
 >
-> I'm about to create a new Slack App called "Vellum Assistant" in your workspace. This app will only have the permissions you approve in the next step. It won't post anything or access any data until you explicitly authorize it.
-
-Wait for the user to approve. If they decline, explain that the app is required for OAuth and offer to try again or cancel.
-
-Once approved:
-
-1. Click "Create New App"
-2. Select "From scratch"
-3. Enter app name: "Vellum Assistant"
-4. Select the user's workspace from the dropdown
-5. Click "Create App"
-
-Take a `browser_screenshot` to show the result.
-
-Tell the user: "App created! Now let's configure the permissions it needs."
-
-## Step 3: Configure OAuth Scopes
-
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
-
-> **Configure Slack Permissions**
+> You'll need to click **Add an OAuth Scope** and add each of these scopes one at a time:
 >
-> I'm about to add the following User Token Scopes to your Slack App. These let Vellum read your messages and channels, send messages on your behalf, search your message history, and add emoji reactions:
+> - `channels:read` — view basic channel info
+> - `channels:history` — read public channel messages
+> - `groups:read` — view private channel info
+> - `groups:history` — read private channel messages
+> - `im:read` — view direct message info
+> - `im:history` — read direct messages
+> - `im:write` — start and send direct messages
+> - `mpim:read` — view group DM info
+> - `mpim:history` — read group DM messages
+> - `users:read` — view user profiles
+> - `chat:write` — send messages
+> - `search:read` — search messages
+> - `reactions:write` — add emoji reactions
 >
-> - `channels:read` — View basic channel info
-> - `channels:history` — Read message history in public channels
-> - `groups:read` — View private channel info
-> - `groups:history` — Read message history in private channels
-> - `im:read` — View direct message info
-> - `im:history` — Read direct message history
-> - `im:write` — Open and send direct messages
-> - `mpim:read` — View group DM info
-> - `mpim:history` — Read group DM history
-> - `users:read` — View user profiles
-> - `chat:write` — Send messages
-> - `search:read` — Search messages
-> - `reactions:write` — Add emoji reactions
+> You can start typing the scope name to filter the dropdown — it goes pretty fast once you get the rhythm.
 
-Wait for the user to approve.
+Wait for the user to confirm all 13 scopes are added.
 
-Once approved:
+**Milestone (3 of 8):** "Permissions are set — now let's handle the redirect URL."
 
-1. Navigate to "OAuth & Permissions" in the left sidebar (or go to the app's OAuth page directly)
-2. Scroll to "User Token Scopes"
-3. Add each scope listed above using the "Add an OAuth Scope" button
+---
 
-Take a `browser_screenshot` after adding all scopes.
+### Step 4: Set Up Redirect URL
 
-Tell the user: "Permissions configured! Now let's set up the redirect URL and get the credentials."
+Before this step, resolve the redirect URI:
 
-## Step 4: Add Redirect URL
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:slack" --json
+```
 
-Navigate to the "OAuth & Permissions" page if not already there.
-
-Before entering the redirect URL, resolve the exact value from the well-known OAuth config:
+Check the `redirectUri` from `credential_store describe`:
 
 ```
 credential_store describe:
   service: "integration:slack"
 ```
 
-Read the `redirectUri` field from that response and use it exactly as shown.
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user to scroll up to the **Redirect URLs** section on the same OAuth & Permissions page, click **Add New Redirect URL**, paste the URI, click **Add**, then **Save URLs**.
 
-In the "Redirect URLs" section:
+---
 
-1. If `redirectUri` says "automatic", skip adding a redirect URL for this provider.
-2. If `redirectUri` mentions "not currently configured" or `ingress.publicBaseUrl`, stop and ask the user to configure public ingress first.
-3. Otherwise, click "Add New Redirect URL" and enter the `redirectUri` value exactly as returned.
-4. Click "Add" then "Save URLs"
+### Step 5: Get Client ID and Client Secret
 
-Take a `browser_snapshot` to confirm.
+> Now let's grab the credentials. In the left sidebar, click **Basic Information**.
 
-Tell the user: "Redirect URL configured using the redirect URI from Vellum's Slack OAuth profile."
+Open: the app's **Basic Information** page via the sidebar.
 
-## Step 5: Extract Client ID and Client Secret
+> Scroll down to the **App Credentials** section. You should see **Client ID** and **Client Secret** listed there.
 
-Navigate to "Basic Information" in the left sidebar.
+**Milestone (5 of 8):** "Almost there — just need to save these credentials."
 
-Use `browser_extract` to read:
+---
 
-1. **Client ID** from the "App Credentials" section
-2. **Client Secret** — click "Show" first, then extract the value
+### Step 6: Store Credentials
 
-**Important:** Slack requires a client secret for the token exchange (unlike Google which uses PKCE). Both values are needed.
+Collect Client ID conversationally:
 
-Tell the user: "Credentials extracted! Now let's connect your Slack workspace."
+> Copy the **Client ID** and paste it here in the chat.
 
-## Step 6: Connect Slack
-
-Tell the user: "Opening Slack authorization so you can grant Vellum access to your workspace. You'll see a Slack consent page — just click 'Allow'."
-
-Use the `credential_store` tool to connect Slack via OAuth2:
+Collect Client Secret via secure prompt:
 
 ```
-action: "oauth2_connect"
-service: "integration:slack"
-client_id: "<the extracted Client ID>"
-client_secret: "<the extracted Client Secret>"
-scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
+credential_store prompt:
+  service: "integration:slack"
+  field: "client_secret"
+  label: "Slack OAuth Client Secret"
+  description: "Copy the Client Secret from the Basic Information page (you may need to click Show first) and paste it here."
+  placeholder: "..."
 ```
 
-This will open the Slack authorization page in the user's browser. Wait for the flow to complete.
+Register the OAuth app:
 
-## Step 7: Celebrate!
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+```
 
-Once connected, tell the user:
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
 
-"**Slack is connected!** You're all set. You can now read channels, search messages, send messages, and manage your Slack workspace through Vellum. Try asking me to check your unread Slack messages!"
+---
 
-Summarize what was accomplished:
+### Step 7: Authorize
 
-- Created a Slack App called "Vellum Assistant"
-- Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL from the Slack OAuth profile
-- Connected your Slack workspace
+> I'll start the Slack authorization flow now. You should see a Slack consent page asking you to allow **Vellum Assistant** to access your workspace.
+>
+> Review the permissions and click **Allow**.
 
-## Error Handling
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:slack --client-id <client-id>
+```
 
-- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
-- **Workspace selection issues:** The user may need admin permissions to install apps. Explain this clearly.
-- **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. Slack's UI may have changed; adapt your selectors.
-- **User declines an approval gate:** Don't push back. Explain briefly why the step matters, offer to try again, or cancel gracefully.
-- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry. The app is already created, so they only need to re-run the connect step.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance.
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:slack --client-id <client-id>)" "https://slack.com/api/auth.test" | python3 -m json.tool
+```
+
+**On success:** "Slack is connected! You can now ask me to check your Slack messages, search conversations, send messages, and react to posts."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Slack-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URLs** on the OAuth & Permissions page
+- Client Secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/slack-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/slack-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,135 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Slack from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Slack workspace where you can install apps
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Slack App
+
+Tell the user:
+
+> **Step 1: Create a Slack App**
+>
+> Open this link:
+> `https://api.slack.com/apps`
+>
+> 1. Click **Create New App**
+> 2. Choose **From scratch**
+> 3. Set the app name to **Vellum Assistant**
+> 4. Select your workspace from the dropdown
+> 5. Click **Create App**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add User Token Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> In the left sidebar, click **OAuth & Permissions**. Scroll down to **User Token Scopes** and add each of these scopes using the **Add an OAuth Scope** button:
+>
+> `channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `im:write`, `mpim:read`, `mpim:history`, `users:read`, `chat:write`, `search:read`, `reactions:write`
+>
+> That's 13 scopes total. You can type the name to filter the dropdown.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Still on the **OAuth & Permissions** page, scroll up to the **Redirect URLs** section.
+>
+> 1. Click **Add New Redirect URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Add**
+> 4. Click **Save URLs**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> In the left sidebar, click **Basic Information**. Scroll down to the **App Credentials** section.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:slack"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **Client Secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:slack"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+Note: Slack client secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Slack**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:slack --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Slack consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **Slack is connected!** You can now ask me to check your Slack messages, search conversations, send messages, and react to posts.

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: spotify-oauth-setup
+description: Set up Spotify OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Spotify OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "spotify"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Spotify OAuth credentials so the Spotify integration can control playback, manage playlists, and access their library.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Spotify-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:spotify`
+- **Dashboard:** `https://developer.spotify.com/dashboard`
+- **Ping URL:** `https://api.spotify.com/v1/me`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Spotify-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Spotify account? Any Spotify account (free or premium) can create developer apps.
+
+If the user doesn't have a Spotify account, direct them to sign up at `https://www.spotify.com/signup` first.
+
+---
+
+### Step 1: Open Spotify Developer Dashboard
+
+Open: `https://developer.spotify.com/dashboard`
+
+> I've opened the Spotify Developer Dashboard. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create App** button. Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following:
+>
+> - **App name:** Vellum Assistant
+> - **App description:** Personal assistant integration
+> - **Redirect URI:** (I'll get the right URL for you in a moment)
+
+Before providing the redirect URI, resolve it:
+
+```
+credential_store describe:
+  service: "integration:spotify"
+```
+
+- If the redirect URI is **"automatic"** or the callback transport is loopback with no ingress requirement, tell the user to enter `http://localhost:17322/callback` as the redirect URI.
+- If the redirect URI mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, provide the concrete redirect URI from the credential store.
+
+Then:
+
+> For **Which API/SDKs are you planning to use?**, check **Web API**.
+>
+> Check the terms of service box, then click **Save**.
+
+**Known issues:**
+- If the dashboard shows a "You need to verify your email" banner, the user must verify their Spotify email first
+- Free and premium accounts both have access to the developer dashboard
+
+**Milestone (2 of 7):** "App created — now let's grab the credentials."
+
+---
+
+### Step 3: Get Client ID and App Secret
+
+> You should now be on the app's overview page. The **Client ID** is shown right there.
+>
+> To find the app secret, click **Settings** in the top-right area of the app page.
+
+Open: the app's **Settings** page.
+
+> On the Settings page, you should see the **Client ID** and a hidden **app secret**. Click **View app secret** to reveal it.
+
+**Milestone (3 of 7):** "Credentials are visible — let's save them."
+
+---
+
+### Step 4: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:spotify"
+  field: "oauth_secret"
+  label: "Spotify OAuth App Secret"
+  description: "Copy the app secret from the Settings page (click View app secret to reveal it) and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:spotify --client-id <client-id> --client-secret-credential-path "integration:spotify:oauth_secret"
+```
+
+**Milestone (4 of 7):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 5: Authorize
+
+> I'll start the Spotify authorization flow now. You should see a Spotify consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Agree**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:spotify --client-id <client-id>
+```
+
+The scopes requested will include:
+- `user-read-playback-state` — see what's playing
+- `user-modify-playback-state` — play, pause, skip tracks
+- `user-read-currently-playing` — see the current track
+- `user-read-recently-played` — see listening history
+- `playlist-read-private` — view private playlists
+- `playlist-modify-public` — create and edit public playlists
+- `playlist-modify-private` — create and edit private playlists
+- `user-library-read` — view saved tracks and albums
+- `user-library-modify` — save and remove tracks and albums
+
+---
+
+### Step 6: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:spotify --client-id <client-id>)" "https://api.spotify.com/v1/me" | python3 -m json.tool
+```
+
+**On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Spotify-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI in the app's Settings page under **Redirect URIs**
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,110 @@
+# Path B: Manual Channel Setup (Spotify)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Spotify from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Spotify account (free or premium)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Spotify App
+
+Tell the user:
+
+> **Step 1: Create a Spotify App**
+>
+> Open this link:
+> `https://developer.spotify.com/dashboard`
+>
+> 1. Click **Create App**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Set the description to **Personal assistant integration**
+> 4. Set the redirect URI to `OAUTH_CALLBACK_URL`
+> 5. Under **Which API/SDKs are you planning to use?**, check **Web API**
+> 6. Check the terms of service box
+> 7. Click **Save**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> On the app overview page, click **Settings** in the top-right area.
+>
+> You should see your **Client ID** and a hidden **app secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:spotify"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now click **View app secret** to reveal it, then send it to me. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:spotify"
+  field: "oauth_secret"
+  value: "<the app secret the user sent>"
+```
+
+Note: Spotify app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 5: Authorize
+
+Tell the user:
+
+> **Step 3: Authorize Spotify**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:spotify --client-id <client-id> --client-secret-credential-path "integration:spotify:oauth_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:spotify --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.
+
+## Path B Step 6: Done
+
+After authorization:
+
+> **Spotify is connected!** You can now ask me to control playback, manage your playlists, check what's playing, and browse your library.

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: todoist-oauth-setup
+description: Set up Todoist OAuth credentials using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Todoist OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "todoist"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Todoist OAuth credentials so the Todoist integration can connect to their account.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Todoist-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:todoist`
+- **Dashboard:** `https://developer.todoist.com/appconsole.html`
+- **Scopes:** `data:read_write`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+- **Ping URL:** `https://api.todoist.com/rest/v2/projects`
+
+## Todoist-Specific Flow
+
+The flow has 7 steps total, takes about 2-3 minutes.
+
+### Step 1: Open Todoist App Console
+
+Open: `https://developer.todoist.com/appconsole.html`
+
+> I've opened the Todoist App Console. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create a new app** button and click it.
+
+Then:
+
+> Set the app name to **Vellum Assistant** and click **Create app**.
+
+**Milestone (2 of 7):** "App created — now let's set up the redirect URL."
+
+---
+
+### Step 3: Set Up OAuth Redirect URL
+
+Before this step, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:todoist"
+```
+
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user:
+
+> In the app settings, find the **OAuth redirect URL** field and paste in this URL:
+>
+> `<redirect URI from credential_store>`
+>
+> Then click **Save settings**.
+
+**Milestone (3 of 7):** "Redirect URL is set — now let's grab the credentials."
+
+---
+
+### Step 4: Copy Client ID and App Secret
+
+> You should see the **Client ID** and **App secret** displayed in the app settings page.
+
+**Milestone (4 of 7):** "Credentials are visible — let's save them."
+
+---
+
+### Step 5: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** and paste it here in the chat.
+
+Collect the app secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:todoist"
+  field: "app_secret"
+  label: "Todoist OAuth App Secret"
+  description: "Copy the app secret from the Todoist app settings page and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:todoist --client-id <client-id> --client-secret-credential-path "integration:todoist:app_secret"
+```
+
+**Milestone (5 of 7):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 6: Authorize
+
+> I'll start the Todoist authorization flow now. You should see a Todoist consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Agree**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:todoist --client-id <client-id>
+```
+
+---
+
+### Step 7: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:todoist --client-id <client-id>)" "https://api.todoist.com/rest/v2/projects" | python3 -m json.tool
+```
+
+**On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Todoist-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **OAuth redirect URL** in the app settings
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,117 @@
+# Path B: Manual Channel Setup (Todoist)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Todoist from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Todoist account
+> 2. About 3 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Todoist App
+
+Tell the user:
+
+> **Step 1: Create a Todoist App**
+>
+> Open this link:
+> `https://developer.todoist.com/appconsole.html`
+>
+> 1. Click **Create a new app**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Redirect URL
+
+Tell the user:
+
+> **Step 2: Add redirect URL**
+>
+> In the app settings, find the **OAuth redirect URL** field.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Click **Save settings**
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> On the app settings page, you should see the **Client ID** and **App secret** displayed.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:todoist"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **app secret**. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:todoist"
+  field: "app_secret"
+  value: "<the secret the user sent>"
+```
+
+Note: Todoist app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 4: Authorize Todoist**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:todoist --client-id <client-id> --client-secret-credential-path "integration:todoist:app_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:todoist --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Todoist is connected!** You can now ask me to manage your tasks, create projects, and organize your to-do lists.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: twitter-oauth-setup
+description: Set up Twitter/X OAuth credentials for Twitter integration using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Twitter / X OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "twitter"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Twitter/X OAuth credentials so the Twitter integration can post tweets, read timelines, and access user data.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Twitter-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:twitter`
+- **Auth URL:** `https://twitter.com/i/oauth2/authorize`
+- **Token URL:** `https://api.x.com/2/oauth2/token`
+- **Ping URL:** `https://api.x.com/2/users/me`
+- **Base URL:** `https://api.x.com`
+- **Default scopes:** `tweet.read`, `tweet.write`, `users.read`, `offline.access`
+- **Token endpoint auth method:** `client_secret_basic`
+- **Callback transport:** Gateway (requires public ingress)
+- **Requires secret:** Yes (token endpoint uses `client_secret_basic`, so both Client ID and Client Secret are needed)
+
+## Twitter-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Twitter/X account you'd like to use for this? You'll also need access to the Twitter Developer Portal.
+
+If no account -> guide them to create one or defer.
+If no developer account -> they'll be prompted to sign up during Step 1. Free tier is sufficient.
+
+---
+
+### Step 1: Open Twitter Developer Portal
+
+Open: `https://developer.x.com/en/portal/dashboard`
+
+> I've opened the Twitter Developer Portal. If it's asking you to sign in, go ahead and do that first.
+
+**Known issues:**
+- First-time developers will see a sign-up flow — they need to agree to the developer agreement and describe their use case. "Personal project" or "Building a tool" works fine for the description.
+- Free tier is sufficient for OAuth 2.0 with PKCE.
+
+---
+
+### Step 2: Create a Project
+
+> Look for **Projects & Apps** in the left sidebar. If you already have a project you'd like to use, let me know. Otherwise, click **+ Add Project**.
+
+Guide through project creation:
+
+> 1. **Project name:** `Vellum Assistant` (or whatever you prefer)
+> 2. **Use case:** Select **Making a bot** or **Exploring the API** — either works
+> 3. **Project description:** Something brief like "Personal assistant integration"
+> 4. Click **Next** through each step
+
+**Known issues:**
+- Free tier allows only one project — if the user already has one, reuse it
+- If they see "You've reached your project limit", use the existing project
+
+**Milestone (2 of 8):** "Project created — now let's set up an app inside it."
+
+---
+
+### Step 3: Create an App (or select existing)
+
+If the project creation wizard prompts to create an app immediately, follow along. Otherwise:
+
+> Inside your project, look for an **+ Add App** button or a prompt to create a new app.
+>
+> Set the app name to **Vellum Assistant** and click **Next** or **Create**.
+
+After creation, the portal may show API keys (API Key and Secret, Bearer Token). These are for OAuth 1.0a — we don't need them for OAuth 2.0, but it doesn't hurt to save them somewhere safe.
+
+> You may see API Key, API Secret, and Bearer Token on this screen. You can save these somewhere safe if you like, but we won't need them — we're using OAuth 2.0. Go ahead and click **App Settings** or navigate to your app's settings page.
+
+---
+
+### Step 4: Configure OAuth 2.0 Settings
+
+Navigate to the app's settings. If not already there:
+
+> In the left sidebar under your project, click on your app name, then look for **Settings** or **Edit** under the **User authentication settings** section.
+
+Open the User Authentication Settings:
+
+> Scroll down to **User authentication settings** and click **Set up** or **Edit**.
+
+Guide through the OAuth 2.0 configuration:
+
+> You should see an authentication setup page. Here's what to fill in:
+>
+> 1. **App permissions:** Select **Read and write** (this covers tweet.read, tweet.write, and users.read)
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **App info:**
+>    - **Callback URI / Redirect URL:** I'll give you the URL in a moment
+>    - **Website URL:** You can use `https://vellum.ai` or any URL you own
+
+Before providing the redirect URI, resolve it:
+
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:twitter" --json
+```
+
+Check the redirect URI situation. Since callbackTransport is `gateway`, public ingress must be configured:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+
+> For the **Callback URI / Redirect URL**, paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> For the **Website URL**, you can enter `https://vellum.ai` or any website you own.
+>
+> Then click **Save**.
+
+**Milestone (4 of 8):** "OAuth settings configured — now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and Client Secret
+
+> After saving, you should be back on the app settings page. Look for the **Keys and tokens** tab at the top of the page, then scroll down to **OAuth 2.0 Client ID and Client Secret**.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it. You may need to confirm by typing "Yes" in a dialog.
+
+Note: The token endpoint auth method (`basic`) requires both a Client ID and a secret, so the skill collects both.
+
+**Milestone (5 of 8):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** (it's a long string, sometimes called "OAuth 2.0 Client ID") and paste it here in the chat.
+
+Collect Client Secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:twitter"
+  field: "client_secret"
+  label: "Twitter OAuth 2.0 Client Secret"
+  description: "Copy the Client Secret from the Keys and tokens page and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+```
+
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 7: Authorize
+
+> I'll start the Twitter authorization flow now. You should see a Twitter consent page asking you to authorize **Vellum Assistant** to access your account.
+>
+> Review the permissions — it will ask for permission to read your tweets, post tweets, and read your profile info. Click **Authorize app**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:twitter --client-id <client-id>
+```
+
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:twitter --client-id <client-id>)" "https://api.x.com/2/users/me" | python3 -m json.tool
+```
+
+**On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Twitter-specific differences for Path B:
+- Gateway callback requires public ingress — must be configured before starting
+- OAuth 2.0 Client Secret doesn't have a known prefix that triggers channel scanners, but still use `credential_store store` for security
+- App type must be **Web App, Automated App or Bot** (same as Path A, since gateway transport is used in both paths)

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,130 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the gateway callback is not reachable without it.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Twitter / X from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Twitter/X account with access to the Developer Portal
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Project and App
+
+Tell the user:
+
+> **Step 1: Create a Project and App**
+>
+> Open this link to the Twitter Developer Portal:
+> `https://developer.x.com/en/portal/dashboard`
+>
+> 1. In the left sidebar, find **Projects & Apps**
+> 2. Click **+ Add Project** (if you already have a project, you can reuse it)
+> 3. Set the project name to **Vellum Assistant**
+> 4. For the use case, pick **Making a bot** or **Exploring the API**
+> 5. Add a brief description and click through each step
+> 6. When prompted, create a new app named **Vellum Assistant**
+>
+> You may see API Key, API Secret, and Bearer Token — save them if you like, but we won't use them. Navigate to your app's settings page.
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Configure OAuth 2.0
+
+Tell the user:
+
+> **Step 2: Configure OAuth 2.0 settings**
+>
+> On your app's settings page, scroll down to **User authentication settings** and click **Set up** (or **Edit** if already configured).
+>
+> Fill in:
+>
+> 1. **App permissions:** Select **Read and write**
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **Callback URI / Redirect URL:** `OAUTH_CALLBACK_URL`
+> 4. **Website URL:** `https://vellum.ai` (or any website you own)
+>
+> Click **Save**.
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> Go to the **Keys and tokens** tab at the top of your app page. Scroll down to the **OAuth 2.0 Client ID and Client Secret** section.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it and confirm.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:twitter"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **Client Secret**. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:twitter"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+Note: Twitter OAuth 2.0 Client Secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 4: Authorize Twitter**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:twitter --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Twitter is connected!** You can now ask me to read your timeline, post tweets, and check your profile.


### PR DESCRIPTION
## Summary

- Migrate Notion and Slack OAuth setup skills from browser automation to the collaborative guided flow pattern (matching Google OAuth)
- Add Twitter/X OAuth setup skill with collaborative guided flow
- Add identity verifier functions for all providers (Google, Slack, Notion, Twitter, GitHub, Linear, Spotify, Todoist, Discord, Dropbox, Asana, Airtable, HubSpot, Figma)
- Add 10 new OAuth integrations with full seed data, provider behaviors, injection templates, and collaborative setup skills: **GitHub, Linear, Spotify, Todoist, Discord, Dropbox, Asana, Airtable, HubSpot, Figma**
- Add Google Drive as optional scopes on the existing Gmail provider
- Update generic `oauth-setup` skill to use collaborative flow and delegate to provider-specific setup skills
- All skills include Path B (manual channel setup) for non-interactive channels

## New integrations

| Service | Scopes | Callback | Dashboard |
|---------|--------|----------|-----------|
| GitHub | repo, read:user, notifications | loopback | github.com/settings/developers |
| Linear | read, write, issues:create | loopback | linear.app/settings/api |
| Spotify | playback, playlists, library | loopback | developer.spotify.com/dashboard |
| Todoist | data:read_write | loopback | developer.todoist.com/appconsole |
| Discord | identify, guilds, messages | loopback | discord.com/developers |
| Dropbox | files, sharing | loopback | dropbox.com/developers/apps |
| Asana | default | loopback | app.asana.com/0/my-apps |
| Airtable | records, schema | loopback | airtable.com/create/oauth |
| HubSpot | contacts, deals, companies | loopback | app.hubspot.com/developer |
| Figma | files:read, comments:write | loopback | figma.com/developers/apps |

## Test plan

- [ ] Verify Notion OAuth setup works end-to-end via collaborative flow (Path A)
- [ ] Verify Slack OAuth setup works end-to-end via collaborative flow (Path A)
- [ ] Verify Twitter/X OAuth setup works end-to-end via collaborative flow
- [ ] Test identity verifiers show "Connected as..." after successful OAuth connection
- [ ] Verify Path B instructions work for non-interactive channels
- [ ] Confirm generic `oauth-setup` skill delegates to provider-specific skills
- [ ] Spot-check 2-3 new integrations (e.g., GitHub, Spotify, Linear) end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)