### PR TITLE
fix: support multiple OAuth accounts per service

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -48,8 +48,10 @@ import {
   getAppByProviderAndClientId,
   getConnection,
   getConnectionByProvider,
+  getConnectionByProviderAndAccount,
   getProvider,
   isProviderConnected,
+  listActiveConnectionsByProvider,
   listConnections,
   registerProvider,
   seedProviders,
@@ -617,6 +619,145 @@ describe("connection operations", () => {
 
     test("returns undefined when no active connections exist", () => {
       expect(getConnectionByProvider("github")).toBeUndefined();
+    });
+  });
+
+  describe("getConnectionByProviderAndAccount", () => {
+    test("returns the connection matching the given account", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      const conn1 = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user1@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 1000,
+      });
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user2@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+        createdAt: 2000,
+      });
+
+      const result = getConnectionByProviderAndAccount(
+        "github",
+        "user1@example.com",
+      );
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(conn1.id);
+    });
+
+    test("falls back to getConnectionByProvider when accountInfo is undefined", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      const result = getConnectionByProviderAndAccount("github", undefined);
+      expect(result).toBeDefined();
+      expect(result!.id).toBe(conn.id);
+    });
+
+    test("returns undefined when no connection matches the account", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      const result = getConnectionByProviderAndAccount(
+        "github",
+        "other@example.com",
+      );
+      expect(result).toBeUndefined();
+    });
+
+    test("skips revoked connections", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      const conn = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+      updateConnection(conn.id, { status: "revoked" });
+
+      const result = getConnectionByProviderAndAccount(
+        "github",
+        "user@example.com",
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("listActiveConnectionsByProvider", () => {
+    test("returns all active connections for a provider", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user1@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user2@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      const results = listActiveConnectionsByProvider("github");
+      expect(results).toHaveLength(2);
+    });
+
+    test("excludes revoked connections", async () => {
+      const app = await createTestApp("github", "client-1");
+
+      createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user1@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+
+      const conn2 = createConnection({
+        oauthAppId: app.id,
+        providerKey: "github",
+        accountInfo: "user2@example.com",
+        grantedScopes: ["repo"],
+        hasRefreshToken: false,
+      });
+      updateConnection(conn2.id, { status: "revoked" });
+
+      const results = listActiveConnectionsByProvider("github");
+      expect(results).toHaveLength(1);
+      expect(results[0]!.accountInfo).toBe("user1@example.com");
+    });
+
+    test("returns empty array when no active connections exist", () => {
+      const results = listActiveConnectionsByProvider("github");
+      expect(results).toHaveLength(0);
     });
   });
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,18 +1,30 @@
 import { getSecureKey } from "../security/secure-keys.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
-import { getApp, getConnectionByProvider, getProvider } from "./oauth-store.js";
+import {
+  getApp,
+  getConnectionByProvider,
+  getConnectionByProviderAndAccount,
+  getProvider,
+} from "./oauth-store.js";
 
 /**
  * Resolve an OAuthConnection for a given credential service.
+ *
+ * When `accountInfo` is provided, resolves the connection for that specific
+ * account (e.g. "user@gmail.com"). Otherwise falls back to the most recent
+ * active connection.
  *
  * Reads exclusively from the SQLite oauth-store. Throws if no connection
  * exists (authorization required).
  */
 export function resolveOAuthConnection(
   credentialService: string,
+  accountInfo?: string,
 ): OAuthConnection {
-  const conn = getConnectionByProvider(credentialService);
+  const conn = accountInfo
+    ? getConnectionByProviderAndAccount(credentialService, accountInfo)
+    : getConnectionByProvider(credentialService);
   if (!conn) {
     throw new Error(
       `No credential found for "${credentialService}". Authorization required.`,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -442,6 +442,52 @@ export function getConnectionByProvider(
 }
 
 /**
+ * Get the active connection for a provider matching a specific account.
+ * Falls back to getConnectionByProvider when accountInfo is undefined.
+ */
+export function getConnectionByProviderAndAccount(
+  providerKey: string,
+  accountInfo?: string,
+): OAuthConnectionRow | undefined {
+  if (!accountInfo) return getConnectionByProvider(providerKey);
+
+  const db = getDb();
+  return db
+    .select()
+    .from(oauthConnections)
+    .where(
+      and(
+        eq(oauthConnections.providerKey, providerKey),
+        eq(oauthConnections.accountInfo, accountInfo),
+        eq(oauthConnections.status, "active"),
+      ),
+    )
+    .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
+    .limit(1)
+    .get();
+}
+
+/**
+ * Get ALL active connections for a provider (supports multi-account).
+ */
+export function listActiveConnectionsByProvider(
+  providerKey: string,
+): OAuthConnectionRow[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(oauthConnections)
+    .where(
+      and(
+        eq(oauthConnections.providerKey, providerKey),
+        eq(oauthConnections.status, "active"),
+      ),
+    )
+    .orderBy(desc(oauthConnections.createdAt), sql`rowid DESC`)
+    .all();
+}
+
+/**
  * Check whether a provider has a usable OAuth connection: an active row in the
  * database AND a corresponding access token in secure storage.
  *
@@ -544,6 +590,10 @@ export function deleteConnection(id: string): boolean {
  * Fully disconnect an OAuth provider: delete the new-format secure keys
  * (access_token and refresh_token) and remove the connection row from SQLite.
  *
+ * When `connectionId` is provided, disconnects that specific connection
+ * (useful for multi-account providers). Otherwise falls back to the most
+ * recent active connection.
+ *
  * Returns `"disconnected"` if a connection was found and cleaned up,
  * `"not-found"` if no active connection existed for the given provider,
  * or `"error"` if secure key deletion failed (connection row is preserved
@@ -552,8 +602,11 @@ export function deleteConnection(id: string): boolean {
 export async function disconnectOAuthProvider(
   providerKey: string,
   clientId?: string,
+  connectionId?: string,
 ): Promise<"disconnected" | "not-found" | "error"> {
-  const conn = getConnectionByProvider(providerKey, clientId);
+  const conn = connectionId
+    ? getConnection(connectionId)
+    : getConnectionByProvider(providerKey, clientId);
   if (!conn) return "not-found";
 
   const r1 = await deleteSecureKeyAsync(

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -24,6 +24,7 @@ import {
   createConnection,
   getApp,
   getConnectionByProvider,
+  getConnectionByProviderAndAccount,
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
@@ -123,14 +124,28 @@ export async function storeOAuth2Tokens(
     }
   }
 
-  // 2. Upsert oauth_connection — reuse existing active connection for this
-  //    provider, or create a new one.
-  const existingConn = getConnectionByProvider(service);
+  // 2. Upsert oauth_connection — reuse existing active connection for the
+  //    same account, or create a new one for a different account.
+  //    First try to match by account info (email); fall back to provider-only
+  //    lookup so that re-auth without userinfo still updates the right row.
+  const existingConn = resolvedAccountInfo
+    ? getConnectionByProviderAndAccount(service, resolvedAccountInfo)
+    : getConnectionByProvider(service);
   let connId: string;
 
   const hasRefreshToken = !!tokens.refreshToken;
 
-  if (existingConn) {
+  // Only reuse the existing connection if it's the same account (or we can't
+  // tell). When the user connects a different account for the same service,
+  // create a separate connection so we don't overwrite the first account's
+  // tokens.
+  const isNewAccount =
+    existingConn &&
+    resolvedAccountInfo !== undefined &&
+    existingConn.accountInfo !== undefined &&
+    resolvedAccountInfo !== existingConn.accountInfo;
+
+  if (existingConn && !isNewAccount) {
     connId = existingConn.id;
     updateConnection(connId, {
       oauthAppId: app.id,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -3,6 +3,7 @@ import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import {
   disconnectOAuthProvider,
   getAppByProviderAndClientId,
+  getConnectionByProviderAndAccount,
   getMostRecentAppByProvider,
   getProvider,
 } from "../../oauth/oauth-store.js";
@@ -71,6 +72,11 @@ class CredentialStoreTool implements Tool {
           service: {
             type: "string",
             description: "Service name, e.g. gmail, github",
+          },
+          account: {
+            type: "string",
+            description:
+              "Account identifier (e.g. email address) to target a specific connection when multiple accounts are connected for the same service. If omitted, uses the most recently connected account.",
           },
           field: {
             type: "string",
@@ -453,7 +459,19 @@ class CredentialStoreTool implements Tool {
         }
         // Also clean up any OAuth connection for this service (best-effort)
         try {
-          const oauthResult = await disconnectOAuthProvider(service);
+          const accountHint = input.account as string | undefined;
+          let oauthResult: "disconnected" | "not-found" | "error";
+          if (accountHint) {
+            const targetConn = getConnectionByProviderAndAccount(
+              service,
+              accountHint,
+            );
+            oauthResult = targetConn
+              ? await disconnectOAuthProvider(service, undefined, targetConn.id)
+              : "not-found";
+          } else {
+            oauthResult = await disconnectOAuthProvider(service);
+          }
           if (oauthResult === "error") {
             log.warn(
               { service },


### PR DESCRIPTION
## Summary
- Stop overwriting existing OAuth connections when connecting a different account for the same service (e.g. two Gmail accounts)
- Add `getConnectionByProviderAndAccount` and `listActiveConnectionsByProvider` to oauth-store for account-aware lookups
- Add `account` parameter to `credential_store` tool schema so the model can target specific accounts
- Update `resolveOAuthConnection` and `disconnectOAuthProvider` to support account-level targeting

## Original prompt
Fix multi-account OAuth: stop overwriting existing connections when connecting a different account for the same service. The core issue is in `token-persistence.ts` where `getConnectionByProvider` returns the most recent connection and updates it, even when the new OAuth flow completed for a different account (different email). The fix checks whether `resolvedAccountInfo` differs from the existing connection's `accountInfo` and creates a new connection row instead of overwriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)