### PR TITLE
fix: update stale apiKeys guidance to use keys CLI

### DIFF
--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -166,7 +166,7 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   if (provider !== "ollama" && !config.apiKeys[provider]) {
     return {
       kind: "unknown",
-      message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`config set apiKeys.${provider} <your-key>\``,
+      message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`keys set ${provider} <your-key>\``,
     };
   }
 
@@ -216,9 +216,7 @@ function resolveModelList(): SlashResolution {
   }
 
   lines.push("\n✓ = API key configured, ✗ = not configured");
-  lines.push(
-    "\nTip: Configure a provider with `config set apiKeys.<provider> <key>`",
-  );
+  lines.push("\nTip: Configure a provider with `keys set <provider> <key>`");
 
   return {
     kind: "unknown",
@@ -286,7 +284,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
     const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
     return {
       kind: "unknown",
-      message: `Cannot switch to ${displayName}. No API key configured for Anthropic.\n\nSet it with: \`config set apiKeys.anthropic <your-key>\``,
+      message: `Cannot switch to ${displayName}. No API key configured for Anthropic.\n\nSet it with: \`keys set anthropic <your-key>\``,
     };
   }
 

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -32,7 +32,7 @@ export async function generateAvatar(
 
   if (!credentials) {
     throw new ConfigError(
-      "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
+      "Gemini API key is not configured. Set it via `keys set gemini <key>` or the GEMINI_API_KEY environment variable.",
     );
   }
 

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -113,7 +113,7 @@ public struct ModelListBubble: View {
             }
 
             // Footer
-            Text("Switch with /shortcut or `config set apiKeys.<provider> <key>` to add a provider.")
+            Text("Switch with /shortcut or `keys set <provider> <key>` to add a provider.")
                 .font(VFont.small)
                 .foregroundColor(VColor.contentTertiary)
                 .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
## Summary
- Update 3 user-facing messages in `session-slash.ts` from `config set apiKeys.<provider>` to `keys set <provider>`
- Update 1 error message in `avatar-router.ts` from `config set apiKeys.gemini` to `keys set gemini`
- Update 1 UI string in `ModelListBubble.swift` from `config set apiKeys.<provider>` to `keys set <provider>`

Fixes gaps identified during plan review for remove-apikeys-merge-on-read.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
