### PR TITLE
feat: standardize OAuth integrations on collaborative guided flow

### DIFF
--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -155,12 +155,20 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
   "integration:twitter": {
     service: "integration:twitter",
+    injectionTemplates: [
+      {
+        hostPattern: "api.x.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
     setupSkillId: "twitter-oauth-setup",
     setup: {
       displayName: "Twitter / X",
       dashboardUrl: "https://developer.x.com/en/portal/dashboard",
       appType: "App",
-      requiresClientSecret: false,
+      requiresClientSecret: true,
     },
     identityVerifier: async (
       accessToken: string,

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -101,6 +101,7 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
             user?: string;
             team?: string;
           };
+          if (!body.ok) return undefined;
           if (body.user && body.team) return `@${body.user} (${body.team})`;
           if (body.user) return `@${body.user}`;
         }
@@ -124,7 +125,7 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
     setupSkillId: "notion-oauth-setup",
     setup: {
       displayName: "Notion",
-      dashboardUrl: "https://www.notion.so/my-integrations",
+      dashboardUrl: "https://www.notion.so/profile/integrations",
       appType: "Public integration",
       requiresClientSecret: true,
     },

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -47,6 +47,28 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       appType: "Desktop app",
       requiresClientSecret: true,
     },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch(
+          "https://www.googleapis.com/oauth2/v2/userinfo",
+          {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          },
+        );
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            email?: string;
+            name?: string;
+          };
+          return body.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
   },
 
   "integration:slack": {
@@ -65,6 +87,27 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       dashboardUrl: "https://api.slack.com/apps",
       appType: "Slack App",
       requiresClientSecret: true,
+    },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://slack.com/api/auth.test", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            ok: boolean;
+            user?: string;
+            team?: string;
+          };
+          if (body.user && body.team) return `@${body.user} (${body.team})`;
+          if (body.user) return `@${body.user}`;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
     },
   },
 
@@ -85,10 +128,34 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
       appType: "Public integration",
       requiresClientSecret: true,
     },
+    identityVerifier: async (
+      accessToken: string,
+    ): Promise<string | undefined> => {
+      try {
+        const resp = await fetch("https://api.notion.com/v1/users/me", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Notion-Version": "2022-06-28",
+          },
+        });
+        if (resp.ok) {
+          const body = (await resp.json()) as {
+            name?: string;
+            type?: string;
+            person?: { email?: string };
+          };
+          return body.name ?? body.person?.email;
+        }
+      } catch {
+        // Non-fatal — identity verification is best-effort
+      }
+      return undefined;
+    },
   },
 
   "integration:twitter": {
     service: "integration:twitter",
+    setupSkillId: "twitter-oauth-setup",
     setup: {
       displayName: "Twitter / X",
       dashboardUrl: "https://developer.x.com/en/portal/dashboard",

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -51,6 +51,21 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
   "integration:slack": {
     service: "integration:slack",
+    injectionTemplates: [
+      {
+        hostPattern: "slack.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    setupSkillId: "slack-oauth-setup",
+    setup: {
+      displayName: "Slack",
+      dashboardUrl: "https://api.slack.com/apps",
+      appType: "Slack App",
+      requiresClientSecret: true,
+    },
   },
 
   "integration:notion": {
@@ -63,6 +78,13 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
         valuePrefix: "Bearer ",
       },
     ],
+    setupSkillId: "notion-oauth-setup",
+    setup: {
+      displayName: "Notion",
+      dashboardUrl: "https://www.notion.so/my-integrations",
+      appType: "Public integration",
+      requiresClientSecret: true,
+    },
   },
 
   "integration:twitter": {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -55,6 +55,18 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "collaborative-oauth-flow",
+      "name": "collaborative-oauth-flow",
+      "description": "Reusable pattern for walking users through OAuth app setup via AppleScript browser navigation",
+      "metadata": {
+        "emoji": "🔑",
+        "vellum": {
+          "display-name": "Collaborative OAuth Flow"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "deploy-fullstack-vercel",
       "name": "deploy-fullstack-vercel",
       "description": "Build and deploy a full-stack app (React frontend + Python/FastAPI backend) to Vercel as a serverless demo with seeded data",
@@ -129,18 +141,6 @@
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.",
       "metadata": {
         "emoji": "🎨"
-      },
-      "compatibility": "Designed for Vellum personal assistants"
-    },
-    {
-      "id": "collaborative-oauth-flow",
-      "name": "collaborative-oauth-flow",
-      "description": "Reusable pattern for walking users through OAuth app setup via AppleScript browser navigation",
-      "metadata": {
-        "emoji": "🔑",
-        "vellum": {
-          "display-name": "Collaborative OAuth Flow"
-        }
       },
       "compatibility": "Designed for Vellum personal assistants"
     },
@@ -232,15 +232,15 @@
     {
       "id": "notion-oauth-setup",
       "name": "notion-oauth-setup",
-      "description": "Create a Notion integration and OAuth credentials for Notion integration using browser automation",
+      "description": "Set up Notion OAuth credentials for Notion integration using a collaborative guided flow",
       "metadata": {
         "emoji": "🔑",
         "vellum": {
           "display-name": "Notion OAuth Setup",
           "user-invocable": "true",
+          "credential-setup-for": "notion",
           "includes": [
-            "browser",
-            "public-ingress"
+            "collaborative-oauth-flow"
           ]
         }
       },
@@ -249,14 +249,14 @@
     {
       "id": "oauth-setup",
       "name": "oauth-setup",
-      "description": "Connect any OAuth service — create app credentials and authorize via browser automation",
+      "description": "Connect any OAuth service — walk users through app setup via a collaborative guided flow",
       "metadata": {
         "emoji": "🔑",
         "vellum": {
           "display-name": "OAuth Setup",
           "user-invocable": "true",
           "includes": [
-            "browser"
+            "collaborative-oauth-flow"
           ]
         }
       },
@@ -323,7 +323,7 @@
     {
       "id": "skills-catalog",
       "name": "skills-catalog",
-      "description": "Discover bundled skills and search/install community skills from Clawhub",
+      "description": "Discover bundled skills and search/install community skills from the skills.sh registry",
       "metadata": {
         "emoji": "🧩",
         "vellum": {
@@ -369,14 +369,15 @@
     {
       "id": "slack-oauth-setup",
       "name": "slack-oauth-setup",
-      "description": "Create Slack App and OAuth credentials for Slack integration using browser automation",
+      "description": "Set up Slack OAuth credentials for Slack integration using a collaborative guided flow",
       "metadata": {
         "emoji": "🔑",
         "vellum": {
           "display-name": "Slack OAuth Setup",
           "user-invocable": "true",
+          "credential-setup-for": "slack",
           "includes": [
-            "browser"
+            "collaborative-oauth-flow"
           ]
         }
       },
@@ -434,6 +435,23 @@
           "user-invocable": "true",
           "includes": [
             "public-ingress"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
+      "id": "twitter-oauth-setup",
+      "name": "twitter-oauth-setup",
+      "description": "Set up Twitter/X OAuth credentials for Twitter integration using a collaborative guided flow",
+      "metadata": {
+        "emoji": "🔑",
+        "vellum": {
+          "display-name": "Twitter / X OAuth Setup",
+          "user-invocable": "true",
+          "credential-setup-for": "twitter",
+          "includes": [
+            "collaborative-oauth-flow"
           ]
         }
       },

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -54,12 +54,14 @@ Open: `https://www.notion.so/profile/integrations`
 > Look for the **"New integration"** button (or a **"+"** button) and click it.
 >
 > On the creation form:
+>
 > 1. Set the name to **Vellum Assistant**
 > 2. Select your workspace from the **Associated workspace** dropdown
 > 3. For the **Type**, select **Public** — this is required for OAuth
 > 4. Click **Submit**
 
 **Known issues:**
+
 - If "Public" is not available as a type, the user may need to check their workspace settings or plan level
 - If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it — skip ahead to Step 3
 
@@ -89,6 +91,7 @@ host_bash:
 ```
 
 **Known issues:**
+
 - Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use the base domain from `ingress.publicBaseUrl`
 - If the page shows "Internal integration" with no Distribution tab, the integration was created as Internal — they'll need to recreate it as Public
 
@@ -97,6 +100,7 @@ host_bash:
 ### Step 4: Copy Client ID and Client Secret
 
 > Now look for the **Secrets** section on the integration page. You should see:
+>
 > - **OAuth client ID**
 > - **OAuth client secret** (you may need to click **Show** to reveal it)
 >
@@ -126,6 +130,7 @@ Register the OAuth app and start the authorization flow. See the collaborative g
 > You should see a Notion consent page asking you to **select which pages** to share with Vellum Assistant. Pick the pages or databases you'd like to connect, then click **Allow access**.
 
 **Known issues:**
+
 - If the consent page shows an error about the redirect URI, double-check that the URI in Step 3 matches exactly
 - The user can always re-authorize later to share additional pages
 
@@ -150,5 +155,6 @@ bash:
 For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
 
 Key Notion-specific differences for Path B:
+
 - Still requires public ingress for the redirect URI (no loopback alternative)
 - Client Secret prefix is `secret_` — use `credential_store prompt` to collect it securely; split entry is not needed since this prefix doesn't trigger channel scanners

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -1,133 +1,154 @@
 ---
 name: notion-oauth-setup
-description: Create a Notion integration and OAuth credentials for Notion integration using browser automation
+description: Set up Notion OAuth credentials for Notion integration using a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "Notion OAuth Setup"
     user-invocable: true
-    includes: ["browser", "public-ingress"]
+    credential-setup-for: "notion"
+    includes: ["collaborative-oauth-flow"]
 ---
 
-You are helping your user create a Notion integration (OAuth app) so Vellum can connect to their Notion workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
+You are helping your user set up Notion OAuth credentials so the Notion integration can connect to their workspace.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Notion-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:notion`
+- **Credential type:** Public integration (OAuth)
+- **Token endpoint auth:** `client_secret_basic` (client secret always required)
+- **Scopes:** None (Notion does not use explicit OAuth scopes)
+- **Extra params:** `owner=user`
 
 ## Prerequisites
 
-Before starting, check that `ingress.publicBaseUrl` is configured (Settings > Public Ingress). If it is not set, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the public URL. The OAuth redirect URI depends on this value.
+Before beginning the user-facing flow, ensure **public ingress** is configured. Notion OAuth requires a publicly reachable redirect URI — there is no loopback/desktop-app alternative.
 
-## Before You Start
+Read the configured public gateway URL from `ingress.publicBaseUrl`. If it is missing, load and run the `public-ingress` skill first (`skill_load` with `skill: "public-ingress"`). Build the redirect URI as `<publicBaseUrl>/webhooks/oauth/callback`.
 
-Tell the user:
+## Notion-Specific Flow
 
-- "I'll walk you through creating a Notion integration so Vellum can read and write pages and databases in your workspace. The whole process takes a few minutes."
-- "I'll be automating the Notion integrations page in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
-- "No sensitive credentials will be shown in the conversation."
+The flow has 6 steps total, takes about 2-3 minutes.
 
-## Step 1: Navigate to Notion Integrations
+### Step 0: Prerequisite Check
 
-Tell the user: "First, let me open the Notion integrations page."
+> Before we start — do you have a Notion account and workspace you'd like to connect?
 
-Use `browser_navigate` to go to `https://www.notion.so/my-integrations`.
+If no Notion account, guide them to create one at `https://www.notion.so/signup` or defer.
 
-Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+---
 
-- **If a sign-in page appears:** Tell the user "Please sign in to your Notion account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
-- **If the integrations dashboard loads:** Tell the user "Notion integrations page is loaded. Let's create your integration!" and continue to Step 2.
+### Step 1: Open Notion Integrations
 
-## Step 2: Create a New Integration
+Open: `https://www.notion.so/profile/integrations`
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+> I've opened the Notion integrations page. If it's asking you to sign in, go ahead and do that first. Once you're in, you should see your list of integrations (it might be empty).
 
-> **Create a Notion Integration**
+---
+
+### Step 2: Create a New Public Integration
+
+> Look for the **"New integration"** button (or a **"+"** button) and click it.
 >
-> I'm about to create a new Notion integration called "Vellum Assistant". This integration will only have the capabilities you approve — it won't access any pages or databases until you explicitly share them with it or authorize it via OAuth.
+> On the creation form:
+> 1. Set the name to **Vellum Assistant**
+> 2. Select your workspace from the **Associated workspace** dropdown
+> 3. For the **Type**, select **Public** — this is required for OAuth
+> 4. Click **Submit**
 
-Wait for the user to approve. If they decline, explain that the integration is required for OAuth and offer to try again or cancel.
+**Known issues:**
+- If "Public" is not available as a type, the user may need to check their workspace settings or plan level
+- If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it — skip ahead to Step 3
 
-Once approved:
+**Milestone (2 of 6):** "Integration created — now we'll configure the OAuth redirect."
 
-1. Click "New integration" (or the "+" button)
-2. Select "Public" as the integration type (required for OAuth)
-3. Enter integration name: "Vellum Assistant"
-4. Select the user's workspace
-5. Click "Submit" or "Create"
+---
 
-Take a `browser_screenshot` to show the result.
+### Step 3: Configure OAuth Redirect URI
 
-Tell the user: "Integration created! Now let's configure the OAuth settings."
+The integration settings page should load after creation. Guide the user to the **Distribution** tab or section.
 
-## Step 3: Configure OAuth Settings
-
-Navigate to the integration's "Distribution" or "OAuth Domain & URIs" tab.
-
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
-
-> **Configure OAuth Redirect URI**
+> Now look for the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**). Click into it.
 >
-> I'm about to add the OAuth redirect URI to your Notion integration. This allows Notion to send the authorization code back to Vellum after you approve the connection.
+> You should see a field for **Redirect URIs**. Paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> Then scroll down and click **Save changes**.
 
-Wait for the user to approve.
+Replace `OAUTH_CALLBACK_URL` with the concrete redirect URI built from `ingress.publicBaseUrl`. Never send the placeholder literally.
 
-Once approved:
-
-1. Find the "Redirect URIs" field
-2. Enter `${ingress.publicBaseUrl}/webhooks/oauth/callback` (e.g. `https://abc123.ngrok-free.app/webhooks/oauth/callback`). Read the `ingress.publicBaseUrl` value from the assistant's workspace config (Settings > Public Ingress).
-3. Save the settings
-
-Take a `browser_snapshot` to confirm.
-
-Tell the user: "Redirect URI configured. Now let's get your OAuth credentials."
-
-## Step 4: Extract Client ID and Client Secret
-
-Stay on the integration settings page and navigate to the "Secrets" or "OAuth Clients" section.
-
-Use `browser_extract` to read:
-
-1. **OAuth client_id** — this is the integration's OAuth client ID
-2. **OAuth client_secret** — click "Show" or "Reveal" first, then extract the value
-
-**Important:** Notion requires a client secret for the token exchange (sent via HTTP Basic Auth). Both values are needed.
-
-Tell the user: "Credentials extracted! Now let's connect your Notion workspace."
-
-## Step 5: Connect Notion
-
-Tell the user: "Opening Notion authorization so you can grant Vellum access to your workspace. You'll see a Notion consent page — just click 'Allow access'."
-
-Use the `credential_store` tool to connect Notion via OAuth2:
+Copy the redirect URI to the clipboard before navigating so the user can paste it:
 
 ```
-action: "oauth2_connect"
-service: "integration:notion"
-client_id: "<the extracted OAuth client_id>"
-client_secret: "<the extracted OAuth client_secret>"
-scopes: []
+host_bash:
+  command: |
+    echo -n "OAUTH_CALLBACK_URL" | pbcopy && /tmp/vellum-nav.sh "https://www.notion.so/profile/integrations"
 ```
 
-This will open the Notion authorization page in the user's browser. Wait for the flow to complete.
+**Known issues:**
+- Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use the base domain from `ingress.publicBaseUrl`
+- If the page shows "Internal integration" with no Distribution tab, the integration was created as Internal — they'll need to recreate it as Public
 
-## Step 6: Celebrate!
+---
 
-Once connected, tell the user:
+### Step 4: Copy Client ID and Client Secret
 
-"**Notion is connected!** You're all set. You can now read and write pages and databases in your Notion workspace through Vellum. Try asking me to list your databases or read a specific page!"
+> Now look for the **Secrets** section on the integration page. You should see:
+> - **OAuth client ID**
+> - **OAuth client secret** (you may need to click **Show** to reveal it)
+>
+> Copy the **Client ID** and paste it here in the chat.
 
-Summarize what was accomplished:
+After receiving the Client ID, collect the secret securely:
 
-- Created a Notion public integration called "Vellum Assistant"
-- Configured the OAuth redirect URI
-- Connected your Notion workspace with read and write access
+```
+credential_store prompt:
+  service: "integration:notion"
+  field: "client_secret"
+  label: "Notion OAuth Client Secret"
+  description: "Copy the Client Secret from the Notion integration page and paste it here."
+  placeholder: "secret_..."
+```
 
-## Error Handling
+**Milestone (4 of 6):** "Credentials collected — almost done."
 
-- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
-- **"Public" integration type not available:** The user may need to enable public integrations in their workspace settings. Guide them to Workspace Settings > Integrations.
-- **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. Notion's UI may have changed; adapt your selectors.
-- **User declines an approval gate:** Don't push back. Explain briefly why the step matters, offer to try again, or cancel gracefully.
-- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry. The integration is already created, so they only need to re-run the connect step.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance.
+---
+
+### Step 5: Store Credentials and Authorize
+
+Register the OAuth app and start the authorization flow. See the collaborative guided flow reference for the exact commands (`assistant oauth apps upsert` and `assistant oauth connections connect`).
+
+> I'll save your credentials and start the Notion authorization flow now.
+>
+> You should see a Notion consent page asking you to **select which pages** to share with Vellum Assistant. Pick the pages or databases you'd like to connect, then click **Allow access**.
+
+**Known issues:**
+- If the consent page shows an error about the redirect URI, double-check that the URI in Step 3 matches exactly
+- The user can always re-authorize later to share additional pages
+
+---
+
+### Step 6: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id <client-id>)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+```
+
+**On success:** "Notion is connected! You can now ask me to read and write pages and databases in your Notion workspace."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Notion-specific differences for Path B:
+- Still requires public ingress for the redirect URI (no loopback alternative)
+- Client Secret prefix is `secret_` — use `credential_store prompt` to collect it securely; split entry is not needed since this prefix doesn't trigger channel scanners

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -119,6 +119,7 @@ Tell the user:
 credential_store:
   action: "oauth2_connect"
   service: "integration:notion"
+  client_id: "<the client id the user sent>"
 ```
 
 Send the returned auth URL to the user:

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,133 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The OAuth callback goes through the public gateway URL.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Notion integration from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Notion account with a workspace you want to connect
+> 2. About 3 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create a Public Integration
+
+Tell the user:
+
+> **Step 1: Create a Notion integration**
+>
+> Open this link to go to your Notion integrations page:
+> `https://www.notion.so/profile/integrations`
+>
+> If you need to sign in, do that first.
+>
+> Then:
+> 1. Click **"New integration"** (or the **"+"** button)
+> 2. Set the name to **Vellum Assistant**
+> 3. Select your workspace from the **Associated workspace** dropdown
+> 4. For the **Type**, select **Public** (this is required for OAuth)
+> 5. Click **Submit**
+>
+> Let me know when the integration is created.
+
+## Path B Step 3: Configure OAuth Redirect URI
+
+Before sending the next step, resolve the concrete callback URL:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+Tell the user:
+
+> **Step 2: Configure the redirect URI**
+>
+> In your integration settings, find the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**).
+>
+> In the **Redirect URIs** field, paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> Scroll down and click **Save changes**.
+>
+> Let me know when it's saved.
+
+## Path B Step 4: Copy Credentials
+
+Tell the user:
+
+> **Step 3: Copy your credentials**
+>
+> In your integration settings, find the **Secrets** section. You should see:
+> - **OAuth client ID**
+> - **OAuth client secret** (you may need to click **Show** to reveal it)
+>
+> Send me the **Client ID** first. It looks like a UUID or alphanumeric string.
+
+Wait for the user to send the Client ID.
+
+## Path B Step 5: Store Credentials
+
+### Path B Step 5a: Client ID
+
+After the user sends the Client ID:
+
+```
+credential_store store:
+  service: "integration:notion"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+### Path B Step 5b: Client Secret
+
+Tell the user:
+
+> **Step 4: Send your Client Secret**
+>
+> Now send me the **Client Secret** from the Secrets section. It starts with `secret_`.
+>
+> Send it as a standalone message with no other text.
+
+After the user sends it:
+
+```
+credential_store store:
+  service: "integration:notion"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Notion**
+>
+> I'll generate an authorization link for you now.
+
+```
+credential_store:
+  action: "oauth2_connect"
+  service: "integration:notion"
+```
+
+Send the returned auth URL to the user:
+
+> Open this link to authorize Vellum Assistant:
+> `<auth URL>`
+>
+> You'll see a Notion consent page. Select the pages and databases you'd like to share, then click **Allow access**.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Notion is connected!** You can now ask me to read and write pages and databases in your Notion workspace.

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -29,6 +29,7 @@ Tell the user:
 > If you need to sign in, do that first.
 >
 > Then:
+>
 > 1. Click **"New integration"** (or the **"+"** button)
 > 2. Set the name to **Vellum Assistant**
 > 3. Select your workspace from the **Associated workspace** dropdown
@@ -66,6 +67,7 @@ Tell the user:
 > **Step 3: Copy your credentials**
 >
 > In your integration settings, find the **Secrets** section. You should see:
+>
 > - **OAuth client ID**
 > - **OAuth client secret** (you may need to click **Show** to reveal it)
 >

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -21,6 +21,7 @@ You will be given a `service` name (e.g., "discord", "linear", "spotify"). If no
 ## Step 1: Read the service config
 
 Use `credential_store` with `action: "describe"` and `service: "<name>"` to get the well-known OAuth config. This returns:
+
 - `scopes` — permissions to request
 - `redirectUri` — the callback URL to register
 - `callbackTransport` — loopback or gateway
@@ -28,6 +29,7 @@ Use `credential_store` with `action: "describe"` and `service: "<name>"` to get 
 - `authUrl` / `tokenUrl` — OAuth endpoints
 
 It may also include a `setup` object with rich metadata:
+
 - `setup.displayName` — the provider's name
 - `setup.dashboardUrl` — where to create the app
 - `setup.appType` — what kind of app to create
@@ -88,6 +90,7 @@ Wait for user confirmation before proceeding.
 > Look for a button to create a new app or integration — it might say "Create App", "New Application", or "New Integration". Go ahead and click it.
 
 Guide the user through the creation flow:
+
 1. Name it "Vellum Assistant"
 2. Follow any guidance from `setup.notes` (e.g., select "Public" for Notion, "From scratch" for Slack)
 3. Complete the creation
@@ -111,6 +114,7 @@ If scopes are empty (e.g. Notion), skip this step.
 ### Step 8: Set redirect URL
 
 Check the `redirectUri` from the config:
+
 - If it says "automatic" — skip this step entirely (no redirect URI needed for loopback)
 - If it mentions `ingress.publicBaseUrl` — the user needs a public gateway URL. Check if one is configured; if not, load the `public-ingress` skill first
 - Otherwise, tell the user exactly where to add the redirect URI

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: oauth-setup
-description: Connect any OAuth service — create app credentials and authorize via browser automation
+description: Connect any OAuth service — walk users through app setup via a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "OAuth Setup"
     user-invocable: true
-    includes: ["browser"]
+    includes: ["collaborative-oauth-flow"]
 ---
 
 You are helping the user connect an OAuth-based service to Vellum. This is a generic setup flow that works for any provider with a well-known OAuth config.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines the generic provider-agnostic steps.
 
 ## Input
 
@@ -36,17 +36,21 @@ It may also include a `setup` object with rich metadata:
 
 If no config is found, tell the user this service doesn't have a pre-configured setup and offer to help them configure it manually via `oauth2_connect`.
 
-## Step 2: Choose the flow based on setup metadata
+## Step 2: Check for a dedicated setup skill
 
-### If `setup` metadata is present (rich flow)
+If the `credential_store describe` response includes a `setupSkillId`, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
 
-Continue to Step 3 (Rich Flow).
+## Step 3: Choose the flow based on setup metadata
+
+### If `setup` metadata is present (guided flow)
+
+Continue to Step 4.
 
 ### If `setup` metadata is absent (manual flow)
 
-The provider has OAuth config (endpoints, scopes) but no setup automation metadata. Guide the user through a manual app creation:
+The provider has OAuth config (endpoints, scopes) but no setup guidance. Guide the user through a manual app creation:
 
-1. Tell the user: "I have the OAuth endpoints and scopes for this service, but I don't have developer dashboard automation for it. You'll need to create an OAuth app manually."
+1. Tell the user: "I have the OAuth endpoints and scopes for this service, but I don't have step-by-step guidance for its developer dashboard. You'll need to create an OAuth app manually."
 2. Provide the details they need:
    - **Scopes to request:** list the `scopes` from the config
    - **Redirect URI:** show the `redirectUri` value
@@ -57,92 +61,130 @@ The provider has OAuth config (endpoints, scopes) but no setup automation metada
    - Set the redirect URI
    - Configure the required scopes
    - Copy the Client ID (and Client Secret if required)
-4. Once they provide the credentials, skip to **Step 8: Connect**.
+4. Once they provide the credentials, skip to **Step 9: Store and Connect**.
 
 ---
 
-## Rich Flow (when `setup` is present)
+## Guided Flow (when `setup` is present)
 
-### Step 3: Tell the user what's happening
+### Step 4: Pre-Flow Setup
 
-Tell the user:
-- "I'll walk you through creating a {setup.appType} so Vellum can connect to {setup.displayName}. The whole process takes a few minutes."
-- "I'll be automating the {setup.displayName} developer dashboard in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
+> We're going to set up {setup.displayName} OAuth together. I'll open each page in your browser and tell you exactly what to do. You can pause anytime.
+>
+> Your Mac may ask for permissions along the way — if you see an option to allow for a longer duration (like 10 minutes), that'll save you from approving every single step.
 
-### Step 4: Navigate to the developer dashboard
+### Step 5: Open the developer dashboard
 
-Use `browser_navigate` to go to `setup.dashboardUrl`.
+Open: `{setup.dashboardUrl}`
 
-Take a `browser_screenshot` and `browser_snapshot`:
-- **If a sign-in page appears:** Tell the user to sign in and wait for confirmation.
-- **If the dashboard loads:** Continue to Step 5.
+> I've opened the {setup.displayName} developer dashboard. If it's asking you to sign in, go ahead and do that first.
 
-### Step 5: Create an app
+Wait for user confirmation before proceeding.
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` explaining what you're about to create.
+---
 
-Once approved:
-1. Find and click the "Create App" / "New Application" / "New Integration" button (adapt to the provider's UI)
-2. Name it "Vellum Assistant"
-3. Follow any guidance from `setup.notes`
-4. Complete the creation flow
+### Step 6: Create an app
 
-Take a `browser_screenshot` to confirm.
+> Look for a button to create a new app or integration — it might say "Create App", "New Application", or "New Integration". Go ahead and click it.
 
-### Step 6: Configure scopes/permissions
+Guide the user through the creation flow:
+1. Name it "Vellum Assistant"
+2. Follow any guidance from `setup.notes` (e.g., select "Public" for Notion, "From scratch" for Slack)
+3. Complete the creation
 
-**Ask for approval before proceeding.** List the `scopes` from the config and explain what each grants.
+Wait for confirmation.
 
-Once approved, navigate to the OAuth/permissions section and add each scope. Follow `setup.notes` for any provider-specific guidance (e.g., "User Token Scopes" vs "Bot Token Scopes").
+---
 
-Take a `browser_screenshot` after adding all scopes.
+### Step 7: Configure scopes/permissions (if any)
 
-### Step 7: Set redirect URL
+If scopes are non-empty, guide the user to the OAuth/permissions section:
+
+> Now we need to add the permissions {setup.displayName} needs. Look for an OAuth, Permissions, or Scopes section.
+
+List each scope and what it grants. Guide the user to add them one at a time or paste them.
+
+If scopes are empty (e.g. Notion), skip this step.
+
+---
+
+### Step 8: Set redirect URL
 
 Check the `redirectUri` from the config:
-- If it mentions "not currently configured" or `ingress.publicBaseUrl` — the user needs a public gateway URL configured. Check if one is set; if not, load the `public-ingress` skill first.
-- If it says "automatic" — skip this step entirely (no redirect URI needed).
-- Otherwise, enter the `redirectUri` exactly as provided.
+- If it says "automatic" — skip this step entirely (no redirect URI needed for loopback)
+- If it mentions `ingress.publicBaseUrl` — the user needs a public gateway URL. Check if one is configured; if not, load the `public-ingress` skill first
+- Otherwise, tell the user exactly where to add the redirect URI
 
-Take a `browser_snapshot` to confirm.
-
-### Step 7b: Extract credentials
-
-Navigate to the app's credentials/settings section.
-
-Use `browser_extract` to read:
-1. **Client ID** (or equivalent)
-2. **Client Secret** (if `requiresClientSecret` is true) — click "Show"/"Reveal" first if needed
+> Look for "Redirect URLs" or "OAuth Redirect URIs" in the settings. Add this URL: `{redirectUri}`
 
 ---
 
-## Step 8: Connect
+### Step 9: Store and Connect
 
-Tell the user you're opening the authorization page.
+#### Collect Client ID
 
-Use `credential_store` with:
+> Copy the Client ID from the app's credentials page and paste it here in the chat.
+
+#### Collect Client Secret (if required)
+
+Always use a secure prompt:
+
 ```
-action: "oauth2_connect"
-service: "<service name>"
-client_id: "<extracted client ID>"
-client_secret: "<extracted client secret>"  (if required)
+credential_store prompt:
+  service: "<provider-key>"
+  field: "client_secret"
+  label: "{setup.displayName} OAuth Client Secret"
+  description: "Copy the Client Secret from the credentials page and paste it here."
+  placeholder: "..."
 ```
 
-Everything else (endpoints, scopes, params) is auto-filled from the well-known config. Wait for the flow to complete.
+#### Register and authorize
 
-## Step 9: Celebrate!
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>:client_secret"
+```
 
-Once connected, tell the user:
-- If `setup` is present: "**{setup.displayName} is connected!** You're all set."
-- If `setup` is absent: "**{service} is connected!** You're all set."
+```
+bash:
+  command: |
+    assistant oauth connections connect <provider-key> --client-id <client-id>
+```
+
+If the service shows an "unverified app" or consent warning, tell the user how to proceed.
+
+---
+
+### Step 10: Verify Connection
+
+If a ping URL is available, verify:
+
+```
+bash:
+  command: |
+    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id <client-id>)" "<provider-ping-url>"
+```
+
+**On success:** "**{setup.displayName} is connected!** You're all set."
 
 Summarize what was accomplished.
 
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels (Telegram, Slack, etc.), provide all URLs and instructions as text messages. Key differences:
+
+- The user navigates on their own — give them the URLs to open
+- Use **Web application** credentials if the provider distinguishes (callback goes through public gateway)
+- Collect the Client Secret via `credential_store prompt` or split entry if the prefix could trigger channel scanners
+- Resolve the redirect URI from `ingress.publicBaseUrl` before sending instructions; if not configured, load the `public-ingress` skill first
+
 ## Error Handling
 
-- **Page load failures:** Retry once. If it still fails, ask the user to check their connection.
-- **Element not found:** Take a fresh `browser_snapshot`. The provider's UI may have changed — adapt dynamically.
-- **User declines an approval gate:** Don't push back. Explain why it matters, offer to retry or cancel.
+- **User lands on unexpected page:** Offer to screenshot, identify where they are, navigate back
+- **User not signed in:** Tell them to sign in, wait, continue
+- **Feature already configured:** "Looks like this is already set up — great, let's skip ahead."
+- **User is confused or frustrated:** Pause, acknowledge, simplify
 - **OAuth flow timeout or failure:** Offer to retry. The app is already created, so only the connect step needs to be re-run.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask for guidance.

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -40,7 +40,9 @@ If no config is found, tell the user this service doesn't have a pre-configured 
 
 ## Step 2: Check for a dedicated setup skill
 
-If the `credential_store describe` response includes a `setupSkillId`, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
+Check if there is a skill with `credential-setup-for` matching this service name. If so, load that skill instead — it has provider-specific steps that are more reliable than the generic flow. Use `skill_load` with that skill ID and hand off completely.
+
+Well-known services with dedicated setup skills: `gmail`, `slack`, `notion`, `twitter`, `github`, `linear`, `spotify`, `todoist`, `discord`, `dropbox`, `asana`, `airtable`, `hubspot`, `figma`.
 
 ## Step 3: Choose the flow based on setup metadata
 

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -111,9 +111,10 @@ credential_store describe:
   service: "integration:slack"
 ```
 
-- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
 - If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
-- Otherwise, tell the user to scroll up to the **Redirect URLs** section on the same OAuth & Permissions page, click **Add New Redirect URL**, paste the URI, click **Add**, then **Save URLs**.
+- Otherwise (including loopback URIs like `http://localhost:17322/callback`), tell the user to scroll up to the **Redirect URLs** section on the same OAuth & Permissions page, click **Add New Redirect URL**, paste the URI, click **Add**, then **Save URLs**.
+
+> Slack requires the redirect URL to be registered even for local loopback callbacks. Without it, the authorization step will fail with a redirect mismatch error.
 
 ---
 

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -1,166 +1,195 @@
 ---
 name: slack-oauth-setup
-description: Create Slack App and OAuth credentials for Slack integration using browser automation
+description: Set up Slack OAuth credentials for Slack integration using a collaborative guided flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔑"
   vellum:
     display-name: "Slack OAuth Setup"
     user-invocable: true
-    includes: ["browser"]
+    credential-setup-for: "slack"
+    includes: ["collaborative-oauth-flow"]
 ---
 
-You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.
+You are helping your user set up Slack OAuth credentials so the Slack messaging integration can connect to their workspace.
 
-**Tone:** Be friendly and reassuring throughout. Narrate what you're doing in plain language so the user always knows what's happening. After each step, briefly confirm what was accomplished before moving on.
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Slack-specific steps.
 
-## Before You Start
+## Provider Details
 
-Tell the user:
+- **Provider key:** `integration:slack`
+- **Auth URL:** `https://slack.com/oauth/v2/authorize`
+- **Token URL:** `https://slack.com/api/oauth.v2.access`
+- **Ping URL:** `https://slack.com/api/auth.test`
+- **Callback transport:** Loopback (port 17322)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
 
-- "I'll walk you through creating a Slack App so Vellum can connect to your workspace. The whole process takes a few minutes."
-- "I'll be automating the Slack API website in the browser — you'll be able to see everything I'm doing."
-- "I'll ask for your approval before each major step, so nothing happens without your say-so."
-- "No sensitive credentials will be shown in the conversation."
+## Slack-Specific Flow
 
-## Step 1: Navigate to Slack API
+The flow has 8 steps total, takes about 3-5 minutes.
 
-Tell the user: "First, let me open the Slack API dashboard."
+### Step 0: Prerequisite Check
 
-Use `browser_navigate` to go to `https://api.slack.com/apps`.
+> Before we start — do you have a Slack workspace where you have permission to install apps?
 
-Take a `browser_screenshot` to show the user what loaded, then take a `browser_snapshot` to check the page state:
+If no workspace or no admin access, explain that workspace admin approval may be needed and offer to proceed anyway (some workspaces allow member-installed apps).
 
-- **If a sign-in page appears:** Tell the user "Please sign in to your Slack account in the browser window. Let me know when you're done." Wait for their confirmation, then take another snapshot.
-- **If the apps dashboard loads:** Tell the user "Slack API dashboard is loaded. Let's create your app!" and continue to Step 2.
+---
 
-## Step 2: Create a Slack App
+### Step 1: Open Slack API Dashboard
 
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
+Open: `https://api.slack.com/apps`
 
-> **Create a Slack App**
+> I've opened the Slack API dashboard. If it's asking you to sign in, go ahead and do that first — then let me know.
+
+---
+
+### Step 2: Create a New Slack App
+
+> Look for the **Create New App** button (usually green, top-right area). Go ahead and click it.
+
+After the user clicks:
+
+> You should see two options — **From scratch** and **From an app manifest**. Pick **From scratch**.
+
+Then:
+
+> Set the app name to **Vellum Assistant** and select your workspace from the dropdown. Then click **Create App**.
+
+**Known issues:**
+- If the workspace dropdown is empty, the user may need to sign in to a different workspace
+- Some workspaces require admin approval for new apps — if blocked, explain that they'll need an admin to approve the app
+
+**Milestone (2 of 8):** "App created — now let's add the permissions it needs."
+
+---
+
+### Step 3: Add User Token Scopes
+
+Open: the app's **OAuth & Permissions** page. Look for it in the left sidebar, or navigate directly if you have the app URL.
+
+> In the left sidebar, click **OAuth & Permissions**. Scroll down until you see **User Token Scopes**.
 >
-> I'm about to create a new Slack App called "Vellum Assistant" in your workspace. This app will only have the permissions you approve in the next step. It won't post anything or access any data until you explicitly authorize it.
-
-Wait for the user to approve. If they decline, explain that the app is required for OAuth and offer to try again or cancel.
-
-Once approved:
-
-1. Click "Create New App"
-2. Select "From scratch"
-3. Enter app name: "Vellum Assistant"
-4. Select the user's workspace from the dropdown
-5. Click "Create App"
-
-Take a `browser_screenshot` to show the result.
-
-Tell the user: "App created! Now let's configure the permissions it needs."
-
-## Step 3: Configure OAuth Scopes
-
-**Ask for approval before proceeding.** Use `ui_show` with `surface_type: "confirmation"` and this message:
-
-> **Configure Slack Permissions**
+> You'll need to click **Add an OAuth Scope** and add each of these scopes one at a time:
 >
-> I'm about to add the following User Token Scopes to your Slack App. These let Vellum read your messages and channels, send messages on your behalf, search your message history, and add emoji reactions:
+> - `channels:read` — view basic channel info
+> - `channels:history` — read public channel messages
+> - `groups:read` — view private channel info
+> - `groups:history` — read private channel messages
+> - `im:read` — view direct message info
+> - `im:history` — read direct messages
+> - `im:write` — start and send direct messages
+> - `mpim:read` — view group DM info
+> - `mpim:history` — read group DM messages
+> - `users:read` — view user profiles
+> - `chat:write` — send messages
+> - `search:read` — search messages
+> - `reactions:write` — add emoji reactions
 >
-> - `channels:read` — View basic channel info
-> - `channels:history` — Read message history in public channels
-> - `groups:read` — View private channel info
-> - `groups:history` — Read message history in private channels
-> - `im:read` — View direct message info
-> - `im:history` — Read direct message history
-> - `im:write` — Open and send direct messages
-> - `mpim:read` — View group DM info
-> - `mpim:history` — Read group DM history
-> - `users:read` — View user profiles
-> - `chat:write` — Send messages
-> - `search:read` — Search messages
-> - `reactions:write` — Add emoji reactions
+> You can start typing the scope name to filter the dropdown — it goes pretty fast once you get the rhythm.
 
-Wait for the user to approve.
+Wait for the user to confirm all 13 scopes are added.
 
-Once approved:
+**Milestone (3 of 8):** "Permissions are set — now let's handle the redirect URL."
 
-1. Navigate to "OAuth & Permissions" in the left sidebar (or go to the app's OAuth page directly)
-2. Scroll to "User Token Scopes"
-3. Add each scope listed above using the "Add an OAuth Scope" button
+---
 
-Take a `browser_screenshot` after adding all scopes.
+### Step 4: Set Up Redirect URL
 
-Tell the user: "Permissions configured! Now let's set up the redirect URL and get the credentials."
+Before this step, resolve the redirect URI:
 
-## Step 4: Add Redirect URL
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:slack" --json
+```
 
-Navigate to the "OAuth & Permissions" page if not already there.
-
-Before entering the redirect URL, resolve the exact value from the well-known OAuth config:
+Check the `redirectUri` from `credential_store describe`:
 
 ```
 credential_store describe:
   service: "integration:slack"
 ```
 
-Read the `redirectUri` field from that response and use it exactly as shown.
+- If `redirectUri` says **"automatic"** or the callback transport is loopback with no ingress requirement, skip adding a redirect URL — tell the user: "The redirect URL is handled automatically for this setup, so we can skip this part."
+- If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- Otherwise, tell the user to scroll up to the **Redirect URLs** section on the same OAuth & Permissions page, click **Add New Redirect URL**, paste the URI, click **Add**, then **Save URLs**.
 
-In the "Redirect URLs" section:
+---
 
-1. If `redirectUri` says "automatic", skip adding a redirect URL for this provider.
-2. If `redirectUri` mentions "not currently configured" or `ingress.publicBaseUrl`, stop and ask the user to configure public ingress first.
-3. Otherwise, click "Add New Redirect URL" and enter the `redirectUri` value exactly as returned.
-4. Click "Add" then "Save URLs"
+### Step 5: Get Client ID and Client Secret
 
-Take a `browser_snapshot` to confirm.
+> Now let's grab the credentials. In the left sidebar, click **Basic Information**.
 
-Tell the user: "Redirect URL configured using the redirect URI from Vellum's Slack OAuth profile."
+Open: the app's **Basic Information** page via the sidebar.
 
-## Step 5: Extract Client ID and Client Secret
+> Scroll down to the **App Credentials** section. You should see **Client ID** and **Client Secret** listed there.
 
-Navigate to "Basic Information" in the left sidebar.
+**Milestone (5 of 8):** "Almost there — just need to save these credentials."
 
-Use `browser_extract` to read:
+---
 
-1. **Client ID** from the "App Credentials" section
-2. **Client Secret** — click "Show" first, then extract the value
+### Step 6: Store Credentials
 
-**Important:** Slack requires a client secret for the token exchange (unlike Google which uses PKCE). Both values are needed.
+Collect Client ID conversationally:
 
-Tell the user: "Credentials extracted! Now let's connect your Slack workspace."
+> Copy the **Client ID** and paste it here in the chat.
 
-## Step 6: Connect Slack
-
-Tell the user: "Opening Slack authorization so you can grant Vellum access to your workspace. You'll see a Slack consent page — just click 'Allow'."
-
-Use the `credential_store` tool to connect Slack via OAuth2:
+Collect Client Secret via secure prompt:
 
 ```
-action: "oauth2_connect"
-service: "integration:slack"
-client_id: "<the extracted Client ID>"
-client_secret: "<the extracted Client Secret>"
-scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "im:write", "mpim:read", "mpim:history", "users:read", "chat:write", "search:read", "reactions:write"]
+credential_store prompt:
+  service: "integration:slack"
+  field: "client_secret"
+  label: "Slack OAuth Client Secret"
+  description: "Copy the Client Secret from the Basic Information page (you may need to click Show first) and paste it here."
+  placeholder: "..."
 ```
 
-This will open the Slack authorization page in the user's browser. Wait for the flow to complete.
+Register the OAuth app:
 
-## Step 7: Celebrate!
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+```
 
-Once connected, tell the user:
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
 
-"**Slack is connected!** You're all set. You can now read channels, search messages, send messages, and manage your Slack workspace through Vellum. Try asking me to check your unread Slack messages!"
+---
 
-Summarize what was accomplished:
+### Step 7: Authorize
 
-- Created a Slack App called "Vellum Assistant"
-- Configured User Token Scopes for reading, writing, and searching
-- Set up the OAuth redirect URL from the Slack OAuth profile
-- Connected your Slack workspace
+> I'll start the Slack authorization flow now. You should see a Slack consent page asking you to allow **Vellum Assistant** to access your workspace.
+>
+> Review the permissions and click **Allow**.
 
-## Error Handling
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:slack --client-id <client-id>
+```
 
-- **Page load failures:** Retry navigation once. If it still fails, tell the user and ask them to check their internet connection.
-- **Workspace selection issues:** The user may need admin permissions to install apps. Explain this clearly.
-- **Element not found for click/type:** Take a fresh `browser_snapshot` to re-assess the page layout. Slack's UI may have changed; adapt your selectors.
-- **User declines an approval gate:** Don't push back. Explain briefly why the step matters, offer to try again, or cancel gracefully.
-- **OAuth flow timeout or failure:** Tell the user what happened and offer to retry. The app is already created, so they only need to re-run the connect step.
-- **Any unexpected state:** Take a `browser_screenshot` and `browser_snapshot`, describe what you see, and ask the user for guidance.
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:slack --client-id <client-id>)" "https://slack.com/api/auth.test" | python3 -m json.tool
+```
+
+**On success:** "Slack is connected! You can now ask me to check your Slack messages, search conversations, send messages, and react to posts."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Slack-specific differences for Path B:
+- Loopback callback won't work from a remote channel — need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URLs** on the OAuth & Permissions page
+- Client Secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -57,6 +57,7 @@ Then:
 > Set the app name to **Vellum Assistant** and select your workspace from the dropdown. Then click **Create App**.
 
 **Known issues:**
+
 - If the workspace dropdown is empty, the user may need to sign in to a different workspace
 - Some workspaces require admin approval for new apps — if blocked, explain that they'll need an admin to approve the app
 
@@ -190,6 +191,7 @@ bash:
 For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
 
 Key Slack-specific differences for Path B:
+
 - Loopback callback won't work from a remote channel — need public ingress configured
 - Add the ingress-based redirect URI under **Redirect URLs** on the OAuth & Permissions page
 - Client Secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/slack-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/slack-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,135 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17322) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Slack from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Slack workspace where you can install apps
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Slack App
+
+Tell the user:
+
+> **Step 1: Create a Slack App**
+>
+> Open this link:
+> `https://api.slack.com/apps`
+>
+> 1. Click **Create New App**
+> 2. Choose **From scratch**
+> 3. Set the app name to **Vellum Assistant**
+> 4. Select your workspace from the dropdown
+> 5. Click **Create App**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add User Token Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> In the left sidebar, click **OAuth & Permissions**. Scroll down to **User Token Scopes** and add each of these scopes using the **Add an OAuth Scope** button:
+>
+> `channels:read`, `channels:history`, `groups:read`, `groups:history`, `im:read`, `im:history`, `im:write`, `mpim:read`, `mpim:history`, `users:read`, `chat:write`, `search:read`, `reactions:write`
+>
+> That's 13 scopes total. You can type the name to filter the dropdown.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Still on the **OAuth & Permissions** page, scroll up to the **Redirect URLs** section.
+>
+> 1. Click **Add New Redirect URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Add**
+> 4. Click **Save URLs**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> In the left sidebar, click **Basic Information**. Scroll down to the **App Credentials** section.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:slack"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **Client Secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:slack"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+Note: Slack client secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize
+
+Tell the user:
+
+> **Step 5: Authorize Slack**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:slack --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Slack consent page.
+
+## Path B Step 8: Done
+
+After authorization:
+
+> **Slack is connected!** You can now ask me to check your Slack messages, search conversations, send messages, and react to posts.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -47,6 +47,7 @@ Open: `https://developer.x.com/en/portal/dashboard`
 > I've opened the Twitter Developer Portal. If it's asking you to sign in, go ahead and do that first.
 
 **Known issues:**
+
 - First-time developers will see a sign-up flow — they need to agree to the developer agreement and describe their use case. "Personal project" or "Building a tool" works fine for the description.
 - Free tier is sufficient for OAuth 2.0 with PKCE.
 
@@ -64,6 +65,7 @@ Guide through project creation:
 > 4. Click **Next** through each step
 
 **Known issues:**
+
 - Free tier allows only one project — if the user already has one, reuse it
 - If they see "You've reached your project limit", use the existing project
 
@@ -203,6 +205,7 @@ bash:
 For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
 
 Key Twitter-specific differences for Path B:
+
 - Gateway callback requires public ingress — must be configured before starting
 - OAuth 2.0 Client Secret doesn't have a known prefix that triggers channel scanners, but still use `credential_store store` for security
 - App type must be **Web App, Automated App or Bot** (same as Path A, since gateway transport is used in both paths)

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: twitter-oauth-setup
+description: Set up Twitter/X OAuth credentials for Twitter integration using a collaborative guided flow
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🔑"
+  vellum:
+    display-name: "Twitter / X OAuth Setup"
+    user-invocable: true
+    credential-setup-for: "twitter"
+    includes: ["collaborative-oauth-flow"]
+---
+
+You are helping your user set up Twitter/X OAuth credentials so the Twitter integration can post tweets, read timelines, and access user data.
+
+This skill follows the **Collaborative Guided Flow** pattern from the included `collaborative-oauth-flow` skill. That reference covers the navigation helper setup, step rhythm, rules, tone, error handling, and guardrails. This file defines only the Twitter-specific steps.
+
+## Provider Details
+
+- **Provider key:** `integration:twitter`
+- **Auth URL:** `https://twitter.com/i/oauth2/authorize`
+- **Token URL:** `https://api.x.com/2/oauth2/token`
+- **Ping URL:** `https://api.x.com/2/users/me`
+- **Base URL:** `https://api.x.com`
+- **Default scopes:** `tweet.read`, `tweet.write`, `users.read`, `offline.access`
+- **Token endpoint auth method:** `client_secret_basic`
+- **Callback transport:** Gateway (requires public ingress)
+- **Requires secret:** Yes (token endpoint uses `client_secret_basic`, so both Client ID and Client Secret are needed)
+
+## Twitter-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start — do you have a Twitter/X account you'd like to use for this? You'll also need access to the Twitter Developer Portal.
+
+If no account -> guide them to create one or defer.
+If no developer account -> they'll be prompted to sign up during Step 1. Free tier is sufficient.
+
+---
+
+### Step 1: Open Twitter Developer Portal
+
+Open: `https://developer.x.com/en/portal/dashboard`
+
+> I've opened the Twitter Developer Portal. If it's asking you to sign in, go ahead and do that first.
+
+**Known issues:**
+- First-time developers will see a sign-up flow — they need to agree to the developer agreement and describe their use case. "Personal project" or "Building a tool" works fine for the description.
+- Free tier is sufficient for OAuth 2.0 with PKCE.
+
+---
+
+### Step 2: Create a Project
+
+> Look for **Projects & Apps** in the left sidebar. If you already have a project you'd like to use, let me know. Otherwise, click **+ Add Project**.
+
+Guide through project creation:
+
+> 1. **Project name:** `Vellum Assistant` (or whatever you prefer)
+> 2. **Use case:** Select **Making a bot** or **Exploring the API** — either works
+> 3. **Project description:** Something brief like "Personal assistant integration"
+> 4. Click **Next** through each step
+
+**Known issues:**
+- Free tier allows only one project — if the user already has one, reuse it
+- If they see "You've reached your project limit", use the existing project
+
+**Milestone (2 of 8):** "Project created — now let's set up an app inside it."
+
+---
+
+### Step 3: Create an App (or select existing)
+
+If the project creation wizard prompts to create an app immediately, follow along. Otherwise:
+
+> Inside your project, look for an **+ Add App** button or a prompt to create a new app.
+>
+> Set the app name to **Vellum Assistant** and click **Next** or **Create**.
+
+After creation, the portal may show API keys (API Key and Secret, Bearer Token). These are for OAuth 1.0a — we don't need them for OAuth 2.0, but it doesn't hurt to save them somewhere safe.
+
+> You may see API Key, API Secret, and Bearer Token on this screen. You can save these somewhere safe if you like, but we won't need them — we're using OAuth 2.0. Go ahead and click **App Settings** or navigate to your app's settings page.
+
+---
+
+### Step 4: Configure OAuth 2.0 Settings
+
+Navigate to the app's settings. If not already there:
+
+> In the left sidebar under your project, click on your app name, then look for **Settings** or **Edit** under the **User authentication settings** section.
+
+Open the User Authentication Settings:
+
+> Scroll down to **User authentication settings** and click **Set up** or **Edit**.
+
+Guide through the OAuth 2.0 configuration:
+
+> You should see an authentication setup page. Here's what to fill in:
+>
+> 1. **App permissions:** Select **Read and write** (this covers tweet.read, tweet.write, and users.read)
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **App info:**
+>    - **Callback URI / Redirect URL:** I'll give you the URL in a moment
+>    - **Website URL:** You can use `https://vellum.ai` or any URL you own
+
+Before providing the redirect URI, resolve it:
+
+```
+bash:
+  command: assistant oauth providers list --provider-key "integration:twitter" --json
+```
+
+Check the redirect URI situation. Since callbackTransport is `gateway`, public ingress must be configured:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+
+> For the **Callback URI / Redirect URL**, paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> For the **Website URL**, you can enter `https://vellum.ai` or any website you own.
+>
+> Then click **Save**.
+
+**Milestone (4 of 8):** "OAuth settings configured — now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and Client Secret
+
+> After saving, you should be back on the app settings page. Look for the **Keys and tokens** tab at the top of the page, then scroll down to **OAuth 2.0 Client ID and Client Secret**.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it. You may need to confirm by typing "Yes" in a dialog.
+
+Note: The token endpoint auth method (`basic`) requires both a Client ID and a secret, so the skill collects both.
+
+**Milestone (5 of 8):** "Almost there — just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials
+
+Collect Client ID conversationally:
+
+> Copy the **Client ID** (it's a long string, sometimes called "OAuth 2.0 Client ID") and paste it here in the chat.
+
+Collect Client Secret via secure prompt:
+
+```
+credential_store prompt:
+  service: "integration:twitter"
+  field: "client_secret"
+  label: "Twitter OAuth 2.0 Client Secret"
+  description: "Copy the Client Secret from the Keys and tokens page and paste it here."
+  placeholder: "..."
+```
+
+Register the OAuth app:
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+```
+
+**Milestone (6 of 8):** "Credentials saved — just the authorization step left."
+
+---
+
+### Step 7: Authorize
+
+> I'll start the Twitter authorization flow now. You should see a Twitter consent page asking you to authorize **Vellum Assistant** to access your account.
+>
+> Review the permissions — it will ask for permission to read your tweets, post tweets, and read your profile info. Click **Authorize app**.
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:twitter --client-id <client-id>
+```
+
+---
+
+### Step 8: Verify Connection
+
+Use the ping URL to verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:twitter --client-id <client-id>)" "https://api.x.com/2/users/me" | python3 -m json.tool
+```
+
+**On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
+
+Key Twitter-specific differences for Path B:
+- Gateway callback requires public ingress — must be configured before starting
+- OAuth 2.0 Client Secret doesn't have a known prefix that triggers channel scanners, but still use `credential_store store` for security
+- App type must be **Web App, Automated App or Bot** (same as Path A, since gateway transport is used in both paths)

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -1,0 +1,130 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the gateway callback is not reachable without it.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Twitter / X from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Twitter/X account with access to the Developer Portal
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Project and App
+
+Tell the user:
+
+> **Step 1: Create a Project and App**
+>
+> Open this link to the Twitter Developer Portal:
+> `https://developer.x.com/en/portal/dashboard`
+>
+> 1. In the left sidebar, find **Projects & Apps**
+> 2. Click **+ Add Project** (if you already have a project, you can reuse it)
+> 3. Set the project name to **Vellum Assistant**
+> 4. For the use case, pick **Making a bot** or **Exploring the API**
+> 5. Add a brief description and click through each step
+> 6. When prompted, create a new app named **Vellum Assistant**
+>
+> You may see API Key, API Secret, and Bearer Token — save them if you like, but we won't use them. Navigate to your app's settings page.
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Configure OAuth 2.0
+
+Tell the user:
+
+> **Step 2: Configure OAuth 2.0 settings**
+>
+> On your app's settings page, scroll down to **User authentication settings** and click **Set up** (or **Edit** if already configured).
+>
+> Fill in:
+>
+> 1. **App permissions:** Select **Read and write**
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **Callback URI / Redirect URL:** `OAUTH_CALLBACK_URL`
+> 4. **Website URL:** `https://vellum.ai` (or any website you own)
+>
+> Click **Save**.
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> Go to the **Keys and tokens** tab at the top of your app page. Scroll down to the **OAuth 2.0 Client ID and Client Secret** section.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it and confirm.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then store it:
+
+```
+credential_store store:
+  service: "integration:twitter"
+  field: "client_id"
+  value: "<the client id the user sent>"
+```
+
+Then ask for the secret:
+
+> Now send me the **Client Secret**. Send it as a standalone message with no other text.
+
+Store the secret:
+
+```
+credential_store store:
+  service: "integration:twitter"
+  field: "client_secret"
+  value: "<the client secret the user sent>"
+```
+
+Note: Twitter OAuth 2.0 Client Secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize
+
+Tell the user:
+
+> **Step 4: Authorize Twitter**
+>
+> I'll generate an authorization link for you now.
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connections connect integration:twitter --client-id <client-id>
+```
+
+Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.
+
+## Path B Step 7: Done
+
+After authorization:
+
+> **Twitter is connected!** You can now ask me to read your timeline, post tweets, and check your profile.


### PR DESCRIPTION
## Summary

- Migrate Notion and Slack OAuth setup skills from browser automation to the collaborative guided flow pattern (matching Google OAuth)
- Add Twitter/X OAuth setup skill with collaborative guided flow
- Add identity verifier functions for Google (email), Slack (@user/team), Notion (name/email) — Twitter already had one
- Enrich provider behaviors with `setupSkillId`, `setup` metadata, and `injectionTemplates` for Slack and Notion
- Update generic `oauth-setup` skill to use collaborative flow and delegate to provider-specific setup skills
- All skills include Path B (manual channel setup) for non-interactive channels

## Test plan

- [ ] Verify Notion OAuth setup works end-to-end via collaborative flow (Path A)
- [ ] Verify Slack OAuth setup works end-to-end via collaborative flow (Path A)
- [ ] Verify Twitter/X OAuth setup works end-to-end via collaborative flow
- [ ] Test identity verifiers show "Connected as..." after successful OAuth connection
- [ ] Verify Path B instructions work for non-interactive channels
- [ ] Confirm generic `oauth-setup` skill delegates to provider-specific skills when `setupSkillId` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
