### PR TITLE
feat: add account parameter to Gmail and Calendar tools

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/TOOLS.json
+++ b/assistant/src/config/bundled-skills/gmail/TOOLS.json
@@ -42,6 +42,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["confidence"]
@@ -89,6 +93,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["confidence"]
@@ -115,6 +123,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["message_id", "confidence"]
@@ -141,6 +153,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["message_id", "confidence"]
@@ -183,6 +199,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["to", "subject", "body"]
@@ -209,6 +229,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["draft_id", "confidence"]
@@ -244,6 +268,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["action", "message_id"]
@@ -278,6 +306,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["message_id", "to", "confidence"]
@@ -309,6 +341,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["action", "confidence"]
@@ -378,6 +414,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["action", "confidence"]
@@ -429,6 +469,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["action", "confidence"]
@@ -463,6 +507,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         }
       },
@@ -496,6 +544,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Gmail account to use. Required when multiple Gmail accounts are connected. If omitted, uses the most recently connected account."
           }
         }
       },

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -18,6 +18,7 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const query = input.query as string | undefined;
   const scanId = input.scan_id as string | undefined;
   const senderIds = input.sender_ids as string[] | undefined;
@@ -34,7 +35,7 @@ export async function run(
     }
 
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
       let truncated = false;
@@ -103,7 +104,7 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
       return ok("Message archived.");
     } catch (e) {
@@ -121,7 +122,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     if (messageIds.length === 1) {
       await modifyMessage(connection, messageIds[0], {
         removeLabelIds: ["INBOX"],

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -48,6 +48,7 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const action = input.action as string;
   const messageId = input.message_id as string;
 
@@ -56,7 +57,7 @@ export async function run(
 
   if (action === "list") {
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       const message = await getMessage(connection, messageId, "full");
       const attachments = collectAttachments(message.payload?.parts);
 
@@ -78,7 +79,7 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       const attachment = await getAttachment(
         connection,
         messageId,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -10,6 +10,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const to = input.to as string;
   const subject = input.subject as string;
   const body = input.body as string;
@@ -22,7 +23,7 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     const draft = await createDraft(
       connection,
       to,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -18,6 +18,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const action = input.action as string;
 
   if (!action) {
@@ -25,7 +26,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     switch (action) {
       case "list": {
         const filters = await listFilters(connection);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -30,6 +30,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const action = input.action as string;
 
   if (!action) {
@@ -37,7 +38,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     switch (action) {
       case "track": {
         const messageId = input.message_id as string;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -67,6 +67,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const messageId = input.message_id as string;
   const forwardTo = input.to as string;
   const additionalText = input.text as string | undefined;
@@ -75,7 +76,7 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     const message = await getMessage(connection, messageId, "full");
     const headers = message.payload?.headers ?? [];
     const originalFrom = extractHeader(headers, "From");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -13,6 +13,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const messageId = input.message_id as string | undefined;
   const messageIds = input.message_ids as string[] | undefined;
   const addLabelIds = input.add_label_ids as string[] | undefined;
@@ -20,7 +21,7 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       await batchModifyMessages(connection, messageIds, {
         addLabelIds,
         removeLabelIds,
@@ -33,7 +34,7 @@ export async function run(
 
   if (messageId) {
     try {
-      const connection = resolveOAuthConnection("integration:gmail");
+      const connection = resolveOAuthConnection("integration:gmail", account);
       await modifyMessage(connection, messageId, {
         addLabelIds,
         removeLabelIds,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -44,6 +44,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const maxMessages = Math.min(
     (input.max_messages as number) ?? 2000,
     MAX_MESSAGES_CAP,
@@ -55,7 +56,7 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     // Pipeline: fire metadata fetches for each page of IDs as they arrive
     const allMessageIds: string[] = [];
     const fetchPromises: Promise<GmailMessage[]>[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -10,11 +10,12 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const draftId = input.draft_id as string;
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     const msg = await sendDraft(connection, draftId);
     return ok(`Draft sent (Message ID: ${msg.id}).`);
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -48,6 +48,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const query = (input.query as string) ?? "category:promotions newer_than:90d";
   const maxMessages = Math.min(
     (input.max_messages as number) ?? 5000,
@@ -57,7 +58,7 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     // Pipeline: fire metadata fetches for each page of IDs as they arrive,
     // overlapping fetch latency with pagination latency
     const allMessageIds: string[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -10,6 +10,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const messageId = input.message_id as string;
 
   if (!messageId) {
@@ -17,7 +18,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     await trashMessage(connection, messageId);
     return ok("Message moved to trash.");
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -18,6 +18,7 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   if (!context.triggeredBySurfaceAction) {
     return err(
       "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
@@ -31,7 +32,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     const message = await getMessage(connection, messageId, "metadata", [
       "List-Unsubscribe",
       "List-Unsubscribe-Post",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -14,6 +14,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const action = input.action as string;
 
   if (!action) {
@@ -21,7 +22,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:gmail", account);
     switch (action) {
       case "get": {
         const settings = await getVacation(connection);

--- a/assistant/src/config/bundled-skills/google-calendar/TOOLS.json
+++ b/assistant/src/config/bundled-skills/google-calendar/TOOLS.json
@@ -41,6 +41,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Google account to use. Required when multiple Google accounts are connected. If omitted, uses the most recently connected account."
           }
         }
       },
@@ -66,6 +70,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Google account to use. Required when multiple Google accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["event_id"]
@@ -123,6 +131,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Google account to use. Required when multiple Google accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["summary", "start", "end", "confidence"]
@@ -160,6 +172,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Google account to use. Required when multiple Google accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["time_min", "time_max"]
@@ -195,6 +211,10 @@
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Google account to use. Required when multiple Google accounts are connected. If omitted, uses the most recently connected account."
           }
         },
         "required": ["event_id", "response", "confidence"]

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
@@ -9,12 +9,13 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const timeMin = input.time_min as string;
   const timeMax = input.time_max as string;
   const calendarIds = (input.calendar_ids as string[]) ?? ["primary"];
   const timezone = input.timezone as string | undefined;
 
-  const connection = getCalendarConnection();
+  const connection = getCalendarConnection(account);
   const result = await calendar.freeBusy(connection, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
@@ -9,6 +9,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const summary = input.summary as string;
   const startRaw = input.start as string;
   const endRaw = input.end as string;
@@ -40,7 +41,7 @@ export async function run(
     eventBody.attendees = attendees.map((email) => ({ email }));
   }
 
-  const connection = getCalendarConnection();
+  const connection = getCalendarConnection(account);
   const event = await calendar.createEvent(connection, eventBody, calendarId);
   const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
   return ok(`Event created (ID: ${event.id}).${link}`);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
@@ -9,10 +9,11 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const eventId = input.event_id as string;
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = getCalendarConnection();
+  const connection = getCalendarConnection(account);
   const event = await calendar.getEvent(connection, eventId, calendarId);
   return ok(JSON.stringify(event, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
@@ -9,6 +9,7 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const calendarId = (input.calendar_id as string) ?? "primary";
   const timeMin = (input.time_min as string) ?? new Date().toISOString();
   const timeMax = input.time_max as string | undefined;
@@ -17,7 +18,7 @@ export async function run(
   const singleEvents = (input.single_events as boolean) ?? true;
   const orderBy = input.order_by as "startTime" | "updated" | undefined;
 
-  const connection = getCalendarConnection();
+  const connection = getCalendarConnection(account);
   const result = await calendar.listEvents(connection, calendarId, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
@@ -9,11 +9,12 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
   const eventId = input.event_id as string;
   const response = input.response as "accepted" | "declined" | "tentative";
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = getCalendarConnection();
+  const connection = getCalendarConnection(account);
 
   // First get the event to find the user's attendee entry
   const event = await calendar.getEvent(connection, eventId, calendarId);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -10,6 +10,6 @@ export function ok(content: string): ToolExecutionResult {
  * Calendar uses the same OAuth credential service as Gmail since both
  * scopes are granted in a single OAuth consent flow.
  */
-export function getCalendarConnection(): OAuthConnection {
-  return resolveOAuthConnection("integration:gmail");
+export function getCalendarConnection(account?: string): OAuthConnection {
+  return resolveOAuthConnection("integration:gmail", account);
 }


### PR DESCRIPTION
## Summary
- Add optional `account` parameter to all 13 Gmail tools and 5 Google Calendar tools
- Passes account info through to `resolveOAuthConnection` so the model can target a specific OAuth account when multiple are connected
- Calendar tools route through updated `getCalendarConnection(account?)` shared helper

## Original prompt
Add `account` parameter to all Gmail and Google Calendar tools so the model can target a specific OAuth account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
