### PR TITLE
fix: restore user message image attachments on history load

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for handleListMessages attachment handling.
+ *
+ * Verifies that:
+ * - User message image attachments include base64 data for client thumbnail generation
+ * - User message non-image attachments stay metadata-only (no base64 blob)
+ * - Assistant message attachments remain metadata-only
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "list-messages-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  getRootDir: () => testDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    apiKeys: {},
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
+  }),
+}));
+
+import {
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../memory/attachments-store.js";
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function createTestUrl(conversationId: string): URL {
+  return new URL(
+    `http://localhost/v1/messages?conversationId=${conversationId}`,
+  );
+}
+
+interface AttachmentPayload {
+  data?: string;
+  mimeType: string;
+  thumbnailData?: string;
+}
+
+interface MessagePayload {
+  attachments?: AttachmentPayload[];
+}
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+const DOC_BASE64 = "JVBERi0xLjQKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwo";
+
+describe("handleListMessages attachments", () => {
+  beforeEach(resetTables);
+
+  test("user message image attachments include base64 data", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "check this image" }]),
+    );
+    const stored = uploadAttachment("photo.png", "image/png", IMAGE_BASE64);
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    const attachments = body.messages[0].attachments;
+    expect(attachments).toBeDefined();
+    expect(attachments).toHaveLength(1);
+    expect(attachments![0].mimeType).toBe("image/png");
+    expect(attachments![0].data).toBe(IMAGE_BASE64);
+  });
+
+  test("user message non-image attachments stay metadata-only", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "check this doc" }]),
+    );
+    const stored = uploadAttachment(
+      "report.pdf",
+      "application/pdf",
+      DOC_BASE64,
+    );
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    const attachments = body.messages[0].attachments;
+    expect(attachments).toBeDefined();
+    expect(attachments).toHaveLength(1);
+    expect(attachments![0].mimeType).toBe("application/pdf");
+    // Non-image attachments should NOT include base64 data
+    expect(attachments![0].data).toBeUndefined();
+  });
+
+  test("assistant message attachments remain metadata-only", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "here is an image" }]),
+    );
+    const stored = uploadAttachment("result.png", "image/png", IMAGE_BASE64);
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(1);
+    const attachments = body.messages[0].attachments;
+    expect(attachments).toBeDefined();
+    expect(attachments).toHaveLength(1);
+    expect(attachments![0].mimeType).toBe("image/png");
+    // Assistant attachments should NOT include base64 data (metadata-only)
+    expect(attachments![0].data).toBeUndefined();
+  });
+
+  test("user message with mixed attachments only inlines images", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "here are files" }]),
+    );
+    const imgStored = uploadAttachment("photo.jpg", "image/jpeg", IMAGE_BASE64);
+    const docStored = uploadAttachment(
+      "doc.pdf",
+      "application/pdf",
+      DOC_BASE64,
+    );
+    linkAttachmentToMessage(msg.id, imgStored.id, 0);
+    linkAttachmentToMessage(msg.id, docStored.id, 1);
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    const attachments = body.messages[0].attachments!;
+    expect(attachments).toHaveLength(2);
+
+    const imgAtt = attachments.find((a) => a.mimeType === "image/jpeg");
+    const docAtt = attachments.find((a) => a.mimeType === "application/pdf");
+    expect(imgAtt!.data).toBe(IMAGE_BASE64);
+    expect(docAtt!.data).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -231,6 +231,8 @@ export interface RuntimeAttachmentMetadata {
   mimeType: string;
   sizeBytes: number;
   kind: string;
+  data?: string;
+  thumbnailData?: string;
 }
 
 export interface RuntimeMessagePayload {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -315,16 +315,34 @@ export function handleListMessages(
   let prevAssistantTimestamp = 0;
   const messages: RuntimeMessagePayload[] = parsed.map((m) => {
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
-    if (m.role === "assistant" && m.id) {
-      const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
-      if (linked.length > 0) {
-        msgAttachments = linked.map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          sizeBytes: a.sizeBytes,
-          kind: a.kind,
-        }));
+    if (m.id) {
+      if (m.role === "user") {
+        // User messages need full attachment data so the client can generate
+        // thumbnails for inline image display on history restore.
+        const linked = attachmentsStore.getAttachmentsForMessage(m.id);
+        if (linked.length > 0) {
+          msgAttachments = linked.map((a) => ({
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            sizeBytes: a.sizeBytes,
+            kind: a.kind ?? "",
+            ...(a.dataBase64 ? { data: a.dataBase64 } : {}),
+            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
+          }));
+        }
+      } else {
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
+        if (linked.length > 0) {
+          msgAttachments = linked.map((a) => ({
+            id: a.id,
+            filename: a.originalFilename,
+            mimeType: a.mimeType,
+            sizeBytes: a.sizeBytes,
+            kind: a.kind,
+            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
+          }));
+        }
       }
     }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -317,19 +317,27 @@ export function handleListMessages(
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.id) {
       if (m.role === "user") {
-        // User messages need full attachment data so the client can generate
-        // thumbnails for inline image display on history restore.
+        // User image attachments need full base64 data so the client can
+        // generate thumbnails for inline display on history restore.
+        // Non-image attachments (documents, audio) stay metadata-only to
+        // avoid inflating the response with large blobs.
         const linked = attachmentsStore.getAttachmentsForMessage(m.id);
         if (linked.length > 0) {
-          msgAttachments = linked.map((a) => ({
-            id: a.id,
-            filename: a.originalFilename,
-            mimeType: a.mimeType,
-            sizeBytes: a.sizeBytes,
-            kind: a.kind ?? "",
-            ...(a.dataBase64 ? { data: a.dataBase64 } : {}),
-            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
-          }));
+          msgAttachments = linked.map((a) => {
+            const includeData =
+              a.mimeType.startsWith("image/") && !!a.dataBase64;
+            return {
+              id: a.id,
+              filename: a.originalFilename,
+              mimeType: a.mimeType,
+              sizeBytes: a.sizeBytes,
+              kind: a.kind ?? "",
+              ...(includeData ? { data: a.dataBase64 } : {}),
+              ...(a.thumbnailBase64
+                ? { thumbnailData: a.thumbnailBase64 }
+                : {}),
+            };
+          });
         }
       } else {
         const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -317,22 +317,33 @@ export function handleListMessages(
     let msgAttachments: RuntimeAttachmentMetadata[] = [];
     if (m.id) {
       if (m.role === "user") {
-        // User image attachments need full base64 data so the client can
+        // Use metadata-only query first to avoid loading large base64
+        // blobs for non-image attachments (documents, audio). Then
+        // selectively fetch full data only for images so the client can
         // generate thumbnails for inline display on history restore.
-        // Non-image attachments (documents, audio) stay metadata-only to
-        // avoid inflating the response with large blobs.
-        const linked = attachmentsStore.getAttachmentsForMessage(m.id);
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
         if (linked.length > 0) {
           msgAttachments = linked.map((a) => {
-            const includeData =
-              a.mimeType.startsWith("image/") && !!a.dataBase64;
+            if (a.mimeType.startsWith("image/")) {
+              const full = attachmentsStore.getAttachmentById(a.id);
+              return {
+                id: a.id,
+                filename: a.originalFilename,
+                mimeType: a.mimeType,
+                sizeBytes: a.sizeBytes,
+                kind: a.kind,
+                ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
+                ...(a.thumbnailBase64
+                  ? { thumbnailData: a.thumbnailBase64 }
+                  : {}),
+              };
+            }
             return {
               id: a.id,
               filename: a.originalFilename,
               mimeType: a.mimeType,
               sizeBytes: a.sizeBytes,
-              kind: a.kind ?? "",
-              ...(includeData ? { data: a.dataBase64 } : {}),
+              kind: a.kind,
               ...(a.thumbnailBase64
                 ? { thumbnailData: a.thumbnailBase64 }
                 : {}),


### PR DESCRIPTION
## Summary
- The `GET /v1/messages` endpoint only fetched attachments for assistant messages (`m.role === "assistant"`), causing user-sent images to render as `[Image attachment] image/png, 68.0 KB` placeholder text after restarting the app
- Removed the role filter so attachments are fetched for all messages
- For user messages specifically, return full base64 data (via `getAttachmentsForMessage`) so the client can generate image thumbnails for inline display
- Added `data` and `thumbnailData` optional fields to `RuntimeAttachmentMetadata`

## Test plan
- [ ] Send an image in a conversation
- [ ] Restart the daemon and macOS app
- [ ] Verify the image displays inline in the user message bubble (not as placeholder text)
- [ ] Verify assistant message attachments still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
