### PR TITLE
feat: replace Connected buttons with status chip on channel cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -136,14 +136,15 @@ struct AssistantChannelsDetailView: View {
         let status = store.channelSetupStatus["telegram"]
         return SettingsCard(title: "Telegram", subtitle: "Message your assistant from Telegram") {
             if status == "ready" {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
-                        store.clearTelegramCredentials()
-                        telegramBotTokenText = ""
-                        telegramSetupExpanded = false
-                        store.channelSetupStatus["telegram"] = "not_configured"
-                    }
+                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+            }
+        } content: {
+            if status == "ready" {
+                VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
+                    store.clearTelegramCredentials()
+                    telegramBotTokenText = ""
+                    telegramSetupExpanded = false
+                    store.channelSetupStatus["telegram"] = "not_configured"
                 }
             } else if (status == "incomplete" && store.telegramHasBotToken) || telegramSetupExpanded {
                 telegramCredentialEntry
@@ -206,15 +207,16 @@ struct AssistantChannelsDetailView: View {
         let status = store.channelSetupStatus["slack"]
         return SettingsCard(title: "Slack", subtitle: "Message your assistant from Slack") {
             if status == "ready" {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
-                        store.clearSlackChannelConfig()
-                        slackChannelBotTokenInput = ""
-                        slackChannelAppTokenInput = ""
-                        slackChannelSetupExpanded = false
-                        store.channelSetupStatus["slack"] = "not_configured"
-                    }
+                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+            }
+        } content: {
+            if status == "ready" {
+                VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
+                    store.clearSlackChannelConfig()
+                    slackChannelBotTokenInput = ""
+                    slackChannelAppTokenInput = ""
+                    slackChannelSetupExpanded = false
+                    store.channelSetupStatus["slack"] = "not_configured"
                 }
             } else if (status == "incomplete" && (store.slackChannelHasBotToken || store.slackChannelHasAppToken)) || slackChannelSetupExpanded {
                 slackChannelCredentialEntry
@@ -291,6 +293,10 @@ struct AssistantChannelsDetailView: View {
     private var voiceCard: some View {
         let status = store.channelSetupStatus["phone"]
         return SettingsCard(title: "Phone Calling", subtitle: "Receive and make phone calls via Twilio") {
+            if status == "ready" {
+                VBadge(style: .label("Connected"), color: VColor.systemPositiveStrong)
+            }
+        } content: {
             // Phone number dropdown: show when credentials are configured
             if (status == "ready" || status == "incomplete") && store.twilioHasCredentials {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -313,12 +319,9 @@ struct AssistantChannelsDetailView: View {
             }
 
             if status == "ready" {
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .primary) {}
-                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
-                        store.clearTwilioCredentials()
-                        store.channelSetupStatus["phone"] = "not_configured"
-                    }
+                VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
+                    store.clearTwilioCredentials()
+                    store.channelSetupStatus["phone"] = "not_configured"
                 }
             } else if (status == "incomplete" && store.twilioHasCredentials) || voiceSetupExpanded {
                 voiceCredentialEntry

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -1,30 +1,44 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Standardized settings card with title, optional subtitle, and content.
+/// Standardized settings card with title, optional subtitle, optional accessory (top-right), and content.
 /// Title and subtitle have 4pt spacing between them, with 16pt spacing to the content.
-struct SettingsCard<Content: View>: View {
+struct SettingsCard<Content: View, Accessory: View>: View {
     let title: String
     var subtitle: String? = nil
+    @ViewBuilder let accessory: () -> Accessory
     @ViewBuilder let content: () -> Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text(title)
-                    .font(VFont.sectionTitle)
-                    .foregroundColor(VColor.contentEmphasized)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(VFont.sectionDescription)
-                        .foregroundColor(VColor.contentTertiary)
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(title)
+                        .font(VFont.sectionTitle)
+                        .foregroundColor(VColor.contentEmphasized)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(VFont.sectionDescription)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
                 }
+                Spacer()
+                accessory()
             }
             content()
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceOverlay)
+    }
+}
+
+extension SettingsCard where Accessory == EmptyView {
+    init(title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.accessory = { EmptyView() }
+        self.content = content
     }
 }
 


### PR DESCRIPTION
## Summary
- Added optional `accessory` view slot to `SettingsCard` (top-right of header), with backward-compatible `EmptyView` default for all existing callers
- Replaced the large green "Connected" buttons on Telegram, Slack, and Phone Calling channel cards with a small `VBadge` chip in the card header
- Kept the "Disconnect" button in the card content area for each channel

## Original prompt
We currently show contact connection state via these big green "Connected" buttons. We should instead use a small chip in the top right of the channel card itself (not a button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
