### PR TITLE
fix: unify popover styles, composer padding, and add pill button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -391,10 +391,11 @@ struct ComposerView: View {
             content()
         }
         .padding(.vertical, VSpacing.sm)
-        .padding(.horizontal, VSpacing.md)
+        .padding(.leading, VSpacing.md)
+        .padding(.trailing, VSpacing.sm)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surfaceLift)
+                .fill(VColor.surfaceOverlay)
         )
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .shadow(color: VColor.auxBlack.opacity(0.05), radius: 2, x: 0, y: 2)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -106,10 +106,19 @@ struct SidebarThreadItem: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .help(thread.title)
+
+                if sidebar.threadPendingDeletion == thread.id {
+                    VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
+                        threadManager.archiveThread(id: thread.id)
+                        sidebar.threadPendingDeletion = nil
+                    }
+                    .fixedSize()
+                    .accessibilityLabel("Confirm archive \(thread.title)")
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, hasTrailingIcon ? (VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs) : VSpacing.sm)
+            .padding(.trailing, hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {
@@ -137,14 +146,7 @@ struct SidebarThreadItem: View {
             selectThread()
         }
         .overlay(alignment: .trailing) {
-            if sidebar.threadPendingDeletion == thread.id {
-                VButton(label: "Confirm", style: .danger) {
-                    threadManager.archiveThread(id: thread.id)
-                    sidebar.threadPendingDeletion = nil
-                }
-                .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Confirm archive \(thread.title)")
-            } else if isHovered {
+            if isHovered && sidebar.threadPendingDeletion != thread.id {
                 Button {
                     sidebar.threadPendingDeletion = thread.id
                 } label: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
@@ -11,18 +11,17 @@ struct ThreadSwitcherDrawer: View {
     let onDismiss: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: SidebarLayoutMetrics.listRowGap) {
             Text("\(regularThreads.count) threads")
                 .font(VFont.caption)
-                .foregroundColor(VColor.contentSecondary)
+                .foregroundColor(VColor.contentDisabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.top, VSpacing.sm)
                 .padding(.bottom, VSpacing.xs)
 
-            VColor.borderBase.frame(height: 1)
+            VColor.surfaceBase.frame(height: 1)
                 .padding(.horizontal, VSpacing.xs)
-                .padding(.bottom, VSpacing.xs)
 
             ForEach(regularThreads) { thread in
                 SidebarThreadItem(
@@ -33,18 +32,14 @@ struct ThreadSwitcherDrawer: View {
                     selectThread: { selectThread(thread) },
                     onSelect: onDismiss
                 )
-                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
             }
         }
-        .padding(.vertical, VSpacing.sm)
+        .padding(VSpacing.sm)
         .fixedSize(horizontal: false, vertical: true)
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
-        .shadow(color: VColor.auxBlack.opacity(0.15), radius: 6, y: 2)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .onDisappear {
             if sidebar.isHoveredThread != nil {
                 sidebar.isHoveredThread = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
@@ -52,14 +52,11 @@ struct ThreadActionsDrawer: View {
 
             SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive thread", action: onArchive)
         }
-        .padding(.vertical, VSpacing.sm)
-        .background(VColor.surfaceOverlay)
+        .padding(VSpacing.sm)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
-        .shadow(color: VColor.auxBlack.opacity(0.15), radius: 6, y: 2)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
+        .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
         .frame(width: 200)
         .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
     }

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct VButton: View {
     public enum Style: Hashable { case primary, danger, dangerOutline, outlined, ghost, contrast }
+    public enum Size: Hashable { case regular, pill }
 
     public let label: String
     public var leftIcon: String? = nil
@@ -12,6 +13,7 @@ public struct VButton: View {
     public var isDisabled: Bool = false
     public var isActive: Bool = false
     public var iconSize: CGFloat? = nil
+    public var size: Size = .regular
     public var tooltip: String? = nil
     public var accessibilityID: String? = nil
     public let action: () -> Void
@@ -19,7 +21,7 @@ public struct VButton: View {
     @State private var isHovered = false
     @FocusState private var isFocused: Bool
 
-    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, size: Size = .regular, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, action: @escaping () -> Void) {
         self.label = label
         self.leftIcon = leftIcon ?? icon
         self.rightIcon = rightIcon
@@ -29,6 +31,7 @@ public struct VButton: View {
         self.isDisabled = isDisabled
         self.isActive = isActive
         self.iconSize = iconSize
+        self.size = size
         self.tooltip = tooltip
         self.accessibilityID = accessibilityID
         self.action = action
@@ -48,7 +51,7 @@ public struct VButton: View {
                         VIconView(.resolve(leftIcon), size: textIconSize)
                     }
                     Text(label)
-                        .font(VFont.bodyMedium)
+                        .font(size == .pill ? VFont.captionMedium : VFont.bodyMedium)
                     if isFullWidth && (leftIcon != nil || rightIcon != nil) {
                         Spacer(minLength: 0)
                     }
@@ -61,6 +64,7 @@ public struct VButton: View {
         .focused($isFocused)
         .buttonStyle(VButtonStyle(
             style: style,
+            size: size,
             isHovered: isHovered,
             isFullWidth: isFullWidth,
             isIconOnly: iconOnly != nil,
@@ -96,6 +100,7 @@ public struct VButton: View {
 
 public struct VButtonStyle: ButtonStyle {
     let style: VButton.Style
+    let size: VButton.Size
     let isHovered: Bool
     let isFullWidth: Bool
     let isIconOnly: Bool
@@ -105,11 +110,12 @@ public struct VButtonStyle: ButtonStyle {
 
     /// Creates an icon-only button style for custom button compositions.
     public static func iconOnly(style: VButton.Style = .ghost, isHovered: Bool, isFocused: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil) -> VButtonStyle {
-        VButtonStyle(style: style, isHovered: isHovered, isFullWidth: false, isIconOnly: true, isActive: isActive, isFocused: isFocused, iconSize: iconSize)
+        VButtonStyle(style: style, size: .regular, isHovered: isHovered, isFullWidth: false, isIconOnly: true, isActive: isActive, isFocused: isFocused, iconSize: iconSize)
     }
 
-    init(style: VButton.Style, isHovered: Bool, isFullWidth: Bool, isIconOnly: Bool = false, isActive: Bool = false, isFocused: Bool = false, iconSize: CGFloat? = nil) {
+    init(style: VButton.Style, size: VButton.Size = .regular, isHovered: Bool, isFullWidth: Bool, isIconOnly: Bool = false, isActive: Bool = false, isFocused: Bool = false, iconSize: CGFloat? = nil) {
         self.style = style
+        self.size = size
         self.isHovered = isHovered
         self.isFullWidth = isFullWidth
         self.isIconOnly = isIconOnly
@@ -121,12 +127,14 @@ public struct VButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(configuration: Configuration) -> some View {
-        let shape = RoundedRectangle(cornerRadius: VRadius.md)
+        let cornerRadius = size == .pill ? VRadius.pill : VRadius.md
+        let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         configuration.label
             .foregroundColor(foregroundColor)
             .modifier(ButtonLayoutModifier(
                 style: style,
+                size: size,
                 isIconOnly: isIconOnly,
                 isFullWidth: isFullWidth,
                 iconSize: iconSize
@@ -234,6 +242,7 @@ public struct VButtonStyle: ButtonStyle {
 
 private struct ButtonLayoutModifier: ViewModifier {
     let style: VButton.Style
+    let size: VButton.Size
     let isIconOnly: Bool
     let isFullWidth: Bool
     let iconSize: CGFloat?
@@ -242,6 +251,11 @@ private struct ButtonLayoutModifier: ViewModifier {
         if isIconOnly {
             content
                 .frame(width: iconSize ?? 32, height: iconSize ?? 32)
+        } else if size == .pill {
+            content
+                .padding(.horizontal, VSpacing.sm)
+                .frame(height: 24)
+                .frame(maxWidth: isFullWidth ? .infinity : nil)
         } else {
             content
                 .padding(.horizontal, VSpacing.md)


### PR DESCRIPTION
## Summary
- Match thread actions drawer and thread switcher popover to preferences popover style (surfaceLift bg, dual shadow, no border)
- Update composer padding (12px left, 8px right) and background to surfaceOverlay
- Add pill size variant to VButton (24px height, pill radius, captionMedium font)
- Use inline dangerOutline pill button for thread delete confirmation

## Test plan
- [ ] Verify thread actions popover matches preferences popover styling
- [ ] Verify collapsed sidebar thread switcher popover matches
- [ ] Check composer input padding and background color
- [ ] Test thread delete confirmation button (pill, inline with name)
- [ ] Verify pill button in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
