### PR TITLE
Fix inline ToolConfirmationBubble horizontal padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -426,7 +426,7 @@ struct AssistantProgressView: View {
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
                         onTemporaryAllow: onTemporaryAllow
                     )
-                    .padding(.leading, VSpacing.md)
+                    .padding(.horizontal, VSpacing.md)
                     .padding(.vertical, VSpacing.xs)
                 }
             }


### PR DESCRIPTION
## Summary
- Change `.padding(.leading, VSpacing.md)` to `.padding(.horizontal, VSpacing.md)` on the inline ToolConfirmationBubble in AssistantProgressView so it has equal padding on both sides and is centered within the progress view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
