### PR TITLE
feat: split phone invite into two steps with explicit call trigger

### DIFF
--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -41,12 +41,24 @@ mock.module("../telegram/bot-username.js", () => ({
   getTelegramBotUsername: () => mockTelegramBotUsername,
 }));
 
+// Mock startInviteCall from call-domain — test env lacks Twilio credentials.
+let mockStartInviteCallResult:
+  | { ok: true; callSid: string }
+  | { ok: false; error: string; status?: number } = {
+  ok: true,
+  callSid: "CA_test_sid_123",
+};
+mock.module("../calls/call-domain.js", () => ({
+  startInviteCall: async () => mockStartInviteCallResult,
+}));
+
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   handleCreateInvite,
   handleListInvites,
   handleRedeemInvite,
   handleRevokeInvite,
+  handleTriggerInviteCall,
 } from "../runtime/routes/invite-routes.js";
 
 initializeDb();
@@ -539,5 +551,117 @@ describe("voice invite HTTP routes", () => {
 
     expect(res.status).toBe(400);
     expect(body.ok).toBe(false);
+  });
+
+  test("voice invite creation returns guardianInstruction with friend name", async () => {
+    const req = new Request("http://localhost/v1/contacts/invites", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceChannel: "phone",
+        expectedExternalUserId: "+15551234567",
+        friendName: "Alice",
+        guardianName: "Bob",
+      }),
+    });
+
+    const res = await handleCreateInvite(req);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    const invite = body.invite as Record<string, unknown>;
+    expect(invite.guardianInstruction).toBe(
+      "Alice will need this code when they answer. Share it with them first.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger invite call endpoint
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/contacts/invites/:id/call", () => {
+  beforeEach(() => {
+    resetTables();
+    mockStartInviteCallResult = { ok: true, callSid: "CA_test_sid_123" };
+  });
+
+  test("triggers a call for an active phone invite", async () => {
+    const createRes = await handleCreateInvite(
+      new Request("http://localhost/v1/contacts/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceChannel: "phone",
+          expectedExternalUserId: "+15551234567",
+          friendName: "Alice",
+          guardianName: "Bob",
+        }),
+      }),
+    );
+    const created = (await createRes.json()) as { invite: { id: string } };
+
+    const res = await handleTriggerInviteCall(created.invite.id);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.callSid).toBe("CA_test_sid_123");
+  });
+
+  test("returns 400 for non-existent invite", async () => {
+    const res = await handleTriggerInviteCall("nonexistent-id");
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Invite not found");
+  });
+
+  test("returns 400 for a revoked (non-active) invite", async () => {
+    const createRes = await handleCreateInvite(
+      new Request("http://localhost/v1/contacts/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceChannel: "phone",
+          expectedExternalUserId: "+15551234567",
+          friendName: "Alice",
+          guardianName: "Bob",
+        }),
+      }),
+    );
+    const created = (await createRes.json()) as { invite: { id: string } };
+
+    // Revoke the invite
+    handleRevokeInvite(created.invite.id);
+
+    const res = await handleTriggerInviteCall(created.invite.id);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Invite is not active");
+  });
+
+  test("returns 400 for a non-phone invite", async () => {
+    const createRes = await handleCreateInvite(
+      new Request("http://localhost/v1/contacts/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+        }),
+      }),
+    );
+    const created = (await createRes.json()) as { invite: { id: string } };
+
+    const res = await handleTriggerInviteCall(created.invite.id);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Only phone invites support call triggering");
   });
 });

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -313,6 +313,20 @@ export function findByTokenHash(tokenHash: string): IngressInvite | null {
 }
 
 // ---------------------------------------------------------------------------
+// findById
+// ---------------------------------------------------------------------------
+
+export function findById(inviteId: string): IngressInvite | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(eq(assistantIngressInvites.id, inviteId))
+    .get();
+  return row ? rowToInvite(row) : null;
+}
+
+// ---------------------------------------------------------------------------
 // findActiveVoiceInvites
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -12,6 +12,7 @@ import { startInviteCall } from "../calls/call-domain.js";
 import { isChannelId } from "../channels/types.js";
 import {
   createInvite,
+  findById,
   findByTokenHash,
   hashToken,
   type IngressInvite,
@@ -24,7 +25,6 @@ import {
   DEFAULT_USER_REFERENCE,
   resolveGuardianName,
 } from "../prompts/user-reference.js";
-import { getLogger } from "../util/logger.js";
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import {
@@ -38,8 +38,6 @@ import {
   redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
   type VoiceRedemptionOutcome,
 } from "./invite-redemption-service.js";
-
-const log = getLogger("invite-service");
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and message handlers
@@ -254,25 +252,8 @@ export async function createIngressInvite(params: {
     });
   }
 
-  // For voice invites with a known phone number, initiate an outbound call
-  // so the contact is prompted to enter their code immediately.
-  if (
-    params.sourceChannel === "phone" &&
-    params.expectedExternalUserId &&
-    params.friendName &&
-    effectiveGuardianName
-  ) {
-    // Fire-and-forget: don't block invite creation on call initiation
-    startInviteCall({
-      phoneNumber: params.expectedExternalUserId,
-      friendName: params.friendName,
-      guardianName: effectiveGuardianName,
-    }).catch((err) => {
-      log.warn(
-        { err, inviteId: invite.id },
-        "Failed to initiate outbound invite call",
-      );
-    });
+  if (isVoice && params.friendName) {
+    guardianInstruction = `${params.friendName} will need this code when they answer. Share it with them first.`;
   }
 
   // Voice invites must not expose the token — callers must redeem via the
@@ -314,6 +295,32 @@ export function revokeIngressInvite(
     return { ok: false, error: "Invite not found or already revoked" };
   }
   return { ok: true, data: inviteToResponse(revoked) };
+}
+
+export async function triggerInviteCall(
+  inviteId: string,
+): Promise<IngressResult<{ callSid: string }>> {
+  if (!inviteId) return { ok: false, error: "inviteId is required" };
+  const invite = findById(inviteId);
+  if (!invite) return { ok: false, error: "Invite not found" };
+  if (invite.status !== "active")
+    return { ok: false, error: "Invite is not active" };
+  if (invite.sourceChannel !== "phone")
+    return { ok: false, error: "Only phone invites support call triggering" };
+  if (
+    !invite.expectedExternalUserId ||
+    !invite.friendName ||
+    !invite.guardianName
+  ) {
+    return { ok: false, error: "Invite is missing required voice metadata" };
+  }
+  const result = await startInviteCall({
+    phoneNumber: invite.expectedExternalUserId,
+    friendName: invite.friendName,
+    guardianName: invite.guardianName,
+  });
+  if (!result.ok) return { ok: false, error: result.error };
+  return { ok: true, data: { callSid: result.callSid } };
 }
 
 export function redeemIngressInvite(params: {

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -2,10 +2,11 @@
  * Route handlers for invite management.
  *
  * Invites:
- *   GET    /v1/contacts/invites        — list invites
- *   POST   /v1/contacts/invites        — create an invite (supports voice)
- *   DELETE /v1/contacts/invites/:id    — revoke an invite
- *   POST   /v1/contacts/invites/redeem — redeem an invite (token or voice code)
+ *   GET    /v1/contacts/invites           — list invites
+ *   POST   /v1/contacts/invites           — create an invite (supports voice)
+ *   DELETE /v1/contacts/invites/:id       — revoke an invite
+ *   POST   /v1/contacts/invites/redeem    — redeem an invite (token or voice code)
+ *   POST   /v1/contacts/invites/:id/call  — trigger an outbound call for a phone invite
  */
 
 import type { RouteDefinition } from "../http-router.js";
@@ -15,6 +16,7 @@ import {
   redeemIngressInvite,
   redeemVoiceInviteCode,
   revokeIngressInvite,
+  triggerInviteCall,
 } from "../invite-service.js";
 
 // ---------------------------------------------------------------------------
@@ -141,6 +143,22 @@ export async function handleRedeemInvite(req: Request): Promise<Response> {
   return Response.json({ ok: true, invite: result.data });
 }
 
+/**
+ * POST /v1/contacts/invites/:id/call
+ *
+ * Trigger an outbound call for a phone invite. The invite must be active and
+ * have sourceChannel "phone" with the required voice metadata populated.
+ */
+export async function handleTriggerInviteCall(
+  inviteId: string,
+): Promise<Response> {
+  const result = await triggerInviteCall(inviteId);
+  if (!result.ok) {
+    return Response.json({ ok: false, error: result.error }, { status: 400 });
+  }
+  return Response.json({ ok: true, callSid: result.data.callSid });
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -167,6 +185,12 @@ export function inviteRouteDefinitions(): RouteDefinition[] {
       method: "DELETE",
       policyKey: "contacts/invites",
       handler: ({ params }) => handleRevokeInvite(params.id),
+    },
+    {
+      endpoint: "contacts/invites/:id/call",
+      method: "POST",
+      policyKey: "contacts/invites",
+      handler: async ({ params }) => handleTriggerInviteCall(params.id),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Remove automatic Twilio call on phone invite creation; add `guardianInstruction` telling the guardian to share the code first
- Add `findById` to invite store and `triggerInviteCall` service function
- Add `POST /v1/contacts/invites/:id/call` route to trigger the call on demand
- Add tests for the new endpoint and guardianInstruction

Part of plan: two-step-phone-invite.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
