### PR TITLE
fix: rename "Installed Skills" tab to "Skills"

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -117,7 +117,7 @@ struct IdentityView: View {
 
             // Navigation section
             Section {
-                // Installed Skills
+                // Skills
                 NavigationLink {
                     if let store = viewModel.skillsStore {
                         InstalledSkillsView(skillsStore: store)
@@ -127,7 +127,7 @@ struct IdentityView: View {
                         VIconView(.brain, size: 16)
                             .foregroundColor(VColor.primaryBase)
                             .frame(width: 24)
-                        Text("Installed Skills")
+                        Text("Skills")
                             .font(VFont.body)
                             .foregroundColor(VColor.contentDefault)
                         Spacer()

--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -17,7 +17,7 @@ struct InstalledSkillsView: View {
                 skillsList
             }
         }
-        .navigationTitle("Installed Skills")
+        .navigationTitle("Skills")
         .refreshable {
             skillsStore.fetchSkills(force: true)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -124,7 +124,7 @@ struct AgentPanelContent: View {
         .frame(width: 180)
     }
 
-    // MARK: - Installed Skills Content
+    // MARK: - Skills Content
 
     @ViewBuilder
     private var skillsContent: some View {
@@ -287,7 +287,7 @@ struct AgentPanelContent: View {
             }) {
                 HStack(spacing: VSpacing.sm) {
                     VIconView(.chevronLeft, size: 11)
-                    Text("Installed Skills")
+                    Text("Skills")
                         .font(VFont.caption)
                 }
                 .foregroundColor(VColor.contentTertiary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -12,7 +12,7 @@ struct IntelligencePanel: View {
 
     private enum IntelligenceTab: String, CaseIterable {
         case identity = "Identity"
-        case installedSkills = "Installed Skills"
+        case installedSkills = "Skills"
         case workspace = "Workspace"
         case memories = "Memories"
     }


### PR DESCRIPTION
## Summary
- Renamed "Installed Skills" to "Skills" across iOS and macOS clients (tab labels, navigation titles, back buttons, and comments)

## Original prompt
rename the "Installed Skills" tab to just read "Skills"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
