### PR TITLE
feat: add "Call" button to phone invite flow for two-step verification

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -29,8 +29,11 @@ struct ContactDetailView: View {
     @State private var telegramBootstrapChannelId: String?
     @State private var invitePhoneNumber = ""
     @State private var inviteInProgress: String?
+    @State private var inviteCallInProgress = false
+    @State private var inviteCallTriggered = false
     @State private var inviteResult: (
         type: String,
+        inviteId: String,
         token: String?,
         shareUrl: String?,
         inviteCode: String?,
@@ -640,6 +643,27 @@ struct ContactDetailView: View {
                         }
                     }
                 }
+
+                if type == "phone", let result = inviteResult {
+                    if inviteCallTriggered {
+                        HStack(spacing: VSpacing.sm) {
+                            Image(systemName: "phone.fill")
+                                .foregroundColor(VColor.systemPositiveStrong)
+                            Text("Call started")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.systemPositiveStrong)
+                        }
+                    } else {
+                        VButton(
+                            label: inviteCallInProgress ? "Calling..." : "Call \(displayContact.displayName)",
+                            icon: VIcon.phoneCall.rawValue,
+                            style: .primary,
+                            isDisabled: inviteCallInProgress
+                        ) {
+                            triggerInviteCallAction(inviteId: result.inviteId)
+                        }
+                    }
+                }
             }
         } else if let shareableText = result.shareUrl ?? result.token {
             // Fallback: no invite code available, show raw token
@@ -992,6 +1016,8 @@ struct ContactDetailView: View {
         inviteInProgress = type
         inviteError = nil
         inviteResult = nil
+        inviteCallInProgress = false
+        inviteCallTriggered = false
         inviteCodeRevealed = false
         inviteHandleInput = ""
         Task {
@@ -1013,6 +1039,7 @@ struct ContactDetailView: View {
                 ) {
                     inviteResult = (
                         type: type,
+                        inviteId: result.inviteId,
                         token: result.token,
                         shareUrl: result.shareUrl,
                         inviteCode: result.inviteCode,
@@ -1027,6 +1054,24 @@ struct ContactDetailView: View {
                 inviteError = "Failed to create invite: \(error.localizedDescription)"
             }
             inviteInProgress = nil
+        }
+    }
+
+    private func triggerInviteCallAction(inviteId: String) {
+        guard let daemonClient, !inviteCallInProgress else { return }
+        inviteCallInProgress = true
+        Task {
+            do {
+                let success = try await daemonClient.triggerInviteCall(inviteId: inviteId)
+                if success {
+                    inviteCallTriggered = true
+                } else {
+                    inviteError = "Failed to initiate call"
+                }
+            } catch {
+                inviteError = "Failed to initiate call: \(error.localizedDescription)"
+            }
+            inviteCallInProgress = false
         }
     }
 

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2099,6 +2099,21 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #endif
     }
 
+    /// Trigger an invite call via `POST /v1/contacts/invites/:id/call`.
+    public func triggerInviteCall(inviteId: String) async throws -> Bool {
+        if let httpTransport { return try await httpTransport.triggerInviteCall(inviteId: inviteId) }
+        #if os(macOS)
+        guard var request = buildLocalRequest(target: .gateway, path: "v1/contacts/invites/\(inviteId)/call", method: "POST") else { return false }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...201).contains(http.statusCode) else { return false }
+        return true
+        #else
+        return false
+        #endif
+    }
+
     /// A single readiness check result from the API.
     public struct ReadinessCheck {
         public let name: String

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -272,6 +272,7 @@ public final class HTTPTransport {
         case contactChannelUpdate(contactChannelId: String)
         case contactsUpsert
         case contactsInvitesCreate
+        case contactsInvitesCall(id: String)
         case channelsReadiness
         case surfaceContent(surfaceId: String, sessionId: String)
         case usageTotals(from: Int, to: Int)
@@ -532,6 +533,9 @@ public final class HTTPTransport {
             return ("/v1/contacts", nil)
         case .contactsInvitesCreate:
             return ("/v1/contacts/invites", nil)
+        case .contactsInvitesCall(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/contacts/invites/\(encoded)/call", nil)
         case .channelsReadiness:
             return ("/v1/channels/readiness", nil)
         case .surfaceContent(let surfaceId, let sessionId):
@@ -940,6 +944,9 @@ public final class HTTPTransport {
             return ("\(prefix)/contacts/", nil)
         case .contactsInvitesCreate:
             return ("\(prefix)/contacts/invites/", nil)
+        case .contactsInvitesCall(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/contacts/invites/\(encoded)/call/", nil)
         case .channelsReadiness:
             return ("\(prefix)/channels/readiness/", nil)
         case .surfaceContent(let surfaceId, let sessionId):
@@ -2568,6 +2575,27 @@ public final class HTTPTransport {
         let decoded = try decoder.decode(HTTPCreateInviteResponse.self, from: data)
         guard let invite = decoded.invite else { return nil }
         return (inviteId: invite.id, token: invite.token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, voiceCode: invite.voiceCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
+    }
+
+    // MARK: - Invite Call
+
+    func triggerInviteCall(inviteId: String, isRetry: Bool = false) async throws -> Bool {
+        guard let url = buildURL(for: .contactsInvitesCall(id: inviteId)) else { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+        request.httpBody = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse {
+            if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                if case .success = refreshResult { return try await triggerInviteCall(inviteId: inviteId, isRetry: true) }
+                return false
+            }
+            guard (200...201).contains(http.statusCode) else { return false }
+        }
+        return true
     }
 
     // MARK: - Channel Readiness


### PR DESCRIPTION
## Summary
- Add `contactsInvitesCall` endpoint enum case and path resolution in HTTPDaemonClient
- Add `triggerInviteCall` methods to HTTPDaemonClient and DaemonClient
- Add `inviteId` to invite result state tuple and call state tracking in ContactDetailView
- Add "Call {name}" button with loading/success states after the invite code display

Part of plan: two-step-phone-invite.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
