### PR TITLE
feat: add eye blink animation to AnimatedAvatarView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -40,6 +40,16 @@ class AvatarLayerView: NSView {
     /// Track current configuration to skip redundant updates.
     private var currentKey: String?
 
+    /// Pre-computed open and closed eye CGPaths for blink animation.
+    private var openEyePaths: [CGPath] = []
+    private var closedEyePaths: [CGPath] = []
+
+    /// Timer that fires random blinks.
+    private var blinkTask: Task<Void, Never>?
+
+    /// Whether blinks are currently enabled (paused when window is inactive).
+    private var blinkEnabled = true
+
     override init(frame: NSRect) {
         super.init(frame: frame)
         wantsLayer = true
@@ -47,6 +57,10 @@ class AvatarLayerView: NSView {
     }
 
     required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        blinkTask?.cancel()
+    }
 
     func configure(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor, size: CGFloat) {
         let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)-\(color.rawValue)-\(Int(size))"
@@ -84,11 +98,15 @@ class AvatarLayerView: NSView {
             bodyTransform: bodyTransform
         )
 
+        // Pre-compute blink paths
+        openEyePaths.removeAll()
+        closedEyePaths.removeAll()
+
         for eyePath in eyeStyle.paths {
             let eyeEditable = parseSVGPathToEditable(eyePath.svgPath)
             let eyeCGPath = eyeEditable.toCGPath()
             var mutableEyeTransform = eyeXform
-            let transformedEyePath = eyeCGPath.copy(using: &mutableEyeTransform)
+            let transformedEyePath = eyeCGPath.copy(using: &mutableEyeTransform)!
 
             let eyeLayer = CAShapeLayer()
             eyeLayer.path = transformedEyePath
@@ -96,8 +114,54 @@ class AvatarLayerView: NSView {
             eyeLayer.frame = CGRect(x: 0, y: 0, width: size, height: size)
             layer?.addSublayer(eyeLayer)
             eyeLayers.append(eyeLayer)
+
+            // Store the open path (reuse the already-computed transformedEyePath)
+            openEyePaths.append(transformedEyePath)
+
+            // Closed path — squish Y toward center, then apply same transform
+            let closedEditable = eyeEditable.blinked(amount: 1.0)
+            let closedCGPath = closedEditable.toCGPath()
+            var closedTransform = eyeXform
+            closedEyePaths.append(closedCGPath.copy(using: &closedTransform)!)
         }
 
         CATransaction.commit()
+
+        startBlinkTimer()
+    }
+
+    private func startBlinkTimer() {
+        blinkTask?.cancel()
+        blinkTask = Task { [weak self] in
+            while !Task.isCancelled {
+                // Random delay between 3-7 seconds
+                let delay = Double.random(in: 3.0...7.0)
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    guard let self, self.blinkEnabled else { return }
+                    self.performBlink()
+                }
+            }
+        }
+    }
+
+    private func performBlink() {
+        guard !eyeLayers.isEmpty,
+              eyeLayers.count == openEyePaths.count,
+              eyeLayers.count == closedEyePaths.count else { return }
+
+        for (i, eyeLayer) in eyeLayers.enumerated() {
+            let animation = CAKeyframeAnimation(keyPath: "path")
+            animation.values = [openEyePaths[i], closedEyePaths[i], openEyePaths[i]]
+            animation.keyTimes = [0, 0.3, 1.0]  // Quick close at 30%, slow open to 100%
+            animation.duration = 0.25
+            animation.timingFunctions = [
+                CAMediaTimingFunction(name: .easeIn),   // Close quickly
+                CAMediaTimingFunction(name: .easeOut),   // Open slowly
+            ]
+            animation.isRemovedOnCompletion = true
+            eyeLayer.add(animation, forKey: "blink")
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Avatar/EditablePath+Blink.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/EditablePath+Blink.swift
@@ -1,0 +1,54 @@
+import CoreGraphics
+
+extension EditablePath {
+    /// Returns a new EditablePath with all Y coordinates collapsed toward the path's
+    /// vertical center, simulating a closed eye. The `amount` parameter controls how
+    /// much to close: 0.0 = fully open (no change), 1.0 = fully closed (all Y = center).
+    ///
+    /// Uses the path's bounding box to find the vertical center, then linearly
+    /// interpolates each point's Y toward that center.
+    func blinked(amount: CGFloat = 1.0) -> EditablePath {
+        // Compute vertical bounds
+        var minY: CGFloat = .greatestFiniteMagnitude
+        var maxY: CGFloat = -.greatestFiniteMagnitude
+        for element in elements {
+            for point in element.allPoints {
+                minY = min(minY, point.y)
+                maxY = max(maxY, point.y)
+            }
+        }
+        guard minY < maxY else { return self }
+        let centerY = (minY + maxY) / 2
+
+        let newElements = elements.map { element -> PathElement in
+            element.squishingY(toward: centerY, amount: amount)
+        }
+        return EditablePath(elements: newElements)
+    }
+}
+
+extension EditablePath.PathElement {
+    /// All CGPoints contained in this element (for bounding-box computation).
+    var allPoints: [CGPoint] {
+        switch self {
+        case .moveTo(let p): return [p]
+        case .lineTo(let p): return [p]
+        case .curveTo(let to, let c1, let c2): return [to, c1, c2]
+        case .close: return []
+        }
+    }
+
+    /// Returns a new element with Y coordinates interpolated toward `centerY`.
+    func squishingY(toward centerY: CGFloat, amount: CGFloat) -> EditablePath.PathElement {
+        func squish(_ p: CGPoint) -> CGPoint {
+            CGPoint(x: p.x, y: p.y + (centerY - p.y) * amount)
+        }
+        switch self {
+        case .moveTo(let p): return .moveTo(squish(p))
+        case .lineTo(let p): return .lineTo(squish(p))
+        case .curveTo(let to, let c1, let c2):
+            return .curveTo(to: squish(to), control1: squish(c1), control2: squish(c2))
+        case .close: return .close
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add EditablePath.blinked() extension that collapses Y coordinates toward vertical center for eye close effect
- Pre-compute open/closed CGPaths for each eye layer during configure()
- Add randomized blink timer (3-7s intervals) with CAKeyframeAnimation for smooth open→close→open transitions

Part of plan: avatar-animations.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
