### PR TITLE
fix: suppress "Starting up..." ACK for /start commands with invite payloads

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -357,7 +357,9 @@ export function createTelegramWebhookHandler(
 
       // Forward to runtime with command-intent metadata so the assistant
       // generates a natural greeting via the normal agent loop.
-      if (!normalized.message.callbackQueryId) {
+      // Skip the ACK when the /start includes a payload (e.g. invite token) —
+      // the runtime will send its own contextual reply during ACL enforcement.
+      if (!normalized.message.callbackQueryId && !startCmd.payload) {
         sendTelegramReply(
           config,
           normalized.message.conversationExternalId,


### PR DESCRIPTION
## Summary
- Suppress the "Starting up..." ACK when /start includes a payload (invite token)
- The runtime sends its own contextual reply during ACL enforcement, so the ACK is redundant and causes confusing message ordering

Part of plan: contact-bound-invites.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
