### PR TITLE
feat: add contactId column to assistant_ingress_invites table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -67,6 +67,7 @@ import {
   migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
   migrateInviteCodeHashColumn,
+  migrateInviteContactId,
   migrateMemoryItemSupersession,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -371,6 +372,9 @@ export function initializeDb(): void {
 
   // 59. Add invite metadata columns to call_sessions for outbound invite call routing
   migrateCallSessionInviteMetadata(database);
+
+  // 60. Add required contact_id to assistant_ingress_invites and clean up legacy rows
+  migrateInviteContactId(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -41,6 +41,8 @@ export interface IngressInvite {
   // Display metadata for personalized voice prompts (null for non-voice invites)
   friendName: string | null;
   guardianName: string | null;
+  // Contact binding — every invite is bound to a specific contact
+  contactId: string;
   createdAt: number;
   updatedAt: number;
 }
@@ -86,6 +88,7 @@ function rowToInvite(
     inviteCodeHash: row.inviteCodeHash,
     friendName: row.friendName,
     guardianName: row.guardianName,
+    contactId: row.contactId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -97,6 +100,7 @@ function rowToInvite(
 
 export function createInvite(params: {
   sourceChannel: string;
+  contactId?: string;
   createdBySessionId?: string;
   note?: string;
   maxUses?: number;
@@ -135,6 +139,7 @@ export function createInvite(params: {
     inviteCodeHash: params.inviteCodeHash ?? null,
     friendName: params.friendName ?? null,
     guardianName: params.guardianName ?? null,
+    contactId: params.contactId ?? "",
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/memory/migrations/157-invite-contact-id.ts
+++ b/assistant/src/memory/migrations/157-invite-contact-id.ts
@@ -1,0 +1,21 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Add a required contact_id column to assistant_ingress_invites.
+ * Invites must be bound to the contact they were created for.
+ * Legacy rows without a contact_id are deleted since they cannot
+ * be redeemed correctly.
+ */
+export function migrateInviteContactId(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN contact_id TEXT NOT NULL REFERENCES contacts(id) DEFAULT ''`,
+    );
+  } catch {
+    /* already exists */
+  }
+  // Delete legacy rows that have no contact binding (empty string from DEFAULT).
+  database.run(
+    /*sql*/ `DELETE FROM assistant_ingress_invites WHERE contact_id = ''`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -98,6 +98,7 @@ export { migrateDropEntityTables } from "./153-drop-entity-tables.js";
 export { migrateDropMemorySegmentFts } from "./154-drop-fts.js";
 export { migrateDropConflicts } from "./155-drop-conflicts.js";
 export { migrateCallSessionInviteMetadata } from "./156-call-session-invite-metadata.js";
+export { migrateInviteContactId } from "./157-invite-contact-id.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -87,6 +87,7 @@ export const assistantIngressInvites = sqliteTable(
     // Display metadata for personalized voice prompts (nullable — non-voice invites leave these NULL)
     friendName: text("friend_name"),
     guardianName: text("guardian_name"),
+    contactId: text("contact_id").notNull(),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },


### PR DESCRIPTION
## Summary
- Add NOT NULL contact_id column to assistant_ingress_invites via migration 157
- Delete legacy invite rows that lack a contact binding
- Update drizzle schema to include contactId field
- Update invite-store types and createInvite to support contactId

Part of plan: contact-bound-invites.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
