### PR TITLE
fix: add gateway route for POST /v1/contacts/invites/:id/call

### DIFF
--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -146,6 +146,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       return proxyToRuntime(req, "/v1/contacts/invites/redeem", "");
     },
 
+    async handleCallInvite(req: Request, inviteId: string): Promise<Response> {
+      return proxyToRuntime(req, `/v1/contacts/invites/${inviteId}/call`, "");
+    },
+
     async handleRevokeInvite(
       req: Request,
       inviteId: string,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -467,6 +467,13 @@ async function main() {
       handler: (req) => contactsControlPlaneProxy.handleRedeemInvite(req),
     },
     {
+      path: /^\/v1\/contacts\/invites\/([^/]+)\/call$/,
+      method: "POST",
+      auth: "edge",
+      handler: (req, params) =>
+        contactsControlPlaneProxy.handleCallInvite(req, params[0]),
+    },
+    {
       path: /^\/v1\/contacts\/invites\/([^/]+)$/,
       method: "DELETE",
       auth: "edge",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for two-step-phone-invite.md.

**Gap:** Missing gateway route for POST /v1/contacts/invites/:id/call
**What was expected:** The new endpoint should be routable through the gateway
**What was found:** Endpoint only registered in daemon runtime, not in gateway route table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
