### PR TITLE
fix: check invite expiry before triggering call

### DIFF
--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -18,6 +18,7 @@ import {
   type IngressInvite,
   type InviteStatus,
   listInvites,
+  markInviteExpired,
   revokeInvite,
 } from "../memory/invite-store.js";
 import {
@@ -305,6 +306,10 @@ export async function triggerInviteCall(
   if (!invite) return { ok: false, error: "Invite not found" };
   if (invite.status !== "active")
     return { ok: false, error: "Invite is not active" };
+  if (invite.expiresAt && invite.expiresAt <= Date.now()) {
+    markInviteExpired(invite.id);
+    return { ok: false, error: "Invite has expired" };
+  }
   if (invite.sourceChannel !== "phone")
     return { ok: false, error: "Only phone invites support call triggering" };
   if (


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for two-step-phone-invite.md.

**Gap:** Expired invites not checked before dialing
**What was expected:** triggerInviteCall should check expiry before placing the call
**What was found:** Only status === "active" was checked, not expiresAt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
