### PR TITLE
fix: use checkmark icon for call-started success state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -647,7 +647,7 @@ struct ContactDetailView: View {
                 if type == "phone", let result = inviteResult {
                     if inviteCallTriggered {
                         HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "phone.fill")
+                            Image(systemName: "checkmark.circle.fill")
                                 .foregroundColor(VColor.systemPositiveStrong)
                             Text("Call started")
                                 .font(VFont.caption)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for two-step-phone-invite.md.

**Gap:** Success state icon is phone.fill instead of checkmark
**What was expected:** Checkmark icon next to "Call started"
**What was found:** phone.fill icon was used instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
