### PR TITLE
feat: add idle breathing animation to AnimatedAvatarView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -84,6 +84,10 @@ class AvatarLayerView: NSView {
         bodyLayer.fillColor = color.nsColor.cgColor
         bodyLayer.frame = CGRect(x: 0, y: 0, width: size, height: size)
 
+        // Anchor scale from the center of the body layer so breathing animates symmetrically
+        bodyLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        bodyLayer.position = CGPoint(x: frame.width / 2, y: frame.height / 2)
+
         // --- Eye layers ---
         // Remove old eye layers
         for layer in eyeLayers { layer.removeFromSuperlayer() }
@@ -128,6 +132,7 @@ class AvatarLayerView: NSView {
         CATransaction.commit()
 
         startBlinkTimer()
+        startBreathing()
     }
 
     private func startBlinkTimer() {
@@ -144,6 +149,19 @@ class AvatarLayerView: NSView {
                 }
             }
         }
+    }
+
+    private func startBreathing() {
+        bodyLayer.removeAnimation(forKey: "breathing")
+
+        let breathe = CABasicAnimation(keyPath: "transform.scale")
+        breathe.fromValue = 1.0
+        breathe.toValue = 1.03  // 3% expansion
+        breathe.duration = 2.0  // 2s inhale
+        breathe.autoreverses = true  // 2s exhale
+        breathe.repeatCount = .infinity
+        breathe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        bodyLayer.add(breathe, forKey: "breathing")
     }
 
     private func performBlink() {


### PR DESCRIPTION
## Summary
- Add continuous breathing animation on body layer using CABasicAnimation on transform.scale
- Subtle 3% scale oscillation with 4-second cycle (2s inhale + 2s exhale)
- Eyes remain stationary during breathing (body-only effect)
- Anchor point and position set within CATransaction to prevent implicit animations

Part of plan: avatar-animations.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
