### PR TITLE
fix: stop saveRawConfig from migrating apiKeys to secure storage

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -428,28 +428,10 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   ensureMigratedDataDir();
   const configPath = getConfigPath();
 
-  // Route apiKeys to secure storage and strip from plaintext file
-  const apiKeys = config.apiKeys;
-  if (apiKeys && typeof apiKeys === "object" && !Array.isArray(apiKeys)) {
-    for (const [provider, value] of Object.entries(
-      apiKeys as Record<string, unknown>,
-    )) {
-      if (typeof value === "string" && value.length > 0) {
-        if (!setSecureKey(provider, value)) {
-          throw new ConfigError(
-            `Failed to save API key for "${provider}" to secure storage. Key not removed from config to prevent data loss.`,
-          );
-        }
-      } else if (value == null || value === "") {
-        deleteSecureKey(provider);
-      }
-    }
-    // Remove apiKeys from plaintext config
-    const { apiKeys: _, ...rest } = config;
-    writeFileSync(configPath, JSON.stringify(rest, null, 2) + "\n");
-  } else {
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-  }
+  // Strip apiKeys from plaintext config — secure storage is managed
+  // by saveConfig() and `assistant keys` commands, not here.
+  const { apiKeys: _, ...rest } = config;
+  writeFileSync(configPath, JSON.stringify(rest, null, 2) + "\n");
 
   cached = null; // invalidate cache
 }


### PR DESCRIPTION
## Summary
- **Bug**: `saveRawConfig()` called `setSecureKey()` for every apiKey found in the config object. In CI (no keychain), this caused `config set twilio.accountSid` to fail with `ConfigError: Failed to save API key for "anthropic" to secure storage` when the anthropic key was present from env-var injection.
- **Fix**: Removed the secure-storage migration side effect from `saveRawConfig()`. It now just strips `apiKeys` before writing to disk. Secure storage is already managed by `saveConfig()` and the `assistant keys` CLI.

## Original prompt
Fix CI failures where `config set` for non-apiKey fields fails because `saveRawConfig()` tries to migrate apiKeys to keychain, which is unavailable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
