### PR TITLE
feat: thread contactId through invite creation from store to API

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -178,6 +178,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with valid invite token becomes active member without guardian approval", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -231,6 +232,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with expired token gets appropriate message", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
       expiresInMs: -1, // already expired
     });
@@ -252,6 +254,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with revoked token gets refusal text", async () => {
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
     revokeInvite(invite.id);
@@ -292,6 +295,7 @@ describe("inbound invite redemption intercept", () => {
   test("duplicate Telegram webhook deliveries do not double-redeem", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -353,7 +357,11 @@ describe("inbound invite redemption intercept", () => {
 
   test("channel mismatch returns appropriate message", async () => {
     // Create an invite for voice, but try to redeem via Telegram
-    const { rawToken } = createInvite({ sourceChannel: "phone", maxUses: 5 });
+    const { rawToken } = createInvite({
+      sourceChannel: "phone",
+      contactId: "test-contact-id",
+      maxUses: 5,
+    });
 
     const req = buildInviteRequest(rawToken);
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
@@ -372,6 +380,7 @@ describe("inbound invite redemption intercept", () => {
   test("already-active member with invite token gets acknowledgement", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -399,6 +408,7 @@ describe("inbound invite redemption intercept", () => {
   test("reactivation via invite preserves existing guardian-managed member display name", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -63,6 +63,7 @@ describe("invite-redemption-service", () => {
   test("redeems a valid invite and returns typed outcome", () => {
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -84,6 +85,7 @@ describe("invite-redemption-service", () => {
   test("marks channel as verified via invite on redemption", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -110,6 +112,7 @@ describe("invite-redemption-service", () => {
     const inviteCode = "123456";
     createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
       inviteCodeHash: hashVoiceCode(inviteCode),
     });
@@ -147,6 +150,7 @@ describe("invite-redemption-service", () => {
     // Create an invite that expired 1 ms ago
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
       expiresInMs: -1,
     });
@@ -163,6 +167,7 @@ describe("invite-redemption-service", () => {
   test("returns revoked for a revoked invite", () => {
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
     revokeStoreFn(invite.id);
@@ -179,6 +184,7 @@ describe("invite-redemption-service", () => {
   test("returns max_uses_reached when invite is fully consumed", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -203,6 +209,7 @@ describe("invite-redemption-service", () => {
   test("returns channel_mismatch when redeeming on wrong channel", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -218,6 +225,7 @@ describe("invite-redemption-service", () => {
   test("returns missing_identity when no externalUserId or externalChatId", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -232,6 +240,7 @@ describe("invite-redemption-service", () => {
   test("returns already_member when user is already an active member", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -262,6 +271,7 @@ describe("invite-redemption-service", () => {
   test("returns invalid_token for a blocked member to avoid leaking membership status", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -284,6 +294,7 @@ describe("invite-redemption-service", () => {
   test("downgrades a revoked guardian to contact when they redeem an invite", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -325,6 +336,7 @@ describe("invite-redemption-service", () => {
     const inviteCodeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
       inviteCodeHash,
     });
@@ -364,6 +376,7 @@ describe("invite-redemption-service", () => {
   test("does not return already_member for a revoked member", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 
@@ -391,6 +404,7 @@ describe("invite-redemption-service", () => {
   test("raw token is not present in the outcome object", () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
     });
 
@@ -406,7 +420,11 @@ describe("invite-redemption-service", () => {
   });
 
   test("channel enforcement blocks cross-channel redemption (voice invite via slack)", () => {
-    const { rawToken } = createInvite({ sourceChannel: "phone", maxUses: 1 });
+    const { rawToken } = createInvite({
+      sourceChannel: "phone",
+      contactId: "test-contact-id",
+      maxUses: 1,
+    });
 
     const outcome = redeemInvite({
       rawToken,
@@ -439,6 +457,7 @@ describe("invite-redemption-service", () => {
     // Create an expired invite
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 5,
       expiresInMs: -1,
     });
@@ -464,6 +483,7 @@ describe("invite-redemption-service", () => {
     // Create an invite for voice
     const { rawToken } = createInvite({
       sourceChannel: "phone",
+      contactId: "test-contact-id",
       maxUses: 5,
     });
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2053,6 +2053,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
+      contactId: "test-contact-id",
       maxUses: 1,
       expectedExternalUserId: "+15558887777",
       voiceCodeHash: codeHash,
@@ -2126,6 +2127,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
+      contactId: "test-contact-id",
       maxUses: 1,
       expectedExternalUserId: "+15558886666",
       voiceCodeHash: codeHash,
@@ -4013,6 +4015,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
+      contactId: "test-contact-id",
       maxUses: 1,
       expectedExternalUserId: "+15557776666",
       voiceCodeHash: codeHash,

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -151,6 +151,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const { invite } = createInvite({
       sourceChannel: "phone",
+      contactId: "test-contact-id",
       maxUses: opts.maxUses ?? 1,
       expiresInMs: opts.expiresInMs,
       expectedExternalUserId: opts.callerPhone ?? "+15551234567",
@@ -285,6 +286,7 @@ describe("redeemVoiceInviteCode", () => {
 
     createInvite({
       sourceChannel: "telegram",
+      contactId: "test-contact-id",
       maxUses: 1,
       expectedExternalUserId: "+15551234567",
       voiceCodeHash: codeHash,

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -497,6 +497,7 @@ Examples:
       "--guardian-name <name>",
       "Guardian name (required for voice invites)",
     )
+    .requiredOption("--contact-id <id>", "Contact ID to bind the invite to")
     .addHelpText(
       "after",
       `
@@ -529,6 +530,7 @@ Examples:
           expectedExternalUserId?: string;
           friendName?: string;
           guardianName?: string;
+          contactId: string;
         },
         cmd: Command,
       ) => {
@@ -563,6 +565,7 @@ Examples:
             expectedExternalUserId: opts.expectedExternalUserId,
             friendName: opts.friendName,
             guardianName: opts.guardianName,
+            contactId: opts.contactId,
           });
           if (result.ok) {
             writeOutput(cmd, { ok: true, invite: result.data });

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -100,7 +100,7 @@ function rowToInvite(
 
 export function createInvite(params: {
   sourceChannel: string;
-  contactId?: string;
+  contactId: string;
   createdBySessionId?: string;
   note?: string;
   maxUses?: number;
@@ -139,7 +139,7 @@ export function createInvite(params: {
     inviteCodeHash: params.inviteCodeHash ?? null,
     friendName: params.friendName ?? null,
     guardianName: params.guardianName ?? null,
-    contactId: params.contactId ?? "",
+    contactId: params.contactId,
     createdAt: now,
     updatedAt: now,
   };

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -158,6 +158,7 @@ export async function createIngressInvite(params: {
   voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
+  contactId: string;
 }): Promise<IngressResult<InviteResponseData>> {
   if (!params.sourceChannel) {
     return { ok: false, error: "sourceChannel is required for create" };
@@ -212,6 +213,7 @@ export async function createIngressInvite(params: {
 
   const { invite, rawToken } = createInvite({
     sourceChannel: params.sourceChannel,
+    contactId: params.contactId,
     note: params.note,
     maxUses: params.maxUses,
     expiresInMs: params.expiresInMs,

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -59,6 +59,7 @@ export async function handleCreateInvite(req: Request): Promise<Response> {
     voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,
     guardianName: body.guardianName as string | undefined,
+    contactId: body.contactId as string,
   });
 
   if (!result.ok) {


### PR DESCRIPTION
## Summary
- Make contactId required in createInvite() and createIngressInvite() params
- Thread contactId through both voice and non-voice invite creation paths
- Extract contactId from HTTP request body in the invite route handler
- Add --contact-id CLI option to `contacts invites create` command
- Update all test call sites to supply required contactId

Part of plan: contact-bound-invites.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
