### PR TITLE
feat: add window-aware lifecycle management for avatar animations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -50,6 +50,9 @@ class AvatarLayerView: NSView {
     /// Whether blinks are currently enabled (paused when window is inactive).
     private var blinkEnabled = true
 
+    /// Notification observers for window key/resign-key events.
+    private var notificationObservers: [NSObjectProtocol] = []
+
     override init(frame: NSRect) {
         super.init(frame: frame)
         wantsLayer = true
@@ -60,6 +63,9 @@ class AvatarLayerView: NSView {
 
     deinit {
         blinkTask?.cancel()
+        for observer in notificationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     func configure(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor, size: CGFloat) {
@@ -131,8 +137,10 @@ class AvatarLayerView: NSView {
 
         CATransaction.commit()
 
-        startBlinkTimer()
-        startBreathing()
+        if blinkEnabled {
+            startBlinkTimer()
+            startBreathing()
+        }
     }
 
     private func startBlinkTimer() {
@@ -162,6 +170,57 @@ class AvatarLayerView: NSView {
         breathe.repeatCount = .infinity
         breathe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         bodyLayer.add(breathe, forKey: "breathing")
+    }
+
+    // MARK: - Window-aware lifecycle
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Clean up old observers
+        for observer in notificationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        notificationObservers.removeAll()
+
+        guard let window else {
+            pauseAnimations()
+            return
+        }
+
+        let keyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resumeAnimations()
+        }
+        let resignKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.pauseAnimations()
+        }
+        notificationObservers = [keyObserver, resignKeyObserver]
+
+        // Start in correct state
+        if window.isKeyWindow {
+            resumeAnimations()
+        } else {
+            pauseAnimations()
+        }
+    }
+
+    private func pauseAnimations() {
+        blinkEnabled = false
+        blinkTask?.cancel()
+        bodyLayer.removeAnimation(forKey: "breathing")
+    }
+
+    private func resumeAnimations() {
+        blinkEnabled = true
+        startBlinkTimer()
+        startBreathing()
     }
 
     private func performBlink() {


### PR DESCRIPTION
## Summary
- Add window-level notification observers (didBecomeKey/didResignKey) to pause and resume avatar animations
- Uses viewDidMoveToWindow() for proper lifecycle — avoids NSApplication notifications which don't fire for LSUIElement apps
- Animations only run when the window is key; configure() respects paused state via blinkEnabled flag
- Clean observer teardown in deinit prevents leaks

Part of plan: avatar-animations.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
