### PR TITLE
feat: pass contactId from macOS Contacts page when creating invites

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -1033,6 +1033,7 @@ struct ContactDetailView: View {
                     sourceChannel: type,
                     note: "Invite for \(displayContact.displayName)",
                     contactName: displayContact.displayName,
+                    contactId: displayContact.id,
                     expectedExternalUserId: phoneNumber,
                     friendName: type == "phone" ? displayContact.displayName : nil,
                     guardianName: resolvedGuardianName

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2048,12 +2048,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         note: String? = nil,
         maxUses: Int? = nil,
         contactName: String? = nil,
+        contactId: String? = nil,
         expectedExternalUserId: String? = nil,
         friendName: String? = nil,
         guardianName: String? = nil
     ) async throws -> (inviteId: String, token: String?, shareUrl: String?, inviteCode: String?, voiceCode: String?, guardianInstruction: String?, channelHandle: String?)? {
         if let httpTransport {
-            return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, expectedExternalUserId: expectedExternalUserId, friendName: friendName, guardianName: guardianName)
+            return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, contactId: contactId, expectedExternalUserId: expectedExternalUserId, friendName: friendName, guardianName: guardianName)
         }
 
         #if os(macOS)
@@ -2064,6 +2065,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         if let note { body["note"] = note }
         if let maxUses { body["maxUses"] = maxUses }
         if let contactName { body["contactName"] = contactName }
+        if let contactId { body["contactId"] = contactId }
         if let expectedExternalUserId { body["expectedExternalUserId"] = expectedExternalUserId }
         if let friendName { body["friendName"] = friendName }
         if let guardianName { body["guardianName"] = guardianName }

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2538,6 +2538,7 @@ public final class HTTPTransport {
         note: String? = nil,
         maxUses: Int? = nil,
         contactName: String? = nil,
+        contactId: String? = nil,
         expectedExternalUserId: String? = nil,
         friendName: String? = nil,
         guardianName: String? = nil,
@@ -2554,6 +2555,7 @@ public final class HTTPTransport {
         if let note { body["note"] = note }
         if let maxUses { body["maxUses"] = maxUses }
         if let contactName { body["contactName"] = contactName }
+        if let contactId { body["contactId"] = contactId }
         if let expectedExternalUserId { body["expectedExternalUserId"] = expectedExternalUserId }
         if let friendName { body["friendName"] = friendName }
         if let guardianName { body["guardianName"] = guardianName }
@@ -2565,7 +2567,7 @@ public final class HTTPTransport {
             if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {
-                    return try await createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, expectedExternalUserId: expectedExternalUserId, friendName: friendName, guardianName: guardianName, isRetry: true)
+                    return try await createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, contactId: contactId, expectedExternalUserId: expectedExternalUserId, friendName: friendName, guardianName: guardianName, isRetry: true)
                 }
                 return nil
             }


### PR DESCRIPTION
## Summary
- Add contactId parameter to DaemonClient.createInvite and HTTPDaemonClient.createInvite
- Include contactId in the HTTP request body when creating invites
- Pass displayContact.id as contactId from ContactDetailView.createInviteForChannel

Part of plan: contact-bound-invites.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
