### PR TITLE
fix: correct double-blink keyTimes and use layer pause/resume for breathing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -214,13 +214,20 @@ class AvatarLayerView: NSView {
     private func pauseAnimations() {
         blinkEnabled = false
         blinkTask?.cancel()
-        bodyLayer.removeAnimation(forKey: "breathing")
+        let pausedTime = bodyLayer.convertTime(CACurrentMediaTime(), from: nil)
+        bodyLayer.speed = 0
+        bodyLayer.timeOffset = pausedTime
     }
 
     private func resumeAnimations() {
         blinkEnabled = true
         startBlinkTimer()
-        startBreathing()
+        let pausedTime = bodyLayer.timeOffset
+        bodyLayer.speed = 1
+        bodyLayer.timeOffset = 0
+        bodyLayer.beginTime = 0
+        let timeSincePause = bodyLayer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+        bodyLayer.beginTime = timeSincePause
     }
 
     private func performBlink() {
@@ -242,7 +249,7 @@ class AvatarLayerView: NSView {
                     closedEyePaths[i],  // Second close
                     openEyePaths[i],    // Final open
                 ]
-                animation.keyTimes = [0, 0.15, 0.35, 0.50, 0.75]
+                animation.keyTimes = [0, 0.15, 0.35, 0.50, 1.0]
                 animation.duration = 0.45
                 animation.timingFunctions = [
                     CAMediaTimingFunction(name: .easeIn),


### PR DESCRIPTION
## Summary
Fixes two gaps found during plan review for avatar-animations.md:

**Gap 1:** Double-blink keyTimes last value was 0.75 instead of the Apple-required 1.0. Fixed to [0, 0.15, 0.35, 0.50, 1.0].

**Gap 2:** Breathing animation was removed and re-added on window focus changes, causing a visible jump. Now uses the standard Core Animation layer pause/resume pattern (speed=0/1 with timeOffset) to resume in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
