### PR TITLE
feat: generate identity intro via daemon on iOS

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -9,6 +9,8 @@ import VellumAssistantShared
 final class IdentityViewModel {
     var identity: RemoteIdentityInfo?
     var isLoading = false
+    var introText: String? = nil
+    private var introTask: Task<Void, Never>?
 
     var skillsStore: SkillsStore?
     var contactsStore: ContactsStore?
@@ -69,6 +71,35 @@ final class IdentityViewModel {
         isLoading = true
         identity = await daemonClient.fetchRemoteIdentity()
         isLoading = false
+        generateIntro(client: client)
+    }
+
+    func generateIntro(client: any DaemonClientProtocol) {
+        introTask?.cancel()
+        introText = nil
+        introTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let key = "identity-intro-\(UUID().uuidString)"
+            var result = ""
+            do {
+                let stream = client.sendBtwMessage(
+                    content: "Generate a very short intro for yourself (2-5 words, like \"I'm [name]!\" or \"It's [name]\" or \"Yo I'm [name]\"). Output ONLY the intro text, nothing else.",
+                    conversationKey: key
+                )
+                for try await delta in stream {
+                    guard !Task.isCancelled else { return }
+                    result += delta
+                }
+                self.introText = result.isEmpty ? nil : result
+            } catch is CancellationError {
+                return
+            } catch {
+                // Fallback to formatted name
+                if let name = self.identity?.name, !name.isEmpty {
+                    self.introText = "I'm \(name)!"
+                }
+            }
+        }
     }
 }
 
@@ -108,6 +139,18 @@ struct IdentityView: View {
 
     private var intelligenceContent: some View {
         List {
+            // Intro text section
+            if let introText = viewModel.introText {
+                Section {
+                    Text(introText)
+                        .font(.system(size: 22, weight: .regular, design: .rounded))
+                        .foregroundColor(VColor.contentDefault)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                }
+            }
+
             // Identity card section
             if let identity = viewModel.identity {
                 Section {


### PR DESCRIPTION
## Summary
- Add daemon-generated intro text to the iOS Intelligence view via /v1/btw
- Intro appears centered above the identity card after loading
- Fallback to "I'm {name}!" on error; regenerates each time the view loads

Part of plan: gen-dynamic-text.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
