### PR TITLE
feat: generate identity intro via daemon on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -15,6 +15,8 @@ struct IdentityPanel: View {
     @State private var viewingFilePath: String?
     @State private var isFullscreen: Bool = false
     @State private var showAvatarSheet: Bool = false
+    @State private var introText: String? = nil
+    @State private var introTask: Task<Void, Never>? = nil
 
     private let sidebarMinWidth: CGFloat = 200
     private let sidebarMaxWidth: CGFloat = 280
@@ -40,14 +42,16 @@ struct IdentityPanel: View {
                 if !isFullscreen {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
-                            // "I'm [name]!" heading
-                            Text("I'm \(assistantDisplayName)!")
-                                .font(.system(size: 22, weight: .regular, design: .rounded))
-                                .foregroundColor(VColor.contentDefault)
-                                .multilineTextAlignment(.center)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                                .padding(.top, VSpacing.xxl)
-                                .padding(.horizontal, VSpacing.lg)
+                            // Daemon-generated intro heading (nil = loading, shows nothing)
+                            if let introText {
+                                Text(introText)
+                                    .font(.system(size: 22, weight: .regular, design: .rounded))
+                                    .foregroundColor(VColor.contentDefault)
+                                    .multilineTextAlignment(.center)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                    .padding(.top, VSpacing.xxl)
+                                    .padding(.horizontal, VSpacing.lg)
+                            }
 
                             Spacer()
 
@@ -163,6 +167,38 @@ struct IdentityPanel: View {
                         remoteIdentity = await daemonClient.fetchRemoteIdentity()
                     }
                 }
+
+                generateIntro()
+            }
+            .onDisappear { introTask?.cancel() }
+        }
+    }
+
+    // MARK: - Intro Generation
+
+    private func generateIntro() {
+        introTask?.cancel()
+        introText = nil
+
+        introTask = Task {
+            let key = "identity-intro-\(UUID().uuidString)"
+            let prompt = "Generate a very short intro for yourself (2-5 words, like \"I'm [name]!\" or \"It's [name]\" or \"Yo I'm [name]\"). Output ONLY the intro text, nothing else."
+            var result = ""
+            do {
+                let stream = daemonClient.sendBtwMessage(
+                    content: prompt,
+                    conversationKey: key
+                )
+                for try await delta in stream {
+                    guard !Task.isCancelled else { return }
+                    result += delta
+                }
+                self.introText = result
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.introText = "I'm \(assistantDisplayName)!"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace hard-coded "I'm {name}!" text on the macOS Identity panel with a daemon-generated intro via /v1/btw
- Loading state shows nothing; fallback to "I'm {name}!" on error
- Intro regenerates each time the panel is opened

Part of plan: gen-dynamic-text.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
