### PR TITLE
test: add tests for contact-bound invite redemption

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -25,6 +25,7 @@ mock.module("../util/logger.js", () => ({
 
 import {
   findContactChannel,
+  getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
@@ -57,13 +58,19 @@ function resetTables() {
   getSqlite().run("DELETE FROM contacts");
 }
 
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Target Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
+}
+
 describe("invite-redemption-service", () => {
   beforeEach(resetTables);
 
   test("redeems a valid invite and returns typed outcome", () => {
+    const targetContactId = createTargetContact();
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -83,9 +90,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("marks channel as verified via invite on redemption", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -109,10 +117,11 @@ describe("invite-redemption-service", () => {
   });
 
   test("marks channel as verified via invite on 6-digit code redemption", () => {
+    const targetContactId = createTargetContact();
     const inviteCode = "123456";
     createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
       inviteCodeHash: hashVoiceCode(inviteCode),
     });
@@ -147,10 +156,11 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns expired for an expired invite", () => {
+    const targetContactId = createTargetContact();
     // Create an invite that expired 1 ms ago
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
       expiresInMs: -1,
     });
@@ -165,9 +175,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns revoked for a revoked invite", () => {
+    const targetContactId = createTargetContact();
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
     revokeStoreFn(invite.id);
@@ -182,9 +193,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns max_uses_reached when invite is fully consumed", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -207,9 +219,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns channel_mismatch when redeeming on wrong channel", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -223,9 +236,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns missing_identity when no externalUserId or externalChatId", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -238,17 +252,18 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns already_member when user is already an active member", () => {
-    const { rawToken } = createInvite({
-      sourceChannel: "telegram",
-      contactId: "test-contact-id",
-      maxUses: 5,
-    });
-
-    // Pre-create an active member
-    upsertContactChannel({
+    // Pre-create an active member and find their contact
+    const member = upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "existing-user",
       status: "active",
+    });
+
+    // Create an invite targeting the same contact that owns the channel
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: member!.contact.id,
+      maxUses: 5,
     });
 
     const outcome = redeemInvite({
@@ -269,17 +284,18 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns invalid_token for a blocked member to avoid leaking membership status", () => {
-    const { rawToken } = createInvite({
-      sourceChannel: "telegram",
-      contactId: "test-contact-id",
-      maxUses: 5,
-    });
-
-    // Pre-create a blocked member — simulates a guardian-initiated block
-    upsertContactChannel({
+    // Pre-create a blocked member and find their contact
+    const member = upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
       status: "blocked",
+    });
+
+    // Create an invite targeting the same contact that owns the channel
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: member!.contact.id,
+      maxUses: 5,
     });
 
     const outcome = redeemInvite({
@@ -291,15 +307,9 @@ describe("invite-redemption-service", () => {
     expect(outcome).toEqual({ ok: false, reason: "invalid_token" });
   });
 
-  test("downgrades a revoked guardian to contact when they redeem an invite", () => {
-    const { rawToken } = createInvite({
-      sourceChannel: "telegram",
-      contactId: "test-contact-id",
-      maxUses: 5,
-    });
-
+  test("binds redeemer to the invite's target contact, not the guardian", () => {
     // Pre-create a guardian contact with a revoked telegram channel
-    upsertContact({
+    const guardianContact = upsertContact({
       displayName: "Guardian",
       role: "guardian",
       channels: [
@@ -312,36 +322,48 @@ describe("invite-redemption-service", () => {
       ],
     });
 
+    // Create a separate target contact "Mom"
+    const momContact = upsertContact({
+      displayName: "Mom",
+      role: "contact",
+    });
+
+    // Create an invite targeting Mom's contact
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: momContact.id,
+      maxUses: 5,
+    });
+
+    // Redeem using the guardian's Telegram identity
     const outcome = redeemInvite({
       rawToken,
       sourceChannel: "telegram",
       externalUserId: "guardian-tg-id",
     });
 
-    // Should succeed — guardian is downgraded to a regular contact
+    // Should succeed — redeemer's channel is bound to Mom
     expect(outcome.ok).toBe(true);
     expect((outcome as { type: string }).type).toBe("redeemed");
 
-    // Verify the contact was downgraded from guardian to contact
+    // Verify the redeemer's Telegram ID is now bound to Mom's contact
     const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "guardian-tg-id",
     });
-    expect(result?.contact.role).toBe("contact");
-    expect(result?.channel.status).toBe("active");
+    expect(result).not.toBeNull();
+    expect(result!.contact.id).toBe(momContact.id);
+    expect(result!.channel.status).toBe("active");
+
+    // Verify the original guardian contact was NOT modified
+    const guardian = getContact(guardianContact.id);
+    expect(guardian).not.toBeNull();
+    expect(guardian!.role).toBe("guardian");
   });
 
-  test("downgrades a revoked guardian to contact via 6-digit invite code", () => {
-    const code = "123456";
-    const inviteCodeHash = hashVoiceCode(code);
-    createInvite({
-      sourceChannel: "telegram",
-      contactId: "test-contact-id",
-      maxUses: 5,
-      inviteCodeHash,
-    });
-
-    upsertContact({
+  test("binds redeemer to the invite's target contact via 6-digit code, not the guardian", () => {
+    // Pre-create a guardian contact with a revoked telegram channel
+    const guardianContact = upsertContact({
       displayName: "Guardian",
       role: "guardian",
       channels: [
@@ -354,29 +376,53 @@ describe("invite-redemption-service", () => {
       ],
     });
 
+    // Create a separate target contact "Mom"
+    const momContact = upsertContact({
+      displayName: "Mom",
+      role: "contact",
+    });
+
+    // Create an invite targeting Mom's contact with a 6-digit code
+    const code = "123456";
+    const inviteCodeHash = hashVoiceCode(code);
+    createInvite({
+      sourceChannel: "telegram",
+      contactId: momContact.id,
+      maxUses: 5,
+      inviteCodeHash,
+    });
+
+    // Redeem using the guardian's Telegram identity
     const outcome = redeemInviteByCode({
       code,
       sourceChannel: "telegram",
       externalUserId: "guardian-code-id",
     });
 
-    // Should succeed — guardian is downgraded to a regular contact
+    // Should succeed — redeemer's channel is bound to Mom
     expect(outcome.ok).toBe(true);
     expect((outcome as { type: string }).type).toBe("redeemed");
 
-    // Verify the contact was downgraded from guardian to contact
+    // Verify the redeemer's Telegram ID is now bound to Mom's contact
     const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "guardian-code-id",
     });
-    expect(result?.contact.role).toBe("contact");
-    expect(result?.channel.status).toBe("active");
+    expect(result).not.toBeNull();
+    expect(result!.contact.id).toBe(momContact.id);
+    expect(result!.channel.status).toBe("active");
+
+    // Verify the original guardian contact was NOT modified
+    const guardian = getContact(guardianContact.id);
+    expect(guardian).not.toBeNull();
+    expect(guardian!.role).toBe("guardian");
   });
 
   test("does not return already_member for a revoked member", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 5,
     });
 
@@ -402,9 +448,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("raw token is not present in the outcome object", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -420,9 +467,10 @@ describe("invite-redemption-service", () => {
   });
 
   test("channel enforcement blocks cross-channel redemption (voice invite via slack)", () => {
+    const targetContactId = createTargetContact();
     const { rawToken } = createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
     });
 
@@ -454,10 +502,11 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns expired for an active member with an expired invite token", () => {
+    const targetContactId = createTargetContact();
     // Create an expired invite
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 5,
       expiresInMs: -1,
     });
@@ -480,10 +529,11 @@ describe("invite-redemption-service", () => {
   });
 
   test("returns channel_mismatch for an active member with a valid token for a different channel", () => {
+    const targetContactId = createTargetContact();
     // Create an invite for voice
     const { rawToken } = createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 5,
     });
 

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -25,6 +25,7 @@ mock.module("../util/logger.js", () => ({
 
 import {
   findContactChannel,
+  getContact,
   upsertContact,
 } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
@@ -48,6 +49,11 @@ function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");
   getSqlite().run("DELETE FROM contact_channels");
   getSqlite().run("DELETE FROM contacts");
+}
+
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Target Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,15 +149,18 @@ describe("redeemVoiceInviteCode", () => {
       expiresInMs?: number;
       voiceCodeDigits?: number;
       assistantId?: string;
+      contactId?: string;
     } = {},
   ) {
     const digits = opts.voiceCodeDigits ?? 6;
     const code = generateVoiceCode(digits);
     const codeHash = hashVoiceCode(code);
 
+    const contactId = opts.contactId ?? createTargetContact();
+
     const { invite } = createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId,
       maxUses: opts.maxUses ?? 1,
       expiresInMs: opts.expiresInMs,
       expectedExternalUserId: opts.callerPhone ?? "+15551234567",
@@ -281,12 +290,13 @@ describe("redeemVoiceInviteCode", () => {
     // Create a non-voice invite with voice code metadata to simulate a
     // hypothetical misconfiguration. The redemption service filters by
     // sourceChannel='phone', so non-phone invites are invisible.
+    const targetContactId = createTargetContact();
     const code = generateVoiceCode(6);
     const codeHash = hashVoiceCode(code);
 
     createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: targetContactId,
       maxUses: 1,
       expectedExternalUserId: "+15551234567",
       voiceCodeHash: codeHash,
@@ -306,14 +316,19 @@ describe("redeemVoiceInviteCode", () => {
 
   test("already-member caller gets already_member outcome", () => {
     const phone = "+15551234567";
-    const { code } = createVoiceInvite({ callerPhone: phone });
 
     // Pre-create an active member for this phone on voice channel
-    upsertContactChannel({
+    const member = upsertContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "active",
       policy: "allow",
+    });
+
+    // Create a voice invite targeting the same contact that owns the channel
+    const { code } = createVoiceInvite({
+      callerPhone: phone,
+      contactId: member!.contact.id,
     });
 
     const result = redeemVoiceInviteCode({
@@ -332,13 +347,19 @@ describe("redeemVoiceInviteCode", () => {
 
   test("blocked member gets generic failure to avoid leaking membership status", () => {
     const phone = "+15551234567";
-    const { code } = createVoiceInvite({ callerPhone: phone });
 
-    upsertContactChannel({
+    // Pre-create a blocked member and find their contact
+    const member = upsertContactChannel({
       sourceChannel: "phone",
       externalUserId: phone,
       status: "blocked",
       policy: "deny",
+    });
+
+    // Create a voice invite targeting the same contact that owns the channel
+    const { code } = createVoiceInvite({
+      callerPhone: phone,
+      contactId: member!.contact.id,
     });
 
     const result = redeemVoiceInviteCode({
@@ -360,12 +381,11 @@ describe("redeemVoiceInviteCode", () => {
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });
 
-  test("downgrades a revoked guardian to contact when they redeem a voice invite", () => {
+  test("binds redeemer to the invite's target contact, not the guardian, on voice redemption", () => {
     const phone = "+15559998888";
-    const { code } = createVoiceInvite({ callerPhone: phone });
 
     // Pre-create a guardian contact with a revoked phone channel
-    upsertContact({
+    const guardianContact = upsertContact({
       displayName: "Guardian",
       role: "guardian",
       channels: [
@@ -378,22 +398,40 @@ describe("redeemVoiceInviteCode", () => {
       ],
     });
 
+    // Create a separate target contact "Mom"
+    const momContact = upsertContact({
+      displayName: "Mom",
+      role: "contact",
+    });
+
+    // Create a voice invite targeting Mom's contact
+    const { code } = createVoiceInvite({
+      callerPhone: phone,
+      contactId: momContact.id,
+    });
+
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
       sourceChannel: "phone",
       code,
     });
 
-    // Should succeed — guardian is downgraded to a regular contact
+    // Should succeed — redeemer's channel is bound to Mom
     expect(result.ok).toBe(true);
     expect((result as { type: string }).type).toBe("redeemed");
 
-    // Verify the contact was downgraded from guardian to contact
+    // Verify the redeemer's phone is now bound to Mom's contact
     const contactResult = findContactChannel({
       channelType: "phone",
       externalUserId: phone,
     });
-    expect(contactResult?.contact.role).toBe("contact");
-    expect(contactResult?.channel.status).toBe("active");
+    expect(contactResult).not.toBeNull();
+    expect(contactResult!.contact.id).toBe(momContact.id);
+    expect(contactResult!.channel.status).toBe("active");
+
+    // Verify the original guardian contact was NOT modified
+    const guardian = getContact(guardianContact.id);
+    expect(guardian).not.toBeNull();
+    expect(guardian!.role).toBe("guardian");
   });
 });

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -140,6 +140,10 @@ export function upsertContact(params: {
   contactType?: ContactType;
   principalId?: string | null;
   channels?: SyncChannelData[];
+  /** When true, conflicting channels on other contacts are reassigned to this
+   *  contact instead of being skipped. Used by invite redemption to bind a
+   *  redeemer's existing channel identity to the invite's target contact. */
+  reassignConflictingChannels?: boolean;
 }): ContactWithChannels & { created: boolean } {
   const db = getDb();
   const now = Date.now();
@@ -171,7 +175,12 @@ export function upsertContact(params: {
         .run();
 
       if (params.channels) {
-        syncChannels(contactId, params.channels, now);
+        syncChannels(
+          contactId,
+          params.channels,
+          now,
+          params.reassignConflictingChannels,
+        );
       }
 
       emitContactChange();
@@ -253,6 +262,7 @@ function syncChannels(
   contactId: string,
   channels: SyncChannelData[],
   now: number,
+  reassignConflicting?: boolean,
 ): void {
   const db = getDb();
 
@@ -312,7 +322,34 @@ function syncChannels(
       .get();
 
     if (conflicting) {
-      // Channel belongs to another contact -- skip to avoid unique constraint violation.
+      if (reassignConflicting) {
+        // Reassign the channel to the target contact. Used by invite redemption
+        // to bind a redeemer's existing channel identity to the invite's target.
+        const reassignSet: Record<string, unknown> = {
+          contactId,
+          updatedAt: now,
+        };
+        if (ch.externalUserId !== undefined)
+          reassignSet.externalUserId = ch.externalUserId;
+        if (ch.externalChatId !== undefined)
+          reassignSet.externalChatId = ch.externalChatId;
+        if (ch.status !== undefined) reassignSet.status = ch.status;
+        if (ch.policy !== undefined) reassignSet.policy = ch.policy;
+        if (ch.verifiedAt !== undefined) reassignSet.verifiedAt = ch.verifiedAt;
+        if (ch.verifiedVia !== undefined)
+          reassignSet.verifiedVia = ch.verifiedVia;
+        if (ch.inviteId !== undefined) reassignSet.inviteId = ch.inviteId;
+        if (ch.revokedReason !== undefined)
+          reassignSet.revokedReason = ch.revokedReason;
+        if (ch.blockedReason !== undefined)
+          reassignSet.blockedReason = ch.blockedReason;
+
+        db.update(contactChannels)
+          .set(reassignSet)
+          .where(eq(contactChannels.id, conflicting.id))
+          .run();
+      }
+      // When not reassigning, skip to avoid unique constraint violation.
       // The caller should use contact_merge to combine the two contacts.
       continue;
     }

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -194,6 +194,10 @@ export function upsertContactChannel(params: {
         verifiedVia: params.verifiedVia ?? undefined,
       },
     ],
+    // When a specific contactId is provided, reassign conflicting channels from
+    // other contacts. This enables invite redemption to bind a redeemer's
+    // existing channel identity to the invite's target contact.
+    reassignConflictingChannels: !!params.contactId,
   });
 
   const contactResult = findContactChannel({


### PR DESCRIPTION
## Summary
- Update guardian-downgrade tests to verify contact-bound invite behavior
- Tests now create a target contact and verify the redeemer's channel binds to it
- Verify guardian contact is untouched when a different contact's invite is redeemed
- Fix FK constraint violations in tests by creating real contacts for invite `contactId`
- Add `reassignConflictingChannels` option to `syncChannels` so invite redemption can rebind channels from one contact to another

Part of plan: contact-bound-invites.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
