### PR TITLE
fix: update oauth connections help text to include disconnect subcommand

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -93,7 +93,8 @@ Examples:
   $ assistant oauth connections token integration:twitter
   $ assistant oauth connections ping integration:gmail
   $ assistant oauth connections connect integration:gmail
-  $ assistant oauth connections connect integration:gmail --open-browser`,
+  $ assistant oauth connections connect integration:gmail --open-browser
+  $ assistant oauth connections disconnect integration:gmail`,
   );
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -17,7 +17,7 @@ The oauth command group manages the full OAuth lifecycle:
 
   providers   Protocol-level configurations (auth URLs, scopes, endpoints)
   apps        Client credentials (client ID / secret pairs)
-  connections Active token grants per provider (list, get, token)
+  connections Active token grants per provider (list, get, token, disconnect)
 
 Providers are seeded on startup for built-in integrations. Apps and connections
 are created during the OAuth authorization flow or can be managed manually via


### PR DESCRIPTION
## Summary
- Update parent help text in `oauth/index.ts` to list `disconnect` in the connections subcommand list
- Add a `disconnect` example to the connections namespace help text in `connections.ts`

## Original prompt
Address the feedback on PR #15734: move disconnect command from credentials to oauth connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
