### PR TITLE
fix: update VToggle colors to match Figma design

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -8,8 +8,8 @@ public struct VToggle: View {
 
     private let trackWidth: CGFloat = 36
     private let trackHeight: CGFloat = 24
-    private let knobSize: CGFloat = 18
-    private let knobPadding: CGFloat = 3
+    private let knobSize: CGFloat = 20
+    private let knobPadding: CGFloat = 2
 
     public init(isOn: Binding<Bool>, label: String? = nil, helperText: String? = nil) {
         self._isOn = isOn
@@ -27,7 +27,7 @@ public struct VToggle: View {
                     if let label {
                         Text(label)
                             .font(VFont.bodyMedium)
-                            .foregroundColor(isEnabled ? VColor.contentDefault : VColor.contentTertiary)
+                            .foregroundColor(isEnabled ? VColor.contentDefault : VColor.contentDisabled)
                     }
                     if let helperText {
                         Text(helperText)
@@ -71,16 +71,16 @@ public struct VToggle: View {
 
     private var trackColor: Color {
         if !isEnabled {
-            return isOn ? VColor.primaryDisabled : VColor.surfaceBase
+            return VColor.surfaceBase
         }
-        return isOn ? VColor.primaryBase : VColor.surfaceBase
+        return isOn ? VColor.primaryActive : VColor.surfaceBase
     }
 
     private var knobColor: Color {
         if !isEnabled {
-            return VColor.contentDisabled
+            return VColor.surfaceOverlay
         }
-        return VColor.contentInset
+        return VColor.auxWhite
     }
 }
 


### PR DESCRIPTION
## Summary
- Update toggle track color to primaryActive when on (was primaryBase)
- Update knob color to auxWhite (was contentInset), disabled to surfaceOverlay
- Adjust knob size to 20px with 2px padding (was 18px/3px)
- Update disabled label color to contentDisabled

## Test plan
- [ ] Verify toggle on/off/disabled states in light and dark mode
- [ ] Check component gallery toggle section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
