### PR TITLE
feat: daemon-generated greeting with slide animation on macOS empty state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -27,10 +27,22 @@ struct ChatEmptyStateView: View {
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
+    var daemonGreeting: String? = nil
+    var onRequestGreeting: (() -> Void)? = nil
 
     @State private var visible = false
-    @State private var title: String = titles.randomElement()!
     @State private var placeholder: String = placeholderTexts.randomElement()!
+
+    // Stable random pick from SOUL.md (computed once per view lifecycle)
+    @State private var soulGreeting: String? = {
+        let custom = IdentityInfo.loadGreetings()
+        return custom.isEmpty ? nil : custom.randomElement()!
+    }()
+
+    // The greeting to display: SOUL.md takes priority, then daemon, then nil (loading)
+    private var effectiveGreeting: String? {
+        soulGreeting ?? daemonGreeting
+    }
 
     private let appearance = AvatarAppearanceManager.shared
 
@@ -43,11 +55,6 @@ struct ChatEmptyStateView: View {
         "Let's make something happen.",
         "Ready when you are.",
     ]
-
-    static var titles: [String] {
-        let custom = IdentityInfo.loadGreetings()
-        return custom.isEmpty ? defaultGreetings : custom
-    }
 
     static let placeholderTexts = [
         "Ask me anything...",
@@ -67,12 +74,16 @@ struct ChatEmptyStateView: View {
             HStack(spacing: VSpacing.md) {
                 VAvatarImage(image: appearance.chatAvatarImage, size: 32)
 
-                Text(title)
-                    .font(.custom("Fraunces", size: 28).weight(.regular))
-                    .foregroundColor(VColor.contentSecondary)
-                    .multilineTextAlignment(.leading)
+                if let greeting = effectiveGreeting {
+                    Text(greeting)
+                        .font(.custom("Fraunces", size: 28).weight(.regular))
+                        .foregroundColor(VColor.contentSecondary)
+                        .multilineTextAlignment(.leading)
+                        .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .leading)))
+                }
             }
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+            .animation(.easeOut(duration: 0.4), value: effectiveGreeting != nil)
             .opacity(visible ? 1 : 0)
             .scaleEffect(visible ? 1 : 0.8)
             .padding(.horizontal, VSpacing.xl)
@@ -112,6 +123,7 @@ struct ChatEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
+            onRequestGreeting?()
             withAnimation(.easeOut(duration: 0.5)) {
                 visible = true
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -64,6 +64,8 @@ struct ChatView: View {
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
     var threadId: UUID?
+    var daemonGreeting: String? = nil
+    var onRequestGreeting: (() -> Void)? = nil
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
 
@@ -166,7 +168,9 @@ struct ChatView: View {
                             recordingAmplitude: recordingAmplitude,
                             onDictateToggle: onDictateToggle,
                             onVoiceModeToggle: onVoiceModeToggle,
-                            threadId: threadId
+                            threadId: threadId,
+                            daemonGreeting: daemonGreeting,
+                            onRequestGreeting: onRequestGreeting
                         )
                     }
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -686,6 +686,8 @@ struct ActiveChatViewWrapper: View {
             onDictateToggle: onDictateToggle,
             onVoiceModeToggle: onVoiceModeToggle,
             threadId: threadId,
+            daemonGreeting: viewModel.emptyStateGreeting,
+            onRequestGreeting: { [weak viewModel] in viewModel?.generateGreeting() },
             anchorMessageId: $anchorMessageId,
             btwResponse: viewModel.btwResponse,
             btwLoading: viewModel.btwLoading,


### PR DESCRIPTION
## Summary
- Replace hardcoded greeting on macOS chat empty state with daemon-generated text via ChatViewModel.generateGreeting()
- SOUL.md custom greetings take priority; daemon greeting used as fallback
- Avatar starts centered; slides left with smooth animation when greeting text arrives

Part of plan: gen-dynamic-text.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
