### PR TITLE
fix: add rollback and race protection to Slack/Telegram disconnect flows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -505,6 +505,7 @@ public final class SettingsStore: ObservableObject {
                 self.fetchChannelSetupStatus()
             } else {
                 self.telegramError = response.error
+                self.fetchChannelSetupStatus()
             }
         }
 
@@ -1126,13 +1127,21 @@ public final class SettingsStore: ObservableObject {
     }
 
     func clearSlackChannelConfig() {
+        slackChannelSaveInProgress = true
         slackChannelError = nil
-        guard var request = buildDaemonRequest(path: "v1/integrations/slack/channel/config", method: "DELETE") else { return }
+        guard var request = buildDaemonRequest(path: "v1/integrations/slack/channel/config", method: "DELETE") else {
+            slackChannelSaveInProgress = false
+            return
+        }
         request.timeoutInterval = 10
         Task {
             do {
                 let (_, response) = try await URLSession.shared.data(for: request)
-                guard let httpResp = response as? HTTPURLResponse else { return }
+                guard let httpResp = response as? HTTPURLResponse else {
+                    self.slackChannelSaveInProgress = false
+                    self.fetchChannelSetupStatus()
+                    return
+                }
                 if (200..<300).contains(httpResp.statusCode) {
                     self.slackChannelHasBotToken = false
                     self.slackChannelHasAppToken = false
@@ -1141,8 +1150,15 @@ public final class SettingsStore: ObservableObject {
                     self.slackChannelTeamName = nil
                     self.slackChannelError = nil
                     self.fetchChannelSetupStatus()
+                } else {
+                    self.slackChannelError = "Failed to disconnect: HTTP \(httpResp.statusCode)"
+                    self.fetchChannelSetupStatus()
                 }
+                self.slackChannelSaveInProgress = false
             } catch {
+                self.slackChannelSaveInProgress = false
+                self.slackChannelError = error.localizedDescription
+                self.fetchChannelSetupStatus()
                 log.error("Failed to clear Slack channel config: \(error)")
             }
         }


### PR DESCRIPTION
## Summary
- Add `fetchChannelSetupStatus()` calls on all failure paths in `clearSlackChannelConfig()` so the optimistic status gets corrected when the DELETE fails
- Set `slackChannelSaveInProgress = true` during `clearSlackChannelConfig()` to prevent reconnect race while disconnect is in flight
- Add `fetchChannelSetupStatus()` call on the Telegram disconnect failure path in `onTelegramConfigResponse`

## Original prompt
Address the feedback on PR #15724: gate channel setup on both Slack tokens and add optimistic disconnect status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
