### PR TITLE
fix: remove unused fields from StoreOAuth2TokensParams interface

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -48,7 +48,6 @@ function resolveBehavior(providerKey: string): {
   setup?: OAuthProviderBehavior["setup"];
   setupSkillId?: string;
   postConnectHookId?: string;
-  injectionTemplates?: OAuthProviderBehavior["injectionTemplates"];
 } {
   const behavior = getProviderBehavior(providerKey);
   if (!behavior) return {};
@@ -57,7 +56,6 @@ function resolveBehavior(providerKey: string): {
     setup: behavior.setup,
     setupSkillId: behavior.setupSkillId,
     postConnectHookId: behavior.postConnectHookId,
-    injectionTemplates: behavior.injectionTemplates,
   };
 }
 
@@ -90,8 +88,6 @@ export interface OAuthConnectOptions {
   openUrl?: (url: string) => void;
   /** Send a message to the client (e.g. open_url). */
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
-  /** Tools allowed to use the resulting credential. */
-  allowedTools?: string[];
 
   /**
    * Called when the deferred (non-interactive) flow completes — either
@@ -216,11 +212,7 @@ export async function orchestrateOAuthConnect(
     service: resolvedService,
     clientId: options.clientId,
     clientSecret: options.clientSecret,
-    tokenUrl,
-    tokenEndpointAuthMethod,
     userinfoUrl,
-    allowedTools: options.allowedTools,
-    wellKnownInjectionTemplates: behavior.injectionTemplates,
   };
 
   // -----------------------------------------------------------------------

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -10,15 +10,11 @@
  * `oauth_connection/{id}/...`).
  */
 
-import type {
-  OAuth2FlowResult,
-  TokenEndpointAuthMethod,
-} from "../security/oauth2.js";
+import type { OAuth2FlowResult } from "../security/oauth2.js";
 import {
   deleteSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
-import type { CredentialInjectionTemplate } from "../tools/credentials/policy-types.js";
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
 import {
   createConnection,
@@ -40,11 +36,7 @@ export interface StoreOAuth2TokensParams {
   rawTokenResponse: Record<string, unknown>;
   clientId: string;
   clientSecret?: string;
-  tokenUrl: string;
-  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
   userinfoUrl?: string;
-  allowedTools?: string[];
-  wellKnownInjectionTemplates?: CredentialInjectionTemplate[];
   /** Fallback account info from an identity verifier (e.g. @username, email). */
   identityAccountInfo?: string;
   /** Pre-resolved oauth_app ID — skips the upsertApp() call if provided. */

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -812,7 +812,6 @@ class CredentialStoreTool implements Tool {
           clientSecret,
           isInteractive: !!context.isInteractive,
           sendToClient: context.sendToClient,
-          allowedTools: input.allowed_tools as string[] | undefined,
           ...(inputScopes ? { requestedScopes: inputScopes } : {}),
           onDeferredComplete: (deferredResult) => {
             // Emit oauth_connect_result to all connected SSE clients so the


### PR DESCRIPTION
## Summary
- Remove unused `tokenUrl`, `tokenEndpointAuthMethod`, `allowedTools`, and `wellKnownInjectionTemplates` fields from `StoreOAuth2TokensParams`
- These fields were accepted by the interface but silently ignored in `storeOAuth2Tokens()`
- Remove now-dead `allowedTools` from `OAuthConnectOptions` and `injectionTemplates` from `resolveBehavior()` return type
- Clean up unused imports (`TokenEndpointAuthMethod`, `CredentialInjectionTemplate`)

## Original prompt
Address the feedback on PR #15736: persist client_secret when oauthAppId is pre-resolved in storeOAuth2Tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
