### PR TITLE
fix: redact secrets inside array metadata entries

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -47,7 +47,13 @@ function redactMetadata(obj: Record<string, unknown>): Record<string, unknown> {
   for (const [key, value] of Object.entries(obj)) {
     if (REDACTED_METADATA_KEYS.has(key)) {
       result[key] = "[REDACTED]";
-    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
+      result[key] = value.map((item) =>
+        item && typeof item === "object" && !Array.isArray(item)
+          ? redactMetadata(item as Record<string, unknown>)
+          : item,
+      );
+    } else if (value && typeof value === "object") {
       result[key] = redactMetadata(value as Record<string, unknown>);
     } else {
       result[key] = value;


### PR DESCRIPTION
## Summary
- Updated the `redactSecrets` function in oauth connections CLI to recursively process array elements, not just plain objects
- Previously, metadata shaped like `{ "accounts": [{ "access_token": "..." }] }` would leak raw tokens because the redaction logic skipped array entries

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15737

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
