### PR TITLE
fix: telegram/slack credential checks and lifecycle robustness

### DIFF
--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -91,13 +91,17 @@ export async function setSlackChannelConfig(
         user?: string;
       };
       if (!data.ok) {
-        const errConn = getConnectionByProvider("slack_channel");
-        const errConnected = !!(errConn && errConn.status === "active");
+        const errHasBotToken = !!getSecureKey(
+          credentialKey("slack_channel", "bot_token"),
+        );
+        const errHasAppToken = !!getSecureKey(
+          credentialKey("slack_channel", "app_token"),
+        );
         return {
           success: false,
-          hasBotToken: errConnected,
-          hasAppToken: errConnected,
-          connected: errConnected,
+          hasBotToken: errHasBotToken,
+          hasAppToken: errHasAppToken,
+          connected: errHasBotToken && errHasAppToken,
           error: `Slack API validation failed: ${
             data.error ?? "unknown error"
           }`,
@@ -111,13 +115,17 @@ export async function setSlackChannelConfig(
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const errConn = getConnectionByProvider("slack_channel");
-      const errConnected = !!(errConn && errConn.status === "active");
+      const errHasBotToken = !!getSecureKey(
+        credentialKey("slack_channel", "bot_token"),
+      );
+      const errHasAppToken = !!getSecureKey(
+        credentialKey("slack_channel", "app_token"),
+      );
       return {
         success: false,
-        hasBotToken: errConnected,
-        hasAppToken: errConnected,
-        connected: errConnected,
+        hasBotToken: errHasBotToken,
+        hasAppToken: errHasAppToken,
+        connected: errHasBotToken && errHasAppToken,
         error: `Failed to validate bot token: ${message}`,
       };
     }
@@ -127,13 +135,17 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      const errConn = getConnectionByProvider("slack_channel");
-      const errConnected = !!(errConn && errConn.status === "active");
+      const errHasBotToken = !!getSecureKey(
+        credentialKey("slack_channel", "bot_token"),
+      );
+      const errHasAppToken = !!getSecureKey(
+        credentialKey("slack_channel", "app_token"),
+      );
       return {
         success: false,
-        hasBotToken: errConnected,
-        hasAppToken: errConnected,
-        connected: errConnected,
+        hasBotToken: errHasBotToken,
+        hasAppToken: errHasAppToken,
+        connected: errHasBotToken && errHasAppToken,
         error: "Failed to store bot token in secure storage",
       };
     }
@@ -161,13 +173,17 @@ export async function setSlackChannelConfig(
   // Validate and store app token
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
-      const errConn = getConnectionByProvider("slack_channel");
-      const errConnected = !!(errConn && errConn.status === "active");
+      const errHasBotToken = !!getSecureKey(
+        credentialKey("slack_channel", "bot_token"),
+      );
+      const errHasAppToken = !!getSecureKey(
+        credentialKey("slack_channel", "app_token"),
+      );
       return {
         success: false,
-        hasBotToken: errConnected,
-        hasAppToken: errConnected,
-        connected: errConnected,
+        hasBotToken: errHasBotToken,
+        hasAppToken: errHasAppToken,
+        connected: errHasBotToken && errHasAppToken,
         error: 'Invalid app token: must start with "xapp-"',
       };
     }
@@ -177,13 +193,17 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      const errConn = getConnectionByProvider("slack_channel");
-      const errConnected = !!(errConn && errConn.status === "active");
+      const errHasBotToken = !!getSecureKey(
+        credentialKey("slack_channel", "bot_token"),
+      );
+      const errHasAppToken = !!getSecureKey(
+        credentialKey("slack_channel", "app_token"),
+      );
       return {
         success: false,
-        hasBotToken: errConnected,
-        hasAppToken: errConnected,
-        connected: errConnected,
+        hasBotToken: errHasBotToken,
+        hasAppToken: errHasAppToken,
+        connected: errHasBotToken && errHasAppToken,
         error: "Failed to store app token in secure storage",
       };
     }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -167,7 +167,14 @@ export async function runDaemon(): Promise<void> {
     // Backfill oauth_connection rows for manual-token providers (Telegram,
     // Slack channel) that already have keychain credentials from before the
     // oauth_connection migration. Safe to call on every startup.
-    await backfillManualTokenConnections();
+    try {
+      await backfillManualTokenConnections();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Manual-token connection backfill failed — continuing startup",
+      );
+    }
     log.info("Daemon startup: DB initialized");
 
     // Expire any pending canonical guardian requests left over from before

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -55,8 +55,11 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   capabilities: new Set(["send"]),
 
   /**
-   * Custom connectivity check using the oauth_connection record as the
-   * single source of truth, consistent with integration-status.ts.
+   * Custom connectivity check using both the oauth_connection record AND
+   * actual keychain credentials. The connection row alone can become stale
+   * if clearTelegramConfig() returns early on a secure-key deletion error
+   * without removing the row. Checking both ensures we don't report
+   * Telegram as connected when secrets are missing.
    *
    * Both bot_token and webhook_secret are required — the gateway's
    * /deliver/telegram endpoint rejects requests without the webhook
@@ -64,7 +67,11 @@ export const telegramBotMessagingProvider: MessagingProvider = {
    */
   isConnected(): boolean {
     const conn = getConnectionByProvider("telegram");
-    return !!(conn && conn.status === "active");
+    return (
+      !!(conn && conn.status === "active") &&
+      getBotToken() !== undefined &&
+      !!getSecureKey(credentialKey("telegram", "webhook_secret"))
+    );
   },
 
   async testConnection(


### PR DESCRIPTION
## Summary
- Restored credential verification in Telegram adapter `isConnected()` to check both the connection row AND actual keychain credentials (`bot_token` and `webhook_secret`)
- Updated error paths in `setSlackChannelConfig` to use per-field keychain lookups instead of connection-row-based reporting, consistent with the GET handler
- Wrapped `backfillManualTokenConnections()` in try/catch in lifecycle.ts to prevent startup failures

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15742

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
