### PR TITLE
fix: preserve target contact display name during invite redemption

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
-import { findContactChannel } from "../contacts/contact-store.js";
+import { findContactChannel, getContact } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db.js";
 import {
@@ -235,6 +235,16 @@ export function redeemInvite(params: {
 
   // Fresh member creation: upsert into contacts tables and consume an invite
   // use atomically, mirroring the reactivation path above.
+  // When the invite targets a specific contact (targetMismatch path), preserve
+  // the target contact's guardian-assigned display name if it has one.
+  let freshDisplayName = displayName;
+  if (invite.contactId) {
+    const targetContact = getContact(invite.contactId);
+    if (targetContact?.displayName?.trim().length) {
+      freshDisplayName = targetContact.displayName;
+    }
+  }
+
   const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
   let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
   try {
@@ -244,7 +254,7 @@ export function redeemInvite(params: {
           sourceChannel,
           externalUserId,
           externalChatId,
-          displayName,
+          displayName: freshDisplayName,
           username,
           status: "active",
           policy: "allow",
@@ -386,9 +396,17 @@ export function redeemVoiceInviteCode(params: {
   const STALE_INVITE = Symbol("stale_invite");
   let memberId: string | undefined;
 
-  const preservedDisplayName = voiceContact?.displayName?.trim().length
+  // When the invite targets a specific contact (targetMismatch path), preserve
+  // the target contact's guardian-assigned display name if it has one.
+  let preservedDisplayName = voiceContact?.displayName?.trim().length
     ? voiceContact.displayName
     : (invite.friendName ?? undefined);
+  if (targetMismatch && invite.contactId) {
+    const targetContact = getContact(invite.contactId);
+    if (targetContact?.displayName?.trim().length) {
+      preservedDisplayName = targetContact.displayName;
+    }
+  }
 
   try {
     getSqlite()
@@ -596,6 +614,16 @@ export function redeemInviteByCode(params: {
 
   // Fresh member creation: upsert into contacts tables and consume an invite
   // use atomically.
+  // When the invite targets a specific contact (targetMismatch path), preserve
+  // the target contact's guardian-assigned display name if it has one.
+  let freshDisplayName = displayName;
+  if (invite.contactId) {
+    const targetContact = getContact(invite.contactId);
+    if (targetContact?.displayName?.trim().length) {
+      freshDisplayName = targetContact.displayName;
+    }
+  }
+
   const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
   let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
   try {
@@ -605,7 +633,7 @@ export function redeemInviteByCode(params: {
           sourceChannel,
           externalUserId,
           externalChatId,
-          displayName,
+          displayName: freshDisplayName,
           username,
           status: "active",
           policy: "allow",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-bound-invites.md.

**Gap:** Invite redemption overwrites guardian-assigned display name
**What was expected:** Target contact's existing display name (e.g. 'Mom') should be preserved during invite redemption
**What was found:** The redeemer's external display name overwrites the target contact's name in the targetMismatch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
