### PR TITLE
fix: remove dead defaultGreetings array from ChatEmptyStateView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -48,14 +48,6 @@ struct ChatEmptyStateView: View {
 
     // MARK: - Greeting Data
 
-    static let defaultGreetings = [
-        "What are we working on?",
-        "I'm here whenever you need me.",
-        "What's on your mind?",
-        "Let's make something happen.",
-        "Ready when you are.",
-    ]
-
     static let placeholderTexts = [
         "Ask me anything...",
         "Tell me what you need...",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gen-dynamic-text.md.

**Gap:** Dead defaultGreetings array in ChatEmptyStateView
**What was expected:** No dead code left behind after refactor
**What was found:** defaultGreetings array was unreferenced; fallback logic moved to ChatViewModel.fallbackGreetings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
