### PR TITLE
fix: add empty-string guard on macOS identity intro result

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -193,7 +193,7 @@ struct IdentityPanel: View {
                     guard !Task.isCancelled else { return }
                     result += delta
                 }
-                self.introText = result
+                self.introText = result.isEmpty ? nil : result
             } catch is CancellationError {
                 return
             } catch {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for gen-dynamic-text.md.

**Gap:** macOS IdentityPanel missing empty-string guard on intro result
**What was expected:** Guard against empty daemon responses like iOS does
**What was found:** introText was set unconditionally, allowing empty string to render blank text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
