### PR TITLE
fix: write browser fallback URL to stderr in oauth connect json mode

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -586,8 +586,8 @@ Examples:
                       stderr: "ignore",
                     });
                   } else {
-                    // Fallback: print URL for manual opening
-                    process.stdout.write(
+                    // Fallback: print URL for manual opening (stderr to keep --json stdout clean)
+                    process.stderr.write(
                       `Open this URL to authorize:\n\n${url}\n`,
                     );
                   }


### PR DESCRIPTION
## Summary
- When the oauth connect command runs on an unsupported platform (not macOS/Linux), the fallback 'Open this URL...' message was written to stdout, which corrupted --json output for automation consumers
- Changed the fallback branch to use process.stderr.write() instead of process.stdout.write() so JSON output remains valid

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15827

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
