### PR TITLE
fix: remove dead readinessFetchFailed code and filter extraChannels in ContactDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -47,7 +47,6 @@ struct ContactDetailView: View {
     @State private var inviteHandleInput = ""
     @State private var inviteCodeRevealed = false
     @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
-    @State private var readinessFetchFailed = false
     /// Monotonically increasing counter that correlates a verification attempt
     /// with its one-shot response / timeout so stale callbacks are ignored.
     @State private var verificationAttempt: UInt64 = 0
@@ -300,9 +299,10 @@ struct ContactDetailView: View {
         .task {
             do {
                 channelReadiness = try await daemonClient?.fetchChannelReadiness() ?? [:]
-                readinessFetchFailed = false
             } catch {
-                readinessFetchFailed = true
+                // Channel readiness fetch failed — fall back to showing only
+                // channels the contact already has configured (channelReadiness
+                // stays empty so no unconfigured channel cards appear).
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removed dead readinessFetchFailed state variable and its write sites (variable was written but never read after PR #16031)
- Cleaned up the .task catch block with meaningful comment explaining the graceful degradation behavior

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
