### PR TITLE
fix: harden feature-flag registry sync for Docker builds and CI triggers

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - 'assistant/**'
+      - 'meta/feature-flags/**'
       - '.github/workflows/ci-main-assistant.yaml'
 
 jobs:

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - 'gateway/**'
+      - 'meta/feature-flags/**'
       - '.github/workflows/ci-main-gateway.yaml'
 
 jobs:

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'assistant/**'
       - 'scripts/skills/**'
+      - 'meta/feature-flags/**'
       - '.github/workflows/pr-assistant.yaml'
 
 concurrency:

--- a/.github/workflows/pr-gateway.yaml
+++ b/.github/workflows/pr-gateway.yaml
@@ -5,6 +5,7 @@ on:
     types: [labeled, synchronize, opened, reopened]
     paths:
       - 'gateway/**'
+      - 'meta/feature-flags/**'
       - '.github/workflows/pr-gateway.yaml'
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,9 @@ jobs:
         id: image
         run: echo "name=${{ secrets.GCP_REGISTRY_HOST }}/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.ASSISTANT_IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
+      - name: Sync feature flag registry for Docker context
+        run: cp meta/feature-flags/feature-flag-registry.json assistant/src/config/feature-flag-registry.json
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -22,7 +22,7 @@
     "test:stable": "EXCLUDE_EXPERIMENTAL=true bash scripts/test.sh",
     "test:bench": "find src/__tests__ -maxdepth 1 -type f -name '*.benchmark.test.ts' -print0 | xargs -0 -P 1 -I {} bun test {}",
     "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh",
-    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && (bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
+    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",

--- a/assistant/src/config/__tests__/feature-flag-registry-bundled.test.ts
+++ b/assistant/src/config/__tests__/feature-flag-registry-bundled.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Smoke test: verifies that the bundled feature-flag-registry.json exists
+ * in the assistant source tree and is a valid, non-empty registry.
+ *
+ * The bundled copy is created by `meta/feature-flags/sync-bundled-copies.ts`
+ * (run via postinstall or CI sync step). This test catches cases where the
+ * sync was skipped — e.g. Docker builds that forget to copy the registry.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const BUNDLED_PATH = join(
+  import.meta.dirname ?? __dirname,
+  "..",
+  "feature-flag-registry.json",
+);
+
+describe("bundled feature-flag-registry.json", () => {
+  test("file exists", () => {
+    expect(
+      existsSync(BUNDLED_PATH),
+      `Expected bundled registry at ${BUNDLED_PATH}. Run: bun run meta/feature-flags/sync-bundled-copies.ts`,
+    ).toBe(true);
+  });
+
+  test("file is non-empty and valid JSON", () => {
+    const stat = statSync(BUNDLED_PATH);
+    expect(stat.size).toBeGreaterThan(0);
+
+    const raw = readFileSync(BUNDLED_PATH, "utf-8");
+    const registry = JSON.parse(raw);
+
+    expect(registry.version).toBe(1);
+    expect(Array.isArray(registry.flags)).toBe(true);
+    expect(registry.flags.length).toBeGreaterThan(0);
+  });
+});

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
     "prebuild": "cd .. && bun run meta/feature-flags/sync-bundled-copies.ts",
-    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && (bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
+    "postinstall": "cd .. && (git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true) && ([ -f meta/feature-flags/sync-bundled-copies.ts ] && bun run meta/feature-flags/sync-bundled-copies.ts 2>/dev/null || true)"
   },
   "dependencies": {
     "file-type": "^21.3.0",


### PR DESCRIPTION
## Summary
- Guard postinstall sync scripts in assistant/package.json and gateway/package.json to handle missing meta/ directory in Docker builds
- Add meta/feature-flags/** to CI path triggers in all 4 workflow files
- Add feature-flag registry sync step for assistant Docker image in release workflow (gateway already had it)
- Add smoke test asserting bundled registry file exists and is non-empty

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15854

🤖 Generated with [Claude Code](https://claude.com/claude-code)