### PR TITLE
fix: don't set self-referential initiatedFromConversationId on invite calls

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -1088,7 +1088,6 @@ export async function startInviteCall(
       callMode: "invite",
       inviteFriendName: friendName,
       inviteGuardianName: guardianName,
-      initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
 


### PR DESCRIPTION
## Summary
- Remove self-referential initiatedFromConversationId from invite call sessions
- Invite calls don't originate from a user chat thread, so pointer messages (call completed/failed, verification codes) should be skipped, not posted into the call's own minimal conversation
- Follows up on PR #16053 review feedback

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16053

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
