### PR TITLE
fix: align contactId error message with SKILL.md and existing pattern

### DIFF
--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -166,7 +166,7 @@ export async function createIngressInvite(params: {
   }
 
   if (!params.contactId) {
-    return { ok: false, error: "contactId is required" };
+    return { ok: false, error: "contactId is required for create" };
   }
 
   // For voice invites: generate a one-time numeric code, hash it, and pass


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-bound-invites.md.

**Gap:** Error message mismatch
**What was expected:** Error message should match SKILL.md and follow the existing sourceChannel pattern
**What was found:** Service returned 'contactId is required' instead of 'contactId is required for create'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
