### PR TITLE
fix: add missing invites/call schema entry and update telegram /start tests

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -246,7 +246,7 @@ describe("telegram webhook handler: gatewayInternalBaseUrl", () => {
 });
 
 describe("telegram webhook handler: /new rejection", () => {
-  test("/start forwards command intent metadata, does not reset conversation, and sends start acknowledgement", async () => {
+  test("/start with payload forwards command intent metadata, does not reset conversation, and suppresses ACK", async () => {
     const config = makeConfig({
       routingEntries: [
         { type: "conversation_id", key: "12345", assistantId: "assistant-a" },
@@ -275,11 +275,11 @@ describe("telegram webhook handler: /new rejection", () => {
     );
     expect(resetCall).toBeUndefined();
 
+    // ACK is suppressed when /start has a payload
     const sendMessageCall = fetchCalls.find((c) =>
       c.url.includes("/sendMessage"),
     );
-    expect(sendMessageCall).toBeDefined();
-    expect((sendMessageCall!.body as any).text).toContain("Starting up");
+    expect(sendMessageCall).toBeUndefined();
   });
 
   test("/start with routing rejection sends setup notice and does not forward", async () => {

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -239,7 +239,7 @@ describe("telegram-webhook callback query acknowledgment", () => {
     expect(sendTelegramReplyMock).not.toHaveBeenCalled();
   });
 
-  it("forwards /start as channel command-intent metadata and sends start acknowledgement", async () => {
+  it("forwards /start with payload as channel command-intent metadata without sending ACK", async () => {
     const { handler } = createTelegramWebhookHandler(baseConfig, makeCaches());
     const body = JSON.stringify({
       update_id: 314,
@@ -263,14 +263,8 @@ describe("telegram-webhook callback query acknowledgment", () => {
       type: "start",
       payload: "ref-123",
     });
-    expect(sendTelegramReplyMock).toHaveBeenCalledTimes(1);
-    const sendArgs = sendTelegramReplyMock.mock.calls[0] as unknown as [
-      GatewayConfig,
-      string,
-      string,
-    ];
-    expect(sendArgs[1]).toBe("42");
-    expect(sendArgs[2]).toContain("Starting up");
+    // ACK is suppressed when /start has a payload
+    expect(sendTelegramReplyMock).not.toHaveBeenCalled();
   });
 
   it("does not call answerCallbackQuery for regular text messages", async () => {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1145,6 +1145,41 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/contacts/invites/{inviteId}/call": {
+        post: {
+          summary: "Call a contacts invite",
+          description:
+            "Authenticated gateway endpoint that initiates a call for a contacts invite via the assistant runtime.",
+          operationId: "contactsInvitesCallPost",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "inviteId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Invite call initiated" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "404": { description: "Invite not found" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/contacts/invites/{inviteId}": {
         delete: {
           summary: "Revoke contacts invite",


### PR DESCRIPTION
## Summary
- Add missing OpenAPI schema entry for `POST /v1/contacts/invites/{inviteId}/call` to fix route-schema-guard test
- Update two telegram webhook tests to reflect that `/start` ACK is now suppressed when a payload is present (matching behavior from recent commit)

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23064516878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
