### PR TITLE
fix: use stored clientSecretCredentialPath and reorder insert-before-secret in oauth store

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -255,13 +255,6 @@ export async function upsertApp(
   const id = uuid();
   const credPath = clientSecretCredentialPath ?? defaultCredPath(id);
 
-  if (clientSecretValue) {
-    const stored = await setSecureKeyAsync(credPath, clientSecretValue);
-    if (!stored) {
-      throw new Error("Failed to store client_secret in secure storage");
-    }
-  }
-
   const row = {
     id,
     providerKey,
@@ -271,7 +264,16 @@ export async function upsertApp(
     updatedAt: now,
   };
 
+  // Insert the DB row first so that a failed insert doesn't leave an
+  // orphaned secret in secure storage.
   db.insert(oauthApps).values(row).run();
+
+  if (clientSecretValue) {
+    const stored = await setSecureKeyAsync(credPath, clientSecretValue);
+    if (!stored) {
+      throw new Error("Failed to store client_secret in secure storage");
+    }
+  }
 
   return row;
 }


### PR DESCRIPTION
## Summary
- Updated 5 hardcoded oauth_app/${id}/client_secret lookups to use the stored clientSecretCredentialPath from the app row (token-manager.ts, settings-routes.ts x2, connections.ts, vault.ts)
- Reordered upsertApp to do DB insert before secret storage, preventing orphaned secrets on insert failure

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
