### PR TITLE
fix: enforce blocked-user check regardless of targetMismatch

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -152,11 +152,7 @@ export function redeemInvite(params: {
   // Blocked members cannot bypass the guardian's explicit block via invite
   // links. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (
-    existingChannel &&
-    existingChannel.status === "blocked" &&
-    !targetMismatch
-  ) {
+  if (existingChannel && existingChannel.status === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 
@@ -384,11 +380,7 @@ export function redeemVoiceInviteCode(params: {
   }
 
   // Blocked members cannot bypass the guardian's explicit block
-  if (
-    existingVoiceChannel &&
-    existingVoiceChannel.status === "blocked" &&
-    !targetMismatch
-  ) {
+  if (existingVoiceChannel && existingVoiceChannel.status === "blocked") {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
@@ -539,11 +531,7 @@ export function redeemInviteByCode(params: {
   // Blocked members cannot bypass the guardian's explicit block via invite
   // codes. Return the same generic failure as an invalid token to avoid
   // leaking membership status to the caller.
-  if (
-    existingChannel &&
-    existingChannel.status === "blocked" &&
-    !targetMismatch
-  ) {
+  if (existingChannel && existingChannel.status === "blocked") {
     return { ok: false, reason: "invalid_token" };
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-bound-invites.md.

**Gap:** Blocked user bypass via targetMismatch
**What was expected:** Blocked identities should never be reactivated via any invite
**What was found:** The blocked check was skipped when targetMismatch was true, allowing blocked users to circumvent their block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
