### PR TITLE
fix: use correct credential key format in OAuth skill credential paths

### DIFF
--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -142,7 +142,7 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>:client_secret"
+    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "credential/<provider-key>/client_secret"
 ```
 
 ---

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -149,7 +149,7 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>:client_secret"
+    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "credential/<provider-key>/client_secret"
 ```
 
 ```

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -152,7 +152,7 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "credential/integration:slack/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."

--- a/skills/slack-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/slack-oauth-setup/references/path-b-manual-setup.md
@@ -117,7 +117,7 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "integration:slack:client_secret"
+    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "credential/integration:slack/client_secret"
 ```
 
 ```

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -165,7 +165,7 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "credential/integration:twitter/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -112,7 +112,7 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "integration:twitter:client_secret"
+    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "credential/integration:twitter/client_secret"
 ```
 
 ```


### PR DESCRIPTION
## Summary
- Fix `--client-secret-credential-path` in all OAuth skill docs to use `credential/<provider-key>/client_secret` format matching `credentialKey()` output
- Previously used `<provider-key>:client_secret` (colon separator, missing `credential/` prefix) which caused `upsertApp` to throw "No secret found at credential path"
- Fixes collaborative-oauth-flow, oauth-setup, slack-oauth-setup, and twitter-oauth-setup skills (both SKILL.md and path-b references)

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
