### PR TITLE
fix: use real contact IDs in invite test files to satisfy FK constraint

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -85,7 +85,10 @@ mock.module("../runtime/approval-message-composer.js", () => ({
   composeApprovalMessageGenerative: async () => "mock generative message",
 }));
 
-import { findContactChannel } from "../contacts/contact-store.js";
+import {
+  findContactChannel,
+  upsertContact,
+} from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
@@ -105,6 +108,11 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Test Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
+}
 
 const TEST_BEARER_TOKEN = "test-token";
 let msgCounter = 0;
@@ -178,7 +186,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with valid invite token becomes active member without guardian approval", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 5,
     });
 
@@ -232,7 +240,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with expired token gets appropriate message", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 1,
       expiresInMs: -1, // already expired
     });
@@ -254,7 +262,7 @@ describe("inbound invite redemption intercept", () => {
   test("non-member with revoked token gets refusal text", async () => {
     const { rawToken, invite } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 5,
     });
     revokeInvite(invite.id);
@@ -295,7 +303,7 @@ describe("inbound invite redemption intercept", () => {
   test("duplicate Telegram webhook deliveries do not double-redeem", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 5,
     });
 
@@ -359,7 +367,7 @@ describe("inbound invite redemption intercept", () => {
     // Create an invite for voice, but try to redeem via Telegram
     const { rawToken } = createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 5,
     });
 
@@ -380,7 +388,7 @@ describe("inbound invite redemption intercept", () => {
   test("already-active member with invite token gets acknowledgement", async () => {
     const { rawToken } = createInvite({
       sourceChannel: "telegram",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 5,
     });
 
@@ -406,12 +414,8 @@ describe("inbound invite redemption intercept", () => {
   });
 
   test("reactivation via invite preserves existing guardian-managed member display name", async () => {
-    const { rawToken } = createInvite({
-      sourceChannel: "telegram",
-      contactId: "test-contact-id",
-      maxUses: 5,
-    });
-
+    // Pre-create a revoked member named "Jeff" — the invite should preserve
+    // that guardian-assigned name rather than overwriting with the Telegram name.
     upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-invite-123",
@@ -419,6 +423,21 @@ describe("inbound invite redemption intercept", () => {
       status: "revoked",
       policy: "allow",
       displayName: "Jeff",
+    });
+
+    // Look up the contact that upsertContactChannel created so we can use
+    // its ID as the invite's contactId (satisfies the FK constraint).
+    const existing = findContactChannel({
+      channelType: "telegram",
+      externalUserId: "user-invite-123",
+      externalChatId: "chat-invite-test",
+    });
+    const targetContactId = existing!.contact.id;
+
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      contactId: targetContactId,
+      maxUses: 5,
     });
 
     const req = buildInviteRequest(rawToken, {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -189,6 +189,7 @@ import {
   RelayConnection,
 } from "../calls/relay-server.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
+import { upsertContact } from "../contacts/contact-store.js";
 import {
   createGuardianBinding,
   upsertContactChannel,
@@ -287,6 +288,11 @@ function resetTables() {
     "contacts",
   );
   ensuredConvIds = new Set();
+}
+
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Test Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
 }
 
 function addTrustedVoiceContact(phoneNumber: string): void {
@@ -2053,7 +2059,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 1,
       expectedExternalUserId: "+15558887777",
       voiceCodeHash: codeHash,
@@ -2127,7 +2133,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 1,
       expectedExternalUserId: "+15558886666",
       voiceCodeHash: codeHash,
@@ -4015,7 +4021,7 @@ describe("relay-server", () => {
     const codeHash = hashVoiceCode(code);
     createInvite({
       sourceChannel: "phone",
-      contactId: "test-contact-id",
+      contactId: createTargetContact(),
       maxUses: 1,
       expectedExternalUserId: "+15557776666",
       voiceCodeHash: codeHash,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-bound-invites.md.

**Gap:** Test FK failures with hardcoded test-contact-id
**What was expected:** All tests pass with real contact IDs satisfying the FK constraint
**What was found:** inbound-invite-redemption.test.ts and relay-server.test.ts used fake contact IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
