### PR TITLE
fix: add secret-ingress check to /v1/btw route

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -54,6 +54,17 @@ mock.module("../daemon/session-tool-setup.js", () => ({
   buildToolDefinitions: () => MOCK_TOOLS,
 }));
 
+const mockCheckIngressForSecrets = mock((content: string) => ({
+  blocked: false,
+  userNotice: "",
+  detectedTypes: [] as string[],
+  normalizedContent: content,
+}));
+
+mock.module("../security/secret-ingress.js", () => ({
+  checkIngressForSecrets: mockCheckIngressForSecrets,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -216,6 +227,34 @@ describe("POST /v1/btw", () => {
     };
     expect(body.error.code).toBe("BAD_REQUEST");
     expect(body.error.message).toContain("content");
+  });
+
+  test("returns 422 when content includes a blocked secret", async () => {
+    mockCheckIngressForSecrets.mockReturnValueOnce({
+      blocked: true,
+      userNotice: "Secret detected",
+      detectedTypes: ["api_key"],
+      normalizedContent: "sk-test-123",
+    });
+
+    const provider = makeMockProvider();
+    const session = makeMockSession(provider);
+    const res = await callHandler(
+      { conversationKey: "key", content: "sk-test-123" },
+      { sendMessageDeps: makeSendMessageDeps(session) },
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as {
+      accepted: boolean;
+      error: string;
+      message: string;
+      detectedTypes: string[];
+    };
+    expect(body.accepted).toBe(false);
+    expect(body.error).toBe("secret_blocked");
+    expect(body.detectedTypes).toEqual(["api_key"]);
+    expect(provider.sendMessage).not.toHaveBeenCalled();
   });
 
   // -- Service unavailability (503) --

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -14,6 +14,7 @@ import {
   createTimeout,
   userMessage,
 } from "../../providers/provider-send-message.js";
+import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
@@ -53,6 +54,24 @@ async function handleBtw(
     );
   }
 
+  const trimmedContent = content.trim();
+  const ingressCheck = checkIngressForSecrets(trimmedContent);
+  if (ingressCheck.blocked) {
+    log.warn(
+      { detectedTypes: ingressCheck.detectedTypes },
+      "Blocked /v1/btw message containing secrets",
+    );
+    return Response.json(
+      {
+        accepted: false,
+        error: "secret_blocked",
+        message: ingressCheck.userNotice,
+        detectedTypes: ingressCheck.detectedTypes,
+      },
+      { status: 422 },
+    );
+  }
+
   // Look up an existing conversation — never create one.  BTW is ephemeral
   // (the file header promises "No messages are persisted"), so we must not
   // call getOrCreateConversation which would insert a DB row.  When no
@@ -63,7 +82,7 @@ async function handleBtw(
   const sessionId = mapping?.conversationId ?? conversationKey;
   const session = await deps.sendMessageDeps.getOrCreateSession(sessionId);
 
-  const messages = [...session.getMessages(), userMessage(content.trim())];
+  const messages = [...session.getMessages(), userMessage(trimmedContent)];
   const tools = buildToolDefinitions();
   const { signal: timeoutSignal, cleanup: cleanupTimeout } =
     createTimeout(30_000);


### PR DESCRIPTION
## Summary

- The `/v1/btw` side-chain endpoint was calling `session.provider.sendMessage` without running `checkIngressForSecrets`, unlike `/v1/messages` which enforces this check
- Add `checkIngressForSecrets` call in `btw-routes.ts` before building the message list; return 422 with `secret_blocked` error if blocked
- Add test coverage for the blocked-secret case in `btw-routes.test.ts`

Codex finding: https://chatgpt.com/codex/security/findings/8beadaba3af48191bb64d9647ba5a5c8?sev=critical%2Chigh%2Cmedium%2Clow

## Original prompt
--safe Fix /v1/btw route to run secret-ingress check before forwarding to provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
