### PR TITLE
fix: throw on 401 for token refresh retry and add timeout in oauth ping

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -327,14 +327,35 @@ Examples:
 
           const pingUrl = provider.pingUrl;
 
+          const PING_TIMEOUT_MS = 15_000;
+
           const result = await withValidToken(
             providerKey,
             async (token) => {
-              const res = await fetch(pingUrl, {
-                method: "GET",
-                headers: { Authorization: `Bearer ${token}` },
-              });
-              return { status: res.status, ok: res.ok };
+              const controller = new AbortController();
+              const timer = setTimeout(
+                () => controller.abort(),
+                PING_TIMEOUT_MS,
+              );
+              try {
+                const res = await fetch(pingUrl, {
+                  method: "GET",
+                  headers: { Authorization: `Bearer ${token}` },
+                  signal: controller.signal,
+                });
+
+                if (res.status === 401) {
+                  const err = new Error(
+                    `Ping returned HTTP 401 from ${pingUrl}`,
+                  );
+                  (err as unknown as { status: number }).status = 401;
+                  throw err;
+                }
+
+                return { status: res.status, ok: res.ok };
+              } finally {
+                clearTimeout(timer);
+              }
             },
             opts.clientId,
           );


### PR DESCRIPTION
## Summary
- Throw an error with status 401 when ping endpoint returns HTTP 401, enabling withValidToken's refresh-and-retry path
- Add AbortController with 15s timeout to the ping fetch call to prevent indefinite hangs on stalled endpoints

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/15845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
