### PR TITLE
fix: add fallback when invite has no displayable fields

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -692,6 +692,11 @@ struct ContactDetailView: View {
                     }
                 }
             }
+        } else {
+            // Fallback: invite was created but no displayable fields are available
+            Text("Invite created but no details available")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a fallback else branch in inviteResultDisplay(for:) so users always see feedback after an invite is created, even when inviteCode, voiceCode, shareUrl, and token are all nil
- Addresses review feedback from PR #16054 where making token optional introduced a silent empty state

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
