### PR TITLE
fix: cache avatar transparency before animated VAvatarImage usage

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ComingAliveOverlay.swift
@@ -10,6 +10,9 @@ struct ComingAliveOverlay: View {
 
     @State private var appearance = AvatarAppearanceManager.shared
 
+    // Precomputed transparency flag — avoids expensive bitmap analysis during animation frames.
+    @State private var avatarIsTransparent = false
+
     // Animation state
     @State private var avatarScale: CGFloat = 0.0
     @State private var avatarOpacity: Double = 0.0
@@ -45,13 +48,14 @@ struct ComingAliveOverlay: View {
                 .scaleEffect(glowScale)
                 .allowsHitTesting(false)
 
-            // Avatar image
-            VAvatarImage(image: appearance.fullAvatarImage, size: 200, showBorder: false)
+            // Avatar image — uses precomputed transparency to keep the view body lightweight.
+            VAvatarImage(image: appearance.fullAvatarImage, size: 200, isTransparent: avatarIsTransparent, showBorder: false)
                 .shadow(color: Meadow.avatarGradientStart.opacity(0.3), radius: 12)
                 .scaleEffect(avatarScale)
                 .opacity(avatarOpacity)
         }
         .onAppear {
+            avatarIsTransparent = VAvatarImage.imageHasTransparency(appearance.fullAvatarImage)
             startAnimation()
         }
         .accessibilityHidden(true)

--- a/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AvatarRevealStepView.swift
@@ -13,6 +13,8 @@ struct AvatarRevealStepView: View {
     @State private var isGenerating = true
     @State private var generationFailed = false
     @State private var avatarImage: NSImage?
+    // Precomputed transparency flag — avoids expensive bitmap analysis during animation frames.
+    @State private var avatarIsTransparent = false
     @State private var showAvatar = false
     @State private var showText = false
     @State private var showButton = false
@@ -128,7 +130,7 @@ struct AvatarRevealStepView: View {
     private var revealedAvatar: some View {
         Group {
             if let image = avatarImage {
-                VAvatarImage(image: image, size: 160, showBorder: false)
+                VAvatarImage(image: image, size: 160, isTransparent: avatarIsTransparent, showBorder: false)
                     .shadow(color: VColor.primaryBase.opacity(0.3), radius: 12, y: 4)
                     .scaleEffect(showAvatar ? 1.0 : 0.8)
                     .opacity(showAvatar ? 1 : 0)
@@ -154,10 +156,12 @@ struct AvatarRevealStepView: View {
                     // Connection failed — show fallback avatar immediately
                     // instead of falling through to the generate request.
                     await MainActor.run {
-                        avatarImage = AvatarAppearanceManager.buildInitialLetterAvatar(
+                        let fallback = AvatarAppearanceManager.buildInitialLetterAvatar(
                             name: assistantName,
                             size: 160
                         )
+                        avatarImage = fallback
+                        avatarIsTransparent = VAvatarImage.imageHasTransparency(fallback)
                         generationFailed = true
 
                         withAnimation(.spring(duration: 0.6, bounce: 0.2)) {
@@ -228,14 +232,18 @@ struct AvatarRevealStepView: View {
                 if success {
                     // Reload avatar from disk
                     AvatarAppearanceManager.shared.reloadAvatar()
-                    avatarImage = AvatarAppearanceManager.shared.fullAvatarImage
+                    let image = AvatarAppearanceManager.shared.fullAvatarImage
+                    avatarImage = image
+                    avatarIsTransparent = VAvatarImage.imageHasTransparency(image)
                     generationFailed = false
                 } else {
                     // Use fallback initial-letter avatar
-                    avatarImage = AvatarAppearanceManager.buildInitialLetterAvatar(
+                    let fallback = AvatarAppearanceManager.buildInitialLetterAvatar(
                         name: assistantName,
                         size: 160
                     )
+                    avatarImage = fallback
+                    avatarIsTransparent = VAvatarImage.imageHasTransparency(fallback)
                     generationFailed = true
                 }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/Hatch/CreatureView.swift
@@ -8,6 +8,9 @@ struct CreatureView: View {
     var animated: Bool = true
     @State private var appearance = AvatarAppearanceManager.shared
 
+    // Precomputed transparency flag — avoids expensive bitmap analysis during animation frames.
+    @State private var avatarIsTransparent = false
+
     @State private var appeared = false
     @State private var bounceOffset: CGFloat = 0
     @State private var breatheScaleY: CGFloat = 1.0
@@ -21,6 +24,7 @@ struct CreatureView: View {
                 .scaleEffect(appeared ? 1.0 : 0.0)
                 .opacity(appeared ? 1.0 : 0.0)
                 .onAppear {
+                    avatarIsTransparent = VAvatarImage.imageHasTransparency(appearance.fullAvatarImage)
                     if animated {
                         withAnimation(.spring(response: 0.6, dampingFraction: 0.5, blendDuration: 0)) {
                             appeared = true
@@ -50,7 +54,7 @@ struct CreatureView: View {
     }
 
     private var avatarImage: some View {
-        VAvatarImage(image: appearance.fullAvatarImage, size: 200, showBorder: false)
+        VAvatarImage(image: appearance.fullAvatarImage, size: 200, isTransparent: avatarIsTransparent, showBorder: false)
             .shadow(radius: 8)
     }
 }

--- a/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
+++ b/clients/shared/DesignSystem/Core/Display/VAvatarImage.swift
@@ -25,6 +25,18 @@ public struct VAvatarImage: View {
         self.isTransparent = Self.imageHasTransparency(image)
     }
 
+    /// Initializer that accepts a precomputed transparency flag, avoiding the expensive
+    /// bitmap analysis in `imageHasTransparency`. Use this in animated render paths
+    /// where the view is rebuilt frequently (e.g. scale/opacity animations) and the
+    /// underlying image doesn't change between frames.
+    public init(image: NSImage, size: CGFloat, isTransparent: Bool, borderColor: Color = VColor.borderBase, showBorder: Bool = true) {
+        self.image = image
+        self.size = size
+        self.borderColor = borderColor
+        self.showBorder = showBorder
+        self.isTransparent = isTransparent
+    }
+
     public var body: some View {
         Image(nsImage: image)
             .interpolation(.none)
@@ -42,7 +54,9 @@ public struct VAvatarImage: View {
     }
 
     /// Detect whether an NSImage contains transparent pixels by sampling its bitmap.
-    private static func imageHasTransparency(_ nsImage: NSImage) -> Bool {
+    /// Public so callers in animated render paths can precompute the result once
+    /// (e.g. in `@State` + `.task {}`) and pass it to the `isTransparent:` initializer.
+    public static func imageHasTransparency(_ nsImage: NSImage) -> Bool {
         guard let tiffData = nsImage.tiffRepresentation,
               let bitmap = NSBitmapImageRep(data: tiffData) else {
             return false


### PR DESCRIPTION
## Summary
- Add a precomputed-transparency initializer to VAvatarImage that skips expensive bitmap analysis
- Make imageHasTransparency public so animated views can precompute the result once in onAppear
- Update ComingAliveOverlay, CreatureView, and AvatarRevealStepView to precompute transparency outside the render path

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16084

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
