### PR TITLE
fix: reject unknown client IDs in oauth connect and add missing getConnection mock

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -554,6 +554,14 @@ Examples:
             if (!clientId) clientId = dbApp.clientId;
             const storedSecret = getSecureKey(dbApp.clientSecretCredentialPath);
             if (storedSecret) clientSecret = storedSecret;
+          } else if (opts.clientId) {
+            // --client-id was explicitly provided but no matching app exists
+            writeOutput(cmd, {
+              ok: false,
+              error: `No registered app found for "${resolvedServiceKey}" with client ID "${opts.clientId}". Register it first with 'assistant oauth apps upsert --client-id ${opts.clientId}'.`,
+            });
+            process.exitCode = 1;
+            return;
           }
 
           // c. Validate client_id

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -100,6 +100,12 @@ const mockProviders = new Map<
 
 mock.module("./oauth-store.js", () => ({
   getConnectionByProvider: (service: string) => mockConnections.get(service),
+  getConnection: (id: string) => {
+    for (const conn of mockConnections.values()) {
+      if (conn.id === id) return conn;
+    }
+    return undefined;
+  },
   getApp: (id: string) => mockApps.get(id),
   getProvider: (key: string) => mockProviders.get(key),
   updateConnection: () => {},


### PR DESCRIPTION
## Summary
- When --client-id is provided but no matching DB app is found, now throws an error instead of silently falling through with an arbitrary client ID
- Added missing getConnection mock to byo-connection.test.ts to prevent TypeError when refresh path calls getConnection(connId)

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16030

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
