### PR TITLE
fix: add VoiceOver hint for unconfigured channel invite button

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -284,6 +284,7 @@ struct ContactDetailView: View {
                                         createInviteForChannel(type: type)
                                     }
                                 }
+                                .accessibilityHint("\(channelLabel(for: type)) is not connected for this contact")
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Add `.accessibilityHint` to the Invite button on unconfigured channel rows so VoiceOver users get an explicit cue that the channel is not connected for this contact
- Addresses the Devin review feedback on #16067 about accessibility impact of removing the "Not set up" visual label
- The hint reads e.g. "Telegram is not connected for this contact" — descriptive without the misleading connotation of the old label

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16067

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
