### PR TITLE
fix(avatar): first cycle click now lands on first enum value instead of skipping it

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -195,14 +195,6 @@ struct AvatarManagementSheet: View {
         return all[(idx - 1 + all.count) % all.count]
     }
 
-    private func ensureDraftsInitialized() {
-        if draftBody == nil || draftEyes == nil || draftColor == nil {
-            if draftBody == nil { draftBody = AvatarBodyShape.allCases.first }
-            if draftEyes == nil { draftEyes = AvatarEyeStyle.allCases.first }
-            if draftColor == nil { draftColor = AvatarColor.allCases.first }
-        }
-    }
-
     // MARK: - Cycle Controls
 
     @ViewBuilder
@@ -211,13 +203,15 @@ struct AvatarManagementSheet: View {
             cycleRow(
                 label: "Body",
                 onLeft: {
-                    ensureDraftsInitialized()
                     draftBody = cycleBackward(draftBody)
+                    if draftEyes == nil { draftEyes = AvatarEyeStyle.allCases.first }
+                    if draftColor == nil { draftColor = AvatarColor.allCases.first }
                     renderDraft()
                 },
                 onRight: {
-                    ensureDraftsInitialized()
                     draftBody = cycleForward(draftBody)
+                    if draftEyes == nil { draftEyes = AvatarEyeStyle.allCases.first }
+                    if draftColor == nil { draftColor = AvatarColor.allCases.first }
                     renderDraft()
                 }
             ) {
@@ -231,13 +225,15 @@ struct AvatarManagementSheet: View {
             cycleRow(
                 label: "Eyes",
                 onLeft: {
-                    ensureDraftsInitialized()
                     draftEyes = cycleBackward(draftEyes)
+                    if draftBody == nil { draftBody = AvatarBodyShape.allCases.first }
+                    if draftColor == nil { draftColor = AvatarColor.allCases.first }
                     renderDraft()
                 },
                 onRight: {
-                    ensureDraftsInitialized()
                     draftEyes = cycleForward(draftEyes)
+                    if draftBody == nil { draftBody = AvatarBodyShape.allCases.first }
+                    if draftColor == nil { draftColor = AvatarColor.allCases.first }
                     renderDraft()
                 }
             ) {
@@ -251,13 +247,15 @@ struct AvatarManagementSheet: View {
             cycleRow(
                 label: "Color",
                 onLeft: {
-                    ensureDraftsInitialized()
                     draftColor = cycleBackward(draftColor)
+                    if draftBody == nil { draftBody = AvatarBodyShape.allCases.first }
+                    if draftEyes == nil { draftEyes = AvatarEyeStyle.allCases.first }
                     renderDraft()
                 },
                 onRight: {
-                    ensureDraftsInitialized()
                     draftColor = cycleForward(draftColor)
+                    if draftBody == nil { draftBody = AvatarBodyShape.allCases.first }
+                    if draftEyes == nil { draftEyes = AvatarEyeStyle.allCases.first }
                     renderDraft()
                 }
             ) {


### PR DESCRIPTION
## Summary
- Remove `ensureDraftsInitialized()` which was setting draft properties to `.first` before the cycle function ran, causing the first forward-click to skip the first enum value
- Cycle the target property first (which handles `nil` by returning the first element), then nil-check and initialize the other two properties
- Applies the fix to all six closures (Body/Eyes/Color x forward/backward)

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
