### PR TITLE
fix: update assistant tests for contactId, OAuth flow, and doctor.ts allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -236,6 +236,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/oauth-store.ts", // OAuth provider disconnect (delete stored tokens)
       "cli/commands/oauth/connections.ts", // CLI OAuth connection delete (legacy credential cleanup)
       "oauth/manual-token-connection.ts", // manual-token provider backfill (keychain credential existence check)
+      "cli/commands/doctor.ts", // CLI diagnostic API key verification via secure storage
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -52,6 +52,7 @@ mock.module("../calls/call-domain.js", () => ({
   startInviteCall: async () => mockStartInviteCallResult,
 }));
 
+import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   handleCreateInvite,
@@ -62,6 +63,11 @@ import {
 } from "../runtime/routes/invite-routes.js";
 
 initializeDb();
+
+/** Create a throwaway contact and return its ID, for use as the invite's contactId. */
+function createTargetContact(displayName = "Test Contact"): string {
+  return upsertContact({ displayName, role: "contact" }).id;
+}
 
 afterAll(() => {
   resetDb();
@@ -91,6 +97,7 @@ describe("ingress invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "telegram",
+        contactId: createTargetContact(),
         note: "Test invite",
         maxUses: 5,
       }),
@@ -120,6 +127,7 @@ describe("ingress invite HTTP routes", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "telegram",
+          contactId: createTargetContact(),
           note: "Share link test",
         }),
       });
@@ -163,14 +171,20 @@ describe("ingress invite HTTP routes", () => {
       new Request("http://localhost/v1/contacts/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceChannel: "telegram" }),
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+          contactId: createTargetContact(),
+        }),
       }),
     );
     await handleCreateInvite(
       new Request("http://localhost/v1/contacts/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceChannel: "telegram" }),
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+          contactId: createTargetContact(),
+        }),
       }),
     );
 
@@ -189,7 +203,10 @@ describe("ingress invite HTTP routes", () => {
       new Request("http://localhost/v1/contacts/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceChannel: "telegram" }),
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+          contactId: createTargetContact(),
+        }),
       }),
     );
     const created = (await createRes.json()) as { invite: { id: string } };
@@ -214,7 +231,11 @@ describe("ingress invite HTTP routes", () => {
       new Request("http://localhost/v1/contacts/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceChannel: "telegram", maxUses: 1 }),
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+          contactId: createTargetContact(),
+          maxUses: 1,
+        }),
       }),
     );
     const created = (await createRes.json()) as { invite: { token: string } };
@@ -282,7 +303,10 @@ describe("ingress service shared logic", () => {
       new Request("http://localhost/v1/contacts/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceChannel: "telegram" }),
+        body: JSON.stringify({
+          sourceChannel: "telegram",
+          contactId: createTargetContact(),
+        }),
       }),
     );
     const created = (await createRes.json()) as {
@@ -312,6 +336,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         friendName: "Alice",
         guardianName: "Bob",
@@ -348,6 +373,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         friendName: "Alice",
         guardianName: "Bob",
       }),
@@ -367,6 +393,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "not-a-phone-number",
         friendName: "Alice",
         guardianName: "Bob",
@@ -387,6 +414,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         guardianName: "Bob",
       }),
@@ -406,6 +434,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         friendName: "Alice",
       }),
@@ -425,6 +454,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         friendName: "Alice",
         guardianName: "Bob",
@@ -448,6 +478,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         friendName: "Alice",
         guardianName: "Bob",
@@ -472,6 +503,7 @@ describe("voice invite HTTP routes", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "phone",
+          contactId: createTargetContact(),
           expectedExternalUserId: "+15551234567",
           friendName: "Alice",
           guardianName: "Bob",
@@ -529,6 +561,7 @@ describe("voice invite HTTP routes", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "phone",
+          contactId: createTargetContact(),
           expectedExternalUserId: "+15551234567",
           friendName: "Alice",
           guardianName: "Bob",
@@ -559,6 +592,7 @@ describe("voice invite HTTP routes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         sourceChannel: "phone",
+        contactId: createTargetContact(),
         expectedExternalUserId: "+15551234567",
         friendName: "Alice",
         guardianName: "Bob",
@@ -594,6 +628,7 @@ describe("POST /v1/contacts/invites/:id/call", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "phone",
+          contactId: createTargetContact(),
           expectedExternalUserId: "+15551234567",
           friendName: "Alice",
           guardianName: "Bob",
@@ -626,6 +661,7 @@ describe("POST /v1/contacts/invites/:id/call", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "phone",
+          contactId: createTargetContact(),
           expectedExternalUserId: "+15551234567",
           friendName: "Alice",
           guardianName: "Bob",
@@ -652,6 +688,7 @@ describe("POST /v1/contacts/invites/:id/call", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           sourceChannel: "telegram",
+          contactId: createTargetContact(),
         }),
       }),
     );

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -674,13 +674,13 @@ describe("ingress-dependent setup skills declare public-ingress", () => {
     expect(includes).toContain("public-ingress");
   });
 
-  test("slack-oauth-setup includes browser", () => {
+  test("slack-oauth-setup includes collaborative-oauth-flow", () => {
     const includes = readSkillIncludes(
       FIRST_PARTY_SKILLS_DIR,
       "slack-oauth-setup",
     );
     expect(includes).toBeDefined();
-    expect(includes).toContain("browser");
+    expect(includes).toContain("collaborative-oauth-flow");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `contactId: createTargetContact()` to all invite creation request bodies in `invite-routes-http.test.ts` to satisfy the new validation added in #16239
- Update skills test assertion from `"browser"` to `"collaborative-oauth-flow"` to match the SKILL.md change from #16197
- Add `cli/commands/doctor.ts` to the `ALLOWED_IMPORTERS` set in credential-security-invariants test, since #16193 added a legitimate `getSecureKey` import for API key diagnostics

## Original prompt
fix any remaining CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23064693762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
