### PR TITLE
fix(calls): use direction-aware log message in invite redemption

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1157,7 +1157,7 @@ export class RelayConnection {
 
     log.info(
       { callSessionId: this.callSessionId, assistantId },
-      "Inbound voice invite redemption started",
+      `${isOutbound ? "Outbound" : "Inbound"} voice invite redemption started`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Fix log message in `startInviteRedemption()` to say "Outbound" or "Inbound" based on `isOutbound` parameter instead of always saying "Inbound"

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
