### PR TITLE
fix(contacts): address PR #16090 review — task cancellation and stale channel selection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -79,12 +79,12 @@ struct GuardianChannelsDetailView: View {
             for channel in Self.verificationSupportedChannels {
                 store?.refreshChannelVerificationStatus(channel: channel)
             }
-            Task {
-                channelReadiness = (try? await daemonClient?.fetchChannelReadiness()) ?? [:]
-            }
         }
         .onDisappear {
             stopVerificationCountdownTimer()
+        }
+        .task {
+            channelReadiness = (try? await daemonClient?.fetchChannelReadiness()) ?? [:]
         }
         .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             verificationStoreRevision += 1
@@ -98,7 +98,12 @@ struct GuardianChannelsDetailView: View {
         SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type)) {
             let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
 
-            if let channel = existingChannels.first, channel.status == "active", channel.verifiedAt != nil {
+            // Prefer the latest verified channel to avoid showing stale status when
+            // multiple non-revoked rows exist for the same channel type.
+            let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
+                ?? existingChannels.first
+
+            if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
                 // Verified channel — delegate to ChannelVerificationFlowView
                 verifiedChannelContent(channel: channel, type: type)
             } else if !existingChannels.isEmpty || setupExpanded.contains(type) {


### PR DESCRIPTION
## Summary
- Move unstructured `Task {}` in `onAppear` to `.task {}` modifier for automatic cancellation on disappear, fixing a task leak that violated clients/AGENTS.md rules
- Prefer the latest verified channel over `existingChannels.first` to avoid showing stale status when multiple non-revoked rows exist for the same channel type

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16090

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
