### PR TITLE
fix: resolve credential names in oauth apps upsert --client-secret-credential-path

### DIFF
--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -8,6 +8,8 @@ import {
   listApps,
   upsertApp,
 } from "../../../oauth/oauth-store.js";
+import { credentialKey } from "../../../security/credential-key.js";
+import { getCredentialMetadata } from "../../../tools/credentials/metadata-store.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -183,10 +185,16 @@ You can supply the client secret directly via --client-secret, or reference an
 existing credential in the store via --client-secret-credential-path. These two
 options are mutually exclusive — providing both is an error.
 
+The --client-secret-credential-path accepts two formats:
+  1. Full credential path: "credential/integration:google/client_secret"
+  2. Short name (service:field): "integration:google:client_secret"
+     Resolved via the metadata store by splitting on the first colon.
+
 Examples:
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
   $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
-  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "custom/path"
+  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "credential/integration:slack/client_secret"
+  $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "integration:slack:client_secret"
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123 --json`,
     )
     .action(
@@ -210,10 +218,28 @@ Examples:
             return;
           }
 
+          let resolvedCredentialPath = opts.clientSecretCredentialPath;
+          if (
+            resolvedCredentialPath &&
+            !resolvedCredentialPath.startsWith("credential/")
+          ) {
+            // Attempt to interpret as a credential key — replace first colon with / to get service/field
+            const firstColon = resolvedCredentialPath.indexOf(":");
+            if (firstColon > 0) {
+              const asService = resolvedCredentialPath.slice(0, firstColon);
+              const asField = resolvedCredentialPath.slice(firstColon + 1);
+              // If a credential exists in metadata with these coordinates, resolve it
+              const meta = getCredentialMetadata(asService, asField);
+              if (meta) {
+                resolvedCredentialPath = credentialKey(asService, asField);
+              }
+            }
+          }
+
           const clientSecretOpts = opts.clientSecret
             ? { clientSecretValue: opts.clientSecret }
-            : opts.clientSecretCredentialPath
-              ? { clientSecretCredentialPath: opts.clientSecretCredentialPath }
+            : resolvedCredentialPath
+              ? { clientSecretCredentialPath: resolvedCredentialPath }
               : undefined;
           const row = await upsertApp(
             opts.provider,


### PR DESCRIPTION
## Summary
- Add credential path resolution in `oauth apps upsert` CLI handler to support non-prefixed credential names
- When `--client-secret-credential-path` doesn't start with `credential/`, attempt to resolve it by splitting on first colon and looking up metadata
- Preserves existing behavior for properly formatted `credential/` paths

Part of plan: fix-credential-path-parsing.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
