### PR TITLE
refactor(contacts): use VEmptyState for empty contacts state instead of custom VStack

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -169,17 +169,13 @@ struct ContactsListView: View {
             }
 
             if !viewModel.hasNonGuardianContacts {
-                VStack(spacing: VSpacing.md) {
-                    VIconView(.users, size: 24)
-                        .foregroundColor(VColor.contentTertiary)
-                        .accessibilityHidden(true)
-                    Text("No contacts yet")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    VButton(label: "Add Contact", leftIcon: VIcon.plus.rawValue, style: .primary) {
-                        viewModel.isCreatingContact = true
-                    }
-                }
+                VEmptyState(
+                    title: "No contacts yet",
+                    icon: VIcon.users.rawValue,
+                    actionLabel: "Add Contact",
+                    actionIcon: VIcon.plus.rawValue,
+                    action: { viewModel.isCreatingContact = true }
+                )
                 .padding(.vertical, VSpacing.lg)
                 .frame(maxWidth: .infinity)
                 .vCard(background: VColor.surfaceOverlay)

--- a/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
+++ b/clients/shared/DesignSystem/Components/Display/VEmptyState.swift
@@ -4,11 +4,24 @@ public struct VEmptyState: View {
     public let title: String
     public var subtitle: String? = nil
     public var icon: String? = nil
+    public var actionLabel: String? = nil
+    public var actionIcon: String? = nil
+    public var action: (() -> Void)? = nil
 
-    public init(title: String, subtitle: String? = nil, icon: String? = nil) {
+    public init(
+        title: String,
+        subtitle: String? = nil,
+        icon: String? = nil,
+        actionLabel: String? = nil,
+        actionIcon: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
         self.title = title
         self.subtitle = subtitle
         self.icon = icon
+        self.actionLabel = actionLabel
+        self.actionIcon = actionIcon
+        self.action = action
     }
 
     public var body: some View {
@@ -25,9 +38,17 @@ public struct VEmptyState: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.contentTertiary)
             }
+            if let actionLabel, let action {
+                VButton(
+                    label: actionLabel,
+                    leftIcon: actionIcon,
+                    style: .primary,
+                    action: action
+                )
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .ignore)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(title). \(subtitle ?? "")")
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -90,6 +90,33 @@ struct DisplayGallerySection: View {
                 }
             }
 
+            Text("With Action Button")
+                .font(VFont.headline)
+                .foregroundColor(VColor.contentSecondary)
+
+            HStack(spacing: VSpacing.lg) {
+                VCard {
+                    VEmptyState(
+                        title: "No contacts yet",
+                        icon: VIcon.users.rawValue,
+                        actionLabel: "Add Contact",
+                        actionIcon: VIcon.plus.rawValue,
+                        action: {}
+                    )
+                    .frame(height: 200)
+                }
+                VCard {
+                    VEmptyState(
+                        title: "No documents",
+                        subtitle: "Upload a file to get started",
+                        icon: VIcon.fileText.rawValue,
+                        actionLabel: "Upload",
+                        action: {}
+                    )
+                    .frame(height: 200)
+                }
+            }
+
             Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
             // MARK: - VDisclosureSection


### PR DESCRIPTION
## Summary
- Extended `VEmptyState` with optional `actionLabel`, `actionIcon`, and `action` parameters to render a `VButton` below the subtitle
- Replaced the custom one-off `VStack` empty state in `ContactsListView` with the shared `VEmptyState` component, per design system duplication rules
- Updated `DisplayGallerySection` to showcase the new action button variant

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
