### PR TITLE
fix: update oauth-cli tests for client-id guard and 401 ping throw

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -685,6 +685,14 @@ describe("assistant oauth connections connect <provider-key>", () => {
   });
 
   test("completes interactive flow and prints success (human mode)", async () => {
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: false,
@@ -704,6 +712,14 @@ describe("assistant oauth connections connect <provider-key>", () => {
   });
 
   test("completes interactive flow and returns JSON with --json flag", async () => {
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: false,
@@ -729,6 +745,14 @@ describe("assistant oauth connections connect <provider-key>", () => {
   });
 
   test("returns auth URL in default (non-interactive) mode (JSON)", async () => {
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: true,
@@ -821,6 +845,14 @@ describe("assistant oauth connections connect <provider-key>", () => {
   });
 
   test("outputs error from orchestrator", async () => {
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "x",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
     mockOrchestrateOAuthConnect = async () => ({
       success: false,
       error: "Something went wrong",
@@ -841,6 +873,14 @@ describe("assistant oauth connections connect <provider-key>", () => {
   });
 
   test("fails when client_secret is required but missing", async () => {
+    mockGetAppByProviderAndClientId = () => ({
+      id: "app-1",
+      clientId: "test-id",
+      clientSecretCredentialPath: "oauth_app/app-1/client_secret",
+      providerKey: "integration:gmail",
+      createdAt: 0,
+      updatedAt: 0,
+    });
     mockGetProviderBehavior = () => ({
       setup: {
         requiresClientSecret: true,
@@ -1082,8 +1122,9 @@ describe("assistant oauth connections ping <provider-key>", () => {
       updatedAt: Date.now(),
     });
     const originalFetch = globalThis.fetch;
+    // Use 403 (not 401) — 401 now throws inside withValidToken for retry
     globalThis.fetch = (async () =>
-      new Response("Unauthorized", { status: 401 })) as unknown as typeof fetch;
+      new Response("Forbidden", { status: 403 })) as unknown as typeof fetch;
     try {
       const { exitCode, stdout } = await runCli([
         "connections",
@@ -1094,7 +1135,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
       expect(exitCode).toBe(1);
       const parsed = JSON.parse(stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.status).toBe(401);
+      expect(parsed.status).toBe(403);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- Add `mockGetAppByProviderAndClientId` returning a valid app in all 5 `connect` tests that pass `--client-id`, since commit f11a4cb now rejects unknown client IDs
- Change ping test mock from HTTP 401 to 403, since commit bb9149f now throws on 401 inside `withValidToken` for retry instead of returning a status object

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23065036411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
