### PR TITLE
docs: update skill files to use --service/--field credential CLI flags

### DIFF
--- a/skills/amazon/SKILL.md
+++ b/skills/amazon/SKILL.md
@@ -69,7 +69,7 @@ Alternatively, run `bun run {baseDir}/scripts/amazon.ts variations <asin> --json
 Session cookies are stored in the encrypted credential store under the key `amazon:session:cookies`. You can inspect the stored session with:
 
 ```bash
-assistant credentials inspect amazon:session:cookies
+assistant credentials inspect --service amazon --field session:cookies
 ```
 
 Session capture (`bun run {baseDir}/scripts/amazon.ts refresh`) and session checks (`bun run {baseDir}/scripts/amazon.ts status`) use the credential store automatically — no manual file management is needed.

--- a/skills/amazon/scripts/amazon.ts
+++ b/skills/amazon/scripts/amazon.ts
@@ -352,8 +352,9 @@ switch (subcommand) {
                 "[amazon:verbose] ----------------------------\n\n",
               );
             }
-            const d = (result as unknown as Record<string, unknown>)
-              .__debug as Record<string, unknown> | undefined;
+            const d = (result as unknown as Record<string, unknown>).__debug as
+              | Record<string, unknown>
+              | undefined;
             if (d?.addCartJson) {
               process.stderr.write(
                 `[amazon:verbose] Raw Amazon response: ${d.addCartJson}\n\n`,

--- a/skills/amazon/scripts/headless-cookies.ts
+++ b/skills/amazon/scripts/headless-cookies.ts
@@ -80,10 +80,7 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
   // 3. Copy the Cookies DB to a temp file, then query the copy.
   //    Reading Chrome's live SQLite DB directly can interfere with Chrome's
   //    WAL journaling and cause session logouts. Copying first is safe.
-  const tmpCookiesDb = join(
-    tmpdir(),
-    `vellum-chrome-cookies-${Date.now()}.db`,
-  );
+  const tmpCookiesDb = join(tmpdir(), `vellum-chrome-cookies-${Date.now()}.db`);
   let rawOutput: string;
   try {
     copyFileSync(CHROME_COOKIES_DB, tmpCookiesDb);

--- a/skills/elevenlabs-voice/SKILL.md
+++ b/skills/elevenlabs-voice/SKILL.md
@@ -75,21 +75,21 @@ Users with an ElevenLabs API key can go beyond the curated list above.
 ### Check for an existing key
 
 ```bash
-assistant credentials inspect elevenlabs:api_key --json
+assistant credentials inspect --service elevenlabs --field api_key --json
 ```
 
 ### Browse the voice library
 
 ```bash
 curl -s "https://api.elevenlabs.io/v2/voices?category=premade&page_size=50" \
-  -H "xi-api-key: $(assistant credentials reveal elevenlabs:api_key)" | python3 -m json.tool
+  -H "xi-api-key: $(assistant credentials reveal --service elevenlabs --field api_key)" | python3 -m json.tool
 ```
 
 ### Search for a specific style
 
 ```bash
 curl -s "https://api.elevenlabs.io/v2/voices?search=warm+female&page_size=10" \
-  -H "xi-api-key: $(assistant credentials reveal elevenlabs:api_key)" | python3 -m json.tool
+  -H "xi-api-key: $(assistant credentials reveal --service elevenlabs --field api_key)" | python3 -m json.tool
 ```
 
 ### Custom and cloned voices

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -105,10 +105,10 @@ Collect the app token securely:
 After collection, validate the app token format:
 
 ```bash
-APP_TOKEN=$(assistant credentials reveal slack_channel:app_token)
+APP_TOKEN=$(assistant credentials reveal --service slack_channel --field app_token)
 if [[ "$APP_TOKEN" != xapp-* ]]; then
   echo "ERROR: App token must start with xapp-"
-  assistant credentials delete slack_channel:app_token
+  assistant credentials delete --service slack_channel --field app_token
   exit 1
 fi
 echo "App token format valid"
@@ -127,7 +127,7 @@ After installation, collect the bot token securely:
 ## Step 4: Validate Bot Token & Store Workspace Metadata
 
 ```bash
-BOT_TOKEN=$(assistant credentials reveal slack_channel:bot_token)
+BOT_TOKEN=$(assistant credentials reveal --service slack_channel --field bot_token)
 AUTH_RESPONSE=$(curl -sf -X POST "https://slack.com/api/auth.test" \
   -H "Authorization: Bearer $BOT_TOKEN")
 echo "$AUTH_RESPONSE" | jq .
@@ -174,8 +174,8 @@ Summarize:
 To disconnect Slack:
 
 ```bash
-assistant credentials delete slack_channel:bot_token
-assistant credentials delete slack_channel:app_token
+assistant credentials delete --service slack_channel --field bot_token
+assistant credentials delete --service slack_channel --field app_token
 assistant config set slack.teamId ""
 assistant config set slack.teamName ""
 assistant config set slack.botUserId ""

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -36,7 +36,7 @@ Collect the token through the secure credential prompt:
 ## Step 2: Validate Token and Configure Bot
 
 ```bash
-BOT_TOKEN=$(assistant credentials reveal telegram:bot_token)
+BOT_TOKEN=$(assistant credentials reveal --service telegram --field bot_token)
 GETME_RESPONSE=$(curl -sf "https://api.telegram.org/bot${BOT_TOKEN}/getMe")
 BOT_USERNAME=$(echo "$GETME_RESPONSE" | jq -r '.result.username')
 assistant config set telegram.botUsername "$BOT_USERNAME"
@@ -55,13 +55,13 @@ Telegram needs a publicly reachable URL to send webhook events to. Load the `pub
 
 Check to see if one already exists:
 ```bash
-assistant credentials inspect telegram:webhook_secret
+assistant credentials inspect --service telegram --field webhook_secret
 ```
 
 If not, generate and set one:
 
 ```bash
-assistant credentials set telegram:webhook_secret "$(uuidgen)"
+assistant credentials set --service telegram --field webhook_secret "$(uuidgen)"
 ```
 
 ### Register Platform Callback Route
@@ -75,7 +75,7 @@ Only needed for containerized deployments. A "not available" error is expected l
 ## Step 4: Register Bot Commands
 
 ```bash
-BOT_TOKEN=$(assistant credentials reveal telegram:bot_token)
+BOT_TOKEN=$(assistant credentials reveal --service telegram --field bot_token)
 curl -sf -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
   -H "Content-Type: application/json" \
   -d '{"commands":[{"command":"new","description":"Start a new conversation"},{"command":"help","description":"Show available commands"}]}'
@@ -104,7 +104,7 @@ Summarize:
 To disconnect Telegram:
 
 ```bash
-assistant credentials delete telegram:bot_token
-assistant credentials delete telegram:webhook_secret
+assistant credentials delete --service telegram --field bot_token
+assistant credentials delete --service telegram --field webhook_secret
 assistant config set telegram.botUsername ""
 ```

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -44,7 +44,6 @@ assistant config set telegram.botUsername "$BOT_USERNAME"
 
 If the `curl` call fails, the token is invalid — ask the user to re-enter (repeat Step 1).
 
-
 ## Step 3: Set Up Public Ingress and Webhooks
 
 ### Verify Public Ingress is Set Up
@@ -54,6 +53,7 @@ Telegram needs a publicly reachable URL to send webhook events to. Load the `pub
 ### Generate Webhook Secret
 
 Check to see if one already exists:
+
 ```bash
 assistant credentials inspect --service telegram --field webhook_secret
 ```

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -16,14 +16,14 @@ You are helping your user configure Twilio for voice calls. Walk through each st
 
 Before you begin, understand how each Twilio value is stored:
 
-| Value        | Type       | Storage method                                | Secret? |
-| ------------ | ---------- | --------------------------------------------- | ------- |
-| Account SID  | Config     | `assistant config set twilio.accountSid`      | No      |
+| Value        | Type       | Storage method                                                  | Secret? |
+| ------------ | ---------- | --------------------------------------------------------------- | ------- |
+| Account SID  | Config     | `assistant config set twilio.accountSid`                        | No      |
 | Auth Token   | Credential | `assistant credentials set --service twilio --field auth_token` | **Yes** |
-| Phone Number | Config     | `assistant config set twilio.phoneNumber`     | No      |
+| Phone Number | Config     | `assistant config set twilio.phoneNumber`                       | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
-**Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat.
+  **Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat.
 
 ## Retrieving Twilio Credentials
 
@@ -175,7 +175,6 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
   -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
-
 
 ## Clearing Credentials
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -19,7 +19,7 @@ Before you begin, understand how each Twilio value is stored:
 | Value        | Type       | Storage method                                | Secret? |
 | ------------ | ---------- | --------------------------------------------- | ------- |
 | Account SID  | Config     | `assistant config set twilio.accountSid`      | No      |
-| Auth Token   | Credential | `assistant credentials set twilio:auth_token` | **Yes** |
+| Auth Token   | Credential | `assistant credentials set --service twilio --field auth_token` | **Yes** |
 | Phone Number | Config     | `assistant config set twilio.phoneNumber`     | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
@@ -31,7 +31,7 @@ Many steps below require the Account SID and Auth Token. Retrieve them with:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant credentials reveal --service twilio --field auth_token)
 ```
 
 # Checking Current Configuration
@@ -40,7 +40,7 @@ You can determine whether Twilio has been fully set up by checking to see that a
 
 ```bash
 assistant config get twilio.accountSid
-assistant credentials inspect twilio:auth_token --json  # check "hasSecret" field
+assistant credentials inspect --service twilio --field auth_token --json  # check "hasSecret" field
 assistant config get twilio.phoneNumber
 ```
 
@@ -81,7 +81,7 @@ Ask the user for their Auth Token. This IS a secret value, so the user should be
 Confirm it has been stored successfully:
 
 ```bash
-assistant credentials inspect "twilio:auth_token"
+assistant credentials inspect --service twilio --field auth_token
 ```
 
 If credentials are invalid, Twilio API calls in Step 3 will fail -- ask the user to re-enter.
@@ -155,7 +155,7 @@ Retrieve credentials and config values:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant credentials reveal --service twilio --field auth_token)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 ```
@@ -182,7 +182,7 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
 To disconnect Twilio:
 
 ```bash
-assistant credentials delete twilio:auth_token
+assistant credentials delete --service twilio --field auth_token
 assistant config set twilio.accountSid ""
 ```
 
@@ -218,7 +218,7 @@ Webhooks on the Twilio phone number may not match the current ingress URL. This 
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant credentials reveal --service twilio --field auth_token)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 


### PR DESCRIPTION
## Summary
- Update all skill documentation to use new `--service`/`--field` flag syntax for credential CLI commands
- Affects: telegram-setup, slack-app-setup, twilio-setup, elevenlabs-voice, amazon skills

Part of plan: fix-credential-path-parsing.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
