### PR TITLE
fix(contacts): remove unused store property from ContactsListView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -33,8 +33,7 @@ struct ContactsContainerView: View {
             ScrollView {
                 ContactsListView(
                     viewModel: viewModel,
-                    selection: $selection,
-                    store: store
+                    selection: $selection
                 )
                 .padding(VSpacing.lg)
             }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -7,7 +7,6 @@ import VellumAssistantShared
 struct ContactsListView: View {
     @ObservedObject var viewModel: ContactsViewModel
     @Binding var selection: ContactSelection?
-    var store: SettingsStore?
 
     @State private var hoveredContactId: String?
     @State private var isAssistantHovered = false


### PR DESCRIPTION
## Summary
- Remove unused `store: SettingsStore?` property from `ContactsListView` — it became dead code when the `assistantChannelSummary` computed property (its only consumer) was removed in PR #16087
- Clean up the call-site in `ContactsContainerView` that passed `store: store` to the initializer

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16087

🤖 Generated with [Claude Code](https://claude.com/claude-code)