### PR TITLE
fix(contacts): restore verified UI and stale-state fallback in guardian channel cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -104,7 +104,7 @@ struct GuardianChannelsDetailView: View {
                 ?? existingChannels.first
 
             if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
-                // Verified channel — delegate to ChannelVerificationFlowView
+                // Verified channel — show address, badge, date + revoke action
                 verifiedChannelContent(channel: channel, type: type)
             } else if !existingChannels.isEmpty || setupExpanded.contains(type) {
                 // Existing unverified channel or user clicked "Set Up" — show verification flow
@@ -123,29 +123,90 @@ struct GuardianChannelsDetailView: View {
 
     @ViewBuilder
     private func verifiedChannelContent(channel: ContactChannelPayload, type: String) -> some View {
-        // ChannelVerificationFlowView already renders the full verified state
-        // (identity text + "Revoke" button), so we delegate entirely to it.
-        if let store {
-            let state = store.channelVerificationState(for: type)
-            let destinationBinding = Binding<String>(
-                get: { verificationDestinationTexts[type] ?? "" },
-                set: { verificationDestinationTexts[type] = $0 }
-            )
-            ChannelVerificationFlowView(
-                state: state,
-                countdownNow: $verificationCountdownNow,
-                destinationText: destinationBinding,
-                onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
-                onResend: { store.resendOutboundVerification(channel: type) },
-                onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
-                onRevoke: { store.revokeChannelVerification(channel: type) },
-                onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
-                onCancelSession: { store.cancelVerificationSession(channel: type) },
-                botUsername: store.telegramBotUsername,
-                phoneNumber: store.twilioPhoneNumber,
-                showLabel: false
-            )
+        // Show the channel address, verified badge, and date from the channel payload,
+        // then delegate to ChannelVerificationFlowView for revoke/re-verify actions.
+        // The channel payload is the source of truth for verified state — it is always
+        // populated, even if the store hasn't refreshed yet (startup/offline).
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: VSpacing.sm) {
+                        Text(channel.address)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .lineLimit(1)
+
+                        Text("Verified")
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xxs)
+                            .background(VColor.systemPositiveWeak)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
+                    }
+
+                    if let verifiedAt = channel.verifiedAt, verifiedAt > 0 {
+                        let dateStr = formatDate(epochMs: verifiedAt)
+                        let via = channel.verifiedVia ?? "unknown"
+                        Text("Verified via \(via) on \(dateStr)")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
+                }
+
+                Spacer()
+            }
+
+            // Use store state for the revoke/re-verify action flow, falling back to
+            // a verified state derived from the channel payload when the store hasn't
+            // loaded yet (startup, offline, or stale refresh).
+            if let store {
+                let storeState = store.channelVerificationState(for: type)
+                let effectiveState = storeState.verified ? storeState : ChannelVerificationState(
+                    channel: type,
+                    identity: channel.address,
+                    username: nil,
+                    displayName: nil,
+                    verified: true,
+                    inProgress: false,
+                    instruction: nil,
+                    error: nil,
+                    alreadyBound: false,
+                    outboundSessionId: nil,
+                    outboundExpiresAt: nil,
+                    outboundNextResendAt: nil,
+                    outboundSendCount: 0,
+                    outboundCode: nil,
+                    bootstrapUrl: nil
+                )
+                let destinationBinding = Binding<String>(
+                    get: { verificationDestinationTexts[type] ?? "" },
+                    set: { verificationDestinationTexts[type] = $0 }
+                )
+                ChannelVerificationFlowView(
+                    state: effectiveState,
+                    countdownNow: $verificationCountdownNow,
+                    destinationText: destinationBinding,
+                    onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
+                    onResend: { store.resendOutboundVerification(channel: type) },
+                    onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
+                    onRevoke: { store.revokeChannelVerification(channel: type) },
+                    onStartSession: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
+                    onCancelSession: { store.cancelVerificationSession(channel: type) },
+                    botUsername: store.telegramBotUsername,
+                    phoneNumber: store.twilioPhoneNumber,
+                    showLabel: false
+                )
+            }
         }
+    }
+
+    private func formatDate(epochMs: Int) -> String {
+        let date = Date(timeIntervalSince1970: Double(epochMs) / 1000)
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
     }
 
     // MARK: - Verification Flow Content


### PR DESCRIPTION
## Summary
- Restore channel address, green "Verified" badge, and verification date display in `GuardianChannelsDetailView` verified channel cards
- Add verified fallback from channel payload when store state is stale (startup/offline), preventing regression where verified channels briefly appear unverified
- Restore `formatDate` helper removed by the original PR

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
