### PR TITLE
fix(contacts): prevent 'No Channels Available' empty state flash during readiness fetch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -16,6 +16,7 @@ struct GuardianChannelsDetailView: View {
     var onSelectAssistant: (() -> Void)?
 
     @State var currentContact: ContactPayload?
+    @State private var isLoadingReadiness: Bool = true
     @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
     @State private var verificationDestinationTexts: [String: String] = [:]
     @State private var verificationCountdownNow: Date = Date()
@@ -48,7 +49,11 @@ struct GuardianChannelsDetailView: View {
                     return hasExisting || channelReadiness[type]?.ready == true
                 }
 
-                if visibleTypes.isEmpty {
+                if isLoadingReadiness && visibleTypes.isEmpty {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, VSpacing.xl)
+                } else if visibleTypes.isEmpty {
                     VStack(spacing: VSpacing.md) {
                         VIconView(.messageCircle, size: 24)
                             .foregroundColor(VColor.contentTertiary)
@@ -85,6 +90,7 @@ struct GuardianChannelsDetailView: View {
         }
         .task {
             channelReadiness = (try? await daemonClient?.fetchChannelReadiness()) ?? [:]
+            isLoadingReadiness = false
         }
         .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             verificationStoreRevision += 1


### PR DESCRIPTION
## Summary
- Add `isLoadingReadiness` state to track when channel readiness data is being fetched
- Show a `ProgressView()` spinner instead of the misleading "No Channels Available" empty state while the async fetch is in progress
- Only display the empty state with "Set Up Assistant" button after loading completes and no channels are truly available

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
