### PR TITLE
fix(contacts): gate channel empty state on readiness fetch completion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -47,6 +47,7 @@ struct ContactDetailView: View {
     @State private var inviteHandleInput = ""
     @State private var inviteCodeRevealed = false
     @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
+    @State private var channelReadinessLoaded = false
     /// Monotonically increasing counter that correlates a verification attempt
     /// with its one-shot response / timeout so stale callbacks are ignored.
     @State private var verificationAttempt: UInt64 = 0
@@ -252,7 +253,20 @@ struct ContactDetailView: View {
         }
 
         return VStack(alignment: .leading, spacing: VSpacing.md) {
-            if visibleTypes.isEmpty {
+            if !channelReadinessLoaded && visibleTypes.isEmpty {
+                // Still loading channel readiness — show a spinner instead of a
+                // false "No channels available" message.
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading channels...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.contentTertiary)
+                }
+                .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .vCard(background: VColor.surfaceOverlay)
+            } else if visibleTypes.isEmpty {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     Text("No channels available")
                         .font(VFont.sectionTitle)
@@ -305,6 +319,7 @@ struct ContactDetailView: View {
                 // channels the contact already has configured (channelReadiness
                 // stays empty so no unconfigured channel cards appear).
             }
+            channelReadinessLoaded = true
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `channelReadinessLoaded` state to track whether the channel readiness fetch has completed
- Show a loading spinner while readiness is being fetched instead of a false "No channels available" empty state
- Only show the definitive empty state after the fetch completes (success or failure)

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
