### PR TITLE
fix(avatar): add frame constraint and fix fractional size cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -12,6 +12,7 @@ struct AnimatedAvatarView: View {
 
     var body: some View {
         AvatarLayerRepresentable(bodyShape: bodyShape, eyeStyle: eyeStyle, color: color, size: size)
+            .frame(width: size, height: size)
             .accessibilityHidden(true)
     }
 }
@@ -69,7 +70,7 @@ class AvatarLayerView: NSView {
     }
 
     func configure(bodyShape: AvatarBodyShape, eyeStyle: AvatarEyeStyle, color: AvatarColor, size: CGFloat) {
-        let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)-\(color.rawValue)-\(Int(size))"
+        let key = "\(bodyShape.rawValue)-\(eyeStyle.rawValue)-\(color.rawValue)-\(String(format: "%.1f", size))"
         guard key != currentKey else { return }
         currentKey = key
 


### PR DESCRIPTION
## Summary
- Adds .frame(width: size, height: size) to AnimatedAvatarView body to prevent layout mismatch between SwiftUI and CAShapeLayer rendering
- Fixes the configuration cache key to use fractional size values instead of Int truncation, preventing stale rendering at non-integer dimensions

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
