### PR TITLE
fix(contacts): restore channel handle display in unconfigured channel rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -289,6 +289,12 @@ struct ContactDetailView: View {
                                 }
                             }
                         } else {
+                            if let handle = channelReadiness[type]?.channelHandle {
+                                Text(handle)
+                                    .font(VFont.monoSmall)
+                                    .foregroundColor(VColor.contentTertiary)
+                                    .lineLimit(1)
+                            }
                             if inviteExpanded.contains(type) {
                                 unconfiguredChannelContent(type: type)
                             } else {


### PR DESCRIPTION
## Summary
- Restores the channel handle display (e.g., Telegram bot username) in unconfigured channel cards that was accidentally removed in PR #16105
- Adds the handle text below the card title without re-introducing the duplicate icon and label

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
