### PR TITLE
fix: use lastIndexOf for credential path colon split in oauth apps upsert

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1046,14 +1046,14 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
   });
 
   test("upsert resolves non-prefixed credential path via metadata store", async () => {
-    // The resolution logic splits on the FIRST colon, so
-    // "integration:google:client_secret" → service="integration", field="google:client_secret"
+    // The resolution logic splits on the LAST colon, so
+    // "integration:google:client_secret" → service="integration:google", field="client_secret"
     mockGetCredentialMetadata = (service, field) =>
-      service === "integration" && field === "google:client_secret"
+      service === "integration:google" && field === "client_secret"
         ? {
             credentialId: "cred-1",
-            service: "integration",
-            field: "google:client_secret",
+            service: "integration:google",
+            field: "client_secret",
             allowedTools: [],
             allowedDomains: [],
             createdAt: Date.now(),
@@ -1080,7 +1080,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       clientId: "abc",
       clientSecretOpts: {
         clientSecretCredentialPath:
-          "credential/integration/google:client_secret",
+          "credential/integration:google/client_secret",
       },
     });
     const parsed = JSON.parse(stdout);

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -188,7 +188,7 @@ options are mutually exclusive — providing both is an error.
 The --client-secret-credential-path accepts two formats:
   1. Full credential path: "credential/integration:google/client_secret"
   2. Short name (service:field): "integration:google:client_secret"
-     Resolved via the metadata store by splitting on the first colon.
+     Resolved via the metadata store by splitting on the last colon.
 
 Examples:
   $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
@@ -223,11 +223,11 @@ Examples:
             resolvedCredentialPath &&
             !resolvedCredentialPath.startsWith("credential/")
           ) {
-            // Attempt to interpret as a credential key — replace first colon with / to get service/field
-            const firstColon = resolvedCredentialPath.indexOf(":");
-            if (firstColon > 0) {
-              const asService = resolvedCredentialPath.slice(0, firstColon);
-              const asField = resolvedCredentialPath.slice(firstColon + 1);
+            // Attempt to interpret as a credential key — split on the LAST colon to get service/field
+            const lastColon = resolvedCredentialPath.lastIndexOf(":");
+            if (lastColon > 0) {
+              const asService = resolvedCredentialPath.slice(0, lastColon);
+              const asField = resolvedCredentialPath.slice(lastColon + 1);
               // If a credential exists in metadata with these coordinates, resolve it
               const meta = getCredentialMetadata(asService, asField);
               if (meta) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-credential-path-parsing.md.

**Gap:** Short-name credential path resolution splits on first colon instead of last colon
**What was expected:** `integration:google:client_secret` should resolve to service=`integration:google`, field=`client_secret`
**What was found:** `indexOf(":")` split on first colon producing service=`integration`, field=`google:client_secret` — never matches real metadata

- Change `indexOf(":")` to `lastIndexOf(":")` in `apps.ts` credential path resolution
- Fix test mock to use correct service/field coordinates and expected resolved path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
