### PR TITLE
fix: use self.showHiddenFiles in loadFile instead of parameter default

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -41,7 +41,7 @@ final class WorkspaceBrowserState {
         }
     }
 
-    func loadFile(path targetPath: String, using daemonClient: DaemonClient, showHidden: Bool = false) async {
+    func loadFile(path targetPath: String, using daemonClient: DaemonClient) async {
         selectedFilePath = targetPath
         isLoadingFile = true
         selectedFileDetail = nil
@@ -49,7 +49,7 @@ final class WorkspaceBrowserState {
         editableContent = ""
         fileLoadTask?.cancel()
         let task = Task {
-            let detail = await daemonClient.fetchWorkspaceFile(path: targetPath, showHidden: showHidden)
+            let detail = await daemonClient.fetchWorkspaceFile(path: targetPath, showHidden: showHiddenFiles)
             guard !Task.isCancelled, selectedFilePath == targetPath else { return }
             selectedFileDetail = detail
             editableContent = detail?.content ?? ""
@@ -88,7 +88,7 @@ struct WorkspacePanel: View {
             Button("Discard", role: .destructive) {
                 if let targetPath = state.pendingSwitchPath {
                     state.pendingSwitchPath = nil
-                    Task { await state.loadFile(path: targetPath, using: daemonClient, showHidden: state.showHiddenFiles) }
+                    Task { await state.loadFile(path: targetPath, using: daemonClient) }
                 } else if let newValue = state.pendingHiddenFilesToggle {
                     state.pendingHiddenFilesToggle = nil
                     applyHiddenFilesToggle(newValue)
@@ -569,7 +569,7 @@ private struct WorkspaceTreeRow: View {
                 state.pendingSwitchPath = targetPath
                 state.showingDirtyAlert = true
             } else {
-                await state.loadFile(path: targetPath, using: daemonClient, showHidden: state.showHiddenFiles)
+                await state.loadFile(path: targetPath, using: daemonClient)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removes the misleading showHidden parameter from WorkspaceBrowserState.loadFile
- Now reads self.showHiddenFiles directly, matching the pattern used by refreshDirectory
- Prevents future callers from accidentally using the false default when hidden files are enabled

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
