### PR TITLE
fix(contacts): scope invite Cancel to only clear matching channel result

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -398,7 +398,9 @@ struct ContactDetailView: View {
                         }
                         VButton(label: "Cancel", style: .outlined) {
                             inviteExpanded.remove(type)
-                            inviteResult = nil
+                            if inviteResult?.type == type {
+                                inviteResult = nil
+                            }
                             inviteError = nil
                         }
                     }
@@ -435,7 +437,9 @@ struct ContactDetailView: View {
                             }
                             VButton(label: "Cancel", style: .outlined) {
                                 inviteExpanded.remove(type)
-                                inviteResult = nil
+                                if inviteResult?.type == type {
+                                    inviteResult = nil
+                                }
                                 inviteError = nil
                             }
                         }
@@ -531,7 +535,9 @@ struct ContactDetailView: View {
                 }
                 VButton(label: "Cancel", style: .outlined) {
                     inviteExpanded.remove(type)
-                    inviteResult = nil
+                    if inviteResult?.type == type {
+                        inviteResult = nil
+                    }
                     inviteError = nil
                     inviteHandleInput = ""
                     inviteCodeRevealed = false


### PR DESCRIPTION
## Summary
- Fixes the Cancel button in invite expand/collapse to only clear inviteResult when it belongs to the same channel type being cancelled
- Previously, cancelling one channel's invite would clear the invite result from a different channel that was also expanded

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16107

🤖 Generated with [Claude Code](https://claude.com/claude-code)