### PR TITLE
fix: doctor plaintext key fallback for unmigrated apiKeys

### DIFF
--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -87,10 +87,13 @@ Examples:
       const configKey = getSecureKey(provider);
       const envVar = providerEnvVar[provider];
       const envKey = envVar ? process.env[envVar] : undefined;
+      const plaintextKey = (
+        raw.apiKeys as Record<string, string> | undefined
+      )?.[provider];
 
       if (provider === "ollama") {
         pass("Provider configured (Ollama; API key optional)");
-      } else if (envKey || configKey) {
+      } else if (envKey || configKey || plaintextKey) {
         pass("API key configured");
       } else {
         fail(


### PR DESCRIPTION
## Summary
- Adds plaintext `apiKeys` fallback in the `assistant doctor` key check so keys still in `config.json` (when secure storage writes fail) are not falsely reported as missing
- The stale `session-slash.ts` references were already addressed in PR #16196

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16193

🤖 Generated with [Claude Code](https://claude.com/claude-code)