### PR TITLE
fix(contacts): scope inline invite errors to the originating channel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -42,6 +42,7 @@ struct ContactDetailView: View {
         channelHandle: String?
     )?
     @State private var inviteError: String?
+    @State private var inviteErrorChannel: String?
     @State private var inviteCopiedType: String?
     @State private var inviteExpanded: Set<String> = []
     @State private var inviteHandleInput = ""
@@ -93,6 +94,7 @@ struct ContactDetailView: View {
             inviteExpanded = []
             inviteResult = nil
             inviteError = nil
+            inviteErrorChannel = nil
         }
         .onDisappear {
             verificationTimeoutTask?.cancel()
@@ -402,12 +404,13 @@ struct ContactDetailView: View {
                                 inviteResult = nil
                             }
                             inviteError = nil
+                            inviteErrorChannel = nil
                         }
                     }
                 }
 
                 // Inline error display so the message appears inside the channel card
-                if let inviteError {
+                if let inviteError, inviteErrorChannel == type {
                     Text(inviteError)
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemNegativeStrong)
@@ -441,6 +444,7 @@ struct ContactDetailView: View {
                                     inviteResult = nil
                                 }
                                 inviteError = nil
+                                inviteErrorChannel = nil
                             }
                         }
                     }
@@ -451,7 +455,7 @@ struct ContactDetailView: View {
                 }
 
                 // Inline error display so the message appears inside the channel card
-                if let inviteError {
+                if let inviteError, inviteErrorChannel == type {
                     Text(inviteError)
                         .font(VFont.caption)
                         .foregroundColor(VColor.systemNegativeStrong)
@@ -539,6 +543,7 @@ struct ContactDetailView: View {
                         inviteResult = nil
                     }
                     inviteError = nil
+                    inviteErrorChannel = nil
                     inviteHandleInput = ""
                     inviteCodeRevealed = false
                 }
@@ -1048,6 +1053,7 @@ struct ContactDetailView: View {
         guard let daemonClient, inviteInProgress == nil else { return }
         inviteInProgress = type
         inviteError = nil
+        inviteErrorChannel = nil
         inviteResult = nil
         inviteCallInProgress = false
         inviteCallTriggered = false
@@ -1083,9 +1089,11 @@ struct ContactDetailView: View {
                     )
                 } else {
                     inviteError = "Failed to create invite"
+                    inviteErrorChannel = type
                 }
             } catch {
                 inviteError = "Failed to create invite: \(error.localizedDescription)"
+                inviteErrorChannel = type
             }
             inviteInProgress = nil
         }
@@ -1101,9 +1109,11 @@ struct ContactDetailView: View {
                     inviteCallTriggered = true
                 } else {
                     inviteError = "Failed to initiate call"
+                    inviteErrorChannel = "phone"
                 }
             } catch {
                 inviteError = "Failed to initiate call: \(error.localizedDescription)"
+                inviteErrorChannel = "phone"
             }
             inviteCallInProgress = false
         }


### PR DESCRIPTION
## Summary
- Adds inviteErrorChannel state to track which channel produced an invite error
- Inline error displays now only render when the error belongs to the current channel type
- Prevents cross-channel error misattribution (e.g., Telegram failure showing in phone card)

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
