### PR TITLE
fix: block drag-and-drop into hidden workspace directories

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -423,8 +423,8 @@ private struct WorkspaceTreeRow: View {
                 .background(isSelected ? VColor.surfaceActive : Color.clear)
             }
             .buttonStyle(.plain)
-            .onDrop(of: entry.isDirectory ? [.fileURL] : [], isTargeted: .none) { providers in
-                guard entry.isDirectory else { return false }
+            .onDrop(of: entry.isDirectory && !isHiddenPath(entry.path) ? [.fileURL] : [], isTargeted: .none) { providers in
+                guard entry.isDirectory, !isHiddenPath(entry.path) else { return false }
                 handleDrop(providers: providers, targetDir: entry.path, state: state, daemonClient: daemonClient)
                 return true
             }


### PR DESCRIPTION
## Summary
- Adds isHiddenPath guard to the drag-and-drop handler in WorkspacePanel
- Prevents users from dropping files into hidden directories, which would bypass the read-only protection added in PR #16189

## Original prompt
Address the feedback on https://github.com/vellum-ai/vellum-assistant/pull/16189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
