### PR TITLE
Add KVO-observable UserDefaults properties for new shortcut keys

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -54,6 +54,54 @@ extension UserDefaults {
     @objc dynamic var quickInputHotkeyKeyCode: Int {
         return integer(forKey: "quickInputHotkeyKeyCode")
     }
+    @objc dynamic var quickInputAboveDockShortcut: String {
+        if UserDefaults.standard.object(forKey: "quickInputAboveDockShortcut") == nil {
+            return "cmd+shift+v"
+        }
+        return string(forKey: "quickInputAboveDockShortcut") ?? ""
+    }
+    @objc dynamic var newThreadShortcut: String {
+        if UserDefaults.standard.object(forKey: "newThreadShortcut") == nil {
+            return "cmd+n"
+        }
+        return string(forKey: "newThreadShortcut") ?? ""
+    }
+    @objc dynamic var commandPaletteShortcut: String {
+        if UserDefaults.standard.object(forKey: "commandPaletteShortcut") == nil {
+            return "cmd+k"
+        }
+        return string(forKey: "commandPaletteShortcut") ?? ""
+    }
+    @objc dynamic var navigateBackShortcut: String {
+        if UserDefaults.standard.object(forKey: "navigateBackShortcut") == nil {
+            return "cmd+["
+        }
+        return string(forKey: "navigateBackShortcut") ?? ""
+    }
+    @objc dynamic var navigateForwardShortcut: String {
+        if UserDefaults.standard.object(forKey: "navigateForwardShortcut") == nil {
+            return "cmd+]"
+        }
+        return string(forKey: "navigateForwardShortcut") ?? ""
+    }
+    @objc dynamic var zoomInShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomInShortcut") == nil {
+            return "cmd+="
+        }
+        return string(forKey: "zoomInShortcut") ?? ""
+    }
+    @objc dynamic var zoomOutShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomOutShortcut") == nil {
+            return "cmd+-"
+        }
+        return string(forKey: "zoomOutShortcut") ?? ""
+    }
+    @objc dynamic var zoomResetShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomResetShortcut") == nil {
+            return "cmd+0"
+        }
+        return string(forKey: "zoomResetShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -69,16 +117,31 @@ extension AppDelegate {
         registerFnVMonitor()
         registerCmdKMonitor()
         registerCmdNMonitor()
+        registerNavigationMonitor()
+        registerZoomMonitor()
 
-        globalHotkeyObserver = Publishers.Merge3(
-            UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
-            UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () },
-            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }
-        )
+        globalHotkeyObserver = Publishers.MergeMany([
+            UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputAboveDockShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.newThreadShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.commandPaletteShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.navigateBackShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.navigateForwardShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomInShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomOutShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomResetShortcut).map { _ in () }.eraseToAnyPublisher(),
+        ])
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
+            self?.registerFnVMonitor()
+            self?.registerCmdKMonitor()
+            self?.registerCmdNMonitor()
+            self?.registerNavigationMonitor()
+            self?.registerZoomMonitor()
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds @objc dynamic UserDefaults properties for 8 new configurable shortcuts
- Expands globalHotkeyObserver to use Publishers.MergeMany for all shortcut KVO publishers
- Re-registers all monitors when any shortcut changes

Part of plan: keyboard-shortcuts-customization.md (PR 3 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
