### PR TITLE
Make New Conversation shortcut (Cmd+N) configurable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -260,12 +260,32 @@ extension AppDelegate {
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+N as a local shortcut to create a new thread.
+    /// Registers a local shortcut to create a new thread.
+    /// Reads the shortcut from UserDefaults (`newThreadShortcut`), defaulting to "cmd+n".
+    /// Skips re-registration if the shortcut hasn't changed.
     func registerCmdNMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "newThreadShortcut") ?? "cmd+n"
+
+        if shortcut == lastRegisteredNewThreadShortcut { return }
+
+        // Tear down previous monitor
+        if let monitor = cmdNLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdNLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredNewThreadShortcut = shortcut
+            log.info("New Thread: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 45, // kVK_ANSI_N
-                  mods == [.command] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -275,6 +295,8 @@ extension AppDelegate {
             return nil
         }
         cmdNLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredNewThreadShortcut = shortcut
     }
 
     /// Registers Cmd+K as a local shortcut to open the command palette.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredNewThreadShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false


### PR DESCRIPTION
## Summary
- Replaces hard-coded Cmd+N check with dynamic shortcut from UserDefaults
- Adds skip-if-unchanged guard and tear-down before re-registration
- Empty shortcut disables the feature

Part of plan: keyboard-shortcuts-customization.md (PR 5 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
