### PR TITLE
Make Zoom In/Out/Reset shortcuts configurable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -573,6 +573,9 @@ extension AppDelegate {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredZoomInShortcut = nil
+        lastRegisteredZoomOutShortcut = nil
+        lastRegisteredZoomResetShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -331,32 +331,61 @@ extension AppDelegate {
         navLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.
+    /// Registers zoom shortcuts as local event monitors for window zoom.
+    /// Reads `zoomInShortcut`, `zoomOutShortcut`, and `zoomResetShortcut` from
+    /// UserDefaults (defaults: "cmd+=", "cmd+-", "cmd+0"). Any shortcut can be
+    /// independently disabled by setting it to an empty string.
     /// Uses event monitoring instead of NSMenu key equivalents because
     /// SwiftUI manages the menu bar and strips programmatic items.
     func registerZoomMonitor() {
-        guard zoomLocalMonitor == nil else { return }
-        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard let chars = event.charactersIgnoringModifiers else { return event }
-            // Cmd+= (same physical key as Cmd++, shift ignored)
-            if chars == "=" && mods.contains(.command) && !mods.contains(.control) {
-                Task { @MainActor in self?.zoomManager.zoomIn() }
-                return nil
-            }
-            // Cmd+-
-            if chars == "-" && mods == [.command] {
-                Task { @MainActor in self?.zoomManager.zoomOut() }
-                return nil
-            }
-            // Cmd+0
-            if chars == "0" && mods == [.command] {
-                Task { @MainActor in self?.zoomManager.resetZoom() }
-                return nil
-            }
-            return event
+        let zoomIn = UserDefaults.standard.string(forKey: "zoomInShortcut") ?? "cmd+="
+        let zoomOut = UserDefaults.standard.string(forKey: "zoomOutShortcut") ?? "cmd+-"
+        let zoomReset = UserDefaults.standard.string(forKey: "zoomResetShortcut") ?? "cmd+0"
+
+        // Skip re-registration if all three shortcuts are unchanged
+        if zoomIn == lastRegisteredZoomInShortcut
+            && zoomOut == lastRegisteredZoomOutShortcut
+            && zoomReset == lastRegisteredZoomResetShortcut { return }
+
+        // Tear down existing monitor before re-registration
+        if let monitor = zoomLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            zoomLocalMonitor = nil
         }
-        zoomLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        // Parse each shortcut (empty strings yield empty key, which won't match)
+        let (zoomInMods, zoomInKey) = ShortcutHelper.parseShortcut(zoomIn)
+        let (zoomOutMods, zoomOutKey) = ShortcutHelper.parseShortcut(zoomOut)
+        let (zoomResetMods, zoomResetKey) = ShortcutHelper.parseShortcut(zoomReset)
+
+        // Only install the monitor if at least one shortcut is enabled
+        let hasAnyShortcut = !zoomIn.isEmpty || !zoomOut.isEmpty || !zoomReset.isEmpty
+
+        if hasAnyShortcut {
+            let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+                let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                guard let chars = event.charactersIgnoringModifiers else { return event }
+
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods == zoomInMods {
+                    Task { @MainActor in self?.zoomManager.zoomIn() }
+                    return nil
+                }
+                if !zoomOutKey.isEmpty && chars.lowercased() == zoomOutKey.lowercased() && mods == zoomOutMods {
+                    Task { @MainActor in self?.zoomManager.zoomOut() }
+                    return nil
+                }
+                if !zoomResetKey.isEmpty && chars.lowercased() == zoomResetKey.lowercased() && mods == zoomResetMods {
+                    Task { @MainActor in self?.zoomManager.resetZoom() }
+                    return nil
+                }
+                return event
+            }
+            zoomLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+        }
+
+        lastRegisteredZoomInShortcut = zoomIn
+        lastRegisteredZoomOutShortcut = zoomOut
+        lastRegisteredZoomResetShortcut = zoomReset
     }
 
     func toggleCommandPalette() {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredZoomInShortcut: String?
+    var lastRegisteredZoomOutShortcut: String?
+    var lastRegisteredZoomResetShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false


### PR DESCRIPTION
## Summary
- Replaces hard-coded Cmd+=/Cmd+-/Cmd+0 checks with dynamic shortcuts from UserDefaults
- Adds skip-if-unchanged guards and tear-down before re-registration
- Any zoom shortcut can be independently disabled via empty string

Part of plan: keyboard-shortcuts-customization.md (PR 8 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
