### PR TITLE
Make Quick Input Above Dock shortcut (Cmd+Shift+V) configurable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -566,13 +566,14 @@ extension AppDelegate {
     ///
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
-    /// 2. Clears both `lastRegisteredGlobalHotkey` and `lastRegisteredQuickInputHotkey`
-    ///    so re-registration is not short-circuited
+    /// 2. Clears `lastRegisteredGlobalHotkey`, `lastRegisteredQuickInputHotkey`, and
+    ///    `lastRegisteredQuickInputAboveDockShortcut` so re-registration is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredQuickInputAboveDockShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -237,14 +237,36 @@ extension AppDelegate {
         }
     }
 
-    /// Registers Cmd+Shift+V as a global shortcut to open the quick input text field.
-    /// Uses NSEvent monitors (global + local).
+    /// Registers the Quick Input Above Dock shortcut (default Cmd+Shift+V) as a
+    /// global + local monitor. Reads the shortcut from UserDefaults and skips
+    /// re-registration if unchanged. An empty shortcut disables the feature.
     func registerFnVMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "quickInputAboveDockShortcut") ?? "cmd+shift+v"
+
+        if shortcut == lastRegisteredQuickInputAboveDockShortcut { return }
+
+        // Tear down previous monitors
+        if let monitor = fnVGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVGlobalMonitor = nil
+        }
+        if let monitor = fnVLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredQuickInputAboveDockShortcut = shortcut
+            log.info("Quick Input Above Dock: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+Shift+V: keyCode 9 is kVK_ANSI_V
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 9,
-                  mods == [.command, .shift] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -258,6 +280,8 @@ extension AppDelegate {
             _ = handler(event)
         }
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredQuickInputAboveDockShortcut = shortcut
     }
 
     /// Registers Cmd+N as a local shortcut to create a new thread.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredQuickInputAboveDockShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false


### PR DESCRIPTION
## Summary
- Replaces hard-coded Cmd+Shift+V check with dynamic shortcut from UserDefaults
- Adds skip-if-unchanged guard and tear-down before re-registration
- Empty shortcut disables the feature

Part of plan: keyboard-shortcuts-customization.md (PR 4 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
