### PR TITLE
Make Navigate Back/Forward shortcuts configurable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -566,13 +566,15 @@ extension AppDelegate {
     ///
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
-    /// 2. Clears both `lastRegisteredGlobalHotkey` and `lastRegisteredQuickInputHotkey`
-    ///    so re-registration is not short-circuited
+    /// 2. Clears `lastRegistered*` shortcut properties so re-registration
+    ///    is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredNavBackShortcut = nil
+        lastRegisteredNavForwardShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -306,29 +306,63 @@ extension AppDelegate {
     /// Only consumes the event when navigation actually occurs — if the history
     /// stack is empty, the event passes through to the responder chain.
     func registerNavigationMonitor() {
-        guard navLocalMonitor == nil else { return }
+        let backShortcut = UserDefaults.standard.string(forKey: "navigateBackShortcut") ?? "cmd+["
+        let forwardShortcut = UserDefaults.standard.string(forKey: "navigateForwardShortcut") ?? "cmd+]"
+
+        // Skip re-registration if neither shortcut changed.
+        if backShortcut == lastRegisteredNavBackShortcut,
+           forwardShortcut == lastRegisteredNavForwardShortcut { return }
+
+        // Tear down existing monitor before re-registration.
+        if let monitor = navLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            navLocalMonitor = nil
+        }
+
+        // If both shortcuts are disabled, record state and return.
+        guard !backShortcut.isEmpty || !forwardShortcut.isEmpty else {
+            lastRegisteredNavBackShortcut = backShortcut
+            lastRegisteredNavForwardShortcut = forwardShortcut
+            log.info("Navigation: both shortcuts disabled")
+            return
+        }
+
+        // Parse shortcuts into modifier flags and key strings.
+        let backParsed: (NSEvent.ModifierFlags, String)? = backShortcut.isEmpty ? nil : ShortcutHelper.parseShortcut(backShortcut)
+        let forwardParsed: (NSEvent.ModifierFlags, String)? = forwardShortcut.isEmpty ? nil : ShortcutHelper.parseShortcut(forwardShortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard mods == [.command] else { return event }
             guard let chars = event.charactersIgnoringModifiers else { return event }
-            switch chars {
-            case "[":
+
+            // Check back shortcut
+            if let (backMods, backKey) = backParsed,
+               mods == backMods,
+               chars.lowercased() == backKey.lowercased() {
                 guard self?.mainWindow?.windowState.navigationHistory.canGoBack == true else { return event }
                 Task { @MainActor in
                     self?.mainWindow?.windowState.navigateBack()
                 }
                 return nil
-            case "]":
+            }
+
+            // Check forward shortcut
+            if let (fwdMods, fwdKey) = forwardParsed,
+               mods == fwdMods,
+               chars.lowercased() == fwdKey.lowercased() {
                 guard self?.mainWindow?.windowState.navigationHistory.canGoForward == true else { return event }
                 Task { @MainActor in
                     self?.mainWindow?.windowState.navigateForward()
                 }
                 return nil
-            default:
-                return event
             }
+
+            return event
         }
         navLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredNavBackShortcut = backShortcut
+        lastRegisteredNavForwardShortcut = forwardShortcut
     }
 
     /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredNavBackShortcut: String?
+    var lastRegisteredNavForwardShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false


### PR DESCRIPTION
## Summary
- Replaces hard-coded Cmd+[ and Cmd+] checks with dynamic shortcuts from UserDefaults
- Adds skip-if-unchanged guards and tear-down before re-registration
- Either shortcut can be independently disabled via empty string

Part of plan: keyboard-shortcuts-customization.md (PR 7 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
