### PR TITLE
Make Command Palette shortcut (Cmd+K) configurable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -566,13 +566,14 @@ extension AppDelegate {
     ///
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
-    /// 2. Clears both `lastRegisteredGlobalHotkey` and `lastRegisteredQuickInputHotkey`
-    ///    so re-registration is not short-circuited
+    /// 2. Clears `lastRegisteredGlobalHotkey`, `lastRegisteredQuickInputHotkey`, and
+    ///    `lastRegisteredCommandPaletteShortcut` so re-registration is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredCommandPaletteShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -277,14 +277,32 @@ extension AppDelegate {
         cmdNLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+K as a local shortcut to open the command palette.
+    /// Registers a local shortcut to open the command palette.
     /// Only active when the app is focused (local monitor, not global).
+    /// Reads the shortcut from UserDefaults. Skips re-registration if unchanged.
     func registerCmdKMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "commandPaletteShortcut") ?? "cmd+k"
+
+        if shortcut == lastRegisteredCommandPaletteShortcut { return }
+
+        // Tear down previous registration
+        if let monitor = cmdKLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdKLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredCommandPaletteShortcut = shortcut
+            log.info("Command Palette: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+K: keyCode 40 is kVK_ANSI_K
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 40,
-                  mods == [.command] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -294,6 +312,8 @@ extension AppDelegate {
             return nil // consume the event
         }
         cmdKLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredCommandPaletteShortcut = shortcut
     }
 
     /// Registers Cmd+[ and Cmd+] as local shortcuts for back/forward navigation.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredCommandPaletteShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false


### PR DESCRIPTION
## Summary
- Replaces hard-coded Cmd+K check with dynamic shortcut from UserDefaults
- Adds skip-if-unchanged guard and tear-down before re-registration
- Empty shortcut disables the feature

Part of plan: keyboard-shortcuts-customization.md (PR 6 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
