### PR TITLE
Add Permission Required/Reason prefixes to confirmation UI

### DIFF
--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -100,7 +100,7 @@ public final class ToolConfirmationNotificationService {
 
     private func formatTitle(_ message: ConfirmationRequestMessage) -> String {
         let toolName = toolDisplayName(message.toolName)
-        var title = "\(toolName) — \(message.riskLevel) risk"
+        var title = "Permission Required: \(toolName) — \(message.riskLevel) risk"
         if let target = message.executionTarget, !target.isEmpty {
             title += " (\(target))"
         }
@@ -108,6 +108,9 @@ public final class ToolConfirmationNotificationService {
     }
 
     private func formatBody(_ message: ConfirmationRequestMessage) -> String {
+        if let reason = confirmationReasonDescription(input: message.input) {
+            return reason.count > 200 ? String(reason.prefix(197)) + "..." : reason
+        }
         let description = confirmationHumanDescription(
             toolName: message.toolName,
             input: message.input

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -149,14 +149,16 @@ public final class ToolConfirmationNotificationService {
 
     private func toolDisplayName(_ toolName: String) -> String {
         switch toolName {
-        case "file_write":      return "Write File"
-        case "file_edit":       return "Edit File"
-        case "bash", "host_bash": return "Run Command"
-        case "web_fetch":       return "Fetch URL"
-        case "schedule_create": return "Create Schedule"
-        case "schedule_update": return "Update Schedule"
-        case "schedule_delete": return "Delete Schedule"
-        case "schedule_list":   return "List Schedules"
+        case "file_write", "host_file_write":   return "Write File"
+        case "file_edit", "host_file_edit":     return "Edit File"
+        case "file_read", "host_file_read":     return "Read File"
+        case "bash", "host_bash":               return "Run Command"
+        case "web_fetch":                       return "Fetch URL"
+        case "web_search":                      return "Web Search"
+        case "schedule_create":                 return "Create Schedule"
+        case "schedule_update":                 return "Update Schedule"
+        case "schedule_delete":                 return "Delete Schedule"
+        case "schedule_list":                   return "List Schedules"
         default: return toolName.replacingOccurrences(of: "_", with: " ").capitalized
         }
     }

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -111,11 +111,40 @@ public final class ToolConfirmationNotificationService {
         if let reason = confirmationReasonDescription(input: message.input) {
             return reason.count > 200 ? String(reason.prefix(197)) + "..." : reason
         }
-        let description = confirmationHumanDescription(
-            toolName: message.toolName,
-            input: message.input
-        )
-        return description.count > 200 ? String(description.prefix(197)) + "..." : description
+        // Provide contextual detail from tool input (command, path, URL) so the
+        // notification body adds information beyond the title.
+        let body = notificationBodyDetail(toolName: message.toolName, input: message.input)
+        return body.count > 200 ? String(body.prefix(197)) + "..." : body
+    }
+
+    /// Extracts a contextual detail string from tool input for notification bodies.
+    /// Provides specifics (command text, file path, URL) that complement the title.
+    private func notificationBodyDetail(toolName: String, input: [String: AnyCodable]) -> String {
+        switch toolName {
+        case "bash", "host_bash":
+            if let cmd = input["command"]?.value as? String {
+                return cmd
+            }
+        case "file_write", "host_file_write", "file_edit", "host_file_edit", "file_read", "host_file_read":
+            if let path = input["path"]?.value as? String {
+                return path
+            }
+        case "web_fetch":
+            if let url = input["url"]?.value as? String {
+                return url
+            }
+        case "browser_navigate":
+            if let url = input["url"]?.value as? String {
+                return url
+            }
+        case "credential_store":
+            if let service = input["service"]?.value as? String {
+                return service
+            }
+        default:
+            break
+        }
+        return "Approve or deny this action."
     }
 
     private func toolDisplayName(_ toolName: String) -> String {

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -583,9 +583,8 @@ public struct ToolConfirmationData: Equatable {
 }
 
 /// Shared helper that builds a human-friendly confirmation description from tool
-/// metadata. Used by both the inline `ToolConfirmationBubble` (via
-/// `ToolConfirmationData.humanDescription`) and system notifications (via
-/// `ToolConfirmationNotificationService`).
+/// metadata. Used by `ToolConfirmationBubble` (via
+/// `ToolConfirmationData.humanDescription`).
 public func confirmationHumanDescription(
     toolName: String,
     input: [String: AnyCodable],
@@ -637,6 +636,10 @@ public func confirmationHumanDescription(
 
     switch toolName {
     case "request_system_permission":
+        let reason = (input["reason"]?.value as? String) ?? ""
+        if !reason.isEmpty {
+            return reason
+        }
         return "Permission Required: \(perm)"
     case "bash", "host_bash":
         return "Permission Required: Run Command"

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -529,6 +529,11 @@ public struct ToolConfirmationData: Equatable {
         )
     }
 
+    /// Reason text prefixed with "Reason:" when available.
+    public var humanReason: String? {
+        confirmationReasonDescription(input: input)
+    }
+
     public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestDiff? = nil, allowlistOptions: [ConfirmationRequestAllowlistOption] = [], scopeOptions: [ConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], toolUseId: String? = nil, state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
@@ -587,16 +592,6 @@ public func confirmationHumanDescription(
     toolCategory: String? = nil,
     permissionFriendlyName: String? = nil
 ) -> String {
-    // Use reason, falling back to description/message for tools that provide
-    // context via other fields (e.g. context_overflow_compression uses description)
-    let rawReason = (input["reason"]?.value as? String) ?? ""
-    let reason: String = rawReason.isEmpty
-        ? (input["description"]?.value as? String)
-            ?? (input["message"]?.value as? String)
-            ?? ""
-        : rawReason
-    let r = reason.isEmpty ? "" : reason.prefix(1).lowercased() + reason.dropFirst()
-
     // Derive permissionFriendlyName from input when not provided
     let perm: String = permissionFriendlyName ?? {
         guard let type = input["permission_type"]?.value as? String else { return "Permission" }
@@ -642,78 +637,83 @@ public func confirmationHumanDescription(
 
     switch toolName {
     case "request_system_permission":
-        if reason.isEmpty {
-            return "I need \(perm) access to continue."
-        }
-        return reason
+        return "Permission Required: \(perm)"
     case "bash", "host_bash":
-        if !r.isEmpty { return "Allow running a command on your computer \(r)?" }
-        return "Allow running a command on your computer?"
+        return "Permission Required: Run Command"
     case "file_write", "host_file_write":
-        if !r.isEmpty { return "Allow writing a file \(r)?" }
         let path = (input["path"]?.value as? String) ?? ""
-        if path.isEmpty { return "Allow writing a file?" }
-        return "Allow writing to \(URL(fileURLWithPath: path).lastPathComponent)?"
+        if path.isEmpty { return "Permission Required: Write File" }
+        return "Permission Required: Write \(URL(fileURLWithPath: path).lastPathComponent)"
     case "file_edit", "host_file_edit":
-        if !r.isEmpty { return "Allow editing a file \(r)?" }
         let path = (input["path"]?.value as? String) ?? ""
-        if path.isEmpty { return "Allow editing a file?" }
-        return "Allow editing \(URL(fileURLWithPath: path).lastPathComponent)?"
+        if path.isEmpty { return "Permission Required: Edit File" }
+        return "Permission Required: Edit \(URL(fileURLWithPath: path).lastPathComponent)"
     case "file_read", "host_file_read":
-        if !r.isEmpty { return "Allow reading a file \(r)?" }
         let path = (input["path"]?.value as? String) ?? ""
-        if path.isEmpty { return "Allow reading a file?" }
-        return "Allow reading \(URL(fileURLWithPath: path).lastPathComponent)?"
+        if path.isEmpty { return "Permission Required: Read File" }
+        return "Permission Required: Read \(URL(fileURLWithPath: path).lastPathComponent)"
     case "web_fetch":
-        if !r.isEmpty { return "Allow fetching a URL \(r)?" }
         let url = (input["url"]?.value as? String) ?? ""
         if let host = URL(string: url)?.host {
-            return "Allow fetching data from \(host)?"
+            return "Permission Required: Fetch from \(host)"
         }
-        return "Allow fetching a URL?"
+        return "Permission Required: Fetch URL"
     case "browser_navigate":
-        if !r.isEmpty { return "Allow opening a page \(r)?" }
         let url = (input["url"]?.value as? String) ?? ""
         if let host = URL(string: url)?.host {
-            return "Allow opening \(host)?"
+            return "Permission Required: Open \(host)"
         }
-        return "Allow opening a page?"
+        return "Permission Required: Open Page"
     case "credential_store":
         let action = (input["action"]?.value as? String) ?? ""
         let service = (input["service"]?.value as? String) ?? ""
         switch action {
         case "oauth2_connect":
             return service.isEmpty
-                ? "Allow connecting an account?"
-                : "Allow connecting your \(service.capitalized) account?"
+                ? "Permission Required: Connect Account"
+                : "Permission Required: Connect \(service.capitalized) Account"
         case "store":
             return service.isEmpty
-                ? "Allow saving a credential securely?"
-                : "Allow saving a \(service) credential securely?"
+                ? "Permission Required: Save Credential"
+                : "Permission Required: Save \(service) Credential"
         case "delete":
             return service.isEmpty
-                ? "Allow removing a stored credential?"
-                : "Allow removing a \(service) credential?"
+                ? "Permission Required: Remove Credential"
+                : "Permission Required: Remove \(service) Credential"
         case "prompt":
             return service.isEmpty
-                ? "Allow asking for a credential?"
-                : "Allow asking for a \(service) credential?"
+                ? "Permission Required: Request Credential"
+                : "Permission Required: Request \(service) Credential"
         default:
-            return "Allow accessing secure storage?"
+            return "Permission Required: Secure Storage"
         }
     case "schedule_create":
         let name = (input["name"]?.value as? String) ?? ""
         return name.isEmpty
-            ? "Allow creating a schedule?"
-            : "Allow creating schedule \"\(name)\"?"
+            ? "Permission Required: Create Schedule"
+            : "Permission Required: Create Schedule \"\(name)\""
     case "schedule_update":
-        return "Allow updating a schedule?"
+        return "Permission Required: Update Schedule"
     case "schedule_delete":
-        return "Allow deleting a schedule?"
+        return "Permission Required: Delete Schedule"
     default:
-        if !r.isEmpty { return "Allow using \(tc.lowercased()) \(r)?" }
-        return "Allow using \(tc.lowercased())?"
+        return "Permission Required: \(tc)"
     }
+}
+
+/// Extracts and formats the reason/description from tool input, prefixed with "Reason:".
+/// Returns `nil` when no reason text is available.
+public func confirmationReasonDescription(
+    input: [String: AnyCodable]
+) -> String? {
+    let rawReason = (input["reason"]?.value as? String) ?? ""
+    let reason: String = rawReason.isEmpty
+        ? (input["description"]?.value as? String)
+            ?? (input["message"]?.value as? String)
+            ?? ""
+        : rawReason
+    guard !reason.isEmpty else { return nil }
+    return "Reason: \(reason)"
 }
 
 /// A single sub-tool invocation within a claude_code tool call.

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -139,6 +139,12 @@ public struct ToolConfirmationBubble: View {
                 .font(VFont.body)
                 .foregroundColor(VColor.contentSecondary)
 
+            if let reason = confirmation.humanReason {
+                Text(reason)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+            }
+
             HStack(spacing: VSpacing.sm) {
                 VButton(label: "Open System Settings", style: .primary) {
                     #if os(macOS)
@@ -220,6 +226,12 @@ public struct ToolConfirmationBubble: View {
             Text(confirmation.humanDescription)
                 .font(VFont.bodyBold)
                 .foregroundColor(VColor.contentDefault)
+
+            if let reason = confirmation.humanReason {
+                Text(reason)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+            }
 
             // First-time educational banner for command confirmations
             if isCommandTool && !hasSeenCommandExplanation {


### PR DESCRIPTION
## Summary
- Update confirmation dialog titles to use "Permission Required: [action]" format instead of "Allow [action]?"
- Add separate "Reason: [reason text]" display below the title when a reason is provided
- Update system notifications to use the new prefixed format with reason-first body

## Changes
- `clients/shared/Features/Chat/ChatMessage.swift`: Updated `confirmationHumanDescription()` to return "Permission Required: [action]" format, added `confirmationReasonDescription()` helper, added `humanReason` computed property to `ToolConfirmationData`
- `clients/shared/Features/Chat/ToolConfirmationBubble.swift`: Added `humanReason` display in both `pendingContent` and `systemPermissionCard` views
- `clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift`: Prefixed notification title with "Permission Required:", updated body to prioritize reason text

## Milestone PRs (merged into feature branch)
- #16298: M1: Add Permission Required/Reason prefixes to confirmation descriptions

## Project issue
Closes #16293

## Test plan
- [ ] Verify confirmation bubbles show "Permission Required: [action]" as bold title
- [ ] Verify "Reason: [reason text]" appears below title when a reason is provided
- [ ] Verify system notifications show prefixed title and reason-first body
- [ ] Verify system permission cards show "Permission Required: [permission name]"
- [ ] Verify collapsed/decided state still displays correctly

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
