### PR TITLE
fix: narrow OAuth provider seed upsert to only overwrite implementation fields

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -38,8 +38,11 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
- * CONFLICT DO UPDATE so that corrections to seed data (e.g. a fixed baseUrl)
- * propagate to existing installations on the next startup.
+ * CONFLICT DO UPDATE so that corrections to Vellum implementation fields
+ * (authUrl, tokenUrl, tokenEndpointAuthMethod, extraParams, callbackTransport,
+ * loopbackPort, pingUrl) propagate to existing installations on the next
+ * startup. User-customizable fields (defaultScopes, scopePolicy, userinfoUrl,
+ * baseUrl) are only written on initial insert and preserved across restarts.
  */
 export function seedProviders(
   profiles: Array<{
@@ -95,10 +98,6 @@ export function seedProviders(
           authUrl,
           tokenUrl,
           tokenEndpointAuthMethod,
-          userinfoUrl,
-          baseUrl,
-          defaultScopes,
-          scopePolicy,
           extraParams,
           callbackTransport,
           loopbackPort,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -4,10 +4,15 @@ import { seedProviders } from "./oauth-store.js";
  * Protocol-level seed data for each well-known OAuth provider.
  *
  * These values are upserted into the `oauth_providers` SQLite table on
- * every startup so that corrections (e.g. a fixed baseUrl) propagate to
- * existing installations. Code-side behavioral fields (identityVerifier,
- * injectionTemplates, setup, etc.) live in `provider-behaviors.ts` and
- * are never persisted to the DB.
+ * every startup. Only Vellum implementation fields (authUrl, tokenUrl,
+ * tokenEndpointAuthMethod, extraParams, callbackTransport, loopbackPort,
+ * pingUrl) are overwritten on subsequent startups — user-customizable
+ * fields (defaultScopes, scopePolicy, userinfoUrl, baseUrl) are only
+ * written on initial insert and preserved across restarts.
+ *
+ * Code-side behavioral fields (identityVerifier, injectionTemplates,
+ * setup, etc.) live in `provider-behaviors.ts` and are never persisted
+ * to the DB.
  */
 const PROVIDER_SEED_DATA: Record<
   string,
@@ -103,6 +108,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { owner: "user" },
     tokenEndpointAuthMethod: "client_secret_basic",
+    callbackTransport: "gateway",
   },
 
   "integration:twitter": {


### PR DESCRIPTION
## Summary
- Add explicit callbackTransport: gateway to Notion provider seed data (Notion requires https:// redirect URIs, no localhost support)
- Narrow the seed upsert ON CONFLICT UPDATE to only overwrite Vellum implementation fields (authUrl, tokenUrl, tokenEndpointAuthMethod, extraParams, callbackTransport, loopbackPort, pingUrl)
- Preserve user-customizable fields (defaultScopes, scopePolicy, userinfoUrl, baseUrl) across daemon restarts

Part of plan: oauth-loopback-default.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
