### PR TITLE
fix: sync greeting text and avatar slide animations on empty state

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -443,7 +443,7 @@ struct ChatContentView: View {
                         .font(.system(size: 22, weight: .medium))
                         .foregroundColor(VColor.contentSecondary)
                         .multilineTextAlignment(.leading)
-                        .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .leading)))
+                        .transition(.opacity.combined(with: .move(edge: .leading)))
                 }
             }
             .animation(.easeOut(duration: 0.4), value: viewModel.emptyStateGreeting != nil)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -71,7 +71,7 @@ struct ChatEmptyStateView: View {
                         .font(.custom("Fraunces", size: 28).weight(.regular))
                         .foregroundColor(VColor.contentSecondary)
                         .multilineTextAlignment(.leading)
-                        .transition(.opacity.combined(with: .scale(scale: 0.8, anchor: .leading)))
+                        .transition(.opacity.combined(with: .move(edge: .leading)))
                 }
             }
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)


### PR DESCRIPTION
## Summary
- Replace `.scale(scale: 0.8, anchor: .leading)` transition with `.move(edge: .leading)` on both macOS and iOS greeting text
- The `.scale` render transform was expanding the text visually at a different rate than the HStack layout animation was sliding the avatar, causing text/avatar overlap during the transition
- `.move(edge: .leading)` makes the text slide in from the avatar's position, naturally synchronized with the layout-driven avatar movement

## Original prompt
On the greeting page, the avatar currently slides to the left more slowly than the greeting expands outwards, such that the text and the avatar overlap. Help me adjust the rate of each animation such that they grow and slide smoothly together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
