### PR TITLE
fix: default OAuth callbackTransport to loopback instead of gateway

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -160,7 +160,7 @@ export async function orchestrateOAuthConnect(
     | undefined;
   const callbackTransport =
     (providerRow.callbackTransport as "loopback" | "gateway" | null) ??
-    "gateway";
+    "loopback";
   const loopbackPort = providerRow.loopbackPort;
 
   // Resolve scopes via the scope policy engine

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -420,18 +420,17 @@ export interface OAuth2PreparedFlow {
  * URL directly in chat and the callback arrives asynchronously via the gateway.
  *
  * Supports two transports:
- * - **gateway** (default): routes callbacks through the public ingress URL.
- *   Requires `ingress.publicBaseUrl` to be configured.
- * - **loopback**: starts a temporary localhost server to receive the callback.
- *   Used for services like Slack that require pre-registered localhost redirect
- *   URIs. The daemon is always local, so this works even in non-interactive
- *   (channel) sessions.
+ * - **loopback** (default): starts a temporary localhost server to receive the
+ *   callback. Works without any public URL or tunnel.
+ * - **gateway**: routes callbacks through the public ingress URL.
+ *   Requires `ingress.publicBaseUrl` to be configured. Used for providers that
+ *   don't support localhost redirects (e.g. Twitter, Notion).
  */
 export async function prepareOAuth2Flow(
   config: OAuth2Config,
   options?: OAuth2FlowOptions,
 ): Promise<OAuth2PreparedFlow> {
-  const transport = options?.callbackTransport ?? "gateway";
+  const transport = options?.callbackTransport ?? "loopback";
 
   if (transport === "loopback") {
     return prepareLoopbackFlow(config, options?.loopbackPort);


### PR DESCRIPTION
## Summary
- Change the default callbackTransport from gateway to loopback in the OAuth connect orchestrator (connect-orchestrator.ts)
- Change the matching default in prepareOAuth2Flow (oauth2.ts) for consistency
- Loopback (temporary localhost server) is the safer default for a local-first assistant — it works in both interactive and non-interactive contexts without requiring a public ingress URL

Part of plan: oauth-loopback-default.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
