### PR TITLE
M1: Add notification icon export and NotificationIconProvider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -344,9 +344,9 @@ final class AvatarAppearanceManager {
             destURL = URL(fileURLWithPath: baseDataDir)
                 .appendingPathComponent("workspace/data/avatar/notification-icon.png")
         } else {
-            destURL = Self.workspaceCustomAvatarURL()
-                .deletingLastPathComponent()
-                .appendingPathComponent("notification-icon.png")
+            // No assistant-scoped path available — return nil to avoid
+            // writing to a shared location that could serve the wrong avatar.
+            return nil
         }
 
         // 2. Get the current avatar image (chatAvatarImage handles all fallbacks)

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -325,6 +325,45 @@ final class AvatarAppearanceManager {
         source.resume()
     }
 
+    // MARK: - Notification Icon Export
+
+    /// Exports the current avatar as a PNG file suitable for UNNotificationAttachment.
+    /// Writes to `{baseDataDir}/workspace/data/avatar/notification-icon.png`.
+    /// Returns the file URL on success, nil on failure.
+    func exportNotificationIcon(for assistantId: String) -> URL? {
+        // 1. Resolve the destination path
+        let destURL: URL
+        if let assistant = LockfileAssistant.loadByName(assistantId),
+           let baseDataDir = assistant.baseDataDir {
+            destURL = URL(fileURLWithPath: baseDataDir)
+                .appendingPathComponent("workspace/data/avatar/notification-icon.png")
+        } else {
+            destURL = Self.workspaceCustomAvatarURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("notification-icon.png")
+        }
+
+        // 2. Get the current avatar image (chatAvatarImage handles all fallbacks)
+        let image = chatAvatarImage
+
+        // 3. Export to PNG
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            return nil
+        }
+
+        // 4. Ensure directory exists and write
+        let dir = destURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        do {
+            try pngData.write(to: destURL)
+            return destURL
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: - Image Utilities
 
     /// Resize an NSImage to a square of the given point size using aspect-fill:

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -327,13 +327,19 @@ final class AvatarAppearanceManager {
 
     // MARK: - Notification Icon Export
 
-    /// Exports the current avatar as a PNG file suitable for UNNotificationAttachment.
+    /// Exports the currently connected assistant's avatar as a PNG file suitable
+    /// for `UNNotificationAttachment`. Always uses `chatAvatarImage`, which
+    /// renders the *connected* assistant's avatar (custom upload or fallback).
+    /// The destination path is derived from `connectedAssistantId` in
+    /// UserDefaults, matching the same resolution used by `customAvatarURL`.
+    ///
     /// Writes to `{baseDataDir}/workspace/data/avatar/notification-icon.png`.
     /// Returns the file URL on success, nil on failure.
-    func exportNotificationIcon(for assistantId: String) -> URL? {
-        // 1. Resolve the destination path
+    func exportNotificationIcon() -> URL? {
+        // 1. Resolve the destination path from the connected assistant
         let destURL: URL
-        if let assistant = LockfileAssistant.loadByName(assistantId),
+        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+           let assistant = LockfileAssistant.loadByName(assistantId),
            let baseDataDir = assistant.baseDataDir {
             destURL = URL(fileURLWithPath: baseDataDir)
                 .appendingPathComponent("workspace/data/avatar/notification-icon.png")

--- a/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
+++ b/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
@@ -17,9 +17,9 @@ final class NotificationIconProvider: NotificationIconProviding {
             iconURL = URL(fileURLWithPath: baseDataDir)
                 .appendingPathComponent("workspace/data/avatar/notification-icon.png")
         } else {
-            iconURL = AvatarAppearanceManager.workspaceCustomAvatarURL()
-                .deletingLastPathComponent()
-                .appendingPathComponent("notification-icon.png")
+            // No assistant-scoped path available — return nil to avoid
+            // serving another assistant's notification icon.
+            return nil
         }
 
         guard FileManager.default.fileExists(atPath: iconURL.path) else {

--- a/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
+++ b/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
@@ -1,0 +1,30 @@
+import Foundation
+import VellumAssistantShared
+
+/// Protocol for providing notification icon URLs per assistant.
+@MainActor
+protocol NotificationIconProviding {
+    func notificationIconURL(for assistantId: String) -> URL?
+}
+
+/// Looks up the pre-exported notification icon PNG on disk.
+@MainActor
+final class NotificationIconProvider: NotificationIconProviding {
+    func notificationIconURL(for assistantId: String) -> URL? {
+        let iconURL: URL
+        if let assistant = LockfileAssistant.loadByName(assistantId),
+           let baseDataDir = assistant.baseDataDir {
+            iconURL = URL(fileURLWithPath: baseDataDir)
+                .appendingPathComponent("workspace/data/avatar/notification-icon.png")
+        } else {
+            iconURL = AvatarAppearanceManager.workspaceCustomAvatarURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("notification-icon.png")
+        }
+
+        guard FileManager.default.fileExists(atPath: iconURL.path) else {
+            return nil
+        }
+        return iconURL
+    }
+}


### PR DESCRIPTION
## Summary
- Add `exportNotificationIcon(for:)` method to `AvatarAppearanceManager` that exports the current avatar as a PNG for `UNNotificationAttachment`
- Create `NotificationIconProvider` protocol and implementation for notification services to look up the exported icon on disk

## Test plan
- [ ] Verify `exportNotificationIcon` writes PNG to expected path
- [ ] Verify `NotificationIconProvider` returns nil when no icon exists
- [ ] Verify `NotificationIconProvider` returns URL when icon has been exported
- [ ] Verify multi-instance path resolution via `LockfileAssistant`

Part of #16313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
