### PR TITLE
Add Reset All to Defaults button for keyboard shortcuts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Foundation
 
 /// Describes a single keyboard shortcut that can be customized by the user.
@@ -123,6 +124,37 @@ enum KeyboardShortcutRegistry {
             let normalizedCurrent = ShortcutHelper.normalizeShortcut(current)
             return normalizedCurrent == normalizedTarget
         }
+    }
+
+    /// Resets all keyboard shortcuts on the given store back to their registry defaults.
+    @MainActor static func resetAllToDefaults(store: SettingsStore) {
+        for definition in allShortcuts {
+            switch definition.id {
+            case "globalHotkeyShortcut":
+                store.globalHotkeyShortcut = definition.defaultShortcut
+            case "quickInputHotkeyShortcut":
+                store.quickInputHotkeyShortcut = definition.defaultShortcut
+            case "quickInputAboveDockShortcut":
+                store.quickInputAboveDockShortcut = definition.defaultShortcut
+            case "newThreadShortcut":
+                store.newThreadShortcut = definition.defaultShortcut
+            case "commandPaletteShortcut":
+                store.commandPaletteShortcut = definition.defaultShortcut
+            case "navigateBackShortcut":
+                store.navigateBackShortcut = definition.defaultShortcut
+            case "navigateForwardShortcut":
+                store.navigateForwardShortcut = definition.defaultShortcut
+            case "zoomInShortcut":
+                store.zoomInShortcut = definition.defaultShortcut
+            case "zoomOutShortcut":
+                store.zoomOutShortcut = definition.defaultShortcut
+            case "zoomResetShortcut":
+                store.zoomResetShortcut = definition.defaultShortcut
+            default:
+                break
+            }
+        }
+        store.quickInputHotkeyKeyCode = kVK_ANSI_Slash
     }
 
     /// Returns the user's current shortcut for the given definition id,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -15,6 +15,7 @@ struct SettingsAppearanceTab: View {
     @State private var debouncedTimezoneSearchText: String = ""
     @State private var isTimezoneDropdownOpen: Bool = false
     @State private var timezoneSearchDebounceTask: Task<Void, Never>?
+    @State private var showResetConfirmation = false
     @FocusState private var isTimezoneSearchFocused: Bool
 
     var body: some View {
@@ -308,10 +309,28 @@ struct SettingsAppearanceTab: View {
                     helperText: "When enabled, Enter inserts a new line and cmd+enter sends."
                 )
                 .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
+                HStack {
+                    Spacer()
+                    VButton(label: "Reset All to Defaults", style: .outlined) {
+                        showResetConfirmation = true
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
                 }
             }
             .onDisappear {
                 activeRecordingId = nil
+            }
+            .alert("Reset Keyboard Shortcuts?", isPresented: $showResetConfirmation) {
+                Button("Reset", role: .destructive) {
+                    KeyboardShortcutRegistry.resetAllToDefaults(store: store)
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This will reset all keyboard shortcuts to their default values.")
             }
 
             // MEDIA EMBEDS section


### PR DESCRIPTION
## Summary
- Adds `resetAllToDefaults(store:)` method to `KeyboardShortcutRegistry` that iterates all shortcut definitions and resets each store property to its default value
- Adds "Reset All to Defaults" button at bottom of Keyboard Shortcuts settings card
- Shows confirmation dialog before resetting

Part of plan: keyboard-shortcuts-customization.md (PR 10 of 11)
Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
