### PR TITLE
fix: filter guardian role from contacts list sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -38,14 +38,16 @@ final class ContactsViewModel: ObservableObject {
 
     // MARK: - Computed Properties
 
-    /// Contacts filtered by the current search query, matching against
-    /// displayName and channel addresses.
+    /// Non-guardian contacts filtered by the current search query, matching
+    /// against displayName and channel addresses. Guardians are excluded
+    /// because they have a dedicated section in the list.
     var filteredContacts: [ContactPayload] {
+        let nonGuardian = contacts.filter { $0.role != "guardian" }
         guard !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return contacts
+            return nonGuardian
         }
         let query = searchQuery.lowercased()
-        return contacts.filter { contact in
+        return nonGuardian.filter { contact in
             if contact.displayName.lowercased().contains(query) {
                 return true
             }


### PR DESCRIPTION
## Summary
- Filter out contacts with role 'guardian' from the Contacts list sidebar
- The guardian already has a dedicated 'Guardian (You)' card, so showing them in the contacts list is redundant

## Original prompt
We seem to now show a contact card for the Guardian but should filter that role out. They already have their own special card above where it says 'Guardian (You)'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
