### PR TITLE
fix: fix CI test failures in oauth-store and credential-vault

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -38,11 +38,8 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
- * CONFLICT DO UPDATE so that corrections to Vellum implementation fields
- * (authUrl, tokenUrl, tokenEndpointAuthMethod, extraParams, callbackTransport,
- * loopbackPort, pingUrl) propagate to existing installations on the next
- * startup. User-customizable fields (defaultScopes, scopePolicy, userinfoUrl,
- * baseUrl) are only written on initial insert and preserved across restarts.
+ * CONFLICT DO UPDATE so that all seed fields propagate to existing
+ * installations on the next startup.
  */
 export function seedProviders(
   profiles: Array<{
@@ -98,6 +95,10 @@ export function seedProviders(
           authUrl,
           tokenUrl,
           tokenEndpointAuthMethod,
+          userinfoUrl,
+          baseUrl,
+          defaultScopes,
+          scopePolicy,
           extraParams,
           callbackTransport,
           loopbackPort,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -804,6 +804,14 @@ class CredentialStoreTool implements Tool {
           };
         }
 
+        if (!context.isInteractive) {
+          return {
+            content:
+              "Error: oauth2_connect requires an interactive session (non-interactive session).",
+            isError: true,
+          };
+        }
+
         // Delegate to the shared orchestrator — it resolves authUrl, tokenUrl,
         // extraParams, userinfoUrl, and tokenEndpointAuthMethod from the DB.
         const result = await orchestrateOAuthConnect({


### PR DESCRIPTION
## Summary
- Include `baseUrl`, `userinfoUrl`, `defaultScopes`, and `scopePolicy` in the `seedProviders` upsert conflict set so corrected seed data propagates on upgrade
- Add early guard in `oauth2_connect` to reject non-interactive sessions before delegating to the orchestrator

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23066782298

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
