### PR TITLE
test: verify OAuth seed upsert scoping and loopback transport default

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -890,6 +890,74 @@ describe("assistant oauth connections connect <provider-key>", () => {
     expect(parsed.error).toBe("Something went wrong");
   });
 
+  test("succeeds when callbackTransport is null (loopback default)", async () => {
+    // Provider row has callbackTransport: null — orchestrator should default
+    // to loopback and not require a public ingress URL.
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-loopback",
+      clientId: "loopback-client",
+      clientSecretCredentialPath: "oauth_app/app-loopback/client_secret",
+      providerKey: "integration:test-loopback",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    let capturedOpts: Record<string, unknown> | undefined;
+    mockOrchestrateOAuthConnect = async (opts) => {
+      capturedOpts = opts;
+      return {
+        success: true,
+        deferred: true,
+        authUrl: "https://example.com/auth?loopback",
+        state: "state-loopback",
+        service: "integration:test-loopback",
+      };
+    };
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:test-loopback",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.deferred).toBe(true);
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.clientId).toBe("loopback-client");
+  });
+
+  test("returns ingress URL error when callbackTransport is explicitly gateway", async () => {
+    // Provider row has callbackTransport: "gateway" — orchestrator should
+    // require a public ingress URL, which is not configured in the test env.
+    mockGetMostRecentAppByProvider = () => ({
+      id: "app-gateway",
+      clientId: "gateway-client",
+      clientSecretCredentialPath: "oauth_app/app-gateway/client_secret",
+      providerKey: "integration:test-gateway",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+
+    mockOrchestrateOAuthConnect = async () => ({
+      success: false,
+      error:
+        "oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.",
+    });
+
+    const { exitCode, stdout } = await runCli([
+      "connections",
+      "connect",
+      "integration:test-gateway",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("requires a public ingress URL");
+  });
+
   test("fails when client_secret is required but missing", async () => {
     mockGetAppByProviderAndClientId = () => ({
       id: "app-1",

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -38,7 +38,10 @@ mock.module("../security/secure-keys.js", () => ({
     Promise.resolve(secureKeyValues.get(account)),
 }));
 
-import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import { eq } from "drizzle-orm";
+
+import { getDb, initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import { oauthProviders } from "../memory/schema/oauth.js";
 import {
   createConnection,
   deleteApp,
@@ -141,7 +144,7 @@ describe("provider operations", () => {
       });
     });
 
-    test("updates existing provider rows with corrected seed data", () => {
+    test("updates implementation fields while preserving user-customizable fields on re-seed", () => {
       seedProviders([
         {
           providerKey: "github",
@@ -172,14 +175,16 @@ describe("provider operations", () => {
 
       const row = getProvider("github");
       expect(row).toBeDefined();
-      // Seed data should overwrite the existing row
+      // Implementation fields should be overwritten by the re-seed
       expect(row!.authUrl).toBe("https://github.com/login/oauth/authorize-v2");
       expect(row!.tokenUrl).toBe(
         "https://github.com/login/oauth/access_token-v2",
       );
-      expect(row!.baseUrl).toBe("https://api.github.com/v2");
-      expect(JSON.parse(row!.defaultScopes)).toEqual(["repo", "user"]);
-      expect(JSON.parse(row!.scopePolicy)).toEqual({ required: ["repo"] });
+      // User-customizable fields (baseUrl, defaultScopes, scopePolicy) are
+      // preserved from the original insert — not overwritten on re-seed.
+      expect(row!.baseUrl).toBe("https://api.github.com");
+      expect(JSON.parse(row!.defaultScopes)).toEqual(["repo"]);
+      expect(JSON.parse(row!.scopePolicy)).toEqual({});
       // createdAt should be preserved from the original insert
       expect(row!.createdAt).toBe(originalCreatedAt);
     });
@@ -211,6 +216,92 @@ describe("provider operations", () => {
       ]);
       const row = getProvider("github");
       expect(row!.pingUrl).toBeNull();
+    });
+
+    test("preserves user-customizable fields while overwriting implementation fields on re-seed", () => {
+      // Initial seed with all fields
+      seedProviders([
+        {
+          providerKey: "github",
+          authUrl: "https://github.com/authorize",
+          tokenUrl: "https://github.com/token",
+          tokenEndpointAuthMethod: "client_secret_post",
+          defaultScopes: ["repo"],
+          scopePolicy: { required: ["repo"] },
+          userinfoUrl: "https://api.github.com/user",
+          baseUrl: "https://api.github.com",
+          extraParams: { prompt: "consent" },
+          callbackTransport: "loopback",
+          loopbackPort: 8765,
+          pingUrl: "https://api.github.com/user",
+        },
+      ]);
+
+      // Manually update user-customizable fields to simulate user edits
+      const db = getDb();
+      db.update(oauthProviders)
+        .set({
+          defaultScopes: JSON.stringify(["repo", "user", "gist"]),
+          scopePolicy: JSON.stringify({
+            required: ["repo"],
+            allowAdditionalScopes: true,
+          }),
+          userinfoUrl: "https://api.github.com/user/custom",
+          baseUrl: "https://custom.github.com/api",
+        })
+        .where(eq(oauthProviders.providerKey, "github"))
+        .run();
+
+      // Verify the manual updates took effect
+      const beforeReseed = getProvider("github");
+      expect(JSON.parse(beforeReseed!.defaultScopes)).toEqual([
+        "repo",
+        "user",
+        "gist",
+      ]);
+      expect(beforeReseed!.userinfoUrl).toBe(
+        "https://api.github.com/user/custom",
+      );
+      expect(beforeReseed!.baseUrl).toBe("https://custom.github.com/api");
+
+      // Re-seed with updated implementation fields
+      seedProviders([
+        {
+          providerKey: "github",
+          authUrl: "https://github.com/authorize-v2",
+          tokenUrl: "https://github.com/token-v2",
+          tokenEndpointAuthMethod: "client_secret_basic",
+          defaultScopes: ["repo-only"],
+          scopePolicy: {},
+          userinfoUrl: "https://api.github.com/user-v2",
+          baseUrl: "https://api.github.com/v2",
+          extraParams: { prompt: "login" },
+          callbackTransport: "gateway",
+          loopbackPort: 9999,
+          pingUrl: "https://api.github.com/user-v2",
+        },
+      ]);
+
+      const row = getProvider("github");
+      expect(row).toBeDefined();
+
+      // User-customizable fields should retain their manual values
+      expect(JSON.parse(row!.defaultScopes)).toEqual(["repo", "user", "gist"]);
+      expect(JSON.parse(row!.scopePolicy)).toEqual({
+        required: ["repo"],
+        allowAdditionalScopes: true,
+      });
+      expect(row!.userinfoUrl).toBe("https://api.github.com/user/custom");
+      expect(row!.baseUrl).toBe("https://custom.github.com/api");
+
+      // Implementation fields should be overwritten from the seed data
+      expect(row!.authUrl).toBe("https://github.com/authorize-v2");
+      expect(row!.tokenUrl).toBe("https://github.com/token-v2");
+      expect(row!.tokenEndpointAuthMethod).toBe("client_secret_basic");
+      expect(JSON.parse(row!.extraParams!)).toEqual({ prompt: "login" });
+      expect(row!.callbackTransport).toBe("gateway");
+      expect(row!.loopbackPort).toBe(9999);
+      expect(row!.pingUrl).toBe("https://api.github.com/user-v2");
     });
   });
 


### PR DESCRIPTION
## Summary
- Add test in oauth-store.test.ts verifying that seed upsert preserves user-customizable fields (defaultScopes, scopePolicy, userinfoUrl, baseUrl) while overwriting implementation fields
- Add test in oauth-cli.test.ts verifying that null callbackTransport defaults to loopback (no ingress URL error)
- Add test in oauth-cli.test.ts verifying that explicit gateway transport still requires public ingress URL
- Fix existing stale test that expected baseUrl to be overwritten on re-seed (now correctly expects preservation)

Part of plan: oauth-loopback-default.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
