### PR TITLE
fix: add missing lastRegisteredNewThreadShortcut reset in teardown

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -580,6 +580,7 @@ extension AppDelegate {
         lastRegisteredZoomInShortcut = nil
         lastRegisteredZoomOutShortcut = nil
         lastRegisteredZoomResetShortcut = nil
+        lastRegisteredNewThreadShortcut = nil
         tearDownQuickInputMonitors()
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for keyboard-shortcuts-customization.md.

**Gap:** lastRegisteredNewThreadShortcut not cleared in tearDownHotKeyState()
**What was expected:** All lastRegistered* properties reset on teardown
**What was found:** 9 of 10 properties reset, lastRegisteredNewThreadShortcut omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
