### PR TITLE
fix: restore Cmd+Shift+= (Cmd++) zoom-in support

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -466,7 +466,9 @@ extension AppDelegate {
                 let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
                 guard let chars = event.charactersIgnoringModifiers else { return event }
 
-                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods == zoomInMods {
+                // Allow Shift to be present for zoom-in: on US keyboards Cmd+Shift+= produces "+"
+                // which is the standard zoom-in gesture. Using subtracting(.shift) preserves that behavior.
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods.subtracting(.shift) == zoomInMods {
                     Task { @MainActor in self?.zoomManager.zoomIn() }
                     return nil
                 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for keyboard-shortcuts-customization.md.

**Gap:** Zoom-in shortcut breaks Cmd+Shift+= (Cmd++) on US keyboards
**What was expected:** Pressing Cmd+Shift+= should trigger zoom-in (old behavior)
**What was found:** Strict modifier matching rejects the extra Shift modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
