### PR TITLE
fix: clean up NSEvent monitors when Settings disappears during recording

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -556,6 +556,14 @@ private struct ConfigurableShortcutRow: View {
                     .padding(.bottom, VSpacing.xs)
             }
         }
+        .onDisappear {
+            stopRecording()
+        }
+        .onChange(of: activeRecordingId) { _, newValue in
+            if newValue != registryId && (shortcutMonitor != nil || flagsMonitor != nil) {
+                stopRecording()
+            }
+        }
     }
 
     private func startRecording() {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for keyboard-shortcuts-customization.md.

**Gap:** NSEvent monitor leak when navigating away from Settings during recording
**What was expected:** NSEvent monitors cleaned up on view disappear
**What was found:** onDisappear only sets activeRecordingId = nil, doesn't call stopRecording()

**Fix:** Added `.onDisappear` and `.onChange(of: activeRecordingId)` modifiers to `ConfigurableShortcutRow` so NSEvent monitors are properly removed when the view disappears or another row starts recording.

Part of LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
