### PR TITLE
fix: clean up phone invite UI layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -430,21 +430,20 @@ struct ContactDetailView: View {
                                 .background(VColor.surfaceActive)
                                 .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                         }
-                        HStack(spacing: VSpacing.sm) {
-                            VButton(
-                                label: "Invite",
-                                style: .outlined,
-                                isDisabled: inviteInProgress != nil || (type == "phone" && invitePhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty)
-                            ) {
-                                createInviteForChannel(type: type)
-                            }
-                            VButton(label: "Cancel", style: .outlined) {
-                                inviteExpanded.remove(type)
-                                if inviteResult?.type == type {
-                                    inviteResult = nil
+                        if inviteResult?.type != type {
+                            HStack(spacing: VSpacing.sm) {
+                                VButton(
+                                    label: "Invite",
+                                    style: .outlined,
+                                    isDisabled: inviteInProgress != nil || (type == "phone" && invitePhoneNumber.trimmingCharacters(in: .whitespaces).isEmpty)
+                                ) {
+                                    createInviteForChannel(type: type)
                                 }
-                                inviteError = nil
-                                inviteErrorChannel = nil
+                                VButton(label: "Cancel", style: .outlined) {
+                                    inviteExpanded.remove(type)
+                                    inviteError = nil
+                                    inviteErrorChannel = nil
+                                }
                             }
                         }
                     }
@@ -660,41 +659,50 @@ struct ContactDetailView: View {
                     .tracking(4)
                     .padding(.vertical, VSpacing.xs)
 
-                VButton(
-                    label: inviteCopiedType == type ? "Copied!" : "Copy Code",
-                    icon: VIcon.copy.rawValue,
-                    style: .outlined
-                ) {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(inviteCode, forType: .string)
-                    inviteCopiedType = type
-                    Task {
-                        try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        guard !Task.isCancelled else { return }
-                        if inviteCopiedType == type {
-                            inviteCopiedType = nil
+                HStack(spacing: VSpacing.sm) {
+                    VButton(
+                        label: inviteCopiedType == type ? "Copied!" : "Copy Code",
+                        icon: VIcon.copy.rawValue,
+                        style: .outlined
+                    ) {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(inviteCode, forType: .string)
+                        inviteCopiedType = type
+                        Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            guard !Task.isCancelled else { return }
+                            if inviteCopiedType == type {
+                                inviteCopiedType = nil
+                            }
                         }
                     }
-                }
 
-                if type == "phone", let result = inviteResult {
-                    if inviteCallTriggered {
-                        HStack(spacing: VSpacing.sm) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(VColor.systemPositiveStrong)
-                            Text("Call started")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.systemPositiveStrong)
+                    if type == "phone", let result = inviteResult {
+                        if inviteCallTriggered {
+                            HStack(spacing: VSpacing.sm) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(VColor.systemPositiveStrong)
+                                Text("Call started")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.systemPositiveStrong)
+                            }
+                        } else {
+                            VButton(
+                                label: inviteCallInProgress ? "Calling..." : "Call \(displayContact.displayName)",
+                                icon: VIcon.phoneCall.rawValue,
+                                style: .primary,
+                                isDisabled: inviteCallInProgress
+                            ) {
+                                triggerInviteCallAction(inviteId: result.inviteId)
+                            }
                         }
-                    } else {
-                        VButton(
-                            label: inviteCallInProgress ? "Calling..." : "Call \(displayContact.displayName)",
-                            icon: VIcon.phoneCall.rawValue,
-                            style: .primary,
-                            isDisabled: inviteCallInProgress
-                        ) {
-                            triggerInviteCallAction(inviteId: result.inviteId)
-                        }
+                    }
+
+                    VButton(label: "Cancel", style: .outlined) {
+                        inviteExpanded.remove(type)
+                        inviteResult = nil
+                        inviteError = nil
+                        inviteErrorChannel = nil
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Hide the "Invite" and pre-result "Cancel" buttons when the invite result is displayed for the phone channel
- Move Copy Code, "Call {name}", and Cancel buttons into a single horizontal row instead of stacking vertically

## Original prompt
Clean up the phone invite UI in ContactDetailView.swift: 1) Hide the "Invite" button when inviteResult is showing (phone channel only), 2) Put Copy Code, "Call {name}", and Cancel buttons all on the same row in an HStack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
