### PR TITLE
fix: conditionally strip Shift in zoom-in shortcut matching

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -467,8 +467,12 @@ extension AppDelegate {
                 guard let chars = event.charactersIgnoringModifiers else { return event }
 
                 // Allow Shift to be present for zoom-in: on US keyboards Cmd+Shift+= produces "+"
-                // which is the standard zoom-in gesture. Using subtracting(.shift) preserves that behavior.
-                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods.subtracting(.shift) == zoomInMods {
+                // which is the standard zoom-in gesture. Only strip Shift when the configured
+                // shortcut doesn't already include it, so custom shortcuts like cmd+shift+z still work.
+                let zoomInModsMatch = zoomInMods.contains(.shift)
+                    ? mods == zoomInMods
+                    : mods.subtracting(.shift) == zoomInMods
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && zoomInModsMatch {
                     Task { @MainActor in self?.zoomManager.zoomIn() }
                     return nil
                 }


### PR DESCRIPTION
## Summary
Fixes edge case where custom zoom-in shortcuts that explicitly include Shift
(e.g. cmd+shift+z) would never fire because .subtracting(.shift) was applied
unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
