### PR TITLE
fix: explicitly pass gateway transport in deferred OAuth path

### DIFF
--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -241,7 +241,9 @@ export async function orchestrateOAuthConnect(
         oauthConfig,
         callbackTransport === "loopback"
           ? { callbackTransport, loopbackPort: loopbackPort ?? undefined }
-          : undefined,
+          : callbackTransport === "gateway"
+            ? { callbackTransport }
+            : undefined,
       );
 
       // Fire-and-forget: store tokens when the callback arrives


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-loopback-default.md.

**Gap:** Deferred path doesn't pass gateway transport explicitly to prepareOAuth2Flow
**What was expected:** Gateway providers should use gateway transport in deferred (non-interactive) flows
**What was found:** Deferred path passed undefined options for gateway providers, which now defaults to loopback

- Update the deferred path in connect-orchestrator.ts to use the same three-way conditional as the interactive path
- Explicitly pass { callbackTransport: 'gateway' } for gateway providers instead of undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
