### PR TITLE
fix: restore narrowed seed upsert and remove blanket non-interactive oauth2_connect guard

### DIFF
--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -38,8 +38,11 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
- * CONFLICT DO UPDATE so that all seed fields propagate to existing
- * installations on the next startup.
+ * CONFLICT DO UPDATE so that implementation fields (authUrl, tokenUrl,
+ * tokenEndpointAuthMethod, extraParams, callbackTransport, loopbackPort,
+ * pingUrl) propagate to existing installations on every startup, while
+ * user-customizable fields (defaultScopes, scopePolicy, userinfoUrl,
+ * baseUrl) are only written on the initial insert.
  */
 export function seedProviders(
   profiles: Array<{
@@ -95,10 +98,6 @@ export function seedProviders(
           authUrl,
           tokenUrl,
           tokenEndpointAuthMethod,
-          userinfoUrl,
-          baseUrl,
-          defaultScopes,
-          scopePolicy,
           extraParams,
           callbackTransport,
           loopbackPort,

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -804,14 +804,6 @@ class CredentialStoreTool implements Tool {
           };
         }
 
-        if (!context.isInteractive) {
-          return {
-            content:
-              "Error: oauth2_connect requires an interactive session (non-interactive session).",
-            isError: true,
-          };
-        }
-
         // Delegate to the shared orchestrator — it resolves authUrl, tokenUrl,
         // extraParams, userinfoUrl, and tokenEndpointAuthMethod from the DB.
         const result = await orchestrateOAuthConnect({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-loopback-default.md.

**Gap:** PR #16324 reverted the seed upsert narrowing and added blanket non-interactive rejection
**What was expected:** Seed upsert should only overwrite implementation fields; non-interactive sessions should be able to use oauth2_connect (deferred flow)
**What was found:** All seed fields were being overwritten; non-interactive oauth2_connect was completely blocked

- Restore narrowed onConflictDoUpdate in seedProviders to only overwrite implementation fields (authUrl, tokenUrl, tokenEndpointAuthMethod, extraParams, callbackTransport, loopbackPort, pingUrl)
- Remove blanket !context.isInteractive guard in vault.ts that was blocking the deferred OAuth flow
- Restore docstring describing selective upsert behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
