### PR TITLE
feat: keyboard shortcuts & customization (LUM-178)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -567,12 +567,14 @@ extension AppDelegate {
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
     /// 2. Clears `lastRegisteredGlobalHotkey`, `lastRegisteredQuickInputHotkey`, and
-    ///    `lastRegisteredQuickInputAboveDockShortcut` so re-registration is not short-circuited
+    ///    `lastRegisteredCommandPaletteShortcut`, and `lastRegisteredQuickInputAboveDockShortcut`
+    ///    so re-registration is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredCommandPaletteShortcut = nil
         lastRegisteredQuickInputAboveDockShortcut = nil
         lastRegisteredZoomInShortcut = nil
         lastRegisteredZoomOutShortcut = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -566,9 +566,8 @@ extension AppDelegate {
     ///
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
-    /// 2. Clears `lastRegisteredGlobalHotkey`, `lastRegisteredQuickInputHotkey`, and
-    ///    `lastRegisteredCommandPaletteShortcut`, and `lastRegisteredQuickInputAboveDockShortcut`
-    ///    so re-registration is not short-circuited
+    /// 2. Clears `lastRegistered*` shortcut properties so re-registration
+    ///    is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
@@ -576,6 +575,8 @@ extension AppDelegate {
         lastRegisteredQuickInputHotkey = nil
         lastRegisteredCommandPaletteShortcut = nil
         lastRegisteredQuickInputAboveDockShortcut = nil
+        lastRegisteredNavBackShortcut = nil
+        lastRegisteredNavForwardShortcut = nil
         lastRegisteredZoomInShortcut = nil
         lastRegisteredZoomOutShortcut = nil
         lastRegisteredZoomResetShortcut = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -580,6 +580,7 @@ extension AppDelegate {
         lastRegisteredZoomInShortcut = nil
         lastRegisteredZoomOutShortcut = nil
         lastRegisteredZoomResetShortcut = nil
+        lastRegisteredNewThreadShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -573,6 +573,9 @@ extension AppDelegate {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredZoomInShortcut = nil
+        lastRegisteredZoomOutShortcut = nil
+        lastRegisteredZoomResetShortcut = nil
         tearDownQuickInputMonitors()
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -566,13 +566,14 @@ extension AppDelegate {
     ///
     /// Consolidates three bug fixes:
     /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
-    /// 2. Clears both `lastRegisteredGlobalHotkey` and `lastRegisteredQuickInputHotkey`
-    ///    so re-registration is not short-circuited
+    /// 2. Clears `lastRegisteredGlobalHotkey`, `lastRegisteredQuickInputHotkey`, and
+    ///    `lastRegisteredQuickInputAboveDockShortcut` so re-registration is not short-circuited
     /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
     func tearDownHotKeyState() {
         hasSetupHotKey = false
         lastRegisteredGlobalHotkey = nil
         lastRegisteredQuickInputHotkey = nil
+        lastRegisteredQuickInputAboveDockShortcut = nil
         lastRegisteredZoomInShortcut = nil
         lastRegisteredZoomOutShortcut = nil
         lastRegisteredZoomResetShortcut = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -466,7 +466,9 @@ extension AppDelegate {
                 let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
                 guard let chars = event.charactersIgnoringModifiers else { return event }
 
-                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods == zoomInMods {
+                // Allow Shift to be present for zoom-in: on US keyboards Cmd+Shift+= produces "+"
+                // which is the standard zoom-in gesture. Using subtracting(.shift) preserves that behavior.
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods.subtracting(.shift) == zoomInMods {
                     Task { @MainActor in self?.zoomManager.zoomIn() }
                     return nil
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -372,29 +372,63 @@ extension AppDelegate {
     /// Only consumes the event when navigation actually occurs — if the history
     /// stack is empty, the event passes through to the responder chain.
     func registerNavigationMonitor() {
-        guard navLocalMonitor == nil else { return }
+        let backShortcut = UserDefaults.standard.string(forKey: "navigateBackShortcut") ?? "cmd+["
+        let forwardShortcut = UserDefaults.standard.string(forKey: "navigateForwardShortcut") ?? "cmd+]"
+
+        // Skip re-registration if neither shortcut changed.
+        if backShortcut == lastRegisteredNavBackShortcut,
+           forwardShortcut == lastRegisteredNavForwardShortcut { return }
+
+        // Tear down existing monitor before re-registration.
+        if let monitor = navLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            navLocalMonitor = nil
+        }
+
+        // If both shortcuts are disabled, record state and return.
+        guard !backShortcut.isEmpty || !forwardShortcut.isEmpty else {
+            lastRegisteredNavBackShortcut = backShortcut
+            lastRegisteredNavForwardShortcut = forwardShortcut
+            log.info("Navigation: both shortcuts disabled")
+            return
+        }
+
+        // Parse shortcuts into modifier flags and key strings.
+        let backParsed: (NSEvent.ModifierFlags, String)? = backShortcut.isEmpty ? nil : ShortcutHelper.parseShortcut(backShortcut)
+        let forwardParsed: (NSEvent.ModifierFlags, String)? = forwardShortcut.isEmpty ? nil : ShortcutHelper.parseShortcut(forwardShortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard mods == [.command] else { return event }
             guard let chars = event.charactersIgnoringModifiers else { return event }
-            switch chars {
-            case "[":
+
+            // Check back shortcut
+            if let (backMods, backKey) = backParsed,
+               mods == backMods,
+               chars.lowercased() == backKey.lowercased() {
                 guard self?.mainWindow?.windowState.navigationHistory.canGoBack == true else { return event }
                 Task { @MainActor in
                     self?.mainWindow?.windowState.navigateBack()
                 }
                 return nil
-            case "]":
+            }
+
+            // Check forward shortcut
+            if let (fwdMods, fwdKey) = forwardParsed,
+               mods == fwdMods,
+               chars.lowercased() == fwdKey.lowercased() {
                 guard self?.mainWindow?.windowState.navigationHistory.canGoForward == true else { return event }
                 Task { @MainActor in
                     self?.mainWindow?.windowState.navigateForward()
                 }
                 return nil
-            default:
-                return event
             }
+
+            return event
         }
         navLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredNavBackShortcut = backShortcut
+        lastRegisteredNavForwardShortcut = forwardShortcut
     }
 
     /// Registers zoom shortcuts as local event monitors for window zoom.

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -323,14 +323,32 @@ extension AppDelegate {
         lastRegisteredNewThreadShortcut = shortcut
     }
 
-    /// Registers Cmd+K as a local shortcut to open the command palette.
+    /// Registers a local shortcut to open the command palette.
     /// Only active when the app is focused (local monitor, not global).
+    /// Reads the shortcut from UserDefaults. Skips re-registration if unchanged.
     func registerCmdKMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "commandPaletteShortcut") ?? "cmd+k"
+
+        if shortcut == lastRegisteredCommandPaletteShortcut { return }
+
+        // Tear down previous registration
+        if let monitor = cmdKLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdKLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredCommandPaletteShortcut = shortcut
+            log.info("Command Palette: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+K: keyCode 40 is kVK_ANSI_K
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 40,
-                  mods == [.command] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -340,6 +358,8 @@ extension AppDelegate {
             return nil // consume the event
         }
         cmdKLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredCommandPaletteShortcut = shortcut
     }
 
     /// Registers Cmd+[ and Cmd+] as local shortcuts for back/forward navigation.

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -488,6 +488,12 @@ extension AppDelegate {
         lastRegisteredZoomResetShortcut = zoomReset
     }
 
+    /// Returns a display string for a shortcut stored in UserDefaults, or `nil` if the shortcut is unbound.
+    private func shortcutHint(forKey key: String, default defaultShortcut: String) -> String? {
+        let shortcut = UserDefaults.standard.string(forKey: key) ?? defaultShortcut
+        return shortcut.isEmpty ? nil : ShortcutHelper.displayString(for: shortcut)
+    }
+
     func toggleCommandPalette() {
         if let window = commandPaletteWindow, window.isVisible {
             window.dismiss()
@@ -498,7 +504,7 @@ extension AppDelegate {
 
         // Static actions
         window.actions = [
-            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
+            CommandPaletteAction(id: "new-conversation", icon: VIcon.squarePen.rawValue, label: "New Conversation", shortcutHint: shortcutHint(forKey: "newThreadShortcut", default: "cmd+n")) { [weak self] in
                 self?.mainWindow?.threadManager.createThread()
                 if let id = self?.mainWindow?.threadManager.activeThreadId {
                     self?.mainWindow?.windowState.selection = .thread(id)
@@ -513,19 +519,19 @@ extension AppDelegate {
             CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.intelligence)
             },
-            CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: "\u{2318}[") { [weak self] in
+            CommandPaletteAction(id: "navigate-back", icon: VIcon.chevronLeft.rawValue, label: "Back", shortcutHint: shortcutHint(forKey: "navigateBackShortcut", default: "cmd+[")) { [weak self] in
                 self?.mainWindow?.windowState.navigateBack()
             },
-            CommandPaletteAction(id: "navigate-forward", icon: VIcon.chevronRight.rawValue, label: "Forward", shortcutHint: "\u{2318}]") { [weak self] in
+            CommandPaletteAction(id: "navigate-forward", icon: VIcon.chevronRight.rawValue, label: "Forward", shortcutHint: shortcutHint(forKey: "navigateForwardShortcut", default: "cmd+]")) { [weak self] in
                 self?.mainWindow?.windowState.navigateForward()
             },
-            CommandPaletteAction(id: "zoom-in", icon: VIcon.zoomIn.rawValue, label: "Zoom In", shortcutHint: "\u{2318}+") { [weak self] in
+            CommandPaletteAction(id: "zoom-in", icon: VIcon.zoomIn.rawValue, label: "Zoom In", shortcutHint: shortcutHint(forKey: "zoomInShortcut", default: "cmd+=")) { [weak self] in
                 self?.zoomManager.zoomIn()
             },
-            CommandPaletteAction(id: "zoom-out", icon: VIcon.zoomOut.rawValue, label: "Zoom Out", shortcutHint: "\u{2318}-") { [weak self] in
+            CommandPaletteAction(id: "zoom-out", icon: VIcon.zoomOut.rawValue, label: "Zoom Out", shortcutHint: shortcutHint(forKey: "zoomOutShortcut", default: "cmd+-")) { [weak self] in
                 self?.zoomManager.zoomOut()
             },
-            CommandPaletteAction(id: "zoom-reset", icon: VIcon.search.rawValue, label: "Actual Size", shortcutHint: "\u{2318}0") { [weak self] in
+            CommandPaletteAction(id: "zoom-reset", icon: VIcon.search.rawValue, label: "Actual Size", shortcutHint: shortcutHint(forKey: "zoomResetShortcut", default: "cmd+0")) { [weak self] in
                 self?.zoomManager.resetZoom()
             },
         ]

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -54,6 +54,54 @@ extension UserDefaults {
     @objc dynamic var quickInputHotkeyKeyCode: Int {
         return integer(forKey: "quickInputHotkeyKeyCode")
     }
+    @objc dynamic var quickInputAboveDockShortcut: String {
+        if UserDefaults.standard.object(forKey: "quickInputAboveDockShortcut") == nil {
+            return "cmd+shift+v"
+        }
+        return string(forKey: "quickInputAboveDockShortcut") ?? ""
+    }
+    @objc dynamic var newThreadShortcut: String {
+        if UserDefaults.standard.object(forKey: "newThreadShortcut") == nil {
+            return "cmd+n"
+        }
+        return string(forKey: "newThreadShortcut") ?? ""
+    }
+    @objc dynamic var commandPaletteShortcut: String {
+        if UserDefaults.standard.object(forKey: "commandPaletteShortcut") == nil {
+            return "cmd+k"
+        }
+        return string(forKey: "commandPaletteShortcut") ?? ""
+    }
+    @objc dynamic var navigateBackShortcut: String {
+        if UserDefaults.standard.object(forKey: "navigateBackShortcut") == nil {
+            return "cmd+["
+        }
+        return string(forKey: "navigateBackShortcut") ?? ""
+    }
+    @objc dynamic var navigateForwardShortcut: String {
+        if UserDefaults.standard.object(forKey: "navigateForwardShortcut") == nil {
+            return "cmd+]"
+        }
+        return string(forKey: "navigateForwardShortcut") ?? ""
+    }
+    @objc dynamic var zoomInShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomInShortcut") == nil {
+            return "cmd+="
+        }
+        return string(forKey: "zoomInShortcut") ?? ""
+    }
+    @objc dynamic var zoomOutShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomOutShortcut") == nil {
+            return "cmd+-"
+        }
+        return string(forKey: "zoomOutShortcut") ?? ""
+    }
+    @objc dynamic var zoomResetShortcut: String {
+        if UserDefaults.standard.object(forKey: "zoomResetShortcut") == nil {
+            return "cmd+0"
+        }
+        return string(forKey: "zoomResetShortcut") ?? ""
+    }
 }
 
 // MARK: - Input Monitors
@@ -69,16 +117,31 @@ extension AppDelegate {
         registerFnVMonitor()
         registerCmdKMonitor()
         registerCmdNMonitor()
+        registerNavigationMonitor()
+        registerZoomMonitor()
 
-        globalHotkeyObserver = Publishers.Merge3(
-            UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
-            UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () },
-            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }
-        )
+        globalHotkeyObserver = Publishers.MergeMany([
+            UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.quickInputAboveDockShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.newThreadShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.commandPaletteShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.navigateBackShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.navigateForwardShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomInShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomOutShortcut).map { _ in () }.eraseToAnyPublisher(),
+            UserDefaults.standard.publisher(for: \.zoomResetShortcut).map { _ in () }.eraseToAnyPublisher(),
+        ])
         .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
         .sink { [weak self] _ in
             self?.registerGlobalHotkeyMonitor()
             self?.registerQuickInputMonitor()
+            self?.registerFnVMonitor()
+            self?.registerCmdKMonitor()
+            self?.registerCmdNMonitor()
+            self?.registerNavigationMonitor()
+            self?.registerZoomMonitor()
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -353,32 +353,61 @@ extension AppDelegate {
         navLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+=/Cmd+-/Cmd+0 as local shortcuts for window zoom.
+    /// Registers zoom shortcuts as local event monitors for window zoom.
+    /// Reads `zoomInShortcut`, `zoomOutShortcut`, and `zoomResetShortcut` from
+    /// UserDefaults (defaults: "cmd+=", "cmd+-", "cmd+0"). Any shortcut can be
+    /// independently disabled by setting it to an empty string.
     /// Uses event monitoring instead of NSMenu key equivalents because
     /// SwiftUI manages the menu bar and strips programmatic items.
     func registerZoomMonitor() {
-        guard zoomLocalMonitor == nil else { return }
-        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard let chars = event.charactersIgnoringModifiers else { return event }
-            // Cmd+= (same physical key as Cmd++, shift ignored)
-            if chars == "=" && mods.contains(.command) && !mods.contains(.control) {
-                Task { @MainActor in self?.zoomManager.zoomIn() }
-                return nil
-            }
-            // Cmd+-
-            if chars == "-" && mods == [.command] {
-                Task { @MainActor in self?.zoomManager.zoomOut() }
-                return nil
-            }
-            // Cmd+0
-            if chars == "0" && mods == [.command] {
-                Task { @MainActor in self?.zoomManager.resetZoom() }
-                return nil
-            }
-            return event
+        let zoomIn = UserDefaults.standard.string(forKey: "zoomInShortcut") ?? "cmd+="
+        let zoomOut = UserDefaults.standard.string(forKey: "zoomOutShortcut") ?? "cmd+-"
+        let zoomReset = UserDefaults.standard.string(forKey: "zoomResetShortcut") ?? "cmd+0"
+
+        // Skip re-registration if all three shortcuts are unchanged
+        if zoomIn == lastRegisteredZoomInShortcut
+            && zoomOut == lastRegisteredZoomOutShortcut
+            && zoomReset == lastRegisteredZoomResetShortcut { return }
+
+        // Tear down existing monitor before re-registration
+        if let monitor = zoomLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            zoomLocalMonitor = nil
         }
-        zoomLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        // Parse each shortcut (empty strings yield empty key, which won't match)
+        let (zoomInMods, zoomInKey) = ShortcutHelper.parseShortcut(zoomIn)
+        let (zoomOutMods, zoomOutKey) = ShortcutHelper.parseShortcut(zoomOut)
+        let (zoomResetMods, zoomResetKey) = ShortcutHelper.parseShortcut(zoomReset)
+
+        // Only install the monitor if at least one shortcut is enabled
+        let hasAnyShortcut = !zoomIn.isEmpty || !zoomOut.isEmpty || !zoomReset.isEmpty
+
+        if hasAnyShortcut {
+            let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+                let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                guard let chars = event.charactersIgnoringModifiers else { return event }
+
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods == zoomInMods {
+                    Task { @MainActor in self?.zoomManager.zoomIn() }
+                    return nil
+                }
+                if !zoomOutKey.isEmpty && chars.lowercased() == zoomOutKey.lowercased() && mods == zoomOutMods {
+                    Task { @MainActor in self?.zoomManager.zoomOut() }
+                    return nil
+                }
+                if !zoomResetKey.isEmpty && chars.lowercased() == zoomResetKey.lowercased() && mods == zoomResetMods {
+                    Task { @MainActor in self?.zoomManager.resetZoom() }
+                    return nil
+                }
+                return event
+            }
+            zoomLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+        }
+
+        lastRegisteredZoomInShortcut = zoomIn
+        lastRegisteredZoomOutShortcut = zoomOut
+        lastRegisteredZoomResetShortcut = zoomReset
     }
 
     func toggleCommandPalette() {

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -467,8 +467,12 @@ extension AppDelegate {
                 guard let chars = event.charactersIgnoringModifiers else { return event }
 
                 // Allow Shift to be present for zoom-in: on US keyboards Cmd+Shift+= produces "+"
-                // which is the standard zoom-in gesture. Using subtracting(.shift) preserves that behavior.
-                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && mods.subtracting(.shift) == zoomInMods {
+                // which is the standard zoom-in gesture. Only strip Shift when the configured
+                // shortcut doesn't already include it, so custom shortcuts like cmd+shift+z still work.
+                let zoomInModsMatch = zoomInMods.contains(.shift)
+                    ? mods == zoomInMods
+                    : mods.subtracting(.shift) == zoomInMods
+                if !zoomInKey.isEmpty && chars.lowercased() == zoomInKey.lowercased() && zoomInModsMatch {
                     Task { @MainActor in self?.zoomManager.zoomIn() }
                     return nil
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -237,14 +237,36 @@ extension AppDelegate {
         }
     }
 
-    /// Registers Cmd+Shift+V as a global shortcut to open the quick input text field.
-    /// Uses NSEvent monitors (global + local).
+    /// Registers the Quick Input Above Dock shortcut (default Cmd+Shift+V) as a
+    /// global + local monitor. Reads the shortcut from UserDefaults and skips
+    /// re-registration if unchanged. An empty shortcut disables the feature.
     func registerFnVMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "quickInputAboveDockShortcut") ?? "cmd+shift+v"
+
+        if shortcut == lastRegisteredQuickInputAboveDockShortcut { return }
+
+        // Tear down previous monitors
+        if let monitor = fnVGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVGlobalMonitor = nil
+        }
+        if let monitor = fnVLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredQuickInputAboveDockShortcut = shortcut
+            log.info("Quick Input Above Dock: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+Shift+V: keyCode 9 is kVK_ANSI_V
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 9,
-                  mods == [.command, .shift] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -258,6 +280,8 @@ extension AppDelegate {
             _ = handler(event)
         }
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredQuickInputAboveDockShortcut = shortcut
     }
 
     /// Registers a local shortcut to create a new thread.

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -260,12 +260,32 @@ extension AppDelegate {
         fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
     }
 
-    /// Registers Cmd+N as a local shortcut to create a new thread.
+    /// Registers a local shortcut to create a new thread.
+    /// Reads the shortcut from UserDefaults (`newThreadShortcut`), defaulting to "cmd+n".
+    /// Skips re-registration if the shortcut hasn't changed.
     func registerCmdNMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "newThreadShortcut") ?? "cmd+n"
+
+        if shortcut == lastRegisteredNewThreadShortcut { return }
+
+        // Tear down previous monitor
+        if let monitor = cmdNLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdNLocalMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredNewThreadShortcut = shortcut
+            log.info("New Thread: shortcut disabled")
+            return
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 45, // kVK_ANSI_N
-                  mods == [.command] else {
+            guard mods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else {
                 return event
             }
             Task { @MainActor in
@@ -275,6 +295,8 @@ extension AppDelegate {
             return nil
         }
         cmdNLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+
+        lastRegisteredNewThreadShortcut = shortcut
     }
 
     /// Registers Cmd+K as a local shortcut to open the command palette.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredNewThreadShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -22,6 +22,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
     var lastRegisteredNewThreadShortcut: String?
+    var lastRegisteredZoomInShortcut: String?
+    var lastRegisteredZoomOutShortcut: String?
+    var lastRegisteredZoomResetShortcut: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
     var hasSetupHotKey = false

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -24,6 +24,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var lastRegisteredCommandPaletteShortcut: String?
     var lastRegisteredQuickInputAboveDockShortcut: String?
     var lastRegisteredNewThreadShortcut: String?
+    var lastRegisteredNavBackShortcut: String?
+    var lastRegisteredNavForwardShortcut: String?
     var lastRegisteredZoomInShortcut: String?
     var lastRegisteredZoomOutShortcut: String?
     var lastRegisteredZoomResetShortcut: String?

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredCommandPaletteShortcut: String?
     var lastRegisteredQuickInputAboveDockShortcut: String?
     var lastRegisteredNewThreadShortcut: String?
     var lastRegisteredZoomInShortcut: String?

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -21,6 +21,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var hotKeyMonitor: Any?
     var lastRegisteredGlobalHotkey: String?
     var lastRegisteredQuickInputHotkey: String?
+    var lastRegisteredQuickInputAboveDockShortcut: String?
     var lastRegisteredNewThreadShortcut: String?
     var lastRegisteredZoomInShortcut: String?
     var lastRegisteredZoomOutShortcut: String?

--- a/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Foundation
 
 /// Describes a single keyboard shortcut that can be customized by the user.
@@ -123,6 +124,37 @@ enum KeyboardShortcutRegistry {
             let normalizedCurrent = ShortcutHelper.normalizeShortcut(current)
             return normalizedCurrent == normalizedTarget
         }
+    }
+
+    /// Resets all keyboard shortcuts on the given store back to their registry defaults.
+    @MainActor static func resetAllToDefaults(store: SettingsStore) {
+        for definition in allShortcuts {
+            switch definition.id {
+            case "globalHotkeyShortcut":
+                store.globalHotkeyShortcut = definition.defaultShortcut
+            case "quickInputHotkeyShortcut":
+                store.quickInputHotkeyShortcut = definition.defaultShortcut
+            case "quickInputAboveDockShortcut":
+                store.quickInputAboveDockShortcut = definition.defaultShortcut
+            case "newThreadShortcut":
+                store.newThreadShortcut = definition.defaultShortcut
+            case "commandPaletteShortcut":
+                store.commandPaletteShortcut = definition.defaultShortcut
+            case "navigateBackShortcut":
+                store.navigateBackShortcut = definition.defaultShortcut
+            case "navigateForwardShortcut":
+                store.navigateForwardShortcut = definition.defaultShortcut
+            case "zoomInShortcut":
+                store.zoomInShortcut = definition.defaultShortcut
+            case "zoomOutShortcut":
+                store.zoomOutShortcut = definition.defaultShortcut
+            case "zoomResetShortcut":
+                store.zoomResetShortcut = definition.defaultShortcut
+            default:
+                break
+            }
+        }
+        store.quickInputHotkeyKeyCode = kVK_ANSI_Slash
     }
 
     /// Returns the user's current shortcut for the given definition id,

--- a/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/KeyboardShortcutRegistry.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Describes a single keyboard shortcut that can be customized by the user.
+struct KeyboardShortcutDefinition {
+    /// UserDefaults key used to persist the user's custom shortcut.
+    let id: String
+    /// Human-readable label shown in the Settings UI (e.g. "New Conversation").
+    let label: String
+    /// Default shortcut string (e.g. "cmd+n").
+    let defaultShortcut: String
+    /// Raw virtual key code for Carbon `RegisterEventHotKey`, or nil when Carbon
+    /// registration is not needed.
+    let defaultKeyCode: Int?
+    /// Whether this shortcut is monitored globally (true) or only while the app
+    /// is active (false).
+    let isGlobal: Bool
+    /// Whether this shortcut requires Carbon `RegisterEventHotKey` registration.
+    let requiresCarbonHotkey: Bool
+}
+
+/// Central registry of all keyboard shortcuts in the app.
+///
+/// Every shortcut the app listens for is declared here so that the Settings UI,
+/// conflict detection, and input monitors can share a single source of truth.
+enum KeyboardShortcutRegistry {
+
+    static let allShortcuts: [KeyboardShortcutDefinition] = [
+        KeyboardShortcutDefinition(
+            id: "globalHotkeyShortcut",
+            label: "Open Vellum",
+            defaultShortcut: "cmd+shift+g",
+            defaultKeyCode: nil,
+            isGlobal: true,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "quickInputHotkeyShortcut",
+            label: "Quick Input",
+            defaultShortcut: "cmd+shift+/",
+            defaultKeyCode: 44, // kVK_ANSI_Slash
+            isGlobal: true,
+            requiresCarbonHotkey: true
+        ),
+        KeyboardShortcutDefinition(
+            id: "quickInputAboveDockShortcut",
+            label: "Quick Input Above Dock",
+            defaultShortcut: "cmd+shift+v",
+            defaultKeyCode: nil,
+            isGlobal: true,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "newThreadShortcut",
+            label: "New Conversation",
+            defaultShortcut: "cmd+n",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "commandPaletteShortcut",
+            label: "Command Palette",
+            defaultShortcut: "cmd+k",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "navigateBackShortcut",
+            label: "Navigate Back",
+            defaultShortcut: "cmd+[",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "navigateForwardShortcut",
+            label: "Navigate Forward",
+            defaultShortcut: "cmd+]",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "zoomInShortcut",
+            label: "Zoom In",
+            defaultShortcut: "cmd+=",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "zoomOutShortcut",
+            label: "Zoom Out",
+            defaultShortcut: "cmd+-",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+        KeyboardShortcutDefinition(
+            id: "zoomResetShortcut",
+            label: "Actual Size",
+            defaultShortcut: "cmd+0",
+            defaultKeyCode: nil,
+            isGlobal: false,
+            requiresCarbonHotkey: false
+        ),
+    ]
+
+    /// Returns the first shortcut definition whose current (or default) value
+    /// conflicts with `shortcut`, ignoring the definition identified by
+    /// `excluding`.
+    static func conflictingShortcut(
+        for shortcut: String,
+        excluding id: String
+    ) -> KeyboardShortcutDefinition? {
+        let normalizedTarget = ShortcutHelper.normalizeShortcut(shortcut)
+        guard !normalizedTarget.isEmpty else { return nil }
+
+        return allShortcuts.first { definition in
+            guard definition.id != id else { return false }
+            let current = currentShortcut(for: definition.id)
+            let normalizedCurrent = ShortcutHelper.normalizeShortcut(current)
+            return normalizedCurrent == normalizedTarget
+        }
+    }
+
+    /// Returns the user's current shortcut for the given definition id,
+    /// falling back to the definition's default if no override is stored.
+    static func currentShortcut(for id: String) -> String {
+        if let stored = UserDefaults.standard.string(forKey: id) {
+            return stored
+        }
+        return allShortcuts.first { $0.id == id }?.defaultShortcut ?? ""
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -9,12 +9,7 @@ struct SettingsAppearanceTab: View {
     var afterTimezone: AnyView? = nil
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
-    @State private var isRecordingGlobalHotkey = false
-    @State private var isRecordingQuickInputHotkey = false
-    @State private var shortcutMonitor: Any?
-    @State private var flagsMonitor: Any?
-    @State private var recordingDisplayString: String?
-    @State private var shortcutConflictWarning: String?
+    @State private var activeRecordingId: String?
     @State private var selectedTimezone: String = ""
     @State private var timezoneSearchText: String = ""
     @State private var debouncedTimezoneSearchText: String = ""
@@ -191,76 +186,112 @@ struct SettingsAppearanceTab: View {
                 VStack(alignment: .leading, spacing: 0) {
 
                 // Open Vellum (configurable)
-                HStack {
-                    Text("Open Vellum")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    Spacer()
-                    if isRecordingGlobalHotkey, let display = recordingDisplayString, !display.isEmpty {
-                        VShortcutTag(display)
-                    } else {
-                        VShortcutTag(ShortcutHelper.displayString(for: store.globalHotkeyShortcut))
-                    }
-
-                    if isRecordingGlobalHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined) {
-                            stopRecording()
-                        }
-                    } else {
-                        HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
-                                startRecording()
-                            }
-                            if !store.globalHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
-                                    store.globalHotkeyShortcut = ""
-                                }
-                            }
-                        }
-                    }
-                }
-                .padding(.vertical, VSpacing.md)
-
-                if let shortcutConflictWarning {
-                    Text(shortcutConflictWarning)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.systemNegativeHover)
-                        .padding(.bottom, VSpacing.xs)
-                }
+                ConfigurableShortcutRow(
+                    label: "Open Vellum",
+                    shortcutBinding: $store.globalHotkeyShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "globalHotkeyShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
 
                 SettingsDivider()
 
                 // Quick Input (configurable)
-                HStack {
-                    Text("Quick Input")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                    Spacer()
-                    if isRecordingQuickInputHotkey, let display = recordingDisplayString, !display.isEmpty {
-                        VShortcutTag(display)
-                    } else {
-                        VShortcutTag(ShortcutHelper.displayString(for: store.quickInputHotkeyShortcut))
-                    }
+                ConfigurableShortcutRow(
+                    label: "Quick Input",
+                    shortcutBinding: $store.quickInputHotkeyShortcut,
+                    keyCodeBinding: $store.quickInputHotkeyKeyCode,
+                    registryId: "quickInputHotkeyShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
 
-                    if isRecordingQuickInputHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined) {
-                            stopRecording()
-                        }
-                    } else {
-                        HStack(spacing: VSpacing.sm) {
-                            VButton(label: "Record", style: .outlined) {
-                                startRecordingQuickInput()
-                            }
-                            if !store.quickInputHotkeyShortcut.isEmpty {
-                                VButton(label: "Unbind", style: .outlined) {
-                                    store.quickInputHotkeyShortcut = ""
-                                    store.quickInputHotkeyKeyCode = 0
-                                }
-                            }
-                        }
-                    }
-                }
-                .padding(.vertical, VSpacing.md)
+                SettingsDivider()
+
+                // Quick Input Above Dock (configurable)
+                ConfigurableShortcutRow(
+                    label: "Quick Input Above Dock",
+                    shortcutBinding: $store.quickInputAboveDockShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "quickInputAboveDockShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // New Conversation (configurable)
+                ConfigurableShortcutRow(
+                    label: "New Conversation",
+                    shortcutBinding: $store.newThreadShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "newThreadShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Command Palette (configurable)
+                ConfigurableShortcutRow(
+                    label: "Command Palette",
+                    shortcutBinding: $store.commandPaletteShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "commandPaletteShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Navigate Back (configurable)
+                ConfigurableShortcutRow(
+                    label: "Navigate Back",
+                    shortcutBinding: $store.navigateBackShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "navigateBackShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Navigate Forward (configurable)
+                ConfigurableShortcutRow(
+                    label: "Navigate Forward",
+                    shortcutBinding: $store.navigateForwardShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "navigateForwardShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Zoom In (configurable)
+                ConfigurableShortcutRow(
+                    label: "Zoom In",
+                    shortcutBinding: $store.zoomInShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "zoomInShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Zoom Out (configurable)
+                ConfigurableShortcutRow(
+                    label: "Zoom Out",
+                    shortcutBinding: $store.zoomOutShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "zoomOutShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
+
+                SettingsDivider()
+
+                // Actual Size (configurable)
+                ConfigurableShortcutRow(
+                    label: "Actual Size",
+                    shortcutBinding: $store.zoomResetShortcut,
+                    keyCodeBinding: nil,
+                    registryId: "zoomResetShortcut",
+                    activeRecordingId: $activeRecordingId
+                )
 
                 SettingsDivider()
 
@@ -280,7 +311,7 @@ struct SettingsAppearanceTab: View {
                 }
             }
             .onDisappear {
-                stopRecording()
+                activeRecordingId = nil
             }
 
             // MEDIA EMBEDS section
@@ -444,30 +475,76 @@ struct SettingsAppearanceTab: View {
         }
     }
 
-    // MARK: - Shortcut Recording
+}
+
+/// A configurable shortcut row with Record/Unbind buttons, real-time modifier display, and conflict detection.
+private struct ConfigurableShortcutRow: View {
+    let label: String
+    @Binding var shortcutBinding: String
+    var keyCodeBinding: Binding<Int>?
+    let registryId: String
+    @Binding var activeRecordingId: String?
+
+    @State private var shortcutMonitor: Any?
+    @State private var flagsMonitor: Any?
+    @State private var recordingDisplayString: String?
+    @State private var conflictWarning: String?
+
+    private var isRecording: Bool {
+        activeRecordingId == registryId
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(label)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                Spacer()
+                if isRecording, let display = recordingDisplayString, !display.isEmpty {
+                    VShortcutTag(display)
+                } else {
+                    VShortcutTag(ShortcutHelper.displayString(for: shortcutBinding))
+                }
+
+                if isRecording {
+                    VButton(label: "Press shortcut...", style: .outlined) {
+                        stopRecording()
+                    }
+                } else {
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Record", style: .outlined) {
+                            startRecording()
+                        }
+                        if !shortcutBinding.isEmpty {
+                            VButton(label: "Unbind", style: .outlined) {
+                                shortcutBinding = ""
+                                if keyCodeBinding != nil {
+                                    keyCodeBinding?.wrappedValue = 0
+                                }
+                                conflictWarning = nil
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, VSpacing.md)
+
+            if let conflictWarning {
+                Text(conflictWarning)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.systemNegativeHover)
+                    .padding(.bottom, VSpacing.xs)
+            }
+        }
+    }
 
     private func startRecording() {
-        startRecordingShortcut { shortcut, _ in
-            store.globalHotkeyShortcut = shortcut
-        }
-        isRecordingGlobalHotkey = true
-    }
-
-    private func startRecordingQuickInput() {
-        startRecordingShortcut { shortcut, keyCode in
-            store.quickInputHotkeyShortcut = shortcut
-            store.quickInputHotkeyKeyCode = Int(keyCode)
-        }
-        isRecordingQuickInputHotkey = true
-    }
-
-    /// Shared recording logic. The callback receives the shortcut string and the raw NSEvent key code.
-    private func startRecordingShortcut(onRecord: @escaping (String, UInt16) -> Void) {
         stopRecording()
-        shortcutConflictWarning = nil
+        conflictWarning = nil
         recordingDisplayString = nil
+        activeRecordingId = registryId
 
-        // Monitor modifier key changes to show pressed modifiers in real-time.
         flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             recordingDisplayString = ShortcutHelper.modifierDisplayString(from: mods)
@@ -477,6 +554,7 @@ struct SettingsAppearanceTab: View {
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
+            // Escape cancels recording
             if event.keyCode == 53 {
                 stopRecording()
                 return nil
@@ -493,16 +571,25 @@ struct SettingsAppearanceTab: View {
                 from: mods, key: chars, keyCode: event.keyCode
             )
 
-            shortcutConflictWarning = nil
-            onRecord(shortcut, event.keyCode)
+            // Check for conflicts
+            conflictWarning = nil
+            if let conflict = KeyboardShortcutRegistry.conflictingShortcut(for: shortcut, excluding: registryId) {
+                conflictWarning = "Conflicts with \(conflict.label)"
+            }
+
+            shortcutBinding = shortcut
+            if let keyCodeBinding {
+                keyCodeBinding.wrappedValue = Int(event.keyCode)
+            }
             stopRecording()
             return nil
         }
     }
 
     private func stopRecording() {
-        isRecordingGlobalHotkey = false
-        isRecordingQuickInputHotkey = false
+        if activeRecordingId == registryId {
+            activeRecordingId = nil
+        }
         recordingDisplayString = nil
         if let monitor = shortcutMonitor {
             NSEvent.removeMonitor(monitor)
@@ -513,7 +600,6 @@ struct SettingsAppearanceTab: View {
             flagsMonitor = nil
         }
     }
-
 }
 
 /// A read-only row displaying a keyboard shortcut and its description.
@@ -532,4 +618,3 @@ private struct ShortcutRow: View {
         .padding(.vertical, VSpacing.md)
     }
 }
-

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -15,6 +15,7 @@ struct SettingsAppearanceTab: View {
     @State private var debouncedTimezoneSearchText: String = ""
     @State private var isTimezoneDropdownOpen: Bool = false
     @State private var timezoneSearchDebounceTask: Task<Void, Never>?
+    @State private var showResetConfirmation = false
     @FocusState private var isTimezoneSearchFocused: Bool
 
     var body: some View {
@@ -308,10 +309,28 @@ struct SettingsAppearanceTab: View {
                     helperText: "When enabled, Enter inserts a new line and cmd+enter sends."
                 )
                 .padding(.vertical, VSpacing.md)
+
+                SettingsDivider()
+
+                HStack {
+                    Spacer()
+                    VButton(label: "Reset All to Defaults", style: .outlined) {
+                        showResetConfirmation = true
+                    }
+                }
+                .padding(.vertical, VSpacing.md)
                 }
             }
             .onDisappear {
                 activeRecordingId = nil
+            }
+            .alert("Reset Keyboard Shortcuts?", isPresented: $showResetConfirmation) {
+                Button("Reset", role: .destructive) {
+                    KeyboardShortcutRegistry.resetAllToDefaults(store: store)
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This will reset all keyboard shortcuts to their default values.")
             }
 
             // MEDIA EMBEDS section

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -556,6 +556,14 @@ private struct ConfigurableShortcutRow: View {
                     .padding(.bottom, VSpacing.xs)
             }
         }
+        .onDisappear {
+            stopRecording()
+        }
+        .onChange(of: activeRecordingId) { _, newValue in
+            if newValue != registryId && (shortcutMonitor != nil || flagsMonitor != nil) {
+                stopRecording()
+            }
+        }
     }
 
     private func startRecording() {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -71,6 +71,14 @@ public final class SettingsStore: ObservableObject {
     @Published var globalHotkeyShortcut: String
     @Published var quickInputHotkeyShortcut: String
     @Published var quickInputHotkeyKeyCode: Int
+    @Published var quickInputAboveDockShortcut: String
+    @Published var newThreadShortcut: String
+    @Published var commandPaletteShortcut: String
+    @Published var navigateBackShortcut: String
+    @Published var navigateForwardShortcut: String
+    @Published var zoomInShortcut: String
+    @Published var zoomOutShortcut: String
+    @Published var zoomResetShortcut: String
     @Published var cmdEnterToSend: Bool
 
     // MARK: - Media Embed Settings
@@ -316,6 +324,47 @@ public final class SettingsStore: ObservableObject {
         let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
         self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
 
+        if UserDefaults.standard.object(forKey: "quickInputAboveDockShortcut") == nil {
+            self.quickInputAboveDockShortcut = "cmd+shift+v"
+        } else {
+            self.quickInputAboveDockShortcut = UserDefaults.standard.string(forKey: "quickInputAboveDockShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "newThreadShortcut") == nil {
+            self.newThreadShortcut = "cmd+n"
+        } else {
+            self.newThreadShortcut = UserDefaults.standard.string(forKey: "newThreadShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "commandPaletteShortcut") == nil {
+            self.commandPaletteShortcut = "cmd+k"
+        } else {
+            self.commandPaletteShortcut = UserDefaults.standard.string(forKey: "commandPaletteShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "navigateBackShortcut") == nil {
+            self.navigateBackShortcut = "cmd+["
+        } else {
+            self.navigateBackShortcut = UserDefaults.standard.string(forKey: "navigateBackShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "navigateForwardShortcut") == nil {
+            self.navigateForwardShortcut = "cmd+]"
+        } else {
+            self.navigateForwardShortcut = UserDefaults.standard.string(forKey: "navigateForwardShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "zoomInShortcut") == nil {
+            self.zoomInShortcut = "cmd+="
+        } else {
+            self.zoomInShortcut = UserDefaults.standard.string(forKey: "zoomInShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "zoomOutShortcut") == nil {
+            self.zoomOutShortcut = "cmd+-"
+        } else {
+            self.zoomOutShortcut = UserDefaults.standard.string(forKey: "zoomOutShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "zoomResetShortcut") == nil {
+            self.zoomResetShortcut = "cmd+0"
+        } else {
+            self.zoomResetShortcut = UserDefaults.standard.string(forKey: "zoomResetShortcut") ?? ""
+        }
+
         #if DEBUG
         self.isDevMode = UserDefaults.standard.object(forKey: "devModeEnabled") as? Bool ?? true
         #else
@@ -402,6 +451,46 @@ public final class SettingsStore: ObservableObject {
         $quickInputHotkeyKeyCode
             .dropFirst()
             .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyKeyCode") }
+            .store(in: &cancellables)
+
+        $quickInputAboveDockShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "quickInputAboveDockShortcut") }
+            .store(in: &cancellables)
+
+        $newThreadShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "newThreadShortcut") }
+            .store(in: &cancellables)
+
+        $commandPaletteShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "commandPaletteShortcut") }
+            .store(in: &cancellables)
+
+        $navigateBackShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "navigateBackShortcut") }
+            .store(in: &cancellables)
+
+        $navigateForwardShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "navigateForwardShortcut") }
+            .store(in: &cancellables)
+
+        $zoomInShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "zoomInShortcut") }
+            .store(in: &cancellables)
+
+        $zoomOutShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "zoomOutShortcut") }
+            .store(in: &cancellables)
+
+        $zoomResetShortcut
+            .dropFirst()
+            .sink { value in UserDefaults.standard.set(value, forKey: "zoomResetShortcut") }
             .store(in: &cancellables)
 
         $isDevMode


### PR DESCRIPTION
## Summary
- Makes all hard-coded keyboard shortcuts in the macOS app fully customizable through Settings
- Adds `KeyboardShortcutRegistry` to centralize shortcut definitions with conflict detection
- All 10 shortcuts now have UserDefaults-backed settings with recording UI, unbind, and reset-to-defaults
- Command palette hints dynamically reflect custom bindings
- Previously hard-coded: Cmd+N, Cmd+K, Cmd+Shift+V, Cmd+[/], Cmd+=/Cmd+-/Cmd+0

## What changed
- **New file**: `KeyboardShortcutRegistry.swift` — centralized shortcut definitions, conflict detection, reset-all
- **SettingsStore.swift** — 8 new `@Published` shortcut properties with UserDefaults persistence
- **AppDelegate+InputMonitors.swift** — all monitor functions read shortcuts dynamically from UserDefaults with skip-if-unchanged guards, tear-down before re-register, and empty-shortcut disable support. Command palette hints are dynamic.
- **AppDelegate.swift** — `lastRegistered*` tracking properties for all new shortcuts
- **AppDelegate+AuthLifecycle.swift** — teardown resets for all tracking properties
- **SettingsAppearanceTab.swift** — reusable `ConfigurableShortcutRow` with recording, conflict detection, and proper NSEvent monitor cleanup. Reset All to Defaults button with confirmation.

Closes LUM-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
