### PR TITLE
fix: update identity intro prompt to encourage personality-matched variety

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -83,7 +83,7 @@ final class IdentityViewModel {
             var result = ""
             do {
                 let stream = client.sendBtwMessage(
-                    content: "Generate a very short intro for yourself (2-5 words, like \"I'm [name]!\" or \"It's [name]\" or \"Yo I'm [name]\"). Output ONLY the intro text, nothing else.",
+                    content: "Generate a very short intro for yourself (2-5 words). This should feel natural to your personality — playful, formal, chill, whatever fits you. Some examples for inspiration (don't limit yourself to these): \"I'm [name]!\", \"It's [name]\", \"Hey, I'm [name]\", \"[name] here.\", \"[name], at your service.\" Output ONLY the intro text, nothing else.",
                     conversationKey: key
                 )
                 for try await delta in stream {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -182,7 +182,7 @@ struct IdentityPanel: View {
 
         introTask = Task {
             let key = "identity-intro-\(UUID().uuidString)"
-            let prompt = "Generate a very short intro for yourself (2-5 words, like \"I'm [name]!\" or \"It's [name]\" or \"Yo I'm [name]\"). Output ONLY the intro text, nothing else."
+            let prompt = "Generate a very short intro for yourself (2-5 words). This should feel natural to your personality — playful, formal, chill, whatever fits you. Some examples for inspiration (don't limit yourself to these): \"I'm [name]!\", \"It's [name]\", \"Hey, I'm [name]\", \"[name] here.\", \"[name], at your service.\" Output ONLY the intro text, nothing else."
             var result = ""
             do {
                 let stream = daemonClient.sendBtwMessage(


### PR DESCRIPTION
## Summary
- Updated the daemon prompt for identity intro generation on both macOS and iOS
- Reframed examples as inspiration rather than templates to reduce over-indexing on specific phrases (e.g. "Yo...")
- Added explicit guidance to match the assistant's personality when generating the intro

## Original prompt
ship it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
