### PR TITLE
M2: Add readiness gate infrastructure to notification services

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -226,6 +226,17 @@ extension AppDelegate {
         }
     }
 
+    /// Marks notification intents as ready to post and flushes any enqueued closures.
+    func markNotificationIntentsReady() {
+        guard !notificationIntentsReady else { return }
+        notificationIntentsReady = true
+        let pending = pendingNotificationIntentClosures
+        pendingNotificationIntentClosures.removeAll()
+        for closure in pending {
+            closure()
+        }
+    }
+
     private func postNotificationIntent(
         sourceEventName: String,
         title: String,
@@ -233,6 +244,20 @@ extension AppDelegate {
         deepLinkMetadata: [String: AnyCodable]?,
         deliveryId: String? = nil
     ) {
+        guard notificationIntentsReady else {
+            // Enqueue until ready
+            pendingNotificationIntentClosures.append { [self] in
+                self.postNotificationIntent(
+                    sourceEventName: sourceEventName,
+                    title: title,
+                    body: body,
+                    deepLinkMetadata: deepLinkMetadata,
+                    deliveryId: deliveryId
+                )
+            }
+            return
+        }
+
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -135,6 +135,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Last time we surfaced the denied-notification permission toast.
     var lastNotificationPermissionToastAtMs: Double = 0
 
+    /// Whether notification intents are ready to post (e.g. avatar icon exported).
+    /// When false, intents are enqueued and flushed once `markNotificationIntentsReady()` is called.
+    private(set) var notificationIntentsReady = false
+    /// Closures captured while `notificationIntentsReady` was false.
+    var pendingNotificationIntentClosures: [() -> Void] = []
+
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.
     var isCurrentAssistantRemote = false

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -21,6 +21,34 @@ public protocol ActivityNotificationServiceProtocol {
 public final class ActivityNotificationService: ActivityNotificationServiceProtocol {
     private let settingsStore: SettingsStore
 
+    // MARK: - Readiness Gate
+
+    /// Whether this service is ready to post notifications (e.g. avatar icon exported).
+    /// Callers of notification methods will transparently wait until ready.
+    private var isReady = false
+
+    /// Continuations waiting for the service to become ready.
+    private var readinessWaiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Marks the service as ready and resumes any callers waiting on readiness.
+    public func markReady() {
+        guard !isReady else { return }
+        isReady = true
+        let waiters = readinessWaiters
+        readinessWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    /// Suspends the caller until the service is ready. Returns immediately if already ready.
+    private func waitUntilReady() async {
+        guard !isReady else { return }
+        await withCheckedContinuation { continuation in
+            readinessWaiters.append(continuation)
+        }
+    }
+
     public init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
     }
@@ -35,6 +63,7 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         toolCalls: [ToolCallData],
         sessionId: String
     ) async {
+        await waitUntilReady()
         log.info("notifySessionComplete called for session \(sessionId, privacy: .public)")
 
         // Check if notifications enabled in settings
@@ -88,6 +117,8 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
     /// Sends a notification when a quick input response completes.
     /// Only sends if the app is not active and notification permissions are granted.
     public func notifyQuickInputComplete(summary: String) async {
+        await waitUntilReady()
+
         // Check if app is in background
         guard !NSApp.isActive else { return }
 

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -11,9 +11,38 @@ public final class ToolConfirmationNotificationService {
 
     private var pendingRequests: [String: CheckedContinuation<String, Never>] = [:]
 
+    // MARK: - Readiness Gate
+
+    /// Whether this service is ready to post notifications (e.g. avatar icon exported).
+    /// Callers of `showConfirmation` will transparently wait until ready.
+    private var isReady = false
+
+    /// Continuations waiting for the service to become ready.
+    private var readinessWaiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Marks the service as ready and resumes any callers waiting on readiness.
+    public func markReady() {
+        guard !isReady else { return }
+        isReady = true
+        let waiters = readinessWaiters
+        readinessWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    /// Suspends the caller until the service is ready. Returns immediately if already ready.
+    private func waitUntilReady() async {
+        guard !isReady else { return }
+        await withCheckedContinuation { continuation in
+            readinessWaiters.append(continuation)
+        }
+    }
+
     /// Shows a native notification for a tool confirmation request and awaits the user's response.
     /// Returns "allow" or "deny".
     public func showConfirmation(_ message: ConfirmationRequestMessage) async -> String {
+        await waitUntilReady()
         let content = UNMutableNotificationContent()
         content.title = formatTitle(message)
         content.body = formatBody(message)


### PR DESCRIPTION
## Summary
- Add `isReady` flag and continuation-based queuing to `ToolConfirmationNotificationService` and `ActivityNotificationService` — async callers transparently `await` until the service is marked ready
- Add closure-based queue to `AppDelegate.postNotificationIntent` — sync callers are enqueued and flushed when `markNotificationIntentsReady()` is called
- No wiring yet — `markReady()` / `markNotificationIntentsReady()` will be called by M3 (eager export)

## Test plan
- [ ] Verify app compiles with no errors
- [ ] Verify notifications still work when `markReady()` is called immediately
- [ ] Verify notifications are held when `markReady()` is not called, then flush correctly when it is

Part of #16313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
