### PR TITLE
feat: collapsible filters for Memory page

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -46,7 +46,6 @@ struct IntelligencePanel: View {
 
             // Tab content
             tabContent
-                .padding(.top, VSpacing.sm)
         }
         .padding(VSpacing.xl)
     }
@@ -85,6 +84,7 @@ struct IntelligencePanel: View {
                 onClose: onClose,
                 daemonClient: daemonClient
             )
+            .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             .clipped()
 
@@ -93,10 +93,12 @@ struct IntelligencePanel: View {
                 onInvokeSkill: onInvokeSkill,
                 daemonClient: daemonClient
             )
+            .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .workspace:
             WorkspacePanel(daemonClient: daemonClient)
+                .padding(.top, VSpacing.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -51,6 +51,7 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
+    @State private var showFilters = false
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -85,25 +86,16 @@ struct MemoriesPanel: View {
 
     // MARK: - Filter Bar
 
+    /// Whether any filter is set to a non-default value.
+    private var hasActiveFilters: Bool {
+        selectedKind != nil || statusFilter != .active
+    }
+
     @ViewBuilder
     private var filterBar: some View {
-        VStack(spacing: VSpacing.sm) {
-            // Row 1: Kind filter chips
-            kindChips
-
-            // Row 2: Status, Search, Sort, New button
+        VStack(spacing: 0) {
+            // Primary row: Search, Filters toggle, Sort, New
             HStack(spacing: VSpacing.sm) {
-                VDropdown(
-                    placeholder: "Status",
-                    selection: $statusFilter,
-                    options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
-                )
-                .frame(width: 100)
-                .onChange(of: statusFilter) {
-                    store.statusFilter = statusFilter.apiValue
-                    Task { await store.loadItems() }
-                }
-
                 VSearchBar(placeholder: "Search memories...", text: $store.searchText)
                     .onChange(of: store.searchText) {
                         searchDebounceTask?.cancel()
@@ -113,6 +105,16 @@ struct MemoriesPanel: View {
                             await store.loadItems()
                         }
                     }
+
+                VButton(
+                    label: "Filters",
+                    icon: VIcon.slidersHorizontal.rawValue,
+                    style: .ghost,
+                    isActive: showFilters || hasActiveFilters
+                ) {
+                    showFilters.toggle()
+                }
+                .accessibilityLabel("Toggle filters")
 
                 VDropdown(
                     placeholder: "Sort",
@@ -126,46 +128,77 @@ struct MemoriesPanel: View {
                     Task { await store.loadItems() }
                 }
 
-                VButton(label: "New", icon: VIcon.plus.rawValue, style: .outlined) {
+                VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
                     showCreateSheet = true
                 }
                 .accessibilityLabel("Create new memory")
             }
-        }
-        .padding(VSpacing.md)
-    }
+            .padding(VSpacing.md)
 
-    @ViewBuilder
-    private var kindChips: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: VSpacing.xs) {
-                kindChip(label: "All", kind: nil)
-                ForEach(MemoryKind.allCases) { kind in
-                    kindChip(label: kind.label, kind: kind)
+            // Secondary row: Kind chips + Status (collapsible)
+            if showFilters {
+                Divider().background(VColor.borderDisabled)
+
+                HStack(spacing: VSpacing.sm) {
+                    Text("Topic:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: VSpacing.xs) {
+                            // "All" chip — uses .primary when selected
+                            VButton(
+                                label: "All",
+                                style: selectedKind == nil ? .primary : .ghost,
+                                size: .pill,
+                                isActive: selectedKind == nil
+                            ) {
+                                selectedKind = nil
+                                store.kindFilter = nil
+                                Task { await store.loadItems() }
+                            }
+                            .accessibilityLabel("All filter")
+                            .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
+
+                            ForEach(MemoryKind.allCases) { kind in
+                                VButton(
+                                    label: kind.label,
+                                    style: .ghost,
+                                    size: .pill,
+                                    isActive: selectedKind == kind
+                                ) {
+                                    selectedKind = kind
+                                    store.kindFilter = kind.rawValue
+                                    Task { await store.loadItems() }
+                                }
+                                .accessibilityLabel("\(kind.label) filter")
+                                .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
+                            }
+                        }
+                    }
+
+                    Divider()
+                        .frame(height: VSpacing.xl)
+
+                    Text("Status:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+
+                    VDropdown(
+                        placeholder: "Status",
+                        selection: $statusFilter,
+                        options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
+                    )
+                    .frame(width: 100)
+                    .onChange(of: statusFilter) {
+                        store.statusFilter = statusFilter.apiValue
+                        Task { await store.loadItems() }
+                    }
                 }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
             }
         }
-    }
-
-    @ViewBuilder
-    private func kindChip(label: String, kind: MemoryKind?) -> some View {
-        let isSelected = selectedKind == kind
-        Button {
-            selectedKind = kind
-            store.kindFilter = kind?.rawValue
-            Task { await store.loadItems() }
-        } label: {
-            Text(label)
-                .font(VFont.caption)
-                .foregroundColor(isSelected ? VColor.auxWhite : VColor.contentDefault)
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.xxs)
-                .background(isSelected ? VColor.primaryBase : VColor.surfaceActive)
-                .clipShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(label) filter")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     // MARK: - Content View

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -137,9 +137,10 @@ struct MemoriesPanel: View {
 
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: VSpacing.xs) {
-                        TopicChip(
+                        VButton(
                             label: "All",
-                            isSelected: selectedKind == nil
+                            style: selectedKind == nil ? .primary : .outlined,
+                            size: .pill
                         ) {
                             selectedKind = nil
                             store.kindFilter = nil
@@ -149,9 +150,10 @@ struct MemoriesPanel: View {
                         .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
 
                         ForEach(MemoryKind.allCases) { kind in
-                            TopicChip(
+                            VButton(
                                 label: kind.label,
-                                isSelected: selectedKind == kind
+                                style: selectedKind == kind ? .primary : .outlined,
+                                size: .pill
                             ) {
                                 selectedKind = kind
                                 store.kindFilter = kind.rawValue
@@ -207,36 +209,3 @@ struct MemoriesPanel: View {
     }
 }
 
-// MARK: - Topic Chip
-
-private struct TopicChip: View {
-    let label: String
-    let isSelected: Bool
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(VFont.captionMedium)
-                .foregroundColor(isSelected ? VColor.auxWhite : VColor.contentDefault)
-                .padding(.horizontal, VSpacing.md)
-                .frame(height: 24)
-                .background(backgroundColor)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-
-    private var backgroundColor: Color {
-        if isSelected {
-            return VColor.primaryBase
-        } else if isHovered {
-            return VColor.surfaceActive
-        } else {
-            return .clear
-        }
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -200,7 +200,9 @@ struct MemoriesPanel: View {
                     }
                 }
                 .padding(VSpacing.md)
+                .background { OverlayScrollerStyle() }
             }
+            .scrollContentBackground(.hidden)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -51,7 +51,6 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
-    @State private var showFilters = false
 
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
@@ -86,15 +85,10 @@ struct MemoriesPanel: View {
 
     // MARK: - Filter Bar
 
-    /// Whether any filter is set to a non-default value.
-    private var hasActiveFilters: Bool {
-        selectedKind != nil || statusFilter != .active
-    }
-
     @ViewBuilder
     private var filterBar: some View {
-        VStack(spacing: 0) {
-            // Primary row: Search, Filters toggle, Sort, New
+        VStack(spacing: VSpacing.lg) {
+            // Row 1: Search, Status, Sort, New
             HStack(spacing: VSpacing.sm) {
                 VSearchBar(placeholder: "Search memories...", text: $store.searchText)
                     .onChange(of: store.searchText) {
@@ -106,15 +100,16 @@ struct MemoriesPanel: View {
                         }
                     }
 
-                VButton(
-                    label: "Filters",
-                    icon: VIcon.slidersHorizontal.rawValue,
-                    style: .ghost,
-                    isActive: showFilters || hasActiveFilters
-                ) {
-                    showFilters.toggle()
+                VDropdown(
+                    placeholder: "Status",
+                    selection: $statusFilter,
+                    options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
+                )
+                .frame(width: 110)
+                .onChange(of: statusFilter) {
+                    store.statusFilter = statusFilter.apiValue
+                    Task { await store.loadItems() }
                 }
-                .accessibilityLabel("Toggle filters")
 
                 VDropdown(
                     placeholder: "Sort",
@@ -133,72 +128,45 @@ struct MemoriesPanel: View {
                 }
                 .accessibilityLabel("Create new memory")
             }
-            .padding(VSpacing.md)
 
-            // Secondary row: Kind chips + Status (collapsible)
-            if showFilters {
-                Divider().background(VColor.borderDisabled)
+            // Row 2: Topic chips
+            HStack(spacing: VSpacing.sm) {
+                Text("Topic:")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentTertiary)
 
-                HStack(spacing: VSpacing.sm) {
-                    Text("Topic:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: VSpacing.xs) {
+                        TopicChip(
+                            label: "All",
+                            isSelected: selectedKind == nil
+                        ) {
+                            selectedKind = nil
+                            store.kindFilter = nil
+                            Task { await store.loadItems() }
+                        }
+                        .accessibilityLabel("All filter")
+                        .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
 
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: VSpacing.xs) {
-                            // "All" chip — uses .primary when selected
-                            VButton(
-                                label: "All",
-                                style: selectedKind == nil ? .primary : .ghost,
-                                size: .pill,
-                                isActive: selectedKind == nil
+                        ForEach(MemoryKind.allCases) { kind in
+                            TopicChip(
+                                label: kind.label,
+                                isSelected: selectedKind == kind
                             ) {
-                                selectedKind = nil
-                                store.kindFilter = nil
+                                selectedKind = kind
+                                store.kindFilter = kind.rawValue
                                 Task { await store.loadItems() }
                             }
-                            .accessibilityLabel("All filter")
-                            .accessibilityAddTraits(selectedKind == nil ? .isSelected : [])
-
-                            ForEach(MemoryKind.allCases) { kind in
-                                VButton(
-                                    label: kind.label,
-                                    style: .ghost,
-                                    size: .pill,
-                                    isActive: selectedKind == kind
-                                ) {
-                                    selectedKind = kind
-                                    store.kindFilter = kind.rawValue
-                                    Task { await store.loadItems() }
-                                }
-                                .accessibilityLabel("\(kind.label) filter")
-                                .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
-                            }
+                            .accessibilityLabel("\(kind.label) filter")
+                            .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
                         }
                     }
-
-                    Divider()
-                        .frame(height: VSpacing.xl)
-
-                    Text("Status:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.contentTertiary)
-
-                    VDropdown(
-                        placeholder: "Status",
-                        selection: $statusFilter,
-                        options: MemoryStatusFilter.allCases.map { ($0.rawValue, $0) }
-                    )
-                    .frame(width: 100)
-                    .onChange(of: statusFilter) {
-                        store.statusFilter = statusFilter.apiValue
-                        Task { await store.loadItems() }
-                    }
                 }
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.sm)
             }
         }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.top, VSpacing.sm)
+        .padding(.bottom, VSpacing.md)
     }
 
     // MARK: - Content View
@@ -233,6 +201,40 @@ struct MemoriesPanel: View {
                 }
                 .padding(VSpacing.md)
             }
+        }
+    }
+}
+
+// MARK: - Topic Chip
+
+private struct TopicChip: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(VFont.captionMedium)
+                .foregroundColor(isSelected ? VColor.auxWhite : VColor.contentDefault)
+                .padding(.horizontal, VSpacing.md)
+                .frame(height: 24)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+
+    private var backgroundColor: Color {
+        if isSelected {
+            return VColor.primaryBase
+        } else if isHovered {
+            return VColor.surfaceActive
+        } else {
+            return .clear
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -59,7 +59,6 @@ struct MemoryItemDetailSheet: View {
                 .padding(.bottom, VSpacing.sm)
             }
 
-            Divider().background(VColor.borderBase)
             footer
         }
         .frame(width: 480, height: 520)
@@ -84,45 +83,53 @@ struct MemoryItemDetailSheet: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: VSpacing.sm) {
-            kindBadge
+        HStack(alignment: .center, spacing: VSpacing.sm) {
             Text(displayItem.subject)
-                .font(VFont.headline)
+                .font(VFont.cardTitle)
                 .foregroundColor(VColor.contentDefault)
                 .lineLimit(1)
+
             Spacer()
 
             if !isEditing {
+                HStack(spacing: VSpacing.xs) {
+                    VButton(
+                        label: "Edit",
+                        iconOnly: VIcon.pencil.rawValue,
+                        style: .ghost,
+                        tooltip: "Edit memory"
+                    ) {
+                        isEditing = true
+                    }
+
+                    VButton(
+                        label: "Delete",
+                        iconOnly: VIcon.trash.rawValue,
+                        style: .ghost,
+                        tooltip: "Delete memory"
+                    ) {
+                        showDeleteConfirm = true
+                    }
+
+                    VButton(
+                        label: "Close",
+                        iconOnly: VIcon.x.rawValue,
+                        style: .ghost,
+                        tooltip: "Close"
+                    ) {
+                        onDismiss()
+                    }
+                }
+            } else {
                 VButton(
-                    label: "Edit",
-                    iconOnly: VIcon.pencil.rawValue,
+                    label: "Close",
+                    iconOnly: VIcon.x.rawValue,
                     style: .ghost,
-                    tooltip: "Edit memory"
+                    tooltip: "Close"
                 ) {
-                    isEditing = true
-                }
-
-                VButton(
-                    label: "Delete",
-                    iconOnly: VIcon.trash.rawValue,
-                    style: .danger,
-                    tooltip: "Delete memory"
-                ) {
-                    showDeleteConfirm = true
+                    onDismiss()
                 }
             }
-
-            Button {
-                onDismiss()
-            } label: {
-                VIconView(.x, size: 11)
-                    .foregroundColor(VColor.contentTertiary)
-                    .frame(width: 24, height: 24)
-                    .background(VColor.surfaceBase)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close")
         }
         .padding(.horizontal, VSpacing.xl)
         .padding(.vertical, VSpacing.lg)
@@ -135,7 +142,7 @@ struct MemoryItemDetailSheet: View {
         // Statement
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             Text("Statement")
-                .font(VFont.caption)
+                .font(VFont.bodyMedium)
                 .foregroundColor(VColor.contentTertiary)
             Text(displayItem.statement)
                 .font(VFont.body)
@@ -146,10 +153,16 @@ struct MemoryItemDetailSheet: View {
         // Metadata
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Details")
-                .font(VFont.caption)
+                .font(VFont.bodyMedium)
                 .foregroundColor(VColor.contentTertiary)
 
-            metadataRow(label: "Kind", value: memoryKind?.label ?? displayItem.kind.capitalized)
+            HStack(spacing: VSpacing.xs) {
+                Text("Kind")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentTertiary)
+                    .frame(width: 110, alignment: .leading)
+                kindBadge
+            }
             metadataRow(label: "Status", value: displayItem.status.capitalized)
             metadataRow(label: "Confidence", value: "\(Int(displayItem.confidence * 100))%")
             if let importance = displayItem.importance {
@@ -159,20 +172,20 @@ struct MemoryItemDetailSheet: View {
             // Verification state
             HStack(spacing: VSpacing.xs) {
                 Text("Verification")
-                    .font(VFont.caption)
+                    .font(VFont.body)
                     .foregroundColor(VColor.contentTertiary)
-                    .frame(width: 100, alignment: .leading)
+                    .frame(width: 110, alignment: .leading)
                 if displayItem.isUserConfirmed {
-                    VIconView(.circleCheck, size: 12)
+                    VIconView(.circleCheck, size: 13)
                         .foregroundColor(VColor.systemPositiveStrong)
                     Text("Confirmed by you")
-                        .font(VFont.caption)
+                        .font(VFont.bodyMedium)
                         .foregroundColor(VColor.contentSecondary)
                 } else {
-                    VIconView(.sparkles, size: 12)
+                    VIconView(.sparkles, size: 13)
                         .foregroundColor(VColor.contentTertiary)
                     Text("Inferred by assistant")
-                        .font(VFont.caption)
+                        .font(VFont.bodyMedium)
                         .foregroundColor(VColor.contentSecondary)
                 }
             }
@@ -352,11 +365,11 @@ struct MemoryItemDetailSheet: View {
     private func metadataRow(label: String, value: String) -> some View {
         HStack(spacing: VSpacing.xs) {
             Text(label)
-                .font(VFont.caption)
+                .font(VFont.body)
                 .foregroundColor(VColor.contentTertiary)
-                .frame(width: 100, alignment: .leading)
+                .frame(width: 110, alignment: .leading)
             Text(value)
-                .font(VFont.caption)
+                .font(VFont.bodyMedium)
                 .foregroundColor(VColor.contentSecondary)
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -9,34 +9,32 @@ struct MemoryItemRow: View {
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(alignment: .top, spacing: VSpacing.md) {
-                kindBadge
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                HStack(spacing: VSpacing.sm) {
+                    Text(item.subject)
+                        .font(VFont.bodyBold)
+                        .foregroundColor(VColor.contentDefault)
 
-                VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    HStack {
-                        Text(item.subject)
-                            .font(VFont.bodyBold)
-                            .foregroundColor(VColor.contentDefault)
+                    kindBadge
 
-                        Spacer()
+                    Spacer()
 
-                        if item.isUserConfirmed {
-                            VIconView(.circleCheck, size: 12)
-                                .foregroundColor(VColor.systemPositiveStrong)
-                                .accessibilityLabel("User confirmed")
-                        }
-
-                        Text(item.relativeLastSeen)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
+                    if item.isUserConfirmed {
+                        VIconView(.circleCheck, size: 12)
+                            .foregroundColor(VColor.systemPositiveStrong)
+                            .accessibilityLabel("User confirmed")
                     }
 
-                    Text(item.statement)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.contentSecondary)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
+                    Text(item.relativeLastSeen)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
                 }
+
+                Text(item.statement)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
             }
             .padding(VSpacing.md)
             .background(isHovered ? VColor.surfaceActive : Color.clear)


### PR DESCRIPTION
## Summary
Restructure the Memory page's filter bar into a collapsible layout. The search bar, sort dropdown, and new button remain always visible on the primary row. A new "Filters" toggle button shows/hides a secondary row containing the Topic kind chips and Status dropdown.

## Changes
- Added collapsible filter panel toggled by a "Filters" button (VButton .ghost + slidersHorizontal icon)
- Primary row: VSearchBar + Filters toggle + Sort VDropdown + New VButton
- Secondary row (collapsible): "Topic:" label + kind chips (VButton .pill) + vertical divider + "Status:" label + Status VDropdown
- Replaced custom inline kind chips with VButton design system components
- `hasActiveFilters` computed property drives the Filters button's active state
- All existing filter/sort/search functionality preserved

## Milestone PRs (merged into feature branch)
- #16335: M1: Restructure MemoriesPanel filter bar with collapsible layout

## Project issue
Closes #16333

## Test plan
- [ ] Open Memory page, verify search bar, sort, and new button are visible
- [ ] Click "Filters" button — verify Topic chips and Status dropdown appear
- [ ] Click "Filters" again — verify they collapse
- [ ] Select a kind chip — verify filtering works and Filters button shows active state
- [ ] Change status filter — verify filtering works
- [ ] Search memories — verify debounce and search work
- [ ] Sort by different options — verify sorting works
- [ ] Create/view/edit/delete memories — verify CRUD still works

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
