### PR TITLE
M3: Wire up eager export on launch, avatar change, and assistant switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -303,6 +303,9 @@ extension AppDelegate {
         //    UserDefaults so the daemon can initialize its LLM providers.
         syncApiKeysToAssistant(assistant)
 
+        // 7. Reload avatar for the new assistant and re-export notification icon
+        AvatarAppearanceManager.shared.reloadAvatar()
+
         showMainWindow()
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -254,6 +254,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         applyThemePreference()
         registerBundledFonts()
         AvatarAppearanceManager.shared.start()
+        _ = AvatarAppearanceManager.shared.exportNotificationIcon()
+        toolConfirmationNotificationService.markReady()
+        services.activityNotificationService.markReady()
+        self.markNotificationIntentsReady()
 
         #if DEBUG
         let skipOnboarding = CommandLine.arguments.contains("--skip-onboarding")

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -196,6 +196,8 @@ final class AvatarAppearanceManager {
         characterEyeStyle = eyeStyle
         characterColor = color
         saveAvatarComponents()
+
+        _ = exportNotificationIcon()
     }
 
     /// Reloads the custom avatar from disk. Called when the daemon notifies
@@ -206,6 +208,7 @@ final class AvatarAppearanceManager {
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
         loadCustomAvatar()
+        _ = exportNotificationIcon()
     }
 
     func clearCustomAvatar() {
@@ -219,6 +222,7 @@ final class AvatarAppearanceManager {
         cachedChatAvatar = nil
         cachedFallbackAvatar = nil
         cachedFullFallbackAvatar = nil
+        _ = exportNotificationIcon()
     }
 
     // MARK: - Avatar Components Persistence
@@ -281,6 +285,7 @@ final class AvatarAppearanceManager {
             let flags = source.data
             Task { @MainActor [weak self] in
                 self?.loadCustomAvatar()
+                _ = self?.exportNotificationIcon()
                 if flags.contains(.delete) || flags.contains(.rename) {
                     self?.watchAvatarFile()
                 }
@@ -312,6 +317,7 @@ final class AvatarAppearanceManager {
                 guard let self else { return }
                 if FileManager.default.fileExists(atPath: self.customAvatarURL.path) {
                     self.loadCustomAvatar()
+                    _ = self.exportNotificationIcon()
                     self.watchAvatarFile()
                 }
             }


### PR DESCRIPTION
## Summary
- Call `exportNotificationIcon()` after avatar loads on app launch and mark all three notification services ready (`toolConfirmationNotificationService`, `activityNotificationService`, `markNotificationIntentsReady`)
- Re-export notification icon on avatar save, reload, clear, and file watcher changes in `AvatarAppearanceManager`
- Re-export on assistant switch via `performSwitchAssistant` (calls `reloadAvatar()` which now triggers export internally)

## Test plan
- [ ] Verify notification icon PNG is written after app launch
- [ ] Change avatar and verify notification-icon.png is updated
- [ ] Clear custom avatar and verify fallback is exported
- [ ] Switch assistants and verify icon is re-exported for new assistant
- [ ] Verify all three notification services are marked ready on launch

Part of #16313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
