### PR TITLE
M4: Attach avatar icon in all notification services

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -1,4 +1,5 @@
 import AppKit
+import UniformTypeIdentifiers
 import UserNotifications
 import CoreText
 import VellumAssistantShared
@@ -279,6 +280,17 @@ extension AppDelegate {
             }
         }
         content.userInfo = userInfo
+
+        // Attach assistant avatar icon
+        let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+        if let iconURL = notificationIconProvider.notificationIconURL(for: assistantId),
+           let attachment = try? UNNotificationAttachment(
+               identifier: "assistant-avatar",
+               url: iconURL,
+               options: [UNNotificationAttachmentOptionsTypeHintKey: UTType.png.identifier]
+           ) {
+            content.attachments = [attachment]
+        }
 
         let notificationId = "notification-intent-\(UUID().uuidString)"
         let request = UNNotificationRequest(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -48,7 +48,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var cmdNLocalMonitor: Any?
     var navLocalMonitor: Any?
     var zoomLocalMonitor: Any?
-    public let services = AppServices()
+    public lazy var services = AppServices(notificationIconProvider: notificationIconProvider)
     let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
     let debugStateWriter = DebugStateWriter()
@@ -63,7 +63,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var zoomManager: ZoomManager { services.zoomManager }
     var conversationZoomManager: ConversationZoomManager { services.conversationZoomManager }
 
-    let toolConfirmationNotificationService = ToolConfirmationNotificationService()
+    let notificationIconProvider: NotificationIconProviding = NotificationIconProvider()
+    lazy var toolConfirmationNotificationService = ToolConfirmationNotificationService(notificationIconProvider: notificationIconProvider)
     lazy var recordingManager: RecordingManager = RecordingManager(daemonClient: daemonClient)
     var recordingPickerWindow: RecordingSourcePickerWindow?
     var recordingHUDWindow: RecordingHUDWindow?

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -18,14 +18,19 @@ public final class AppServices {
         daemonClient: daemonClient
     )
 
+    /// Notification icon provider for attaching assistant avatar to notifications.
+    let notificationIconProvider: NotificationIconProviding
+
     /// Activity notification service for sending push notifications on task completion.
     /// Lazy because it needs `settingsStore` which is set above.
     public lazy var activityNotificationService: ActivityNotificationService = ActivityNotificationService(
-        settingsStore: settingsStore
+        settingsStore: settingsStore,
+        notificationIconProvider: notificationIconProvider
     )
 
-    init() {
+    init(notificationIconProvider: NotificationIconProviding) {
         self.daemonClient = DaemonClient()
+        self.notificationIconProvider = notificationIconProvider
     }
 
     /// Reconfigure the daemon client's transport in place (e.g., for HTTP transport).

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import VellumAssistantShared
 import Foundation
+import UniformTypeIdentifiers
 import UserNotifications
 import os
 import Combine
@@ -1099,6 +1100,18 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             content.body = String(responseText.prefix(200))
             content.sound = .default
             content.categoryIdentifier = "VOICE_RESPONSE_COMPLETE"
+
+            // Attach assistant avatar as notification icon
+            let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            let iconProvider = NotificationIconProvider()
+            if let iconURL = iconProvider.notificationIconURL(for: assistantId),
+               let attachment = try? UNNotificationAttachment(
+                   identifier: "assistant-avatar",
+                   url: iconURL,
+                   options: [UNNotificationAttachmentOptionsTypeHintKey: UTType.png.identifier]
+               ) {
+                content.attachments = [attachment]
+            }
 
             let request = UNNotificationRequest(
                 identifier: "voice-response-\(UUID().uuidString)",

--- a/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ActivityNotificationService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 import UserNotifications
 import AppKit
 import VellumAssistantShared
@@ -20,6 +21,7 @@ public protocol ActivityNotificationServiceProtocol {
 @MainActor
 public final class ActivityNotificationService: ActivityNotificationServiceProtocol {
     private let settingsStore: SettingsStore
+    private let notificationIconProvider: NotificationIconProviding
 
     // MARK: - Readiness Gate
 
@@ -49,8 +51,9 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         }
     }
 
-    public init(settingsStore: SettingsStore) {
+    public init(settingsStore: SettingsStore, notificationIconProvider: NotificationIconProviding) {
         self.settingsStore = settingsStore
+        self.notificationIconProvider = notificationIconProvider
     }
 
     /// Sends a notification when a session completes.
@@ -97,6 +100,17 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         content.sound = .default
         content.userInfo = ["sessionId": sessionId, "type": "activity_complete"]
 
+        // Attach assistant avatar icon
+        let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+        if let iconURL = notificationIconProvider.notificationIconURL(for: assistantId),
+           let attachment = try? UNNotificationAttachment(
+               identifier: "assistant-avatar",
+               url: iconURL,
+               options: [UNNotificationAttachmentOptionsTypeHintKey: UTType.png.identifier]
+           ) {
+            content.attachments = [attachment]
+        }
+
         log.info("Sending notification: \(content.title, privacy: .public)")
 
         // Send notification
@@ -135,6 +149,17 @@ public final class ActivityNotificationService: ActivityNotificationServiceProto
         content.body = truncated.isEmpty ? "Response complete" : truncated
         content.sound = .default
         content.userInfo = ["type": "quick_input_complete"]
+
+        // Attach assistant avatar icon
+        let qiAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+        if let iconURL = notificationIconProvider.notificationIconURL(for: qiAssistantId),
+           let attachment = try? UNNotificationAttachment(
+               identifier: "assistant-avatar",
+               url: iconURL,
+               options: [UNNotificationAttachmentOptionsTypeHintKey: UTType.png.identifier]
+           ) {
+            content.attachments = [attachment]
+        }
 
         let request = UNNotificationRequest(
             identifier: UUID().uuidString,

--- a/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
+++ b/clients/macos/vellum-assistant/Services/ToolConfirmationNotificationService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 import UserNotifications
 import os
 import VellumAssistantShared
@@ -9,7 +10,12 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "To
 @MainActor
 public final class ToolConfirmationNotificationService {
 
+    private let notificationIconProvider: NotificationIconProviding
     private var pendingRequests: [String: CheckedContinuation<String, Never>] = [:]
+
+    public init(notificationIconProvider: NotificationIconProviding) {
+        self.notificationIconProvider = notificationIconProvider
+    }
 
     // MARK: - Readiness Gate
 
@@ -53,8 +59,14 @@ public final class ToolConfirmationNotificationService {
             "type": "tool_confirmation"
         ]
 
-        // Attach app icon
-        if let attachment = createAppIconAttachment() {
+        // Attach assistant avatar icon
+        let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+        if let iconURL = notificationIconProvider.notificationIconURL(for: assistantId),
+           let attachment = try? UNNotificationAttachment(
+               identifier: "assistant-avatar",
+               url: iconURL,
+               options: [UNNotificationAttachmentOptionsTypeHintKey: UTType.png.identifier]
+           ) {
             content.attachments = [attachment]
         }
 
@@ -158,16 +170,4 @@ public final class ToolConfirmationNotificationService {
         }
     }
 
-    private func createAppIconAttachment() -> UNNotificationAttachment? {
-        // Find the app icon in the bundle resources
-        guard let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns") else {
-            // Try to find in the resource bundle
-            let resourceBundle = Bundle(identifier: "com.vellum.vellum-assistant")
-            guard let bundleIconURL = resourceBundle?.url(forResource: "AppIcon", withExtension: "icns") else {
-                return nil
-            }
-            return try? UNNotificationAttachment(identifier: "app-icon", url: bundleIconURL, options: nil)
-        }
-        return try? UNNotificationAttachment(identifier: "app-icon", url: iconURL, options: nil)
-    }
 }


### PR DESCRIPTION
## Summary
- Replace the app icon attachment in `ToolConfirmationNotificationService` with the assistant's avatar via `NotificationIconProvider`
- Add avatar attachment to `ActivityNotificationService` (both `notifySessionComplete` and `notifyQuickInputComplete`)
- Add avatar attachment to `AppDelegate+Notifications` `postNotificationIntent`
- Inject `NotificationIconProvider` into all services via init, wired through `AppServices` and `AppDelegate`

Part of #16313.

## Test plan
- [ ] Verify tool confirmation notifications show the assistant's avatar icon instead of the app icon
- [ ] Verify activity completion notifications show the assistant's avatar icon
- [ ] Verify quick input completion notifications show the assistant's avatar icon
- [ ] Verify notification intent notifications show the assistant's avatar icon
- [ ] Verify graceful fallback: when no avatar icon file exists, notifications still post without an attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
