### PR TITLE
fix: disable Telegram Send button when handle input is empty

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -536,6 +536,7 @@ struct ContactDetailView: View {
                 VButton(label: "Send", style: .outlined) {
                     inviteCodeRevealed = true
                 }
+                .disabled(inviteHandleInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 VButton(label: "Cancel", style: .outlined) {
                     inviteExpanded.remove(type)
                     if inviteResult?.type == type {


### PR DESCRIPTION
## Summary
- Disables the "Send" button on the Telegram channel invite card when the handle input field is empty or whitespace-only
- Prevents users from revealing the invite code before entering a contact's Telegram handle

## Original prompt
for the Telegram channel card on the selected contact state on the Contacts page, we should disable the "Send" button if the user has not yet entered a telegram handle into the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
