### PR TITLE
fix: use opacity-only transition for greeting text so layout expansion drives the animation

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -443,7 +443,7 @@ struct ChatContentView: View {
                         .font(.system(size: 22, weight: .medium))
                         .foregroundColor(VColor.contentSecondary)
                         .multilineTextAlignment(.leading)
-                        .transition(.opacity.combined(with: .move(edge: .leading)))
+                        .transition(.opacity)
                 }
             }
             .animation(.easeOut(duration: 0.4), value: viewModel.emptyStateGreeting != nil)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -71,7 +71,7 @@ struct ChatEmptyStateView: View {
                         .font(.custom("Fraunces", size: 28).weight(.regular))
                         .foregroundColor(VColor.contentSecondary)
                         .multilineTextAlignment(.leading)
-                        .transition(.opacity.combined(with: .move(edge: .leading)))
+                        .transition(.opacity)
                 }
             }
             .frame(maxWidth: VSpacing.chatBubbleMaxWidth)


### PR DESCRIPTION
## Summary
- Replace `.move(edge: .leading)` transition with `.opacity` on both macOS and iOS greeting text
- The "growing outward" effect comes from the HStack re-centering as it expands to fit the text — the layout animation naturally slides the avatar left while the right edge extends right
- Text simply fades in at its real size, avoiding any visual transform (scale or move) that fights with the layout animation

## Original prompt
I don't really like the change you made to the animation. Now the greeting text slides in from the left. I preferred when it grew outwards from the center and the avatar slid left as the text grew outward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
