### PR TITLE
fix: pin gateway Bun install to official oven/bun image

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,15 +1,12 @@
+# Bun binary source (pinned version)
+FROM oven/bun:1.2.21 AS bun
+
 # Build stage
 FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS builder
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
@@ -22,13 +19,11 @@ FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa1
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
-    curl \
-    unzip \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy bun binary from builder instead of re-installing
-COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
+# Copy bun binary from builder
+COPY --from=builder /usr/local/bin/bun /usr/local/bin/bun
 
 RUN groupadd --system --gid 1001 gateway && \
     useradd --system --uid 1001 --gid gateway --create-home gateway

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
-# Bun binary source (pinned version)
-FROM oven/bun:1.2.21 AS bun
+# Bun binary source (pinned to SHA digest for immutable reference)
+FROM oven/bun:1.2.21@sha256:5a2011bf09364b9af658ac1e66f60d08092f4291aeefbff448d58b027734fdd0 AS bun
 
 # Build stage
 FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS builder


### PR DESCRIPTION
## Summary
- Replace unverified `curl -fsSL https://bun.sh/install | bash` in the build stage with a `COPY --from=oven/bun:1.2.21` instruction
- Eliminates supply-chain risk from unverified remote installer script execution during Docker builds
- Also removes now-unneeded `curl` and `unzip` packages from both build and runtime stages

Codex finding: https://chatgpt.com/codex/security/findings/1df6c222e0d0819180f1d9702af790bf?sev=critical%2Chigh%2Cmedium%2Clow&page=7

## Original prompt
Fix supply-chain vulnerability in gateway/Dockerfile: replace unverified curl|bash Bun install with pinned official Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
