### PR TITLE
fix: use dangerOutline style for Revoke/Block buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -769,7 +769,7 @@ struct ContactDetailView: View {
                     }
                     VButton(
                         label: "Revoke Access",
-                        style: .danger,
+                        style: .dangerOutline,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "revoked")
@@ -777,14 +777,14 @@ struct ContactDetailView: View {
                 default:
                     VButton(
                         label: "Revoke Access",
-                        style: .danger,
+                        style: .dangerOutline,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "revoked")
                     }
                     VButton(
                         label: "Block",
-                        style: .danger,
+                        style: .dangerOutline,
                         isDisabled: anyActionInFlight
                     ) {
                         updateChannelStatus(channelId: channel.id, status: "blocked")


### PR DESCRIPTION
## Summary
- Change Revoke Access and Block buttons from `.danger` (solid red fill) to `.dangerOutline` (red outline) so they look like standard buttons instead of chips

## Original prompt
Fix Revoke/Block buttons in ContactDetailView.swift to use the standard VButton component instead of chip-like styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
