### PR TITLE
fix: prevent audio file drag-and-drop overlay from getting stuck on screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -435,6 +435,10 @@ struct ChatView: View {
                                 DispatchQueue.main.async {
                                     if let data {
                                         onDropImageData(data, suggestedName)
+                                    } else if let url, url.isFileURL {
+                                        // Image data load failed — fall back to
+                                        // the file URL (may be a file promise).
+                                        urls.append(url)
                                     }
                                     group.leave()
                                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -401,6 +401,11 @@ struct ChatView: View {
     /// is used as a fallback for providers without a backing file (e.g. screenshot
     /// thumbnails or images dragged from certain apps).
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        // Reset overlay immediately — SwiftUI's isTargeted binding may not
+        // reset reliably when AppKit's NSDraggingDestination (e.g. the
+        // NSTextView inside the composer) intercepts the drag session.
+        isDropTargeted = false
+
         var urls: [URL] = []
         var imageDataItems: [NSItemProvider] = []
         let group = DispatchGroup()
@@ -411,9 +416,16 @@ struct ChatView: View {
                     || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
                     || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
                 group.enter()
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                _ = provider.loadObject(ofClass: URL.self) { url, error in
                     DispatchQueue.main.async {
                         if let url, FileManager.default.fileExists(atPath: url.path) {
+                            urls.append(url)
+                            group.leave()
+                        } else if let url, url.isFileURL {
+                            // The URL is a file reference but doesn't exist yet
+                            // (e.g. file promises from Music.app, Voice Memos).
+                            // Try using it anyway — the attachment loader will
+                            // report an error if the file is truly inaccessible.
                             urls.append(url)
                             group.leave()
                         } else if hasImageFallback {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -421,13 +421,6 @@ struct ChatView: View {
                         if let url, FileManager.default.fileExists(atPath: url.path) {
                             urls.append(url)
                             group.leave()
-                        } else if let url, url.isFileURL {
-                            // The URL is a file reference but doesn't exist yet
-                            // (e.g. file promises from Music.app, Voice Memos).
-                            // Try using it anyway — the attachment loader will
-                            // report an error if the file is truly inaccessible.
-                            urls.append(url)
-                            group.leave()
                         } else if hasImageFallback {
                             let typeIdentifier: String
                             if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
@@ -446,6 +439,14 @@ struct ChatView: View {
                                     group.leave()
                                 }
                             }
+                        } else if let url, url.isFileURL {
+                            // File URL doesn't exist on disk yet (e.g. file
+                            // promises from Music.app, Voice Memos) and no
+                            // image data fallback is available. Try the URL
+                            // anyway — the attachment loader will report an
+                            // error if the file is truly inaccessible.
+                            urls.append(url)
+                            group.leave()
                         } else {
                             group.leave()
                         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -279,6 +279,11 @@ struct ComposerView: View {
             }
         }
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isComposerDropTargeted) { providers in
+            // Reset overlay immediately — SwiftUI's isTargeted binding may not
+            // reset reliably when AppKit's NSDraggingDestination (e.g. the
+            // NSTextView inside the composer) intercepts the drag session.
+            isComposerDropTargeted = false
+
             let group = DispatchGroup()
             // Collect URLs on the main queue to avoid concurrent Array mutation
             // from loadObject callbacks that may fire on different threads.
@@ -290,9 +295,14 @@ struct ComposerView: View {
                         || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
                         || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
                     group.enter()
-                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    _ = provider.loadObject(ofClass: URL.self) { url, error in
                         DispatchQueue.main.async {
                             if let url, FileManager.default.fileExists(atPath: url.path) {
+                                urls.append(url)
+                                group.leave()
+                            } else if let url, url.isFileURL {
+                                // File promise or security-scoped URL — try it
+                                // anyway and let the attachment loader report errors.
                                 urls.append(url)
                                 group.leave()
                             } else if hasImageFallback, let onDropImageData {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -314,6 +314,10 @@ struct ComposerView: View {
                                     DispatchQueue.main.async {
                                         if let data {
                                             onDropImageData(data, suggestedName)
+                                        } else if let url, url.isFileURL {
+                                            // Image data load failed — fall back to
+                                            // the file URL (may be a file promise).
+                                            urls.append(url)
                                         }
                                         group.leave()
                                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -300,11 +300,6 @@ struct ComposerView: View {
                             if let url, FileManager.default.fileExists(atPath: url.path) {
                                 urls.append(url)
                                 group.leave()
-                            } else if let url, url.isFileURL {
-                                // File promise or security-scoped URL — try it
-                                // anyway and let the attachment loader report errors.
-                                urls.append(url)
-                                group.leave()
                             } else if hasImageFallback, let onDropImageData {
                                 let typeIdentifier: String
                                 if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
@@ -323,6 +318,12 @@ struct ComposerView: View {
                                         group.leave()
                                     }
                                 }
+                            } else if let url, url.isFileURL {
+                                // File promise (e.g. Music.app, Voice Memos) with
+                                // no image data fallback. Try the URL anyway — the
+                                // attachment loader will report errors if inaccessible.
+                                urls.append(url)
+                                group.leave()
                             } else {
                                 group.leave()
                             }


### PR DESCRIPTION
## Summary
- Reset drop overlay immediately on drop to prevent it getting stuck when AppKit's NSDraggingDestination intercepts the drag session
- Accept file URLs that don't pass fileExists check (file promises from Music.app, Voice Memos) instead of silently dropping them

## Original prompt
--safe https://linear.app/vellum/issue/LUM-200/audio-file-drag-and-drop-gets-stuck-on-screen fix it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
