### PR TITLE
refactor: rename integration:gmail provider key to integration:google

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -151,7 +151,7 @@ sequenceDiagram
 
     Note over UI,API: Tool Execution Flow
     Tool->>TokenMgr: withValidToken("gmail", callback)
-    TokenMgr->>Store: getConnectionByProvider("integration:gmail")
+    TokenMgr->>Store: getConnectionByProvider("integration:google")
     TokenMgr->>Vault: getSecureKey("oauth_connection/{conn.id}/access_token")
     TokenMgr->>Store: check oauth_connections.expires_at
     alt Token expired
@@ -228,7 +228,7 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 Protocol fields (`authUrl`, `tokenUrl`, `defaultScopes`, `scopePolicy`, `callbackTransport`) are stored in the `oauth_providers` database table rather than in code.
 
-Registered providers: `integration:gmail`, `integration:slack`, `integration:notion`. Short aliases (e.g. `gmail`, `slack`) are resolved via `resolveService()`.
+Registered providers: `integration:google`, `integration:slack`, `integration:notion`. Short aliases (e.g. `gmail`, `slack`) are resolved via `resolveService()`.
 
 ### Scope Policy Engine
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -505,7 +505,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
   test("upsertCredentialMetadata does not accept oauth2ClientSecret or other OAuth fields", () => {
     const record = upsertCredentialMetadata(
-      "integration:gmail",
+      "integration:google",
       "access_token",
       {
         allowedTools: ["api_request"],
@@ -518,14 +518,14 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
   test("client secret is read from secure store, not metadata", () => {
     setSecureKey(
-      credentialKey("integration:gmail", "client_secret"),
+      credentialKey("integration:google", "client_secret"),
       "my-secret",
     );
-    upsertCredentialMetadata("integration:gmail", "access_token", {
+    upsertCredentialMetadata("integration:google", "access_token", {
       allowedTools: ["api_request"],
     });
 
-    const meta = getCredentialMetadata("integration:gmail", "access_token");
+    const meta = getCredentialMetadata("integration:google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
     // OAuth-specific fields are no longer in metadata (v5)
@@ -534,7 +534,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
     // Secret is in secure store
     expect(
-      getSecureKey(credentialKey("integration:gmail", "client_secret")),
+      getSecureKey(credentialKey("integration:google", "client_secret")),
     ).toBe("my-secret");
   });
 
@@ -544,7 +544,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       credentials: [
         {
           credentialId: "cred-v2-secret",
-          service: "integration:gmail",
+          service: "integration:google",
           field: "access_token",
           allowedTools: [],
           allowedDomains: [],
@@ -562,7 +562,7 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
       "utf-8",
     );
 
-    const meta = getCredentialMetadata("integration:gmail", "access_token");
+    const meta = getCredentialMetadata("integration:google", "access_token");
     expect(meta).toBeDefined();
     expect("oauth2ClientSecret" in meta!).toBe(false);
 

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -531,8 +531,8 @@ describe("credential_store tool — prompt action", () => {
 describe("credential_store tool — oauth2_connect error paths", () => {
   /** Well-known provider rows returned by the mocked getProvider */
   const wellKnownProviders: Record<string, object> = {
-    "integration:gmail": {
-      key: "integration:gmail",
+    "integration:google": {
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -655,7 +655,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("non-interactive session");
   });
 
-  test("resolves gmail alias to integration:gmail", async () => {
+  test("resolves gmail alias to integration:google", async () => {
     // Even with alias resolution, missing client_id should still fail
     const result = await credentialStoreTool.execute(
       {
@@ -687,13 +687,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // and store client_secret in the secure store.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       clientId: "stored-client-id-123",
       clientSecretCredentialPath: "oauth_app/test-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:gmail",
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -731,12 +731,12 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     mockGetAppByProviderAndClientId.mockImplementation(
       (providerKey: string, cId: string) => {
         if (
-          providerKey === "integration:gmail" &&
+          providerKey === "integration:google" &&
           cId === "caller-supplied-client-id"
         ) {
           return {
             id: "matched-app-id",
-            providerKey: "integration:gmail",
+            providerKey: "integration:google",
             clientId: "caller-supplied-client-id",
             clientSecretCredentialPath:
               "oauth_app/matched-app-id/client_secret",
@@ -747,7 +747,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       },
     );
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:gmail",
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -782,13 +782,13 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // use getMostRecentAppByProvider (the fallback heuristic).
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "recent-app-id",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       clientId: "recent-client-id",
       clientSecretCredentialPath: "oauth_app/recent-app-id/client_secret",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:gmail",
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -822,7 +822,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // report the missing secret error.
     mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:gmail",
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
@@ -853,12 +853,12 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     // guardrail.
     mockGetMostRecentAppByProvider.mockImplementation(() => ({
       id: "test-app-id-no-secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       clientId: "stored-client-id-456",
       createdAt: Date.now(),
     }));
     mockGetProvider.mockImplementation(() => ({
-      key: "integration:gmail",
+      key: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -735,7 +735,7 @@ describe("credential_store tool", () => {
       await credentialStoreTool.execute(
         {
           action: "store",
-          service: "integration:gmail",
+          service: "integration:google",
           field: "api_key",
           value: "test-value",
         },
@@ -743,9 +743,9 @@ describe("credential_store tool", () => {
       );
 
       // Simulate an active OAuth connection for this service
-      mockConnections.set("integration:gmail", {
+      mockConnections.set("integration:google", {
         id: "conn-gmail",
-        providerKey: "integration:gmail",
+        providerKey: "integration:google",
         oauthAppId: "app-gmail",
         expiresAt: Date.now() + 3600_000,
       });
@@ -753,7 +753,7 @@ describe("credential_store tool", () => {
       const result = await credentialStoreTool.execute(
         {
           action: "delete",
-          service: "integration:gmail",
+          service: "integration:google",
           field: "api_key",
         },
         _ctx,
@@ -764,7 +764,7 @@ describe("credential_store tool", () => {
       // Verify disconnectOAuthProvider was called with the service name
       expect(mockDisconnectOAuthProvider).toHaveBeenCalledTimes(1);
       expect(mockDisconnectOAuthProvider).toHaveBeenCalledWith(
-        "integration:gmail",
+        "integration:google",
       );
     });
   });
@@ -1343,7 +1343,7 @@ describe("withValidToken refresh deduplication", () => {
   }
 
   test("3 concurrent 401 refreshes for the same service call doRefresh exactly once", async () => {
-    setupService("integration:gmail");
+    setupService("integration:google");
 
     let resolveRefresh!: (value: {
       accessToken: string;
@@ -1367,9 +1367,9 @@ describe("withValidToken refresh deduplication", () => {
 
     // Launch 3 concurrent withValidToken calls — all will get a non-expired
     // token first, call the callback, get a 401, and then try to refresh.
-    const p1 = withValidToken("integration:gmail", callback);
-    const p2 = withValidToken("integration:gmail", callback);
-    const p3 = withValidToken("integration:gmail", callback);
+    const p1 = withValidToken("integration:google", callback);
+    const p2 = withValidToken("integration:google", callback);
+    const p3 = withValidToken("integration:google", callback);
 
     // Let the event loop tick so all 3 calls enter the 401 retry path
     await new Promise((r) => setTimeout(r, 10));
@@ -1391,7 +1391,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("concurrent refreshes for different services proceed independently", async () => {
-    setupService("integration:gmail");
+    setupService("integration:google");
     setupService("integration:slack");
 
     let resolveGmail!: (value: {
@@ -1436,7 +1436,7 @@ describe("withValidToken refresh deduplication", () => {
       return `slack-${token}`;
     };
 
-    const p1 = withValidToken("integration:gmail", gmailCallback);
+    const p1 = withValidToken("integration:google", gmailCallback);
     const p2 = withValidToken("integration:slack", slackCallback);
 
     await new Promise((r) => setTimeout(r, 10));
@@ -1455,7 +1455,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication cleans up after refresh completes, allowing subsequent refreshes", async () => {
-    setupService("integration:gmail");
+    setupService("integration:google");
 
     let refreshCount = 0;
     mockRefreshOAuth2Token.mockImplementation(() => {
@@ -1470,7 +1470,7 @@ describe("withValidToken refresh deduplication", () => {
 
     // First call triggers a refresh (old token → 401 → refresh → token-1)
     const r1 = await withValidToken(
-      "integration:gmail",
+      "integration:google",
       async (token: string) => {
         if (token !== "token-1") throw err401;
         return token;
@@ -1482,7 +1482,7 @@ describe("withValidToken refresh deduplication", () => {
     // Second call also triggers a 401 to verify dedup state was cleaned up
     // and a new refresh is allowed (not deduplicated with the first).
     const r2 = await withValidToken(
-      "integration:gmail",
+      "integration:google",
       async (token: string) => {
         if (token !== "token-2") throw err401;
         return token;
@@ -1495,7 +1495,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication propagates refresh errors to all waiting callers", async () => {
-    setupService("integration:gmail");
+    setupService("integration:google");
 
     mockRefreshOAuth2Token.mockImplementation(() =>
       Promise.reject(
@@ -1513,8 +1513,8 @@ describe("withValidToken refresh deduplication", () => {
     };
 
     // Launch 2 concurrent calls — both should fail with the same error
-    const p1 = withValidToken("integration:gmail", callback);
-    const p2 = withValidToken("integration:gmail", callback);
+    const p1 = withValidToken("integration:google", callback);
+    const p2 = withValidToken("integration:google", callback);
 
     const results = await Promise.allSettled([p1, p2]);
 

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -56,7 +56,7 @@ describe("integration-status", () => {
     });
 
     test("returns all connected when all keys are set", () => {
-      setOAuthConnected("integration:gmail");
+      setOAuthConnected("integration:google");
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
@@ -129,7 +129,7 @@ describe("integration-status", () => {
     });
 
     test("all connected", () => {
-      setOAuthConnected("integration:gmail");
+      setOAuthConnected("integration:google");
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
@@ -163,7 +163,7 @@ describe("integration-status", () => {
     });
 
     test("email category checks Gmail", () => {
-      setOAuthConnected("integration:gmail");
+      setOAuthConnected("integration:google");
       expect(hasCapability("email")).toBe(true);
     });
   });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -337,11 +337,11 @@ describe("assistant oauth connections token <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "token",
-      "integration:gmail",
+      "integration:google",
     ]);
     expect(exitCode).toBe(0);
     expect(stdout).toBe("gmail-token\n");
-    expect(capturedService).toBe("integration:gmail");
+    expect(capturedService).toBe("integration:google");
   });
 
   test("exits 1 when no token exists", async () => {
@@ -421,30 +421,30 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     const result = await runCli([
       "connections",
       "disconnect",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(result.exitCode).toBe(0);
     const parsed = JSON.parse(result.stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.service).toBe("integration:gmail");
+    expect(parsed.service).toBe("integration:google");
 
     // disconnectOAuthProvider should have been called with the full provider key
-    expect(disconnectOAuthProviderCalls).toEqual(["integration:gmail"]);
+    expect(disconnectOAuthProviderCalls).toEqual(["integration:google"]);
   });
 
   test("reports not-found when nothing exists", async () => {
     const result = await runCli([
       "connections",
       "disconnect",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(result.exitCode).toBe(1);
     const parsed = JSON.parse(result.stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No OAuth connection or credentials");
-    expect(parsed.error).toContain("integration:gmail");
+    expect(parsed.error).toContain("integration:google");
   });
 
   test("cleans up legacy credential keys if present", async () => {
@@ -457,12 +457,12 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     ];
     for (const field of legacyFields) {
       secureKeyStore.set(
-        credentialKey("integration:gmail", field),
+        credentialKey("integration:google", field),
         `legacy_${field}_value`,
       );
       metadataStore.push({
         credentialId: nextUUID(),
-        service: "integration:gmail",
+        service: "integration:google",
         field,
         allowedTools: [],
         allowedDomains: [],
@@ -474,22 +474,22 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     const result = await runCli([
       "connections",
       "disconnect",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(result.exitCode).toBe(0);
     const parsed = JSON.parse(result.stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.service).toBe("integration:gmail");
+    expect(parsed.service).toBe("integration:google");
 
     // All legacy keys should be removed
     for (const field of legacyFields) {
       expect(
-        secureKeyStore.has(credentialKey("integration:gmail", field)),
+        secureKeyStore.has(credentialKey("integration:google", field)),
       ).toBe(false);
       expect(
         metadataStore.find(
-          (m) => m.service === "integration:gmail" && m.field === field,
+          (m) => m.service === "integration:google" && m.field === field,
         ),
       ).toBeUndefined();
     }
@@ -501,12 +501,12 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
 
     // Seed a legacy credential key
     secureKeyStore.set(
-      credentialKey("integration:gmail", "access_token"),
+      credentialKey("integration:google", "access_token"),
       "legacy_token",
     );
     metadataStore.push({
       credentialId: nextUUID(),
-      service: "integration:gmail",
+      service: "integration:google",
       field: "access_token",
       allowedTools: [],
       allowedDomains: [],
@@ -517,7 +517,7 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     const result = await runCli([
       "connections",
       "disconnect",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(result.exitCode).toBe(0);
@@ -525,9 +525,9 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
     expect(parsed.ok).toBe(true);
 
     // Both should be cleaned up
-    expect(disconnectOAuthProviderCalls).toEqual(["integration:gmail"]);
+    expect(disconnectOAuthProviderCalls).toEqual(["integration:google"]);
     expect(
-      secureKeyStore.has(credentialKey("integration:gmail", "access_token")),
+      secureKeyStore.has(credentialKey("integration:google", "access_token")),
     ).toBe(false);
   });
 });
@@ -539,7 +539,7 @@ describe("assistant oauth connections disconnect <provider-key>", () => {
 describe("assistant oauth providers list", () => {
   const fakeProviders = [
     {
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
@@ -596,7 +596,7 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
     expect(keys).toContain("integration:slack");
     expect(keys).toContain("integration:twitter");
@@ -613,7 +613,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].providerKey).toBe("integration:gmail");
+    expect(parsed[0].providerKey).toBe("integration:google");
   });
 
   test("filters by comma-separated OR values", async () => {
@@ -628,7 +628,7 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(2);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
   });
 
@@ -657,7 +657,7 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(2);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
   });
 
@@ -673,7 +673,7 @@ describe("assistant oauth providers list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(2);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
-    expect(keys).toContain("integration:gmail");
+    expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
   });
 });
@@ -707,7 +707,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -721,7 +721,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "test-id",
     ]);
@@ -734,7 +734,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -748,7 +748,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "test-id",
       "--json",
@@ -767,7 +767,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -776,13 +776,13 @@ describe("assistant oauth connections connect <provider-key>", () => {
       deferred: true,
       authUrl: "https://example.com/auth",
       state: "abc",
-      service: "integration:gmail",
+      service: "integration:google",
     });
 
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "test-id",
       "--json",
@@ -800,7 +800,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(exitCode).toBe(1);
@@ -814,7 +814,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "db-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -829,7 +829,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       };
     };
 
-    await runCli(["connections", "connect", "integration:gmail"]);
+    await runCli(["connections", "connect", "integration:google"]);
     expect(capturedClientId).toBe("db-client-id");
   });
 
@@ -838,7 +838,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "db-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -856,7 +856,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       };
     };
 
-    await runCli(["connections", "connect", "integration:gmail"]);
+    await runCli(["connections", "connect", "integration:google"]);
     expect(capturedOpts).toBeDefined();
     expect(capturedOpts!.clientId).toBe("db-client-id");
     expect(capturedOpts!.clientSecret).toBe("db-secret");
@@ -867,7 +867,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "x",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -879,7 +879,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "x",
       "--json",
@@ -963,7 +963,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -979,7 +979,7 @@ describe("assistant oauth connections connect <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "connect",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "test-id",
       "--json",
@@ -1007,7 +1007,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     mockUpsertAppCalls = [];
     mockUpsertAppResult = {
       id: "app-upsert-1",
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       clientId: "abc123",
       createdAt: 1700000000000,
       updatedAt: 1700000000000,
@@ -1031,7 +1031,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "abc123",
       "--client-secret-credential-path",
@@ -1041,7 +1041,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:gmail",
+      provider: "integration:google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretCredentialPath: "custom/path" },
     });
@@ -1054,7 +1054,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -1078,7 +1078,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "abc123",
       "--client-secret",
@@ -1088,7 +1088,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:gmail",
+      provider: "integration:google",
       clientId: "abc123",
       clientSecretOpts: { clientSecretValue: "s3cret" },
     });
@@ -1099,7 +1099,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       "apps",
       "upsert",
       "--provider",
-      "integration:gmail",
+      "integration:google",
       "--client-id",
       "abc123",
       "--json",
@@ -1107,7 +1107,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(exitCode).toBe(0);
     expect(mockUpsertAppCalls).toHaveLength(1);
     expect(mockUpsertAppCalls[0]).toEqual({
-      provider: "integration:gmail",
+      provider: "integration:google",
       clientId: "abc123",
       clientSecretOpts: undefined,
     });
@@ -1224,7 +1224,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
 
   test("returns ok when ping endpoint returns 200", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -1241,7 +1241,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
       const { exitCode, stdout } = await runCli([
         "connections",
         "ping",
-        "integration:gmail",
+        "integration:google",
         "--json",
       ]);
       expect(exitCode).toBe(0);
@@ -1293,7 +1293,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
 
   test("exits 1 when ping endpoint returns non-2xx", async () => {
     mockGetProvider = () => ({
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -1311,7 +1311,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
       const { exitCode, stdout } = await runCli([
         "connections",
         "ping",
-        "integration:gmail",
+        "integration:google",
         "--json",
       ]);
       expect(exitCode).toBe(1);
@@ -1325,10 +1325,10 @@ describe("assistant oauth connections ping <provider-key>", () => {
 
   test("exits 1 when no token exists", async () => {
     mockWithValidToken = async () => {
-      throw new Error('No access token found for "integration:gmail".');
+      throw new Error('No access token found for "integration:google".');
     };
     mockGetProvider = () => ({
-      providerKey: "integration:gmail",
+      providerKey: "integration:google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
@@ -1341,7 +1341,7 @@ describe("assistant oauth connections ping <provider-key>", () => {
     const { exitCode, stdout } = await runCli([
       "connections",
       "ping",
-      "integration:gmail",
+      "integration:google",
       "--json",
     ]);
     expect(exitCode).toBe(1);

--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -10,7 +10,7 @@ describe("oauth provider behaviors", () => {
     const service = resolveService("gmail");
     const behavior = getProviderBehavior(service);
 
-    expect(service).toBe("integration:gmail");
+    expect(service).toBe("integration:google");
     expect(behavior).toBeDefined();
     expect(behavior?.injectionTemplates).toBeDefined();
     expect(behavior?.injectionTemplates).toHaveLength(3);

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -47,8 +47,8 @@ client_secret linked to a provider. Each provider can have multiple apps
 Examples:
   $ assistant oauth apps list
   $ assistant oauth apps get --id <uuid>
-  $ assistant oauth apps get --provider integration:gmail
-  $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
+  $ assistant oauth apps get --provider integration:google
+  $ assistant oauth apps upsert --provider integration:google --client-id abc123
   $ assistant oauth apps delete <id>`,
   );
 
@@ -98,7 +98,7 @@ Examples:
       "Look up an OAuth app by ID, provider + client-id, or provider",
     )
     .option("--id <id>", "App ID (UUID)")
-    .option("--provider <key>", "Provider key (e.g. integration:gmail)")
+    .option("--provider <key>", "Provider key (e.g. integration:google)")
     .option("--client-id <id>", "OAuth client ID (requires --provider)")
     .addHelpText(
       "after",
@@ -109,10 +109,10 @@ Three lookup modes are supported:
      $ assistant oauth apps get --id <uuid>
 
   2. By provider + client ID (exact match):
-     $ assistant oauth apps get --provider integration:gmail --client-id abc123
+     $ assistant oauth apps get --provider integration:google --client-id abc123
 
   3. By provider only (returns the most recently created app):
-     $ assistant oauth apps get --provider integration:gmail
+     $ assistant oauth apps get --provider integration:google
 
 At least --id or --provider must be specified.`,
     )
@@ -161,7 +161,10 @@ At least --id or --provider must be specified.`,
   apps
     .command("upsert")
     .description("Create or return an existing OAuth app registration")
-    .requiredOption("--provider <key>", "Provider key (e.g. integration:gmail)")
+    .requiredOption(
+      "--provider <key>",
+      "Provider key (e.g. integration:google)",
+    )
     .requiredOption("--client-id <id>", "OAuth client ID")
     .option(
       "--client-secret <secret>",
@@ -191,11 +194,11 @@ The --client-secret-credential-path accepts two formats:
      Resolved via the metadata store by splitting on the last colon.
 
 Examples:
-  $ assistant oauth apps upsert --provider integration:gmail --client-id abc123
+  $ assistant oauth apps upsert --provider integration:google --client-id abc123
   $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret s3cret
   $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "credential/integration:slack/client_secret"
   $ assistant oauth apps upsert --provider integration:slack --client-id def456 --client-secret-credential-path "integration:slack:client_secret"
-  $ assistant oauth apps upsert --provider integration:gmail --client-id abc123 --json`,
+  $ assistant oauth apps upsert --provider integration:google --client-id abc123 --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -91,16 +91,16 @@ token expiry, refresh token availability, account info, and status.
 
 Examples:
   $ assistant oauth connections list
-  $ assistant oauth connections list --provider integration:gmail
+  $ assistant oauth connections list --provider integration:google
   $ assistant oauth connections list --client-id abc123
   $ assistant oauth connections get --id <uuid>
-  $ assistant oauth connections get --provider integration:gmail
-  $ assistant oauth connections get --provider integration:gmail --client-id abc123
+  $ assistant oauth connections get --provider integration:google
+  $ assistant oauth connections get --provider integration:google --client-id abc123
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections ping integration:gmail
-  $ assistant oauth connections connect integration:gmail
-  $ assistant oauth connections connect integration:gmail --open-browser
-  $ assistant oauth connections disconnect integration:gmail`,
+  $ assistant oauth connections ping integration:google
+  $ assistant oauth connections connect integration:google
+  $ assistant oauth connections connect integration:google --open-browser
+  $ assistant oauth connections disconnect integration:google`,
   );
 
   // ---------------------------------------------------------------------------
@@ -112,7 +112,7 @@ Examples:
     .description("List all OAuth connections")
     .option(
       "--provider <key>",
-      "Filter by provider key (e.g. integration:gmail)",
+      "Filter by provider key (e.g. integration:google)",
     )
     .option("--client-id <id>", "Filter by OAuth client ID")
     .addHelpText(
@@ -125,7 +125,7 @@ expiry, refresh token availability, and status.
 
 Examples:
   $ assistant oauth connections list
-  $ assistant oauth connections list --provider integration:gmail
+  $ assistant oauth connections list --provider integration:google
   $ assistant oauth connections list --client-id abc123`,
     )
     .action((opts: { provider?: string; clientId?: string }, cmd: Command) => {
@@ -171,8 +171,8 @@ Two lookup modes are supported:
      $ assistant oauth connections get --id <uuid>
 
   2. By provider (returns the most recent active connection):
-     $ assistant oauth connections get --provider integration:gmail
-     $ assistant oauth connections get --provider integration:gmail --client-id abc123
+     $ assistant oauth connections get --provider integration:google
+     $ assistant oauth connections get --provider integration:google --client-id abc123
 
 At least --id or --provider must be specified.`,
     )
@@ -229,7 +229,7 @@ At least --id or --provider must be specified.`,
       "after",
       `
 Arguments:
-  provider-key   Provider key (e.g. integration:gmail, integration:twitter)
+  provider-key   Provider key (e.g. integration:google, integration:twitter)
 
 Returns a valid OAuth access token for the given provider. If the stored token
 is expired or near-expiry, it is refreshed automatically before being returned.
@@ -241,8 +241,8 @@ Exits with code 1 if no access token exists or refresh fails.
 
 Examples:
   $ assistant oauth connections token integration:twitter
-  $ assistant oauth connections token integration:gmail --json
-  $ assistant oauth connections token integration:gmail --client-id abc123`,
+  $ assistant oauth connections token integration:google --json
+  $ assistant oauth connections token integration:google --client-id abc123`,
     )
     .action(
       async (
@@ -286,7 +286,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   Provider key (e.g. integration:gmail, integration:twitter)
+  provider-key   Provider key (e.g. integration:google, integration:twitter)
 
 Fetches a valid access token (refreshing if needed) and sends a GET request
 to the provider's configured ping URL. Reports success (HTTP 2xx) or failure.
@@ -295,9 +295,9 @@ The ping URL is set per-provider in seed data or via "providers register --ping-
 If no ping URL is configured for the provider, exits with an error.
 
 Examples:
-  $ assistant oauth connections ping integration:gmail
+  $ assistant oauth connections ping integration:google
   $ assistant oauth connections ping integration:twitter --json
-  $ assistant oauth connections ping integration:gmail --client-id abc123`,
+  $ assistant oauth connections ping integration:google --client-id abc123`,
     )
     .action(
       async (
@@ -409,7 +409,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   The full provider key (e.g. integration:gmail, integration:slack)
+  provider-key   The full provider key (e.g. integration:google, integration:slack)
 
 Removes the OAuth connection, tokens, and any legacy credential metadata for
 the provider. The <provider-key> argument is the full provider key as-is — it
@@ -419,9 +419,9 @@ Legacy credential keys for common fields (access_token, refresh_token,
 client_id, client_secret) are also cleaned up if present.
 
 Examples:
-  $ assistant oauth connections disconnect integration:gmail
+  $ assistant oauth connections disconnect integration:google
   $ assistant oauth connections disconnect integration:slack
-  $ assistant oauth connections disconnect integration:gmail --client-id abc123`,
+  $ assistant oauth connections disconnect integration:google --client-id abc123`,
     )
     .action(
       async (
@@ -510,7 +510,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   Provider key (e.g. integration:gmail) or alias (e.g. gmail)
+  provider-key   Provider key (e.g. integration:google) or alias (e.g. gmail)
 
 Initiates an OAuth2 authorization flow for the given provider. By default,
 prints the authorization URL to stdout — useful for headless/remote sessions.
@@ -523,10 +523,10 @@ Client credentials are resolved from the OAuth app store. Use --client-id
 to select a specific app when multiple apps exist for the same provider.
 
 Examples:
-  $ assistant oauth connections connect integration:gmail
+  $ assistant oauth connections connect integration:google
   $ assistant oauth connections connect gmail --open-browser
   $ assistant oauth connections connect integration:slack --client-id abc123
-  $ assistant oauth connections connect integration:gmail --scopes calendar.readonly --json`,
+  $ assistant oauth connections connect integration:google --scopes calendar.readonly --json`,
     )
     .action(
       async (

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -26,9 +26,9 @@ their respective subcommands.
 Examples:
   $ assistant oauth connections token integration:twitter
   $ assistant oauth connections list
-  $ assistant oauth connections get --provider integration:gmail
+  $ assistant oauth connections get --provider integration:google
   $ assistant oauth providers list
-  $ assistant oauth providers get integration:gmail
+  $ assistant oauth providers get integration:google
   $ assistant oauth providers register --provider-key custom:myapi --auth-url https://example.com/auth --token-url https://example.com/token`,
   );
 

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -39,7 +39,7 @@ authorization URL, token URL, default scopes, and other endpoint details.
 They are seeded on startup for built-in integrations (e.g. Gmail, Twitter,
 Slack) but can also be registered dynamically via the "register" subcommand.
 
-Each provider is identified by a provider key (e.g. "integration:gmail").`,
+Each provider is identified by a provider key (e.g. "integration:google").`,
   );
 
   // ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ Examples:
       "after",
       `
 Arguments:
-  provider-key   The full provider key (e.g. "integration:gmail").
+  provider-key   The full provider key (e.g. "integration:google").
                  Must match the key used during registration or seeding.
 
 Returns the full provider configuration including auth URL, token URL,
@@ -123,7 +123,7 @@ default scopes, scope policy, and extra parameters. Exits with code 1
 if the provider key is not found.
 
 Examples:
-  $ assistant oauth providers get integration:gmail
+  $ assistant oauth providers get integration:google
   $ assistant oauth providers get integration:twitter --json`,
     )
     .action((providerKey: string, _opts: unknown, cmd: Command) => {

--- a/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/google-contacts.ts
@@ -43,7 +43,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail");
+    const connection = resolveOAuthConnection("integration:google");
     switch (action) {
       case "list": {
         const pageSize = (input.page_size as number) ?? 50;

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -21,7 +21,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox — that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:gmail has expired."
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:google has expired."
 - **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
 - **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do — just do it and narrate lightly.
 

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-archive.ts
@@ -35,7 +35,7 @@ export async function run(
     }
 
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       const allMessageIds: string[] = [];
       let pageToken: string | undefined;
       let truncated = false;
@@ -104,7 +104,7 @@ export async function run(
   } else if (messageId) {
     // Single message path
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       await modifyMessage(connection, messageId, { removeLabelIds: ["INBOX"] });
       return ok("Message archived.");
     } catch (e) {
@@ -122,7 +122,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     if (messageIds.length === 1) {
       await modifyMessage(connection, messageIds[0], {
         removeLabelIds: ["INBOX"],

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-attachments.ts
@@ -57,7 +57,7 @@ export async function run(
 
   if (action === "list") {
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       const message = await getMessage(connection, messageId, "full");
       const attachments = collectAttachments(message.payload?.parts);
 
@@ -79,7 +79,7 @@ export async function run(
     if (!filename) return err("filename is required for download.");
 
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       const attachment = await getAttachment(
         connection,
         messageId,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-draft.ts
@@ -23,7 +23,7 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     const draft = await createDraft(
       connection,
       to,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-filters.ts
@@ -26,7 +26,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     switch (action) {
       case "list": {
         const filters = await listFilters(connection);

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-follow-up.ts
@@ -38,7 +38,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     switch (action) {
       case "track": {
         const messageId = input.message_id as string;

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-forward.ts
@@ -76,7 +76,7 @@ export async function run(
   if (!forwardTo) return err("to is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     const message = await getMessage(connection, messageId, "full");
     const headers = message.payload?.headers ?? [];
     const originalFrom = extractHeader(headers, "From");

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-label.ts
@@ -21,7 +21,7 @@ export async function run(
 
   if (messageIds && messageIds.length > 0) {
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       await batchModifyMessages(connection, messageIds, {
         addLabelIds,
         removeLabelIds,
@@ -34,7 +34,7 @@ export async function run(
 
   if (messageId) {
     try {
-      const connection = resolveOAuthConnection("integration:gmail", account);
+      const connection = resolveOAuthConnection("integration:google", account);
       await modifyMessage(connection, messageId, {
         addLabelIds,
         removeLabelIds,

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-outreach-scan.ts
@@ -56,7 +56,7 @@ export async function run(
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     // Pipeline: fire metadata fetches for each page of IDs as they arrive
     const allMessageIds: string[] = [];
     const fetchPromises: Promise<GmailMessage[]>[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-send-draft.ts
@@ -15,7 +15,7 @@ export async function run(
   if (!draftId) return err("draft_id is required.");
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     const msg = await sendDraft(connection, draftId);
     return ok(`Draft sent (Message ID: ${msg.id}).`);
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-sender-digest.ts
@@ -58,7 +58,7 @@ export async function run(
   const inputPageToken = input.page_token as string | undefined;
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     // Pipeline: fire metadata fetches for each page of IDs as they arrive,
     // overlapping fetch latency with pagination latency
     const allMessageIds: string[] = [];

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-trash.ts
@@ -18,7 +18,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     await trashMessage(connection, messageId);
     return ok("Message moved to trash.");
   } catch (e) {

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-unsubscribe.ts
@@ -32,7 +32,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     const message = await getMessage(connection, messageId, "metadata", [
       "List-Unsubscribe",
       "List-Unsubscribe-Post",

--- a/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
+++ b/assistant/src/config/bundled-skills/gmail/tools/gmail-vacation.ts
@@ -22,7 +22,7 @@ export async function run(
   }
 
   try {
-    const connection = resolveOAuthConnection("integration:gmail", account);
+    const connection = resolveOAuthConnection("integration:google", account);
     switch (action) {
       case "get": {
         const settings = await getVacation(connection);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -11,5 +11,5 @@ export function ok(content: string): ToolExecutionResult {
  * scopes are granted in a single OAuth consent flow.
  */
 export function getCalendarConnection(account?: string): OAuthConnection {
-  return resolveOAuthConnection("integration:gmail", account);
+  return resolveOAuthConnection("integration:google", account);
 }

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -23,7 +23,7 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox — that's obviously what they want.
-- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:gmail has expired."
+- **Keep it human.** Never mention OAuth, tokens, APIs, sandboxes, credential proxies, or other technical internals. If something isn't working, say "Gmail needs to be reconnected" — not "the OAuth2 access token for integration:google has expired."
 - **Show progress.** When running a tool that scans many emails, tell the user what you're doing: "Scanning your inbox for clutter..." Don't go silent.
 - **Be brief and warm.** One or two sentences per update is plenty. Don't over-explain what you're about to do — just do it and narrate lightly.
 

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -86,7 +86,7 @@ function mapGmailMessage(msg: GmailMessage): Message {
 export const gmailMessagingProvider: MessagingProvider = {
   id: "gmail",
   displayName: "Gmail",
-  credentialService: "integration:gmail",
+  credentialService: "integration:google",
   capabilities: new Set([
     "threads",
     "labels",

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -195,7 +195,7 @@ function setupCredential(
     tokenUrl: "https://oauth2.googleapis.com/token",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
     baseUrl:
-      service === "integration:gmail"
+      service === "integration:google"
         ? "https://gmail.googleapis.com/gmail/v1/users/me"
         : undefined,
   });
@@ -224,7 +224,7 @@ function setupCredential(
   upsertCredentialMetadata(service, "access_token", {});
 }
 
-function createConnection(service = "integration:gmail"): BYOOAuthConnection {
+function createConnection(service = "integration:google"): BYOOAuthConnection {
   return new BYOOAuthConnection({
     id: "test-cred-id",
     providerKey: service,
@@ -242,7 +242,7 @@ function createConnection(service = "integration:gmail"): BYOOAuthConnection {
 describe("BYOOAuthConnection", () => {
   describe("request()", () => {
     test("makes authenticated request with Bearer token", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       const result = await conn.request({
@@ -266,7 +266,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("appends query parameters", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -282,7 +282,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("uses per-request baseUrl override", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -296,7 +296,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("sends JSON body for POST requests", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -316,7 +316,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries once on 401 response", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       // First call returns 401, second returns 200
@@ -344,7 +344,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles empty response body", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -361,7 +361,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles non-JSON response body", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -378,7 +378,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("returns response headers", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -402,7 +402,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("includes custom request headers", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -421,7 +421,7 @@ describe("BYOOAuthConnection", () => {
   describe("proactive token refresh", () => {
     test("refreshes token when near expiry (within 5-minute buffer)", async () => {
       // Set token to expire in 2 minutes (within 5-min buffer)
-      setupCredential("integration:gmail", {
+      setupCredential("integration:google", {
         expiresAt: Date.now() + 2 * 60 * 1000,
       });
       const conn = createConnection();
@@ -445,7 +445,7 @@ describe("BYOOAuthConnection", () => {
 
   describe("withToken()", () => {
     test("provides valid token to callback", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       const result = await conn.withToken(async (token) => {
@@ -456,7 +456,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries callback on 401 error", async () => {
-      setupCredential("integration:gmail");
+      setupCredential("integration:google");
       const conn = createConnection();
 
       let callCount = 0;
@@ -489,11 +489,11 @@ describe("BYOOAuthConnection", () => {
 
 describe("resolveOAuthConnection", () => {
   test("returns a BYOOAuthConnection for valid credential", () => {
-    setupCredential("integration:gmail");
-    const conn = resolveOAuthConnection("integration:gmail");
+    setupCredential("integration:google");
+    const conn = resolveOAuthConnection("integration:google");
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
-    expect(conn.providerKey).toBe("integration:gmail");
+    expect(conn.providerKey).toBe("integration:google");
     expect(conn.grantedScopes).toEqual(["read", "write"]);
   });
 

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -9,7 +9,7 @@ import {
 
 const DEFAULT_OPTIONS = {
   id: "conn-1",
-  providerKey: "integration:gmail",
+  providerKey: "integration:google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
   grantedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -16,8 +16,8 @@ import type { OAuthProviderBehavior } from "./connect-types.js";
 // ---------------------------------------------------------------------------
 
 export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
-  "integration:gmail": {
-    service: "integration:gmail",
+  "integration:google": {
+    service: "integration:google",
     // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register
     // all of them so proxied bash can inject the OAuth bearer token reliably.
     injectionTemplates: [
@@ -586,7 +586,8 @@ export const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
 /** Map shorthand aliases to canonical service names. */
 export const SERVICE_ALIASES: Record<string, string> = {
-  gmail: "integration:gmail",
+  gmail: "integration:google",
+  google: "integration:google",
   slack: "integration:slack",
   notion: "integration:notion",
   twitter: "integration:twitter",

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -35,8 +35,8 @@ const PROVIDER_SEED_DATA: Record<
     loopbackPort?: number;
   }
 > = {
-  "integration:gmail": {
-    providerKey: "integration:gmail",
+  "integration:google": {
+    providerKey: "integration:google",
     authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
     tokenUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -15,7 +15,7 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "Gmail",
     category: "email",
-    isConnected: () => isProviderConnected("integration:gmail"),
+    isConnected: () => isProviderConnected("integration:google"),
   },
   {
     name: "Slack",

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -20,7 +20,7 @@ import { getSecureKey, setSecureKeyAsync } from "./secure-keys.js";
 
 const log = getLogger("token-manager");
 
-const MESSAGING_SERVICES = new Set(["integration:gmail", "integration:slack"]);
+const MESSAGING_SERVICES = new Set(["integration:google", "integration:slack"]);
 
 function recoveryHint(service: string): string {
   const shortName = service.startsWith("integration:")

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -741,7 +741,7 @@ class CredentialStoreTool implements Tool {
             isError: true,
           };
 
-        // Resolve aliases (e.g. "gmail" → "integration:gmail")
+        // Resolve aliases (e.g. "gmail" → "integration:google")
         const service = resolveService(rawService);
 
         // Code-side behavioral fields (identityVerifier, setup, etc.)

--- a/assistant/src/watcher/provider-types.ts
+++ b/assistant/src/watcher/provider-types.ts
@@ -28,7 +28,7 @@ export interface WatcherProvider {
   id: string;
   /** Human-readable name. */
   displayName: string;
-  /** Credential service required (e.g. 'integration:gmail'). */
+  /** Credential service required (e.g. 'integration:google'). */
   requiredCredentialService: string;
 
   /**

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -115,7 +115,7 @@ class HistoryExpiredError extends Error {
 export const gmailProvider: WatcherProvider = {
   id: "gmail",
   displayName: "Gmail",
-  requiredCredentialService: "integration:gmail",
+  requiredCredentialService: "integration:google",
 
   async getInitialWatermark(credentialService: string): Promise<string> {
     const connection = resolveOAuthConnection(credentialService);

--- a/assistant/src/watcher/providers/google-calendar.ts
+++ b/assistant/src/watcher/providers/google-calendar.ts
@@ -25,7 +25,7 @@ import type {
 const log = getLogger("watcher:google-calendar");
 
 /** The credential service — calendar shares OAuth tokens with Gmail. */
-const CREDENTIAL_SERVICE = "integration:gmail";
+const CREDENTIAL_SERVICE = "integration:google";
 
 function eventToItem(event: CalendarEvent, eventType: string): WatcherItem {
   const start = event.start?.dateTime ?? event.start?.date ?? "";

--- a/skills/google-oauth-applescript/SKILL.md
+++ b/skills/google-oauth-applescript/SKILL.md
@@ -51,6 +51,7 @@ Open: `https://console.cloud.google.com/cloud-resource-manager`
 **New project:** Open `https://console.cloud.google.com/projectcreate` → name it `vellum-assistant` → click Create → get the project ID.
 
 **Known issues:**
+
 - Workspace accounts may show an Organization/Location dropdown — leave as-is
 - Project quota limit → suggest requesting increase, deleting unused, or reusing existing
 
@@ -135,6 +136,7 @@ host_bash:
 > 2. Back on the main page, scroll down and click **Save**
 >
 > You should see:
+>
 > - **Non-sensitive:** `userinfo.email`, `contacts.readonly`
 > - **Sensitive:** `calendar.readonly`, `calendar.events`, `gmail.send`
 > - **Restricted:** `gmail.modify`, `gmail.readonly`
@@ -186,6 +188,7 @@ Use the ping URL from the provider registration to verify the connection.
 For non-interactive channels, see [references/path-b-manual-setup.md](references/path-b-manual-setup.md).
 
 Key Google-specific differences for Path B:
+
 - Use **Web application** credentials (not Desktop app)
 - Add redirect URI under **Authorized redirect URIs**
 - Client Secret prefix is `GOCSPX-` — use split entry to avoid channel scanners

--- a/skills/google-oauth-applescript/references/path-b-manual-setup.md
+++ b/skills/google-oauth-applescript/references/path-b-manual-setup.md
@@ -126,7 +126,7 @@ After the user sends it:
 
 ```
 credential_store store:
-  service: "integration:gmail"
+  service: "integration:google"
   field: "client_id"
   value: "<the client id the user sent>"
 ```
@@ -145,7 +145,7 @@ After the user sends the suffix, reconstruct and store the full secret:
 
 ```
 credential_store store:
-  service: "integration:gmail"
+  service: "integration:google"
   field: "client_secret"
   value: "GOCSPX-<the suffix the user sent>"
 ```
@@ -161,7 +161,7 @@ Tell the user:
 ```
 credential_store:
   action: "oauth2_connect"
-  service: "integration:gmail"
+  service: "integration:google"
 ```
 
 Send the returned auth URL to the user. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.


### PR DESCRIPTION
## Summary
- Renames the `integration:gmail` OAuth provider key to `integration:google` across all source files, tests, CLI help text, and documentation (~40 files)
- Adds `google` as a new short alias alongside the existing `gmail` alias in `SERVICE_ALIASES`
- The Google OAuth provider covers Gmail, Calendar, Contacts, and Drive — the old name was misleading

Part of plan: gmail-to-google-rename.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
