### PR TITLE
fix(build): auto-clean stale PCH module cache on worktree switch

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -32,9 +32,21 @@ set -euo pipefail
 swift_with_retry() {
     local max_attempts="${SWIFT_RETRY_ATTEMPTS:-3}"
     local attempt=1
+    local _pch_cleaned=0
+    local _stderr_log
+    _stderr_log=$(mktemp)
+    trap "rm -f '$_stderr_log'" RETURN
     while true; do
-        if "$@"; then
+        if "$@" 2> >(tee "$_stderr_log" >&2); then
             return 0
+        fi
+        # Auto-clean stale PCH module cache (happens when switching between
+        # worktrees that share the same .build directory via symlink).
+        if [ "$_pch_cleaned" -eq 0 ] && grep -q "PCH was compiled with module cache path" "$_stderr_log" 2>/dev/null; then
+            echo "warning: stale module cache detected, cleaning and retrying..."
+            find "$SCRIPT_DIR/../.build" -type d -name "ModuleCache" -exec rm -rf {} + 2>/dev/null || true
+            _pch_cleaned=1
+            continue
         fi
         if [ "$attempt" -ge "$max_attempts" ]; then
             echo "ERROR: swift command failed after $max_attempts attempts: $*"


### PR DESCRIPTION
## Summary
- When worktrees share `.build` via symlink, switching between them leaves stale PCH files with baked-in absolute paths from the old worktree, causing `swift build` to fail repeatedly
- Modified `swift_with_retry` in `build.sh` to detect "PCH was compiled with module cache path" errors and automatically delete the `ModuleCache` directory before retrying (guarded to only attempt once per invocation)

## Original prompt
Fix stale PCH module cache errors when building after switching worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
