### PR TITLE
fix: guard poke animation against paused state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -240,6 +240,7 @@ class AvatarLayerView: NSView {
     }
 
     private func performPoke() {
+        guard blinkEnabled else { return }
         guard let rootLayer = layer else { return }
 
         // Remove any in-progress poke animation (enables interruptible rapid clicks)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-poke-reaction.md.

**Gap:** Poke animation fires when animations are paused
**What was expected:** Poke should not play when the window is not key
**What was found:** performPoke() had no guard on blinkEnabled

Added `guard blinkEnabled else { return }` to `performPoke()` so the poke animation respects the window-aware lifecycle pause state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
