### PR TITLE
fix: remove image attachment placeholder text from rendered history

### DIFF
--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -78,7 +78,7 @@ describe("renderHistoryContent", () => {
     );
   });
 
-  test("renders image attachments in history output", () => {
+  test("skips image attachment placeholder text (images sent as separate attachments)", () => {
     const output = renderHistoryContent([
       {
         type: "image",
@@ -90,7 +90,7 @@ describe("renderHistoryContent", () => {
       },
     ]);
 
-    expect(output.text).toContain("[Image attachment] image/png, 5 B");
+    expect(output.text).toBe("");
   });
 
   test("appends attachment lines after text content", () => {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -176,22 +176,6 @@ function clampAttachmentText(text: string): string {
   return `${text.slice(0, HISTORY_ATTACHMENT_TEXT_LIMIT)}<truncated />`;
 }
 
-function renderImageBlockForHistory(block: Record<string, unknown>): string {
-  const source = isRecord(block.source) ? block.source : null;
-  const mediaType =
-    source && typeof source.media_type === "string"
-      ? source.media_type
-      : "image/*";
-  const sizeBytes =
-    source && typeof source.data === "string"
-      ? estimateBase64Bytes(source.data)
-      : 0;
-  if (sizeBytes <= 0) {
-    return `[Image attachment] ${mediaType}`;
-  }
-  return `[Image attachment] ${mediaType}, ${formatBytes(sizeBytes)}`;
-}
-
 function renderFileBlockForHistory(block: Record<string, unknown>): string {
   const source = isRecord(block.source) ? block.source : null;
   const mediaType =
@@ -328,7 +312,9 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       continue;
     }
     if (block.type === "image") {
-      attachmentParts.push(renderImageBlockForHistory(block));
+      // Image data is sent as a separate attachment — skip the placeholder
+      // text so the client doesn't render both "[Image attachment]" and the
+      // actual image thumbnail.
       continue;
     }
     if (block.type === "tool_use") {


### PR DESCRIPTION
## Summary
- Stop including `[Image attachment] image/png, 157.8 KB` placeholder text in rendered message text
- Image data is now sent as a separate attachment (since #16200), so the placeholder is redundant and causes the client to show both the text AND the image thumbnail

## Test plan
- [x] `server-history-render.test.ts` updated and passing (23/23)
- [ ] Verify in macOS app that user messages with images no longer show the `[Image attachment]` text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
