### PR TITLE
fix: vertically center traffic light buttons in header bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -436,7 +436,7 @@ public final class MainWindow {
         guard let origin = defaultTrafficLightOrigin else { return }
         containerView.setFrameOrigin(NSPoint(
             x: origin.x + 2,
-            y: origin.y - 2.5
+            y: origin.y - 8
         ))
     }
 


### PR DESCRIPTION
## Summary
- Increased the Y offset for traffic light button repositioning from -2.5 to -8 points, properly centering them vertically within the 48pt header bar to align with the sidebar, search, and navigation buttons

## Original prompt
top left header buttons (red, orange and green) aren't aligned with every other element in that header, all has to be on the same aligned and properly aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
