### PR TITLE
refactor: convert sync getSecureKey to async in already-async functions

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -21,7 +21,7 @@ import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { isGuardian } from "../runtime/channel-verification-service.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { upsertActiveCallLease } from "./active-call-lease.js";
 import { isDeniedNumber } from "./call-constants.js";
@@ -193,7 +193,7 @@ export async function resolveCallerIdentity(
     userNumber = identityConfig.userNumber;
     numberSource = "user_config";
   } else {
-    const secureKeyValue = getSecureKey(
+    const secureKeyValue = await getSecureKeyAsync(
       credentialKey("twilio", "user_phone_number"),
     );
     if (secureKeyValue) {

--- a/assistant/src/email/providers/index.ts
+++ b/assistant/src/email/providers/index.ts
@@ -6,7 +6,7 @@
 
 import { getNestedValue, loadRawConfig } from "../../config/loader.js";
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { ConfigError } from "../../util/errors.js";
 import type { EmailProvider } from "../provider.js";
 
@@ -47,7 +47,7 @@ export async function createProvider(
       const candidates = PROVIDER_KEY_MAP.agentmail;
       let apiKey: string | undefined;
       for (const account of candidates) {
-        apiKey = getSecureKey(account);
+        apiKey = await getSecureKeyAsync(account);
         if (apiKey) break;
       }
       if (!apiKey) {

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -9,7 +9,7 @@
  */
 
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import {
   createConnection,
   deleteConnection,
@@ -80,8 +80,8 @@ export function removeManualTokenConnection(providerKey: string): void {
 export async function backfillManualTokenConnections(): Promise<void> {
   // Telegram: requires both bot_token and webhook_secret
   if (!getConnectionByProvider("telegram")) {
-    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-    const hasWebhookSecret = !!getSecureKey(
+    const hasBotToken = !!await getSecureKeyAsync(credentialKey("telegram", "bot_token"));
+    const hasWebhookSecret = !!await getSecureKeyAsync(
       credentialKey("telegram", "webhook_secret"),
     );
     if (hasBotToken && hasWebhookSecret) {
@@ -91,10 +91,10 @@ export async function backfillManualTokenConnections(): Promise<void> {
 
   // Slack channel: requires both bot_token and app_token
   if (!getConnectionByProvider("slack_channel")) {
-    const hasBotToken = !!getSecureKey(
+    const hasBotToken = !!await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     );
-    const hasAppToken = !!getSecureKey(
+    const hasAppToken = !!await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
     );
     if (hasBotToken && hasAppToken) {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -29,7 +29,7 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../../permissions/checker.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
   type ManifestOverride,
@@ -160,7 +160,7 @@ async function handleOAuthConnectStart(body: {
     const app = getApp(conn.oauthAppId);
     if (app) {
       clientId = app.clientId;
-      clientSecret = getSecureKey(app.clientSecretCredentialPath);
+      clientSecret = await getSecureKeyAsync(app.clientSecretCredentialPath);
     }
   }
 
@@ -170,7 +170,7 @@ async function handleOAuthConnectStart(body: {
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
-        clientSecret = getSecureKey(dbApp.clientSecretCredentialPath);
+        clientSecret = await getSecureKeyAsync(dbApp.clientSecretCredentialPath);
       }
     }
   }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -20,7 +20,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKey,
+  getSecureKeyAsync,
   listSecureKeys,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
@@ -765,7 +765,7 @@ class CredentialStoreTool implements Tool {
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
             if (!clientSecret) {
-              clientSecret = getSecureKey(dbApp.clientSecretCredentialPath);
+              clientSecret = await getSecureKeyAsync(dbApp.clientSecretCredentialPath);
             }
           }
         }


### PR DESCRIPTION
## Summary
- Convert getSecureKey to getSecureKeyAsync in vault.ts, call-domain.ts, email/providers/index.ts, settings-routes.ts, and manual-token-connection.ts
- All call sites are in already-async functions, so this is a straightforward swap with await
- Updates imports to use async variants

Part of plan: async-secure-keys.md (PR 1 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
