### PR TITLE
refactor: convert daemon config getters to use async secure-key functions

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -101,6 +101,8 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+    getSecureKeyAsync: async (account: string) =>
+      secureKeyStore[account] ?? undefined,
     setSecureKey: syncSet,
     deleteSecureKey: syncDelete,
     setSecureKeyAsync: async (account: string, value: string) =>
@@ -230,15 +232,15 @@ describe("Slack channel config handler", () => {
     globalThis.fetch = originalFetch;
   });
 
-  test("GET returns correct shape when not configured", () => {
-    const result = getSlackChannelConfig();
+  test("GET returns correct shape when not configured", async () => {
+    const result = await getSlackChannelConfig();
     expect(result.success).toBe(true);
     expect(result.hasBotToken).toBe(false);
     expect(result.hasAppToken).toBe(false);
     expect(result.connected).toBe(false);
   });
 
-  test("GET returns connected: true when oauth_connection is active and both keys exist", () => {
+  test("GET returns connected: true when oauth_connection is active and both keys exist", async () => {
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",
       status: "active",
@@ -246,14 +248,14 @@ describe("Slack channel config handler", () => {
     secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
     secureKeyStore[credentialKey("slack_channel", "app_token")] = "xapp-test";
 
-    const result = getSlackChannelConfig();
+    const result = await getSlackChannelConfig();
     expect(result.success).toBe(true);
     expect(result.hasBotToken).toBe(true);
     expect(result.hasAppToken).toBe(true);
     expect(result.connected).toBe(true);
   });
 
-  test("GET reports per-field token presence independently of connection row", () => {
+  test("GET reports per-field token presence independently of connection row", async () => {
     // Only bot_token in keychain, no app_token, but connection row exists
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",
@@ -261,7 +263,7 @@ describe("Slack channel config handler", () => {
     };
     secureKeyStore[credentialKey("slack_channel", "bot_token")] = "xoxb-test";
 
-    const result = getSlackChannelConfig();
+    const result = await getSlackChannelConfig();
     expect(result.success).toBe(true);
     expect(result.hasBotToken).toBe(true);
     expect(result.hasAppToken).toBe(false);
@@ -269,7 +271,7 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(false);
   });
 
-  test("GET returns metadata from config when available", () => {
+  test("GET returns metadata from config when available", async () => {
     oauthConnectionStore["slack_channel"] = {
       id: "conn-slack",
       status: "active",
@@ -285,7 +287,7 @@ describe("Slack channel config handler", () => {
       },
     };
 
-    const result = getSlackChannelConfig();
+    const result = await getSlackChannelConfig();
     expect(result.teamId).toBe("T123");
     expect(result.teamName).toBe("TestTeam");
     expect(result.botUserId).toBe("U_BOT");

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -13,7 +13,7 @@ import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKey,
+  getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
@@ -39,13 +39,13 @@ export interface SlackChannelConfigResult {
 
 // -- Business logic --
 
-export function getSlackChannelConfig(): SlackChannelConfigResult {
-  const hasBotToken = !!getSecureKey(
+export async function getSlackChannelConfig(): Promise<SlackChannelConfigResult> {
+  const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
-  );
-  const hasAppToken = !!getSecureKey(
+  ));
+  const hasAppToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "app_token"),
-  );
+  ));
   const conn = getConnectionByProvider("slack_channel");
   const connected =
     !!(conn && conn.status === "active") && hasBotToken && hasAppToken;
@@ -91,12 +91,12 @@ export async function setSlackChannelConfig(
         user?: string;
       };
       if (!data.ok) {
-        const errHasBotToken = !!getSecureKey(
+        const errHasBotToken = !!(await getSecureKeyAsync(
           credentialKey("slack_channel", "bot_token"),
-        );
-        const errHasAppToken = !!getSecureKey(
+        ));
+        const errHasAppToken = !!(await getSecureKeyAsync(
           credentialKey("slack_channel", "app_token"),
-        );
+        ));
         return {
           success: false,
           hasBotToken: errHasBotToken,
@@ -115,12 +115,12 @@ export async function setSlackChannelConfig(
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      const errHasBotToken = !!getSecureKey(
+      const errHasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      );
-      const errHasAppToken = !!getSecureKey(
+      ));
+      const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      );
+      ));
       return {
         success: false,
         hasBotToken: errHasBotToken,
@@ -135,12 +135,12 @@ export async function setSlackChannelConfig(
       botToken,
     );
     if (!stored) {
-      const errHasBotToken = !!getSecureKey(
+      const errHasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      );
-      const errHasAppToken = !!getSecureKey(
+      ));
+      const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      );
+      ));
       return {
         success: false,
         hasBotToken: errHasBotToken,
@@ -173,12 +173,12 @@ export async function setSlackChannelConfig(
   // Validate and store app token
   if (appToken) {
     if (!appToken.startsWith("xapp-")) {
-      const errHasBotToken = !!getSecureKey(
+      const errHasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      );
-      const errHasAppToken = !!getSecureKey(
+      ));
+      const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      );
+      ));
       return {
         success: false,
         hasBotToken: errHasBotToken,
@@ -193,12 +193,12 @@ export async function setSlackChannelConfig(
       appToken,
     );
     if (!stored) {
-      const errHasBotToken = !!getSecureKey(
+      const errHasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
-      );
-      const errHasAppToken = !!getSecureKey(
+      ));
+      const errHasAppToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "app_token"),
-      );
+      ));
       return {
         success: false,
         hasBotToken: errHasBotToken,
@@ -211,12 +211,12 @@ export async function setSlackChannelConfig(
     upsertCredentialMetadata("slack_channel", "app_token", {});
   }
 
-  const hasBotToken = !!getSecureKey(
+  const hasBotToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "bot_token"),
-  );
-  const hasAppToken = !!getSecureKey(
+  ));
+  const hasAppToken = !!(await getSecureKeyAsync(
     credentialKey("slack_channel", "app_token"),
-  );
+  ));
 
   if (hasBotToken && !hasAppToken) {
     warning =
@@ -257,12 +257,12 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
 
   if (r1 === "error" || r2 === "error") {
     // Check each key individually so partial deletions report accurate status.
-    const hasBotToken = !!getSecureKey(
+    const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
-    );
-    const hasAppToken = !!getSecureKey(
+    ));
+    const hasAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
-    );
+    ));
     return {
       success: false,
       hasBotToken,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -16,7 +16,7 @@ import { getConnectionByProvider } from "../../oauth/oauth-store.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKey,
+  getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import { getTelegramBotUsername } from "../../telegram/bot-username.js";
@@ -65,11 +65,13 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 
 // -- Extracted business logic functions --
 
-export function getTelegramConfig(): TelegramConfigResult {
-  const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-  const hasWebhookSecret = !!getSecureKey(
+export async function getTelegramConfig(): Promise<TelegramConfigResult> {
+  const hasBotToken = !!(await getSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+  ));
+  const hasWebhookSecret = !!(await getSecureKeyAsync(
     credentialKey("telegram", "webhook_secret"),
-  );
+  ));
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
   const botUsername = getTelegramBotUsername();
@@ -89,7 +91,8 @@ export async function setTelegramConfig(
   // Track provenance so we only rollback tokens that were freshly provided.
   const isNewToken = !!botToken;
   const resolvedToken =
-    botToken || getSecureKey(credentialKey("telegram", "bot_token"));
+    botToken ||
+    (await getSecureKeyAsync(credentialKey("telegram", "bot_token")));
   if (!resolvedToken) {
     return {
       success: false,
@@ -166,9 +169,9 @@ export async function setTelegramConfig(
   invalidateConfigCache();
 
   // Ensure webhook secret exists (generate if missing)
-  let hasWebhookSecret = !!getSecureKey(
+  let hasWebhookSecret = !!(await getSecureKeyAsync(
     credentialKey("telegram", "webhook_secret"),
-  );
+  ));
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
@@ -241,7 +244,9 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   // The gateway reconcile short-circuits when credentials are absent,
   // so we must call the Telegram API directly while the token is still
   // available.
-  const botToken = getSecureKey(credentialKey("telegram", "bot_token"));
+  const botToken = await getSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+  );
   if (botToken) {
     try {
       await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`);
@@ -260,10 +265,12 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 
   if (r1 === "error" || r2 === "error") {
     // Check each key individually so partial deletions report accurate status.
-    const hasBotToken = !!getSecureKey(credentialKey("telegram", "bot_token"));
-    const hasWebhookSecret = !!getSecureKey(
+    const hasBotToken = !!(await getSecureKeyAsync(
+      credentialKey("telegram", "bot_token"),
+    ));
+    const hasWebhookSecret = !!(await getSecureKeyAsync(
       credentialKey("telegram", "webhook_secret"),
-    );
+    ));
     return {
       success: false,
       hasBotToken,
@@ -297,7 +304,9 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 export async function setTelegramCommands(
   commands?: Array<{ command: string; description: string }>,
 ): Promise<TelegramConfigResult> {
-  const storedToken = getSecureKey(credentialKey("telegram", "bot_token"));
+  const storedToken = await getSecureKeyAsync(
+    credentialKey("telegram", "bot_token"),
+  );
   if (!storedToken) {
     return {
       success: false,
@@ -398,7 +407,7 @@ export async function handleTelegramConfig(
     let result: TelegramConfigResult;
 
     if (msg.action === "get") {
-      result = getTelegramConfig();
+      result = await getTelegramConfig();
     } else if (msg.action === "set") {
       result = await setTelegramConfig(msg.botToken);
     } else if (msg.action === "clear") {

--- a/assistant/src/runtime/routes/integrations/slack/channel.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channel.ts
@@ -20,8 +20,8 @@ import type { RouteDefinition } from "../../../http-router.js";
 /**
  * GET /v1/integrations/slack/channel/config
  */
-export function handleGetSlackChannelConfig(): Response {
-  const result = getSlackChannelConfig();
+export async function handleGetSlackChannelConfig(): Promise<Response> {
+  const result = await getSlackChannelConfig();
   return Response.json(result);
 }
 

--- a/assistant/src/runtime/routes/integrations/telegram.ts
+++ b/assistant/src/runtime/routes/integrations/telegram.ts
@@ -20,8 +20,8 @@ import type { RouteDefinition } from "../../http-router.js";
 /**
  * GET /v1/integrations/telegram/config
  */
-export function handleGetTelegramConfig(): Response {
-  const result = getTelegramConfig();
+export async function handleGetTelegramConfig(): Promise<Response> {
+  const result = await getTelegramConfig();
   return Response.json(result);
 }
 


### PR DESCRIPTION
## Summary
- Make getTelegramConfig() and getSlackChannelConfig() async
- Convert all getSecureKey calls in config-telegram.ts and config-slack-channel.ts to getSecureKeyAsync
- Update all callers (route handlers, tests) to await the now-async getters

Part of plan: async-secure-keys.md (PR 4 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
