### PR TITLE
fix: debounce skeleton loading state to prevent flash on empty thread switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -97,9 +97,15 @@ struct ChatView: View {
     @State private var isSearchActive = false
     @State private var searchText = ""
     @State private var currentMatchIndex = 0
+    @State private var showSkeleton = false
+    @State private var skeletonDebounceTask: Task<Void, Never>? = nil
 
     private var isEmptyState: Bool {
         messages.isEmpty && isHistoryLoaded
+    }
+
+    private var shouldShowSkeleton: Bool {
+        messages.isEmpty && !isHistoryLoaded
     }
 
     /// Message IDs whose text contains the search query, ordered chronologically.
@@ -112,7 +118,7 @@ struct ChatView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                if messages.isEmpty && !isHistoryLoaded {
+                if showSkeleton {
                     ChatLoadingSkeleton()
                         .padding(VSpacing.lg)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -348,6 +354,18 @@ struct ChatView: View {
                 return
             }
             activateSearch()
+        }
+        .onChange(of: shouldShowSkeleton) { _, shouldShow in
+            skeletonDebounceTask?.cancel()
+            if shouldShow {
+                skeletonDebounceTask = Task {
+                    try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
+                    guard !Task.isCancelled else { return }
+                    showSkeleton = true
+                }
+            } else {
+                showSkeleton = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add 200ms debounce to skeleton loading state in ChatView to prevent brief flash when switching to empty threads
- The skeleton only appears if history loading takes >200ms, eliminating the flash for quick daemon responses
- Rapid thread switching properly cancels pending debounce timers

Part of plan: fix-skeleton-flash.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
