### PR TITLE
fix: infer OAuth account from calendar_id for multi-account

### DIFF
--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-check-availability.ts
@@ -15,7 +15,7 @@ export async function run(
   const calendarIds = (input.calendar_ids as string[]) ?? ["primary"];
   const timezone = input.timezone as string | undefined;
 
-  const connection = getCalendarConnection(account);
+  const connection = getCalendarConnection(account, calendarIds[0]);
   const result = await calendar.freeBusy(connection, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-create-event.ts
@@ -41,7 +41,7 @@ export async function run(
     eventBody.attendees = attendees.map((email) => ({ email }));
   }
 
-  const connection = getCalendarConnection(account);
+  const connection = getCalendarConnection(account, calendarId);
   const event = await calendar.createEvent(connection, eventBody, calendarId);
   const link = event.htmlLink ? ` View it here: ${event.htmlLink}` : "";
   return ok(`Event created (ID: ${event.id}).${link}`);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-get-event.ts
@@ -13,7 +13,7 @@ export async function run(
   const eventId = input.event_id as string;
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = getCalendarConnection(account);
+  const connection = getCalendarConnection(account, calendarId);
   const event = await calendar.getEvent(connection, eventId, calendarId);
   return ok(JSON.stringify(event, null, 2));
 }

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-list-events.ts
@@ -18,7 +18,7 @@ export async function run(
   const singleEvents = (input.single_events as boolean) ?? true;
   const orderBy = input.order_by as "startTime" | "updated" | undefined;
 
-  const connection = getCalendarConnection(account);
+  const connection = getCalendarConnection(account, calendarId);
   const result = await calendar.listEvents(connection, calendarId, {
     timeMin,
     timeMax,

--- a/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/calendar-rsvp.ts
@@ -14,7 +14,7 @@ export async function run(
   const response = input.response as "accepted" | "declined" | "tentative";
   const calendarId = (input.calendar_id as string) ?? "primary";
 
-  const connection = getCalendarConnection(account);
+  const connection = getCalendarConnection(account, calendarId);
 
   // First get the event to find the user's attendee entry
   const event = await calendar.getEvent(connection, eventId, calendarId);

--- a/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/google-calendar/tools/shared.ts
@@ -10,6 +10,12 @@ export function ok(content: string): ToolExecutionResult {
  * Calendar uses the same OAuth credential service as Gmail since both
  * scopes are granted in a single OAuth consent flow.
  */
-export function getCalendarConnection(account?: string): OAuthConnection {
-  return resolveOAuthConnection("integration:google", account);
+export function getCalendarConnection(
+  account?: string,
+  calendarId?: string,
+): OAuthConnection {
+  // If no explicit account but calendar_id looks like an email, use it as the account hint
+  const resolved =
+    account ?? (calendarId?.includes("@") ? calendarId : undefined);
+  return resolveOAuthConnection("integration:google", resolved);
 }


### PR DESCRIPTION
## Summary
- When `calendar_id` is an email (e.g. `alexnork@gmail.com`) and no explicit `account` is provided, infer the OAuth account from the calendar ID
- Fixes 404 errors when the model passes `calendar_id` for a personal account but doesn't pass `account`, causing the tool to use the wrong OAuth connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
