### PR TITLE
fix: prevent BTW endpoint from creating ghost conversations

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -19,13 +19,21 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-const mockGetOrCreateConversation = mock((_key: string) => ({
-  conversationId: "conv-test-123",
-  created: false,
-}));
+const mockGetConversationByKey = mock(
+  (_key: string): { conversationId: string } | null => ({
+    conversationId: "conv-test-123",
+  }),
+);
 
 mock.module("../memory/conversation-key-store.js", () => ({
-  getOrCreateConversation: mockGetOrCreateConversation,
+  getConversationByKey: mockGetConversationByKey,
+  // Ensure getOrCreateConversation is never called — BTW must not create
+  // persistent conversations.
+  getOrCreateConversation: () => {
+    throw new Error(
+      "getOrCreateConversation must not be called from btw-routes",
+    );
+  },
 }));
 
 const mockAddMessage = mock(() => {});
@@ -322,5 +330,53 @@ describe("POST /v1/btw", () => {
 
     // processing should still be false — the handler never sets it
     expect(session.processing).toBe(false);
+  });
+
+  // -- No conversation creation (regression) --
+
+  test("unknown conversationKey does not create a DB conversation", async () => {
+    // Simulate a greeting request for a draft thread — no conversation exists.
+    mockGetConversationByKey.mockReturnValueOnce(null);
+
+    const session = makeMockSession();
+    const deps = makeSendMessageDeps(session);
+    const getOrCreateSessionSpy = deps.getOrCreateSession as ReturnType<
+      typeof mock
+    >;
+
+    const res = await callHandler(
+      { conversationKey: "greeting-abc123", content: "Generate a greeting" },
+      { sendMessageDeps: deps },
+    );
+    await readStream(res);
+
+    expect(res.status).toBe(200);
+
+    // Read-only lookup should be called
+    expect(mockGetConversationByKey).toHaveBeenCalledWith("greeting-abc123");
+
+    // Session should be created with the raw key (no DB conversation created)
+    expect(getOrCreateSessionSpy).toHaveBeenCalledWith("greeting-abc123");
+  });
+
+  test("known conversationKey resolves to existing conversation ID", async () => {
+    mockGetConversationByKey.mockReturnValueOnce({
+      conversationId: "existing-conv-id",
+    });
+
+    const session = makeMockSession();
+    const deps = makeSendMessageDeps(session);
+    const getOrCreateSessionSpy = deps.getOrCreateSession as ReturnType<
+      typeof mock
+    >;
+
+    const res = await callHandler(
+      { conversationKey: "my-thread-key", content: "What is 2+2?" },
+      { sendMessageDeps: deps },
+    );
+    await readStream(res);
+
+    expect(res.status).toBe(200);
+    expect(getOrCreateSessionSpy).toHaveBeenCalledWith("existing-conv-id");
   });
 });

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -9,7 +9,7 @@
  */
 
 import { buildToolDefinitions } from "../../daemon/session-tool-setup.js";
-import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
+import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import {
   createTimeout,
   userMessage,
@@ -53,10 +53,15 @@ async function handleBtw(
     );
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
-  const session = await deps.sendMessageDeps.getOrCreateSession(
-    mapping.conversationId,
-  );
+  // Look up an existing conversation — never create one.  BTW is ephemeral
+  // (the file header promises "No messages are persisted"), so we must not
+  // call getOrCreateConversation which would insert a DB row.  When no
+  // conversation exists (e.g. greeting generation for a draft thread), we
+  // still get a usable session via getOrCreateSession with the raw key; the
+  // session lives only in memory and disappears on restart.
+  const mapping = getConversationByKey(conversationKey);
+  const sessionId = mapping?.conversationId ?? conversationKey;
+  const session = await deps.sendMessageDeps.getOrCreateSession(sessionId);
 
   const messages = [...session.getMessages(), userMessage(content.trim())];
   const tools = buildToolDefinitions();


### PR DESCRIPTION
## Summary
- The `/v1/btw` endpoint (used for greeting generation on new threads) called `getOrCreateConversation()` which inserted a DB row for every request — even for draft threads with no messages
- This caused empty "Generating title..." conversations to appear in the sidebar after app restart when the user had clicked "new thread" without sending any messages
- Switched to read-only `getConversationByKey()` so BTW remains truly ephemeral; unknown keys use the raw key as an in-memory-only session ID

## Test plan
- [x] Existing BTW tests updated to assert `getOrCreateConversation` is never called
- [x] Added regression tests: unknown conversationKey does not create DB conversation, known key resolves correctly
- [ ] Manual: click "new thread" multiple times without sending messages, restart app → no ghost threads in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
