### PR TITLE
refactor: convert Twilio credential functions to async

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -10,6 +10,7 @@ const connectedProviders = new Set<string>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
+  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -45,8 +46,8 @@ describe("integration-status", () => {
   });
 
   describe("getIntegrationSummary", () => {
-    test("returns all disconnected when no keys are set", () => {
-      const summary = getIntegrationSummary();
+    test("returns all disconnected when no keys are set", async () => {
+      const summary = await getIntegrationSummary();
       expect(summary).toEqual([
         { name: "Gmail", category: "email", connected: false },
         { name: "Slack", category: "messaging", connected: false },
@@ -55,25 +56,25 @@ describe("integration-status", () => {
       ]);
     });
 
-    test("returns all connected when all keys are set", () => {
+    test("returns all connected when all keys are set", async () => {
       setOAuthConnected("integration:google");
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
 
-      const summary = getIntegrationSummary();
+      const summary = await getIntegrationSummary();
       expect(summary.every((s: { connected: boolean }) => s.connected)).toBe(
         true,
       );
     });
 
-    test("returns mixed status", () => {
+    test("returns mixed status", async () => {
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
 
-      const summary = getIntegrationSummary();
+      const summary = await getIntegrationSummary();
       const connected = summary.filter(
         (s: { connected: boolean }) => s.connected,
       );
@@ -91,17 +92,17 @@ describe("integration-status", () => {
       ]);
     });
 
-    test("Twilio disconnected when only account_sid is set (missing auth_token)", () => {
+    test("Twilio disconnected when only account_sid is set (missing auth_token)", async () => {
       mockTwilioAccountSid = "sid";
 
-      const summary = getIntegrationSummary();
+      const summary = await getIntegrationSummary();
       const twilio = summary.find((s: { name: string }) => s.name === "Twilio");
       expect(twilio?.connected).toBe(false);
     });
 
-    test("Telegram disconnected when no connection record exists", () => {
+    test("Telegram disconnected when no connection record exists", async () => {
       // No oauth_connection record for telegram — should be disconnected
-      const summary = getIntegrationSummary();
+      const summary = await getIntegrationSummary();
       const telegram = summary.find(
         (s: { name: string }) => s.name === "Telegram",
       );
@@ -110,32 +111,32 @@ describe("integration-status", () => {
   });
 
   describe("formatIntegrationSummary", () => {
-    test("shows checkmarks and crosses", () => {
+    test("shows checkmarks and crosses", async () => {
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
 
-      const result = formatIntegrationSummary();
+      const result = await formatIntegrationSummary();
       expect(result).toBe(
         "Gmail \u2717 | Slack \u2717 | Twilio \u2713 | Telegram \u2713",
       );
     });
 
-    test("all disconnected", () => {
-      const result = formatIntegrationSummary();
+    test("all disconnected", async () => {
+      const result = await formatIntegrationSummary();
       expect(result).toBe(
         "Gmail \u2717 | Slack \u2717 | Twilio \u2717 | Telegram \u2717",
       );
     });
 
-    test("all connected", () => {
+    test("all connected", async () => {
       setOAuthConnected("integration:google");
       setOAuthConnected("integration:slack");
       mockTwilioAccountSid = "sid";
       secureKeyValues.set(credentialKey("twilio", "auth_token"), "auth");
       setOAuthConnected("telegram");
 
-      const result = formatIntegrationSummary();
+      const result = await formatIntegrationSummary();
       expect(result).toBe(
         "Gmail \u2713 | Slack \u2713 | Twilio \u2713 | Telegram \u2713",
       );
@@ -143,28 +144,28 @@ describe("integration-status", () => {
   });
 
   describe("hasCapability", () => {
-    test("returns false when no integrations in category are connected", () => {
-      expect(hasCapability("email")).toBe(false);
-      expect(hasCapability("messaging")).toBe(false);
+    test("returns false when no integrations in category are connected", async () => {
+      expect(await hasCapability("email")).toBe(false);
+      expect(await hasCapability("messaging")).toBe(false);
     });
 
-    test("returns true when any integration in category is connected", () => {
+    test("returns true when any integration in category is connected", async () => {
       setOAuthConnected("telegram");
-      expect(hasCapability("messaging")).toBe(true);
+      expect(await hasCapability("messaging")).toBe(true);
     });
 
-    test("returns false when no connection record exists for category integrations", () => {
+    test("returns false when no connection record exists for category integrations", async () => {
       // No oauth_connection record for telegram — should not count as connected
-      expect(hasCapability("messaging")).toBe(false);
+      expect(await hasCapability("messaging")).toBe(false);
     });
 
-    test("returns false for unknown categories", () => {
-      expect(hasCapability("nonexistent")).toBe(false);
+    test("returns false for unknown categories", async () => {
+      expect(await hasCapability("nonexistent")).toBe(false);
     });
 
-    test("email category checks Gmail", () => {
+    test("email category checks Gmail", async () => {
       setOAuthConnected("integration:google");
-      expect(hasCapability("email")).toBe(true);
+      expect(await hasCapability("email")).toBe(true);
     });
   });
 });

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -14,6 +14,7 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -41,8 +42,8 @@ describe("twilio-config", () => {
     };
   });
 
-  test("returns config when credentials and phone number are set", () => {
-    const config = getTwilioConfig();
+  test("returns config when credentials and phone number are set", async () => {
+    const config = await getTwilioConfig();
     expect(config.accountSid).toBe("AC_test_sid");
     expect(config.authToken).toBe("test_auth_token");
     expect(config.phoneNumber).toBe("+15551234567");
@@ -50,16 +51,16 @@ describe("twilio-config", () => {
     expect(config.wssBaseUrl).toBe("wss://test.example.com/twilio/relay");
   });
 
-  test("throws ConfigError when account SID is missing", () => {
+  test("throws ConfigError when account SID is missing", async () => {
     mockLoadConfigResult = {
       twilio: { accountSid: "", phoneNumber: "+15551234567" },
     };
-    expect(() => getTwilioConfig()).toThrow(
+    expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
     );
   });
 
-  test("throws ConfigError when auth token is missing", () => {
+  test("throws ConfigError when auth token is missing", async () => {
     mockSecureKeys = {};
     mockLoadConfigResult = {
       twilio: {
@@ -67,26 +68,26 @@ describe("twilio-config", () => {
         phoneNumber: "+15551234567",
       },
     };
-    expect(() => getTwilioConfig()).toThrow(
+    expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
     );
   });
 
-  test("throws ConfigError when phone number is missing", () => {
+  test("throws ConfigError when phone number is missing", async () => {
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
         phoneNumber: "",
       },
     };
-    expect(() => getTwilioConfig()).toThrow(
+    expect(getTwilioConfig()).rejects.toThrow(
       /Twilio phone number not configured/,
     );
   });
 
-  test("throws ConfigError when twilio config section is absent", () => {
+  test("throws ConfigError when twilio config section is absent", async () => {
     mockLoadConfigResult = {};
-    expect(() => getTwilioConfig()).toThrow(
+    expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
     );
   });

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -46,6 +46,11 @@ mock.module("../security/secure-keys.js", () => ({
     if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;
     return undefined;
   },
+  getSecureKeyAsync: async (key: string) => {
+    if (key === credentialKey("twilio", "auth_token")) return mockAuthToken;
+    if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;
+    return undefined;
+  },
 }));
 
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
@@ -143,15 +148,15 @@ describe("TwilioConversationRelayProvider", () => {
   });
 
   describe("getAuthToken", () => {
-    test("returns the auth token when configured", () => {
+    test("returns the auth token when configured", async () => {
       mockAuthToken = "my-secret-token";
-      const token = TwilioConversationRelayProvider.getAuthToken();
+      const token = await TwilioConversationRelayProvider.getAuthToken();
       expect(token).toBe("my-secret-token");
     });
 
-    test("returns null when auth token is not configured", () => {
+    test("returns null when auth token is not configured", async () => {
       mockAuthToken = undefined;
-      const token = TwilioConversationRelayProvider.getAuthToken();
+      const token = await TwilioConversationRelayProvider.getAuthToken();
       expect(token).toBeNull();
     });
   });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -177,7 +177,7 @@ export async function resolveCallerIdentity(
   }
 
   if (mode === "assistant_number") {
-    const twilioConfig = getTwilioConfig();
+    const twilioConfig = await getTwilioConfig();
     log.info(
       { mode, source, fromNumber: twilioConfig.phoneNumber },
       "Resolved caller identity",

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -4,7 +4,7 @@ import {
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -38,10 +38,11 @@ export function resolveTwilioPhoneNumber(): string {
   return "";
 }
 
-export function getTwilioConfig(): TwilioConfig {
+export async function getTwilioConfig(): Promise<TwilioConfig> {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
-  const authToken = getSecureKey(credentialKey("twilio", "auth_token")) || "";
+  const authToken =
+    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || "";
   const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -24,8 +24,11 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
 
   // ── Credential helpers ──────────────────────────────────────────────
 
-  private getCredentials(): { accountSid: string; authToken: string } {
-    return getTwilioCredentials();
+  private async getCredentials(): Promise<{
+    accountSid: string;
+    authToken: string;
+  }> {
+    return await getTwilioCredentials();
   }
 
   private authHeader(accountSid: string, authToken: string): string {
@@ -39,7 +42,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── VoiceProvider interface ─────────────────────────────────────────
 
   async initiateCall(opts: InitiateCallOptions): Promise<{ callSid: string }> {
-    const { accountSid, authToken } = this.getCredentials();
+    const { accountSid, authToken } = await this.getCredentials();
 
     const body = new URLSearchParams({
       From: opts.from,
@@ -104,7 +107,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   }
 
   async endCall(callSid: string): Promise<void> {
-    const { accountSid, authToken } = this.getCredentials();
+    const { accountSid, authToken } = await this.getCredentials();
 
     log.info({ callSid }, "Ending Twilio call");
 
@@ -139,7 +142,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   }
 
   async getCallStatus(callSid: string): Promise<string> {
-    const { accountSid, authToken } = this.getCredentials();
+    const { accountSid, authToken } = await this.getCredentials();
 
     const res = await fetch(
       `${this.baseUrl(accountSid)}/Calls/${callSid}.json`,
@@ -179,7 +182,7 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   async checkCallerIdEligibility(
     phoneNumber: string,
   ): Promise<{ eligible: boolean; reason?: string }> {
-    const { accountSid, authToken } = this.getCredentials();
+    const { accountSid, authToken } = await this.getCredentials();
     const encodedNumber = encodeURIComponent(phoneNumber);
 
     let incomingOk = false;
@@ -280,8 +283,10 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
    * Exposed as a static method so callers (e.g. the HTTP server webhook
    * middleware) can check availability independently.
    */
-  static getAuthToken(): string | null {
-    return getSecureKey(credentialKey("twilio", "auth_token")) || null;
+  static async getAuthToken(): Promise<string | null> {
+    return (
+      (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || null
+    );
   }
 
   /**

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -8,7 +8,7 @@
 
 import { loadConfig } from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
 export interface TwilioCredentials {
@@ -28,14 +28,17 @@ function resolveAccountSid(): string | undefined {
 }
 
 /** Resolve the Twilio Auth Token from the credential store. */
-function resolveAuthToken(): string | undefined {
-  return getSecureKey(credentialKey("twilio", "auth_token")) || undefined;
+async function resolveAuthToken(): Promise<string | undefined> {
+  return (
+    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) ||
+    undefined
+  );
 }
 
 /** Resolve Twilio credentials from config (SID) and credential store (token). Throws if not configured. */
-export function getTwilioCredentials(): TwilioCredentials {
+export async function getTwilioCredentials(): Promise<TwilioCredentials> {
   const accountSid = resolveAccountSid();
-  const authToken = resolveAuthToken();
+  const authToken = await resolveAuthToken();
   if (!accountSid || !authToken) {
     throw new ConfigError(
       "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
@@ -45,9 +48,9 @@ export function getTwilioCredentials(): TwilioCredentials {
 }
 
 /** Check whether Twilio credentials are present (non-throwing). */
-export function hasTwilioCredentials(): boolean {
+export async function hasTwilioCredentials(): Promise<boolean> {
   try {
-    return !!resolveAccountSid() && !!resolveAuthToken();
+    return !!resolveAccountSid() && !!(await resolveAuthToken());
   } catch {
     return false;
   }

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -161,7 +161,7 @@ export async function handleIngressConfig(
       // Best-effort Twilio webhook reconciliation: when ingress is being
       // enabled/updated and Twilio numbers are assigned with valid credentials,
       // push the new webhook URLs to Twilio so calls route correctly.
-      if (isEnabled && hasTwilioCredentials()) {
+      if (isEnabled && (await hasTwilioCredentials())) {
         const currentConfig = loadRawConfig();
         const twilioConfig = (currentConfig?.twilio ?? {}) as Record<
           string,
@@ -188,7 +188,7 @@ export async function handleIngressConfig(
 
         if (assignedNumbers.size > 0) {
           const { accountSid: acctSid, authToken: acctToken } =
-            getTwilioCredentials();
+            await getTwilioCredentials();
           // Fire-and-forget: webhook sync failure must not block the ingress save.
           // Reconcile every assigned number so assistant-scoped mappings do not
           // retain stale Twilio webhook URLs after ingress URL changes.

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -77,7 +77,7 @@ function checkIngress(): ReadinessCheckResult {
 const voiceProbe: ChannelProbe = {
   channel: "phone",
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
-    const hasCreds = hasTwilioCredentials();
+    const hasCreds = await hasTwilioCredentials();
     const hasPhone = !!resolveTwilioPhoneNumber();
     const ingress = checkIngress();
 

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -57,7 +57,7 @@ export async function validateTwilioWebhook(
 ): Promise<{ body: string } | Response> {
   const rawBody = await req.text();
 
-  const authToken = TwilioConversationRelayProvider.getAuthToken();
+  const authToken = await TwilioConversationRelayProvider.getAuthToken();
 
   if (!authToken) {
     log.error(

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -66,10 +66,10 @@ function pruneAssistantPhoneNumbers(
 /**
  * GET /v1/integrations/twilio/config
  */
-export function handleGetTwilioConfig(): Response {
-  const hasCredentials = hasTwilioCredentials();
+export async function handleGetTwilioConfig(): Promise<Response> {
+  const hasCredentials = await hasTwilioCredentials();
   const accountSid = hasCredentials
-    ? getTwilioCredentials().accountSid
+    ? (await getTwilioCredentials()).accountSid
     : undefined;
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
@@ -100,7 +100,7 @@ export async function handleSetTwilioCredentials(
     return Response.json(
       {
         success: false,
-        hasCredentials: hasTwilioCredentials(),
+        hasCredentials: await hasTwilioCredentials(),
         error: "accountSid and authToken are required",
       },
       { status: 400 },
@@ -120,7 +120,7 @@ export async function handleSetTwilioCredentials(
       const errBody = await res.text();
       return Response.json({
         success: false,
-        hasCredentials: hasTwilioCredentials(),
+        hasCredentials: await hasTwilioCredentials(),
         error: `Twilio API validation failed (${res.status}): ${errBody}`,
       });
     }
@@ -128,7 +128,7 @@ export async function handleSetTwilioCredentials(
     const message = err instanceof Error ? err.message : String(err);
     return Response.json({
       success: false,
-      hasCredentials: hasTwilioCredentials(),
+      hasCredentials: await hasTwilioCredentials(),
       error: `Failed to validate Twilio credentials: ${message}`,
     });
   }
@@ -231,7 +231,7 @@ export async function handleClearTwilioCredentials(): Promise<Response> {
  * GET /v1/integrations/twilio/numbers
  */
 export async function handleListTwilioNumbers(): Promise<Response> {
-  if (!hasTwilioCredentials()) {
+  if (!(await hasTwilioCredentials())) {
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -239,7 +239,7 @@ export async function handleListTwilioNumbers(): Promise<Response> {
     });
   }
 
-  const { accountSid, authToken } = getTwilioCredentials();
+  const { accountSid, authToken } = await getTwilioCredentials();
   const numbers = await listIncomingPhoneNumbers(accountSid, authToken);
 
   return Response.json({ success: true, hasCredentials: true, numbers });
@@ -253,7 +253,7 @@ export async function handleListTwilioNumbers(): Promise<Response> {
 export async function handleProvisionTwilioNumber(
   req: Request,
 ): Promise<Response> {
-  if (!hasTwilioCredentials()) {
+  if (!(await hasTwilioCredentials())) {
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -265,7 +265,7 @@ export async function handleProvisionTwilioNumber(
     country?: string;
     areaCode?: string;
   };
-  const { accountSid, authToken } = getTwilioCredentials();
+  const { accountSid, authToken } = await getTwilioCredentials();
   const country = body.country ?? "US";
 
   const available = await searchAvailableNumbers(
@@ -324,7 +324,7 @@ export async function handleAssignTwilioNumber(
     return Response.json(
       {
         success: false,
-        hasCredentials: hasTwilioCredentials(),
+        hasCredentials: await hasTwilioCredentials(),
         error: "phoneNumber is required",
       },
       { status: 400 },
@@ -339,9 +339,9 @@ export async function handleAssignTwilioNumber(
 
   // Best-effort webhook configuration when credentials are available
   let webhookWarning: string | undefined;
-  if (hasTwilioCredentials()) {
+  if (await hasTwilioCredentials()) {
     const { accountSid: acctSid, authToken: acctToken } =
-      getTwilioCredentials();
+      await getTwilioCredentials();
     const webhookResult = await syncTwilioWebhooks(
       body.phoneNumber,
       acctSid,
@@ -353,7 +353,7 @@ export async function handleAssignTwilioNumber(
 
   return Response.json({
     success: true,
-    hasCredentials: hasTwilioCredentials(),
+    hasCredentials: await hasTwilioCredentials(),
     phoneNumber: body.phoneNumber,
     warning: webhookWarning,
   });
@@ -367,7 +367,7 @@ export async function handleAssignTwilioNumber(
 export async function handleReleaseTwilioNumber(
   req: Request,
 ): Promise<Response> {
-  if (!hasTwilioCredentials()) {
+  if (!(await hasTwilioCredentials())) {
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -389,7 +389,7 @@ export async function handleReleaseTwilioNumber(
     });
   }
 
-  const { accountSid, authToken } = getTwilioCredentials();
+  const { accountSid, authToken } = await getTwilioCredentials();
 
   await releasePhoneNumber(accountSid, authToken, phoneNumber);
 
@@ -416,7 +416,7 @@ export function twilioRouteDefinitions(): RouteDefinition[] {
     {
       endpoint: "integrations/twilio/config",
       method: "GET",
-      handler: () => handleGetTwilioConfig(),
+      handler: async () => handleGetTwilioConfig(),
     },
     {
       endpoint: "integrations/twilio/credentials",

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -7,7 +7,7 @@ import {
 interface IntegrationProbe {
   name: string;
   category: string;
-  isConnected: () => boolean;
+  isConnected: () => boolean | Promise<boolean>;
 }
 
 // Registry — add new integrations here:
@@ -37,27 +37,34 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   },
 ];
 
-export function getIntegrationSummary(): Array<{
-  name: string;
-  category: string;
-  connected: boolean;
-}> {
-  return INTEGRATION_PROBES.map((probe) => ({
-    name: probe.name,
-    category: probe.category,
-    connected: probe.isConnected(),
-  }));
+export async function getIntegrationSummary(): Promise<
+  Array<{
+    name: string;
+    category: string;
+    connected: boolean;
+  }>
+> {
+  return Promise.all(
+    INTEGRATION_PROBES.map(async (probe) => ({
+      name: probe.name,
+      category: probe.category,
+      connected: await probe.isConnected(),
+    })),
+  );
 }
 
-export function formatIntegrationSummary(): string {
-  const summary = getIntegrationSummary();
+export async function formatIntegrationSummary(): Promise<string> {
+  const summary = await getIntegrationSummary();
   return summary
     .map((s) => `${s.name} ${s.connected ? "\u2713" : "\u2717"}`)
     .join(" | ");
 }
 
-export function hasCapability(category: string): boolean {
-  return INTEGRATION_PROBES.some(
-    (probe) => probe.category === category && probe.isConnected(),
+export async function hasCapability(category: string): Promise<boolean> {
+  const results = await Promise.all(
+    INTEGRATION_PROBES.filter((probe) => probe.category === category).map(
+      (probe) => probe.isConnected(),
+    ),
   );
+  return results.some(Boolean);
 }

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -115,7 +115,7 @@ export async function executeScheduleCreate(
       });
 
       const fireDate = formatLocalDate(job.nextRunAt);
-      const integrations = formatIntegrationSummary();
+      const integrations = await formatIntegrationSummary();
       return {
         content: [
           `One-shot schedule created successfully.`,
@@ -197,7 +197,7 @@ export async function executeScheduleCreate(
           : describeCronExpression(job.cronExpression);
 
     const nextRunDate = formatLocalDate(job.nextRunAt);
-    const integrations = formatIntegrationSummary();
+    const integrations = await formatIntegrationSummary();
     return {
       content: [
         `Recurring schedule created successfully.`,


### PR DESCRIPTION
## Summary
- Make resolveAuthToken, getTwilioCredentials, hasTwilioCredentials, getTwilioConfig, and getAuthToken async
- Convert all getSecureKey calls in Twilio modules to getSecureKeyAsync
- Update all callers across twilio-provider, twilio-validation, config-ingress, and twilio routes
- Update integration-status.ts to support async isConnected probes
- Update channel-readiness-service.ts voice probe to await hasTwilioCredentials
- Update call-domain.ts to await getTwilioConfig
- Update test files to await async functions and add getSecureKeyAsync mocks

Part of plan: async-secure-keys.md (PR 8 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
