### PR TITLE
fix: make archive confirm button clickable (LUM-201)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -37,6 +37,11 @@ enum SidebarLayoutMetrics {
     /// Gap below the "Scheduled" label before the first scheduled row.
     static let scheduledHeaderBottomGap: CGFloat = VSpacing.xs  // 4pt
 
+    // MARK: - Archive Confirm
+
+    /// Trailing padding reserved for the "Confirm" pill button overlay during archive flow.
+    static let archiveConfirmTrailingPadding: CGFloat = 72
+
     // MARK: - Section Divider
 
     /// Vertical padding above and below a section divider line.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -111,7 +111,7 @@ struct SidebarThreadItem: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, isPendingDeletion ? 72 : hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
+            .padding(.trailing, isPendingDeletion ? SidebarLayoutMetrics.archiveConfirmTrailingPadding : hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -31,6 +31,7 @@ struct SidebarThreadItem: View {
     private var interactionState: ThreadInteractionState { threadManager.interactionState(for: thread.id) }
     // Reserve trailing space when hovered for archive button overlay.
     private var hasTrailingIcon: Bool { isHovered || sidebar.threadPendingDeletion == thread.id }
+    private var isPendingDeletion: Bool { sidebar.threadPendingDeletion == thread.id }
     private var canMarkUnread: Bool {
         !thread.hasUnseenLatestAssistantMessage &&
             thread.sessionId != nil &&
@@ -110,7 +111,7 @@ struct SidebarThreadItem: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
+            .padding(.trailing, isPendingDeletion ? 72 : hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -107,14 +107,6 @@ struct SidebarThreadItem: View {
                     .truncationMode(.tail)
                     .help(thread.title)
 
-                if sidebar.threadPendingDeletion == thread.id {
-                    VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                        threadManager.archiveThread(id: thread.id)
-                        sidebar.threadPendingDeletion = nil
-                    }
-                    .fixedSize()
-                    .accessibilityLabel("Confirm archive \(thread.title)")
-                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
@@ -146,7 +138,15 @@ struct SidebarThreadItem: View {
             selectThread()
         }
         .overlay(alignment: .trailing) {
-            if isHovered && sidebar.threadPendingDeletion != thread.id {
+            if sidebar.threadPendingDeletion == thread.id {
+                VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
+                    threadManager.archiveThread(id: thread.id)
+                    sidebar.threadPendingDeletion = nil
+                }
+                .fixedSize()
+                .padding(.trailing, VSpacing.xs)
+                .accessibilityLabel("Confirm archive \(thread.title)")
+            } else if isHovered {
                 Button {
                     sidebar.threadPendingDeletion = thread.id
                 } label: {


### PR DESCRIPTION
## Summary
- Moved the archive "Confirm" button from inside the HStack (where `.contentShape(Rectangle())` and `.onTapGesture` on the parent intercepted clicks) to the `.overlay(alignment: .trailing)` position, matching the archive icon button pattern
- The confirm button now sits above the row's tap gesture in the view hierarchy and correctly receives click events

Closes LUM-201

## Original prompt
https://linear.app/vellum/issue/LUM-201/archive-confirm-button-cant-be-clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
