### PR TITLE
fix: update tests for provider rename and non-interactive guard removal

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -624,9 +624,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
     expect(result.content).toContain("client_id is required");
   });
 
-  test("requires interactive context", async () => {
-    // Register custom-svc as a provider so the orchestrator finds it
-    // and reaches the non-interactive check (gateway transport).
+  test("non-interactive loopback oauth2_connect returns deferred auth URL", async () => {
+    // After the blanket non-interactive guard was removed (#16337),
+    // loopback-transport flows succeed with a deferred auth URL so the
+    // agent can present it to the user.
     mockGetProvider.mockImplementation((key: string) => {
       if (key === "custom-svc") {
         return {
@@ -651,8 +652,8 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       },
       { ..._ctx, isInteractive: false },
     );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("non-interactive session");
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("mock-auth-url.example.com");
   });
 
   test("resolves gmail alias to integration:google", async () => {

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -607,13 +607,13 @@ describe("assistant oauth providers list", () => {
       "providers",
       "list",
       "--provider-key",
-      "gmail",
+      "slack",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].providerKey).toBe("integration:google");
+    expect(parsed[0].providerKey).toBe("integration:slack");
   });
 
   test("filters by comma-separated OR values", async () => {
@@ -621,15 +621,16 @@ describe("assistant oauth providers list", () => {
       "providers",
       "list",
       "--provider-key",
-      "gmail,google",
+      "slack,google",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed).toHaveLength(2);
+    expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
+    expect(keys).toContain("integration:slack");
   });
 
   test("returns empty array when comma-separated filter has no matches", async () => {
@@ -650,15 +651,16 @@ describe("assistant oauth providers list", () => {
       "providers",
       "list",
       "--provider-key",
-      "gmail, google",
+      "slack, google",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed).toHaveLength(2);
+    expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
+    expect(keys).toContain("integration:slack");
   });
 
   test("ignores empty segments from extra commas in --provider-key", async () => {
@@ -666,15 +668,16 @@ describe("assistant oauth providers list", () => {
       "providers",
       "list",
       "--provider-key",
-      "gmail,,google",
+      "slack,,google",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed).toHaveLength(2);
+    expect(parsed).toHaveLength(3);
     const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("integration:google");
     expect(keys).toContain("integration:google-calendar");
+    expect(keys).toContain("integration:slack");
   });
 });
 


### PR DESCRIPTION
## Summary
- Update credential-vault-unit test to expect deferred auth URL success instead of rejection for non-interactive loopback oauth2_connect (guard was intentionally removed in #16337)
- Fix oauth-cli provider filter tests that used stale `gmail` needle after providers were renamed from `integration:gmail` to `integration:google`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23068962487

🤖 Generated with [Claude Code](https://claude.com/claude-code)