### PR TITLE
fix: add initial trigger to skeleton debounce onChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -355,7 +355,7 @@ struct ChatView: View {
             }
             activateSearch()
         }
-        .onChange(of: shouldShowSkeleton) { _, shouldShow in
+        .onChange(of: shouldShowSkeleton, initial: true) { _, shouldShow in
             skeletonDebounceTask?.cancel()
             if shouldShow {
                 skeletonDebounceTask = Task {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-skeleton-flash.md.

**Gap:** Missing initial trigger for skeleton debounce
**What was expected:** The onChange should fire on initial render so the debounce works for the first thread load
**What was found:** onChange only fires on state changes, not initial values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
