### PR TITLE
chore: deprecate sync secure-key functions and document async-first policy

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -163,21 +163,30 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 
 ## Callsite Policy
 
+### Async-first policy
+
+**All credential access should use the async functions** (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`). The async variants are the primary API: they check the encrypted store first (instant) and fall back to the keychain broker, ensuring secrets stored in the macOS Keychain are always reachable. The sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) are **deprecated** and bypass the keychain broker entirely.
+
+New code must not introduce sync secure-key calls. Existing sync call sites should be converted to async when their surrounding code paths support it.
+
 ### Runtime request handlers (secret-routes, etc.)
 
 All runtime HTTP handlers that write or delete secrets **must** use the async APIs (`setSecureKeyAsync`, `deleteSecureKeyAsync`). These are the primary entry points for macOS app flows and must go through the broker to reach keychain.
-
-### CLI commands (keys, credentials)
-
-CLI commands may use sync APIs (`setSecureKey`, `deleteSecureKey`, `getSecureKey`) since they run outside the macOS app process and the broker may not be available. The sync path uses the encrypted store directly, which is correct for headless/CLI environments.
 
 ### Gateway (credential-reader)
 
 The gateway reads credentials via async `readCredential()` which tries the broker first (native async UDS), falling back to the encrypted store. The gateway never writes credentials — that responsibility belongs to the assistant runtime.
 
-### Startup / initialization code
+### Known sync exceptions
 
-Sync APIs are acceptable for startup paths (e.g. provider initialization, config loading) where async is impractical or the broker may not yet be available.
+The following call sites still use the deprecated sync variants because they run in contexts where async I/O is not feasible:
+
+| File                                               | Reason                                                                                                                                                                                                                |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/config/loader.ts`                   | Config loading runs synchronously at startup before the event loop is available. The broker socket may not be ready yet, and converting to async would require rearchitecting the entire config initialization chain. |
+| `assistant/src/providers/managed-proxy/context.ts` | Provider context initialization is synchronous. The managed proxy context must resolve credentials before the first request can be processed, and the initialization path does not support awaiting.                  |
+
+These are the only sanctioned sync call sites. Any new sync usage requires explicit justification and should be documented here.
 
 ## Migration
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -3,8 +3,14 @@
  * available (macOS app embedded), with transparent fallback to the
  * encrypted-at-rest file store.
  *
- * Async variants try the encrypted store first; sync variants always use the
- * encrypted store (startup code paths cannot do async I/O).
+ * **Async variants are the primary API.** They try the encrypted store first
+ * and fall back to the keychain broker. All new call sites should use
+ * `getSecureKeyAsync`, `setSecureKeyAsync`, and `deleteSecureKeyAsync`.
+ *
+ * Sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) are
+ * **deprecated startup-only exceptions** that bypass the keychain broker
+ * entirely. They exist solely for code paths that cannot do async I/O
+ * (e.g. `config/loader.ts`, `providers/managed-proxy/context.ts`).
  */
 
 import { getLogger } from "../util/logger.js";
@@ -22,12 +28,17 @@ function getBroker(): KeychainBrokerClient {
 }
 
 // ---------------------------------------------------------------------------
-// Sync variants — encrypted store only (startup / sync call sites)
+// Sync variants — encrypted store only (DEPRECATED — startup-only exceptions)
 // ---------------------------------------------------------------------------
 
 /**
  * Retrieve a secret from secure storage (sync — encrypted store only).
  * Returns `undefined` if the key doesn't exist or on error.
+ *
+ * @deprecated Use `getSecureKeyAsync` instead. This sync variant only reads
+ * from the encrypted file store, bypassing the keychain broker. Retained only
+ * for startup code paths in `config/loader.ts` and `providers/managed-proxy/context.ts`
+ * that cannot do async I/O.
  */
 export function getSecureKey(account: string): string | undefined {
   return encryptedStore.getKey(account);
@@ -36,6 +47,11 @@ export function getSecureKey(account: string): string | undefined {
 /**
  * Store a secret in secure storage (sync — encrypted store only).
  * Returns `true` on success, `false` on failure.
+ *
+ * @deprecated Use `setSecureKeyAsync` instead. This sync variant only writes
+ * to the encrypted file store, bypassing the keychain broker. Retained only
+ * for startup code paths in `config/loader.ts` and `providers/managed-proxy/context.ts`
+ * that cannot do async I/O.
  */
 export function setSecureKey(account: string, value: string): boolean {
   return encryptedStore.setKey(account, value);
@@ -48,6 +64,11 @@ export type DeleteResult = "deleted" | "not-found" | "error";
  * Delete a secret from secure storage (sync — encrypted store only).
  * Returns `"deleted"` on success, `"not-found"` if key doesn't exist,
  * or `"error"` on failure.
+ *
+ * @deprecated Use `deleteSecureKeyAsync` instead. This sync variant only
+ * deletes from the encrypted file store, bypassing the keychain broker.
+ * Retained only for startup code paths in `config/loader.ts` and
+ * `providers/managed-proxy/context.ts` that cannot do async I/O.
  */
 export function deleteSecureKey(account: string): DeleteResult {
   return encryptedStore.deleteKey(account);


### PR DESCRIPTION
## Summary
- Add @deprecated JSDoc tags to getSecureKey, setSecureKey, deleteSecureKey
- Update module-level docs and section banners to reflect async-first policy
- Document remaining sync exceptions (config/loader.ts, providers/managed-proxy/context.ts) in keychain-broker.md

Part of plan: async-secure-keys.md (PR 12 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
