### PR TITLE
feat: use AnimatedAvatarView in chat empty state greeting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -64,7 +64,17 @@ struct ChatEmptyStateView: View {
             Spacer()
 
             HStack(spacing: VSpacing.md) {
-                VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                Group {
+                    if let body = appearance.characterBodyShape,
+                       let eyes = appearance.characterEyeStyle,
+                       let color = appearance.characterColor {
+                        AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: 32,
+                                           breathingEnabled: false)
+                            .frame(width: 32, height: 32)
+                    } else {
+                        VAvatarImage(image: appearance.chatAvatarImage, size: 32)
+                    }
+                }
 
                 if let greeting = effectiveGreeting {
                     Text(greeting)


### PR DESCRIPTION
## Summary
- Replace static VAvatarImage with AnimatedAvatarView in the chat empty state greeting
- Breathing disabled, blink/double-blink and poke enabled at 32pt
- Falls back to VAvatarImage when no character components are available (custom uploaded image)

Part of plan: avatar-animation-props.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
