### PR TITLE
feat: use AnimatedAvatarView for conversation tail avatar in chat threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -312,7 +312,17 @@ struct MessageListView: View {
     private var conversationTailAvatar: some View {
         if shouldShowConversationTailAvatar {
             HStack {
-                VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                if let body = appearance.characterBodyShape,
+                   let eyes = appearance.characterEyeStyle,
+                   let color = appearance.characterColor {
+                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
+                                       size: ConversationAvatarFollower.avatarSize,
+                                       breathingEnabled: false)
+                        .frame(width: ConversationAvatarFollower.avatarSize,
+                               height: ConversationAvatarFollower.avatarSize)
+                } else {
+                    VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                }
                 Spacer()
             }
             .padding(.horizontal, VSpacing.xl)


### PR DESCRIPTION
## Summary
- Replace static VAvatarImage with AnimatedAvatarView in the conversation tail avatar
- Breathing disabled, blink/double-blink enabled at ConversationAvatarFollower.avatarSize
- Poke naturally blocked by existing .allowsHitTesting(false) on the container
- Falls back to VAvatarImage when no character components are available

Part of plan: avatar-animation-props.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
