### PR TITLE
feat: add account parameter to messaging tools

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -13,6 +13,10 @@
             "type": "string",
             "description": "Platform to test (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
           },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
+          },
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -33,6 +37,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "types": {
             "type": "array",
@@ -66,6 +74,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "conversation_id": {
             "type": "string",
@@ -101,6 +113,10 @@
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
           },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
+          },
           "query": {
             "type": "string",
             "description": "Search query using the platform's native syntax"
@@ -130,6 +146,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "conversation_id": {
             "type": "string",
@@ -184,6 +204,10 @@
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
           },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
+          },
           "conversation_id": {
             "type": "string",
             "description": "Conversation/channel ID"
@@ -213,6 +237,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Auto-detected if only one is connected."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "max_messages": {
             "type": "number",
@@ -247,6 +275,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"slack\", \"gmail\"). Required for create/list."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "conversation_id": {
             "type": "string",
@@ -290,6 +322,10 @@
             "type": "string",
             "description": "Platform (e.g. \"gmail\"). Auto-detected if only one is connected."
           },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
+          },
           "query": {
             "type": "string",
             "description": "Search query (default 'category:promotions newer_than:90d')"
@@ -304,7 +340,7 @@
           },
           "page_token": {
             "type": "string",
-            "description": "Resume token from a previous scan (rarely needed \u2014 scans now cover up to 5,000 messages in a single call)"
+            "description": "Resume token from a previous scan (rarely needed — scans now cover up to 5,000 messages in a single call)"
           },
           "reason": {
             "type": "string",
@@ -326,6 +362,10 @@
           "platform": {
             "type": "string",
             "description": "Platform (e.g. \"gmail\"). Auto-detected if only one is connected."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
           },
           "query": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -91,7 +91,8 @@ export async function run(
 
   try {
     const provider = await resolveProvider(platform);
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     // Search for sent messages using the platform's search
     const query =
       queryFilter ?? (provider.id === "gmail" ? "in:sent" : "from:me");

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -30,7 +30,8 @@ export async function run(
       );
     }
 
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     const result = await provider.archiveByQuery!(conn, query);
 
     if (result.archived === 0) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-auth-test.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-auth-test.ts
@@ -12,7 +12,8 @@ export async function run(
 
   try {
     const provider = await resolveProvider(platform);
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     const info = await provider.testConnection(conn);
     return ok(JSON.stringify(info, null, 2));
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-list-conversations.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-list-conversations.ts
@@ -14,7 +14,8 @@ export async function run(
 
   try {
     const provider = await resolveProvider(platform);
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     const conversations = await provider.listConversations(conn, {
       types: types as Array<"channel" | "dm" | "group" | "inbox"> | undefined,
       limit,

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
@@ -23,7 +23,8 @@ export async function run(
         `${provider.displayName} does not support marking messages as read.`,
       );
     }
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     await provider.markRead(conn, conversationId, messageId);
     return ok("Marked as read.");
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-read.ts
@@ -19,7 +19,8 @@ export async function run(
 
   try {
     const provider = await resolveProvider(platform);
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     let messages;
     if (threadId && provider.getThreadReplies) {
       messages = await provider.getThreadReplies(

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-search.ts
@@ -18,7 +18,8 @@ export async function run(
 
   try {
     const provider = await resolveProvider(platform);
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     const result = await provider.search(conn, query, { count: maxResults });
     return ok(JSON.stringify(result, null, 2));
   } catch (e) {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -52,7 +52,8 @@ export async function run(
       return err("Attachments are only supported on Gmail.");
     }
 
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
 
     // Gmail: create a draft instead of sending directly
     if (provider.id === "gmail") {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-sender-digest.ts
@@ -23,7 +23,8 @@ export async function run(
       );
     }
 
-    const conn = await getProviderConnection(provider);
+    const account = input.account as string | undefined;
+    const conn = await getProviderConnection(provider, account);
     const result = await provider.senderDigest!(conn, query, {
       maxMessages,
       maxSenders,

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -134,7 +134,8 @@ export async function resolveProvider(
  */
 export async function getProviderConnection(
   provider: MessagingProvider,
+  account?: string,
 ): Promise<OAuthConnection | string> {
   if (await provider.isConnected?.()) return "";
-  return resolveOAuthConnection(provider.credentialService);
+  return resolveOAuthConnection(provider.credentialService, account);
 }


### PR DESCRIPTION
## Summary
- Add optional `account` parameter to all 10 messaging skill tools (search, read, send, etc.)
- Passes account info through `getProviderConnection` → `resolveOAuthConnection` so the model can target a specific OAuth account when multiple are connected
- Complements the existing account support in Gmail-specific and Calendar tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
