### PR TITLE
fix: use connection ID in withValidToken for multi-account OAuth

### DIFF
--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -48,61 +48,67 @@ export class BYOOAuthConnection implements OAuthConnection {
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
-    return withValidToken(this.credentialService, async (token) => {
-      const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
-      let fullUrl = `${effectiveBaseUrl}${req.path}`;
+    return withValidToken(
+      this.credentialService,
+      async (token) => {
+        const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
+        let fullUrl = `${effectiveBaseUrl}${req.path}`;
 
-      if (req.query && Object.keys(req.query).length > 0) {
-        const params = new URLSearchParams();
-        for (const [key, value] of Object.entries(req.query)) {
-          if (Array.isArray(value)) {
-            for (const v of value) params.append(key, v);
-          } else {
-            params.append(key, value);
+        if (req.query && Object.keys(req.query).length > 0) {
+          const params = new URLSearchParams();
+          for (const [key, value] of Object.entries(req.query)) {
+            if (Array.isArray(value)) {
+              for (const v of value) params.append(key, v);
+            } else {
+              params.append(key, value);
+            }
+          }
+          fullUrl += `?${params.toString()}`;
+        }
+
+        log.debug(
+          { method: req.method, url: fullUrl, provider: this.providerKey },
+          "Making authenticated request",
+        );
+
+        // Use the Headers API for case-insensitive merging. Set defaults
+        // first so caller-supplied headers (in any casing) override them.
+        const headers = new Headers();
+        if (req.body) {
+          headers.set("Content-Type", "application/json");
+        }
+        if (req.headers) {
+          for (const [key, value] of Object.entries(req.headers)) {
+            headers.set(key, value);
           }
         }
-        fullUrl += `?${params.toString()}`;
-      }
+        headers.set("Authorization", `Bearer ${token}`);
 
-      log.debug(
-        { method: req.method, url: fullUrl, provider: this.providerKey },
-        "Making authenticated request",
-      );
+        const resp = await fetch(fullUrl, {
+          method: req.method,
+          headers,
+          body: req.body ? JSON.stringify(req.body) : undefined,
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
 
-      // Use the Headers API for case-insensitive merging. Set defaults
-      // first so caller-supplied headers (in any casing) override them.
-      const headers = new Headers();
-      if (req.body) {
-        headers.set("Content-Type", "application/json");
-      }
-      if (req.headers) {
-        for (const [key, value] of Object.entries(req.headers)) {
-          headers.set(key, value);
+        if (resp.status === 401) {
+          // Throw with a status property so withValidToken detects the 401
+          // and triggers its refresh-and-retry logic.
+          const err = new Error(`HTTP 401 from ${this.providerKey}`);
+          (err as Error & { status: number }).status = 401;
+          throw err;
         }
-      }
-      headers.set("Authorization", `Bearer ${token}`);
 
-      const resp = await fetch(fullUrl, {
-        method: req.method,
-        headers,
-        body: req.body ? JSON.stringify(req.body) : undefined,
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-      });
-
-      if (resp.status === 401) {
-        // Throw with a status property so withValidToken detects the 401
-        // and triggers its refresh-and-retry logic.
-        const err = new Error(`HTTP 401 from ${this.providerKey}`);
-        (err as Error & { status: number }).status = 401;
-        throw err;
-      }
-
-      return buildResponse(resp);
-    });
+        return buildResponse(resp);
+      },
+      { connectionId: this.id },
+    );
   }
 
   async withToken<T>(fn: (token: string) => Promise<T>): Promise<T> {
-    return withValidToken(this.credentialService, fn);
+    return withValidToken(this.credentialService, fn, {
+      connectionId: this.id,
+    });
   }
 }
 

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -374,9 +374,12 @@ async function doRefresh(service: string, connId: string): Promise<string> {
 export async function withValidToken<T>(
   service: string,
   callback: (token: string) => Promise<T>,
-  clientId?: string,
+  opts?: string | { connectionId: string },
 ): Promise<T> {
-  const conn = getConnectionByProvider(service, clientId);
+  const conn =
+    opts && typeof opts === "object"
+      ? getConnection(opts.connectionId)
+      : getConnectionByProvider(service, opts);
   let token = conn
     ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
     : undefined;


### PR DESCRIPTION
## Summary
- **Root cause**: `BYOOAuthConnection.request()` called `withValidToken(credentialService)` which re-resolved the connection using only the service name (e.g. `integration:google`), always returning the most recent connection — ignoring the account-specific connection that was already resolved upstream
- **Fix**: Pass the connection ID through to `withValidToken` via a new `{ connectionId }` option, so it looks up the exact connection instead of re-resolving by provider
- This was the actual reason multi-account OAuth wasn't working despite all the account parameter plumbing being correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
