### PR TITLE
fix: convert withValidToken to use getSecureKeyAsync

### DIFF
--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -16,11 +16,7 @@ import {
 } from "../oauth/oauth-store.js";
 import { getLogger } from "../util/logger.js";
 import { refreshOAuth2Token, type TokenEndpointAuthMethod } from "./oauth2.js";
-import {
-  getSecureKey,
-  getSecureKeyAsync,
-  setSecureKeyAsync,
-} from "./secure-keys.js";
+import { getSecureKeyAsync, setSecureKeyAsync } from "./secure-keys.js";
 
 const log = getLogger("token-manager");
 
@@ -378,7 +374,7 @@ export async function withValidToken<T>(
 ): Promise<T> {
   const conn = getConnectionByProvider(service, clientId);
   let token = conn
-    ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
+    ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
     : undefined;
   if (!token || !conn) {
     throw new TokenExpiredError(


### PR DESCRIPTION
## Summary
Converts the remaining sync getSecureKey call in withValidToken() to use await getSecureKeyAsync(). This was missed during the initial async secure-keys migration.

Part of plan: async-secure-keys.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
