### PR TITLE
fix: update script-proxy-injection-runtime tests to mock getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -32,8 +32,12 @@ let secureKeyValues = new Map<string, string | undefined>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
+  getSecureKeyAsync: (account: string) =>
+    Promise.resolve(secureKeyValues.get(account)),
   setSecureKey: () => true,
+  setSecureKeyAsync: () => Promise.resolve(true),
   deleteSecureKey: () => "deleted",
+  deleteSecureKeyAsync: () => Promise.resolve("deleted"),
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},


### PR DESCRIPTION
## Summary
Fixes test breakage in script-proxy-injection-runtime.test.ts where tests mock the sync getSecureKey but production code now calls getSecureKeyAsync after the async secure-keys migration.

Part of plan: async-secure-keys.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
