### PR TITLE
feat: show YouTube video thumbnails in embed previews

### DIFF
--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -92,8 +92,7 @@ struct InlineVideoEmbedView: View {
                     .fill(Color.black.opacity(0.7))
                     .frame(width: 56, height: 56)
                     .overlay(
-                        Image(systemName: "play.fill")
-                            .font(.system(size: 22))
+                        VIconView(.play, size: 22)
                             .foregroundColor(.white)
                             .offset(x: 2)
                     )

--- a/clients/ios/Views/InlineVideoEmbedView.swift
+++ b/clients/ios/Views/InlineVideoEmbedView.swift
@@ -66,15 +66,46 @@ struct InlineVideoEmbedView: View {
             stateManager.requestPlay()
         } label: {
             ZStack {
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(Color.black.opacity(0.8)) // Intentional: always-dark video placeholder
-                    .frame(height: 200)
+                if let thumbnailURL = VideoThumbnailURL.thumbnailURL(provider: provider, videoID: videoID) {
+                    AsyncImage(url: thumbnailURL) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(height: 200)
+                                .clipped()
+                        case .failure:
+                            fallbackPlaceholder
+                        case .empty:
+                            Color.black.opacity(0.8)
+                                .frame(height: 200)
+                        @unknown default:
+                            fallbackPlaceholder
+                        }
+                    }
+                } else {
+                    fallbackPlaceholder
+                }
 
-                VIconView(.circlePlay, size: 48)
-                    .foregroundColor(.white.opacity(0.9))
+                Circle()
+                    .fill(Color.black.opacity(0.7))
+                    .frame(width: 56, height: 56)
+                    .overlay(
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 22))
+                            .foregroundColor(.white)
+                            .offset(x: 2)
+                    )
             }
         }
         .buttonStyle(.plain)
+    }
+
+    private var fallbackPlaceholder: some View {
+        RoundedRectangle(cornerRadius: VRadius.md)
+            .fill(Color.black.opacity(0.8))
+            .frame(height: 200)
     }
 
     private var videoWebView: some View {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -103,8 +103,7 @@ struct InlineVideoEmbedCard: View {
                 .fill(Color.black.opacity(0.7))
                 .frame(width: 56, height: 56)
                 .overlay(
-                    Image(systemName: "play.fill")
-                        .font(.system(size: 22))
+                    VIconView(.play, size: 22)
                         .foregroundColor(.white)
                         .offset(x: 2)
                 )

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -3,9 +3,9 @@ import VellumAssistantShared
 
 /// Card for a video embed that transitions through click-to-play states.
 ///
-/// Shows a play-button placeholder, then builds an embed URL with autoplay
-/// parameters via `VideoEmbedURLBuilder` and displays the video inside an
-/// `InlineVideoWebView`. The card expands to 16:9 aspect ratio when playing.
+/// Shows a thumbnail placeholder with a play button overlay, then builds an
+/// embed URL with autoplay parameters via `VideoEmbedURLBuilder` and displays
+/// the video inside an `InlineVideoWebView`. The card uses 16:9 aspect ratio.
 struct InlineVideoEmbedCard: View {
     let provider: String
     let videoID: String
@@ -28,7 +28,7 @@ struct InlineVideoEmbedCard: View {
         case .playing, .initializing:
             return 315
         case .placeholder:
-            return 180
+            return 315
         case .failed:
             return 60
         }
@@ -47,6 +47,7 @@ struct InlineVideoEmbedCard: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: cardHeight)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .animation(.easeInOut(duration: 0.25), value: cardHeight)
         .onDisappear {
             // Only reset states that own an active WKWebView.
@@ -75,6 +76,46 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var placeholderView: some View {
+        ZStack {
+            // Video thumbnail background
+            if let thumbnailURL = VideoThumbnailURL.thumbnailURL(provider: provider, videoID: videoID) {
+                AsyncImage(url: thumbnailURL) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    case .failure:
+                        fallbackPlaceholder
+                    case .empty:
+                        // Loading state — show dark background
+                        Color.black
+                    @unknown default:
+                        fallbackPlaceholder
+                    }
+                }
+            } else {
+                fallbackPlaceholder
+            }
+
+            // Play button overlay
+            Circle()
+                .fill(Color.black.opacity(0.7))
+                .frame(width: 56, height: 56)
+                .overlay(
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(.white)
+                        .offset(x: 2)
+                )
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            stateManager.requestPlay()
+        }
+    }
+
+    private var fallbackPlaceholder: some View {
         VStack(spacing: VSpacing.sm) {
             VIconView(.play, size: 44)
                 .foregroundStyle(VColor.contentSecondary)
@@ -83,10 +124,8 @@ struct InlineVideoEmbedCard: View {
                 .font(VFont.caption)
                 .foregroundStyle(VColor.contentSecondary)
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            stateManager.requestPlay()
-        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(VColor.surfaceBase)
     }
 
     /// Single view for both .initializing and .playing so SwiftUI preserves

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -115,16 +115,8 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var fallbackPlaceholder: some View {
-        VStack(spacing: VSpacing.sm) {
-            VIconView(.play, size: 44)
-                .foregroundStyle(VColor.contentSecondary)
-
-            Text(provider.capitalized)
-                .font(VFont.caption)
-                .foregroundStyle(VColor.contentSecondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(VColor.surfaceBase)
+        Color.black.opacity(0.8)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     /// Single view for both .initializing and .playing so SwiftUI preserves

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoProviders/YouTubeParser.swift
@@ -15,10 +15,11 @@ public struct VideoParseResult {
 /// Parses YouTube URLs in various formats and produces a canonical embed URL.
 ///
 /// Supported patterns:
-/// - `youtube.com/watch?v=ID`  (with optional www/m subdomain)
+/// - `youtube.com/watch?v=ID`  (with optional www/m/music subdomain)
 /// - `youtu.be/ID`             (short-link)
 /// - `youtube.com/shorts/ID`
 /// - `youtube.com/embed/ID`
+/// - `music.youtube.com/watch?v=ID`
 ///
 /// Only `https` URLs are accepted.
 public enum YouTubeParser {
@@ -26,7 +27,10 @@ public enum YouTubeParser {
     private static let youtubeHosts: Set<String> = [
         "youtube.com",
         "www.youtube.com",
-        "m.youtube.com"
+        "m.youtube.com",
+        "music.youtube.com",
+        "youtube-nocookie.com",
+        "www.youtube-nocookie.com",
     ]
 
     public static func parse(_ url: URL) -> VideoParseResult? {

--- a/clients/shared/Features/Chat/MediaEmbeds/VideoThumbnailURL.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/VideoThumbnailURL.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Builds publicly-accessible thumbnail URLs for supported video providers.
+///
+/// YouTube thumbnails are served from `img.youtube.com` and require no API
+/// key. Other providers may be added as static URL patterns become available.
+public enum VideoThumbnailURL {
+
+    /// Returns a thumbnail URL for the given provider and video ID, or nil
+    /// if the provider doesn't support static thumbnail URLs.
+    public static func thumbnailURL(provider: String, videoID: String) -> URL? {
+        switch provider.lowercased() {
+        case "youtube":
+            // hqdefault is 480×360 and always available (maxresdefault may 404).
+            return URL(string: "https://img.youtube.com/vi/\(videoID)/hqdefault.jpg")
+        default:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replace generic play-button placeholder with actual YouTube video thumbnails via `img.youtube.com` (publicly available, no API key needed)
- Add `VideoThumbnailURL` helper to build provider-specific thumbnail URLs
- Support `music.youtube.com` and `youtube-nocookie.com` URL formats in the YouTube parser
- Update both macOS and iOS embed cards with thumbnail support and consistent play button overlay

## Original prompt
--safe https://linear.app/vellum/issue/LUM-202/youtube-previews-do-not-appear-in-chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
