### PR TITLE
feat: add global user identity persistence for crash reporting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3,6 +3,7 @@ import Carbon.HIToolbox
 import Combine
 import Foundation
 import os
+import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SettingsStore")

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -20,6 +20,11 @@ public final class SettingsStore: ObservableObject {
     /// SettingsPanel observes this and clears it after applying.
     @Published var pendingSettingsTab: SettingsTab?
 
+    // MARK: - User Identity
+
+    @AppStorage("user.displayName") var userDisplayName: String = ""
+    @AppStorage("user.email") var userEmail: String = ""
+
     // MARK: - API Key State
 
     @Published var hasKey: Bool


### PR DESCRIPTION
## Summary
- Add @AppStorage properties for user.displayName and user.email to SettingsStore
- These persist user identity globally for use in crash reporting and log submissions

Part of plan: onboarding-privacy-diagnostics.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
