### PR TITLE
fix: remove stale token-manager.ts doc entry and fix !!await style

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -197,7 +197,6 @@ These call sites use sync `getSecureKey` in contexts that could potentially supp
 | File                                                          | Sync functions used | Reason deferred                                                                                                       |
 | ------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `assistant/src/tools/credentials/broker.ts`                   | `getSecureKey`      | Credential broker read paths are called synchronously from multiple consumers; converting requires async propagation. |
-| `assistant/src/security/token-manager.ts`                     | `getSecureKey`      | Token resolution is called in sync context during connection token lookup; async would require refactoring callers.   |
 | `assistant/src/runtime/routes/integrations/slack/share.ts`    | `getSecureKey`      | Slack share route reads OAuth token synchronously; converting requires making the route handler async-aware.          |
 | `assistant/src/runtime/channel-invite-transports/telegram.ts` | `getSecureKey`      | Telegram transport reads bot token synchronously; converting requires async transport initialization.                 |
 | `assistant/src/tools/network/web-search.ts`                   | `getSecureKey`      | Web search tool reads API keys synchronously; converting requires async tool execution path.                          |

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -80,10 +80,12 @@ export function removeManualTokenConnection(providerKey: string): void {
 export async function backfillManualTokenConnections(): Promise<void> {
   // Telegram: requires both bot_token and webhook_secret
   if (!getConnectionByProvider("telegram")) {
-    const hasBotToken = !!await getSecureKeyAsync(credentialKey("telegram", "bot_token"));
-    const hasWebhookSecret = !!await getSecureKeyAsync(
+    const hasBotToken = !!(await getSecureKeyAsync(
+      credentialKey("telegram", "bot_token"),
+    ));
+    const hasWebhookSecret = !!(await getSecureKeyAsync(
       credentialKey("telegram", "webhook_secret"),
-    );
+    ));
     if (hasBotToken && hasWebhookSecret) {
       await ensureManualTokenConnection("telegram");
     }
@@ -91,12 +93,12 @@ export async function backfillManualTokenConnections(): Promise<void> {
 
   // Slack channel: requires both bot_token and app_token
   if (!getConnectionByProvider("slack_channel")) {
-    const hasBotToken = !!await getSecureKeyAsync(
+    const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
-    );
-    const hasAppToken = !!await getSecureKeyAsync(
+    ));
+    const hasAppToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "app_token"),
-    );
+    ));
     if (hasBotToken && hasAppToken) {
       await ensureManualTokenConnection("slack_channel");
     }


### PR DESCRIPTION
## Summary
- Removes token-manager.ts from the 'Tracked for future conversion' table in keychain-broker.md since it was already converted to async
- Fixes inconsistent `!!await` operator style in manual-token-connection.ts to use `!!(await ...)` matching the rest of the codebase

Part of plan: async-secure-keys.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
