### PR TITLE
feat: attach user name and email to Sentry events and log reports

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -9,7 +9,7 @@ struct LogReportFormView: View {
     let onCancel: () -> Void
 
     @State private var selectedReason: LogReportReason?
-    @State private var name: String = ""
+    @State private var name: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
 
@@ -30,6 +30,13 @@ struct LogReportFormView: View {
         .padding(VSpacing.xl)
         .background(VColor.surfaceOverlay)
         .frame(width: 480)
+        .onAppear {
+            if email.isEmpty,
+               let globalEmail = UserDefaults.standard.string(forKey: "user.email"),
+               !globalEmail.isEmpty {
+                email = globalEmail
+            }
+        }
     }
 
     // MARK: - Sections

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -118,10 +118,20 @@ enum LogExporter {
             // Sentry's UserFeedback API, linked to the event. This keeps PII
             // out of event tags/extras and lets us use Sentry's built-in
             // feedback UI for triage.
+            // Fall back to global identity when the user leaves form fields blank.
+            let feedbackName: String? = {
+                if !formData.name.isEmpty { return formData.name }
+                return UserDefaults.standard.string(forKey: "user.displayName")
+            }()
+            let feedbackEmail: String = {
+                if !formData.email.isEmpty { return formData.email }
+                return UserDefaults.standard.string(forKey: "user.email") ?? ""
+            }()
+
             let feedback = MetricKitManager.UserFeedbackData(
                 comments: formData.message.isEmpty ? nil : formData.message,
-                email: formData.email,
-                name: formData.name.isEmpty ? nil : formData.name
+                email: feedbackEmail,
+                name: feedbackName
             )
 
             // Route assistant behavior reports to the brain Sentry project

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -39,6 +39,31 @@ enum SentryDeviceInfo {
             }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
         }
+        configureUserIdentity()
+    }
+
+    /// Attaches the user's display name and email to the Sentry scope
+    /// so all events carry identity context when available.
+    /// Reads from the persisted `user.displayName` and `user.email` keys.
+    static func configureUserIdentity() {
+        let displayName = UserDefaults.standard.string(forKey: "user.displayName")
+        let email = UserDefaults.standard.string(forKey: "user.email")
+
+        let hasName = displayName != nil && !displayName!.isEmpty
+        let hasEmail = email != nil && !email!.isEmpty
+
+        guard hasName || hasEmail else { return }
+
+        SentrySDK.configureScope { scope in
+            let user = User()
+            if hasName {
+                user.name = displayName
+            }
+            if hasEmail {
+                user.email = email
+            }
+            scope.setUser(user)
+        }
     }
 
     /// Updates the `assistant_id` Sentry tag when the connected assistant changes.


### PR DESCRIPTION
## Summary
- Add configureUserIdentity() to SentryDeviceInfo that sets Sentry user scope from persisted name/email
- Fall back to global identity in LogExporter when form fields are empty
- Pre-fill LogReportFormView name and email from global identity on appear

Part of plan: onboarding-privacy-diagnostics.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
