### PR TITLE
feat: redesign onboarding privacy step with name, email, ToS consent, and permissions UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -11,68 +11,233 @@ struct ImproveExperienceStepView: View {
     @State private var sharePerformanceMetrics: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? true
 
     var body: some View {
-        Text("Improve Experience")
+        titleSection
+
+        ScrollView {
+            VStack(spacing: VSpacing.xl) {
+                nameAndEmailSection
+                permissionsSection
+                tosConsentSection
+            }
+            .padding(.horizontal, VSpacing.xxl)
+            .padding(.top, VSpacing.lg)
+        }
+        .opacity(showContent ? 1 : 0)
+        .offset(y: showContent ? 0 : 12)
+
+        Spacer()
+
+        buttonsSection
+            .opacity(showContent ? 1 : 0)
+            .offset(y: showContent ? 0 : 12)
+
+        OnboardingFooter(currentStep: state.currentStep, totalSteps: state.needsCloudCredentials ? 4 : 3)
+            .padding(.bottom, VSpacing.lg)
+            .onAppear {
+                // Opt in by default during onboarding, but preserve any existing choice
+                if UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
+                    UserDefaults.standard.set(true, forKey: "collectUsageDataEnabled")
+                }
+                if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
+                    UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
+                }
+
+                // Reset stale cloud provider when the user didn't go through CloudCredentials
+                if !state.needsCloudCredentials && state.cloudProvider != "local" && state.cloudProvider != "docker" {
+                    state.cloudProvider = "local"
+                }
+
+                withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                    showTitle = true
+                }
+                withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+                    showContent = true
+                }
+            }
+    }
+
+    // MARK: - Title
+
+    @ViewBuilder
+    private var titleSection: some View {
+        Text("Welcome to Vellum!")
             .font(VFont.onboardingTitle)
             .foregroundColor(VColor.contentDefault)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
             .padding(.bottom, VSpacing.md)
 
-        Text("Send anonymised performance metrics to help us improve responsiveness. No personal data or message content is included.")
+        Text("Before we get started, we need to ask you for a few things.")
             .font(VFont.onboardingSubtitle)
             .foregroundColor(VColor.contentSecondary)
             .multilineTextAlignment(.center)
             .padding(.horizontal, VSpacing.xxl)
             .opacity(showTitle ? 1 : 0)
             .offset(y: showTitle ? 0 : 8)
+    }
+
+    // MARK: - Name & Email
+
+    @ViewBuilder
+    private var nameAndEmailSection: some View {
+        VStack(spacing: VSpacing.md) {
+            HStack {
+                Text("Your name")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                Spacer()
+            }
+            VTextField(
+                placeholder: "Your name",
+                text: $state.userDisplayName,
+                leadingIcon: VIcon.user.rawValue
+            )
+        }
 
         VStack(spacing: VSpacing.md) {
             HStack {
-                Text("Collect usage data")
+                Text("Email")
                     .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
+                    .foregroundColor(VColor.contentDefault)
                 Spacer()
-                VToggle(isOn: Binding(
-                    get: { collectUsageData },
-                    set: { newValue in
-                        collectUsageData = newValue
-                        UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
-                        UserDefaults.standard.set(true, forKey: "collectUsageDataExplicitlySet")
-                        if !newValue {
-                            sharePerformanceMetrics = false
-                            UserDefaults.standard.set(false, forKey: "sendPerformanceReports")
-                        }
-                    }
-                ))
             }
-
-            HStack {
-                Text("Share performance metrics")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.contentSecondary)
-                Spacer()
-                VToggle(isOn: Binding(
-                    get: { sharePerformanceMetrics },
-                    set: { newValue in
-                        sharePerformanceMetrics = newValue
-                        UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
-                    }
-                ))
-                .disabled(!collectUsageData)
-            }
+            VTextField(
+                placeholder: "you@example.com",
+                text: $state.userEmail,
+                leadingIcon: VIcon.mail.rawValue
+            )
         }
-        .padding(.horizontal, VSpacing.xxl)
-        .padding(.top, VSpacing.xl)
-        .opacity(showContent ? 1 : 0)
-        .offset(y: showContent ? 0 : 12)
+    }
 
-        Spacer()
+    // MARK: - Permissions
 
+    @ViewBuilder
+    private var permissionsSection: some View {
+        VStack(spacing: VSpacing.md) {
+            usageDataRow
+            performanceMetricsRow
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+    }
+
+    @ViewBuilder
+    private var usageDataRow: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Usage data")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                Text("The app will collect usage data to help us improve it. It will never collect the content of your conversations.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentSecondary)
+                HStack(spacing: 0) {
+                    Link("Terms of Service", destination: URL(string: "https://vellum.ai/terms")!)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.primaryBase)
+                    Text(" and ")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
+                    Link("Privacy Policy.", destination: URL(string: "https://vellum.ai/privacy")!)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.primaryBase)
+                }
+            }
+            Spacer()
+            VToggle(isOn: Binding(
+                get: { collectUsageData },
+                set: { newValue in
+                    collectUsageData = newValue
+                    UserDefaults.standard.set(newValue, forKey: "collectUsageDataEnabled")
+                    UserDefaults.standard.set(true, forKey: "collectUsageDataExplicitlySet")
+                    if !newValue {
+                        sharePerformanceMetrics = false
+                        UserDefaults.standard.set(false, forKey: "sendPerformanceReports")
+                    }
+                }
+            ))
+        }
+    }
+
+    @ViewBuilder
+    private var performanceMetricsRow: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Performance metrics")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                Text("Share anonymised performance data to help us improve responsiveness. No personal data or message content is included.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentSecondary)
+            }
+            Spacer()
+            VToggle(isOn: Binding(
+                get: { sharePerformanceMetrics },
+                set: { newValue in
+                    sharePerformanceMetrics = newValue
+                    UserDefaults.standard.set(newValue, forKey: "sendPerformanceReports")
+                }
+            ))
+            .disabled(!collectUsageData)
+        }
+    }
+
+    // MARK: - ToS Consent
+
+    @ViewBuilder
+    private var tosConsentSection: some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Button(action: {
+                state.tosAccepted.toggle()
+            }) {
+                VIconView(state.tosAccepted ? .check : .square, size: 16)
+                    .foregroundColor(state.tosAccepted ? VColor.primaryBase : VColor.contentSecondary)
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+            .accessibilityLabel("Accept terms")
+            .accessibilityValue(state.tosAccepted ? "Accepted" : "Not accepted")
+
+            tosConsentLabel
+        }
+    }
+
+    @ViewBuilder
+    private var tosConsentLabel: some View {
+        HStack(spacing: 0) {
+            Text("I agree to the ")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+            Link("Terms of Service", destination: URL(string: "https://vellum.ai/terms")!)
+                .font(VFont.caption)
+                .foregroundColor(VColor.primaryBase)
+            Text(" and ")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+            Link("Privacy Policy", destination: URL(string: "https://vellum.ai/privacy")!)
+                .font(VFont.caption)
+                .foregroundColor(VColor.primaryBase)
+            Text(".")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentSecondary)
+        }
+    }
+
+    // MARK: - Buttons
+
+    @ViewBuilder
+    private var buttonsSection: some View {
         VStack(spacing: VSpacing.md) {
             OnboardingButton(
-                title: "Continue",
-                style: .primary
+                title: "Accept and Continue",
+                style: .primary,
+                disabled: !state.tosAccepted || state.userEmail.isEmpty
             ) {
+                UserDefaults.standard.set(state.userDisplayName, forKey: "user.displayName")
+                UserDefaults.standard.set(state.userEmail, forKey: "user.email")
+                UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
+                UserDefaults.standard.set(sharePerformanceMetrics, forKey: "sendPerformanceReports")
                 state.isHatching = true
             }
 
@@ -86,34 +251,6 @@ struct ImproveExperienceStepView: View {
         }
         .padding(.horizontal, VSpacing.xxl)
         .padding(.bottom, VSpacing.lg)
-        .opacity(showContent ? 1 : 0)
-        .offset(y: showContent ? 0 : 12)
-        .onAppear {
-            // Opt in by default during onboarding, but preserve any existing choice
-            if UserDefaults.standard.object(forKey: "collectUsageDataEnabled") == nil {
-                UserDefaults.standard.set(true, forKey: "collectUsageDataEnabled")
-            }
-            if UserDefaults.standard.object(forKey: "sendPerformanceReports") == nil {
-                UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
-            }
-
-            // Reset stale cloud provider when the user didn't go through CloudCredentials
-            // (e.g., user_hosted_enabled was turned off after a previous session set cloudProvider to "aws").
-            // Preserve "docker" since Docker users intentionally chose that path.
-            if !state.needsCloudCredentials && state.cloudProvider != "local" && state.cloudProvider != "docker" {
-                state.cloudProvider = "local"
-            }
-
-            withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
-                showTitle = true
-            }
-            withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
-                showContent = true
-            }
-        }
-
-        OnboardingFooter(currentStep: state.currentStep, totalSteps: state.needsCloudCredentials ? 4 : 3)
-            .padding(.bottom, VSpacing.lg)
     }
 
     private func goBack() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -27,7 +27,7 @@ enum ActivationKey: String, CaseIterable {
 final class OnboardingState {
     /// Bump this version whenever the default-flow step order changes so that
     /// persisted step indices from a previous layout are not consumed as-is.
-    private static let currentFlowVersion = 9
+    private static let currentFlowVersion = 10
 
     var currentStep: Int = 0
     var assistantName: String = "Velly"
@@ -60,6 +60,10 @@ final class OnboardingState {
     var sshPrivateKey: String = ""
     var customQRCodeImageData: Data = Data()
     var selectedModel: String = "claude-opus-4-6"
+    var userDisplayName: String = ""
+    var userEmail: String = ""
+    var tosAccepted: Bool = false
+
     var isHatching: Bool = false
     var hatchLogLines: [String] = []
     var hatchCompleted: Bool = false
@@ -127,6 +131,8 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
+            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? ""
+            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? ""
         }
         if let rawVariant = UserDefaults.standard.string(forKey: "onboarding.variant"),
            let variant = OnboardingVariant(rawValue: rawVariant) {
@@ -167,6 +173,8 @@ final class OnboardingState {
         UserDefaults.standard.set(cloudProvider, forKey: "onboarding.cloudProvider")
         UserDefaults.standard.set(onboardingVariant.rawValue, forKey: "onboarding.variant")
         UserDefaults.standard.set(Double(firstMeetingCrackProgress), forKey: "onboarding.firstMeetingCrackProgress")
+        UserDefaults.standard.set(userDisplayName, forKey: "onboarding.userDisplayName")
+        UserDefaults.standard.set(userEmail, forKey: "onboarding.userEmail")
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
     }
 
@@ -200,7 +208,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }


### PR DESCRIPTION
## Summary
- Redesign ImproveExperienceStepView into a Screen Studio-inspired privacy & permissions screen
- Add name, email fields and ToS consent checkbox with accept gate
- Add userDisplayName, userEmail, tosAccepted to OnboardingState with persistence
- Bump flow version to 10

Part of plan: onboarding-privacy-diagnostics.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
