### PR TITLE
fix: add getSecureKeyAsync mocks to test files after async migration

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -115,6 +115,7 @@ mock.module("../calls/twilio-provider.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: () => null,
+  getSecureKeyAsync: async () => null,
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -106,6 +106,7 @@ mock.module("../calls/twilio-config.js", () => ({
 // Mock secure keys
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: () => null,
+  getSecureKeyAsync: async () => null,
 }));
 
 mock.module("../calls/voice-ingress-preflight.js", () => ({

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -49,6 +49,7 @@ mock.module("../email/service.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 
 mock.module("../runtime/channel-invite-transports/whatsapp.js", () => ({


### PR DESCRIPTION
## Summary
Adds getSecureKeyAsync (and other async variants where needed) to test file mocks that were missed during the async secure-keys migration. Ensures tests correctly mock the async functions now called by production code.

Part of plan: async-secure-keys.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
