### PR TITLE
feat: persist ToS acceptance timestamp and gate onboarding completion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -42,6 +42,11 @@ struct ImproveExperienceStepView: View {
                     UserDefaults.standard.set(true, forKey: "sendPerformanceReports")
                 }
 
+                // Pre-check ToS if the user has previously accepted
+                if OnboardingState.hasAcceptedToS {
+                    state.tosAccepted = true
+                }
+
                 // Reset stale cloud provider when the user didn't go through CloudCredentials
                 if !state.needsCloudCredentials && state.cloudProvider != "local" && state.cloudProvider != "docker" {
                     state.cloudProvider = "local"
@@ -238,6 +243,9 @@ struct ImproveExperienceStepView: View {
                 UserDefaults.standard.set(state.userEmail, forKey: "user.email")
                 UserDefaults.standard.set(collectUsageData, forKey: "collectUsageDataEnabled")
                 UserDefaults.standard.set(sharePerformanceMetrics, forKey: "sendPerformanceReports")
+                if state.tosAccepted {
+                    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "tos.acceptedAt")
+                }
                 state.isHatching = true
             }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -82,6 +82,11 @@ final class OnboardingState {
         !speechGranted || !accessibilityGranted || !screenGranted
     }
 
+    /// Whether the user has previously accepted the Terms of Service.
+    static var hasAcceptedToS: Bool {
+        UserDefaults.standard.double(forKey: "tos.acceptedAt") > 0
+    }
+
     var userHostedEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
     }
@@ -208,7 +213,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }


### PR DESCRIPTION
## Summary
- Persist ToS acceptance timestamp to UserDefaults when user continues from privacy step
- Add OnboardingState.hasAcceptedToS computed property for checking prior acceptance
- Pre-check ToS checkbox on appear if previously accepted

Part of plan: onboarding-privacy-diagnostics.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
