### PR TITLE
fix: add loopback callbackTransport to Notion OAuth provider

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -111,7 +111,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { owner: "user" },
     tokenEndpointAuthMethod: "client_secret_basic",
-    callbackTransport: "gateway",
+    callbackTransport: "loopback",
   },
 
   "integration:twitter": {


### PR DESCRIPTION
## Summary
- Notion was the only OAuth provider missing `callbackTransport: "loopback"`, causing the setup flow to require ngrok (public ingress) unnecessarily
- Notion supports localhost redirect URIs, so loopback works fine like all other providers

## Test plan
- [ ] Run "set up notion" — should no longer attempt to load public-ingress/ngrok skill
- [ ] Complete Notion OAuth flow using localhost callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
