### PR TITLE
feat: enable poke interaction on conversation tail avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -311,26 +311,34 @@ struct MessageListView: View {
     @ViewBuilder
     private var conversationTailAvatar: some View {
         if shouldShowConversationTailAvatar {
-            HStack {
-                if let body = appearance.characterBodyShape,
-                   let eyes = appearance.characterEyeStyle,
-                   let color = appearance.characterColor {
+            if let body = appearance.characterBodyShape,
+               let eyes = appearance.characterEyeStyle,
+               let color = appearance.characterColor {
+                HStack {
                     AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
                                        size: ConversationAvatarFollower.avatarSize,
                                        breathingEnabled: false)
                         .frame(width: ConversationAvatarFollower.avatarSize,
                                height: ConversationAvatarFollower.avatarSize)
-                } else {
-                    VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                    Spacer()
                 }
-                Spacer()
+                .padding(.horizontal, VSpacing.xl)
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+                .frame(maxWidth: .infinity)
+                .offset(y: avatarDisplayY)
+                .accessibilityHidden(true)
+            } else {
+                HStack {
+                    VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.xl)
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+                .frame(maxWidth: .infinity)
+                .offset(y: avatarDisplayY)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
             }
-            .padding(.horizontal, VSpacing.xl)
-            .frame(maxWidth: VSpacing.chatColumnMaxWidth)
-            .frame(maxWidth: .infinity)
-            .offset(y: avatarDisplayY)
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
## Summary
- Split conversationTailAvatar into separate animated/static branches with independent hit testing
- Animated avatar branch drops .allowsHitTesting(false) to enable poke interaction
- Static image fallback retains .allowsHitTesting(false) since it has no interactive behavior

Part of plan: tail-avatar-poke.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
