### PR TITLE
feat: surface user identity in Settings Privacy tab and sync to log reports

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -15,11 +15,110 @@ struct SettingsPrivacyTab: View {
     @State private var isUpdating: Bool = false
     @State private var loadError: String?
 
+    // Identity editing state
+    @State private var displayName: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
+    @State private var email: String = UserDefaults.standard.string(forKey: "user.email") ?? ""
+    @State private var isEditingIdentity: Bool = false
+    @State private var editingName: String = ""
+    @State private var editingEmail: String = ""
+
     var body: some View {
-        diagnosticsSection
-            .onAppear {
-                Task { await loadPrivacyFlags() }
+        VStack(spacing: VSpacing.lg) {
+            identitySection
+
+            Text("This information is attached to crash reports and log submissions to help us respond to your issues.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, VSpacing.xs)
+
+            diagnosticsSection
+        }
+        .onAppear {
+            Task { await loadPrivacyFlags() }
+        }
+    }
+
+    // MARK: - Identity Section
+
+    private var identitySection: some View {
+        SettingsCard(title: "Identity") {
+            if isEditingIdentity {
+                identityEditingView
+            } else {
+                identityDisplayView
             }
+        }
+    }
+
+    private var identityDisplayView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Name")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(displayName.isEmpty ? "Not set" : displayName)
+                        .font(VFont.body)
+                        .foregroundColor(displayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                }
+                Spacer()
+            }
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Email")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(email.isEmpty ? "Not set" : email)
+                        .font(VFont.body)
+                        .foregroundColor(email.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                }
+                Spacer()
+            }
+
+            HStack {
+                Spacer()
+                VButton(label: "Edit", style: .outlined) {
+                    editingName = displayName
+                    editingEmail = email
+                    isEditingIdentity = true
+                }
+            }
+        }
+    }
+
+    private var identityEditingView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Name")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VTextField(placeholder: "Your name", text: $editingName)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Email")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VTextField(placeholder: "your@email.com", text: $editingEmail)
+            }
+
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    isEditingIdentity = false
+                }
+                VButton(label: "Save", style: .primary) {
+                    displayName = editingName
+                    email = editingEmail
+                    UserDefaults.standard.set(displayName, forKey: "user.displayName")
+                    UserDefaults.standard.set(email, forKey: "user.email")
+                    SentryDeviceInfo.configureSentryScope()
+                    isEditingIdentity = false
+                }
+            }
+        }
     }
 
     // MARK: - Diagnostics Section


### PR DESCRIPTION
## Summary
- Add Identity card to Settings Privacy tab showing persisted name and email
- Inline edit mode with save that updates UserDefaults and refreshes Sentry scope
- Explanatory note about how identity is used in crash reports

Part of plan: onboarding-privacy-diagnostics.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
