### PR TITLE
fix: restrict conversation tail avatar hit area to avatar bounds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -314,19 +314,16 @@ struct MessageListView: View {
             if let body = appearance.characterBodyShape,
                let eyes = appearance.characterEyeStyle,
                let color = appearance.characterColor {
-                HStack {
-                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
-                                       size: ConversationAvatarFollower.avatarSize,
-                                       breathingEnabled: false)
-                        .frame(width: ConversationAvatarFollower.avatarSize,
-                               height: ConversationAvatarFollower.avatarSize)
-                    Spacer()
-                }
-                .padding(.horizontal, VSpacing.xl)
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
-                .frame(maxWidth: .infinity)
-                .offset(y: avatarDisplayY)
-                .accessibilityHidden(true)
+                AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
+                                   size: ConversationAvatarFollower.avatarSize,
+                                   breathingEnabled: false)
+                    .frame(width: ConversationAvatarFollower.avatarSize,
+                           height: ConversationAvatarFollower.avatarSize)
+                    .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, VSpacing.xl)
+                    .offset(y: avatarDisplayY)
+                    .accessibilityHidden(true)
             } else {
                 HStack {
                     VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tail-avatar-poke.md.

**Gap:** Hit-testing interception across full overlay width
**What was expected:** Only the 52pt avatar area should respond to clicks
**What was found:** The HStack without .allowsHitTesting(false) intercepted clicks across its full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
