### PR TITLE
fix: attach Sentry user identity after onboarding and clear when emptied

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -246,6 +246,7 @@ struct ImproveExperienceStepView: View {
                 if state.tosAccepted {
                     UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "tos.acceptedAt")
                 }
+                SentryDeviceInfo.configureUserIdentity()
                 state.isHatching = true
             }
 

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -52,7 +52,10 @@ enum SentryDeviceInfo {
         let hasName = displayName != nil && !displayName!.isEmpty
         let hasEmail = email != nil && !email!.isEmpty
 
-        guard hasName || hasEmail else { return }
+        guard hasName || hasEmail else {
+            SentrySDK.configureScope { scope in scope.setUser(nil) }
+            return
+        }
 
         SentrySDK.configureScope { scope in
             let user = User()


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for onboarding-privacy-diagnostics.md.

**Gap A:** Sentry identity not attached after onboarding — added configureUserIdentity() call in Accept and Continue action
**Gap B:** Sentry user never cleared when identity emptied — configureUserIdentity() now sets user to nil when both fields are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
