### PR TITLE
fix: consolidate identity keys, wire SettingsStore, clear PII on reset

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -136,8 +136,8 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
-            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? ""
-            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? ""
+            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? UserDefaults.standard.string(forKey: "user.displayName") ?? ""
+            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? UserDefaults.standard.string(forKey: "user.email") ?? ""
         }
         if let rawVariant = UserDefaults.standard.string(forKey: "onboarding.variant"),
            let variant = OnboardingVariant(rawValue: rawVariant) {
@@ -213,7 +213,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt", "user.displayName", "user.email"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -16,8 +16,6 @@ struct SettingsPrivacyTab: View {
     @State private var loadError: String?
 
     // Identity editing state
-    @State private var displayName: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
-    @State private var email: String = UserDefaults.standard.string(forKey: "user.email") ?? ""
     @State private var isEditingIdentity: Bool = false
     @State private var editingName: String = ""
     @State private var editingEmail: String = ""
@@ -58,9 +56,9 @@ struct SettingsPrivacyTab: View {
                     Text("Name")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
-                    Text(displayName.isEmpty ? "Not set" : displayName)
+                    Text(store.userDisplayName.isEmpty ? "Not set" : store.userDisplayName)
                         .font(VFont.body)
-                        .foregroundColor(displayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                        .foregroundColor(store.userDisplayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
                 }
                 Spacer()
             }
@@ -70,9 +68,9 @@ struct SettingsPrivacyTab: View {
                     Text("Email")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
-                    Text(email.isEmpty ? "Not set" : email)
+                    Text(store.userEmail.isEmpty ? "Not set" : store.userEmail)
                         .font(VFont.body)
-                        .foregroundColor(email.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                        .foregroundColor(store.userEmail.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
                 }
                 Spacer()
             }
@@ -80,8 +78,8 @@ struct SettingsPrivacyTab: View {
             HStack {
                 Spacer()
                 VButton(label: "Edit", style: .outlined) {
-                    editingName = displayName
-                    editingEmail = email
+                    editingName = store.userDisplayName
+                    editingEmail = store.userEmail
                     isEditingIdentity = true
                 }
             }
@@ -110,10 +108,8 @@ struct SettingsPrivacyTab: View {
                     isEditingIdentity = false
                 }
                 VButton(label: "Save", style: .primary) {
-                    displayName = editingName
-                    email = editingEmail
-                    UserDefaults.standard.set(displayName, forKey: "user.displayName")
-                    UserDefaults.standard.set(email, forKey: "user.email")
+                    store.userDisplayName = editingName
+                    store.userEmail = editingEmail
                     SentryDeviceInfo.configureSentryScope()
                     isEditingIdentity = false
                 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for onboarding-privacy-diagnostics.md.

**Gap A:** Refactor SettingsPrivacyTab to use store.userDisplayName/userEmail instead of local @State (eliminates dead code)
**Gap B:** OnboardingState.init() falls back to user.* keys when onboarding.* keys are empty
**Gap C:** clearPersistedState() now clears user.displayName and user.email

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
