### PR TITLE
fix: align Notion OAuth skill with loopback callback transport

### DIFF
--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -178,9 +178,9 @@ bash:
 For non-interactive channels, provide all URLs and instructions as text messages. Key differences from Path A:
 
 - The user navigates on their own — give them the URLs to open
-- Use **Web application** credentials (not Desktop app) because the OAuth callback goes through the public gateway URL
+- For providers with `callbackTransport: "gateway"`, use **Web application** credentials and resolve the redirect URI from `ingress.publicBaseUrl`; if not configured, load the `public-ingress` skill first
+- For providers with `callbackTransport: "loopback"`, the redirect URI is handled automatically in Path A; in Path B (remote channel), public ingress is still required since the loopback port is not reachable
 - Collect the Client Secret via split entry if the secret prefix could trigger channel scanners (e.g., Slack's `xoxp-`, Google's `GOCSPX-`)
-- Resolve the redirect URI from `ingress.publicBaseUrl` before sending instructions; if not configured, load the `public-ingress` skill first
 
 ---
 

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -194,16 +194,16 @@ For non-interactive channels, provide all URLs and instructions as text messages
 
 ### Recovery Patterns
 
-| Situation                              | Response                                                                  |
-| -------------------------------------- | ------------------------------------------------------------------------- |
-| User lands on unexpected page          | Offer to screenshot, identify where they are, navigate back               |
-| User not signed in                     | Tell them to sign in, wait, continue                                      |
-| Feature already configured             | "Looks like this is already set up — great, let's skip ahead."            |
-| Quota / billing issue                  | Explain clearly, help resolve or use a different project                  |
-| Secret not shown after creation        | Guide to credential detail page as fallback                               |
-| Auth URL returned instead of auto-open | Send URL to user to open manually                                         |
-| User is confused or frustrated         | Pause, acknowledge, simplify: "Let's take a step back..."                 |
-| `open` command fails                   | Fall back to Path B (give URLs manually)                                  |
+| Situation                              | Response                                                       |
+| -------------------------------------- | -------------------------------------------------------------- |
+| User lands on unexpected page          | Offer to screenshot, identify where they are, navigate back    |
+| User not signed in                     | Tell them to sign in, wait, continue                           |
+| Feature already configured             | "Looks like this is already set up — great, let's skip ahead." |
+| Quota / billing issue                  | Explain clearly, help resolve or use a different project       |
+| Secret not shown after creation        | Guide to credential detail page as fallback                    |
+| Auth URL returned instead of auto-open | Send URL to user to open manually                              |
+| User is confused or frustrated         | Pause, acknowledge, simplify: "Let's take a step back..."      |
+| `open` command fails                   | Fall back to Path B (give URLs manually)                       |
 
 ## Tone & Voice
 

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -25,9 +25,9 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 
 ## Prerequisites
 
-Before beginning the user-facing flow, ensure **public ingress** is configured. Notion OAuth requires a publicly reachable redirect URI — there is no loopback/desktop-app alternative.
+Before beginning the user-facing flow, check the provider's callback configuration:
 
-Read the configured public gateway URL from `ingress.publicBaseUrl`. If it is missing, load and run the `public-ingress` skill first (`skill_load` with `skill: "public-ingress"`). Build the redirect URI as `<publicBaseUrl>/webhooks/oauth/callback`.
+Run `credential_store describe service:"integration:notion"` and check the `redirectUri` field. If it says **"automatic"** or the callback transport is loopback, no redirect URL setup is needed — the assistant handles it automatically. If it mentions `ingress.publicBaseUrl`, load the `public-ingress` skill first.
 
 ## Notion-Specific Flow
 
@@ -71,28 +71,41 @@ Open: `https://www.notion.so/profile/integrations`
 
 ### Step 3: Configure OAuth Redirect URI
 
+First, resolve the redirect URI:
+
+```
+credential_store describe:
+  service: "integration:notion"
+```
+
+**If the redirect URI is "automatic" or the callback transport is loopback:**
+
+> The redirect URL is handled automatically, so we can skip this part. Let's move on to grabbing your credentials.
+
+Skip to Step 4.
+
+**If the redirect URI mentions `ingress.publicBaseUrl`:**
+
 The integration settings page should load after creation. Guide the user to the **Distribution** tab or section.
 
 > Now look for the **Distribution** tab in the left sidebar (or a section called **OAuth Domain & URIs**). Click into it.
 >
 > You should see a field for **Redirect URIs**. Paste this exact URL:
-> `OAUTH_CALLBACK_URL`
+> `<resolved redirect URI>`
 >
 > Then scroll down and click **Save changes**.
 
-Replace `OAUTH_CALLBACK_URL` with the concrete redirect URI built from `ingress.publicBaseUrl`. Never send the placeholder literally.
-
-Copy the redirect URI to the clipboard before navigating so the user can paste it:
+Copy the resolved redirect URI to the clipboard before navigating so the user can paste it:
 
 ```
 host_bash:
   command: |
-    echo -n "OAUTH_CALLBACK_URL" | pbcopy && /tmp/vellum-nav.sh "https://www.notion.so/profile/integrations"
+    echo -n "<resolved redirect URI>" | pbcopy && /tmp/vellum-nav.sh "https://www.notion.so/profile/integrations"
 ```
 
 **Known issues:**
 
-- Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use the base domain from `ingress.publicBaseUrl`
+- Notion may require a "Website" or "Redirect URI" domain to be filled in as well — if so, use the base domain from the redirect URI
 - If the page shows "Internal integration" with no Distribution tab, the integration was created as Internal — they'll need to recreate it as Public
 
 ---
@@ -156,5 +169,5 @@ For non-interactive channels, see [references/path-b-manual-setup.md](references
 
 Key Notion-specific differences for Path B:
 
-- Still requires public ingress for the redirect URI (no loopback alternative)
+- Uses loopback callback by default — no public ingress needed unless on a remote channel
 - Client Secret prefix is `secret_` — use `credential_store prompt` to collect it securely; split entry is not needed since this prefix doesn't trigger channel scanners

--- a/skills/notion-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/notion-oauth-setup/references/path-b-manual-setup.md
@@ -1,6 +1,6 @@
 # Path B: Manual Channel Setup (Telegram, Slack, etc.)
 
-When the user is on a non-interactive channel, walk them through a text-based setup. The OAuth callback goes through the public gateway URL.
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback is not reachable from a remote channel.
 
 ## Path B Step 1: Confirm and Explain
 


### PR DESCRIPTION
## Summary
- Notion SKILL.md was hardcoding public ingress/gateway requirement despite provider config now using loopback
- Made Step 3 (redirect URI) conditional: skip when loopback, guide user when gateway
- Updated collaborative-oauth-flow shared reference to be transport-aware instead of assuming gateway
- Verified all other loopback provider skills already use the dynamic `credential_store describe` approach

## Test plan
- [ ] Run "set up notion" — should skip redirect URI step and not load public-ingress/ngrok
- [ ] Complete Notion OAuth flow using localhost callback
- [ ] Verify Twitter (gateway transport) still correctly requires public ingress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
