### PR TITLE
fix: include user identity and ToS keys in log export snapshot

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -555,6 +555,9 @@ enum LogExporter {
             "ttsVoiceId",
             "selectedImageGenModel",
             "activityNotificationsEnabled",
+            "user.displayName",
+            "user.email",
+            "tos.acceptedAt",
         ]
 
         let boolKeys = [


### PR DESCRIPTION
## Summary
- Add user.displayName, user.email, and tos.acceptedAt to LogExporter UserDefaults snapshot
- Enables support to see identity and ToS state when triaging log reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
