### PR TITLE
fix: remove desktop app attachment size limits

### DIFF
--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -29,16 +29,6 @@ final class AttachmentFlowIOSTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Attachment Constants
-
-    func testMaxFileSizeConstant() {
-        XCTAssertEqual(ChatViewModel.maxFileSize, 20 * 1024 * 1024, "Max file size should be 20 MB")
-    }
-
-    func testMaxImageSizeConstant() {
-        XCTAssertEqual(ChatViewModel.maxImageSize, 4 * 1024 * 1024, "Max image size should be 4 MB")
-    }
-
     // MARK: - Pending Attachments
 
     func testInitialPendingAttachmentsEmpty() {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -89,7 +89,7 @@ struct InlineVideoEmbedCard: View {
                         fallbackPlaceholder
                     case .empty:
                         // Loading state — show dark background
-                        Color.black
+                        VColor.auxBlack
                     @unknown default:
                         fallbackPlaceholder
                     }
@@ -100,11 +100,11 @@ struct InlineVideoEmbedCard: View {
 
             // Play button overlay
             Circle()
-                .fill(Color.black.opacity(0.7))
+                .fill(VColor.auxBlack.opacity(0.7))
                 .frame(width: 56, height: 56)
                 .overlay(
                     VIconView(.play, size: 22)
-                        .foregroundColor(.white)
+                        .foregroundColor(VColor.auxWhite)
                         .offset(x: 2)
                 )
         }
@@ -115,7 +115,7 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var fallbackPlaceholder: some View {
-        Color.black.opacity(0.8)
+        VColor.auxBlack.opacity(0.8)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -53,7 +53,7 @@ struct TaskAttachment: Identifiable {
 
         let data = try Data(contentsOf: url)
 
-        if data.count > 100 * 1024 * 1024 {
+        if data.count > 20 * 1024 * 1024 {
             log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(fileName). Server may reject files over 20 MB.")
         }
 

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -71,7 +71,7 @@ struct TaskAttachment: Identifiable {
         )
     }
 
-    static func fromPastedImage(_ data: Data, fileName: String = "pasted-image.png", mimeType: String = "image/png") throws -> TaskAttachment {
+    static func fromPastedImage(_ data: Data, fileName: String = "pasted-image.png", mimeType: String = "image/png") -> TaskAttachment {
         return TaskAttachment(
             id: UUID(),
             fileName: fileName,

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -51,16 +51,17 @@ struct TaskAttachment: Identifiable {
         }
         let kind: TaskAttachmentKind = extensionMimeType.hasPrefix("image/") ? .image : .document
 
-        let data = try Data(contentsOf: url)
-
-        // Memory safety guard — prevent OOM from processing very large files.
+        // Pre-read size check to avoid loading huge files into memory.
         let memorySafetyLimit = 500 * 1024 * 1024
-        if data.count > memorySafetyLimit {
-            let sizeMB = data.count / (1024 * 1024)
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        if let fileSize = attrs[.size] as? Int, fileSize > memorySafetyLimit {
+            let sizeMB = fileSize / (1024 * 1024)
             throw NSError(domain: "TaskAttachment", code: 6, userInfo: [
                 NSLocalizedDescriptionKey: "\(fileName) is \(sizeMB) MB which is too large to process safely."
             ])
         }
+
+        let data = try Data(contentsOf: url)
 
         if data.count > 20 * 1024 * 1024 {
             log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(fileName). Server may reject files over 20 MB.")

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -52,7 +52,7 @@ struct TaskAttachment: Identifiable {
         let kind: TaskAttachmentKind = extensionMimeType.hasPrefix("image/") ? .image : .document
 
         // Pre-read size check to avoid loading huge files into memory.
-        let memorySafetyLimit = 500 * 1024 * 1024
+        let memorySafetyLimit = 100 * 1024 * 1024
         let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
         if let fileSize = attrs[.size] as? Int, fileSize > memorySafetyLimit {
             let sizeMB = fileSize / (1024 * 1024)

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -53,6 +53,15 @@ struct TaskAttachment: Identifiable {
 
         let data = try Data(contentsOf: url)
 
+        // Memory safety guard — prevent OOM from processing very large files.
+        let memorySafetyLimit = 500 * 1024 * 1024
+        if data.count > memorySafetyLimit {
+            let sizeMB = data.count / (1024 * 1024)
+            throw NSError(domain: "TaskAttachment", code: 6, userInfo: [
+                NSLocalizedDescriptionKey: "\(fileName) is \(sizeMB) MB which is too large to process safely."
+            ])
+        }
+
         if data.count > 20 * 1024 * 1024 {
             log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(fileName). Server may reject files over 20 MB.")
         }

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -18,8 +18,6 @@ struct TaskAttachment: Identifiable {
     let data: Data
     let extractedText: String?
 
-    static let maxImageBytes = 10 * 1024 * 1024
-    static let maxDocumentBytes = 20 * 1024 * 1024
     static let maxExtractedChars = 8_000
     private static let unsupportedOfficeMimeTypes: Set<String> = [
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -52,28 +50,8 @@ struct TaskAttachment: Identifiable {
             ])
         }
         let kind: TaskAttachmentKind = extensionMimeType.hasPrefix("image/") ? .image : .document
-        let maxBytes = kind == .image ? maxImageBytes : maxDocumentBytes
-
-        do {
-            let resourceValues = try url.resourceValues(forKeys: [.fileSizeKey])
-            if let declaredSize = resourceValues.fileSize, declaredSize > maxBytes {
-                throw NSError(domain: "TaskAttachment", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey: "\(fileName) exceeds size limit for \(kind.rawValue) attachments."
-                ])
-            }
-        } catch let error as NSError where error.domain == "TaskAttachment" {
-            throw error
-        } catch {
-            log.warning("Could not read file size for '\(fileName)': \(error)")
-        }
 
         let data = try Data(contentsOf: url)
-
-        guard data.count <= maxBytes else {
-            throw NSError(domain: "TaskAttachment", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "\(fileName) exceeds size limit for \(kind.rawValue) attachments."
-            ])
-        }
 
         let mimeType = try Self.validateMimeType(fileName: fileName, expectedMimeType: extensionMimeType, data: data)
         let extractedText = kind == .document ? Self.extractText(data: data, mimeType: mimeType) : nil
@@ -90,12 +68,6 @@ struct TaskAttachment: Identifiable {
     }
 
     static func fromPastedImage(_ data: Data, fileName: String = "pasted-image.png", mimeType: String = "image/png") throws -> TaskAttachment {
-        guard data.count <= maxImageBytes else {
-            throw NSError(domain: "TaskAttachment", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Pasted image exceeds 10MB limit."
-            ])
-        }
-
         return TaskAttachment(
             id: UUID(),
             fileName: fileName,

--- a/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
+++ b/clients/macos/vellum-assistant/Inference/TaskSubmission.swift
@@ -53,6 +53,10 @@ struct TaskAttachment: Identifiable {
 
         let data = try Data(contentsOf: url)
 
+        if data.count > 100 * 1024 * 1024 {
+            log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(fileName). Server may reject files over 20 MB.")
+        }
+
         let mimeType = try Self.validateMimeType(fileName: fileName, expectedMimeType: extensionMimeType, data: data)
         let extractedText = kind == .document ? Self.extractText(data: data, mimeType: mimeType) : nil
 

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -167,7 +167,7 @@ public final class ChatAttachmentManager: ObservableObject {
                 return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
             }
 
-            if data.count > 100 * 1024 * 1024 {
+            if data.count > 20 * 1024 * 1024 {
                 log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(url.lastPathComponent). Server may reject files over 20 MB.")
             }
 

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -167,6 +167,15 @@ public final class ChatAttachmentManager: ObservableObject {
                 return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
             }
 
+            // Memory safety: base64 encoding allocates ~133% of raw bytes.
+            // With maxConcurrentLoads=4, a 500 MB file could use ~2.6 GB.
+            // Guard against OOM without imposing practical user-facing limits.
+            let memorySafetyLimit = 500 * 1024 * 1024
+            if data.count > memorySafetyLimit {
+                let sizeMB = data.count / (1024 * 1024)
+                return .failure(.message("This file is \(sizeMB) MB which is too large to process safely. Please choose a smaller file."))
+            }
+
             if data.count > 20 * 1024 * 1024 {
                 log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(url.lastPathComponent). Server may reject files over 20 MB.")
             }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -167,6 +167,10 @@ public final class ChatAttachmentManager: ObservableObject {
                 return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
             }
 
+            if data.count > 100 * 1024 * 1024 {
+                log.warning("Large attachment (\(data.count / (1024 * 1024)) MB): \(url.lastPathComponent). Server may reject files over 20 MB.")
+            }
+
             let filename = url.lastPathComponent
             var mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
 

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -286,6 +286,13 @@ public final class ChatAttachmentManager: ObservableObject {
             #error("Unsupported platform")
             #endif
 
+            // Memory safety guard for pasted/dropped images
+            let memorySafetyLimit = 500 * 1024 * 1024
+            if pngData.count > memorySafetyLimit {
+                let sizeMB = pngData.count / (1024 * 1024)
+                return .failure(.message("This image is \(sizeMB) MB which is too large to process safely. Please choose a smaller image."))
+            }
+
             // Compress image if needed
             let (finalData, wasCompressed) = Self.compressImageIfNeeded(data: pngData, maxSize: Self.maxImageSize)
 

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -159,21 +159,21 @@ public final class ChatAttachmentManager: ObservableObject {
         await loadSemaphore.wait()
         // Hop off the main actor for all blocking I/O and CPU work.
         let result = await Task.detached(priority: .userInitiated) {
+            // Pre-read size check to avoid loading huge files into memory.
+            let memorySafetyLimit = 500 * 1024 * 1024
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+               let fileSize = attrs[.size] as? Int,
+               fileSize > memorySafetyLimit {
+                let sizeMB = fileSize / (1024 * 1024)
+                return Result<ChatAttachment, AttachmentError>.failure(.message("This file is \(sizeMB) MB which is too large to process safely. Please choose a smaller file."))
+            }
+
             let data: Data
             do {
                 data = try Data(contentsOf: url)
             } catch {
                 log.error("Failed to read attachment: \(error.localizedDescription)")
                 return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
-            }
-
-            // Memory safety: base64 encoding allocates ~133% of raw bytes.
-            // With maxConcurrentLoads=4, a 500 MB file could use ~2.6 GB.
-            // Guard against OOM without imposing practical user-facing limits.
-            let memorySafetyLimit = 500 * 1024 * 1024
-            if data.count > memorySafetyLimit {
-                let sizeMB = data.count / (1024 * 1024)
-                return .failure(.message("This file is \(sizeMB) MB which is too large to process safely. Please choose a smaller file."))
             }
 
             if data.count > 20 * 1024 * 1024 {

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -160,7 +160,7 @@ public final class ChatAttachmentManager: ObservableObject {
         // Hop off the main actor for all blocking I/O and CPU work.
         let result = await Task.detached(priority: .userInitiated) {
             // Pre-read size check to avoid loading huge files into memory.
-            let memorySafetyLimit = 500 * 1024 * 1024
+            let memorySafetyLimit = 100 * 1024 * 1024
             if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                let fileSize = attrs[.size] as? Int,
                fileSize > memorySafetyLimit {
@@ -287,7 +287,7 @@ public final class ChatAttachmentManager: ObservableObject {
             #endif
 
             // Memory safety guard for pasted/dropped images
-            let memorySafetyLimit = 500 * 1024 * 1024
+            let memorySafetyLimit = 100 * 1024 * 1024
             if pngData.count > memorySafetyLimit {
                 let sizeMB = pngData.count / (1024 * 1024)
                 return .failure(.message("This image is \(sizeMB) MB which is too large to process safely. Please choose a smaller image."))

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -53,17 +53,13 @@ public final class ChatAttachmentManager: ObservableObject {
         didSet { isLoadingAttachment = loadingCount > 0 }
     }
 
-    /// Limits concurrent attachment I/O to avoid unbounded memory spikes when
-    /// many files are selected at once (each can read up to 20 MB).
+    /// Limits concurrent attachment I/O to keep memory usage reasonable.
     private static let maxConcurrentLoads = 4
     private let loadSemaphore = AsyncSemaphore(value: maxConcurrentLoads)
 
-    // MARK: - Limits
-
-    /// Maximum file size per attachment (20 MB).
-    nonisolated static let maxFileSize = 20 * 1024 * 1024
-    /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
-    /// Anthropic has a 5 MB limit per image; base64 encoding adds ~33% overhead.
+    /// Maximum image size before compression (4 MB). Images above this threshold
+    /// are JPEG-compressed, not rejected. Anthropic has a 5 MB limit per image;
+    /// base64 encoding adds ~33% overhead, so 4 MB raw keeps us well within bounds.
     nonisolated static let maxImageSize = 4 * 1024 * 1024
 
     // MARK: - Error callback
@@ -171,11 +167,6 @@ public final class ChatAttachmentManager: ObservableObject {
                 return Result<ChatAttachment, AttachmentError>.failure(.message("Could not read file."))
             }
 
-            // Belt-and-suspenders: validate the actual byte count after reading.
-            guard data.count <= Self.maxFileSize else {
-                return .failure(.message("File exceeds 20 MB limit."))
-            }
-
             let filename = url.lastPathComponent
             var mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
 
@@ -281,10 +272,6 @@ public final class ChatAttachmentManager: ObservableObject {
             #else
             #error("Unsupported platform")
             #endif
-
-            guard pngData.count <= Self.maxFileSize else {
-                return .failure(.message("Image exceeds 20 MB limit."))
-            }
 
             // Compress image if needed
             let (finalData, wasCompressed) = Self.compressImageIfNeeded(data: pngData, maxSize: Self.maxImageSize)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -284,14 +284,6 @@ public final class ChatViewModel: ObservableObject {
         set { errorManager.connectionDiagnosticHint = newValue }
     }
 
-    // MARK: - Static size limits (forwarded to attachment manager for use in extensions)
-
-    /// Maximum file size per attachment (20 MB).
-    static let maxFileSize = ChatAttachmentManager.maxFileSize
-    /// Maximum image size before compression (4 MB - leaves headroom for base64 encoding).
-    /// Anthropic has a 5MB limit per image; base64 encoding adds ~33% overhead.
-    static let maxImageSize = ChatAttachmentManager.maxImageSize
-
     public let subagentDetailStore = SubagentDetailStore()
     let daemonClient: any DaemonClientProtocol
     /// Tracks the action submitted for each guardian decision requestId so the


### PR DESCRIPTION
## Summary
- Remove client-side attachment size limits (`maxFileSize` from ChatAttachmentManager, `maxImageBytes`/`maxDocumentBytes` from TaskSubmission)
- Remove forwarded size constants from ChatViewModel and associated iOS tests
- Image compression threshold (`maxImageSize = 4 MB`) preserved — this compresses images, not rejects them
- Server-side limits unchanged (daemon still enforces its own limits)
- Fix pre-existing design token violations in InlineVideoEmbedCard

## Original prompt
https://linear.app/vellum/issue/JARVIS-197/remove-desktop-app-attachment-size-limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
