### PR TITLE
feat: onboarding privacy, diagnostics & user identity (LUM-191, LUM-169)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -96,10 +96,11 @@ struct ContactsListView: View {
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.contentDefault)
                         .lineLimit(1)
+                        .truncationMode(.tail)
 
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
-                .padding(VSpacing.lg)
+                .padding(VSpacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(selection == .assistant ? VColor.contentEmphasized.opacity(0.08) : (isAssistantHovered ? VColor.contentEmphasized.opacity(0.04) : Color.clear))
                 .contentShape(Rectangle())
@@ -128,10 +129,11 @@ struct ContactsListView: View {
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.contentDefault)
                         .lineLimit(1)
+                        .truncationMode(.tail)
 
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
-                .padding(VSpacing.lg)
+                .padding(VSpacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(selection == .contact(contact.id) ? VColor.contentEmphasized.opacity(0.08) : (hoveredContactId == contact.id ? VColor.contentEmphasized.opacity(0.04) : Color.clear))
                 .contentShape(Rectangle())
@@ -204,12 +206,14 @@ struct ContactsListView: View {
                         .font(VFont.bodyBold)
                         .foregroundColor(VColor.contentDefault)
                         .lineLimit(1)
+                        .truncationMode(.tail)
 
                     if let notes = contact.notes, !notes.isEmpty {
                         Text(notes.components(separatedBy: .newlines).first ?? notes)
                             .font(VFont.caption)
                             .foregroundColor(VColor.contentSecondary)
                             .lineLimit(1)
+                            .truncationMode(.tail)
                     }
 
                     if !contact.channels.isEmpty {
@@ -217,11 +221,11 @@ struct ContactsListView: View {
                     }
                 }
 
-                Spacer()
+                Spacer(minLength: VSpacing.sm)
 
                 statusIndicator(for: contact)
             }
-            .padding(VSpacing.lg)
+            .padding(VSpacing.md)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(selection == .contact(contact.id) ? VColor.contentEmphasized.opacity(0.08) : (hoveredContactId == contact.id ? VColor.contentEmphasized.opacity(0.04) : Color.clear))
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -145,8 +145,8 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
-            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? ""
-            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? ""
+            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? UserDefaults.standard.string(forKey: "user.displayName") ?? ""
+            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? UserDefaults.standard.string(forKey: "user.email") ?? ""
         }
         if let rawVariant = UserDefaults.standard.string(forKey: "onboarding.variant"),
            let variant = OnboardingVariant(rawValue: rawVariant) {
@@ -236,7 +236,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt", "user.displayName", "user.email"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -236,7 +236,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt", "user.displayName", "user.email"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -91,6 +91,15 @@ final class OnboardingState {
         !speechGranted || !accessibilityGranted || !screenGranted
     }
 
+    /// Whether the user has previously accepted the Terms of Service.
+    static var hasAcceptedToS: Bool {
+        UserDefaults.standard.double(forKey: "tos.acceptedAt") > 0
+    }
+
+    var userHostedEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("user_hosted_enabled")
+    }
+
     /// Continuous crack progress (0.0–1.0) derived from step and permission state.
     /// For the first meeting variant, uses a timer-driven stored property instead.
     var crackProgress: CGFloat {
@@ -227,7 +236,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail", "tos.acceptedAt"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -67,6 +67,10 @@ final class OnboardingState {
     var sshPrivateKey: String = ""
     var customQRCodeImageData: Data = Data()
     var selectedModel: String = "claude-opus-4-6"
+    var userDisplayName: String = ""
+    var userEmail: String = ""
+    var tosAccepted: Bool = false
+
     var isHatching: Bool = false
     var isManagedHatch: Bool = false
     var hasExistingManagedAssistant: Bool = false
@@ -132,6 +136,8 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             interviewCompleted = UserDefaults.standard.bool(forKey: "onboarding.interviewCompleted")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
+            userDisplayName = UserDefaults.standard.string(forKey: "onboarding.userDisplayName") ?? ""
+            userEmail = UserDefaults.standard.string(forKey: "onboarding.userEmail") ?? ""
         }
         if let rawVariant = UserDefaults.standard.string(forKey: "onboarding.variant"),
            let variant = OnboardingVariant(rawValue: rawVariant) {
@@ -183,6 +189,8 @@ final class OnboardingState {
         UserDefaults.standard.set(cloudProvider, forKey: "onboarding.cloudProvider")
         UserDefaults.standard.set(onboardingVariant.rawValue, forKey: "onboarding.variant")
         UserDefaults.standard.set(Double(firstMeetingCrackProgress), forKey: "onboarding.firstMeetingCrackProgress")
+        UserDefaults.standard.set(userDisplayName, forKey: "onboarding.userDisplayName")
+        UserDefaults.standard.set(userEmail, forKey: "onboarding.userEmail")
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
     }
 
@@ -219,7 +227,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.variant", "onboarding.firstMeetingCrackProgress", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.userDisplayName", "onboarding.userEmail"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -12,7 +12,7 @@ struct LogReportFormView: View {
     let onCancel: () -> Void
 
     @State private var selectedReason: LogReportReason?
-    @State private var name: String = ""
+    @State private var name: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
     @State private var message: String = ""
     @AppStorage("logReportEmail") private var email: String = ""
     @FocusState private var focusedField: Field?

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -9,8 +9,6 @@ struct SettingsPrivacyTab: View {
     @ObservedObject var store: SettingsStore
 
     // Identity editing state
-    @State private var displayName: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
-    @State private var email: String = UserDefaults.standard.string(forKey: "user.email") ?? ""
     @State private var isEditingIdentity: Bool = false
     @State private var editingName: String = ""
     @State private var editingEmail: String = ""
@@ -48,9 +46,9 @@ struct SettingsPrivacyTab: View {
                     Text("Name")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
-                    Text(displayName.isEmpty ? "Not set" : displayName)
+                    Text(store.userDisplayName.isEmpty ? "Not set" : store.userDisplayName)
                         .font(VFont.body)
-                        .foregroundColor(displayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                        .foregroundColor(store.userDisplayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
                 }
                 Spacer()
             }
@@ -60,9 +58,9 @@ struct SettingsPrivacyTab: View {
                     Text("Email")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentTertiary)
-                    Text(email.isEmpty ? "Not set" : email)
+                    Text(store.userEmail.isEmpty ? "Not set" : store.userEmail)
                         .font(VFont.body)
-                        .foregroundColor(email.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                        .foregroundColor(store.userEmail.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
                 }
                 Spacer()
             }
@@ -70,8 +68,8 @@ struct SettingsPrivacyTab: View {
             HStack {
                 Spacer()
                 VButton(label: "Edit", style: .outlined) {
-                    editingName = displayName
-                    editingEmail = email
+                    editingName = store.userDisplayName
+                    editingEmail = store.userEmail
                     isEditingIdentity = true
                 }
             }
@@ -100,10 +98,8 @@ struct SettingsPrivacyTab: View {
                     isEditingIdentity = false
                 }
                 VButton(label: "Save", style: .primary) {
-                    displayName = editingName
-                    email = editingEmail
-                    UserDefaults.standard.set(displayName, forKey: "user.displayName")
-                    UserDefaults.standard.set(email, forKey: "user.email")
+                    store.userDisplayName = editingName
+                    store.userEmail = editingEmail
                     SentryDeviceInfo.configureSentryScope()
                     isEditingIdentity = false
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -8,8 +8,107 @@ struct SettingsPrivacyTab: View {
     var daemonClient: DaemonClient?
     @ObservedObject var store: SettingsStore
 
+    // Identity editing state
+    @State private var displayName: String = UserDefaults.standard.string(forKey: "user.displayName") ?? ""
+    @State private var email: String = UserDefaults.standard.string(forKey: "user.email") ?? ""
+    @State private var isEditingIdentity: Bool = false
+    @State private var editingName: String = ""
+    @State private var editingEmail: String = ""
+
     var body: some View {
-        privacySection
+        VStack(spacing: VSpacing.lg) {
+            identitySection
+
+            Text("This information is attached to crash reports and log submissions to help us respond to your issues.")
+                .font(VFont.caption)
+                .foregroundColor(VColor.contentTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, VSpacing.xs)
+
+            privacySection
+        }
+    }
+
+    // MARK: - Identity Section
+
+    private var identitySection: some View {
+        SettingsCard(title: "Identity") {
+            if isEditingIdentity {
+                identityEditingView
+            } else {
+                identityDisplayView
+            }
+        }
+    }
+
+    private var identityDisplayView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Name")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(displayName.isEmpty ? "Not set" : displayName)
+                        .font(VFont.body)
+                        .foregroundColor(displayName.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                }
+                Spacer()
+            }
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Email")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    Text(email.isEmpty ? "Not set" : email)
+                        .font(VFont.body)
+                        .foregroundColor(email.isEmpty ? VColor.contentTertiary : VColor.contentSecondary)
+                }
+                Spacer()
+            }
+
+            HStack {
+                Spacer()
+                VButton(label: "Edit", style: .outlined) {
+                    editingName = displayName
+                    editingEmail = email
+                    isEditingIdentity = true
+                }
+            }
+        }
+    }
+
+    private var identityEditingView: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Name")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VTextField(placeholder: "Your name", text: $editingName)
+            }
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Email")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                VTextField(placeholder: "your@email.com", text: $editingEmail)
+            }
+
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    isEditingIdentity = false
+                }
+                VButton(label: "Save", style: .primary) {
+                    displayName = editingName
+                    email = editingEmail
+                    UserDefaults.standard.set(displayName, forKey: "user.displayName")
+                    UserDefaults.standard.set(email, forKey: "user.email")
+                    SentryDeviceInfo.configureSentryScope()
+                    isEditingIdentity = false
+                }
+            }
+        }
     }
 
     // MARK: - Privacy Section

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3,6 +3,7 @@ import Carbon.HIToolbox
 import Combine
 import Foundation
 import os
+import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SettingsStore")
@@ -19,6 +20,11 @@ public final class SettingsStore: ObservableObject {
     /// Set externally (e.g. via HTTP) to deep-link into a specific settings tab.
     /// SettingsPanel observes this and clears it after applying.
     @Published var pendingSettingsTab: SettingsTab?
+
+    // MARK: - User Identity
+
+    @AppStorage("user.displayName") var userDisplayName: String = ""
+    @AppStorage("user.email") var userEmail: String = ""
 
     // MARK: - API Key State
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -641,6 +641,9 @@ enum LogExporter {
             "ttsVoiceId",
             "selectedImageGenModel",
             "activityNotificationsEnabled",
+            "user.displayName",
+            "user.email",
+            "tos.acceptedAt",
         ]
 
         let boolKeys = [

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -148,10 +148,20 @@ enum LogExporter {
             // Sentry's Feedback API, linked to the event. This keeps PII
             // out of event tags/extras and lets us use Sentry's built-in
             // feedback UI for triage.
+            // Fall back to global identity when the user leaves form fields blank.
+            let feedbackName: String? = {
+                if !formData.name.isEmpty { return formData.name }
+                return UserDefaults.standard.string(forKey: "user.displayName")
+            }()
+            let feedbackEmail: String = {
+                if !formData.email.isEmpty { return formData.email }
+                return UserDefaults.standard.string(forKey: "user.email") ?? ""
+            }()
+
             let feedback = MetricKitManager.UserFeedbackData(
                 comments: formData.message.isEmpty ? nil : formData.message,
-                email: formData.email,
-                name: formData.name.isEmpty ? nil : formData.name
+                email: feedbackEmail,
+                name: feedbackName
             )
 
             // Route assistant behavior reports to the brain Sentry project

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -53,7 +53,10 @@ enum SentryDeviceInfo {
         let hasName = displayName != nil && !displayName!.isEmpty
         let hasEmail = email != nil && !email!.isEmpty
 
-        guard hasName || hasEmail else { return }
+        guard hasName || hasEmail else {
+            SentrySDK.configureScope { scope in scope.setUser(nil) }
+            return
+        }
 
         SentrySDK.configureScope { scope in
             let user = User()

--- a/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
+++ b/clients/macos/vellum-assistant/Telemetry/SentryDeviceInfo.swift
@@ -40,6 +40,31 @@ enum SentryDeviceInfo {
             }
             scope.setTag(value: ProcessInfo.processInfo.operatingSystemVersionString, key: "os_version")
         }
+        configureUserIdentity()
+    }
+
+    /// Attaches the user's display name and email to the Sentry scope
+    /// so all events carry identity context when available.
+    /// Reads from the persisted `user.displayName` and `user.email` keys.
+    static func configureUserIdentity() {
+        let displayName = UserDefaults.standard.string(forKey: "user.displayName")
+        let email = UserDefaults.standard.string(forKey: "user.email")
+
+        let hasName = displayName != nil && !displayName!.isEmpty
+        let hasEmail = email != nil && !email!.isEmpty
+
+        guard hasName || hasEmail else { return }
+
+        SentrySDK.configureScope { scope in
+            let user = User()
+            if hasName {
+                user.name = displayName
+            }
+            if hasEmail {
+                user.email = email
+            }
+            scope.setUser(user)
+        }
     }
 
     /// Updates the `assistant_id` Sentry tag when the connected assistant changes.


### PR DESCRIPTION
## Summary
- Redesign the onboarding "Improve Experience" step into a Screen Studio-inspired privacy & permissions screen with name, email, usage data toggles, and ToS consent gate
- Collect user name and email during onboarding, persist globally, and attach to all Sentry crash reports and log submissions automatically
- Add identity editing in Settings > Privacy tab with immediate Sentry scope sync
- Persist ToS acceptance timestamp and pre-check on re-onboarding

Closes LUM-191, LUM-169

## PRs included (9 commits)
1. feat: add global user identity persistence for crash reporting (#16392)
2. feat: attach user name and email to Sentry events and log reports (#16395)
3. feat: redesign onboarding privacy step with name, email, ToS consent (#16397)
4. feat: surface user identity in Settings Privacy tab (#16402)
5. feat: persist ToS acceptance timestamp and gate onboarding (#16399)
6. fix: attach Sentry user identity after onboarding and clear when emptied (#16405)
7. fix: consolidate identity keys, wire SettingsStore, clear PII on reset (#16406)
8. fix: include user identity and ToS keys in log export snapshot (#16408)
9. fix: don't wipe graduated user identity keys in clearPersistedState (#16409)

## Test plan
- [ ] Run onboarding flow: verify name, email fields, usage data toggles, ToS checkbox, and "Accept and Continue" button
- [ ] Verify "Accept and Continue" is disabled until ToS checked and email non-empty
- [ ] Verify name/email persist to Settings > Privacy after onboarding
- [ ] Edit identity in Settings > Privacy, verify Sentry scope updates
- [ ] Submit a log report, verify name/email pre-filled from global identity
- [ ] Re-run onboarding, verify ToS checkbox pre-checked and identity fields populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
