### PR TITLE
fix: match padding modifier order in animated conversation tail avatar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -319,9 +319,9 @@ struct MessageListView: View {
                                    breathingEnabled: false)
                     .frame(width: ConversationAvatarFollower.avatarSize,
                            height: ConversationAvatarFollower.avatarSize)
+                    .padding(.horizontal, VSpacing.xl)
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, VSpacing.xl)
                     .offset(y: avatarDisplayY)
                     .accessibilityHidden(true)
             } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tail-avatar-poke.md.

**Gap:** Horizontal padding order mismatch causes position offset
**What was expected:** Both branches should position the avatar identically
**What was found:** Animated branch applied padding after frames; static fallback applied it before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
