### PR TITLE
fix(ios): add save guard and use liveItem for edit comparisons in MemoryItemDetailView

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -8,6 +8,7 @@ struct MemoryItemDetailView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var isEditing = false
+    @State private var isSaving = false
     @State private var editSubject: String
     @State private var editStatement: String
     @State private var editKind: String
@@ -52,6 +53,7 @@ struct MemoryItemDetailView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { saveEdits() }
+                        .disabled(isSaving)
                 }
             } else {
                 ToolbarItem(placement: .primaryAction) {
@@ -229,15 +231,19 @@ struct MemoryItemDetailView: View {
     // MARK: - Actions
 
     private func saveEdits() {
+        guard !isSaving else { return }
+        isSaving = true
         Task {
+            let current = liveItem
             let result = await store.updateItem(
-                id: item.id,
-                subject: editSubject != item.subject ? editSubject : nil,
-                statement: editStatement != item.statement ? editStatement : nil,
-                kind: editKind != item.kind ? editKind : nil,
-                status: editStatus != item.status ? editStatus : nil,
-                importance: editImportance != (item.importance ?? 0.5) ? editImportance : nil
+                id: current.id,
+                subject: editSubject != current.subject ? editSubject : nil,
+                statement: editStatement != current.statement ? editStatement : nil,
+                kind: editKind != current.kind ? editKind : nil,
+                status: editStatus != current.status ? editStatus : nil,
+                importance: editImportance != (current.importance ?? 0.5) ? editImportance : nil
             )
+            isSaving = false
             if result != nil {
                 isEditing = false
             } else {


### PR DESCRIPTION
Addresses review feedback from PR #16133:

- Add `isSaving` state to prevent concurrent save requests while awaiting updateItem
- Disable Save button while save is in-flight
- Compare edit fields against `liveItem` instead of stale `item` in `saveEdits()` to prevent silently dropping edits after a prior save

Part of memories-tab review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
