### PR TITLE
fix(ios): move filter controls above list so they remain visible when results are empty

### DIFF
--- a/clients/ios/Views/Intelligence/MemoriesListView.swift
+++ b/clients/ios/Views/Intelligence/MemoriesListView.swift
@@ -27,13 +27,16 @@ struct MemoriesListView: View {
     @State private var searchDebounceTask: Task<Void, Never>?
 
     var body: some View {
-        Group {
-            if store.isLoading && store.items.isEmpty {
-                loadingState
-            } else if store.items.isEmpty {
-                emptyState
-            } else {
-                memoriesList
+        VStack(spacing: 0) {
+            filterBar
+            Group {
+                if store.isLoading && store.items.isEmpty {
+                    loadingState
+                } else if store.items.isEmpty {
+                    emptyState
+                } else {
+                    memoriesList
+                }
             }
         }
         .searchable(text: $searchText, prompt: "Search memories...")
@@ -66,37 +69,38 @@ struct MemoriesListView: View {
         }
     }
 
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        VStack(spacing: VSpacing.sm) {
+            Picker("Status", selection: $statusFilter) {
+                ForEach(MemoryStatusFilter.allCases, id: \.self) { filter in
+                    Text(filter.rawValue).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: statusFilter) { _, newValue in
+                store.statusFilter = newValue.apiValue
+                Task { await store.loadItems() }
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: VSpacing.sm) {
+                    kindFilterChip("All", kind: nil)
+                    ForEach(MemoryKind.allCases) { kind in
+                        kindFilterChip(kind.label, kind: kind.rawValue)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, VSpacing.sm)
+    }
+
     // MARK: - Memories List
 
     private var memoriesList: some View {
         List {
-            // Status filter
-            Section {
-                Picker("Status", selection: $statusFilter) {
-                    ForEach(MemoryStatusFilter.allCases, id: \.self) { filter in
-                        Text(filter.rawValue).tag(filter)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: statusFilter) { _, newValue in
-                    store.statusFilter = newValue.apiValue
-                    Task { await store.loadItems() }
-                }
-            }
-
-            // Kind filter chips
-            Section {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: VSpacing.sm) {
-                        kindFilterChip("All", kind: nil)
-                        ForEach(MemoryKind.allCases) { kind in
-                            kindFilterChip(kind.label, kind: kind.rawValue)
-                        }
-                    }
-                }
-            }
-
-            // Memory items
             Section {
                 ForEach(store.items) { item in
                     NavigationLink {


### PR DESCRIPTION
Addresses Devin BUG-0002 from PR #16134:

- Extract status filter picker and kind filter chips into a `filterBar` computed property
- Render filterBar above the conditional content (loading/empty/list) so filters remain accessible even when the current filter returns 0 results
- Follows the macOS pattern from MemoriesPanel.swift

Part of memories-tab review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
