### PR TITLE
fix: make VDropdown clickable on macOS

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -30,8 +30,20 @@ public struct VDropdown<T: Hashable>: View {
     }
 
     public var body: some View {
-        ZStack {
-            // Visual layer — identical to VTextField(trailingIcon: "chevron.down")
+        Menu {
+            ForEach(options, id: \.value) { option in
+                Button {
+                    selection = option.value
+                } label: {
+                    HStack {
+                        Text(option.label)
+                        if option.value == selection {
+                            VIconView(.check, size: 12)
+                        }
+                    }
+                }
+            }
+        } label: {
             HStack(spacing: VSpacing.md) {
                 Group {
                     if let label = selectedLabel {
@@ -58,28 +70,10 @@ public struct VDropdown<T: Hashable>: View {
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .stroke(VColor.borderBase.opacity(0.5), lineWidth: 1)
             )
-
-            // Interaction layer — transparent Menu, no visual chrome
-            Menu {
-                ForEach(options, id: \.value) { option in
-                    Button {
-                        selection = option.value
-                    } label: {
-                        HStack {
-                            Text(option.label)
-                            if option.value == selection {
-                                VIconView(.check, size: 12)
-                            }
-                        }
-                    }
-                }
-            } label: {
-                Color.clear.contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .accessibilityLabel(selectedLabel ?? placeholder)
         }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .accessibilityLabel(selectedLabel ?? placeholder)
         .frame(maxWidth: .infinity)
     }
 }


### PR DESCRIPTION
## Summary
- VDropdown used a ZStack with a transparent `Color.clear` Menu overlay for click handling
- With `.menuStyle(.borderlessButton)`, the AppKit `NSPopUpButton` backing the Menu uses its own hit-testing that ignores SwiftUI's `.contentShape()`, resulting in a zero-size click target
- Moved the visual content into the Menu's `label:` closure so clicks land on the Menu directly — fixes the "Active" and "Newest" dropdowns on the Memories panel (and all other VDropdown usages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
