### PR TITLE
fix(macos): replace raw color literals with design tokens in InlineVideoEmbedCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -89,7 +89,7 @@ struct InlineVideoEmbedCard: View {
                         fallbackPlaceholder
                     case .empty:
                         // Loading state — show dark background
-                        Color.black
+                        VColor.auxBlack
                     @unknown default:
                         fallbackPlaceholder
                     }
@@ -100,11 +100,11 @@ struct InlineVideoEmbedCard: View {
 
             // Play button overlay
             Circle()
-                .fill(Color.black.opacity(0.7))
+                .fill(VColor.auxBlack.opacity(0.7))
                 .frame(width: 56, height: 56)
                 .overlay(
                     VIconView(.play, size: 22)
-                        .foregroundColor(.white)
+                        .foregroundColor(VColor.auxWhite)
                         .offset(x: 2)
                 )
         }
@@ -115,7 +115,7 @@ struct InlineVideoEmbedCard: View {
     }
 
     private var fallbackPlaceholder: some View {
-        Color.black.opacity(0.8)
+        VColor.auxBlack.opacity(0.8)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 


### PR DESCRIPTION
## Summary
- Replace 4 raw color literals (`Color.black`, `.white`) with design tokens (`VColor.auxBlack`, `VColor.auxWhite`) in `InlineVideoEmbedCard.swift`
- Fixes the "Design token guard" CI step which runs in strict mode

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23071869794/job/67023973797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
