### PR TITLE
fix: center conversation tail avatar column to match message layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -321,7 +321,7 @@ struct MessageListView: View {
                            height: ConversationAvatarFollower.avatarSize)
                     .padding(.horizontal, VSpacing.xl)
                     .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxWidth: .infinity)
                     .offset(y: avatarDisplayY)
                     .accessibilityHidden(true)
             } else {


### PR DESCRIPTION
## Summary
- Remove `alignment: .leading` from outer `.frame(maxWidth: .infinity)` on the animated conversation tail avatar
- Centers the avatar column within the full width (matching message column and static fallback), fixing the avatar appearing at the far left edge
- Inner `.frame(maxWidth: chatColumnMaxWidth, alignment: .leading)` still correctly left-aligns the avatar within the centered column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
