### PR TITLE
fix(macos): address review feedback on memory item sheets

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCreateSheet.swift
@@ -79,8 +79,7 @@ struct MemoryItemCreateSheet: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.contentSecondary)
                         }
-                        Slider(value: $importance, in: 0...1, step: 0.1)
-                            .tint(VColor.primaryBase)
+                        VSlider(value: $importance, range: 0...1, step: 0.1)
                     }
 
                     if let errorMessage {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -69,8 +69,12 @@ struct MemoryItemDetailSheet: View {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {
                 Task {
-                    _ = await store.deleteItem(id: item.id)
-                    onDismiss()
+                    let success = await store.deleteItem(id: item.id)
+                    if success {
+                        onDismiss()
+                    } else {
+                        errorMessage = "Failed to delete memory. Please try again."
+                    }
                 }
             }
         } message: {
@@ -168,6 +172,12 @@ struct MemoryItemDetailSheet: View {
                     Text("Confirmed by you")
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentSecondary)
+                } else if displayItem.isUserReported {
+                    VIconView(.user, size: 12)
+                        .foregroundColor(VColor.contentSecondary)
+                    Text("Reported by you")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentSecondary)
                 } else {
                     VIconView(.sparkles, size: 12)
                         .foregroundColor(VColor.contentTertiary)
@@ -261,8 +271,7 @@ struct MemoryItemDetailSheet: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.contentSecondary)
                 }
-                Slider(value: $editImportance, in: 0...1, step: 0.1)
-                    .tint(VColor.primaryBase)
+                VSlider(value: $editImportance, range: 0...1, step: 0.1)
             }
         }
     }
@@ -293,7 +302,7 @@ struct MemoryItemDetailSheet: View {
                 VButton(
                     label: isSaving ? "Saving..." : "Save",
                     style: .primary,
-                    isDisabled: isSaving
+                    isDisabled: !isEditFormValid || isSaving
                 ) {
                     save()
                 }
@@ -303,6 +312,13 @@ struct MemoryItemDetailSheet: View {
         }
         .padding(.horizontal, VSpacing.xl)
         .padding(.vertical, VSpacing.lg)
+    }
+
+    // MARK: - Validation
+
+    private var isEditFormValid: Bool {
+        !editSubject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !editStatement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     // MARK: - Actions

--- a/clients/shared/Features/Memory/MemoryItemPayload.swift
+++ b/clients/shared/Features/Memory/MemoryItemPayload.swift
@@ -64,6 +64,11 @@ public struct MemoryItemPayload: Codable, Identifiable, Hashable, Sendable {
     public var isUserConfirmed: Bool {
         verificationState == "user_confirmed"
     }
+
+    /// Whether this memory was extracted from a user message.
+    public var isUserReported: Bool {
+        verificationState == "user_reported"
+    }
 }
 
 /// Response shape for the memory items list endpoint.


### PR DESCRIPTION
Follow-up to #16128. Addresses review feedback from Codex and Devin:

- Handle `user_reported` verification state in memory detail view
- Add `isEditFormValid` validation to prevent saving blank subject/statement
- Show error message when delete fails instead of unconditionally dismissing
- Replace native `Slider` with design system `VSlider` in both create and detail sheets
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
