### PR TITLE
refactor: convert ensureTelegramBotUsernameResolved to use getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
+++ b/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
@@ -37,10 +37,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (_keyId: string) => mockSecureKey,
-  setSecureKey: (_account: string, _value: string) => true,
-  deleteSecureKey: (_account: string) => "deleted" as const,
-  listSecureKeys: () => [] as string[],
+  getSecureKeyAsync: async (_keyId: string) => mockSecureKey,
 }));
 
 // Suppress logger output during tests

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -17,7 +17,7 @@ import {
   setNestedValue,
 } from "../../config/loader.js";
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import { getLogger } from "../../util/logger.js";
 import type {
@@ -41,7 +41,7 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     return; // Username already cached in config
   }
 
-  const token = getSecureKey(credentialKey("telegram", "bot_token"));
+  const token = await getSecureKeyAsync(credentialKey("telegram", "bot_token"));
   if (!token) return;
 
   try {


### PR DESCRIPTION
## Summary
- Replace getSecureKey with await getSecureKeyAsync in ensureTelegramBotUsernameResolved
- Update test mock from getSecureKey to getSecureKeyAsync

Part of plan: async-secure-keys-remaining.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
