### PR TITLE
refactor: convert CLI doctor command to use getSecureKeyAsync

### DIFF
--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -7,7 +7,7 @@ import { getRuntimeHttpPort } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import { isHttpHealthy } from "../../daemon/daemon-control.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import {
   getDbPath,
   getLogPath,
@@ -84,7 +84,7 @@ Examples:
         fireworks: "FIREWORKS_API_KEY",
         openrouter: "OPENROUTER_API_KEY",
       };
-      const configKey = getSecureKey(provider);
+      const configKey = await getSecureKeyAsync(provider);
       const envVar = providerEnvVar[provider];
       const envKey = envVar ? process.env[envVar] : undefined;
       const plaintextKey = (


### PR DESCRIPTION
## Summary
- Replace getSecureKey with await getSecureKeyAsync in doctor command's async action handler

Part of plan: async-secure-keys-remaining.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
