### PR TITLE
refactor: convert CLI oauth connections to use getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -154,17 +154,8 @@ mock.module("../oauth/oauth-store.js", () => ({
 
 // Stub out transitive dependencies that token-manager would normally pull in
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => mockGetSecureKey(account),
-  setSecureKey: () => true,
-  getSecureKeyAsync: async () => undefined,
+  getSecureKeyAsync: async (account: string) => mockGetSecureKey(account),
   setSecureKeyAsync: async () => true,
-  deleteSecureKey: (account: string) => {
-    if (secureKeyStore.has(account)) {
-      secureKeyStore.delete(account);
-      return "deleted" as const;
-    }
-    return "not-found" as const;
-  },
   deleteSecureKeyAsync: async (account: string) => {
     if (secureKeyStore.has(account)) {
       secureKeyStore.delete(account);

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -17,7 +17,7 @@ import {
 import { credentialKey } from "../../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKey,
+  getSecureKeyAsync,
 } from "../../../security/secure-keys.js";
 import { withValidToken } from "../../../security/token-manager.js";
 import {
@@ -552,7 +552,9 @@ Examples:
 
           if (dbApp) {
             if (!clientId) clientId = dbApp.clientId;
-            const storedSecret = getSecureKey(dbApp.clientSecretCredentialPath);
+            const storedSecret = await getSecureKeyAsync(
+              dbApp.clientSecretCredentialPath,
+            );
             if (storedSecret) clientSecret = storedSecret;
           } else if (opts.clientId) {
             // --client-id was explicitly provided but no matching app exists


### PR DESCRIPTION
## Summary
- Replace getSecureKey with await getSecureKeyAsync in connect subcommand
- Update oauth-cli test mock to use getSecureKeyAsync instead of getSecureKey

Part of plan: async-secure-keys-remaining.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
