### PR TITLE
refactor: convert resolveSlackToken to use getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => secureKeyValues.get(key),
+  getSecureKeyAsync: async (key: string) => secureKeyValues.get(key),
   setSecureKeyAsync: async () => {},
 }));
 

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../messaging/providers/slack/client.js";
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
 import { getConnectionByProvider } from "../../../../oauth/oauth-store.js";
-import { getSecureKey } from "../../../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
 import { httpError } from "../../../http-errors.js";
 import type { RouteDefinition } from "../../../http-router.js";
@@ -27,10 +27,10 @@ const log = getLogger("slack-share");
 /**
  * Resolve the Slack bot token from the OAuth connection store.
  */
-function resolveSlackToken(): string | undefined {
+async function resolveSlackToken(): Promise<string | undefined> {
   const conn = getConnectionByProvider("integration:slack");
   return conn
-    ? getSecureKey(`oauth_connection/${conn.id}/access_token`)
+    ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
     : undefined;
 }
 
@@ -61,7 +61,7 @@ const TYPE_SORT_ORDER: Record<string, number> = {
 };
 
 export async function handleListSlackChannels(): Promise<Response> {
-  const token = resolveSlackToken();
+  const token = await resolveSlackToken();
   if (!token) {
     return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
   }
@@ -137,7 +137,7 @@ export async function handleListSlackChannels(): Promise<Response> {
 export async function handleShareToSlackChannel(
   req: Request,
 ): Promise<Response> {
-  const token = resolveSlackToken();
+  const token = await resolveSlackToken();
   if (!token) {
     return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
   }


### PR DESCRIPTION
## Summary
- Make resolveSlackToken async and use getSecureKeyAsync
- Update callers in handleListSlackChannels and handleShareToSlackChannel to await
- Update test mock from getSecureKey to getSecureKeyAsync

Part of plan: async-secure-keys-remaining.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
