### PR TITLE
refactor: convert credential broker to use getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -371,7 +371,7 @@ describe("CredentialBroker.serverUse", () => {
       expect(r2.result).toBe("triggered");
     });
 
-    test("different services with same field name are independent (serverUseById)", () => {
+    test("different services with same field name are independent (serverUseById)", async () => {
       const meta1 = upsertCredentialMetadata("github", "api_token", {
         allowedTools: ["github_api"],
       });
@@ -382,7 +382,7 @@ describe("CredentialBroker.serverUse", () => {
       setSecureKey(credentialKey("gitlab", "api_token"), "gl_tok");
 
       // github credential should not serve gitlab tool
-      const r1 = broker.serverUseById({
+      const r1 = await broker.serverUseById({
         credentialId: meta1.credentialId,
         requestingTool: "gitlab_api",
       });
@@ -447,7 +447,7 @@ describe("CredentialBroker.serverUseById", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
-  test("returns metadata and injection templates for valid credential", () => {
+  test("returns metadata and injection templates for valid credential", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["media_proxy"],
       injectionTemplates: [
@@ -461,7 +461,7 @@ describe("CredentialBroker.serverUseById", () => {
     });
     setSecureKey(credentialKey("fal", "api_key"), "fal-secret-key");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "media_proxy",
     });
@@ -480,13 +480,13 @@ describe("CredentialBroker.serverUseById", () => {
     expect(serialized).not.toContain("fal-secret-key");
   });
 
-  test("denies when requesting tool is not in allowed list", () => {
+  test("denies when requesting tool is not in allowed list", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["media_proxy"],
     });
     setSecureKey(credentialKey("fal", "api_key"), "fal-secret-key");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "unauthorized_tool",
     });
@@ -498,8 +498,8 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.reason).toContain("media_proxy");
   });
 
-  test("returns not found for unknown credential ID", () => {
-    const result = broker.serverUseById({
+  test("returns not found for unknown credential ID", async () => {
+    const result = await broker.serverUseById({
       credentialId: "nonexistent-id",
       requestingTool: "media_proxy",
     });
@@ -510,14 +510,14 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.reason).toContain("nonexistent-id");
   });
 
-  test("denies when credential has domain restrictions", () => {
+  test("denies when credential has domain restrictions", async () => {
     const meta = upsertCredentialMetadata("github", "oauth_token", {
       allowedTools: ["media_proxy"],
       allowedDomains: ["github.com"],
     });
     setSecureKey(credentialKey("github", "oauth_token"), "gho_test");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "media_proxy",
     });
@@ -528,13 +528,13 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.reason).toContain("cannot be used server-side");
   });
 
-  test("returns empty injection templates when credential has none", () => {
+  test("returns empty injection templates when credential has none", async () => {
     const meta = upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["media_proxy"],
     });
     setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "media_proxy",
     });
@@ -544,13 +544,13 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.injectionTemplates).toEqual([]);
   });
 
-  test("denies with empty allowedTools and suggests updating credential", () => {
+  test("denies with empty allowedTools and suggests updating credential", async () => {
     const meta = upsertCredentialMetadata("stripe", "secret_key", {
       allowedTools: [],
     });
     setSecureKey(credentialKey("stripe", "secret_key"), "sk_test_xyz");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "media_proxy",
     });
@@ -561,7 +561,7 @@ describe("CredentialBroker.serverUseById", () => {
     expect(result.reason).toContain("credential_store");
   });
 
-  test("denies when metadata exists but no stored secret value", () => {
+  test("denies when metadata exists but no stored secret value", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["media_proxy"],
       injectionTemplates: [
@@ -575,7 +575,7 @@ describe("CredentialBroker.serverUseById", () => {
     });
     // No setSecureKey — metadata exists but value doesn't
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "media_proxy",
     });

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -1113,7 +1113,7 @@ describe("CredentialBroker — serverUseById edge cases", () => {
     _resetBackend();
   });
 
-  test("serverUseById with multiple injection templates returns all", () => {
+  test("serverUseById with multiple injection templates returns all", async () => {
     const meta = upsertCredentialMetadata("multi", "api_key", {
       allowedTools: ["proxy"],
       injectionTemplates: [
@@ -1132,7 +1132,7 @@ describe("CredentialBroker — serverUseById edge cases", () => {
     });
     setSecureKey(credentialKey("multi", "api_key"), "multi-secret");
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "proxy",
     });
@@ -1146,13 +1146,13 @@ describe("CredentialBroker — serverUseById edge cases", () => {
     expect(JSON.stringify(result)).not.toContain("multi-secret");
   });
 
-  test("serverUseById verifies secret exists in storage (fail-closed)", () => {
+  test("serverUseById verifies secret exists in storage (fail-closed)", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["proxy"],
     });
     // No setSecureKey — metadata exists but value doesn't
 
-    const result = broker.serverUseById({
+    const result = await broker.serverUseById({
       credentialId: meta.credentialId,
       requestingTool: "proxy",
     });

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   AuthorizeRequest,
@@ -217,7 +217,7 @@ export class CredentialBroker {
     // Deletion is deferred until after a successful fill so the value survives
     // transient failures (e.g. stale element, page navigation, Playwright timeout).
     const transient = this.transientValues.get(storageKey);
-    const value = transient?.value ?? getSecureKey(storageKey);
+    const value = transient?.value ?? (await getSecureKeyAsync(storageKey));
     if (!value) {
       return {
         success: false,
@@ -302,7 +302,7 @@ export class CredentialBroker {
 
     const storageKey = credentialKey(request.service, request.field);
     const transient = this.transientValues.get(storageKey);
-    const value = transient?.value ?? getSecureKey(storageKey);
+    const value = transient?.value ?? (await getSecureKeyAsync(storageKey));
     if (!value) {
       return {
         success: false,
@@ -344,7 +344,9 @@ export class CredentialBroker {
    * never included in the result — the proxy reads it separately via
    * the secure key backend at injection time.
    */
-  serverUseById(request: ServerUseByIdRequest): ServerUseByIdResult {
+  async serverUseById(
+    request: ServerUseByIdRequest,
+  ): Promise<ServerUseByIdResult> {
     const resolved = resolveById(request.credentialId);
     if (!resolved) {
       return {
@@ -383,7 +385,7 @@ export class CredentialBroker {
 
     // Fail-closed: verify the secret value actually exists in secure storage.
     // Without this, downstream proxy code would attempt unauthenticated requests.
-    const value = getSecureKey(resolved.storageKey);
+    const value = await getSecureKeyAsync(resolved.storageKey);
     if (!value) {
       return {
         success: false,


### PR DESCRIPTION
## Summary
- Convert all 3 getSecureKey calls in broker.ts to await getSecureKeyAsync
- Make serverUseById async (zero production callers, only tests)
- Update test files to await async serverUseById calls

Part of plan: async-secure-keys-remaining.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
