### PR TITLE
fix: truncated text overlaps archive button on hover (LUM-203)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -42,6 +42,10 @@ enum SidebarLayoutMetrics {
     /// Trailing padding reserved for the "Confirm" pill button overlay during archive flow.
     static let archiveConfirmTrailingPadding: CGFloat = 72
 
+    /// Trailing padding reserved for the archive icon overlay on hover
+    /// (20pt icon + 4pt trailing padding on the overlay + 4pt gap).
+    static let archiveIconTrailingPadding: CGFloat = 28
+
     // MARK: - Section Divider
 
     /// Vertical padding above and below a section divider line.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -111,7 +111,7 @@ struct SidebarThreadItem: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, isPendingDeletion ? SidebarLayoutMetrics.archiveConfirmTrailingPadding : hasTrailingIcon ? VSpacing.xs : VSpacing.sm)
+            .padding(.trailing, isPendingDeletion ? SidebarLayoutMetrics.archiveConfirmTrailingPadding : hasTrailingIcon ? SidebarLayoutMetrics.archiveIconTrailingPadding : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {


### PR DESCRIPTION
## Summary
- Increased trailing padding on sidebar thread rows from 4pt to 28pt when the archive icon overlay is visible on hover, preventing truncated title text from rendering underneath the icon
- Added `archiveIconTrailingPadding` constant to `SidebarLayoutMetrics` for consistency with the existing `archiveConfirmTrailingPadding`

## Original prompt
--safe https://linear.app/vellum/issue/LUM-203/truncated-text-overlaps-archive-button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
