### PR TITLE
fix: add always_allow_high_risk to domain events decision type

### DIFF
--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -25,6 +25,7 @@ export interface ToolDomainEvents {
       | "allow_10m"
       | "allow_thread"
       | "always_allow"
+      | "always_allow_high_risk"
       | "deny"
       | "always_deny"
       | "temporary_override";


### PR DESCRIPTION
## Summary
- Adds missing `always_allow_high_risk` variant to `tool.permission.decided` decision union in `domain-events.ts`
- This variant exists in `UserDecision` type and can be emitted at runtime via `isAllowDecision()`, but was missing from the domain event type contract

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/12622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
