### PR TITLE
docs: add warnings that workspace contents are exported in logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ When the daemon runs with `BASE_DATA_DIR` set to an instance directory (e.g. `~/
 
 Use `QDRANT_HTTP_PORT` (not `QDRANT_URL`) when allocating per-instance Qdrant ports. Setting `QDRANT_URL` triggers QdrantManager's external/remote mode which bypasses the local managed Qdrant lifecycle (download, start, health checks). The CLI deletes `QDRANT_URL` from the environment when spawning instance daemons to ensure local Qdrant management is used.
 
+## Workspace Export & Secrets
+
+The entire ~/.vellum/workspace directory (minus embedding models and Qdrant vector indices) is included in diagnostic log exports when users choose "Send logs to Vellum". **Never store secrets, API keys, or sensitive credentials in the workspace directory.** Use the credential store (`assistant credentials`) or the `~/.vellum/protected/` directory for sensitive data.
+
 ## Release Update Hygiene
 
 When shipping a release with user/assistant-facing changes, update `assistant/src/prompts/templates/UPDATES.md`. Leave empty for no-op releases. Don't modify `~/.vellum/workspace/UPDATES.md` directly. Checkpoint keys (`updates:active_releases`, `updates:completed_releases`) in `memory_checkpoints` track bulletin lifecycle — don't manipulate directly.

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,5 +1,8 @@
 /**
  * Route handlers for workspace file browsing and content serving.
+ *
+ * WARNING: Workspace contents are included in diagnostic log exports.
+ * Do not store secrets here — use the credential store or protected/ directory.
  */
 import {
   existsSync,

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -328,7 +328,13 @@ export function getHooksDir(): string {
 // These will become the canonical paths after workspace migration.
 // Currently not used by call-sites; wired in later PRs.
 
-/** Returns ~/.vellum/workspace — the workspace root for user-facing state. */
+/**
+ * Returns ~/.vellum/workspace — the workspace root for user-facing state.
+ *
+ * WARNING: The entire workspace directory is included in diagnostic log exports
+ * ("Send logs to Vellum"). Do not store secrets, API keys, or sensitive
+ * credentials here — use the credential store or ~/.vellum/protected/ instead.
+ */
 export function getWorkspaceDir(): string {
   return join(getRootDir(), "workspace");
 }


### PR DESCRIPTION
## Summary
- Add "Workspace Export & Secrets" section to AGENTS.md warning against storing secrets in workspace
- Update `getWorkspaceDir()` JSDoc with export warning
- Update `workspace-routes.ts` module doc with export warning

Part of plan: export-workspace-secret-warning.md (PR 4 of 4)
Part of JARVIS-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
