### PR TITLE
fix: address review feedback from PR #13479

### DIFF
--- a/skills/amazon/SKILL.md
+++ b/skills/amazon/SKILL.md
@@ -13,7 +13,7 @@ You can shop on Amazon (and Amazon Fresh for groceries) for the user using the b
 
 ## Script Setup
 
-**IMPORTANT: Always use `host_bash` (not `bash`) for all Amazon commands.** The scripts need host access for session cookies and the `assistant` CLI binary (used for the Chrome extension relay and credential store), which are not available inside the sandbox.
+**IMPORTANT: Run all Amazon commands in a shell with host access (not inside a sandbox).** The scripts need host access for session cookies and the `assistant` CLI binary (used for the Chrome extension relay and credential store), which are not available inside a sandbox.
 
 The Amazon scripts are bundled with this skill. Run them via `bun run {baseDir}/scripts/amazon.ts <subcommand> [options]`.
 
@@ -66,13 +66,7 @@ Alternatively, run `bun run {baseDir}/scripts/amazon.ts variations <asin> --json
 
 ## Session Storage
 
-Session cookies are stored in the encrypted credential store under the key `amazon:session:cookies`. You can inspect the stored session with:
-
-```bash
-assistant credentials inspect --service amazon --field session:cookies
-```
-
-Session capture (`bun run {baseDir}/scripts/amazon.ts refresh`) and session checks (`bun run {baseDir}/scripts/amazon.ts status`) use the credential store automatically — no manual file management is needed.
+Session cookies are stored in the encrypted credential store under the key `amazon:session:cookies`. Session capture (`bun run {baseDir}/scripts/amazon.ts refresh`) and session checks (`bun run {baseDir}/scripts/amazon.ts status`) use the credential store automatically — no manual file management is needed.
 
 ## Important Behavior
 
@@ -82,7 +76,7 @@ Session capture (`bun run {baseDir}/scripts/amazon.ts refresh`) and session chec
 - **Handle expired sessions gracefully.** If any command returns `"error": "session_expired"`, run `bun run {baseDir}/scripts/amazon.ts refresh --json` to re-capture the session.
 - **Show prices.** Always show prices when presenting products or the cart summary.
 - **Use `--json` flag** on all commands for reliable parsing.
-- **Always use `host_bash`** for these commands, never `bash`.
+- **Always use a host shell** (not a sandboxed shell) for these commands.
 - **Do NOT use the browser skill.** All Amazon interaction goes through the bundled scripts, not browser automation.
 - **Rate limiting.** Amazon may rate-limit rapid sequential requests. Wait 8-10 seconds between cart operations. If you get a 403 error, wait 15-20 seconds and retry.
 - **Always-allow tip.** At the start of an ordering flow, suggest the user enable "always allow" for the Amazon script commands: "Tip: You can type 'a' to always allow Amazon commands for this session so you won't be prompted each time."


### PR DESCRIPTION
## Summary
- Removes `host_bash` tool name references from `skills/amazon/SKILL.md`, replacing with portable phrasing ("shell with host access") per `skills/AGENTS.md` portability rules
- Removes `assistant credentials inspect` command reference that coupled the skill to Vellum internals

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/13479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
