### PR TITLE
fix: add subcommand-level risk classification for vellum/assistant CLIs

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -143,7 +143,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
-  "assistant",
 ]);
 
 // High-risk shell programs / patterns
@@ -195,6 +194,15 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "ls-tree",
   "cat-file",
   "reflog",
+]);
+
+// Vellum/assistant CLI subcommands that are low-risk (read-only)
+const LOW_RISK_CLI_SUBCOMMANDS = new Set([
+  "ps",
+  "doctor",
+  "audit",
+  "completions",
+  "map",
 ]);
 
 // Commands that wrap another program — the real program appears as the first
@@ -645,6 +653,17 @@ async function classifyRiskUncached(
           continue;
         }
         // Non-read-only git commands are medium
+        maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      if (prog === "vellum" || prog === "assistant") {
+        const subcommand = seg.args[0];
+        if (subcommand && LOW_RISK_CLI_SUBCOMMANDS.has(subcommand)) {
+          // Read-only subcommands stay at current risk
+          continue;
+        }
+        // Mutating subcommands are medium
         maxRisk = RiskLevel.Medium;
         continue;
       }


### PR DESCRIPTION
## Summary
- Removes `assistant` from blanket `LOW_RISK_PROGRAMS` set
- Adds `LOW_RISK_CLI_SUBCOMMANDS` (ps, doctor, audit, completions, map) for read-only operations
- Adds subcommand-level handling for `vellum` and `assistant` CLIs matching the existing `git` pattern — read-only subcommands stay low-risk, all others escalate to medium

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
