### PR TITLE
feat: include workspace directory contents in daemon export response

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for workspace file collection in the log export route handler.
+ *
+ * Validates that `POST /v1/export` includes workspace files with correct
+ * filtering: text files included, SQLite DB files dumped as SQL, excluded
+ * directories (embedding-models/, data/qdrant/) absent, binary files skipped.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+// Set up temp directories before mocking
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "log-export-workspace-test-")),
+);
+const testWorkspaceDir = join(testDir, "workspace");
+const testDbDir = join(testDir, "db");
+const testDbPath = join(testDbDir, "assistant.db");
+
+mkdirSync(testWorkspaceDir, { recursive: true });
+mkdirSync(testDbDir, { recursive: true });
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getWorkspaceDir: () => testWorkspaceDir,
+  getWorkspaceConfigPath: () => join(testWorkspaceDir, "config.json"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => testDbPath,
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mock getSecureKeyAsync to avoid keychain access during tests
+mock.module("../util/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
+}));
+
+import { initializeDb, resetDb } from "../memory/db.js";
+import { logExportRouteDefinitions } from "../runtime/routes/log-export-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const routes = logExportRouteDefinitions();
+const exportRoute = routes.find((r) => r.endpoint === "export")!;
+
+async function callExport(): Promise<Response> {
+  const req = new Request("http://localhost/v1/export", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  const url = new URL(req.url);
+  return exportRoute.handler({
+    req,
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: {},
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Seed workspace files
+// ---------------------------------------------------------------------------
+
+// Text files — should be included
+writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), "# My Identity\nHello");
+mkdirSync(join(testWorkspaceDir, "notes"), { recursive: true });
+writeFileSync(join(testWorkspaceDir, "notes", "daily.txt"), "Some daily notes");
+
+// SQLite DB file — should be dumped as .sql
+mkdirSync(join(testWorkspaceDir, "data", "db"), { recursive: true });
+// Create a real sqlite db with a table
+import { Database } from "bun:sqlite";
+const wsDbPath = join(testWorkspaceDir, "data", "db", "assistant.db");
+const wsDb = new Database(wsDbPath);
+wsDb.run("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)");
+wsDb.run("INSERT INTO test_table (name) VALUES ('hello')");
+wsDb.close();
+
+// Excluded directory: embedding-models/
+mkdirSync(join(testWorkspaceDir, "embedding-models"), { recursive: true });
+writeFileSync(
+  join(testWorkspaceDir, "embedding-models", "model.bin"),
+  "large binary model data",
+);
+
+// Excluded directory: data/qdrant/
+mkdirSync(join(testWorkspaceDir, "data", "qdrant"), { recursive: true });
+writeFileSync(
+  join(testWorkspaceDir, "data", "qdrant", "index.bin"),
+  "vector index data",
+);
+
+// Binary file — should be skipped
+writeFileSync(
+  join(testWorkspaceDir, "binary-file.dat"),
+  Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f]), // contains null byte
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/export — workspace files", () => {
+  test("includes text files in workspaceFiles", async () => {
+    const res = await callExport();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    expect(body.workspaceFiles["IDENTITY.md"]).toBe("# My Identity\nHello");
+    expect(body.workspaceFiles["notes/daily.txt"]).toBe("Some daily notes");
+  });
+
+  test("dumps SQLite DB files as .sql text", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    const sqlKey = "data/db/assistant.db.sql";
+    expect(body.workspaceFiles[sqlKey]).toBeDefined();
+    expect(body.workspaceFiles[sqlKey]).toContain("CREATE TABLE");
+    expect(body.workspaceFiles[sqlKey]).toContain("test_table");
+    // The raw .db file should NOT be present
+    expect(body.workspaceFiles["data/db/assistant.db"]).toBeUndefined();
+  });
+
+  test("excludes embedding-models/ directory", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    const embeddingKeys = Object.keys(body.workspaceFiles).filter((k) =>
+      k.startsWith("embedding-models/"),
+    );
+    expect(embeddingKeys).toHaveLength(0);
+  });
+
+  test("excludes data/qdrant/ directory", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    const qdrantKeys = Object.keys(body.workspaceFiles).filter((k) =>
+      k.startsWith("data/qdrant/"),
+    );
+    expect(qdrantKeys).toHaveLength(0);
+  });
+
+  test("skips binary files containing null bytes", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    expect(body.workspaceFiles["binary-file.dat"]).toBeUndefined();
+  });
+
+  test("response includes workspaceFiles field", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      success: boolean;
+      workspaceFiles: Record<string, string>;
+    };
+    expect(body.success).toBe(true);
+    expect(body.workspaceFiles).toBeDefined();
+    expect(typeof body.workspaceFiles).toBe("object");
+  });
+});

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -6,8 +6,9 @@
  * of requiring direct filesystem access.
  */
 
+import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 import { desc } from "drizzle-orm";
 
@@ -18,6 +19,7 @@ import {
   getDataDir,
   getRootDir,
   getWorkspaceConfigPath,
+  getWorkspaceDir,
 } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -36,6 +38,7 @@ interface ExportResponse {
   auditRows: Array<Record<string, unknown>>;
   logFiles: Record<string, string>;
   configSnapshot?: Record<string, unknown>;
+  workspaceFiles: Record<string, string>;
 }
 
 /**
@@ -91,12 +94,16 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
     // --- Sanitized config snapshot ---
     const configSnapshot = readSanitizedConfig();
 
+    // --- Workspace files ---
+    const workspaceFiles = collectWorkspaceFiles();
+
     log.info(
       {
         auditCount: auditRows.length,
         logFileCount: Object.keys(logFiles).length,
         totalBytes,
         hasConfig: configSnapshot !== undefined,
+        workspaceFileCount: Object.keys(workspaceFiles).length,
       },
       "Export completed",
     );
@@ -106,6 +113,7 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       auditRows,
       logFiles,
       configSnapshot,
+      workspaceFiles,
     };
     return Response.json(payload);
   } catch (err) {
@@ -113,6 +121,86 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
     log.error({ err }, "Failed to export");
     return httpError("INTERNAL_ERROR", `Failed to export: ${message}`, 500);
   }
+}
+
+/** Directory prefixes to skip when collecting workspace files. */
+const WORKSPACE_SKIP_DIRS = new Set(["embedding-models", "data/qdrant"]);
+
+/**
+ * Recursively collects files from the workspace directory into a
+ * `Record<string, string>` map of relative path to content.
+ *
+ * - Skips directories in `WORKSPACE_SKIP_DIRS`.
+ * - For `.db` files, shells out to `sqlite3 <path> .dump` and stores the
+ *   SQL text output with a `.sql` suffix appended to the key.
+ * - Skips binary files (detected via null-byte heuristic).
+ */
+function collectWorkspaceFiles(): Record<string, string> {
+  const wsDir = getWorkspaceDir();
+  if (!existsSync(wsDir)) return {};
+
+  const result: Record<string, string> = {};
+
+  function walk(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const relPath = relative(wsDir, fullPath);
+
+      // Check if this path falls under a skipped directory prefix
+      if (
+        [...WORKSPACE_SKIP_DIRS].some(
+          (prefix) => relPath === prefix || relPath.startsWith(prefix + "/"),
+        )
+      ) {
+        continue;
+      }
+
+      try {
+        const stat = statSync(fullPath);
+        if (stat.isDirectory()) {
+          walk(fullPath);
+          continue;
+        }
+        if (!stat.isFile()) continue;
+
+        // SQLite DB handling: dump as SQL text
+        if (entry.endsWith(".db")) {
+          try {
+            const proc = spawnSync("sqlite3", [fullPath, ".dump"], {
+              timeout: 10_000,
+            });
+            if (proc.status === 0 && proc.stdout) {
+              const output =
+                proc.stdout instanceof Buffer
+                  ? proc.stdout.toString("utf-8")
+                  : String(proc.stdout);
+              result[relPath + ".sql"] = output;
+            }
+          } catch {
+            // Skip if dump fails
+          }
+          continue;
+        }
+
+        // Read as UTF-8 and skip binary files (null-byte heuristic)
+        const content = readFileSync(fullPath, "utf-8");
+        if (content.includes("\0")) continue;
+        result[relPath] = content;
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
+
+  walk(wsDir);
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add recursive workspace directory collection to `POST /v1/export` response
- Skip `embedding-models/` and `data/qdrant/` directories
- Export SQLite DB files as portable `.sql` text dumps via `sqlite3 .dump`
- Skip binary files via null-byte detection

Part of plan: export-workspace-secret-warning.md (PR 1 of 4)
Part of JARVIS-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
