### PR TITLE
fix: centralize interactive interface check from PR #14867

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -74,6 +74,22 @@ export function assertInterfaceId(value: unknown, field: string): InterfaceId {
   return value;
 }
 
+/**
+ * Interfaces that have an SSE client capable of displaying interactive
+ * permission prompts. Channel interfaces (telegram, slack, etc.) route
+ * approvals through the guardian system and have no interactive prompter UI.
+ */
+export const INTERACTIVE_INTERFACES: ReadonlySet<InterfaceId> = new Set([
+  "macos",
+  "ios",
+  "cli",
+  "vellum",
+]);
+
+export function isInteractiveInterface(id: InterfaceId): boolean {
+  return INTERACTIVE_INTERFACES.has(id);
+}
+
 export interface TurnInterfaceContext {
   userMessageInterface: InterfaceId;
   assistantMessageInterface: InterfaceId;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -11,6 +11,7 @@ import {
 import {
   CHANNEL_IDS,
   INTERFACE_IDS,
+  isInteractiveInterface,
   parseChannelId,
   parseInterfaceId,
 } from "../../channels/types.js";
@@ -656,14 +657,7 @@ export async function handleSendMessage(
   }
 
   const onEvent = makeHubPublisher(smDeps, mapping.conversationId, session);
-  // Desktop, CLI, and web interfaces have an SSE client that can display
-  // permission prompts. Channel interfaces (telegram, slack, etc.) route
-  // approvals through the guardian system and have no interactive prompter UI.
-  const isInteractiveInterface =
-    sourceInterface === "macos" ||
-    sourceInterface === "ios" ||
-    sourceInterface === "cli" ||
-    sourceInterface === "vellum";
+  const isInteractive = isInteractiveInterface(sourceInterface);
   // Only create the host bash proxy for desktop client interfaces that can
   // execute commands on the user's machine. Non-desktop sessions (CLI,
   // channels, headless) fall back to local execution.
@@ -709,7 +703,7 @@ export async function handleSendMessage(
     session.isProcessing() &&
     sourceInterface !== "macos" &&
     sourceInterface !== "ios";
-  session.updateClient(onEvent, !isInteractiveInterface, {
+  session.updateClient(onEvent, !isInteractive, {
     skipProxySenderUpdate: preservingProxies,
   });
 
@@ -781,7 +775,7 @@ export async function handleSendMessage(
         userMessageInterface: sourceInterface,
         assistantMessageInterface: sourceInterface,
       },
-      { isInteractive: isInteractiveInterface },
+      { isInteractive },
     );
     if (enqueueResult.rejected) {
       return Response.json(
@@ -960,7 +954,7 @@ export async function handleSendMessage(
   // Fire-and-forget the agent loop; events flow to the hub via onEvent.
   session
     .runAgentLoop(resolvedContent, messageId, onEvent, {
-      isInteractive: isInteractiveInterface,
+      isInteractive,
       isUserMessage: true,
     })
     .catch((err) => {


### PR DESCRIPTION
## Summary
- Extracts the inline `isInteractiveInterface` check from `conversation-routes.ts` into a centralized `INTERACTIVE_INTERFACES` constant and `isInteractiveInterface()` helper in `channels/types.ts`
- Addresses the fragility concern raised in PR #14867 review where the hardcoded interface list (`macos`, `ios`, `cli`, `vellum`) was inline and could drift out of sync

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/14867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
