### PR TITLE
fix: preserve file-path attachments and metadata on retry after session error

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2017,16 +2017,18 @@ public final class ChatViewModel: ObservableObject {
             // Preserve attachments so they are resent with the retry.
             // ChatAttachment.data may already be cleared for older messages,
             // but for a just-sent 429'd message it is still populated.
+            // Also keep file-path-based attachments even when data is empty,
+            // since the daemon can read the file from disk.
             lastFailedMessageAttachments = lastMsg.attachments.compactMap { att in
-                guard !att.data.isEmpty else { return nil }
+                guard !att.data.isEmpty || att.filePath != nil else { return nil }
                 return UserMessageAttachment(
                     id: att.id,
                     filename: att.filename,
                     mimeType: att.mimeType,
                     data: att.data,
                     extractedText: nil,
-                    sizeBytes: nil,
-                    thumbnailData: nil,
+                    sizeBytes: att.sizeBytes,
+                    thumbnailData: att.thumbnailData?.base64EncodedString(),
                     filePath: att.filePath
                 )
             }


### PR DESCRIPTION
## Summary
- Fixes the `guard !att.data.isEmpty` filter in `retryAfterSessionError()` to also keep file-path-based attachments (where `data` is empty but `filePath` is set)
- Passes through `sizeBytes` and `thumbnailData` from `ChatAttachment` to `UserMessageAttachment` instead of hardcoding nil

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
