### PR TITLE
fix: apply toolTokenBudget consistently across all estimation calls

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -176,9 +176,18 @@ export class AgentLoop {
     this.toolExecutor = toolExecutor ?? null;
   }
 
-  /** Estimate token cost of the tool definitions passed to the provider. */
-  getToolTokenBudget(): number {
-    return estimateToolsTokens(this.tools);
+  /**
+   * Estimate token cost of the tool definitions sent to the provider.
+   *
+   * When `history` is provided and a dynamic `resolveTools` callback
+   * exists, the budget is derived from the resolved tool list for that
+   * turn — matching what `run()` actually sends. Without `history` (or
+   * without a resolver), falls back to the static `this.tools`.
+   */
+  getToolTokenBudget(history?: Message[]): number {
+    const tools =
+      history && this.resolveTools ? this.resolveTools(history) : this.tools;
+    return estimateToolsTokens(tools);
   }
 
   async run(

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -136,6 +136,7 @@ export class ContextWindowManager {
     try {
       const estimated = estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.provider.name,
+        toolTokenBudget: this.toolTokenBudget,
       });
       const threshold = Math.floor(
         this.config.maxInputTokens * this.config.compactThreshold,
@@ -167,6 +168,7 @@ export class ContextWindowManager {
       options?.precomputedEstimate ??
       estimatePromptTokens(messages, this.systemPrompt, {
         providerName: this.provider.name,
+        toolTokenBudget: this.toolTokenBudget,
       });
     const thresholdTokens = Math.floor(
       this.config.maxInputTokens * this.config.compactThreshold,
@@ -249,6 +251,7 @@ export class ContextWindowManager {
       const estimatedAfterTruncation = didTruncate
         ? estimatePromptTokens(truncatedMessages, this.systemPrompt, {
             providerName: this.provider.name,
+            toolTokenBudget: this.toolTokenBudget,
           })
         : previousEstimatedInputTokens;
       return {
@@ -512,6 +515,7 @@ export class ContextWindowManager {
       );
       return estimatePromptTokens(projectedMessages, this.systemPrompt, {
         providerName: this.provider.name,
+        toolTokenBudget: this.toolTokenBudget,
       });
     };
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -710,7 +710,7 @@ export async function runAgentLoopImpl(
     const preflightBudget = Math.floor(providerMaxTokens * (1 - safetyMargin));
     let reducerState: ReducerState | undefined;
 
-    const toolTokenBudget = ctx.agentLoop.getToolTokenBudget();
+    const toolTokenBudget = ctx.agentLoop.getToolTokenBudget(runMessages);
     const preflightTokens = estimatePromptTokens(
       runMessages,
       ctx.systemPrompt,


### PR DESCRIPTION
## Summary
- Adds toolTokenBudget to all 6 estimatePromptTokens calls in window-manager.ts (was only in 2)
- Fixes inconsistent baselines in gain calculations and keep-boundary binary search
- Makes getToolTokenBudget() accept optional history to derive budget from resolved per-turn tools
- Addresses P1+P2 feedback from both reviewers on PR #16261

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/16261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
