### PR TITLE
fix: correct terminal ordering error message

### DIFF
--- a/assistant/src/__tests__/session-error.test.ts
+++ b/assistant/src/__tests__/session-error.test.ts
@@ -226,7 +226,7 @@ describe("classifySessionError", () => {
         expect(result.code).toBe("PROVIDER_ORDERING");
         expect(result.retryable).toBe(true);
         expect(result.userMessage).toBe(
-          "An internal error occurred. Retrying...",
+          "An internal error occurred. Please try again.",
         );
         expect(result.errorCategory).toBe("tool_ordering");
       });
@@ -257,7 +257,7 @@ describe("classifySessionError", () => {
         expect(result.code).toBe("PROVIDER_WEB_SEARCH");
         expect(result.retryable).toBe(true);
         expect(result.userMessage).toBe(
-          "An internal error occurred with web search. Retrying...",
+          "An internal error occurred with web search. Please try again.",
         );
         expect(result.errorCategory).toBe("web_search_ordering");
       });
@@ -513,7 +513,7 @@ describe("buildSessionErrorMessage", () => {
   it("includes errorCategory for ordering errors", () => {
     const msg = buildSessionErrorMessage("session-789", {
       code: "PROVIDER_ORDERING",
-      userMessage: "An internal error occurred. Retrying...",
+      userMessage: "An internal error occurred. Please try again.",
       retryable: true,
       errorCategory: "tool_ordering",
     });
@@ -525,7 +525,8 @@ describe("buildSessionErrorMessage", () => {
   it("includes errorCategory for web search errors", () => {
     const msg = buildSessionErrorMessage("session-abc", {
       code: "PROVIDER_WEB_SEARCH",
-      userMessage: "An internal error occurred with web search. Retrying...",
+      userMessage:
+        "An internal error occurred with web search. Please try again.",
       retryable: true,
       errorCategory: "web_search_ordering",
     });

--- a/assistant/src/daemon/session-error.ts
+++ b/assistant/src/daemon/session-error.ts
@@ -218,7 +218,7 @@ function classifyCore(
         return {
           code: "PROVIDER_WEB_SEARCH",
           userMessage:
-            "An internal error occurred with web search. Retrying...",
+            "An internal error occurred with web search. Please try again.",
           retryable: true,
           errorCategory: "web_search_ordering",
         };
@@ -226,7 +226,7 @@ function classifyCore(
       if (isOrderingError(message)) {
         return {
           code: "PROVIDER_ORDERING",
-          userMessage: "An internal error occurred. Retrying...",
+          userMessage: "An internal error occurred. Please try again.",
           retryable: true,
           errorCategory: "tool_ordering",
         };
@@ -308,7 +308,8 @@ function classifyByMessage(
   if (isWebSearchOrderingError(message)) {
     return {
       code: "PROVIDER_WEB_SEARCH",
-      userMessage: "An internal error occurred with web search. Retrying...",
+      userMessage:
+        "An internal error occurred with web search. Please try again.",
       retryable: true,
       errorCategory: "web_search_ordering",
     };
@@ -318,7 +319,7 @@ function classifyByMessage(
   if (isOrderingError(message)) {
     return {
       code: "PROVIDER_ORDERING",
-      userMessage: "An internal error occurred. Retrying...",
+      userMessage: "An internal error occurred. Please try again.",
       retryable: true,
       errorCategory: "tool_ordering",
     };


### PR DESCRIPTION
## Summary
- Fixes PROVIDER_ORDERING and PROVIDER_WEB_SEARCH error messages that say 'Retrying...' when used as terminal session_error
- Changes messages to 'Please try again.' which is accurate whether or not an automatic retry occurs
- Updates corresponding test expectations
- Addresses P2 feedback from PR #15882

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
