### PR TITLE
fix: update web-search test mock to use getSecureKeyAsync

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -24,7 +24,7 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 mock.module("../../../security/secure-keys.js", () => ({
-  getSecureKey: (provider: string) => {
+  getSecureKeyAsync: async (provider: string) => {
     if (provider === "brave") return mockBraveSecureKey;
     if (provider === "perplexity") return mockPerplexitySecureKey;
     return undefined;


### PR DESCRIPTION
## Summary
Fixes test breakage in web-search.test.ts where the mock exports sync getSecureKey but production code now imports getSecureKeyAsync.

Part of plan: async-secure-keys-remaining.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
