### PR TITLE
fix: restrict startup guardian request expiry to interaction-bound kinds

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -761,7 +761,7 @@ describe("canonical-guardian-store", () => {
 
   // ── expireAllPendingCanonicalRequests ───────────────────────────────
 
-  test("expireAllPendingCanonicalRequests transitions all pending to expired", () => {
+  test("expireAllPendingCanonicalRequests transitions interaction-bound pending to expired", () => {
     const req1 = createCanonicalGuardianRequest({
       kind: "tool_approval",
       sourceType: "desktop",
@@ -770,7 +770,7 @@ describe("canonical-guardian-store", () => {
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
     });
     const req2 = createCanonicalGuardianRequest({
-      kind: "tool_approval",
+      kind: "pending_question",
       sourceType: "channel",
       conversationId: "conv-bulk-2",
       guardianPrincipalId: TEST_PRINCIPAL,
@@ -782,6 +782,37 @@ describe("canonical-guardian-store", () => {
 
     expect(getCanonicalGuardianRequest(req1.id)!.status).toBe("expired");
     expect(getCanonicalGuardianRequest(req2.id)!.status).toBe("expired");
+  });
+
+  test("expireAllPendingCanonicalRequests does not expire persistent kinds (access_request, tool_grant_request)", () => {
+    const accessReq = createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      conversationId: "conv-bulk-persist-1",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+    const grantReq = createCanonicalGuardianRequest({
+      kind: "tool_grant_request",
+      sourceType: "channel",
+      conversationId: "conv-bulk-persist-2",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+    // Also create an interaction-bound request to verify selective expiry
+    const toolApproval = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "desktop",
+      conversationId: "conv-bulk-persist-3",
+      guardianPrincipalId: TEST_PRINCIPAL,
+    });
+
+    const count = expireAllPendingCanonicalRequests();
+    expect(count).toBe(1); // Only tool_approval expired
+
+    expect(getCanonicalGuardianRequest(accessReq.id)!.status).toBe("pending");
+    expect(getCanonicalGuardianRequest(grantReq.id)!.status).toBe("pending");
+    expect(getCanonicalGuardianRequest(toolApproval.id)!.status).toBe(
+      "expired",
+    );
   });
 
   test("expireAllPendingCanonicalRequests does not affect already-resolved requests", () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -177,15 +177,17 @@ export async function runDaemon(): Promise<void> {
     }
     log.info("Daemon startup: DB initialized");
 
-    // Expire any pending canonical guardian requests left over from before
-    // this process started.  Their in-memory pending-interaction session
-    // references are gone, so they can never be completed.  The agent loop
-    // will re-request tool approvals on the next turn.
+    // Expire pending interaction-bound canonical guardian requests left over
+    // from before this process started.  Their in-memory pending-interaction
+    // session references are gone, so they can never be completed.  Only
+    // interaction-bound kinds (tool_approval, pending_question) are expired;
+    // persistent kinds (access_request, tool_grant_request) remain valid
+    // across restarts.
     const expiredCount = expireAllPendingCanonicalRequests();
     if (expiredCount > 0) {
       log.info(
         { event: "startup_expired_stale_requests", expiredCount },
-        `Expired ${expiredCount} stale pending canonical request(s) from previous process`,
+        `Expired ${expiredCount} stale interaction-bound canonical request(s) from previous process`,
       );
     }
 

--- a/assistant/src/memory/canonical-guardian-store.ts
+++ b/assistant/src/memory/canonical-guardian-store.ts
@@ -7,7 +7,7 @@
  * request from the expected status wins.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { IntegrityError } from "../util/errors.js";
@@ -460,11 +460,28 @@ export function resolveCanonicalGuardianRequest(
 }
 
 /**
- * Expire all pending canonical guardian requests in a single bulk update.
+ * Request kinds whose resolution depends on the in-memory
+ * `pendingInteractions` Map. These kinds become unresolvable after a daemon
+ * restart because the Map is wiped, so they should be expired on startup.
+ *
+ * Persistent kinds (`access_request`, `tool_grant_request`) resolve without
+ * pending interactions and remain valid across restarts — they must NOT be
+ * expired here.
+ */
+const INTERACTION_BOUND_KINDS = ["tool_approval", "pending_question"];
+
+/**
+ * Expire pending interaction-bound canonical guardian requests in a single
+ * bulk update.
  *
  * Called at daemon startup to clean up requests that can never be completed
  * because the in-memory pending-interactions Map (which holds session
  * references needed by resolvers) was wiped on restart.
+ *
+ * Only expires request kinds that depend on in-memory pending interactions
+ * (`tool_approval`, `pending_question`). Persistent kinds like
+ * `access_request` and `tool_grant_request` resolve without pending
+ * interactions and remain valid across restarts.
  *
  * Returns the number of requests transitioned from pending → expired.
  */
@@ -474,7 +491,12 @@ export function expireAllPendingCanonicalRequests(): number {
 
   db.update(canonicalGuardianRequests)
     .set({ status: "expired", updatedAt: now })
-    .where(eq(canonicalGuardianRequests.status, "pending"))
+    .where(
+      and(
+        eq(canonicalGuardianRequests.status, "pending"),
+        inArray(canonicalGuardianRequests.kind, INTERACTION_BOUND_KINDS),
+      ),
+    )
     .run();
 
   return rawChanges();


### PR DESCRIPTION
## Summary
- Restricts startup expiry to only expire interaction-bound guardian request kinds (`tool_approval`, `pending_question`), not persistent ones (`access_request`, `tool_grant_request`)
- Persistent kinds resolve without in-memory pending interactions and remain valid across daemon restarts
- Addresses P1 feedback from PR #15851

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
