### PR TITLE
feat: add `mobile_pairing_enabled` macOS feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -98,6 +98,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "mobile-pairing",
+      "scope": "macos",
+      "key": "mobile_pairing_enabled",
+      "label": "Mobile Pairing",
+      "description": "Show the Mobile (iOS) pairing card in Settings > Account",
+      "defaultEnabled": false
+    },
+    {
       "id": "gmail",
       "scope": "assistant",
       "key": "feature_flags.gmail.enabled",


### PR DESCRIPTION
## Summary
- Add new macOS-scoped feature flag `mobile_pairing_enabled` (default: false) to the feature flag registry
- This flag will gate visibility of the Mobile (iOS) pairing card in Settings

Part of plan: mobile-pairing-flag-move.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
