### PR TITLE
fix: migrate remaining shared-apps callers to async loader pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -18,7 +18,8 @@ struct AppDirectoryView: View {
 
     @State private var localApps: [AppItem] = []
     @State private var sharedApps: [SharedAppItem] = []
-    @State private var pendingResponses = 0
+    @State private var fetchAppsTask: Task<Void, Never>?
+    @State private var fetchAppsGeneration = 0
 
     /// Cache of lazily-loaded preview screenshots keyed by local app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
@@ -126,6 +127,8 @@ struct AppDirectoryView: View {
         .background(VColor.surfaceBase)
         .onAppear { fetchApps() }
         .onDisappear {
+            fetchAppsTask?.cancel()
+            fetchAppsTask = nil
             for task in previewTasks.values { task.cancel() }
             previewTasks.removeAll()
         }
@@ -261,65 +264,44 @@ struct AppDirectoryView: View {
     // MARK: - Data Fetching
 
     private func fetchApps() {
+        fetchAppsTask?.cancel()
+
         isLoading = true
-        pendingResponses = 2
+        fetchAppsGeneration += 1
+        let generation = fetchAppsGeneration
 
-        Task { @MainActor in
-            // Save the previous onError handler so we can restore it once our
-            // requests complete, avoiding swallowing unrelated daemon errors.
-            let previousOnError = daemonClient.onError
-
-            daemonClient.onAppsListResponse = { response in
-                self.localApps = response.apps
-                self.pendingResponses -= 1
-                if self.pendingResponses <= 0 {
-                    daemonClient.onError = previousOnError
-                    self.buildDisplayItems()
-                    self.isLoading = false
+        let task = Task { @MainActor in
+            defer {
+                if fetchAppsGeneration == generation {
+                    fetchAppsTask = nil
                 }
             }
 
-            daemonClient.onSharedAppsListResponse = { response in
-                self.sharedApps = response.apps
-                self.pendingResponses -= 1
-                if self.pendingResponses <= 0 {
-                    daemonClient.onError = previousOnError
-                    self.buildDisplayItems()
-                    self.isLoading = false
+            async let localResult: [AppItem] = {
+                do {
+                    return try await AppsLoader.load(using: daemonClient)
+                } catch {
+                    return []
                 }
-            }
+            }()
 
-            daemonClient.onError = { error in
-                if self.isLoading {
-                    self.pendingResponses -= 1
-                    if self.pendingResponses <= 0 {
-                        daemonClient.onError = previousOnError
-                        self.buildDisplayItems()
-                        self.isLoading = false
-                    }
-                } else {
-                    previousOnError?(error)
+            async let sharedResult: [SharedAppItem] = {
+                do {
+                    return try await SharedAppsLoader.load(using: daemonClient)
+                } catch {
+                    return []
                 }
-            }
+            }()
 
-            do {
-                try daemonClient.sendAppsList()
-            } catch {
-                pendingResponses -= 1
-            }
+            let (fetchedLocal, fetchedShared) = await (localResult, sharedResult)
+            guard fetchAppsGeneration == generation else { return }
 
-            do {
-                try daemonClient.sendSharedAppsList()
-            } catch {
-                pendingResponses -= 1
-            }
-
-            if pendingResponses <= 0 {
-                daemonClient.onError = previousOnError
-                buildDisplayItems()
-                isLoading = false
-            }
+            localApps = fetchedLocal
+            sharedApps = fetchedShared
+            buildDisplayItems()
+            isLoading = false
         }
+        fetchAppsTask = task
     }
 
     /// Fetch preview for a local app when its card appears on screen.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsLoader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsLoader.swift
@@ -1,0 +1,43 @@
+import Foundation
+import VellumAssistantShared
+
+@MainActor
+enum AppsLoader {
+    enum LoadError: Error, Equatable {
+        case timedOut
+    }
+
+    static func load(
+        using daemonClient: DaemonClientProtocol,
+        timeoutNanoseconds: UInt64 = 10_000_000_000
+    ) async throws -> [AppItem] {
+        let stream = daemonClient.subscribe()
+        try daemonClient.send(AppsListRequestMessage())
+
+        return try await withThrowingTaskGroup(of: [AppItem].self) { group in
+            group.addTask {
+                for await message in stream {
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+                    if case .appsListResponse(let response) = message {
+                        return response.apps
+                    }
+                }
+
+                throw LoadError.timedOut
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                throw LoadError.timedOut
+            }
+
+            defer { group.cancelAll() }
+            guard let apps = try await group.next() else {
+                throw LoadError.timedOut
+            }
+            return apps
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -44,8 +44,8 @@ struct GeneratedPanel: View {
     @State private var showShareSheet = false
     @State private var pendingDeleteId: String?
 
-    // Track how many list responses we're waiting for
-    @State private var pendingResponses = 0
+    @State private var fetchAppsTask: Task<Void, Never>?
+    @State private var fetchAppsGeneration = 0
 
     /// Cache of lazily-loaded preview screenshots keyed by local app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
@@ -206,6 +206,8 @@ struct GeneratedPanel: View {
             fetchApps()
         }
         .onDisappear {
+            fetchAppsTask?.cancel()
+            fetchAppsTask = nil
             for task in previewTasks.values { task.cancel() }
             previewTasks.removeAll()
         }
@@ -473,62 +475,44 @@ struct GeneratedPanel: View {
     @State private var sharedApps: [SharedAppItem] = []
 
     private func fetchApps() {
+        fetchAppsTask?.cancel()
+
         isLoading = true
-        pendingResponses = 2
+        fetchAppsGeneration += 1
+        let generation = fetchAppsGeneration
 
-        Task { @MainActor in
-            daemonClient.onAppsListResponse = { response in
-                self.localApps = response.apps
-                self.pendingResponses -= 1
-                if self.pendingResponses <= 0 {
-                    self.buildDisplayItems()
-                    self.isLoading = false
+        let task = Task { @MainActor in
+            defer {
+                if fetchAppsGeneration == generation {
+                    fetchAppsTask = nil
                 }
             }
 
-            daemonClient.onSharedAppsListResponse = { response in
-                self.sharedApps = response.apps
-                self.pendingResponses -= 1
-                if self.pendingResponses <= 0 {
-                    self.buildDisplayItems()
-                    self.isLoading = false
+            async let localResult: [AppItem] = {
+                do {
+                    return try await AppsLoader.load(using: daemonClient)
+                } catch {
+                    return []
                 }
-            }
+            }()
 
-            // Handle daemon-side errors that arrive as generic `error` messages
-            // instead of typed responses — reset loading/bundling state so the UI
-            // never gets permanently stuck.
-            daemonClient.onError = { _ in
-                if self.isLoading {
-                    self.pendingResponses -= 1
-                    if self.pendingResponses <= 0 {
-                        self.buildDisplayItems()
-                        self.isLoading = false
-                    }
+            async let sharedResult: [SharedAppItem] = {
+                do {
+                    return try await SharedAppsLoader.load(using: daemonClient)
+                } catch {
+                    return []
                 }
-                if self.isBundling {
-                    self.isBundling = false
-                    self.sharingAppId = nil
-                }
-            }
+            }()
 
-            do {
-                try daemonClient.sendAppsList()
-            } catch {
-                pendingResponses -= 1
-            }
+            let (fetchedLocal, fetchedShared) = await (localResult, sharedResult)
+            guard fetchAppsGeneration == generation else { return }
 
-            do {
-                try daemonClient.sendSharedAppsList()
-            } catch {
-                pendingResponses -= 1
-            }
-
-            if pendingResponses <= 0 {
-                buildDisplayItems()
-                isLoading = false
-            }
+            localApps = fetchedLocal
+            sharedApps = fetchedShared
+            buildDisplayItems()
+            isLoading = false
         }
+        fetchAppsTask = task
     }
 
     /// Fetch preview for a local app when its row appears on screen.


### PR DESCRIPTION
## Summary
- Migrates `GeneratedPanel` and `AppDirectoryView` from the old singleton callback pattern (`daemonClient.onSharedAppsListResponse`) to the new request-scoped async loader pattern (`SharedAppsLoader` / `AppsLoader`)
- Introduces `AppsLoader` (for local apps) as a counterpart to `SharedAppsLoader`
- Uses generation tokens to guard task cleanup against clobbering, matching the pattern established in `AppsGridView`
- Removes `pendingResponses` counter and `onError` handler patching in both views

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/14764

## Test plan
- [ ] Verify Things page still loads local and shared apps correctly
- [ ] Verify GeneratedPanel loads apps without infinite loading
- [ ] Verify AppDirectoryView loads apps without infinite loading
- [ ] Test rapid view appear/disappear cycles don't cause stale state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
