### PR TITLE
fix: relax BOOTSTRAP.md completion gate criteria

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -73,8 +73,7 @@ describe("onboarding template contracts", () => {
       // User detail fields must be resolved (provided, inferred, or declined)
       expect(lower).toContain("resolved");
       expect(lower).toContain("work role");
-      expect(lower).toContain("2 suggestions shown");
-      expect(lower).toContain("selected one, deferred both");
+      expect(lower).toContain("2 suggestions from step 6");
     });
 
     test("contains refusal policy", () => {

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -66,10 +66,8 @@ Do NOT delete this file until ALL of the following are true:
 
 - You have a name (given by user or self-chosen)
 - You've figured out your vibe and adopted it
-- 2 suggestions shown (via `ui_show` or as text if UI unavailable)
-- The user selected one, deferred both, or typed an alternate direction
 
-Once every condition is met, delete this file. You're done here.
+Once every condition is met, delete this file. You're done here. If you still haven't shown the 2 suggestions from step 6, do that in the same turn before or after deleting.
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed the 2-suggestion criteria from the BOOTSTRAP.md completion gate (showing suggestions + user response)
- The gate now only requires: assistant has a name + vibe is established
- Suggestions are still encouraged in the same turn but no longer block file deletion
- Prevents re-onboarding when users start new threads before completing the suggestion step

## Original prompt
Implement JARVIS-201: Make BOOTSTRAP.md cleanup less strict. Remove the last two completion gate criteria (2 suggestions shown, user responded) so they don't block BOOTSTRAP.md deletion. Keep them as part of the onboarding flow but not as hard gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
