### PR TITLE
fix: add getSecureKeyAsync mock to browser-fill-credential tests

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -59,8 +59,11 @@ let mockGetCredentialMetadata: ReturnType<typeof mock>;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (...args: unknown[]) => mockGetSecureKey(...args),
+  getSecureKeyAsync: async (...args: unknown[]) => mockGetSecureKey(...args),
   setSecureKey: () => true,
+  setSecureKeyAsync: async () => true,
   deleteSecureKey: () => "deleted",
+  deleteSecureKeyAsync: async () => "deleted",
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},


### PR DESCRIPTION
## Summary
Fixes 7 test failures in browser-fill-credential.test.ts where the mock only exports sync getSecureKey but broker.browserFill now calls getSecureKeyAsync.

Part of plan: async-secure-keys-remaining.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
