### PR TITLE
fix: bump Sentry maxAttachmentSize to 100 MB for larger log archives

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -212,6 +212,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
                 profilingOptions.sessionSampleRate = perfOptIn ? 1.0 : 0
             }
             options.sendDefaultPii = false
+            options.maxAttachmentSize = MetricKitManager.sentryMaxAttachmentSize
         }
         SentryDeviceInfo.configureSentryScope()
 

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -55,6 +55,12 @@ import os
         let name: String?
     }
 
+    /// Maximum Sentry attachment size (100 MB). The SDK default is 20 MB,
+    /// but workspace files included in log archives can exceed that. Sentry's
+    /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
+    /// provides sufficient headroom.
+    static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
+
     /// Default DSN for the macOS app Sentry project.
     static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
     /// DSN for the assistant/brain Sentry project.
@@ -99,6 +105,7 @@ import os
                     options.sendDefaultPii = false
                     options.enableCrashHandler = false
                     options.enableAutoSessionTracking = false
+                    options.maxAttachmentSize = sentryMaxAttachmentSize
                 }
                 SentryDeviceInfo.configureSentryScope()
             }
@@ -199,6 +206,7 @@ import os
                 profilingOptions.sessionSampleRate = perfOptIn ? 1.0 : 0
             }
             options.sendDefaultPii = false
+            options.maxAttachmentSize = sentryMaxAttachmentSize
         }
         SentryDeviceInfo.configureSentryScope()
     }

--- a/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
+++ b/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Vellum
+
+final class SentryMaxAttachmentSizeTests: XCTestCase {
+    func testSentryMaxAttachmentSizeIs100MB() {
+        let expectedSize: UInt = 100 * 1024 * 1024  // 100 MB
+        XCTAssertEqual(
+            MetricKitManager.sentryMaxAttachmentSize,
+            expectedSize,
+            "Sentry maxAttachmentSize should be 100 MB to accommodate workspace file exports"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Bump Sentry SDK `maxAttachmentSize` from 20 MB default to 100 MB in both `SentrySDK.start` call sites
- Needed because workspace files are being added to log archives, potentially exceeding the old 20 MB limit
- Sentry server-side limits (200 MB uncompressed / 40 MB compressed) provide sufficient headroom

Part of plan: export-workspace-secret-warning.md (PR 3 of 4)
Part of JARVIS-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
