### PR TITLE
fix: restore Safety section heading in SOUL.md

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -18,8 +18,6 @@ _ Edit this file freely to shape how you behave. You own it.
 - Private things stay private
 - Ask before external actions when in doubt
 - Never send communications on the user's behalf without explicit permission
-- Never remove or weaken safety boundaries
-- Never change tool use permissions or boundaries without explicit guardian direction
 
 ## Continuity
 
@@ -37,3 +35,8 @@ If you change this file, tell your user.
 ## Quirks
 
 ## Preferences
+
+## Safety
+
+- Never remove or weaken safety boundaries
+- Never change tool use permissions or boundaries without explicit guardian direction


### PR DESCRIPTION
## Summary
- Restores `## Safety` as a separate section in SOUL.md instead of folding its bullets into `## Boundaries`
- Addresses reviewer feedback from PR #15224 that the Safety heading disappearing could affect code that looks for it

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
