### PR TITLE
fix: preserve trust context when restoring evicted sessions

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -538,6 +538,22 @@ export class DaemonServer {
         );
         newSession.updateClient(sendToClient, true);
         await newSession.loadFromDb();
+        // Restore trust/auth context and assistant ID from stored options so
+        // that evicted sessions rehydrated by undo/regenerate don't run with
+        // unscoped history.  Without this, an untrusted actor could operate
+        // on the full conversation after eviction.
+        if (storedOptions?.assistantId) {
+          newSession.setAssistantId(storedOptions.assistantId);
+        }
+        if (storedOptions?.trustContext) {
+          newSession.setTrustContext(storedOptions.trustContext);
+        }
+        if (storedOptions?.authContext) {
+          newSession.setAuthContext(storedOptions.authContext);
+        }
+        if (storedOptions?.trustContext || storedOptions?.authContext) {
+          await newSession.ensureActorScopedHistory();
+        }
         this.applyTransportMetadata(newSession, storedOptions);
         this.sessions.set(conversationId, newSession);
         return newSession;


### PR DESCRIPTION
## Summary
- Restores trust/auth context and assistant ID from stored session options when rehydrating evicted sessions in `getOrCreateSession`
- Calls `ensureActorScopedHistory()` after restoring context so history is properly trust-scoped
- Prevents untrusted actors from operating on full conversation history after session eviction during undo/regenerate

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15958

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
