### PR TITLE
feat: collapse Video Domain Allowlist behind VDisclosureSection accordion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -9,6 +9,7 @@ struct SettingsAppearanceTab: View {
     var afterTimezone: AnyView? = nil
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
+    @State private var isVideoDomainsExpanded: Bool = false
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
     @State private var shortcutMonitor: Any?
@@ -296,49 +297,52 @@ struct SettingsAppearanceTab: View {
                 if store.mediaEmbedsEnabled {
                     SettingsDivider()
 
-                    Text("Video Domain Allowlist")
-                        .font(VFont.bodyBold)
-                        .foregroundColor(VColor.contentDefault)
+                    VDisclosureSection(
+                        title: "Video Domain Allowlist",
+                        isExpanded: $isVideoDomainsExpanded
+                    ) {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                                Text("Add Domain")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.contentTertiary)
 
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Add Domain")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.contentTertiary)
+                                HStack(spacing: VSpacing.sm) {
+                                    TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
+                                        .vInputStyle()
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.contentDefault)
+                                        .onSubmit {
+                                            addAllowlistDomain()
+                                        }
 
-                        HStack(spacing: VSpacing.sm) {
-                            TextField("Add domain (e.g. example.com)", text: $newAllowlistDomain)
-                                .vInputStyle()
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentDefault)
-                                .onSubmit {
-                                    addAllowlistDomain()
+                                    VButton(label: "Add", style: .primary, isDisabled: newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                                        addAllowlistDomain()
+                                    }
                                 }
+                            }
 
-                            VButton(label: "Add", style: .primary, isDisabled: newAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                                addAllowlistDomain()
+                            ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
+                                HStack {
+                                    Text(domain)
+                                        .font(VFont.body)
+                                        .foregroundColor(VColor.contentDefault)
+                                        .textSelection(.enabled)
+                                    Spacer()
+                                    VButton(label: "Remove domain", iconOnly: VIcon.trash.rawValue, style: .danger) {
+                                        var domains = store.mediaEmbedVideoAllowlistDomains
+                                        domains.removeAll { $0 == domain }
+                                        store.setMediaEmbedVideoAllowlistDomains(domains)
+                                    }
+                                }
+                                .padding(.horizontal, VSpacing.md)
+                                .padding(.vertical, VSpacing.sm)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: VRadius.lg)
+                                        .strokeBorder(VColor.borderBase, lineWidth: 1)
+                                )
                             }
                         }
-                    }
-
-                    ForEach(store.mediaEmbedVideoAllowlistDomains, id: \.self) { domain in
-                        HStack {
-                            Text(domain)
-                                .font(VFont.body)
-                                .foregroundColor(VColor.contentDefault)
-                                .textSelection(.enabled)
-                            Spacer()
-                            VButton(label: "Remove domain", iconOnly: VIcon.trash.rawValue, style: .danger) {
-                                var domains = store.mediaEmbedVideoAllowlistDomains
-                                domains.removeAll { $0 == domain }
-                                store.setMediaEmbedVideoAllowlistDomains(domains)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .strokeBorder(VColor.borderBase, lineWidth: 1)
-                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Wraps the Video Domain Allowlist section in `VDisclosureSection`, collapsed by default
- Keeps the Media Embeds settings card compact while preserving all existing domain management functionality
- Uses the existing design system accordion component — no new primitives

Part of plan: allowlist-accordion.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
