### PR TITLE
fix: propagate error status in server_tool_complete events

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -79,7 +79,7 @@ export type AgentEvent =
       toolUseId: string;
       input: Record<string, unknown>;
     }
-  | { type: "server_tool_complete"; toolUseId: string }
+  | { type: "server_tool_complete"; toolUseId: string; isError: boolean }
   | { type: "error"; error: Error }
   | {
       type: "usage";
@@ -324,6 +324,7 @@ export class AgentLoop {
                 onEvent({
                   type: "server_tool_complete",
                   toolUseId: event.toolUseId,
+                  isError: event.isError,
                 });
               }
             },

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -865,7 +865,7 @@ export async function dispatchAgentEvent(
         type: "tool_result",
         toolName: "",
         result: "",
-        isError: false,
+        isError: event.isError,
         sessionId: deps.ctx.conversationId,
         toolUseId: event.toolUseId,
       });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -107,7 +107,6 @@ function buildSyntheticToolResult(
   };
 }
 
-
 /**
  * Collect ordered IDs of client-side tool_use blocks only.
  * Server-side tools (server_tool_use / web_search_tool_result) are self-paired
@@ -228,7 +227,10 @@ function normalizeFollowingUserContent(
     toolResultPrefix: orderedResults,
     remainingContent: remaining,
     missingIds,
-    hadOrderedPrefix: hasOrderedToolResultPrefix(nextContent, orderedToolUseIds),
+    hadOrderedPrefix: hasOrderedToolResultPrefix(
+      nextContent,
+      orderedToolUseIds,
+    ),
   };
 }
 
@@ -712,20 +714,26 @@ export class AnthropicProvider implements Provider {
               type: "server_tool_start",
               name: event.content_block.name,
               toolUseId: event.content_block.id,
-              input: (
-                event.content_block as { input?: Record<string, unknown> }
-              ).input ?? {},
+              input:
+                (event.content_block as { input?: Record<string, unknown> })
+                  .input ?? {},
             });
           }
           if (
             event.type === "content_block_start" &&
             event.content_block.type === "web_search_tool_result"
           ) {
+            const block = event.content_block as {
+              tool_use_id: string;
+              content?: { type: "web_search_tool_result_error" } | unknown[];
+            };
+            const isError =
+              !Array.isArray(block.content) &&
+              block.content?.type === "web_search_tool_result_error";
             onEvent?.({
               type: "server_tool_complete",
-              toolUseId: (
-                event.content_block as { tool_use_id: string }
-              ).tool_use_id,
+              toolUseId: block.tool_use_id,
+              isError: !!isError,
             });
           }
           if (event.type === "content_block_stop") {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -123,7 +123,7 @@ export type ProviderEvent =
       toolUseId: string;
       input: Record<string, unknown>;
     }
-  | { type: "server_tool_complete"; toolUseId: string };
+  | { type: "server_tool_complete"; toolUseId: string; isError: boolean };
 
 export interface SendMessageConfig {
   model?: string;


### PR DESCRIPTION
## Summary
- Adds `isError` field to `server_tool_complete` provider event type
- Derives error status from Anthropic `web_search_tool_result` content block (checks for `web_search_tool_result_error` type)
- Propagates `isError` through the agent loop into the daemon handler instead of hardcoding `false`
- Failed native web-search completions now correctly surface as errors in the desktop tool-chip UI

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/16036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
