### PR TITLE
fix: accept HTTP 201 in attachment upload response

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1619,7 +1619,7 @@ public final class HTTPTransport {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else { return .transientFailure }
 
-            if http.statusCode == 200 {
+            if http.statusCode == 200 || http.statusCode == 201 {
                 let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
                 if let id = json?["id"] as? String {
                     return .success(id: id)


### PR DESCRIPTION
## Summary
- Widens the success status check in `uploadAttachment` from `200` only to `200 || 201`, matching standard REST conventions
- The direct runtime server returns 200, but the platform proxy (Django/DRF) may return 201 Created for resource creation
- Addresses remaining reviewer feedback from PR #14930 (Devin review thread about `uploadAttachment` only accepting HTTP 200)

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/14930

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
