### PR TITLE
feat: move mobile pairing card above Theme, gate behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -6,7 +6,6 @@ struct SettingsAppearanceTab: View {
     private static let knownTimezones: [String] = TimeZone.knownTimeZoneIdentifiers.sorted()
 
     @ObservedObject var store: SettingsStore
-    var afterTimezone: AnyView? = nil
     @AppStorage("themePreference") private var themePreference: String = "system"
     @State private var newAllowlistDomain = ""
     @State private var isRecordingGlobalHotkey = false
@@ -183,8 +182,6 @@ struct SettingsAppearanceTab: View {
                     selectedTimezone = mapped
                 }
             }
-
-            if let afterTimezone { afterTimezone }
 
             // KEYBOARD SHORTCUTS section
             SettingsCard(title: "Keyboard Shortcuts") {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -14,7 +14,10 @@ struct SettingsGeneralTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             accountSection
-            SettingsAppearanceTab(store: store, afterTimezone: AnyView(mobilePairingCard))
+            if MacOSClientFeatureFlagManager.shared.isEnabled("mobile_pairing_enabled") {
+                mobilePairingCard
+            }
+            SettingsAppearanceTab(store: store)
         }
         .onAppear {
             Task { await authManager.checkSession() }


### PR DESCRIPTION
## Summary
- Move the Mobile (iOS) pairing card from inside SettingsAppearanceTab (afterTimezone injection) to SettingsGeneralTab, positioned between Account and Appearance sections
- Gate the pairing card behind the `mobile_pairing_enabled` macOS feature flag (hidden by default)
- Remove the now-unused `afterTimezone` parameter from SettingsAppearanceTab

Part of plan: mobile-pairing-flag-move.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
