### PR TITLE
fix: address review feedback from PR #16115

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1099,7 +1099,7 @@ describe("Trust Store", () => {
 
     // ── default allow: browser tools ────────────────────────────
 
-    test("all 10 browser tools have default allow rules", () => {
+    test("all 14 browser tools have default allow rules", () => {
       const templates = getDefaultRuleTemplates();
       const browserTools = [
         "browser_navigate",
@@ -1109,8 +1109,12 @@ describe("Trust Store", () => {
         "browser_click",
         "browser_type",
         "browser_press_key",
+        "browser_scroll",
+        "browser_select_option",
+        "browser_hover",
         "browser_wait_for",
         "browser_extract",
+        "browser_wait_for_download",
         "browser_fill_credential",
       ];
 


### PR DESCRIPTION
## Summary
- Fixes stale browser tools test count: updates from 10 to 14 tools to match `BROWSER_TOOLS_NO_SLASH` array in defaults.ts
- Adds missing browser tools to test array: `browser_scroll`, `browser_select_option`, `browser_hover`, `browser_wait_for_download`
- The Codex P2 concern (restrict auto-allow to trusted binary) was already addressed by PR #16116 (reverted the host_bash allow rule) and PR #16436 (added subcommand-level risk classification)

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/16115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
