### PR TITLE
fix: address review feedback from PR #14579

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1020,7 +1020,6 @@ jobs:
           fi
           DAEMON_FLAGS+=(--define "process.env.COMMIT_SHA='${{ github.sha }}'")
 
-
           # Daemon
           (cd "$ASSISTANT_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
           mkdir -p daemon-bin

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -76,7 +76,7 @@ describe("buildStarterTaskPlaybookSection", () => {
     const section = buildStarterTaskPlaybookSection();
     expect(section).toContain("### Playbook: make_it_yours");
     expect(section).toContain("accent color");
-    expect(section).toContain("Dashboard Color Preference");
+    expect(section).toContain("Color Preference");
     expect(section).toContain("user_selected");
   });
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -309,7 +309,7 @@ export function buildStarterTaskPlaybookSection(): string {
     '3. Let the user pick one. Accept color names, hex values, or descriptions (e.g. "something warm").',
     '4. Confirm the selection: "I\'ll set your accent color to **{label}** ({hex}). Sound good?"',
     "5. On confirmation:",
-    '   - Use `app_file_edit` to update the `## Dashboard Color Preference` section in USER.md with `label`, `hex`, `source: "user_selected"`, and `applied: true`.',
+    '   - Use `app_file_edit` to update the `## Color Preference` section in USER.md with `label`, `hex`, and `source: "user_selected"`.',
     "   - Use `app_file_edit` to update the `## Onboarding Tasks` section: set `make_it_yours` to `done`.",
     "6. If the user declines or wants to skip, set `make_it_yours` to `skipped` in USER.md and move on.",
     "",


### PR DESCRIPTION
## Summary
- Addresses reviewer feedback from PR #14579 (Remove Home Base backend core)
- Removes stale `Dashboard` prefix from `Color Preference` section name in make_it_yours playbook
- Removes misleading `applied: true` field from color preference instruction (nothing to apply post Home Base removal)
- Fixes extra blank line in release.yml left behind by Home Base prebuilt removal
- Updates test assertion to match renamed section

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/14579

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
