### PR TITLE
fix: correct email-setup SKILL.md field references from PR #12623 review

### DIFF
--- a/skills/email-setup/SKILL.md
+++ b/skills/email-setup/SKILL.md
@@ -24,7 +24,7 @@ Before doing anything, check whether you already have an email address configure
 assistant email status
 ```
 
-Inspect `addresses` in the response. If at least one address exists, tell the user the existing address and stop — do NOT create another one.
+Inspect `health.inboxes` in the response. If at least one inbox exists, tell the user the existing address and stop — do NOT create another one.
 
 ## Step 2: Create Your Email
 
@@ -44,7 +44,7 @@ Use the returned `inbox.address` (or `inbox.id` if `address` is empty) as the cr
 assistant email status
 ```
 
-Confirm the created inbox appears in `addresses`.
+Confirm the created inbox appears in `health.inboxes`.
 
 ## Step 4: Confirm Setup
 


### PR DESCRIPTION
## Summary
- Fixed `email-setup/SKILL.md` to reference `health.inboxes` instead of `addresses` when inspecting `assistant email status` output, matching the actual `ProviderHealth` type returned by the service

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/12623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
