### PR TITLE
fix: address review feedback from PR #16116

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1099,7 +1099,7 @@ describe("Trust Store", () => {
 
     // ── default allow: browser tools ────────────────────────────
 
-    test("all 10 browser tools have default allow rules", () => {
+    test("all 14 browser tools have default allow rules", () => {
       const templates = getDefaultRuleTemplates();
       const browserTools = [
         "browser_navigate",
@@ -1109,8 +1109,12 @@ describe("Trust Store", () => {
         "browser_click",
         "browser_type",
         "browser_press_key",
+        "browser_scroll",
+        "browser_select_option",
+        "browser_hover",
         "browser_wait_for",
         "browser_extract",
+        "browser_wait_for_download",
         "browser_fill_credential",
       ];
 

--- a/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/prompts/__tests__/build-cli-reference-section.test.ts
@@ -29,7 +29,7 @@ describe("buildCliReferenceSection", () => {
 
   test("mentions bash as the way to invoke the CLI", () => {
     const result = buildCliReferenceSection();
-    expect(result).toContain("available via `bash`");
+    expect(result).toContain("use the `bash` tool");
   });
 
   test("routes account and auth work through documented assistant CLI commands", () => {


### PR DESCRIPTION
## Summary
- Fix test expectation mismatch in `build-cli-reference-section.test.ts` after CLI prompt wording change (Codex P2 feedback)
- Update browser tools test to cover all 14 browser tools instead of stale count of 10 (Devin feedback)

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/16116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
