### PR TITLE
fix: ensure main window exists before creating schedule/task threads

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -211,6 +211,7 @@ extension AppDelegate {
         // the user sees them in the sidebar without restarting the app.
         daemonClient.onTaskRunThreadCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
+            self.ensureMainWindowExists()
             self.mainWindow?.threadManager.createTaskRunThread(
                 conversationId: msg.conversationId,
                 workItemId: msg.workItemId,
@@ -221,6 +222,7 @@ extension AppDelegate {
         // Schedule threads — created when the scheduler fires and creates a conversation.
         daemonClient.onScheduleThreadCreated = { [weak self] msg in
             guard let self, !self.isBootstrapping else { return }
+            self.ensureMainWindowExists()
             self.mainWindow?.threadManager.createScheduleThread(
                 conversationId: msg.conversationId,
                 scheduleJobId: msg.scheduleJobId,


### PR DESCRIPTION
## Summary

- `onScheduleThreadCreated` and `onTaskRunThreadCreated` in `AppDelegate+DaemonSetup.swift` silently dropped events when the app was backgrounded because `mainWindow` was `nil`
- Added `ensureMainWindowExists()` calls matching the pattern already used by `handleNotificationThreadCreated()`
- This was the root cause of scheduled reminders/cron tasks never showing UI updates or triggering notifications

## Root Cause

The macOS app is a menu bar (`LSUIElement`) app. The main window is lazily created — it's `nil` when the app is in the background/dock. Both handlers used optional chaining (`self.mainWindow?.threadManager.createScheduleThread(...)`) which silently no-ops when `mainWindow` is `nil`. The event is received via SSE but the thread is never created client-side.

The `handleNotificationThreadCreated` handler (added later) correctly calls `ensureMainWindowExists()` first, but the schedule/task handlers were never updated to match.

## Test plan

- [ ] Create a recurring cron schedule (e.g. "remind me to drink water every minute")
- [ ] Close the main window so the app is only in the menu bar
- [ ] Wait for the schedule to fire
- [ ] Verify the thread appears in the sidebar and a notification is delivered
- [ ] Repeat with a one-shot task run schedule

Closes JARVIS-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
