### PR TITLE
fix: address overflow recovery feedback from PR #15918

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1047,6 +1047,7 @@ export async function runAgentLoopImpl(
             ),
         });
         preRepairMessages = updatedHistory;
+        preRunHistoryLength = updatedHistory.length;
       }
       if (!reducerState) {
         reducerState = createInitialReducerState();
@@ -1127,12 +1128,6 @@ export async function runAgentLoopImpl(
         ctx.messages = step.messages;
         currentInjectionMode = step.state.injectionMode;
 
-        // If the reducer is now exhausted without compacting, break out
-        // so the overflow policy path can attempt emergency compaction.
-        if (reducerState.exhausted && !step.compactionResult?.compacted) {
-          break;
-        }
-
         if (step.compactionResult?.compacted) {
           ctx.contextCompactedMessageCount +=
             step.compactionResult.compactedPersistedMessages;
@@ -1186,77 +1181,10 @@ export async function runAgentLoopImpl(
         );
       }
 
-      // When all reducer tiers are exhausted but the context is still too
-      // large, attempt one last emergency compaction before consulting the
-      // overflow policy. This covers the case where progress was made
-      // (messages grew) and the normal tiers couldn't compact enough.
-      if (state.contextTooLargeDetected && reducerState.exhausted) {
-        const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
-          ctx.messages,
-          abortController.signal,
-          {
-            lastCompactedAt: ctx.contextCompactedAt ?? undefined,
-            force: true,
-            minKeepRecentUserTurns: 0,
-            targetInputTokensOverride: correctedTarget,
-          },
-        );
-        if (emergencyCompact.compacted) {
-          ctx.messages = emergencyCompact.messages;
-          ctx.contextCompactedMessageCount +=
-            emergencyCompact.compactedPersistedMessages;
-          ctx.contextCompactedAt = Date.now();
-          updateConversationContextWindow(
-            ctx.conversationId,
-            emergencyCompact.summaryText,
-            ctx.contextCompactedMessageCount,
-          );
-          onEvent({
-            type: "context_compacted",
-            previousEstimatedInputTokens:
-              emergencyCompact.previousEstimatedInputTokens,
-            estimatedInputTokens: emergencyCompact.estimatedInputTokens,
-            maxInputTokens: emergencyCompact.maxInputTokens,
-            thresholdTokens: emergencyCompact.thresholdTokens,
-            compactedMessages: emergencyCompact.compactedMessages,
-            summaryCalls: emergencyCompact.summaryCalls,
-            summaryInputTokens: emergencyCompact.summaryInputTokens,
-            summaryOutputTokens: emergencyCompact.summaryOutputTokens,
-            summaryModel: emergencyCompact.summaryModel,
-          });
-          emitUsage(
-            ctx,
-            emergencyCompact.summaryInputTokens,
-            emergencyCompact.summaryOutputTokens,
-            emergencyCompact.summaryModel,
-            onEvent,
-            "context_compactor",
-            reqId,
-            emergencyCompact.summaryCacheCreationInputTokens ?? 0,
-            emergencyCompact.summaryCacheReadInputTokens ?? 0,
-            collapseRawResponses(emergencyCompact.summaryRawResponses),
-          );
-
-          runMessages = applyRuntimeInjections(ctx.messages, {
-            ...injectionOpts,
-            mode: currentInjectionMode,
-          });
-          preRepairMessages = runMessages;
-          preRunHistoryLength = runMessages.length;
-          state.contextTooLargeDetected = false;
-
-          updatedHistory = await ctx.agentLoop.run(
-            runMessages,
-            eventHandler,
-            abortController.signal,
-            reqId,
-            onCheckpoint,
-          );
-        }
-      }
-
       // All reducer tiers exhausted but provider still rejects —
       // consult the overflow policy for latest-turn compression.
+      // Emergency compaction is deferred to the policy-gated paths below
+      // so that `request_user_approval` sessions collect consent first.
       if (state.contextTooLargeDetected) {
         const action = resolveOverflowAction({
           overflowRecovery,


### PR DESCRIPTION
## Summary
- Fix message duplication: update preRunHistoryLength when incorporating progress messages, preventing ctx.messages corruption when recovery paths fail
- Fix approval gate bypass: remove standalone emergency compaction that ran before resolveOverflowAction(), ensuring request_user_approval sessions collect consent first
- Fix injection downgrade skip: remove early break on exhausted+no-compaction that prevented the injection_downgrade tier from being retried with downgraded injection mode

## Original PR
https://github.com/vellum-ai/vellum-assistant/pull/15918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
