### PR TITLE
feat: write workspace files from daemon export into log archive

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -16,6 +16,7 @@ private let log = Logger(
 /// - `~/Library/Application Support/vellum-assistant/logs/`  — per-session JSON logs
 /// - `~/Library/Application Support/vellum-assistant/debug-state.json` — live debug snapshot (includes session error debug details)
 /// - Daemon logs, audit data, and sanitized config via `POST /v1/export` gateway HTTP API
+/// - Workspace files via `POST /v1/export` — full workspace contents (config, skills, prompts, hooks, DB dump, logs)
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys
@@ -399,6 +400,25 @@ enum LogExporter {
                     options: [.prettyPrinted, .sortedKeys]
                 ) {
                     try? configData.write(to: directory.appendingPathComponent("config-snapshot.json"))
+                }
+            }
+
+            // Write workspace files into a workspace/ subdirectory
+            if let workspaceFiles = json["workspaceFiles"] as? [String: String] {
+                let workspaceDir = directory.appendingPathComponent("workspace", isDirectory: true)
+                try? FileManager.default.createDirectory(at: workspaceDir, withIntermediateDirectories: true)
+                for (relativePath, content) in workspaceFiles {
+                    // Prevent directory traversal — reject paths containing ".."
+                    let components = (relativePath as NSString).pathComponents
+                    guard !components.contains("..") else {
+                        log.warning("Skipping workspace file with path traversal: \(relativePath)")
+                        continue
+                    }
+                    let fileURL = workspaceDir.appendingPathComponent(relativePath)
+                    // Create intermediate directories for nested paths
+                    let parentDir = fileURL.deletingLastPathComponent()
+                    try? FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+                    try? content.write(to: fileURL, atomically: true, encoding: .utf8)
                 }
             }
         } catch {


### PR DESCRIPTION
## Summary
- Consume new `workspaceFiles` field from daemon `POST /v1/export` response
- Write workspace files into `workspace/` subdirectory of the log archive
- Sanitize paths to prevent directory traversal
- Update LogExporter doc comment to list workspace files as a log source

Part of plan: export-workspace-secret-warning.md (PR 2 of 4)
Closes JARVIS-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
