### PR TITLE
fix: skip config.json, symlinks, and add size cap in workspace export

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -11,6 +11,7 @@ import {
   mkdtempSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -130,6 +131,21 @@ writeFileSync(
   Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f]), // contains null byte
 );
 
+// config.json at workspace root — should be skipped (secrets, already in configSnapshot)
+writeFileSync(
+  join(testWorkspaceDir, "config.json"),
+  JSON.stringify({ apiKeys: { anthropic: "sk-secret-key" } }),
+);
+
+// Symlink pointing outside workspace — should be skipped
+const outsideFile = join(testDir, "outside-secret.txt");
+writeFileSync(outsideFile, "sensitive data outside workspace");
+try {
+  symlinkSync(outsideFile, join(testWorkspaceDir, "sneaky-link.txt"));
+} catch {
+  // Symlink creation may fail on some platforms; tests will still pass
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -186,6 +202,22 @@ describe("POST /v1/export — workspace files", () => {
       workspaceFiles: Record<string, string>;
     };
     expect(body.workspaceFiles["binary-file.dat"]).toBeUndefined();
+  });
+
+  test("excludes config.json at workspace root", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    expect(body.workspaceFiles["config.json"]).toBeUndefined();
+  });
+
+  test("skips symlinks", async () => {
+    const res = await callExport();
+    const body = (await res.json()) as {
+      workspaceFiles: Record<string, string>;
+    };
+    expect(body.workspaceFiles["sneaky-link.txt"]).toBeUndefined();
   });
 
   test("response includes workspaceFiles field", async () => {

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -7,7 +7,13 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
 import { join, relative } from "node:path";
 
 import { desc } from "drizzle-orm";
@@ -126,20 +132,31 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
 /** Directory prefixes to skip when collecting workspace files. */
 const WORKSPACE_SKIP_DIRS = new Set(["embedding-models", "data/qdrant"]);
 
+/** Files at the workspace root to skip (already covered by sanitized fields). */
+const WORKSPACE_SKIP_ROOT_FILES = new Set(["config.json"]);
+
+/** Maximum cumulative size for workspace file contents (10 MB). */
+const MAX_WORKSPACE_PAYLOAD_BYTES = 10 * 1024 * 1024;
+
 /**
  * Recursively collects files from the workspace directory into a
  * `Record<string, string>` map of relative path to content.
  *
+ * - Skips `config.json` at the workspace root (already exported as a
+ *   sanitized `configSnapshot`; the raw file contains secrets).
+ * - Skips symlinks to prevent reading files outside the workspace.
  * - Skips directories in `WORKSPACE_SKIP_DIRS`.
  * - For `.db` files, shells out to `sqlite3 <path> .dump` and stores the
  *   SQL text output with a `.sql` suffix appended to the key.
  * - Skips binary files (detected via null-byte heuristic).
+ * - Stops collecting once `MAX_WORKSPACE_PAYLOAD_BYTES` is reached.
  */
 function collectWorkspaceFiles(): Record<string, string> {
   const wsDir = getWorkspaceDir();
   if (!existsSync(wsDir)) return {};
 
   const result: Record<string, string> = {};
+  let totalBytes = 0;
 
   function walk(dir: string): void {
     let entries: string[];
@@ -162,13 +179,26 @@ function collectWorkspaceFiles(): Record<string, string> {
         continue;
       }
 
+      // Skip root-level files that are already exported separately
+      if (dir === wsDir && WORKSPACE_SKIP_ROOT_FILES.has(entry)) {
+        continue;
+      }
+
       try {
-        const stat = statSync(fullPath);
+        // Use lstatSync to avoid following symlinks
+        const stat = lstatSync(fullPath);
+
+        // Skip symlinks — they could point outside the workspace
+        if (stat.isSymbolicLink()) continue;
+
         if (stat.isDirectory()) {
           walk(fullPath);
           continue;
         }
         if (!stat.isFile()) continue;
+
+        // Enforce cumulative size cap
+        if (totalBytes + stat.size > MAX_WORKSPACE_PAYLOAD_BYTES) continue;
 
         // SQLite DB handling: dump as SQL text
         if (entry.endsWith(".db")) {
@@ -182,6 +212,7 @@ function collectWorkspaceFiles(): Record<string, string> {
                   ? proc.stdout.toString("utf-8")
                   : String(proc.stdout);
               result[relPath + ".sql"] = output;
+              totalBytes += Buffer.byteLength(output, "utf-8");
             }
           } catch {
             // Skip if dump fails
@@ -193,6 +224,7 @@ function collectWorkspaceFiles(): Record<string, string> {
         const content = readFileSync(fullPath, "utf-8");
         if (content.includes("\0")) continue;
         result[relPath] = content;
+        totalBytes += stat.size;
       } catch {
         // Skip unreadable files
       }


### PR DESCRIPTION
## Summary
- Skip `config.json` at workspace root to prevent leaking secrets (already covered by sanitized `configSnapshot`)
- Use `lstatSync` and skip symlinks to prevent reading files outside workspace
- Add cumulative size tracking with a cap, matching the pattern used for log files

Fixes gaps identified during plan review for export-workspace-secret-warning.md.

Part of JARVIS-202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
