### PR TITLE
fix: guard watch-mode restart behind source availability

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -3,7 +3,11 @@ import { join } from "path";
 
 import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
-import { startLocalDaemon, startGateway } from "../lib/local";
+import {
+  isWatchModeAvailable,
+  startLocalDaemon,
+  startGateway,
+} from "../lib/local";
 import { maybeStartNgrokTunnel } from "../lib/ngrok";
 
 export async function wake(): Promise<void> {
@@ -56,12 +60,21 @@ export async function wake(): Promise<void> {
         process.kill(pid, 0);
         daemonRunning = true;
         if (watch) {
-          // Restart in watch mode
-          console.log(
-            `Assistant running (pid ${pid}) — restarting in watch mode...`,
-          );
-          await stopProcessByPidFile(pidFile, "assistant");
-          daemonRunning = false;
+          // Restart in watch mode — but only if source files are available.
+          // Watch mode requires bun --watch with .ts sources; packaged desktop
+          // builds only have a compiled binary. Stopping the daemon without a
+          // viable watch-mode path would leave the user with no running assistant.
+          if (!isWatchModeAvailable()) {
+            console.log(
+              `Assistant running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
+            );
+          } else {
+            console.log(
+              `Assistant running (pid ${pid}) — restarting in watch mode...`,
+            );
+            await stopProcessByPidFile(pidFile, "assistant");
+            daemonRunning = false;
+          }
         } else {
           console.log(`Assistant already running (pid ${pid}).`);
         }
@@ -82,12 +95,18 @@ export async function wake(): Promise<void> {
     const { alive, pid } = isProcessAlive(gatewayPidFile);
     if (alive) {
       if (watch) {
-        // Restart in watch mode
-        console.log(
-          `Gateway running (pid ${pid}) — restarting in watch mode...`,
-        );
-        await stopProcessByPidFile(gatewayPidFile, "gateway");
-        await startGateway(watch, resources);
+        // Same guard as the daemon: only restart if watch mode is viable.
+        if (!isWatchModeAvailable()) {
+          console.log(
+            `Gateway running (pid ${pid}) — watch mode not available (no source files). Keeping existing process.`,
+          );
+        } else {
+          console.log(
+            `Gateway running (pid ${pid}) — restarting in watch mode...`,
+          );
+          await stopProcessByPidFile(gatewayPidFile, "gateway");
+          await startGateway(watch, resources);
+        }
       } else {
         console.log(`Gateway already running (pid ${pid}).`);
       }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -715,6 +715,20 @@ export function getLocalLanIPv4(): string | undefined {
   return undefined;
 }
 
+/**
+ * Check whether watch-mode startup is possible. Watch mode requires source
+ * files (bun --watch only works with .ts sources, not compiled binaries).
+ * Returns true when assistant source can be resolved, false otherwise.
+ *
+ * Use this before stopping a running assistant for a watch-mode restart — if
+ * watch mode isn't available (e.g. packaged desktop app without source), the
+ * caller should keep the existing process alive rather than killing it and
+ * failing.
+ */
+export function isWatchModeAvailable(): boolean {
+  return resolveAssistantIndexPath() !== undefined;
+}
+
 // NOTE: startLocalDaemon() is the CLI-side daemon lifecycle manager.
 // It should eventually converge with
 // assistant/src/daemon/daemon-control.ts::startDaemon which is the


### PR DESCRIPTION
## Summary
- Adds `isWatchModeAvailable()` helper to `cli/src/lib/local.ts` that checks whether assistant source files can be resolved
- Guards both daemon and gateway watch-mode restarts in `cli/src/commands/wake.ts` — if source isn't available, keeps the existing process running with a warning instead of stopping it and failing
- Fixes the scenario where a packaged desktop app (compiled binary only) would lose its running assistant when `--watch` was requested

Addresses feedback from #12624.

## Test plan
- [ ] Run `vellum wake --watch` from source tree — should restart in watch mode as before
- [ ] Run `vellum wake --watch` from a packaged desktop build — should log warning and keep existing process
- [ ] Run `vellum wake` (no --watch) — behavior unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
