### PR TITLE
fix: smarter 403 handling and retry scope in Amazon skill

### DIFF
--- a/skills/amazon/scripts/cart.ts
+++ b/skills/amazon/scripts/cart.ts
@@ -375,7 +375,9 @@ export async function removeFromCart(opts: {
 }): Promise<CartSummary> {
   const { tabId } = await prepareRequest();
 
-  return runWithBackoff(async () => {
+  // Run the delete POST with retries, then fetch the updated cart separately.
+  // This avoids re-sending an already-successful delete when viewCart() fails.
+  await runWithBackoff(async () => {
     const url = `${AMAZON_BASE}/gp/cart/view.html`;
     const body = `cartItemId.${opts.cartItemId}=${opts.cartItemId}&quantity.${opts.cartItemId}=0&submit.delete.${opts.cartItemId}=Delete&ie=UTF8&action=delete`;
 
@@ -412,8 +414,9 @@ export async function removeFromCart(opts: {
 
     const result = (await cdpEval(tabId, script)) as Record<string, unknown>;
     handleResult(result);
-    return viewCart();
   });
+
+  return viewCart();
 }
 
 /**

--- a/skills/amazon/scripts/client.ts
+++ b/skills/amazon/scripts/client.ts
@@ -291,6 +291,10 @@ export async function cdpEval(tabId: number, script: string): Promise<unknown> {
 /**
  * Handle the raw result object returned from cdpEval scripts.
  * Throws appropriate errors for auth failures, rate limits, and other errors.
+ *
+ * Not all 403s are rate limits — a 403 from /alm/addtofreshcart with
+ * "fakeOfferId" means the request payload was wrong. We inspect the response
+ * body (surfaced via __addCartJson or __message) before classifying.
  */
 export function handleResult(result: Record<string, unknown>): void {
   if (result.__error) {
@@ -298,6 +302,20 @@ export function handleResult(result: Record<string, unknown>): void {
       throw new SessionExpiredError("Amazon session has expired.");
     }
     if (result.__status === 403) {
+      // Check whether this is a payload rejection rather than a rate limit.
+      // Payload errors contain indicators like "fakeOfferId" in the response body.
+      const bodyHint =
+        ((result.__addCartJson as string) ?? "") +
+        ((result.__message as string) ?? "");
+      const isPayloadError =
+        bodyHint.includes("fakeOfferId") ||
+        bodyHint.includes("INVALID_ITEM") ||
+        bodyHint.includes("offerListingID");
+      if (isPayloadError) {
+        throw new Error(
+          `Amazon rejected the request payload (HTTP 403): ${bodyHint.substring(0, 200)}`,
+        );
+      }
       throw new RateLimitError("Amazon rate limit hit (HTTP 403).");
     }
     throw new Error(


### PR DESCRIPTION
## Summary
- **403 classification**: `handleResult` in `client.ts` now inspects the response body before blindly classifying all HTTP 403s as rate limits. Payload rejections (e.g. `fakeOfferId`, `INVALID_ITEM`) throw a regular `Error` instead of `RateLimitError`, preventing `runWithBackoff` from wasting 35s retrying bad payloads.
- **Retry scope**: `removeFromCart` in `cart.ts` now runs `viewCart()` outside `runWithBackoff`, so a successful delete POST is never re-sent when the subsequent cart view fails.

Addresses remaining feedback from #13482.

## Test plan
- [ ] Verify that a 403 with `fakeOfferId` in the response body throws a regular Error (not RateLimitError)
- [ ] Verify that removeFromCart does not re-send the delete POST when viewCart fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
