### PR TITLE
fix: update recording docs after dead code deletion in #15002

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -202,7 +202,7 @@ idle → starting → recording → stopping → idle
                                       └→ failed → idle
 ```
 
-A recording is initiated via dedicated HTTP endpoints (`/v1/recording/*`). The daemon generates a unique `recordingId`, stores bidirectional mappings (`recordingId ↔ conversationId`), and sends a `recording_start` SSE event to the macOS client. The client manages the actual screen capture via `RecordingManager.swift` and reports status transitions back to the daemon via HTTP.
+A recording is initiated via dedicated HTTP endpoints (`/v1/recordings/*`). The daemon generates a unique `recordingId`, stores bidirectional mappings (`recordingId ↔ conversationId`), and sends a `recording_start` SSE event to the macOS client. The client manages the actual screen capture via `RecordingManager.swift` and reports status transitions back to the daemon via HTTP.
 
 ### Key Files
 
@@ -221,7 +221,7 @@ A recording is initiated via dedicated HTTP endpoints (`/v1/recording/*`). The d
 
 ### Intent Routing
 
-Recording is managed through dedicated HTTP endpoints (`/v1/recording/*`) rather than intent detection in user messages. Clients call these endpoints directly to start, stop, and query recording status.
+Recording is managed through dedicated HTTP endpoints (`/v1/recordings/*`) rather than intent detection in user messages. Clients call these endpoints directly to start, stop, and query recording status.
 
 ### File-Backed Attachments
 
@@ -239,7 +239,7 @@ sequenceDiagram
     participant Daemon as Daemon (Bun)
     participant RM as RecordingManager
 
-    Client->>Daemon: POST /v1/recording/start
+    Client->>Daemon: POST /v1/recordings/start
     Daemon->>Client: recording_start { recordingId, options }
     Client->>RM: startRecording(recordingId)
     RM-->>Client: capture started
@@ -247,7 +247,7 @@ sequenceDiagram
 
     Note over RM: Screen capture in progress...
 
-    Client->>Daemon: POST /v1/recording/stop
+    Client->>Daemon: POST /v1/recordings/stop
     Daemon->>Client: recording_stop { recordingId }
     Client->>RM: stopRecording()
     RM-->>Client: file saved at filePath

--- a/skills/screen-recording/SKILL.md
+++ b/skills/screen-recording/SKILL.md
@@ -51,87 +51,28 @@ This skill activates when the user asks to record their screen. Common phrases:
 - "resume recording"
 - "unpause the recording"
 
-## Intent Classification
-
-Recording prompts are classified by `resolveRecordingIntent` into one of 11 intent kinds:
-
-### Pure commands (handled by the standalone recording route)
-
-- **`start_only`** — Pure start request with no additional task (e.g., "record my screen").
-- **`stop_only`** — Pure stop request (e.g., "stop recording").
-- **`restart_only`** — Pure restart request (e.g., "restart recording", "stop recording and start a new one").
-- **`pause_only`** — Pure pause request (e.g., "pause the recording").
-- **`resume_only`** — Pure resume request (e.g., "resume the recording").
-
-### Recording + additional task (recording action is deferred and executed alongside the task)
-
-- **`start_with_remainder`** — Start recording embedded in a broader task. The recording clause is stripped, and the remainder is processed as a separate task. Example: "open Safari and record my screen" produces remainder "open Safari".
-- **`stop_with_remainder`** — Stop recording embedded in a broader task. Example: "close the browser and stop recording" produces remainder "close the browser".
-- **`restart_with_remainder`** — Restart recording embedded in a broader task. Example: "restart recording and open Safari" produces remainder "open Safari".
-
-### Both start and stop detected
-
-- **`start_and_stop_only`** — Both start and stop patterns present with no additional task (e.g., "stop recording and record my screen").
-- **`start_and_stop_with_remainder`** — Both start and stop patterns present alongside additional task text.
-
-### No recording intent
-
-- **`none`** — No recording intent detected. Normal routing.
-
-Dynamic name prefixes (from IDENTITY.md) are stripped during classification, so "Nova, record my screen" classifies the same as "record my screen".
-
 ## Routing
 
-Recording intent resolution follows a precedence chain:
+Recording is managed through dedicated HTTP endpoints (`/v1/recordings/*`) rather than text-based intent detection. Two routing mechanisms exist:
 
 ### 1. `commandIntent` (structured command) — highest priority
 
 The macOS client can send structured intents with `domain: 'screen_recording'` and `action: 'start' | 'stop' | 'restart' | 'pause' | 'resume'`. These bypass text parsing entirely. The assistant checks for `commandIntent` before any text analysis.
 
-### 2. Deterministic text resolver (`resolveRecordingIntent`)
+### 2. HTTP endpoints
 
-A regex-based pipeline that classifies the user's text. The pipeline:
+Clients call the recording HTTP endpoints directly:
 
-1. Strips dynamic assistant names (leading vocative like "Nova, ...")
-2. Strips leading polite wrappers ("please", "can you", etc.)
-3. Applies the interrogative guard — WH-questions return `none`
-4. Checks restart compound patterns (before independent start/stop, so "stop recording and start a new one" is recognized as restart)
-5. Checks pause/resume patterns
-6. Checks start and stop patterns independently
-7. Determines if the intent is pure or has a remainder by stripping recording clauses and checking for substantive remaining content
+- `POST /v1/recordings/start` — start a screen recording
+- `POST /v1/recordings/stop` — stop the active recording
+- `POST /v1/recordings/pause` — pause the active recording
+- `POST /v1/recordings/resume` — resume a paused recording
+- `GET /v1/recordings/status` — get current recording status
+- `POST /v1/recordings/status` — recording lifecycle callback from the client
 
 ### 3. Normal processing
 
-If no recording intent is detected (kind is `none`), the message flows to the classifier and computer-use session as usual.
-
-## Interrogative Guard
-
-Questions about recording are NOT treated as commands. The resolver filters out WH-questions to prevent side effects from informational queries.
-
-**Filtered (no recording action triggered):**
-
-- "how do I stop recording?"
-- "what does screen recording do?"
-- "why is the recording paused?"
-- "when should I stop recording?"
-
-**Preserved as commands (recording action IS triggered):**
-
-- "can you stop recording?" — polite imperative
-- "could you record my screen?" — polite imperative
-- "please stop recording" — direct command with filler
-
-The guard checks for WH-question starters (how, what, why, when, where, who, which) at the beginning of the text, after stripping dynamic names and polite prefixes.
-
-## Mixed-Intent Examples
-
-When a recording intent is combined with another task, the recording clause is stripped from the text, and both parts are handled:
-
-- **"open Safari and record my screen"** — `start_with_remainder` with remainder "open Safari". Recording starts alongside the Safari task.
-- **"stop recording and start a new one and open Safari"** — `restart_with_remainder` with remainder "open Safari". Restart executes and the remainder is processed separately.
-- **"close the browser and stop recording"** — `stop_with_remainder` with remainder "close the browser". Stop executes and the remainder is processed.
-
-The remainder preserves the user's original phrasing (stripping is applied to the original text, not the normalized form).
+If no recording intent is detected, the message flows to the classifier and computer-use session as usual.
 
 ## Behavior Rules
 


### PR DESCRIPTION
## Summary
- Fixes `/v1/recording/*` to `/v1/recordings/*` (plural) in `clients/ARCHITECTURE.md` to match actual route registrations
- Removes stale `resolveRecordingIntent` pipeline documentation from `skills/screen-recording/SKILL.md` (code was deleted in #15002)
- Replaces intent classification docs with current HTTP endpoint-based routing

## Test plan
- Documentation-only changes, no code affected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
