### PR TITLE
fix: include commandIntent in structured recording intent test

### DIFF
--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -349,6 +349,25 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
 
+  test("structured commandIntent recording actions are ignored by HTTP path", async () => {
+    // Even when the request includes a structured commandIntent for recording,
+    // the HTTP path does not parse or act on it — handleSendMessage only reads
+    // content, conversationKey, attachmentIds, sourceChannel, and interface.
+    // This ensures a future regression that starts parsing commandIntent would
+    // be caught.
+    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const runAgentLoop = mock(async () => undefined);
+    const session = makeSession({ persistUserMessage, runAgentLoop });
+
+    const res = await sendMessage("start screen recording", session, {
+      commandIntent: { type: "start_recording", payload: "screen" },
+    });
+
+    expect(res.status).toBe(202);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+
   test("stop recording commands pass through to the agent loop", async () => {
     const persistUserMessage = mock(async () => "persisted-msg-id");
     const runAgentLoop = mock(async () => undefined);


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #14966: the test claiming to verify that `POST /v1/messages` ignores structured `commandIntent` recording actions was only sending plain text, not actually including a `commandIntent` field
- Adds a new test case that sends `commandIntent: { type: "start_recording", payload: "screen" }` alongside text content, verifying the HTTP path ignores it and proceeds to the agent loop
- This ensures a future regression that starts parsing `commandIntent` would be caught

## Test plan
- [x] New test sends structured `commandIntent` in the request body alongside recording text
- [x] Existing tests remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
