### PR TITLE
fix: add notify mode guidance and restore missing clarification example

### DIFF
--- a/assistant/src/prompts/sections/routing.ts
+++ b/assistant/src/prompts/sections/routing.ts
@@ -8,7 +8,7 @@ export function buildTaskScheduleReminderRoutingSection(): string {
     "## Tool Routing: Tasks vs Schedules vs Notifications",
     "",
     "- `task_list_add` — track work (no time trigger)",
-    "- `schedule_create` — time-based: recurring (cron/RRULE) or one-shot (`fire_at`)",
+    "- `schedule_create` — time-based: recurring (cron/RRULE) or one-shot (`fire_at`). Use `mode: \"notify\"` for reminders, `mode: \"execute\"` for autonomous tasks.",
     "- `send_notification` — **immediate-only**, fires NOW, never for future times",
     "",
     "NEVER use `send_notification` for future-time requests. Use `schedule_create` with `fire_at`.",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -171,7 +171,9 @@
         "emoji": "🔐",
         "vellum": {
           "display-name": "Guardian Verify Setup",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "activation-hints": {},
+          "avoid-when": {}
         }
       },
       "compatibility": "Designed for Vellum personal assistants"
@@ -484,7 +486,9 @@
           ],
           "includes": [
             "elevenlabs-voice"
-          ]
+          ],
+          "activation-hints": {},
+          "avoid-when": {}
         }
       },
       "compatibility": "Designed for Vellum personal assistants"

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -13,7 +13,8 @@ Quick-reference decision guide for choosing the right tool when users ask about 
 ## Decision Tree
 
 1. **Does the request have a specific future time AND should fire only once?**
-   - YES -> `schedule_create` with `fire_at`
+   - YES -> `schedule_create` with `fire_at` and `mode: "notify"` (for simple reminders) or `mode: "execute"` (if the assistant should act autonomously)
+   - Default to `mode: "notify"` for reminder-style requests. Use `mode: "execute"` only when the user wants the assistant to perform a task (e.g. "at 5pm, check my email and summarize it").
    - Examples: "remind me at 3pm", "remind me in 5 minutes", "alert me tomorrow at 9am"
 
 2. **Does the request have a recurring pattern?**
@@ -107,6 +108,7 @@ Phrases like "at the 45 minute mark", "at the top of the hour", "on the half-hou
 - "at the 45 min mark" (no start time, now: 9:50) -> 10:45 AM (wall-clock, next hour)
 - "top of the hour" (now: 9:39) -> 10:00 AM
 - "at noon" -> 12:00 PM today
+- "at the hour mark" with no start time -> ask for clarification
 
 ## Tool Summary
 


### PR DESCRIPTION
## Summary
- Adds explicit `mode: "notify"` guidance to the time-based-actions SKILL.md decision tree for one-shot reminder requests, since `schedule_create` defaults to `mode: "execute"` which would create non-notifying reminders (P1 from Codex review)
- Updates the routing dispatch hint in `routing.ts` to also mention notify vs execute modes
- Restores the dropped "at the hour mark" with no start time -> ask for clarification example (flagged by Devin review)

## Test plan
- [ ] Verify time-based-actions SKILL.md decision tree includes mode guidance
- [ ] Verify routing.ts dispatch hint includes mode guidance
- [ ] Verify clarification example is restored in the examples list
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
