### PR TITLE
fix: address PR #14975 feedback — auto-deny idle-path confirmations and surface secret blocks

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -815,6 +815,31 @@ export async function handleSendMessage(
     );
   }
 
+  // Auto-deny pending confirmations for idle sessions. The legacy
+  // handleUserMessage called autoDenyPendingConfirmations unconditionally
+  // before dispatching, so an idle session with lingering confirmations
+  // (e.g. the user never responded to a tool-approval prompt) must deny
+  // them before starting the new turn.
+  if (session.hasAnyPendingConfirmation()) {
+    for (const interaction of pendingInteractions.getByConversation(
+      mapping.conversationId,
+    )) {
+      if (
+        interaction.session === session &&
+        interaction.kind === "confirmation"
+      ) {
+        session.emitConfirmationStateChanged({
+          sessionId: mapping.conversationId,
+          requestId: interaction.requestId,
+          state: "denied" as const,
+          source: "auto_deny" as const,
+        });
+      }
+    }
+    session.denyAllPendingConfirmations();
+    pendingInteractions.removeBySession(session);
+  }
+
   // Session is idle — persist and fire agent loop immediately
   session.setTurnChannelContext({
     userMessageChannel: sourceChannel,

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1737,6 +1737,18 @@ public final class HTTPTransport {
                         failedMessageContent: content
                     )))
                 }
+            } else if http.statusCode == 422,
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let errorCategory = json["error"] as? String,
+                      errorCategory == "secret_blocked" {
+                // Surface secret-block errors through the .error path so
+                // ChatViewModel's secret_blocked handler can offer "Send Anyway".
+                let message = (json["message"] as? String) ?? "Message blocked — contains secrets"
+                log.warning("Message blocked by secret-ingress check")
+                onMessage?(.error(ErrorMessage(
+                    message: message,
+                    category: "secret_blocked"
+                )))
             } else {
                 let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
                 log.error("Send message failed (\(http.statusCode)): \(errorBody)")


### PR DESCRIPTION
## Summary
- Adds auto-deny pending confirmations to the idle path in `handleSendMessage` (conversation-routes.ts), closing a behavioral gap where the legacy `handleUserMessage` denied confirmations unconditionally but the HTTP handler only did so in the busy/queued branch.
- Handles 422 `secret_blocked` responses in `HTTPDaemonClient.sendMessage` (Swift) by emitting `.error(ErrorMessage(category: "secret_blocked"))` so `ChatViewModel`'s secret-block recovery flow ("Send Anyway") activates instead of a generic HTTP error.

## Test plan
- [ ] Verify idle session with pending confirmation auto-denies when new message arrives via HTTP
- [ ] Verify secret-blocked message on desktop shows the "Send Anyway" recovery UI instead of generic HTTP 422 error

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
