### PR TITLE
fix: restrict starter-task intent to known task IDs

### DIFF
--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -119,6 +119,16 @@ describe("resolveStarterTaskIntent", () => {
     );
     expect(result.kind).toBe("starter_task");
   });
+
+  test("returns none for unknown task IDs", () => {
+    const result = resolveStarterTaskIntent("[STARTER_TASK:foo]");
+    expect(result.kind).toBe("none");
+  });
+
+  test("returns none for typo in task ID", () => {
+    const result = resolveStarterTaskIntent("[STARTER_TASK:make_it_your]");
+    expect(result.kind).toBe("none");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/starter-task-intent.ts
+++ b/assistant/src/daemon/starter-task-intent.ts
@@ -13,6 +13,13 @@ export type StarterTaskIntentResult =
       rewrittenContent: string;
     };
 
+/** Known starter task IDs — must match the playbooks in onboarding-starter-tasks SKILL.md. */
+const KNOWN_TASK_IDS = new Set([
+  "make_it_yours",
+  "research_topic",
+  "research_to_ui",
+]);
+
 /** Pattern matching `[STARTER_TASK:<task_id>]` kickoff messages. */
 const STARTER_TASK_PATTERN = /^\[STARTER_TASK:(\w+)\]$/;
 
@@ -33,6 +40,10 @@ export function resolveStarterTaskIntent(
   }
 
   const taskId = match[1];
+
+  if (!KNOWN_TASK_IDS.has(taskId)) {
+    return { kind: "none" };
+  }
 
   const lines = [
     `The user clicked the "${taskId}" starter task card.`,


### PR DESCRIPTION
## Summary
- Add `KNOWN_TASK_IDS` allowlist to `resolveStarterTaskIntent` so only `make_it_yours`, `research_topic`, and `research_to_ui` trigger the onboarding skill flow
- Unknown task IDs (typos, arbitrary input) now return `kind: "none"` and fall through to normal handling
- Add two new test cases covering unknown and typo task IDs

Addresses review feedback from #15227.

## Test plan
- [x] Verify known task IDs still resolve correctly (existing tests)
- [x] Verify unknown task IDs return `kind: "none"` (new tests)
- [x] Verify typo task IDs return `kind: "none"` (new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
