### PR TITLE
fix: use brace depth tracking in web_search_tool_result guard test

### DIFF
--- a/assistant/src/__tests__/session-history-web-search.test.ts
+++ b/assistant/src/__tests__/session-history-web-search.test.ts
@@ -796,20 +796,32 @@ describe("web_search_tool_result structural guard", () => {
 
     // Track whether we're inside an isToolResultBlock or isToolResultContent
     // helper function definition (which canonically defines the check).
-    let insideHelperFunction = false;
+    // We use brace depth tracking so nested blocks (if/else, etc.) inside the
+    // helper don't prematurely end the allowlisted region.
+    let helperBraceDepth = 0;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      // Detect entry/exit of known helper functions that define the canonical check
-      if (/function isToolResult(Block|Content)\b/.test(line)) {
-        insideHelperFunction = true;
-      }
-      if (insideHelperFunction && line.trim() === "}") {
-        insideHelperFunction = false;
+      // Detect entry of known helper functions that define the canonical check
+      if (
+        helperBraceDepth === 0 &&
+        /function isToolResult(Block|Content)\b/.test(line)
+      ) {
+        // Count opening braces on the declaration line itself (e.g. `function foo() {`)
+        const opens = (line.match(/{/g) || []).length;
+        const closes = (line.match(/}/g) || []).length;
+        helperBraceDepth = opens - closes;
         continue;
       }
-      if (insideHelperFunction) continue;
+
+      // Track brace depth while inside a helper function
+      if (helperBraceDepth > 0) {
+        const opens = (line.match(/{/g) || []).length;
+        const closes = (line.match(/}/g) || []).length;
+        helperBraceDepth += opens - closes;
+        continue;
+      }
 
       // Check for raw tool_result type comparisons (both quote styles)
       const hasRawCheck =


### PR DESCRIPTION
## Summary
- Fixes brittle scope detection in the web_search_tool_result structural guard test
- Replaces naive closing-brace check with brace depth tracking so nested blocks inside isToolResultBlock/isToolResultContent helpers don't prematurely end the allowlisted region
- Addresses review feedback from PR #15917

## Test plan
- [ ] Guard test still passes and correctly allowlists the helper functions
- [ ] Verify nested blocks inside helpers don't cause false violations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
