### PR TITLE
fix: mark intentionally failing overflow tests as test.todo

### DIFF
--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -8,8 +8,8 @@
  *   3. No mid-loop budget check to prevent hitting the provider limit
  *
  * Tests 2, 3, and 4 pass against the current code.
- * Tests 1, 5 fail (documenting bugs to be fixed in PR 2).
- * Tests 6 and 7 are skipped (depend on mid-loop checkpoint changes in PR 3).
+ * Tests 1, 5 are test.todo (documenting bugs to be fixed in PR 2).
+ * Tests 6 and 7 are test.todo (depend on mid-loop checkpoint changes in PR 3).
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -535,7 +535,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   //
   // Expected behavior (PR 2 fix): After progress + context_too_large,
   // the system should still attempt compaction before surfacing error.
-  test("context too large after progress triggers compaction retry instead of immediate failure", async () => {
+  test.todo("context too large after progress triggers compaction retry instead of immediate failure", async () => {
     const events: ServerMessage[] = [];
     let reducerCalled = false;
 
@@ -1045,7 +1045,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // Expected behavior (PR 2 fix): Even after all tiers are exhausted,
   // if progress was made, attempt emergency compaction with
   // `minKeepRecentUserTurns: 0` as a last resort.
-  test("exhausted reducer tiers with progress still attempts emergency compaction", async () => {
+  test.todo("exhausted reducer tiers with progress still attempts emergency compaction", async () => {
     const events: ServerMessage[] = [];
     let emergencyCompactCalled = false;
 
@@ -1230,7 +1230,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // When estimate exceeds the mid-loop threshold (85% of budget),
   // it returns "yield" to break the agent loop.
   // The session-agent-loop then runs compaction and re-enters the agent loop.
-  test("onCheckpoint yields when token estimate exceeds mid-loop budget threshold", async () => {
+  test.todo("onCheckpoint yields when token estimate exceeds mid-loop budget threshold", async () => {
     const events: ServerMessage[] = [];
     let compactionCalled = false;
 
@@ -1406,7 +1406,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // Agent loop runs tool calls with growing history. After the estimate
   // exceeds the mid-loop threshold, the loop yields, compaction runs,
   // and the loop resumes. The provider NEVER rejects with context_too_large.
-  test("mid-loop budget check prevents context_too_large when tools produce large results", async () => {
+  test.todo("mid-loop budget check prevents context_too_large when tools produce large results", async () => {
     const events: ServerMessage[] = [];
     let compactionCalled = false;
 


### PR DESCRIPTION
## Summary
- Convert tests 1, 5 (documenting bugs for PR 2) and tests 6, 7 (depend on PR 3) from `test()` to `test.todo()` so they don't fail CI
- Update file header comments to reflect the change
- Follows project convention: "use `test.todo` so mainline stays green"

Addresses review feedback from #15914.

Part of JARVIS-110
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
