### PR TITLE
fix: address review feedback on amazon skill migration

### DIFF
--- a/skills/amazon/scripts/client.ts
+++ b/skills/amazon/scripts/client.ts
@@ -52,6 +52,8 @@
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
+import { type AmazonSession, loadSession, saveSession } from "./session.js";
+
 const execFileAsync = promisify(execFile);
 
 export interface ExtractedCredential {
@@ -70,8 +72,6 @@ interface RelayResponse {
   result?: unknown;
   error?: string;
 }
-
-import { type AmazonSession, loadSession, saveSession } from "./session.js";
 
 export const AMAZON_BASE = "https://www.amazon.com";
 

--- a/skills/amazon/scripts/headless-cookies.ts
+++ b/skills/amazon/scripts/headless-cookies.ts
@@ -137,7 +137,7 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
       path: path || "/",
       httpOnly: httpOnly === "1",
       secure: secure === "1",
-      expires: expiresUtc
+      expires: expiresUtc && expiresUtc !== "0"
         ? Math.floor(parseInt(expiresUtc, 10) / 1000000 - 11644473600)
         : undefined,
     });

--- a/skills/amazon/scripts/headless-cookies.ts
+++ b/skills/amazon/scripts/headless-cookies.ts
@@ -14,7 +14,7 @@ import type { AmazonSession } from "./session.js";
 
 const CHROME_COOKIES_DB = join(
   homedir(),
-  "Library/Application Support/Google/Chrome/Default/Cookies",
+  "Library/Application Support/Google/Chrome/Default/Cookies"
 );
 
 /**
@@ -24,7 +24,7 @@ const CHROME_COOKIES_DB = join(
  */
 function decryptChromeCookie(
   encHex: string,
-  derivedKey: Buffer,
+  derivedKey: Buffer
 ): string | null {
   const buf = Buffer.from(encHex, "hex");
   if (buf.length < 4 || buf.slice(0, 3).toString() !== "v10") return null;
@@ -53,18 +53,20 @@ function decryptChromeCookie(
  *   - The user must be signed into Amazon in Chrome
  *   - macOS Keychain access for 'Chrome Safe Storage' (will prompt once)
  */
-export async function extractSessionFromChromeCookies(): Promise<AmazonSession> {
+export async function extractSessionFromChromeCookies(): Promise<
+  AmazonSession
+> {
   // 1. Get Chrome Safe Storage key from macOS Keychain
   let keychainPassword: string;
   try {
     keychainPassword = execSync(
       'security find-generic-password -w -s "Chrome Safe Storage" -a "Chrome"',
-      { encoding: "utf-8" },
+      { encoding: "utf-8" }
     ).trim();
   } catch {
     throw new Error(
       "Could not read Chrome Safe Storage key from macOS Keychain. " +
-        "Make sure Chrome is installed and has been opened at least once.",
+        "Make sure Chrome is installed and has been opened at least once."
     );
   }
 
@@ -74,7 +76,7 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
     "saltysalt",
     1003,
     16,
-    "sha1",
+    "sha1"
   );
 
   // 3. Copy the Cookies DB to a temp file, then query the copy.
@@ -92,12 +94,12 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
 
     rawOutput = execSync(
       `sqlite3 "${tmpCookiesDb}" "SELECT name, hex(encrypted_value), host_key, path, is_httponly, is_secure, expires_utc FROM cookies WHERE host_key LIKE '%amazon.com%'"`,
-      { encoding: "utf-8" },
+      { encoding: "utf-8" }
     ).trim();
   } catch {
     throw new Error(
       "Could not read Chrome Cookies database. " +
-        "Make sure Chrome is installed and the Cookies file exists.",
+        "Make sure Chrome is installed and the Cookies file exists."
     );
   } finally {
     // Clean up temp files
@@ -115,7 +117,7 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
   if (!rawOutput) {
     throw new Error(
       "No Amazon cookies found in Chrome. " +
-        "Make sure you are signed into Amazon in Chrome.",
+        "Make sure you are signed into Amazon in Chrome."
     );
   }
 
@@ -137,9 +139,10 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
       path: path || "/",
       httpOnly: httpOnly === "1",
       secure: secure === "1",
-      expires: expiresUtc && expiresUtc !== "0"
-        ? Math.floor(parseInt(expiresUtc, 10) / 1000000 - 11644473600)
-        : undefined,
+      expires:
+        expiresUtc && expiresUtc !== "0"
+          ? Math.floor(parseInt(expiresUtc, 10) / 1000000 - 11644473600)
+          : undefined,
     });
   }
 
@@ -148,19 +151,19 @@ export async function extractSessionFromChromeCookies(): Promise<AmazonSession> 
   if (!cookieNames.has("session-id")) {
     throw new Error(
       "Chrome cookies are missing required Amazon cookie: session-id. " +
-        "Make sure you are signed into Amazon in Chrome.",
+        "Make sure you are signed into Amazon in Chrome."
     );
   }
   if (!cookieNames.has("ubid-main")) {
     throw new Error(
       "Chrome cookies are missing required Amazon cookie: ubid-main. " +
-        "Make sure you are signed into Amazon in Chrome.",
+        "Make sure you are signed into Amazon in Chrome."
     );
   }
   if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
     throw new Error(
       "Chrome cookies are missing required Amazon auth cookie (at-main or x-main). " +
-        "Make sure you are fully signed into Amazon in Chrome.",
+        "Make sure you are fully signed into Amazon in Chrome."
     );
   }
 

--- a/skills/amazon/scripts/headless-cookies.ts
+++ b/skills/amazon/scripts/headless-cookies.ts
@@ -14,7 +14,7 @@ import type { AmazonSession } from "./session.js";
 
 const CHROME_COOKIES_DB = join(
   homedir(),
-  "Library/Application Support/Google/Chrome/Default/Cookies"
+  "Library/Application Support/Google/Chrome/Default/Cookies",
 );
 
 /**
@@ -24,7 +24,7 @@ const CHROME_COOKIES_DB = join(
  */
 function decryptChromeCookie(
   encHex: string,
-  derivedKey: Buffer
+  derivedKey: Buffer,
 ): string | null {
   const buf = Buffer.from(encHex, "hex");
   if (buf.length < 4 || buf.slice(0, 3).toString() !== "v10") return null;
@@ -53,20 +53,18 @@ function decryptChromeCookie(
  *   - The user must be signed into Amazon in Chrome
  *   - macOS Keychain access for 'Chrome Safe Storage' (will prompt once)
  */
-export async function extractSessionFromChromeCookies(): Promise<
-  AmazonSession
-> {
+export async function extractSessionFromChromeCookies(): Promise<AmazonSession> {
   // 1. Get Chrome Safe Storage key from macOS Keychain
   let keychainPassword: string;
   try {
     keychainPassword = execSync(
       'security find-generic-password -w -s "Chrome Safe Storage" -a "Chrome"',
-      { encoding: "utf-8" }
+      { encoding: "utf-8" },
     ).trim();
   } catch {
     throw new Error(
       "Could not read Chrome Safe Storage key from macOS Keychain. " +
-        "Make sure Chrome is installed and has been opened at least once."
+        "Make sure Chrome is installed and has been opened at least once.",
     );
   }
 
@@ -76,7 +74,7 @@ export async function extractSessionFromChromeCookies(): Promise<
     "saltysalt",
     1003,
     16,
-    "sha1"
+    "sha1",
   );
 
   // 3. Copy the Cookies DB to a temp file, then query the copy.
@@ -94,12 +92,12 @@ export async function extractSessionFromChromeCookies(): Promise<
 
     rawOutput = execSync(
       `sqlite3 "${tmpCookiesDb}" "SELECT name, hex(encrypted_value), host_key, path, is_httponly, is_secure, expires_utc FROM cookies WHERE host_key LIKE '%amazon.com%'"`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8" },
     ).trim();
   } catch {
     throw new Error(
       "Could not read Chrome Cookies database. " +
-        "Make sure Chrome is installed and the Cookies file exists."
+        "Make sure Chrome is installed and the Cookies file exists.",
     );
   } finally {
     // Clean up temp files
@@ -117,7 +115,7 @@ export async function extractSessionFromChromeCookies(): Promise<
   if (!rawOutput) {
     throw new Error(
       "No Amazon cookies found in Chrome. " +
-        "Make sure you are signed into Amazon in Chrome."
+        "Make sure you are signed into Amazon in Chrome.",
     );
   }
 
@@ -151,19 +149,19 @@ export async function extractSessionFromChromeCookies(): Promise<
   if (!cookieNames.has("session-id")) {
     throw new Error(
       "Chrome cookies are missing required Amazon cookie: session-id. " +
-        "Make sure you are signed into Amazon in Chrome."
+        "Make sure you are signed into Amazon in Chrome.",
     );
   }
   if (!cookieNames.has("ubid-main")) {
     throw new Error(
       "Chrome cookies are missing required Amazon cookie: ubid-main. " +
-        "Make sure you are signed into Amazon in Chrome."
+        "Make sure you are signed into Amazon in Chrome.",
     );
   }
   if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
     throw new Error(
       "Chrome cookies are missing required Amazon auth cookie (at-main or x-main). " +
-        "Make sure you are fully signed into Amazon in Chrome."
+        "Make sure you are fully signed into Amazon in Chrome.",
     );
   }
 

--- a/skills/amazon/scripts/session.ts
+++ b/skills/amazon/scripts/session.ts
@@ -41,7 +41,7 @@ export async function saveSession(session: AmazonSession): Promise<void> {
     throw new Error(
       `Failed to save Amazon session: ${
         err instanceof Error ? err.message : String(err)
-      }`
+      }`,
     );
   }
 }
@@ -64,7 +64,7 @@ export async function clearSession(): Promise<void> {
  * copies them to the canonical amazon:session:cookies key.
  */
 export async function importFromCredentialStore(
-  targetDomain: string
+  targetDomain: string,
 ): Promise<AmazonSession> {
   const { stdout } = await execFileAsync("assistant", [
     "credentials",
@@ -79,17 +79,17 @@ export async function importFromCredentialStore(
   const cookieNames = new Set(cookies.map((c) => c.name));
   if (!cookieNames.has("session-id")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon cookie: session-id."
+      "Credential store cookies are missing required Amazon cookie: session-id.",
     );
   }
   if (!cookieNames.has("ubid-main")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon cookie: ubid-main."
+      "Credential store cookies are missing required Amazon cookie: ubid-main.",
     );
   }
   if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon auth cookie (at-main or x-main)."
+      "Credential store cookies are missing required Amazon auth cookie (at-main or x-main).",
     );
   }
 

--- a/skills/amazon/scripts/session.ts
+++ b/skills/amazon/scripts/session.ts
@@ -57,7 +57,7 @@ export async function clearSession(): Promise<void> {
 }
 
 /**
- * Import cookies that the daemon saved to the credential store under the
+ * Import cookies that the assistant saved to the credential store under the
  * target domain key. Validates Amazon-specific required cookies, then
  * copies them to the canonical amazon:session:cookies key.
  */

--- a/skills/amazon/scripts/session.ts
+++ b/skills/amazon/scripts/session.ts
@@ -39,7 +39,9 @@ export async function saveSession(session: AmazonSession): Promise<void> {
     ]);
   } catch (err) {
     throw new Error(
-      `Failed to save Amazon session: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to save Amazon session: ${
+        err instanceof Error ? err.message : String(err)
+      }`
     );
   }
 }
@@ -62,7 +64,7 @@ export async function clearSession(): Promise<void> {
  * copies them to the canonical amazon:session:cookies key.
  */
 export async function importFromCredentialStore(
-  targetDomain: string,
+  targetDomain: string
 ): Promise<AmazonSession> {
   const { stdout } = await execFileAsync("assistant", [
     "credentials",
@@ -77,17 +79,17 @@ export async function importFromCredentialStore(
   const cookieNames = new Set(cookies.map((c) => c.name));
   if (!cookieNames.has("session-id")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon cookie: session-id.",
+      "Credential store cookies are missing required Amazon cookie: session-id."
     );
   }
   if (!cookieNames.has("ubid-main")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon cookie: ubid-main.",
+      "Credential store cookies are missing required Amazon cookie: ubid-main."
     );
   }
   if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
     throw new Error(
-      "Credential store cookies are missing required Amazon auth cookie (at-main or x-main).",
+      "Credential store cookies are missing required Amazon auth cookie (at-main or x-main)."
     );
   }
 


### PR DESCRIPTION
## Summary
- Fix session cookie expiration bug in headless-cookies.ts: Chrome stores session cookies with `expires_utc=0`, which is truthy as a string, causing the code to compute a large negative timestamp (-11644473600, year 1601) instead of `undefined`. Session cookies were being treated as expired.
- Replace 'daemon' with 'assistant' in session.ts comment per user-facing terminology rules.

Addresses feedback from #13484.

## Test plan
- Verify headless cookie extraction handles session cookies (expires_utc=0) without setting a past expiration date
- Verify no remaining 'daemon' references in user-facing text in the amazon skill
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
