### PR TITLE
test: add unit tests for parseActualTokensFromError

### DIFF
--- a/assistant/src/daemon/parse-actual-tokens-from-error.test.ts
+++ b/assistant/src/daemon/parse-actual-tokens-from-error.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseActualTokensFromError } from "./session-agent-loop.js";
+
+describe("parseActualTokensFromError", () => {
+  test("returns null for null input", () => {
+    expect(parseActualTokensFromError(null)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseActualTokensFromError("")).toBeNull();
+  });
+
+  test("returns null for unrelated error message", () => {
+    expect(
+      parseActualTokensFromError("something went wrong"),
+    ).toBeNull();
+  });
+
+  test("parses Anthropic-style error: prompt is too long: N tokens > M maximum", () => {
+    expect(
+      parseActualTokensFromError(
+        "prompt is too long: 242201 tokens > 200000 maximum",
+      ),
+    ).toBe(242201);
+  });
+
+  test("parses wrapped ProviderError from Anthropic", () => {
+    expect(
+      parseActualTokensFromError(
+        "Anthropic API error (400): prompt is too long: 242201 tokens > 200000 maximum",
+      ),
+    ).toBe(242201);
+  });
+
+  test("parses OpenAI-style error: too many input tokens: N > M", () => {
+    expect(
+      parseActualTokensFromError("too many input tokens: 150000 > 128000"),
+    ).toBe(150000);
+  });
+
+  test("handles comma-separated numbers", () => {
+    expect(
+      parseActualTokensFromError(
+        "prompt is too long: 242,201 tokens > 200,000 maximum",
+      ),
+    ).toBe(242201);
+  });
+
+  test("handles comma-separated numbers in fallback path", () => {
+    expect(
+      parseActualTokensFromError("too many input tokens: 150,000 > 128,000"),
+    ).toBe(150000);
+  });
+
+  test("parses singular 'token' (without s)", () => {
+    expect(
+      parseActualTokensFromError("prompt is too long: 1 token > 0 maximum"),
+    ).toBe(1);
+  });
+
+  test("handles >= comparator", () => {
+    expect(
+      parseActualTokensFromError(
+        "prompt is too long: 242201 tokens ≥ 200000 maximum",
+      ),
+    ).toBe(242201);
+  });
+
+  test("returns null when no numeric pattern matches", () => {
+    expect(
+      parseActualTokensFromError("context window exceeded"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -133,7 +133,7 @@ const log = getLogger("session-agent-loop");
  *
  * Returns the actual token count or null if it cannot be parsed.
  */
-function parseActualTokensFromError(
+export function parseActualTokensFromError(
   errorMessage: string | null,
 ): number | null {
   if (!errorMessage) return null;


### PR DESCRIPTION
## Summary
- Export `parseActualTokensFromError` from `session-agent-loop.ts` so it can be tested directly
- Add dedicated unit tests covering all provider error formats (Anthropic, OpenAI, wrapped ProviderError)
- Test edge cases: comma-separated numbers, singular "token", ≥ comparator, null/empty input, non-matching messages

Addresses review feedback from #15933.

Part of JARVIS-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
