### PR TITLE
fix: treat active direct sends as in-flight in per-message failure check

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1723,13 +1723,19 @@ extension ChatViewModel {
                 // Only reset sending state if no other messages are in-flight.
                 // Check for genuinely in-flight statuses (.processing, .queued)
                 // — NOT .sent, which is the default/terminal status for all
-                // previously delivered messages.
-                let hasActiveSend = isSending && messages.contains(where: { msg in
-                    guard msg.role == .user else { return false }
-                    if msg.status == .processing { return true }
-                    if case .queued = msg.status { return true }
-                    return false
-                })
+                // previously delivered messages. Also treat an active assistant
+                // response (currentAssistantMessageId != nil) as in-flight,
+                // because direct (non-queued) sends keep the user bubble at
+                // .sent while isSending is true and the assistant streams.
+                let hasActiveSend = isSending && (
+                    currentAssistantMessageId != nil ||
+                    messages.contains(where: { msg in
+                        guard msg.role == .user else { return false }
+                        if msg.status == .processing { return true }
+                        if case .queued = msg.status { return true }
+                        return false
+                    })
+                )
                 if !hasActiveSend {
                     isThinking = false
                     isSending = false


### PR DESCRIPTION
## Summary
- Fix P1 feedback from #15494: the `hasActiveSend` predicate in the per-message failure handler only checked for `.processing` and `.queued` user message statuses
- Direct (non-queued) sends keep the user bubble at `.sent` while `isSending` is true and the assistant streams a response via `currentAssistantMessageId`
- A per-message failure arriving during an active direct send would incorrectly clear `isSending`/`isThinking`, reporting idle while a response was still streaming
- Add `currentAssistantMessageId != nil` as an additional in-flight signal so the UI stays in sending state when another turn is actively streaming

Addresses review feedback from #15494
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
