### PR TITLE
fix: compacting indicator replaces thinking indicator during context compaction

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -552,6 +552,7 @@ struct MessageListView: View {
                     let lastVisibleIsAssistant = lastVisible?.role == .assistant
                     let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
                     let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
+                    let effectiveStatusText = isCompacting ? "Compacting context\u{2026}" : assistantStatusText
                     ForEach(Array(zip(displayMessages.indices, displayMessages)), id: \.1.id) { index, message in
                         MessageCellView(
                             message: message,
@@ -564,7 +565,7 @@ struct MessageListView: View {
                             subagentsByParent: subagentsByParent,
                             canInlineProcessing: canInlineProcessing,
                             shouldShowThinkingIndicator: shouldShowThinkingIndicator,
-                            assistantStatusText: assistantStatusText,
+                            assistantStatusText: effectiveStatusText,
                             dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                             activeSurfaceId: activeSurfaceId,
                             mediaEmbedSettings: mediaEmbedSettings,
@@ -602,11 +603,11 @@ struct MessageListView: View {
                     }
 
                     if shouldShowThinkingIndicator && anchoredThinkingIndex == nil {
-                        thinkingIndicatorRow(displayMessages: displayMessages)
-                    }
-
-                    if isCompacting && !shouldShowThinkingIndicator {
-                        compactingIndicatorRow()
+                        if isCompacting {
+                            compactingIndicatorRow()
+                        } else {
+                            thinkingIndicatorRow(displayMessages: displayMessages)
+                        }
                     }
 
                     Color.clear


### PR DESCRIPTION
## Summary
- Fix compacting indicator being hidden when thinking indicator is active (the most common case during compaction)
- The standalone compacting row now replaces the thinking row when `isCompacting` is true
- Inline processing status text also shows "Compacting context…" when compacting, instead of the default "Thinking" label
- Addresses review feedback from #15927

## Test plan
- [ ] Trigger context overflow recovery and verify "Compacting context…" appears instead of "Thinking"
- [ ] Verify inline case (last message is assistant bubble) also shows "Compacting context…"
- [ ] Verify normal thinking indicator still works when not compacting
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
