### PR TITLE
fix: gate group-chat etiquette on actual group context and remove dead Discord refs

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -12,6 +12,7 @@ import {
   injectChannelTurnContext,
   injectInboundActorContext,
   injectTemporalContext,
+  isGroupChatType,
   resolveChannelCapabilities,
   sanitizePttActivationKey,
   stripChannelCapabilityContext,
@@ -132,6 +133,16 @@ describe("resolveChannelCapabilities", () => {
     expect(caps.supportsDynamicUi).toBe(false);
     expect(caps.supportsVoiceInput).toBe(false);
   });
+
+  test("propagates chatType when provided", () => {
+    const caps = resolveChannelCapabilities("telegram", null, null, "group");
+    expect(caps.chatType).toBe("group");
+  });
+
+  test("chatType is undefined when not provided", () => {
+    const caps = resolveChannelCapabilities("telegram");
+    expect(caps.chatType).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -208,6 +219,102 @@ describe("injectChannelCapabilityContext", () => {
     // Original content should be at the end
     const lastBlock = result.content[result.content.length - 1];
     expect((lastBlock as { type: "text"; text: string }).text).toBe("Hello");
+  });
+
+  test("injects group chat etiquette when chatType is group", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "group",
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("GROUP CHAT ETIQUETTE");
+    expect(text).toContain("chat_type: group");
+    expect(text).toContain("Stay silent when");
+  });
+
+  test("injects group chat etiquette when chatType is supergroup", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "supergroup",
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("GROUP CHAT ETIQUETTE");
+  });
+
+  test("does NOT inject group chat etiquette for private/DM chats", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "private",
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toContain("GROUP CHAT ETIQUETTE");
+    expect(text).not.toContain("Stay silent when");
+  });
+
+  test("does NOT inject group chat etiquette when chatType is absent", () => {
+    const caps: ChannelCapabilities = {
+      channel: "telegram",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).not.toContain("GROUP CHAT ETIQUETTE");
+  });
+
+  test("includes emoji reaction hint for Slack group chats", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+
+    const result = injectChannelCapabilityContext(baseUserMessage, caps);
+    const text = (result.content[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("GROUP CHAT ETIQUETTE");
+    expect(text).toContain("emoji reactions");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGroupChatType
+// ---------------------------------------------------------------------------
+
+describe("isGroupChatType", () => {
+  test("returns true for group chat types", () => {
+    expect(isGroupChatType("group")).toBe(true);
+    expect(isGroupChatType("supergroup")).toBe(true);
+    expect(isGroupChatType("channel")).toBe(true);
+    expect(isGroupChatType("mpim")).toBe(true);
+  });
+
+  test("returns false for private/DM chat types", () => {
+    expect(isGroupChatType("private")).toBe(false);
+    expect(isGroupChatType("im")).toBe(false);
+  });
+
+  test("returns false for undefined/empty", () => {
+    expect(isGroupChatType(undefined)).toBe(false);
+    expect(isGroupChatType("")).toBe(false);
   });
 });
 
@@ -376,6 +483,17 @@ describe("buildChannelAwarenessSection", () => {
   test("gates computer-control on dashboard channel", () => {
     const section = buildChannelAwarenessSection();
     expect(section).toContain("computer-control permissions on non-dashboard");
+  });
+
+  test("does NOT include group chat etiquette (gated per-turn instead)", () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).not.toContain("Group chat etiquette");
+    expect(section).not.toContain("Stay silent when");
+  });
+
+  test("does NOT include Discord references (not a supported channel)", () => {
+    const section = buildChannelAwarenessSection();
+    expect(section).not.toContain("Discord");
   });
 });
 

--- a/assistant/src/daemon/message-types/sessions.ts
+++ b/assistant/src/daemon/message-types/sessions.ts
@@ -24,6 +24,8 @@ export interface SessionTransportMetadata {
   hints?: string[];
   /** Optional concise UX brief for this channel. */
   uxBrief?: string;
+  /** Chat type from the gateway (e.g. "private", "group", "supergroup", "channel"). */
+  chatType?: string;
 }
 
 export interface SessionCreateRequest {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -655,7 +655,12 @@ export class DaemonServer {
     session.setAuthContext(options?.authContext ?? null);
     await session.ensureActorScopedHistory();
     session.setChannelCapabilities(
-      resolveChannelCapabilities(sourceChannel, sourceInterface),
+      resolveChannelCapabilities(
+        sourceChannel,
+        sourceInterface,
+        null,
+        options?.transport?.chatType,
+      ),
     );
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Non-desktop sessions (CLI,

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -37,6 +37,8 @@ export interface ChannelCapabilities {
   pttActivationKey?: string;
   /** Whether the client has been granted microphone permission by the OS. */
   microphonePermissionGranted?: boolean;
+  /** Chat type from the gateway (e.g. "private", "group", "supergroup", "channel", "im", "mpim"). */
+  chatType?: string;
 }
 
 /**
@@ -296,6 +298,7 @@ export function resolveChannelCapabilities(
   sourceChannel?: string | null,
   sourceInterface?: string | null,
   pttMetadata?: PttMetadata | null,
+  chatType?: string | null,
 ): ChannelCapabilities {
   // Normalise legacy pseudo-channel IDs to canonical ChannelId values.
   let channel: string;
@@ -330,6 +333,8 @@ export function resolveChannelCapabilities(
     }
   }
 
+  const resolvedChatType = chatType ?? undefined;
+
   switch (channel) {
     case "vellum": {
       const supportsDesktopUi = iface === "macos";
@@ -342,6 +347,7 @@ export function resolveChannelCapabilities(
           pttMetadata?.pttActivationKey,
         ),
         microphonePermissionGranted: pttMetadata?.microphonePermissionGranted,
+        chatType: resolvedChatType,
       };
     }
     case "telegram":
@@ -354,6 +360,7 @@ export function resolveChannelCapabilities(
         dashboardCapable: false,
         supportsDynamicUi: false,
         supportsVoiceInput: false,
+        chatType: resolvedChatType,
       };
     default:
       return {
@@ -361,7 +368,25 @@ export function resolveChannelCapabilities(
         dashboardCapable: false,
         supportsDynamicUi: false,
         supportsVoiceInput: false,
+        chatType: resolvedChatType,
       };
+  }
+}
+
+/**
+ * Returns true when the chat type indicates a group/multi-party conversation
+ * (Telegram group/supergroup, Slack channel/group/mpim, etc.).
+ */
+export function isGroupChatType(chatType?: string): boolean {
+  if (!chatType) return false;
+  switch (chatType) {
+    case "group":
+    case "supergroup":
+    case "channel":
+    case "mpim":
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -628,6 +653,31 @@ export function injectChannelCapabilityContext(
     if (caps.microphonePermissionGranted !== undefined) {
       lines.push(
         `microphone_permission_granted: ${caps.microphonePermissionGranted}`,
+      );
+    }
+  }
+
+  // Inject group chat etiquette only when the chat type indicates a multi-party
+  // conversation, avoiding misconditioned "stay silent" guidance in 1:1 DMs.
+  if (isGroupChatType(caps.chatType)) {
+    lines.push(`chat_type: ${caps.chatType}`);
+    lines.push("");
+    lines.push("GROUP CHAT ETIQUETTE:");
+    lines.push(
+      "- You are a **participant**, not the user's proxy. Think before you speak.",
+    );
+    lines.push(
+      "- **Respond when:** directly mentioned, you can add genuine value, something witty fits naturally, or correcting important misinformation.",
+    );
+    lines.push(
+      '- **Stay silent when:** casual banter between humans, someone already answered, your response would just be "yeah" or "nice", or the conversation flows fine without you.',
+    );
+    lines.push(
+      "- **The human rule:** humans don't respond to every message in a group chat. Neither should you. Quality over quantity.",
+    );
+    if (caps.channel === "slack") {
+      lines.push(
+        "- Use emoji reactions naturally to acknowledge without cluttering.",
       );
     }
   }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -511,17 +511,8 @@ export function buildChannelAwarenessSection(): string {
     "- When the user asks about voice input or push-to-talk settings, use the tool to apply changes directly rather than directing them to settings.",
     "- When `microphone_permission_granted` is `false`, guide the user to grant microphone access in System Settings before using voice features.",
     "",
-    "### Group chat etiquette",
-    "- In group chats, you are a **participant**, not the user's proxy. Think before you speak.",
-    "- **Respond when:** directly mentioned, you can add genuine value, something witty fits naturally, or correcting important misinformation.",
-    '- **Stay silent when:** it\'s casual banter between humans, someone already answered, your response would just be "yeah" or "nice", or the conversation flows fine without you.',
-    "- **The human rule:** humans don't respond to every message in a group chat. Neither should you. Quality over quantity.",
-    "- On platforms with reactions (Discord, Slack), use emoji reactions naturally to acknowledge without cluttering.",
-    "",
     "### Platform formatting",
-    "- **Discord/WhatsApp:** Do not use markdown tables — use bullet lists instead.",
-    "- **Discord links:** Wrap multiple links in `<>` to suppress embeds.",
-    "- **WhatsApp:** No markdown headers — use **bold** or CAPS for emphasis.",
+    "- **WhatsApp:** Do not use markdown tables — use bullet lists instead. No markdown headers — use **bold** or CAPS for emphasis.",
   ].join("\n");
 }
 

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -170,6 +170,11 @@ export async function sweepFailedEvents(
       sourceMetadata.uxBrief.trim().length > 0
         ? sourceMetadata.uxBrief.trim()
         : undefined;
+    const metadataChatType =
+      typeof sourceMetadata?.chatType === "string" &&
+      sourceMetadata.chatType.trim().length > 0
+        ? sourceMetadata.chatType.trim()
+        : undefined;
 
     try {
       const { messageId: userMessageId } = await processMessage(
@@ -181,6 +186,7 @@ export async function sweepFailedEvents(
             channelId: sourceChannel,
             hints: metadataHints.length > 0 ? metadataHints : undefined,
             uxBrief: metadataUxBrief,
+            chatType: metadataChatType,
           },
           assistantId,
           trustContext,

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -116,6 +116,7 @@ export interface RuntimeMessageSessionOptions {
     channelId: ChannelId;
     hints?: string[];
     uxBrief?: string;
+    chatType?: string;
   };
   assistantId?: string;
   trustContext?: TrustContext;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -390,6 +390,13 @@ export async function handleChannelInbound(
       ? (rawCommandIntent as Record<string, unknown>)
       : undefined;
 
+  // Extract chat type (e.g. "private", "group", "supergroup") for group chat gating
+  const sourceChatType =
+    typeof sourceMetadata?.chatType === "string" &&
+    sourceMetadata.chatType.trim().length > 0
+      ? sourceMetadata.chatType.trim()
+      : undefined;
+
   // Preserve locale from sourceMetadata so the model can greet in the user's language
   const sourceLanguageCode =
     typeof sourceMetadata?.languageCode === "string" &&
@@ -620,6 +627,7 @@ export async function handleChannelInbound(
       assistantId: canonicalAssistantId,
       approvalCopyGenerator,
       externalMessageId: sourceMessageId ?? externalMessageId,
+      chatType: sourceChatType,
     });
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -77,6 +77,8 @@ export interface BackgroundProcessingParams {
   sourceLanguageCode?: string;
   /** External message ID (e.g. Slack message ts) used for reaction indicators. */
   externalMessageId?: string;
+  /** Chat type from the gateway (e.g. "private", "group", "supergroup"). */
+  chatType?: string;
 }
 
 /**
@@ -105,6 +107,7 @@ export function processChannelMessageInBackground(
     commandIntent,
     sourceLanguageCode,
     externalMessageId,
+    chatType,
   } = params;
 
   (async () => {
@@ -193,6 +196,7 @@ export function processChannelMessageInBackground(
             channelId: sourceChannel,
             hints: metadataHints.length > 0 ? metadataHints : undefined,
             uxBrief: metadataUxBrief,
+            chatType,
           },
           assistantId,
           trustContext: trustCtx,


### PR DESCRIPTION
## Summary
- Move group chat etiquette from static system prompt to per-turn `<channel_capabilities>` block, gated on `chatType` metadata from the gateway
- Thread `chatType` from gateway `sourceMetadata` through transport metadata to `ChannelCapabilities`
- Add `isGroupChatType()` helper to classify group vs DM chat types (group, supergroup, channel, mpim)
- Remove dead Discord references from `buildChannelAwarenessSection()` (Discord is not a supported channel)
- Consolidate WhatsApp formatting rules into a single line

Addresses review feedback on #15226 (P1: group-chat etiquette misconditions DMs, Devin: Discord dead code)

## Test plan
- [x] All 87 session-runtime-assembly tests pass
- [x] TypeScript type-checking passes
- [x] New tests verify group chat etiquette is injected only for group chat types
- [x] New tests verify etiquette is NOT injected for private/DM/absent chatType
- [x] New tests verify Discord references removed from static system prompt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
