### PR TITLE
fix: convert remaining failing overflow tests to test.todo (JARVIS-110)

### DIFF
--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -7,9 +7,8 @@
  *   2. Token estimation significantly underestimates actual token count
  *   3. No mid-loop budget check to prevent hitting the provider limit
  *
- * Tests 2, 3, and 4 pass against the current code.
- * Tests 1, 5 are test.todo (documenting bugs to be fixed in PR 2).
- * Tests 6 and 7 are test.todo (depend on mid-loop checkpoint changes in PR 3).
+ * All tests are test.todo — they document expected behavior for bugs
+ * to be fixed in subsequent PRs (PR 2 for tests 1–5, PR 3 for tests 6–7).
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -707,7 +706,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // When estimation says we're within budget but the provider rejects,
   // the post-run convergence loop should kick in and recover.
   // This test should PASS against current code (when no progress is made).
-  test("overflow recovery compacts below limit even when estimation underestimates", async () => {
+  test.todo("overflow recovery compacts below limit even when estimation underestimates", async () => {
     const events: ServerMessage[] = [];
     let callCount = 0;
     let reducerCalled = false;
@@ -825,7 +824,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // inaccuracy. For example: 190k / 1.31 ≈ 145k.
   // Planned fix: targetInputTokensOverride should be adjusted based on
   // the ratio between estimated and actual tokens.
-  test("forced compaction targets a lower budget when estimation has been inaccurate", async () => {
+  test.todo("forced compaction targets a lower budget when estimation has been inaccurate", async () => {
     const events: ServerMessage[] = [];
     let callCount = 0;
     let capturedTargetTokens: number | undefined;
@@ -947,7 +946,7 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // token estimation underestimates. This test should PASS against
   // current code because the agent loop returns same-length history
   // (no progress), so the convergence loop kicks in.
-  test("overflow recovery succeeds for 75+ message conversation with many tool calls", async () => {
+  test.todo("overflow recovery succeeds for 75+ message conversation with many tool calls", async () => {
     const events: ServerMessage[] = [];
     const longHistory = buildLongConversation(75);
     let callCount = 0;


### PR DESCRIPTION
## Summary
- Tests 2, 3, and 4 in `session-agent-loop-overflow.test.ts` were using `test()` but failing, violating the AGENTS.md rule that unfixed bug tests must use `test.todo()`
- Converted tests 2, 3, 4 from `test()` to `test.todo()` (tests 1, 5, 6, 7 were already converted on main)
- Updated header comment to reflect that all 7 tests are now todo

Addresses review feedback from #15940.
Part of JARVIS-110

## Test plan
- [x] Verified all 7 tests show as `todo` (0 pass, 7 todo, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
