### PR TITLE
fix: surface non-404 errors from GitHub tree lookup in skill fetch

### DIFF
--- a/assistant/src/__tests__/skillssh-registry.test.ts
+++ b/assistant/src/__tests__/skillssh-registry.test.ts
@@ -427,6 +427,27 @@ describe("fetchSkillFromGitHub", () => {
     expect(files["scripts/filter.sh"]).toBe("#!/bin/bash\necho filter");
   });
 
+  test("surfaces non-404 errors from tree lookup instead of misleading 'not found'", async () => {
+    mockFetchImpl = (url: string | URL | Request) => {
+      const urlStr = url.toString();
+      // Probe for conventional path returns 404
+      if (urlStr.includes("/contents/skills/my-skill")) {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+      // Tree API returns a rate-limit error
+      if (urlStr.includes("/git/trees/")) {
+        return Promise.resolve(
+          new Response("rate limit exceeded", { status: 403 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    };
+
+    await expect(
+      fetchSkillFromGitHub("owner", "repo", "my-skill"),
+    ).rejects.toThrow("GitHub API error while searching repo tree: HTTP 403");
+  });
+
   test("throws when skill not found in tree either", async () => {
     mockFetchImpl = (url: string | URL | Request) => {
       const urlStr = url.toString();

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -228,7 +228,12 @@ async function findSkillDirInTree(
     headers,
     signal: AbortSignal.timeout(15_000),
   });
-  if (!response.ok) return null;
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API error while searching repo tree: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
 
   const data = (await response.json()) as { tree: GitHubTreeEntry[] };
   const suffix = `${skillSlug}/SKILL.md`;


### PR DESCRIPTION
## Summary
- When `findSkillDirInTree` gets a non-404 error from the GitHub Trees API (auth failures, rate limits, server errors), it now throws with the actual HTTP status instead of returning `null` and producing a misleading "skill not found" error
- Adds a test verifying that a 403 from the tree endpoint propagates as a GitHub API error

Addresses review feedback from #16117.

## Test plan
- [ ] Verify new test passes: `cd assistant && bun test src/__tests__/skillssh-registry.test.ts --grep "surfaces non-404"`
- [ ] Verify existing tests still pass: `cd assistant && bun test src/__tests__/skillssh-registry.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
