### PR TITLE
fix: unify chat widget backgrounds to surfaceOverlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -199,7 +199,7 @@ struct AssistantProgressView: View {
                     .padding(.bottom, VSpacing.xs)
             }
         }
-        .background(colorScheme == .light ? VColor.surfaceOverlay : VColor.surfaceBase.opacity(0.5))
+        .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onChange(of: phase) { _, newPhase in
             if newPhase == .processing {
@@ -426,7 +426,7 @@ struct AssistantProgressView: View {
                         onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
                         onTemporaryAllow: onTemporaryAllow
                     )
-                    .padding(.horizontal, VSpacing.md)
+                    .padding(.horizontal, VSpacing.sm)
                     .padding(.vertical, VSpacing.xs)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -37,7 +37,6 @@ struct AssistantProgressView: View {
     var onTemporaryAllow: ((String, String) -> Void)? = nil
     var activeConfirmationRequestId: String? = nil  // For keyboard focus
 
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var isExpanded: Bool = false
     @State private var startDate: Date = Date()

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -96,7 +96,7 @@ struct InlineVideoAttachmentView: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(VColor.borderBase.opacity(0.4), lineWidth: 0.5)

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoEmbedCard.swift
@@ -37,7 +37,7 @@ struct InlineVideoEmbedCard: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(VColor.borderBase.opacity(0.4), lineWidth: 0.5)

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -105,7 +105,7 @@ public struct GuardianDecisionBubble: View {
         .padding(VSpacing.md)
         .background(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .stroke(config.accent.opacity(0.3), lineWidth: 1)

--- a/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -73,7 +73,7 @@ public struct InlineCardWidget: View {
         .padding(VSpacing.md)
         .background(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase.opacity(0.5))
+                .fill(VColor.surfaceOverlay.opacity(0.5))
         )
     }
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -95,16 +95,6 @@ public struct ToolConfirmationBubble: View {
         }
     }
 
-    /// Color for the risk level badge.
-    private var riskColor: Color {
-        switch confirmation.riskLevel.lowercased() {
-        case "low":    return VColor.contentTertiary
-        case "medium": return VColor.systemNegativeHover
-        case "high":   return VColor.systemNegativeStrong
-        default:       return VColor.contentTertiary
-        }
-    }
-
     public var body: some View {
         if confirmation.isSystemPermissionRequest {
             if isDecided {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -275,38 +275,7 @@ public struct ToolConfirmationBubble: View {
         )
     }
 
-    // MARK: - Header Row
 
-    @ViewBuilder
-    private var headerRow: some View {
-        HStack(spacing: VSpacing.sm) {
-            VIconView(confirmation.toolCategoryIcon, size: 12)
-                .foregroundColor(VColor.contentSecondary)
-
-            Text(confirmation.toolCategory)
-                .font(VFont.captionMedium)
-                .foregroundColor(VColor.contentDefault)
-
-            VBadge(
-                style: .label(confirmation.riskLevel.capitalized),
-                color: riskColor
-            )
-
-            if let target = confirmation.normalizedExecutionTarget {
-                Text(target)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.contentTertiary)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(
-                        Capsule()
-                            .fill(VColor.surfaceOverlay)
-                    )
-            }
-
-            Spacer()
-        }
-    }
 
     // MARK: - Inline Preview
 

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -160,11 +160,11 @@ public struct ToolConfirmationBubble: View {
         .padding(VSpacing.lg)
         .background(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
         )
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
+                .stroke(VColor.borderBase, lineWidth: 0.5)
         )
     }
 
@@ -267,10 +267,10 @@ public struct ToolConfirmationBubble: View {
         .padding(VSpacing.md)
         .background(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.borderBase, lineWidth: 1)
+                        .stroke(VColor.borderBase, lineWidth: 0.5)
                 )
         )
     }
@@ -300,7 +300,7 @@ public struct ToolConfirmationBubble: View {
                     .padding(.vertical, VSpacing.xxs)
                     .background(
                         Capsule()
-                            .fill(VColor.surfaceBase)
+                            .fill(VColor.surfaceOverlay)
                     )
             }
 
@@ -329,7 +329,7 @@ public struct ToolConfirmationBubble: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: VRadius.sm)
-                .fill(VColor.surfaceBase)
+                .fill(VColor.surfaceOverlay)
         )
     }
 


### PR DESCRIPTION
## Summary
- Standardize all chat card/widget backgrounds (AssistantProgressView, ToolConfirmationBubble, InlineVideoEmbedCard, InlineVideoAttachmentView, InlineCardWidget, GuardianDecisionBubble) to `VColor.surfaceOverlay` for visual consistency
- Reduce ToolConfirmationBubble border stroke from 1px to 0.5px
- Align ToolConfirmationBubble horizontal padding with StepDetailRow edges

## Test plan
- [ ] Verify AssistantProgressView card background matches other widgets
- [ ] Verify ToolConfirmationBubble border is thinner and edges align with step rows
- [ ] Check all inline widgets (video, card, guardian decision) have consistent backgrounds
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
