### PR TITLE
feat: screenshot after navigating in collaborative OAuth flow

### DIFF
--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -67,7 +67,7 @@ The helper detects the default browser and navigates in the existing tab. Falls 
 ### Rules
 
 1. **Navigation is your job.** Open every URL for the user — they should never have to type a URL.
-2. **Screenshots are a tool, not a routine.** Give clear landmark-based instructions and let the user report. If they're stuck, offer to screenshot: "Want me to take a look? I can screenshot your screen to see what you're seeing."
+2. **Screenshot after navigating.** After opening a page, take a screenshot to see what's actually on screen. Use what you see to give specific, contextual instructions rather than generic guidance. Developer consoles change frequently — never assume you know the exact layout.
 3. **Never auto-advance.** Wait for user confirmation ("done", "ok", "next") before proceeding.
 4. **Use landmarks, not coordinates.** Say "Look for **APIs & Services**" not "click the third item in the left sidebar."
 5. **Confirm after, not before.** Describe what they _should see after_ they act, not what the page _should_ look like beforehand.
@@ -81,10 +81,11 @@ The helper detects the default browser and navigates in the existing tab. Falls 
 Every step follows this pattern:
 
 1. **Open the URL** using the navigation helper
-2. **Give a landmark-based instruction** — tell the user what to look for
-3. **User acts** and confirms
-4. **If the user reports a mismatch** — offer to screenshot, then adapt
-5. **Move on** once confirmed
+2. **Screenshot** to see the current state of the page
+3. **Give a specific instruction** based on what you actually see on screen — reference exact button labels, section names, and layout
+4. **User acts** and confirms
+5. **If the user reports a mismatch or seems stuck** — screenshot again to see what changed, then adapt
+6. **Move on** once confirmed
 
 ---
 
@@ -188,8 +189,8 @@ For non-interactive channels, provide all URLs and instructions as text messages
 
 ### When Things Don't Match
 
-1. **Don't panic or apologize excessively** — "Okay, this looks a bit different than expected. Let me take a look..."
-2. **Describe what you see and reorient** — "It looks like you're on the project selector page. Let's pick the project we just created..."
+1. **Don't panic or apologize excessively** — "Okay, that looks a bit different than expected. Let me take a look..."
+2. **Screenshot first, then reorient** — take a screenshot to see the actual state, then describe what you see: "It looks like you're on the project selector page. Let's pick the project we just created..."
 3. **Never blame the user** — the UI is the variable, not them.
 
 ### Recovery Patterns

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -65,7 +65,7 @@ Open: `https://www.notion.so/profile/integrations`
 - If "Public" is not available as a type, the user may need to check their workspace settings or plan level
 - If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it — skip ahead to Step 3
 
-**Milestone (2 of 6):** "Integration created — now we'll configure the OAuth redirect."
+**Milestone (2 of 6):** "Integration created — now let's get it configured."
 
 ---
 


### PR DESCRIPTION
## Summary
- Changed rule 2 from "screenshots are a tool, not a routine" to "screenshot after navigating" — the assistant should proactively screenshot after opening each page to see the actual UI state
- Updated step rhythm to include screenshot as step 2 (after opening URL, before giving instructions)
- Updated error handling to screenshot first before trying to reorient
- Minor: updated Notion milestone text for step 2 since redirect URI step is now skippable

## Why
During QA, the assistant was giving generic instructions without knowing what was actually on screen. Developer consoles change frequently — the assistant needs to see the real UI to give useful guidance.

## Test plan
- [ ] Run "set up notion" — assistant should screenshot after opening integrations page and give specific instructions based on what it sees
- [ ] Verify instructions reference actual button labels and layout elements visible on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
