### PR TITLE
refactor: use VButton ghost icon-only for settings back button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -69,15 +69,14 @@ struct SettingsPanel: View {
         VStack(spacing: 0) {
             // Header: back chevron + title
             HStack(spacing: VSpacing.md) {
-                Button(action: onClose) {
-                    VIconView(.chevronLeft, size: 16)
-                        .frame(width: 24, height: 24)
-                        .contentShape(Rectangle())
+                VButton(
+                    label: "Back",
+                    iconOnly: VIcon.chevronLeft.rawValue,
+                    style: .ghost,
+                    tooltip: "Back"
+                ) {
+                    onClose()
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(VColor.primaryBase)
-                .pointerCursor()
-                .accessibilityLabel("Back")
 
                 Text("Settings")
                     .font(VFont.panelTitle)


### PR DESCRIPTION
## Summary
- Replace the custom plain `Button` wrapping `VIconView(.chevronLeft)` with `VButton` using `.ghost` style and `iconOnly` mode
- Consistent with design system conventions — all icon buttons should use `VButton`

## Original prompt
update it so that it's a Vbutton ghost with icon only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
