### PR TITLE
fix: increase sidebar archive icon padding for text truncation (LUM-203)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -43,8 +43,8 @@ enum SidebarLayoutMetrics {
     static let archiveConfirmTrailingPadding: CGFloat = 72
 
     /// Trailing padding reserved for the archive icon overlay on hover
-    /// (20pt icon + 4pt trailing padding on the overlay + 4pt gap).
-    static let archiveIconTrailingPadding: CGFloat = 28
+    /// (20pt icon + 4pt trailing padding on the overlay + 8pt gap).
+    static let archiveIconTrailingPadding: CGFloat = 32
 
     // MARK: - Section Divider
 


### PR DESCRIPTION
## Summary
- Increases `archiveIconTrailingPadding` from 28pt to 32pt to prevent truncated thread titles from overlapping the archive icon overlay on hover
- Follow-up to #16431 which introduced the padding but didn't fully resolve the overlap

## Original prompt
https://linear.app/vellum/issue/LUM-203/truncated-text-overlaps-archive-button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
