### PR TITLE
feat: transition into guardian conversation after outbound phone verification

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -992,14 +992,10 @@ export class RelayConnection {
       }
 
       if (isOutbound) {
-        this.connectionState = "disconnecting";
+        // Send short verification confirmation TTS
         this.sendTextToken(result.ttsMessage!, true);
 
-        updateCallSession(this.callSessionId, {
-          status: "completed",
-          endedAt: Date.now(),
-        });
-
+        // Keep the pointer message back to the initiating conversation
         const successSession = getCallSession(this.callSessionId);
         if (successSession?.initiatedFromConversationId) {
           addPointerMessage(
@@ -1018,9 +1014,24 @@ export class RelayConnection {
           });
         }
 
-        setTimeout(() => {
-          this.endSession("Verified — guardian challenge passed");
-        }, getTtsPlaybackDelayMs());
+        // Update trust context on the controller so the LLM knows this is the guardian
+        if (this.controller) {
+          const verifiedActorTrust = resolveActorTrust({
+            assistantId,
+            sourceChannel: "phone",
+            conversationExternalId: fromNumber,
+            actorExternalId: fromNumber,
+          });
+          this.controller.setTrustContext(
+            toTrustContext(verifiedActorTrust, fromNumber),
+          );
+        }
+
+        // Mark session as in-progress and transition to normal call flow
+        updateCallSession(this.callSessionId, { status: "in_progress" });
+        if (this.controller) {
+          this.startNormalCallFlow(this.controller, false);
+        }
       } else if (result.verificationType === "trusted_contact") {
         this.continueCallAfterTrustedContactActivation({
           assistantId,

--- a/assistant/src/runtime/verification-templates.ts
+++ b/assistant/src/runtime/verification-templates.ts
@@ -165,7 +165,7 @@ const voiceTemplates: Record<
     "That code was incorrect. Please try again.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_SUCCESS]: (_vars) =>
-    "Verification successful. Thank you. Goodbye.",
+    "Verification successful.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE]: (_vars) =>
     "Too many incorrect attempts. Goodbye.",


### PR DESCRIPTION
## Summary
- After successful outbound guardian phone verification, instead of hanging up, the assistant now transitions into a natural guardian conversation
- Updates VOICE_SUCCESS TTS template to remove goodbye language
- Reuses existing startNormalCallFlow to trigger LLM greeting with guardian trust context

Part of plan: outbound-guardian-verify-conversation-transition.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
