### PR TITLE
feat: play avatar entry animation on first message in new thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -164,6 +164,7 @@ struct MessageListView: View {
     @State private var pendingAvatarY: CGFloat?
     @State private var avatarSmoothingTask: Task<Void, Never>?
     @State private var avatarLastAppliedAt: Date?
+    @State private var hasPlayedTailEntryAnimation = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -226,6 +227,10 @@ struct MessageListView: View {
             anchorY: avatarTargetY,
             viewportHeight: scrollViewportHeight
         )
+    }
+
+    private var shouldPlayTailEntryAnimation: Bool {
+        !hasPlayedTailEntryAnimation && messages.count <= 2
     }
 
     private var shouldCoalesceAvatarUpdates: Bool {
@@ -315,7 +320,8 @@ struct MessageListView: View {
                let eyes = appearance.characterEyeStyle,
                let color = appearance.characterColor {
                 AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color,
-                                   size: ConversationAvatarFollower.avatarSize)
+                                   size: ConversationAvatarFollower.avatarSize,
+                                   entryAnimationEnabled: shouldPlayTailEntryAnimation)
                     .frame(width: ConversationAvatarFollower.avatarSize,
                            height: ConversationAvatarFollower.avatarSize)
                     .padding(.horizontal, VSpacing.xl)
@@ -323,6 +329,11 @@ struct MessageListView: View {
                     .frame(maxWidth: .infinity)
                     .offset(y: avatarDisplayY)
                     .accessibilityHidden(true)
+                    .onAppear {
+                        if shouldPlayTailEntryAnimation {
+                            hasPlayedTailEntryAnimation = true
+                        }
+                    }
             } else {
                 HStack {
                     VAvatarImage(image: appearance.chatAvatarImage, size: ConversationAvatarFollower.avatarSize)


### PR DESCRIPTION
## Summary
- Added `hasPlayedTailEntryAnimation` state and `shouldPlayTailEntryAnimation` computed property to MessageListView
- Passes `entryAnimationEnabled` to the conversation tail AnimatedAvatarView when the thread is fresh (messages count <= 2)
- Consumes the flag via `.onAppear` to prevent mid-animation prop changes

Part of plan: avatar-entry-anim.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
