### PR TITLE
refactor: migrate transcribe-media OpenAI key from config.apiKeys to getSecureKeyAsync

### DIFF
--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -10,8 +10,8 @@ import {
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
 
-import { getConfig } from "../../../../config/loader.js";
 import { getAttachmentsByIds } from "../../../../memory/attachments-store.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -417,10 +417,10 @@ export async function run(
   }
 
   // Validate API key for api mode
+  let openaiKey: string | undefined;
   if (mode === "api") {
-    const config = getConfig();
-    const apiKey = config.apiKeys.openai;
-    if (!apiKey) {
+    openaiKey = await getSecureKeyAsync("openai");
+    if (!openaiKey) {
       return {
         content:
           'No OpenAI API key configured. Set your OpenAI API key to use cloud transcription, or use mode "local" for on-device transcription with whisper.cpp.',
@@ -441,8 +441,7 @@ export async function run(
 
     let text: string;
     if (mode === "api") {
-      const config = getConfig();
-      text = await transcribeViaApi(wavPath, config.apiKeys.openai!, context);
+      text = await transcribeViaApi(wavPath, openaiKey!, context);
     } else {
       text = await transcribeViaLocal(wavPath, context);
     }


### PR DESCRIPTION
## Summary
- Replace config.apiKeys.openai with await getSecureKeyAsync("openai") in transcribe-media.ts
- Key is fetched once and reused for both validation and API call

Part of plan: rm-config-apikeys.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
