### PR TITLE
feat: play avatar entry animation when identity panel opens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -60,7 +60,8 @@ struct IdentityPanel: View {
                                 if let body = appearance.characterBodyShape,
                                    let eyes = appearance.characterEyeStyle,
                                    let color = appearance.characterColor {
-                                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: avatarSize)
+                                    AnimatedAvatarView(bodyShape: body, eyeStyle: eyes, color: color, size: avatarSize,
+                                                       entryAnimationEnabled: true)
                                         .frame(width: avatarSize, height: avatarSize)
                                         .frame(maxWidth: .infinity, alignment: .center)
                                 } else {


### PR DESCRIPTION
## Summary
- Added `entryAnimationEnabled: true` to the AnimatedAvatarView in IdentityPanel
- The panel view tree is destroyed on close and recreated on open, so the entry animation naturally replays each time

Part of plan: avatar-entry-anim.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
