### PR TITLE
fix: use correct module import in SentryMaxAttachmentSizeTests

### DIFF
--- a/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
+++ b/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Vellum
+@testable import VellumAssistantLib
 
 final class SentryMaxAttachmentSizeTests: XCTestCase {
     func testSentryMaxAttachmentSizeIs100MB() {


### PR DESCRIPTION
## Summary
- Fix `SentryMaxAttachmentSizeTests` importing `Vellum` (non-existent module) instead of `VellumAssistantLib`, which caused all macOS tests to fail with "no such module 'Vellum'"

## Original prompt
help me fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23076927289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
