### PR TITLE
refactor: migrate provider-commit-message-generator key checks from config.apiKeys to getSecureKeyAsync

### DIFF
--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -1,6 +1,7 @@
 import { getConfig } from "../config/loader.js";
 import { resolveConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Message } from "../providers/types.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { CommitContext } from "./commit-message-provider.js";
 import { DefaultCommitMessageProvider } from "./commit-message-provider.js";
@@ -146,10 +147,13 @@ export class ProviderCommitMessageGenerator {
       const hasAnyKeylessCandidate = candidates.some((name) =>
         KEYLESS_PROVIDERS.has(name),
       );
-      const hasAnyProviderKey = candidates.some((name) => {
-        const value = config.apiKeys[name];
-        return typeof value === "string" && value.length > 0;
-      });
+      const keyChecks = await Promise.all(
+        candidates.map(async (name) => {
+          const value = await getSecureKeyAsync(name);
+          return typeof value === "string" && value.length > 0;
+        }),
+      );
+      const hasAnyProviderKey = keyChecks.some(Boolean);
       if (!hasAnyKeylessCandidate && !hasAnyProviderKey) {
         log.debug(
           "No API keys available for configured/fallback providers; falling back to deterministic",
@@ -168,8 +172,8 @@ export class ProviderCommitMessageGenerator {
 
     // Step 2b: API key preflight for the selected provider (skip keyless).
     if (!KEYLESS_PROVIDERS.has(selectedProviderName)) {
-      const providerApiKey = config.apiKeys[selectedProviderName];
-      if (!providerApiKey || providerApiKey === "") {
+      const providerApiKey = await getSecureKeyAsync(selectedProviderName);
+      if (!providerApiKey) {
         log.debug(
           {
             selectedProvider: selectedProviderName,


### PR DESCRIPTION
## Summary
- Replace config.apiKeys existence checks with getSecureKeyAsync calls
- Both the multi-provider availability check and single-provider preflight now use secure storage directly

Part of plan: rm-config-apikeys.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
