### PR TITLE
refactor: migrate backend-claude-code Anthropic key from config.apiKeys to getSecureKeyAsync

### DIFF
--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -5,9 +5,9 @@
  * is testable and swappable independently of the tool adapter.
  */
 
-import { getConfig } from "../config/loader.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
 import type { ModelIntent } from "../providers/types.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type {
   SwarmWorkerBackend,
@@ -28,9 +28,8 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
   return {
     name: "claude_code",
 
-    isAvailable(): boolean {
-      const config = getConfig();
-      const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+    async isAvailable(): Promise<boolean> {
+      const apiKey = await getSecureKeyAsync("anthropic");
       return !!apiKey;
     },
 
@@ -39,9 +38,7 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
       const stderrLines: string[] = [];
       try {
         const { query } = await import("@anthropic-ai/claude-agent-sdk");
-        const config = getConfig();
-        const apiKey =
-          config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+        const apiKey = await getSecureKeyAsync("anthropic");
         if (!apiKey) {
           return {
             success: false,

--- a/assistant/src/swarm/worker-backend.ts
+++ b/assistant/src/swarm/worker-backend.ts
@@ -125,7 +125,7 @@ export interface SwarmWorkerBackendInput {
 export interface SwarmWorkerBackend {
   readonly name: string;
   /** Check whether the backend is available (e.g. API key present). */
-  isAvailable(): boolean;
+  isAvailable(): boolean | Promise<boolean>;
   /** Run a task with the given input. */
   runTask(input: SwarmWorkerBackendInput): Promise<SwarmWorkerBackendResult>;
 }

--- a/assistant/src/swarm/worker-runner.ts
+++ b/assistant/src/swarm/worker-runner.ts
@@ -63,7 +63,7 @@ export async function runWorkerTask(
   emitStatus(onStatus, task.id, "queued");
 
   // Check backend availability
-  if (!backend.isAvailable()) {
+  if (!(await backend.isAvailable())) {
     emitStatus(onStatus, task.id, "failed");
     return {
       taskId: task.id,


### PR DESCRIPTION
## Summary
- Convert isAvailable() to async, using getSecureKeyAsync("anthropic") instead of config.apiKeys
- Update SwarmWorkerBackend interface to accept async isAvailable()
- Remove process.env.ANTHROPIC_API_KEY fallbacks from backend-claude-code.ts

Part of plan: rm-config-apikeys.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
