### PR TITLE
refactor: migrate Gemini API key consumers from config.apiKeys to getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -22,9 +22,14 @@ let lastGenerateCredentials: unknown = null;
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-
-    apiKeys: { gemini: mockApiKey },
   }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => {
+    if (account === "gemini") return mockApiKey;
+    return undefined;
+  },
 }));
 
 mock.module("../media/gemini-image-service.js", () => ({

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -15,6 +15,7 @@ import {
   resolveManagedProxyContext,
 } from "../../../../providers/managed-proxy/context.js";
 import type { ImageContent } from "../../../../providers/types.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
 import type {
   ToolContext,
@@ -51,7 +52,7 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
-  const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  const apiKey = await getSecureKeyAsync("gemini");
 
   // Resolve credentials: prefer direct API key, fall back to managed proxy
   let credentials: ImageGenCredentials | undefined;

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { getConfig } from "../../../../config/loader.js";
 import { getMediaAssetById } from "../../../../memory/media-store.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -29,8 +29,7 @@ export async function mapSegmentsForAsset(
   options: MapSegmentsOptions,
   onProgress?: (msg: string) => void,
 ): Promise<MapOutput> {
-  const config = getConfig();
-  const apiKey = config.apiKeys.gemini;
+  const apiKey = await getSecureKeyAsync("gemini");
 
   if (!apiKey) {
     throw new Error(
@@ -122,8 +121,7 @@ export async function run(
     let output: MapOutput;
 
     if (mode === "direct_video") {
-      const config = getConfig();
-      const apiKey = config.apiKeys.gemini;
+      const apiKey = await getSecureKeyAsync("gemini");
       if (!apiKey) {
         return {
           content:

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -15,6 +15,7 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../providers/managed-proxy/context.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import {
   generateImage,
@@ -36,7 +37,7 @@ export async function generateAppIcon(
   appDescription?: string,
 ): Promise<void> {
   const config = getConfig();
-  const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  const apiKey = await getSecureKeyAsync("gemini");
 
   let credentials: ImageGenCredentials | undefined;
   if (apiKey) {

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -3,6 +3,7 @@ import {
   buildManagedBaseUrl,
   resolveManagedProxyContext,
 } from "../providers/managed-proxy/context.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 import {
   generateImage,
@@ -13,7 +14,7 @@ export async function generateAvatar(
   prompt: string,
 ): Promise<{ imageBase64: string; mimeType: string }> {
   const config = getConfig();
-  const geminiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  const geminiKey = await getSecureKeyAsync("gemini");
 
   let credentials: ImageGenCredentials | undefined;
   if (geminiKey) {
@@ -32,7 +33,7 @@ export async function generateAvatar(
 
   if (!credentials) {
     throw new ConfigError(
-      "Gemini API key is not configured. Set it via `keys set gemini <key>` or the GEMINI_API_KEY environment variable.",
+      "Gemini API key is not configured. Set it via `keys set gemini <key>`.",
     );
   }
 


### PR DESCRIPTION
## Summary
- Replace config.apiKeys.gemini and process.env.GEMINI_API_KEY with await getSecureKeyAsync("gemini") in avatar-router, app-icon-generator, media-generate-image, and analyze-keyframes
- Remove env var fallbacks — consumers now rely solely on secure storage
- Remove unused getConfig() import from analyze-keyframes (was only used for apiKeys)
- Update media-generate-image test to mock getSecureKeyAsync instead of config.apiKeys

Part of plan: rm-config-apikeys.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
