### PR TITLE
refactor: convert getModelInfo and setModel to async, use getSecureKeyAsync for key checks

### DIFF
--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -1,9 +1,11 @@
 import {
+  API_KEY_PROVIDERS,
   getConfig,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
 import { initializeProviders } from "../../providers/registry.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import type {
   ImageGenModelSetRequest,
   ModelSetRequest,
@@ -26,11 +28,14 @@ export interface ModelInfo {
 }
 
 /** Return current model configuration. */
-export function getModelInfo(): ModelInfo {
+export async function getModelInfo(): Promise<ModelInfo> {
   const config = getConfig();
-  const configured = Object.keys(config.apiKeys).filter(
-    (k) => !!config.apiKeys[k],
-  );
+  const configured: string[] = [];
+  for (const p of API_KEY_PROVIDERS) {
+    if (await getSecureKeyAsync(p)) {
+      configured.push(p);
+    }
+  }
   if (!configured.includes("ollama")) configured.push("ollama");
   return {
     model: config.model,
@@ -58,7 +63,10 @@ export interface ModelSetContext {
  * Set the active model. Returns the resulting ModelInfo, or throws on failure.
  * The caller is responsible for sending the response to the client.
  */
-export function setModel(modelId: string, ctx: ModelSetContext): ModelInfo {
+export async function setModel(
+  modelId: string,
+  ctx: ModelSetContext,
+): Promise<ModelInfo> {
   // If the requested model is already the current model AND the provider
   // is already aligned with what MODEL_TO_PROVIDER expects, skip expensive
   // reinitialization but still return model_info so the client confirms.
@@ -68,17 +76,16 @@ export function setModel(modelId: string, ctx: ModelSetContext): ModelInfo {
     const providerAligned =
       !expectedProvider || current.provider === expectedProvider;
     if (modelId === current.model && providerAligned) {
-      return getModelInfo();
+      return await getModelInfo();
     }
   }
 
   // Validate API key before switching
   const provider = MODEL_TO_PROVIDER[modelId];
   if (provider && provider !== "ollama") {
-    const currentConfig = getConfig();
-    if (!currentConfig.apiKeys[provider]) {
+    if (!(await getSecureKeyAsync(provider))) {
       // Return current model_info so the client resyncs its optimistic state
-      return getModelInfo();
+      return await getModelInfo();
     }
   }
 
@@ -158,20 +165,20 @@ export function setImageGenModel(modelId: string, ctx: ModelSetContext): void {
 // HTTP handlers (delegate to shared logic)
 // ---------------------------------------------------------------------------
 
-export function handleModelGet(ctx: HandlerContext): void {
-  const info = getModelInfo();
+export async function handleModelGet(ctx: HandlerContext): Promise<void> {
+  const info = await getModelInfo();
   ctx.send({
     type: "model_info",
     ...info,
   });
 }
 
-export function handleModelSet(
+export async function handleModelSet(
   msg: ModelSetRequest,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   try {
-    const info = setModel(msg.model, ctx);
+    const info = await setModel(msg.model, ctx);
     ctx.send({ type: "model_info", ...info });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -193,4 +200,3 @@ export function handleImageGenModelSet(
     log.error({ err }, `Failed to set image gen model: ${message}`);
   }
 }
-

--- a/assistant/src/runtime/routes/session-query-routes.ts
+++ b/assistant/src/runtime/routes/session-query-routes.ts
@@ -52,8 +52,8 @@ export function sessionQueryRouteDefinitions(
       endpoint: "model",
       method: "GET",
       policyKey: "model",
-      handler: () => {
-        const info = getModelInfo();
+      handler: async () => {
+        const info = await getModelInfo();
         return Response.json(info);
       },
     },
@@ -74,7 +74,7 @@ export function sessionQueryRouteDefinitions(
           );
         }
         try {
-          const info = setModel(body.modelId, deps.getModelSetContext());
+          const info = await setModel(body.modelId, deps.getModelSetContext());
           return Response.json(info);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Convert getModelInfo and setModel to async functions
- Replace config.apiKeys checks with getSecureKeyAsync calls
- Update handleModelGet, handleModelSet, and session-query-routes callers

Part of plan: rm-config-apikeys.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
