### PR TITLE
refactor: convert resolveSlash chain to async, use getSecureKeyAsync for key checks

### DIFF
--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -66,6 +66,20 @@ mock.module("../config/loader.js", () => ({
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
   invalidateConfigCache: () => {},
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+  ],
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
 }));
 
 mock.module("../prompts/system-prompt.js", () => ({
@@ -401,8 +415,8 @@ describe("Session slash command — known", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveSlash — direct characterization", () => {
-  test('known slash returns {kind: "rewritten"} with model-facing content and skillId', () => {
-    const result = resolveSlash("/start-the-day");
+  test('known slash returns {kind: "rewritten"} with model-facing content and skillId', async () => {
+    const result = await resolveSlash("/start-the-day");
     expect(result.kind).toBe("rewritten");
     if (result.kind !== "rewritten") throw new Error("unreachable");
     expect(result.content).toContain("slash command");
@@ -416,8 +430,10 @@ describe("resolveSlash — direct characterization", () => {
     expect(result.skillId).toBe("start-the-day");
   });
 
-  test("known slash with trailing args includes args in rewritten content and skillId", () => {
-    const result = resolveSlash("/start-the-day check emails and calendar");
+  test("known slash with trailing args includes args in rewritten content and skillId", async () => {
+    const result = await resolveSlash(
+      "/start-the-day check emails and calendar",
+    );
     expect(result.kind).toBe("rewritten");
     if (result.kind !== "rewritten") throw new Error("unreachable");
     expect(result.content).toContain(
@@ -426,23 +442,23 @@ describe("resolveSlash — direct characterization", () => {
     expect(result.skillId).toBe("start-the-day");
   });
 
-  test('normal text returns {kind: "passthrough"} with content unchanged and no skillId', () => {
-    const result = resolveSlash("hello world");
+  test('normal text returns {kind: "passthrough"} with content unchanged and no skillId', async () => {
+    const result = await resolveSlash("hello world");
     expect(result.kind).toBe("passthrough");
     if (result.kind !== "passthrough") throw new Error("unreachable");
     expect(result.content).toBe("hello world");
     expect("skillId" in result).toBe(false);
   });
 
-  test("path-like input returns passthrough (not treated as slash)", () => {
-    const result = resolveSlash("/tmp/some-file.txt");
+  test("path-like input returns passthrough (not treated as slash)", async () => {
+    const result = await resolveSlash("/tmp/some-file.txt");
     expect(result.kind).toBe("passthrough");
     if (result.kind !== "passthrough") throw new Error("unreachable");
     expect(result.content).toBe("/tmp/some-file.txt");
   });
 
-  test('unknown slash returns {kind: "unknown"} with message and no skillId', () => {
-    const result = resolveSlash("/does-not-exist");
+  test('unknown slash returns {kind: "unknown"} with message and no skillId', async () => {
+    const result = await resolveSlash("/does-not-exist");
     expect(result.kind).toBe("unknown");
     if (result.kind !== "unknown") throw new Error("unreachable");
     expect(result.message).toContain("Unknown command `/does-not-exist`");
@@ -450,8 +466,8 @@ describe("resolveSlash — direct characterization", () => {
     expect("skillId" in result).toBe(false);
   });
 
-  test("empty input returns passthrough with no skillId", () => {
-    const result = resolveSlash("");
+  test("empty input returns passthrough with no skillId", async () => {
+    const result = await resolveSlash("");
     expect(result.kind).toBe("passthrough");
     if (result.kind !== "passthrough") throw new Error("unreachable");
     expect(result.content).toBe("");

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -799,7 +799,7 @@ export class DaemonServer {
       sourceInterface,
     );
 
-    const slashResult = resolveSlash(content);
+    const slashResult = await resolveSlash(content);
 
     if (slashResult.kind === "unknown") {
       const serverTurnCtx = session.getTurnChannelContext();

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -15,7 +15,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
-import { getConfig } from "../config/loader.js";
+import { API_KEY_PROVIDERS, getConfig } from "../config/loader.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
 import {
   addMessage,
@@ -27,6 +27,7 @@ import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type {
   ServerMessage,
@@ -47,12 +48,15 @@ import { resolveVerificationSessionIntent } from "./verification-session-intent.
 const log = getLogger("session-process");
 
 /** Build a model_info event with fresh config data. */
-export function buildModelInfoEvent(): ServerMessage {
+export async function buildModelInfoEvent(): Promise<ServerMessage> {
   const config = getConfig();
-  const configured = Object.keys(config.apiKeys).filter(
-    (k) => !!config.apiKeys[k],
-  );
-  if (!configured.includes("ollama")) configured.push("ollama");
+  const configured: string[] = ["ollama"];
+  for (const p of API_KEY_PROVIDERS) {
+    if (p === "ollama") continue;
+    if (await getSecureKeyAsync(p)) {
+      configured.push(p);
+    }
+  }
   return {
     type: "model_info",
     model: config.model,
@@ -296,7 +300,10 @@ export async function drainQueue(
   }
 
   // Resolve slash commands for queued messages
-  const slashResult = resolveSlash(next.content, buildSlashContext(session));
+  const slashResult = await resolveSlash(
+    next.content,
+    buildSlashContext(session),
+  );
 
   // Unknown slash — persist the exchange and continue draining.
   // Persist each message before pushing to session.messages so that a
@@ -365,7 +372,7 @@ export async function drainQueue(
         isModelSlashCommand(next.content) ||
         isProviderShortcut(next.content)
       ) {
-        next.onEvent(buildModelInfoEvent());
+        next.onEvent(await buildModelInfoEvent());
       }
       next.onEvent({ type: "assistant_text_delta", text: slashResult.message });
       session.traceEmitter.emit(
@@ -651,7 +658,7 @@ export async function processMessage(
   }
 
   // Resolve slash commands before persistence
-  const slashResult = resolveSlash(content, buildSlashContext(session));
+  const slashResult = await resolveSlash(content, buildSlashContext(session));
 
   // Unknown slash command — persist the exchange (user + assistant) so the
   // messageId is real.  Persist each message before pushing to session.messages
@@ -715,7 +722,7 @@ export async function processMessage(
     // Emit fresh model info before the text delta so the client has
     // up-to-date configuredProviders when rendering /model or /models UI.
     if (isModelSlashCommand(content) || isProviderShortcut(content)) {
-      onEvent(buildModelInfoEvent());
+      onEvent(await buildModelInfoEvent());
     }
     onEvent({ type: "assistant_text_delta", text: slashResult.message });
     session.traceEmitter.emit(

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -5,10 +5,16 @@ import { join } from "node:path";
 import QRCode from "qrcode";
 
 import { getGatewayPort, getIngressPublicBaseUrl } from "../config/env.js";
-import { getConfig, loadRawConfig, saveRawConfig } from "../config/loader.js";
+import {
+  API_KEY_PROVIDERS,
+  getConfig,
+  loadRawConfig,
+  saveRawConfig,
+} from "../config/loader.js";
 import { resolveSkillStates } from "../config/skill-state.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import { initializeProviders } from "../providers/registry.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import {
   buildInvocableSlashCatalog,
   resolveSlashSkillCommand,
@@ -146,7 +152,9 @@ function matchModel(input: string): string | undefined {
   return AVAILABLE_MODELS.find((m) => m.includes(lower));
 }
 
-function resolveProviderModelCommand(content: string): SlashResolution | null {
+async function resolveProviderModelCommand(
+  content: string,
+): Promise<SlashResolution | null> {
   const trimmed = content.trim();
   if (!trimmed.startsWith("/")) return null;
 
@@ -163,7 +171,7 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   const name = getAssistantName();
 
   // Check if API key exists for this provider (Ollama doesn't require an API key)
-  if (provider !== "ollama" && !config.apiKeys[provider]) {
+  if (provider !== "ollama" && !(await getSecureKeyAsync(provider))) {
     return {
       kind: "unknown",
       message: `Cannot switch to ${displayName}. No API key configured for ${provider}.\n\nSet it with: \`keys set ${provider} <your-key>\``,
@@ -201,14 +209,23 @@ function resolveProviderModelCommand(content: string): SlashResolution | null {
   };
 }
 
-function resolveModelList(): SlashResolution {
+async function resolveModelList(): Promise<SlashResolution> {
   const config = getConfig();
+
+  // Build a set of providers that have a configured API key.
+  const configuredProviders = new Set<string>(["ollama"]);
+  for (const p of API_KEY_PROVIDERS) {
+    if (await getSecureKeyAsync(p)) {
+      configuredProviders.add(p);
+    }
+  }
+
   const lines = ["Available models:\n"];
 
   for (const [cmd, { provider, model, displayName }] of Object.entries(
     PROVIDER_MODEL_SHORTCUTS,
   )) {
-    const hasKey = provider === "ollama" || !!config.apiKeys[provider];
+    const hasKey = configuredProviders.has(provider);
     const isCurrent = config.provider === provider && config.model === model;
     const status = hasKey ? "✓" : "✗";
     const current = isCurrent ? " **[current]**" : "";
@@ -224,11 +241,13 @@ function resolveModelList(): SlashResolution {
   };
 }
 
-function resolveModelCommand(content: string): SlashResolution | null {
+async function resolveModelCommand(
+  content: string,
+): Promise<SlashResolution | null> {
   const trimmed = content.trim();
   // Match /models → route to list
   if (trimmed === "/models") {
-    return resolveModelList();
+    return await resolveModelList();
   }
 
   if (!trimmed.startsWith("/model")) return null;
@@ -251,7 +270,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
 
   // Handle /model list
   if (args === "list") {
-    return resolveModelList();
+    return await resolveModelList();
   }
 
   // Try to match the model name
@@ -280,7 +299,7 @@ function resolveModelCommand(content: string): SlashResolution | null {
   }
 
   // Validate that Anthropic provider is available
-  if (!currentConfig.apiKeys.anthropic) {
+  if (!(await getSecureKeyAsync("anthropic"))) {
     const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
     return {
       kind: "unknown",
@@ -343,16 +362,16 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
  * Resolve slash commands against the current skill catalog.
  * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
  */
-export function resolveSlash(
+export async function resolveSlash(
   content: string,
   context?: SlashContext,
-): SlashResolution {
+): Promise<SlashResolution> {
   // Check provider shortcuts first (/gpt4, /opus, etc.)
-  const providerResult = resolveProviderModelCommand(content);
+  const providerResult = await resolveProviderModelCommand(content);
   if (providerResult) return providerResult;
 
   // Handle /model command
-  const modelResult = resolveModelCommand(content);
+  const modelResult = await resolveModelCommand(content);
   if (modelResult) return modelResult;
 
   // Handle /pair command

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -864,7 +864,7 @@ export async function handleSendMessage(
     provider: config.provider,
     estimatedCost: session.usageStats.estimatedCost,
   };
-  const slashResult = resolveSlash(rawContent, slashContext);
+  const slashResult = await resolveSlash(rawContent, slashContext);
 
   if (slashResult.kind === "unknown") {
     session.processing = true;
@@ -909,7 +909,7 @@ export async function handleSendMessage(
       // a config change from a concurrent request.
       const modelInfoEvent =
         isModelSlashCommand(rawContent) || isProviderShortcut(rawContent)
-          ? buildModelInfoEvent()
+          ? await buildModelInfoEvent()
           : null;
 
       const response = Response.json(


### PR DESCRIPTION
## Summary
- Convert resolveSlash, resolveProviderModelCommand, resolveModelList, resolveModelCommand to async
- Convert buildModelInfoEvent to async
- Replace config.apiKeys with getSecureKeyAsync calls in session-slash, session-process, conversation-routes
- Update all callers (session-process, conversation-routes, server) to await async results
- Update test files to await resolveSlash and mock getSecureKeyAsync/API_KEY_PROVIDERS

Part of plan: rm-config-apikeys.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
