### PR TITLE
feat: add interaction tracking columns to contact_channels table

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -63,6 +63,8 @@ function parseChannel(
     revokedReason: row.revokedReason,
     blockedReason: row.blockedReason,
     lastSeenAt: row.lastSeenAt,
+    interactionCount: row.interactionCount,
+    lastInteraction: row.lastInteraction,
     updatedAt: row.updatedAt,
     createdAt: row.createdAt,
   };

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -70,6 +70,8 @@ export interface ContactChannel {
   revokedReason: string | null;
   blockedReason: string | null;
   lastSeenAt: number | null;
+  interactionCount: number;
+  lastInteraction: number | null;
   updatedAt: number | null;
   createdAt: number;
 }

--- a/assistant/src/daemon/message-types/contacts.ts
+++ b/assistant/src/daemon/message-types/contacts.ts
@@ -58,6 +58,8 @@ export interface ContactChannelPayload {
   verifiedAt?: number;
   verifiedVia?: string;
   lastSeenAt?: number;
+  interactionCount?: number;
+  lastInteraction?: number;
   revokedReason?: string;
   blockedReason?: string;
 }

--- a/assistant/src/memory/migrations/158-channel-interaction-columns.ts
+++ b/assistant/src/memory/migrations/158-channel-interaction-columns.ts
@@ -1,0 +1,18 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+export function migrateChannelInteractionColumns(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE contact_channels ADD COLUMN interaction_count INTEGER NOT NULL DEFAULT 0`,
+    );
+  } catch {
+    /* already exists */
+  }
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE contact_channels ADD COLUMN last_interaction INTEGER`,
+    );
+  } catch {
+    /* already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -99,6 +99,7 @@ export { migrateDropMemorySegmentFts } from "./154-drop-fts.js";
 export { migrateDropConflicts } from "./155-drop-conflicts.js";
 export { migrateCallSessionInviteMetadata } from "./156-call-session-invite-metadata.js";
 export { migrateInviteContactId } from "./157-invite-contact-id.js";
+export { migrateChannelInteractionColumns } from "./158-channel-interaction-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -37,6 +37,8 @@ export const contactChannels = sqliteTable(
     revokedReason: text("revoked_reason"),
     blockedReason: text("blocked_reason"),
     lastSeenAt: integer("last_seen_at"), // epoch ms
+    interactionCount: integer("interaction_count").notNull().default(0),
+    lastInteraction: integer("last_interaction"),
     updatedAt: integer("updated_at"), // epoch ms
     createdAt: integer("created_at").notNull(),
   },

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -891,10 +891,12 @@ public struct ContactChannelPayload: Codable, Sendable {
     public let verifiedAt: Int?
     public let verifiedVia: String?
     public let lastSeenAt: Int?
+    public let interactionCount: Int?
+    public let lastInteraction: Int?
     public let revokedReason: String?
     public let blockedReason: String?
 
-    public init(id: String, type: String, address: String, isPrimary: Bool, externalUserId: String? = nil, status: String, policy: String, verifiedAt: Int? = nil, verifiedVia: String? = nil, lastSeenAt: Int? = nil, revokedReason: String? = nil, blockedReason: String? = nil) {
+    public init(id: String, type: String, address: String, isPrimary: Bool, externalUserId: String? = nil, status: String, policy: String, verifiedAt: Int? = nil, verifiedVia: String? = nil, lastSeenAt: Int? = nil, interactionCount: Int? = nil, lastInteraction: Int? = nil, revokedReason: String? = nil, blockedReason: String? = nil) {
         self.id = id
         self.type = type
         self.address = address
@@ -905,6 +907,8 @@ public struct ContactChannelPayload: Codable, Sendable {
         self.verifiedAt = verifiedAt
         self.verifiedVia = verifiedVia
         self.lastSeenAt = lastSeenAt
+        self.interactionCount = interactionCount
+        self.lastInteraction = lastInteraction
         self.revokedReason = revokedReason
         self.blockedReason = blockedReason
     }


### PR DESCRIPTION
## Summary
- Add `interaction_count` and `last_interaction` columns to the `contact_channels` table via migration 158
- Update Drizzle schema, TypeScript types, and Swift types to include the new fields
- No behavioral changes — foundational schema for moving interaction tracking from contacts to channels

Part of plan: channel-interaction-count.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
