### PR TITLE
fix: reset hasPlayedTailEntryAnimation on thread switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -990,6 +990,7 @@ struct MessageListView: View {
                 avatarDisplayY = .infinity
                 pendingAvatarY = nil
                 avatarLastAppliedAt = nil
+                hasPlayedTailEntryAnimation = false
                 restoreScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-entry-anim.md.

**Gap:** hasPlayedTailEntryAnimation not reset on thread switch
**What was expected:** Entry animation plays for each new qualifying thread
**What was found:** @State flag persisted across thread switches since MessageListView is not remounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
