### PR TITLE
feat: capture Telegram bot ID from getMe and return in config response

### DIFF
--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -34,6 +34,7 @@ export const WhatsAppConfigSchema = z.object({
 });
 
 export const TelegramConfigSchema = z.object({
+  botId: z.string({ error: "telegram.botId must be a string" }).default(""),
   botUsername: z
     .string({ error: "telegram.botUsername must be a string" })
     .default(""),

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -19,7 +19,10 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
-import { getTelegramBotUsername } from "../../telegram/bot-username.js";
+import {
+  getTelegramBotId,
+  getTelegramBotUsername,
+} from "../../telegram/bot-username.js";
 import {
   deleteCredentialMetadata,
   upsertCredentialMetadata,
@@ -74,10 +77,12 @@ export async function getTelegramConfig(): Promise<TelegramConfigResult> {
   ));
   const conn = getConnectionByProvider("telegram");
   const connected = !!(conn && conn.status === "active");
+  const botId = getTelegramBotId();
   const botUsername = getTelegramBotUsername();
   return {
     success: true,
     hasBotToken,
+    botId,
     botUsername,
     connected: connected && hasBotToken && hasWebhookSecret,
     hasWebhookSecret,
@@ -105,6 +110,7 @@ export async function setTelegramConfig(
 
   // Validate token via Telegram getMe API
   let botUsername: string;
+  let botId: string;
   try {
     const res = await fetch(
       `https://api.telegram.org/bot${resolvedToken}/getMe`,
@@ -121,7 +127,7 @@ export async function setTelegramConfig(
     }
     const data = (await res.json()) as {
       ok: boolean;
-      result?: { username?: string };
+      result?: { id?: number; username?: string };
     };
     if (!data.ok || !data.result?.username) {
       return {
@@ -133,6 +139,7 @@ export async function setTelegramConfig(
       };
     }
     botUsername = data.result.username;
+    botId = data.result.id != null ? String(data.result.id) : "";
   } catch (err) {
     const message = summarizeTelegramError(err);
     return {
@@ -162,8 +169,9 @@ export async function setTelegramConfig(
   // Store credential metadata record for policy checks
   upsertCredentialMetadata("telegram", "bot_token", {});
 
-  // Persist bot username to config for the config-based path
+  // Persist bot username and bot ID to config for the config-based path
   const raw = loadRawConfig();
+  setNestedValue(raw, "telegram.botId", botId);
   setNestedValue(raw, "telegram.botUsername", botUsername);
   saveRawConfig(raw);
   invalidateConfigCache();
@@ -190,9 +198,10 @@ export async function setTelegramConfig(
         await deleteSecureKeyAsync(credentialKey("telegram", "bot_token"));
         deleteCredentialMetadata("telegram", "bot_token");
       }
-      // Always revert the config write — the botUsername was written
+      // Always revert the config write — the botId and botUsername were written
       // optimistically before webhook secret provisioning.
       const rawRollback = loadRawConfig();
+      setNestedValue(rawRollback, "telegram.botId", "");
       setNestedValue(rawRollback, "telegram.botUsername", "");
       saveRawConfig(rawRollback);
       invalidateConfigCache();
@@ -220,6 +229,7 @@ export async function setTelegramConfig(
   const result: TelegramConfigResult = {
     success: true,
     hasBotToken: true,
+    botId,
     botUsername,
     connected: true,
     hasWebhookSecret,
@@ -286,9 +296,10 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   // Remove the oauth_connection row so getConnectionByProvider returns undefined.
   removeManualTokenConnection("telegram");
 
-  // Clear bot username from config so getTelegramBotUsername() doesn't
-  // return a stale value after disconnect.
+  // Clear bot ID and username from config so getTelegramBotId() and
+  // getTelegramBotUsername() don't return stale values after disconnect.
   const raw = loadRawConfig();
+  setNestedValue(raw, "telegram.botId", "");
   setNestedValue(raw, "telegram.botUsername", "");
   saveRawConfig(raw);
   invalidateConfigCache();

--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -120,6 +120,7 @@ export interface TelegramConfigResponse {
   type: "telegram_config_response";
   success: boolean;
   hasBotToken: boolean;
+  botId?: string;
   botUsername?: string;
   connected: boolean;
   hasWebhookSecret: boolean;

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -64,7 +64,7 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     }
     const body = (await res.json()) as {
       ok: boolean;
-      result?: { username?: string };
+      result?: { id?: number; username?: string };
     };
     const username = body.result?.username;
     if (!username) {
@@ -75,6 +75,9 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
     }
     // Write to config
     const raw = loadRawConfig();
+    if (body.result?.id != null) {
+      setNestedValue(raw, "telegram.botId", String(body.result.id));
+    }
     setNestedValue(raw, "telegram.botUsername", username);
     saveRawConfig(raw);
     invalidateConfigCache();

--- a/assistant/src/telegram/bot-username.ts
+++ b/assistant/src/telegram/bot-username.ts
@@ -1,6 +1,17 @@
 import { getConfig } from "../config/loader.js";
 
 /**
+ * Read the Telegram bot ID from config.
+ */
+export function getTelegramBotId(): string | undefined {
+  const value = getConfig().telegram.botId;
+  if (value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+/**
  * Read the Telegram bot username from config.
  */
 export function getTelegramBotUsername(): string | undefined {


### PR DESCRIPTION
## Summary
- Add botId field to TelegramConfigSchema and TelegramConfigResponse
- Extract result.id from Telegram getMe API and store in config
- Return botId in telegram config response for client consumption

Part of plan: contact-channels-ui-cleanup.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
