### PR TITLE
feat: parse and store Slack bot user ID and team ID in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -144,6 +144,8 @@ public final class SettingsStore: ObservableObject {
     @Published var slackChannelHasAppToken: Bool = false
     @Published var slackChannelConnected: Bool = false
     @Published var slackChannelBotUsername: String?
+    @Published var slackChannelBotUserId: String?
+    @Published var slackChannelTeamId: String?
     @Published var slackChannelTeamName: String?
     @Published var slackChannelSaveInProgress: Bool = false
     @Published var slackChannelError: String?
@@ -1061,6 +1063,8 @@ public final class SettingsStore: ObservableObject {
                         self.slackChannelHasAppToken = json["hasAppToken"] as? Bool ?? false
                         self.slackChannelConnected = json["connected"] as? Bool ?? false
                         self.slackChannelBotUsername = json["botUsername"] as? String
+                        self.slackChannelBotUserId = json["botUserId"] as? String
+                        self.slackChannelTeamId = json["teamId"] as? String
                         self.slackChannelTeamName = json["teamName"] as? String
                         self.slackChannelError = nil
                     }
@@ -1069,6 +1073,8 @@ public final class SettingsStore: ObservableObject {
                     self.slackChannelHasAppToken = false
                     self.slackChannelConnected = false
                     self.slackChannelBotUsername = nil
+                    self.slackChannelBotUserId = nil
+                    self.slackChannelTeamId = nil
                     self.slackChannelTeamName = nil
                 }
             } catch {
@@ -1102,6 +1108,8 @@ public final class SettingsStore: ObservableObject {
                         self.slackChannelHasAppToken = json["hasAppToken"] as? Bool ?? true
                         self.slackChannelConnected = json["connected"] as? Bool ?? false
                         self.slackChannelBotUsername = json["botUsername"] as? String
+                        self.slackChannelBotUserId = json["botUserId"] as? String
+                        self.slackChannelTeamId = json["teamId"] as? String
                         self.slackChannelTeamName = json["teamName"] as? String
                         self.slackChannelError = nil
                     } else {
@@ -1147,6 +1155,8 @@ public final class SettingsStore: ObservableObject {
                     self.slackChannelHasAppToken = false
                     self.slackChannelConnected = false
                     self.slackChannelBotUsername = nil
+                    self.slackChannelBotUserId = nil
+                    self.slackChannelTeamId = nil
                     self.slackChannelTeamName = nil
                     self.slackChannelError = nil
                     self.fetchChannelSetupStatus()


### PR DESCRIPTION
## Summary
- Add slackChannelBotUserId and slackChannelTeamId @Published properties to SettingsStore
- Parse botUserId and teamId from Slack channel config responses
- Clear both fields on disconnect/error paths

Part of plan: contact-channels-ui-cleanup.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
