### PR TITLE
fix: add missing secure-keys mock to swarm test files

### DIFF
--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -67,6 +67,11 @@ const mockProvider = {
     };
   },
 };
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "test-api-key",
+  getSecureKey: () => "test-api-key",
+}));
+
 mock.module("../providers/registry.js", () => ({
   getProvider: () => mockProvider,
   getFailoverProvider: () => mockProvider,

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -56,6 +56,11 @@ const mockTestProvider = {
     };
   },
 };
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "test-api-key",
+  getSecureKey: () => "test-api-key",
+}));
+
 mock.module("../providers/registry.js", () => ({
   getProvider: () => mockTestProvider,
   getFailoverProvider: () => mockTestProvider,

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -63,6 +63,11 @@ const mockProvider = {
     };
   },
 };
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => "test-api-key",
+  getSecureKey: () => "test-api-key",
+}));
+
 mock.module("../providers/registry.js", () => ({
   getProvider: () => mockProvider,
   getFailoverProvider: () => mockProvider,


### PR DESCRIPTION
## Summary
- Add `getSecureKeyAsync` mock to `swarm-session-integration.test.ts`, `swarm-tool.test.ts`, and `swarm-recursion.test.ts` — the `claude_code` backend's `isAvailable()` was refactored to use `getSecureKeyAsync("anthropic")` instead of `config.apiKeys.anthropic`, but these test files weren't updated with the new mock, causing `Backend "claude_code" is not available` errors

## Original prompt
fix any CI issues in https://github.com/vellum-ai/vellum-assistant/actions/runs/23077153460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
