### PR TITLE
feat: track interactions at channel level instead of contact level

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -595,7 +595,10 @@ export class RelayConnection {
           (resolved.actorTrust.trustClass === "guardian" ||
             resolved.actorTrust.trustClass === "trusted_contact")
         ) {
-          touchContactInteraction(resolved.actorTrust.memberRecord.contact.id);
+          touchContactInteraction(
+            resolved.actorTrust.memberRecord.contact.id,
+            resolved.actorTrust.memberRecord.channel.id,
+          );
         }
         if (this.controller && resolved.actorTrust.trustClass !== "unknown") {
           this.controller.setTrustContext(
@@ -613,6 +616,7 @@ export class RelayConnection {
           ) {
             touchContactInteraction(
               resolved.actorTrust.memberRecord.contact.id,
+              resolved.actorTrust.memberRecord.channel.id,
             );
           }
           if (this.controller && resolved.actorTrust.trustClass !== "unknown") {

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -952,6 +952,23 @@ export function updateContactInteraction(contactId: string): void {
     .run();
 }
 
+/**
+ * Atomically increment interactionCount and set lastInteraction on a contact channel.
+ * Optimized for the hot path — single UPDATE with no prior SELECT.
+ */
+export function updateChannelInteraction(channelId: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(contactChannels)
+    .set({
+      lastInteraction: now,
+      interactionCount: sql`${contactChannels.interactionCount} + 1`,
+      updatedAt: now,
+    })
+    .where(eq(contactChannels.id, channelId))
+    .run();
+}
+
 // ── Assistant Contact Metadata ──────────────────────────────────────
 
 function parseAssistantMetadata(

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -16,6 +16,7 @@ import {
   findGuardianForChannel,
   getChannelById,
   getContactInternal,
+  updateChannelInteraction,
   updateChannelLastSeenById,
   updateChannelStatus,
   updateContactInteraction,
@@ -287,13 +288,20 @@ export function touchChannelLastSeen(channelId: string): void {
 }
 
 /**
- * Increment the interaction count and update lastInteraction on a contact.
- * Expects a plain contact UUID (Contact.id).
+ * Track an interaction on the specific channel that received it.
+ * Swallows errors to avoid disrupting the inbound message hot path.
  */
-export function touchContactInteraction(contactId: string): void {
+export function touchContactInteraction(
+  contactId: string,
+  channelId?: string,
+): void {
   try {
-    updateContactInteraction(contactId);
+    if (channelId) {
+      updateChannelInteraction(channelId);
+    } else {
+      updateContactInteraction(contactId);
+    }
   } catch (err) {
-    log.warn({ err }, "Failed to update contact interaction stats");
+    log.warn({ err }, "Failed to update interaction stats");
   }
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -251,6 +251,7 @@ export async function handleChannelInbound(
       assistantId,
       content,
       contactId: resolvedMember?.contact.id,
+      channelId: resolvedMember?.channel.id,
     });
   }
 
@@ -306,7 +307,10 @@ export async function handleChannelInbound(
   // retries). This was previously in ACL enforcement which runs before dedup,
   // causing retries to inflate interaction counts.
   if (!result.duplicate && resolvedMember) {
-    touchContactInteraction(resolvedMember.contact.id);
+    touchContactInteraction(
+      resolvedMember.contact.id,
+      resolvedMember.channel.id,
+    );
   }
 
   // external_conversation_bindings is assistant-agnostic. Restrict writes to

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -32,6 +32,8 @@ export interface EditInterceptParams {
   content: string | undefined;
   /** Contact ID for interaction tracking; omitted when the sender has no resolved member. */
   contactId?: string;
+  /** Channel ID for channel-level interaction tracking. */
+  channelId?: string;
 }
 
 /**
@@ -53,6 +55,7 @@ export async function handleEditIntercept(
     assistantId,
     content,
     contactId,
+    channelId,
   } = params;
 
   // Dedup the edit event itself (retried edited_message webhooks)
@@ -74,7 +77,7 @@ export async function handleEditIntercept(
   // Track contact interaction only for genuinely new edit events (not webhook
   // retries), matching the pattern used for the normal message path.
   if (contactId) {
-    touchContactInteraction(contactId);
+    touchContactInteraction(contactId, channelId);
   }
 
   // Retry lookup a few times -- the original message may still be processing


### PR DESCRIPTION
## Summary
- Add `updateChannelInteraction` function to atomically increment interaction count on contact channels
- Update `touchContactInteraction` to write to channel level when channelId is provided
- Pass channel ID from all three interaction tracking call sites: inbound messages, edit intercepts, and voice calls

Part of plan: channel-interaction-count.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
