### PR TITLE
feat: restyle trusted contact action buttons and remove assistant handle from unconfigured cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -291,12 +291,6 @@ struct ContactDetailView: View {
                                 }
                             }
                         } else {
-                            if let handle = channelReadiness[type]?.channelHandle {
-                                Text(handle)
-                                    .font(VFont.monoSmall)
-                                    .foregroundColor(VColor.contentTertiary)
-                                    .lineLimit(1)
-                            }
                             if inviteExpanded.contains(type) {
                                 unconfiguredChannelContent(type: type)
                             } else {
@@ -777,7 +771,7 @@ struct ContactDetailView: View {
                     }
                 default:
                     VButton(
-                        label: "Revoke Access",
+                        label: "Revoke",
                         style: .dangerOutline,
                         isDisabled: anyActionInFlight
                     ) {


### PR DESCRIPTION
## Summary
- Rename Revoke Access to Revoke for shorter button labels
- Remove assistant channel handle display from unconfigured trusted contact channel cards

Part of plan: contact-channels-ui-cleanup.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
