### PR TITLE
feat: show verified badge and rich identity on Guardian channel cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -104,6 +104,13 @@ struct GuardianChannelsDetailView: View {
     private func channelCard(for type: String) -> some View {
         SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type)) {
             let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
+            let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
+                ?? existingChannels.first
+            if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
+                VBadge(style: .label("Verified"), color: VColor.systemPositiveStrong)
+            }
+        } content: {
+            let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
 
             // Prefer the latest verified channel to avoid showing stale status when
             // multiple non-revoked rows exist for the same channel type.
@@ -111,7 +118,7 @@ struct GuardianChannelsDetailView: View {
                 ?? existingChannels.first
 
             if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
-                // Verified channel — show address + disconnect
+                // Verified channel — show rich identity + disconnect
                 verifiedChannelContent(channel: channel, type: type)
             } else if (!existingChannels.isEmpty && !dismissedChannels.contains(type)) || setupExpanded.contains(type) {
                 // Existing unverified channel or user clicked "Set Up" — show verification flow
@@ -123,7 +130,6 @@ struct GuardianChannelsDetailView: View {
                     setupExpanded.insert(type)
                 }
             }
-
         }
     }
 
@@ -131,19 +137,122 @@ struct GuardianChannelsDetailView: View {
 
     @ViewBuilder
     private func verifiedChannelContent(channel: ContactChannelPayload, type: String) -> some View {
-        // Guardian verified channels show only the address and a Disconnect button.
-        // Verification metadata (badge, date, identity) is omitted since the guardian
-        // owns the assistant — only trusted contacts need that detail.
+        let verificationState = store?.channelVerificationState(for: type)
+
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text(channel.address)
-                .font(VFont.body)
-                .foregroundColor(VColor.contentDefault)
-                .lineLimit(1)
+            if type == "telegram" {
+                telegramVerifiedIdentity(channel: channel, verificationState: verificationState)
+            } else if type == "slack" {
+                slackVerifiedIdentity(channel: channel, verificationState: verificationState)
+            } else if type == "phone" {
+                Text(channel.address)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                    .lineLimit(1)
+            } else {
+                Text(channel.address)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.contentDefault)
+                    .lineLimit(1)
+            }
 
             if let store {
                 VButton(label: "Disconnect", style: .danger) {
                     store.revokeChannelVerification(channel: type)
                 }
+            }
+        }
+    }
+
+    // MARK: - Telegram Verified Identity
+
+    /// Telegram-specific verified identity layout matching ChannelVerificationFlowView:
+    /// 1. Display name (or username/identity as fallback)
+    /// 2. @username (plain text, if available and not already shown)
+    /// 3. "Telegram ID: " prefix + hyperlinked ID
+    @ViewBuilder
+    private func telegramVerifiedIdentity(channel: ContactChannelPayload, verificationState: ChannelVerificationState?) -> some View {
+        let displayName = verificationState?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = verificationState?.username?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let identity = (verificationState?.identity ?? channel.externalUserId)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let formattedUsername: String? = {
+            guard let username, !username.isEmpty else { return nil }
+            return username.hasPrefix("@") ? username : "@\(username)"
+        }()
+
+        // Primary line: display name, else username, else identity, else address
+        let nameLine = (displayName.flatMap { $0.isEmpty ? nil : $0 })
+            ?? formattedUsername
+            ?? identity
+            ?? channel.address
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text(nameLine)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .lineLimit(1)
+
+            // Show @username if it wasn't already used as the name line
+            if let formattedUsername, formattedUsername != nameLine {
+                Text(formattedUsername)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                    .lineLimit(1)
+            }
+
+            // Telegram ID line: only hyperlink the ID itself
+            if let identity, !identity.isEmpty, identity != nameLine {
+                HStack(spacing: 0) {
+                    Text("Telegram ID: ")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.contentTertiary)
+                    if let url = URL(string: "https://web.telegram.org/a/#\(identity)") {
+                        Link(identity, destination: url)
+                            .font(VFont.caption)
+                            .lineLimit(1)
+                            .pointerCursor()
+                    } else {
+                        Text(identity)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Slack Verified Identity
+
+    @ViewBuilder
+    private func slackVerifiedIdentity(channel: ContactChannelPayload, verificationState: ChannelVerificationState?) -> some View {
+        let displayName = verificationState?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = verificationState?.username?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let identity = (verificationState?.identity ?? channel.externalUserId)?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let formattedUsername: String? = {
+            guard let username, !username.isEmpty else { return nil }
+            return username.hasPrefix("@") ? username : "@\(username)"
+        }()
+
+        // Primary line: display name or @username
+        let primaryLine = (displayName.flatMap { $0.isEmpty ? nil : $0 })
+            ?? formattedUsername
+            ?? channel.address
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text(primaryLine)
+                .font(VFont.body)
+                .foregroundColor(VColor.contentDefault)
+                .lineLimit(1)
+
+            // Secondary line: user ID
+            if let identity, !identity.isEmpty {
+                Text("ID: \(identity)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.contentTertiary)
+                    .lineLimit(1)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add green Verified badge to Guardian channel cards when channel is verified
- Show rich identity display (display name, @username, linked platform ID) instead of plain address
- Match identity display pattern from ChannelVerificationFlowView

Part of plan: contact-channels-ui-cleanup.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
