### PR TITLE
Use `provider: anthropic` for Vellum managed API keys

### DIFF
--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -110,7 +110,7 @@ describe("buildManagedBaseUrl", () => {
       "https://platform.example.com/v1/runtime-proxy/openai",
     );
     expect(buildManagedBaseUrl("anthropic")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/vertex",
+      "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
     expect(buildManagedBaseUrl("gemini")).toBe(
       "https://platform.example.com/v1/runtime-proxy/vertex",

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -200,8 +200,7 @@ describe("managed proxy integration — credential precedence", () => {
 
       expect(anthropicClient).toBeDefined();
       const baseURL: string = anthropicClient.baseURL;
-      expect(baseURL).toContain("/v1/runtime-proxy/vertex");
-      expect(baseURL).not.toContain("/v1/runtime-proxy/anthropic");
+      expect(baseURL).toContain("/v1/runtime-proxy/anthropic");
     });
 
     test("managed gemini uses vertex proxy path instead of gemini proxy path", () => {
@@ -335,10 +334,13 @@ describe("managed proxy integration — constants integrity", () => {
     }
   });
 
-  test("anthropic and gemini route through vertex proxy path", () => {
+  test("anthropic routes through anthropic proxy path", () => {
     expect(MANAGED_PROVIDER_META.anthropic.proxyPath).toBe(
-      "/v1/runtime-proxy/vertex",
+      "/v1/runtime-proxy/anthropic",
     );
+  });
+
+  test("gemini routes through vertex proxy path", () => {
     expect(MANAGED_PROVIDER_META.gemini.proxyPath).toBe(
       "/v1/runtime-proxy/vertex",
     );

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -29,7 +29,7 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   anthropic: {
     name: "anthropic",
     managed: true,
-    proxyPath: "/v1/runtime-proxy/vertex",
+    proxyPath: "/v1/runtime-proxy/anthropic",
   },
   gemini: {
     name: "gemini",

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -226,8 +226,8 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("anthropic", "user-key");
   } else {
-    // No user Anthropic key — route through Vertex managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    // No user Anthropic key — route through managed proxy
+    const managedBaseUrl = buildManagedBaseUrl("anthropic");
     if (managedBaseUrl) {
       const ctx = resolveManagedProxyContext();
       const model = resolveModel(config, "anthropic");


### PR DESCRIPTION
See https://github.com/vellum-ai/vellum-assistant-platform/pull/2235 for details.

Mostly reverts https://github.com/vellum-ai/vellum-assistant/pull/14936

This is also currently broken and blocks usage of Vellum managed keys.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
