### PR TITLE
feat: show Slack bot username and user ID on connected assistant Slack card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -211,12 +211,39 @@ struct AssistantChannelsDetailView: View {
             }
         } content: {
             if status == "ready" {
-                VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
-                    store.clearSlackChannelConfig()
-                    slackChannelBotTokenInput = ""
-                    slackChannelAppTokenInput = ""
-                    slackChannelSetupExpanded = false
-                    store.channelSetupStatus["slack"] = "not_configured"
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    if let username = store.slackChannelBotUsername {
+                        Text("@\(username)")
+                            .font(VFont.body)
+                            .foregroundColor(VColor.contentDefault)
+                            .lineLimit(1)
+                    }
+                    if let botUserId = store.slackChannelBotUserId {
+                        HStack(spacing: 0) {
+                            Text("Bot ID: ")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            if let teamId = store.slackChannelTeamId,
+                               let url = URL(string: "slack://user?team=\(teamId)&id=\(botUserId)") {
+                                Link(botUserId, destination: url)
+                                    .font(VFont.caption)
+                                    .lineLimit(1)
+                                    .pointerCursor()
+                            } else {
+                                Text(botUserId)
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.contentTertiary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
+                        store.clearSlackChannelConfig()
+                        slackChannelBotTokenInput = ""
+                        slackChannelAppTokenInput = ""
+                        slackChannelSetupExpanded = false
+                        store.channelSetupStatus["slack"] = "not_configured"
+                    }
                 }
             } else if (status == "incomplete" && (store.slackChannelHasBotToken || store.slackChannelHasAppToken)) || slackChannelSetupExpanded {
                 slackChannelCredentialEntry


### PR DESCRIPTION
## Summary
- Show @botUsername and Bot ID on connected Slack assistant channel card
- Bot ID links to Slack profile via deep link when team ID is available
- Identity info displayed above Disconnect button

Part of plan: contact-channels-ui-cleanup.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
