### PR TITLE
feat: parse and store Telegram bot ID in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -83,6 +83,7 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Telegram Integration State
 
     @Published var telegramHasBotToken: Bool = false
+    @Published var telegramBotId: String?
     @Published var telegramBotUsername: String?
     @Published var telegramConnected: Bool = false
     @Published var telegramHasWebhookSecret: Bool = false
@@ -500,6 +501,7 @@ public final class SettingsStore: ObservableObject {
             self.telegramSaveInProgress = false
             if response.success {
                 self.telegramHasBotToken = response.hasBotToken
+                self.telegramBotId = response.botId
                 self.telegramBotUsername = response.botUsername
                 self.telegramConnected = response.connected
                 self.telegramHasWebhookSecret = response.hasWebhookSecret

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4249,6 +4249,7 @@ public struct TelegramConfigResponse: Codable, Sendable {
     public let type: String
     public let success: Bool
     public let hasBotToken: Bool
+    public let botId: String?
     public let botUsername: String?
     public let connected: Bool
     public let hasWebhookSecret: Bool
@@ -4259,10 +4260,11 @@ public struct TelegramConfigResponse: Codable, Sendable {
     /// Non-fatal warning (e.g. commands registration failed during setup but token was configured).
     public let warning: String?
 
-    public init(type: String, success: Bool, hasBotToken: Bool, botUsername: String? = nil, connected: Bool, hasWebhookSecret: Bool, lastError: String? = nil, error: String? = nil, commandsRegistered: [String]? = nil, warning: String? = nil) {
+    public init(type: String, success: Bool, hasBotToken: Bool, botId: String? = nil, botUsername: String? = nil, connected: Bool, hasWebhookSecret: Bool, lastError: String? = nil, error: String? = nil, commandsRegistered: [String]? = nil, warning: String? = nil) {
         self.type = type
         self.success = success
         self.hasBotToken = hasBotToken
+        self.botId = botId
         self.botUsername = botUsername
         self.connected = connected
         self.hasWebhookSecret = hasWebhookSecret


### PR DESCRIPTION
## Summary
- Add telegramBotId @Published property to SettingsStore
- Parse botId from Telegram config response (added in PR 1)
- Clear on disconnect path

Part of plan: contact-channels-ui-cleanup.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
