### PR TITLE
feat: derive contact interactionCount by summing across channels

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -595,10 +595,7 @@ export class RelayConnection {
           (resolved.actorTrust.trustClass === "guardian" ||
             resolved.actorTrust.trustClass === "trusted_contact")
         ) {
-          touchContactInteraction(
-            resolved.actorTrust.memberRecord.contact.id,
-            resolved.actorTrust.memberRecord.channel.id,
-          );
+          touchContactInteraction(resolved.actorTrust.memberRecord.channel.id);
         }
         if (this.controller && resolved.actorTrust.trustClass !== "unknown") {
           this.controller.setTrustContext(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -612,7 +612,6 @@ export class RelayConnection {
               resolved.actorTrust.trustClass === "trusted_contact")
           ) {
             touchContactInteraction(
-              resolved.actorTrust.memberRecord.contact.id,
               resolved.actorTrust.memberRecord.channel.id,
             );
           }

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -34,8 +34,8 @@ function parseContact(row: typeof contacts.$inferSelect): Contact {
     id: row.id,
     displayName: row.displayName,
     notes: row.notes,
-    lastInteraction: row.lastInteraction,
-    interactionCount: row.interactionCount,
+    lastInteraction: null,
+    interactionCount: 0,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     role: row.role as Contact["role"],
@@ -82,7 +82,15 @@ function getChannelsForContact(contactId: string): ContactChannel[] {
 }
 
 function withChannels(contact: Contact): ContactWithChannels {
-  return { ...contact, channels: getChannelsForContact(contact.id) };
+  const channels = getChannelsForContact(contact.id);
+  const interactionCount = channels.reduce(
+    (sum, ch) => sum + ch.interactionCount,
+    0,
+  );
+  const lastInteraction =
+    channels.reduce((max, ch) => Math.max(max, ch.lastInteraction ?? 0), 0) ||
+    null;
+  return { ...contact, interactionCount, lastInteraction, channels };
 }
 
 // ── Channel data type for syncChannels ───────────────────────────────
@@ -237,8 +245,6 @@ export function upsertContact(params: {
       id: contactId,
       displayName: params.displayName,
       notes: params.notes ?? null,
-      lastInteraction: null,
-      interactionCount: 0,
       role: params.role ?? "contact",
       contactType: params.contactType ?? "human",
       principalId: params.principalId ?? null,
@@ -490,7 +496,7 @@ export function searchContacts(params: {
       .from(contacts)
       .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
       .where(whereClause)
-      .orderBy(desc(contacts.updatedAt), desc(contacts.lastInteraction))
+      .orderBy(desc(contacts.updatedAt))
       .all();
 
     const contactIds = [...new Set(rows.map((r) => r.contactId))];
@@ -511,7 +517,7 @@ export function searchContacts(params: {
     .select()
     .from(contacts)
     .where(whereClause)
-    .orderBy(desc(contacts.updatedAt), desc(contacts.lastInteraction))
+    .orderBy(desc(contacts.updatedAt))
     .limit(limit)
     .all();
 
@@ -533,11 +539,7 @@ export function listContacts(
     .select()
     .from(contacts)
     .where(conditions.length === 1 ? conditions[0] : and(...conditions))
-    .orderBy(
-      sql`${contacts.role} = 'guardian' DESC`,
-      desc(contacts.updatedAt),
-      desc(contacts.lastInteraction),
-    )
+    .orderBy(sql`${contacts.role} = 'guardian' DESC`, desc(contacts.updatedAt))
     .limit(effectiveLimit)
     .all();
   return rows.map((r) => withChannels(parseContact(r)));
@@ -573,16 +575,8 @@ export function mergeContacts(
       .get();
     if (!merge) throw new Error(`Contact "${mergeId}" not found`);
 
-    // Resolve merged field values — pick the better/more recent value
-    const mergedInteractionCount =
-      keep.interactionCount + merge.interactionCount;
-    const mergedLastInteraction =
-      Math.max(keep.lastInteraction ?? 0, merge.lastInteraction ?? 0) || null;
-
     tx.update(contacts)
       .set({
-        interactionCount: mergedInteractionCount,
-        lastInteraction: mergedLastInteraction,
         notes: [keep.notes, merge.notes].filter(Boolean).join("\n") || null,
         updatedAt: now,
       })
@@ -932,23 +926,6 @@ export function updateChannelLastSeenById(channelId: string): void {
   db.update(contactChannels)
     .set({ lastSeenAt: now, updatedAt: now })
     .where(eq(contactChannels.id, channelId))
-    .run();
-}
-
-/**
- * Atomically increment interactionCount and set lastInteraction on a contact.
- * Optimized for the hot path — single UPDATE with no prior SELECT.
- */
-export function updateContactInteraction(contactId: string): void {
-  const db = getDb();
-  const now = Date.now();
-  db.update(contacts)
-    .set({
-      lastInteraction: now,
-      interactionCount: sql`${contacts.interactionCount} + 1`,
-      updatedAt: now,
-    })
-    .where(eq(contacts.id, contactId))
     .run();
 }
 

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -19,7 +19,6 @@ import {
   updateChannelInteraction,
   updateChannelLastSeenById,
   updateChannelStatus,
-  updateContactInteraction,
   upsertContact,
 } from "./contact-store.js";
 import type {
@@ -291,17 +290,10 @@ export function touchChannelLastSeen(channelId: string): void {
  * Track an interaction on the specific channel that received it.
  * Swallows errors to avoid disrupting the inbound message hot path.
  */
-export function touchContactInteraction(
-  contactId: string,
-  channelId?: string,
-): void {
+export function touchContactInteraction(channelId: string): void {
   try {
-    if (channelId) {
-      updateChannelInteraction(channelId);
-    } else {
-      updateContactInteraction(contactId);
-    }
+    updateChannelInteraction(channelId);
   } catch (err) {
-    log.warn({ err }, "Failed to update interaction stats");
+    log.warn({ err }, "Failed to update channel interaction stats");
   }
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -42,6 +42,7 @@ import {
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateChannelInboundDeliveredSegments,
+  migrateChannelInteractionColumns,
   migrateContactChannelsAccessFields,
   migrateContactChannelsTypeChatIdIndex,
   migrateContactsAssistantId,
@@ -51,6 +52,7 @@ import {
   migrateDropAccountsTable,
   migrateDropAssistantIdColumns,
   migrateDropConflicts,
+  migrateDropContactInteractionColumns,
   migrateDropEntityTables,
   migrateDropLegacyMemberGuardianTables,
   migrateDropMemorySegmentFts,
@@ -375,6 +377,12 @@ export function initializeDb(): void {
 
   // 60. Add required contact_id to assistant_ingress_invites and clean up legacy rows
   migrateInviteContactId(database);
+
+  // 61. Add interaction_count and last_interaction columns to contact_channels
+  migrateChannelInteractionColumns(database);
+
+  // 62. Drop interaction_count and last_interaction columns from contacts (now derived from channels)
+  migrateDropContactInteractionColumns(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/159-drop-contact-interaction-columns.ts
+++ b/assistant/src/memory/migrations/159-drop-contact-interaction-columns.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+export function migrateDropContactInteractionColumns(
+  database: DrizzleDb,
+): void {
+  try {
+    database.run(/*sql*/ `ALTER TABLE contacts DROP COLUMN interaction_count`);
+  } catch {
+    /* already dropped or doesn't exist */
+  }
+  try {
+    database.run(/*sql*/ `ALTER TABLE contacts DROP COLUMN last_interaction`);
+  } catch {
+    /* already dropped or doesn't exist */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -100,6 +100,7 @@ export { migrateDropConflicts } from "./155-drop-conflicts.js";
 export { migrateCallSessionInviteMetadata } from "./156-call-session-invite-metadata.js";
 export { migrateInviteContactId } from "./157-invite-contact-id.js";
 export { migrateChannelInteractionColumns } from "./158-channel-interaction-columns.js";
+export { migrateDropContactInteractionColumns } from "./159-drop-contact-interaction-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -6,8 +6,6 @@ export const contacts = sqliteTable("contacts", {
   id: text("id").primaryKey(),
   displayName: text("display_name").notNull(),
   notes: text("notes"),
-  lastInteraction: integer("last_interaction"), // epoch ms
-  interactionCount: integer("interaction_count").notNull().default(0),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -250,7 +250,6 @@ export async function handleChannelInbound(
       canonicalAssistantId,
       assistantId,
       content,
-      contactId: resolvedMember?.contact.id,
       channelId: resolvedMember?.channel.id,
     });
   }
@@ -307,10 +306,7 @@ export async function handleChannelInbound(
   // retries). This was previously in ACL enforcement which runs before dedup,
   // causing retries to inflate interaction counts.
   if (!result.duplicate && resolvedMember) {
-    touchContactInteraction(
-      resolvedMember.contact.id,
-      resolvedMember.channel.id,
-    );
+    touchContactInteraction(resolvedMember.channel.id);
   }
 
   // external_conversation_bindings is assistant-agnostic. Restrict writes to

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -30,8 +30,6 @@ export interface EditInterceptParams {
   canonicalAssistantId: string;
   assistantId: string;
   content: string | undefined;
-  /** Contact ID for interaction tracking; omitted when the sender has no resolved member. */
-  contactId?: string;
   /** Channel ID for channel-level interaction tracking. */
   channelId?: string;
 }
@@ -54,7 +52,6 @@ export async function handleEditIntercept(
     canonicalAssistantId,
     assistantId,
     content,
-    contactId,
     channelId,
   } = params;
 
@@ -76,8 +73,8 @@ export async function handleEditIntercept(
 
   // Track contact interaction only for genuinely new edit events (not webhook
   // retries), matching the pattern used for the normal message path.
-  if (contactId) {
-    touchContactInteraction(contactId, channelId);
+  if (channelId) {
+    touchContactInteraction(channelId);
   }
 
   // Retry lookup a few times -- the original message may still be processing


### PR DESCRIPTION
## Summary
- Compute contact-level `interactionCount` and `lastInteraction` by aggregating across channels in `withChannels()`
- Simplify `touchContactInteraction` to take only `channelId`, remove contact-level fallback
- Remove `interactionCount` and `lastInteraction` columns from `contacts` table via migration 159
- Clean up merge logic — interaction stats now auto-derive from reassigned channels

Part of plan: channel-interaction-count.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
