### PR TITLE
refactor: remove apiKeys from AssistantConfigSchema and loadConfig pipeline

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -179,16 +179,16 @@ The gateway reads credentials via async `readCredential()` which tries the broke
 
 ### Known sync exceptions
 
-The migration from sync to async secure-key functions is complete for all call sites except two startup paths that require synchronous initialization. The following call sites still use the deprecated sync variants.
+The migration from sync to async secure-key functions is complete for all call sites except provider initialization paths that require synchronous access. The following call sites still use the deprecated sync variants.
 
-#### Startup / top-level config (must remain sync)
+#### Provider initialization (must remain sync)
 
 These call sites run in synchronous initialization contexts where async I/O is not feasible:
 
-| File                                               | Sync functions used                               | Reason                                                                                                                                                                                                                |
-| -------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/config/loader.ts`                   | `getSecureKey`, `setSecureKey`, `deleteSecureKey` | Config loading runs synchronously at startup before the event loop is available. The broker socket may not be ready yet, and converting to async would require rearchitecting the entire config initialization chain. |
-| `assistant/src/providers/managed-proxy/context.ts` | `getSecureKey`                                    | Provider context initialization is synchronous. The managed proxy context must resolve credentials before the first request can be processed, and the initialization path does not support awaiting.                  |
+| File                                               | Sync functions used | Reason                                                                                                                                                                                               |
+| -------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/providers/managed-proxy/context.ts` | `getSecureKey`      | Provider context initialization is synchronous. The managed proxy context must resolve credentials before the first request can be processed, and the initialization path does not support awaiting. |
+| `assistant/src/providers/registry.ts`              | `getSecureKey`      | Provider registry initialization is synchronous. API keys must be resolved at provider construction time, and the call chain from config watcher through to provider init is fully synchronous.      |
 
 Any new sync usage requires explicit justification and should be documented here.
 

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -293,8 +293,8 @@ The embedding backend is selected based on `memory.embeddings.provider` config:
 
 - `auto` (default): Tries local → OpenAI → Gemini → Ollama, using the first available.
 - `local`: ONNX-based local model (bge-small-en-v1.5). Lazy-loaded to avoid crashing in compiled binaries where onnxruntime-node is unavailable.
-- `openai`: OpenAI text-embedding-3-small. Requires `apiKeys.openai`.
-- `gemini`: Gemini gemini-embedding-001. Requires `apiKeys.gemini`. Only backend supporting multimodal embeddings (images, audio, video).
+- `openai`: OpenAI text-embedding-3-small. Requires an OpenAI API key in secure storage.
+- `gemini`: Gemini gemini-embedding-001. Requires a Gemini API key in secure storage. Only backend supporting multimodal embeddings (images, audio, video).
 - `ollama`: Ollama nomic-embed-text. Requires Ollama to be configured.
 
 An in-memory LRU vector cache (32 MB cap, keyed by `sha256(provider + model + content)`) avoids redundant embedding calls for identical content. Sparse embeddings are generated in-process (no external calls).
@@ -570,7 +570,7 @@ graph TB
 
     **Commit message LLM fallback chain**: The generator runs a sequence of pre-flight checks before calling the LLM. Each check that fails produces a machine-readable `llmFallbackReason` in the structured log output and immediately returns a deterministic message. The checks, in order:
     1. `disabled` — `commitMessageLLM.enabled` is `false` or `useConfiguredProvider` is `false`
-    2. `missing_provider_api_key` — the configured provider's API key is not set in `config.apiKeys` (skipped for keyless providers like Ollama that run without an API key)
+    2. `missing_provider_api_key` — the configured provider's API key is not found in secure storage (skipped for keyless providers like Ollama that run without an API key)
     3. `breaker_open` — the generator's internal circuit breaker is open after consecutive LLM failures (exponential backoff)
     4. `insufficient_budget` — the remaining turn budget (`deadlineMs - Date.now()`) is below `minRemainingTurnBudgetMs`
     5. `missing_fast_model` — no fast model could be resolved for the configured provider (see below); the provider is **not** called

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -79,7 +79,6 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     timeouts: { permissionTimeoutSec: 300 },
-    apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },
   }),

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -41,7 +41,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/asset-materialize-tool.test.ts
+++ b/assistant/src/__tests__/asset-materialize-tool.test.ts
@@ -33,7 +33,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   }),

--- a/assistant/src/__tests__/asset-search-tool.test.ts
+++ b/assistant/src/__tests__/asset-search-tool.test.ts
@@ -32,7 +32,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   }),

--- a/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
@@ -40,7 +40,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -30,7 +30,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   }),

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock state — mutable variables control per-test behavior
 // ---------------------------------------------------------------------------
 
-let mockGeminiKey: string | undefined = "test-gemini-key";
 let mockWorkspaceDir = "/tmp/test-workspace-e2e";
 
 const mkdirSyncFn = mock(() => {});
@@ -27,7 +26,6 @@ const geminiGenerateContentFn = mock(async () => geminiGenerateContentResult);
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
-    apiKeys: { gemini: mockGeminiKey },
     imageGenModel: "gemini-2.5-flash-image",
   }),
 }));
@@ -136,7 +134,6 @@ describe("avatar E2E integration", () => {
   const originalGeminiKey = process.env.GEMINI_API_KEY;
 
   beforeEach(() => {
-    mockGeminiKey = "test-gemini-key";
     mockWorkspaceDir = "/tmp/test-workspace-e2e";
 
     mkdirSyncFn.mockClear();
@@ -199,8 +196,6 @@ describe("avatar E2E integration", () => {
   // -----------------------------------------------------------------------
 
   test("no Gemini key — error surfaced", async () => {
-    mockGeminiKey = undefined;
-
     const result = await executeAvatar("a whimsical owl");
 
     expect(result.isError).toBe(true);

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -43,7 +43,6 @@ mock.module("../config/loader.js", () => {
 
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: "test-key" },
     calls: {
       enabled: true,
       provider: "twilio",

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -53,7 +53,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
@@ -62,7 +61,6 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -29,8 +29,6 @@ mock.module("../util/logger.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-
-    apiKeys: { anthropic: "test-key" },
   }),
 }));
 

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -33,8 +33,6 @@ mock.module("../util/logger.js", () => ({
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-
-    apiKeys: { anthropic: "test-key" },
   }),
 }));
 

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -278,13 +278,12 @@ describe("config loader backfill", () => {
     expect(contentAfter).toBe(contentBefore);
   });
 
-  test("does not write apiKeys or dataDir during backfill", () => {
+  test("does not write dataDir during backfill", () => {
     writeConfig({ provider: "anthropic" });
 
     loadConfig();
 
     const raw = readConfig();
-    expect(raw.apiKeys).toBeUndefined();
     expect(raw.dataDir).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -89,7 +89,6 @@ describe("AssistantConfigSchema", () => {
     expect(result.provider).toBe("anthropic");
     expect(result.model).toBe("claude-opus-4-6");
     expect(result.maxTokens).toBe(16000);
-    expect(result.apiKeys).toEqual({});
     expect(result.thinking).toEqual({
       enabled: false,
       streamThinking: false,
@@ -137,7 +136,6 @@ describe("AssistantConfigSchema", () => {
       provider: "openai",
       model: "gpt-4",
       maxTokens: 4096,
-      apiKeys: { openai: "sk-test" },
       thinking: { enabled: true },
       timeouts: {
         shellDefaultTimeoutSec: 30,
@@ -354,13 +352,6 @@ describe("AssistantConfigSchema", () => {
   test("rejects negative auditLog.retentionDays", () => {
     const result = AssistantConfigSchema.safeParse({
       auditLog: { retentionDays: -7 },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  test("rejects non-string apiKeys values", () => {
-    const result = AssistantConfigSchema.safeParse({
-      apiKeys: { anthropic: 123 },
     });
     expect(result.success).toBe(false);
   });
@@ -1163,31 +1154,6 @@ describe("loadConfig with schema validation", () => {
     writeConfig({ permissions: { mode: "yolo" } });
     const config = loadConfig();
     expect(config.permissions.mode).toBe("workspace");
-  });
-
-  test("does not mutate default apiKeys when fallback config is overridden by env keys", () => {
-    const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
-    try {
-      const testKey = ["test", "in", "memory", "default", "leak"].join("-");
-      process.env.ANTHROPIC_API_KEY = testKey;
-      writeConfig("this is not a config object");
-
-      const configWithEnv = loadConfig();
-      expect(configWithEnv.apiKeys.anthropic).toBe(testKey);
-
-      invalidateConfigCache();
-      delete process.env.ANTHROPIC_API_KEY;
-      writeConfig("still not a config object");
-
-      const configWithoutEnv = loadConfig();
-      expect(configWithoutEnv.apiKeys.anthropic).toBeUndefined();
-    } finally {
-      if (originalAnthropicApiKey !== undefined) {
-        process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
-      } else {
-        delete process.env.ANTHROPIC_API_KEY;
-      }
-    }
   });
 
   // ── Calls config (loader integration) ──────────────────────────────

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -30,7 +30,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "claude-opus-4-6",
     provider: "anthropic",
-    apiKeys: { anthropic: "test-key" },
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -57,7 +57,6 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },
@@ -80,7 +79,6 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -22,7 +22,6 @@ mock.module("node:child_process", () => ({
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -38,7 +38,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   }),

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -131,10 +131,10 @@ writeFileSync(
   Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f]), // contains null byte
 );
 
-// config.json at workspace root — should be skipped (secrets, already in configSnapshot)
+// config.json at workspace root — should be skipped (already in configSnapshot)
 writeFileSync(
   join(testWorkspaceDir, "config.json"),
-  JSON.stringify({ apiKeys: { anthropic: "sk-secret-key" } }),
+  JSON.stringify({ provider: "anthropic" }),
 );
 
 // Symlink pointing outside workspace — should be skipped

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -9,7 +9,6 @@ let TEST_DIR = "";
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -52,7 +52,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     timeouts: { shellDefaultTimeoutSec: 30, shellMaxTimeoutSec: 60 },

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -935,7 +935,6 @@ describe("Memory regressions", () => {
     const config = {
       ...DEFAULT_CONFIG,
       provider: "anthropic" as const,
-      apiKeys: {},
       memory: {
         ...DEFAULT_CONFIG.memory,
         embeddings: {

--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -82,7 +82,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -56,7 +56,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -77,7 +77,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -63,7 +63,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -52,7 +52,6 @@ mock.module("../config/loader.js", () => ({
     ui: {},
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -6,12 +6,24 @@ import type { Provider, ProviderResponse } from "../providers/types.js";
 import type { CommitContext } from "../workspace/commit-message-provider.js";
 
 // ---------------------------------------------------------------------------
+// Mock secure keys — controls what getSecureKeyAsync returns per provider
+// ---------------------------------------------------------------------------
+let mockSecureKeys: Record<string, string> = {};
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (name: string) => mockSecureKeys[name] ?? undefined,
+  getSecureKeyAsync: async (name: string) => mockSecureKeys[name] ?? undefined,
+  setSecureKey: () => true,
+  setSecureKeyAsync: async () => true,
+  deleteSecureKey: () => "deleted",
+  deleteSecureKeyAsync: async () => "deleted" as const,
+}));
+
+// ---------------------------------------------------------------------------
 // Deep-clone a base config so each test can tweak fields independently
 // ---------------------------------------------------------------------------
 function cloneConfig(): AssistantConfig {
   const cfg = structuredClone(DEFAULT_CONFIG);
   cfg.provider = "anthropic";
-  cfg.apiKeys = { anthropic: "sk-test-key" } as Record<string, string>;
   cfg.workspaceGit.commitMessageLLM = {
     ...cfg.workspaceGit.commitMessageLLM,
     enabled: true,
@@ -116,6 +128,7 @@ describe("ProviderCommitMessageGenerator", () => {
   beforeEach(() => {
     _resetCommitMessageGenerator();
     currentConfig = cloneConfig();
+    mockSecureKeys = { anthropic: "sk-test-key" };
     mockSendMessage.mockReset();
     resolvedProvider = {
       provider: mockProvider,
@@ -149,7 +162,7 @@ describe("ProviderCommitMessageGenerator", () => {
 
   // 3. missing API key
   test('missing API key → returns deterministic, reason "missing_provider_api_key"', async () => {
-    currentConfig.apiKeys = {} as Record<string, string>;
+    mockSecureKeys = {};
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
       changedFiles: baseContext.changedFiles,
@@ -161,7 +174,7 @@ describe("ProviderCommitMessageGenerator", () => {
 
   // 3b. No resolvable provider and no keys
   test('no resolvable provider + no keys → returns deterministic, reason "missing_provider_api_key"', async () => {
-    currentConfig.apiKeys = {} as Record<string, string>;
+    mockSecureKeys = {};
     resolvedProvider = null;
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
@@ -174,10 +187,7 @@ describe("ProviderCommitMessageGenerator", () => {
 
   // 3c. No resolvable provider despite keys
   test('no resolvable provider with keys present → returns deterministic, reason "provider_not_initialized"', async () => {
-    currentConfig.apiKeys = { anthropic: "sk-test-key" } as Record<
-      string,
-      string
-    >;
+    mockSecureKeys = { anthropic: "sk-test-key" };
     resolvedProvider = null;
     const gen = getCommitMessageGenerator();
     const result = await gen.generateCommitMessage(baseContext, {
@@ -332,7 +342,7 @@ describe("ProviderCommitMessageGenerator", () => {
   // 12. Keyless provider (Ollama) without fast model → missing_fast_model (skips API key check)
   test('Ollama without API key or fast model → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = "ollama";
-    currentConfig.apiKeys = {} as Record<string, string>;
+    mockSecureKeys = {};
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "ollama",
@@ -352,10 +362,7 @@ describe("ProviderCommitMessageGenerator", () => {
   // 13. Unknown provider without fast model default → missing_fast_model, no provider call
   test('Unknown provider without fast model default → returns deterministic, reason "missing_fast_model"', async () => {
     (currentConfig as Record<string, unknown>).provider = "exotic-provider";
-    currentConfig.apiKeys = { "exotic-provider": "sk-exotic" } as Record<
-      string,
-      string
-    >;
+    mockSecureKeys = { "exotic-provider": "sk-exotic" };
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "exotic-provider",
@@ -374,7 +381,7 @@ describe("ProviderCommitMessageGenerator", () => {
   // 14. Fast-model override enables LLM path for provider without built-in default
   test("fast-model override enables LLM path for provider without built-in default", async () => {
     (currentConfig as Record<string, unknown>).provider = "ollama";
-    currentConfig.apiKeys = {} as Record<string, string>; // Ollama is keyless
+    mockSecureKeys = {}; // Ollama is keyless
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "ollama",
@@ -403,7 +410,7 @@ describe("ProviderCommitMessageGenerator", () => {
   test("configured provider unavailable -> selected fallback provider model mapping is used", async () => {
     currentConfig.provider = "anthropic";
     currentConfig.providerOrder = ["openai"];
-    currentConfig.apiKeys = { openai: "sk-openai" } as Record<string, string>;
+    mockSecureKeys = { openai: "sk-openai" };
     resolvedProvider = {
       provider: mockProvider,
       configuredProviderName: "anthropic",

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -10,6 +10,7 @@ import { credentialKey } from "../security/credential-key.js";
 // ---------------------------------------------------------------------------
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey = "";
+let mockProviderKeys: Record<string, string> = {};
 
 const actualEnv = await import("../config/env.js");
 mock.module("../config/env.js", () => ({
@@ -24,7 +25,7 @@ mock.module("../security/secure-keys.js", () => ({
     if (key === credentialKey("vellum", "assistant_api_key")) {
       return mockAssistantApiKey || null;
     }
-    return null;
+    return mockProviderKeys[key] ?? null;
   },
 }));
 
@@ -44,8 +45,8 @@ import { ProviderNotConfiguredError } from "../util/errors.js";
 
 /** Initialize registry with anthropic + openai for most tests. */
 function setupTwoProviders() {
+  mockProviderKeys = { anthropic: "test-key", openai: "test-key" };
   initializeProviders({
-    apiKeys: { anthropic: "test-key", openai: "test-key" },
     provider: "anthropic",
     model: "test-model",
   });
@@ -53,8 +54,8 @@ function setupTwoProviders() {
 
 /** Initialize registry with no providers (empty keys, non-registerable primary). */
 function setupNoProviders() {
+  mockProviderKeys = {};
   initializeProviders({
-    apiKeys: {},
     provider: "gemini",
     model: "test-model",
   });
@@ -183,8 +184,8 @@ describe("managed proxy fallback", () => {
   test("openai registered via managed fallback when no user key but proxy context is valid", () => {
     enableManagedProxy();
     try {
+      mockProviderKeys = { anthropic: "test-key" };
       initializeProviders({
-        apiKeys: { anthropic: "test-key" },
         provider: "anthropic",
         model: "test-model",
       });
@@ -200,8 +201,8 @@ describe("managed proxy fallback", () => {
   test("user key takes precedence over managed fallback", () => {
     enableManagedProxy();
     try {
+      mockProviderKeys = { anthropic: "test-key", openai: "user-openai-key" };
       initializeProviders({
-        apiKeys: { anthropic: "test-key", openai: "user-openai-key" },
         provider: "anthropic",
         model: "test-model",
       });
@@ -218,8 +219,8 @@ describe("managed proxy fallback", () => {
 
   test("managed fallback not activated when proxy context is disabled", () => {
     disableManagedProxy();
+    mockProviderKeys = { anthropic: "test-key" };
     initializeProviders({
-      apiKeys: { anthropic: "test-key" },
       provider: "anthropic",
       model: "test-model",
     });
@@ -232,8 +233,8 @@ describe("managed proxy fallback", () => {
   test("managed providers participate in failover selection", () => {
     enableManagedProxy();
     try {
+      mockProviderKeys = { anthropic: "test-key" };
       initializeProviders({
-        apiKeys: { anthropic: "test-key" },
         provider: "anthropic",
         model: "test-model",
       });
@@ -257,8 +258,8 @@ describe("managed proxy fallback", () => {
     enableManagedProxy();
     try {
       // No anthropic key, no gemini key — only managed providers available
+      mockProviderKeys = {};
       initializeProviders({
-        apiKeys: {},
         provider: "openai",
         model: "test-model",
       });

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -39,6 +39,7 @@ mock.module("@google/genai", () => ({
 // ---------------------------------------------------------------------------
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey: string | null = null;
+let mockProviderKeys: Record<string, string> = {};
 
 mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
@@ -49,7 +50,7 @@ mock.module("../security/secure-keys.js", () => ({
     if (key === credentialKey("vellum", "assistant_api_key")) {
       return mockAssistantApiKey;
     }
-    return null;
+    return mockProviderKeys[key] ?? null;
   },
 }));
 
@@ -86,14 +87,13 @@ function disableManagedProxy() {
 }
 
 /**
- * Build an apiKeys record with a user key for every provider in `names`.
+ * Set mock secure keys with a user key for every provider in `names`.
  */
-function userKeysFor(...names: string[]): Record<string, string> {
-  const keys: Record<string, string> = {};
+function setUserKeysFor(...names: string[]): void {
+  mockProviderKeys = {};
   for (const n of names) {
-    keys[n] = `user-key-${n}`;
+    mockProviderKeys[n] = `user-key-${n}`;
   }
-  return keys;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +102,7 @@ function userKeysFor(...names: string[]): Record<string, string> {
 
 beforeEach(() => {
   disableManagedProxy();
+  mockProviderKeys = {};
   lastGeminiConstructorOpts = null;
 });
 
@@ -111,8 +112,8 @@ describe("managed proxy integration — credential precedence", () => {
       "%s routes via user-key when user key is provided regardless of managed context",
       (provider: string) => {
         enableManagedProxy();
+        setUserKeysFor(provider);
         initializeProviders({
-          apiKeys: userKeysFor(provider),
           provider,
           model: "test-model",
         });
@@ -123,8 +124,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("all five managed providers route via user-key with user keys", () => {
       enableManagedProxy();
+      setUserKeysFor(...MANAGED_PROVIDERS);
       initializeProviders({
-        apiKeys: userKeysFor(...MANAGED_PROVIDERS),
         provider: "anthropic",
         model: "test-model",
       });
@@ -137,8 +138,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("user keys still route via user-key when managed context is disabled", () => {
       disableManagedProxy();
+      setUserKeysFor(...MANAGED_PROVIDERS);
       initializeProviders({
-        apiKeys: userKeysFor(...MANAGED_PROVIDERS),
         provider: "anthropic",
         model: "test-model",
       });
@@ -155,8 +156,8 @@ describe("managed proxy integration — credential precedence", () => {
       "%s routes via managed-proxy when no user key",
       (provider: string) => {
         enableManagedProxy();
+        mockProviderKeys = {};
         initializeProviders({
-          apiKeys: {},
           // For ollama, provider selection does not trigger managed proxy
           provider: provider === "openai" ? "openai" : "anthropic",
           model: "test-model",
@@ -168,8 +169,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("all five managed providers route via managed-proxy simultaneously", () => {
       enableManagedProxy();
+      mockProviderKeys = {};
       initializeProviders({
-        apiKeys: {},
         provider: "anthropic",
         model: "test-model",
       });
@@ -182,8 +183,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("managed anthropic uses vertex proxy path instead of anthropic proxy path", () => {
       enableManagedProxy();
+      mockProviderKeys = {};
       initializeProviders({
-        apiKeys: {},
         provider: "anthropic",
         model: "claude-opus-4-6",
       });
@@ -206,8 +207,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("managed gemini uses vertex proxy path instead of gemini proxy path", () => {
       enableManagedProxy();
+      mockProviderKeys = {};
       initializeProviders({
-        apiKeys: {},
         provider: "anthropic",
         model: "test-model",
       });
@@ -229,8 +230,8 @@ describe("managed proxy integration — credential precedence", () => {
       "%s is NOT registered when no user key and no managed context",
       (provider: string) => {
         disableManagedProxy();
+        mockProviderKeys = {};
         initializeProviders({
-          apiKeys: {},
           provider: "anthropic",
           model: "test-model",
         });
@@ -241,8 +242,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("registry is empty when no keys and no managed context (non-ollama primary)", () => {
       disableManagedProxy();
+      mockProviderKeys = {};
       initializeProviders({
-        apiKeys: {},
         provider: "anthropic",
         model: "test-model",
       });
@@ -253,8 +254,8 @@ describe("managed proxy integration — credential precedence", () => {
   describe("mixed: some user keys + managed fallback fills gaps", () => {
     test("user key for anthropic routes direct, managed fallback fills remaining four via proxy", () => {
       enableManagedProxy();
+      setUserKeysFor("anthropic");
       initializeProviders({
-        apiKeys: userKeysFor("anthropic"),
         provider: "anthropic",
         model: "test-model",
       });
@@ -269,8 +270,8 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("user key for openai routes direct, managed fallback fills remaining four via proxy", () => {
       enableManagedProxy();
+      setUserKeysFor("openai");
       initializeProviders({
-        apiKeys: userKeysFor("openai"),
         provider: "openai",
         model: "test-model",
       });
@@ -288,8 +289,8 @@ describe("managed proxy integration — credential precedence", () => {
 describe("managed proxy integration — ollama exclusion", () => {
   test("ollama is never registered via managed proxy fallback", () => {
     enableManagedProxy();
+    mockProviderKeys = {};
     initializeProviders({
-      apiKeys: {},
       provider: "anthropic",
       model: "test-model",
     });
@@ -298,8 +299,8 @@ describe("managed proxy integration — ollama exclusion", () => {
 
   test("ollama registers only when explicitly configured as provider", () => {
     enableManagedProxy();
+    mockProviderKeys = {};
     initializeProviders({
-      apiKeys: {},
       provider: "ollama",
       model: "test-model",
     });
@@ -308,8 +309,8 @@ describe("managed proxy integration — ollama exclusion", () => {
 
   test("ollama registers with explicit API key", () => {
     enableManagedProxy();
+    mockProviderKeys = { ollama: "ollama-key" };
     initializeProviders({
-      apiKeys: { ollama: "ollama-key" },
       provider: "anthropic",
       model: "test-model",
     });

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -9,7 +9,6 @@ import {
 describe("provider registry (ollama)", () => {
   test("registers ollama when selected provider has no API key", () => {
     initializeProviders({
-      apiKeys: {},
       provider: "ollama",
       model: "claude-opus-4-6",
     });

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -24,7 +24,6 @@ mock.module("../config/loader.js", () => ({
     daemon: { standaloneRecording: true },
     provider: "mock-provider",
     permissions: { mode: "workspace" },
-    apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },
     skills: { load: { extraDirs: [] } },

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -88,7 +88,6 @@ mock.module("../prompts/user-reference.js", () => ({
 const mockConfig = {
   provider: "anthropic",
   providerOrder: ["anthropic"],
-  apiKeys: { anthropic: "test-key" },
   secretDetection: { enabled: false },
   calls: {
     enabled: true,

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -42,7 +42,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   }),

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -49,7 +49,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -41,7 +41,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -18,7 +18,6 @@ const MANAGED_PROVIDERS = [
 ] as const;
 
 const mockConfig = {
-  apiKeys: {},
   provider: "anthropic",
   model: "test-model",
 };

--- a/assistant/src/__tests__/secret-scanner-executor.test.ts
+++ b/assistant/src/__tests__/secret-scanner-executor.test.ts
@@ -13,7 +13,6 @@ import type {
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -48,7 +48,6 @@ mock.module("../config/loader.js", () => ({
 
     model: "test",
     provider: "test",
-    apiKeys: {},
     memory: { enabled: false },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     secretDetection: { enabled: false },

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -49,7 +49,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -51,7 +51,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     workspaceGit: { turnCommitMaxWaitMs: 10 },
     ui: {},
   }),
@@ -197,7 +196,7 @@ mock.module("../daemon/session-memory.js", () => ({
       enabled: false,
       degraded: false,
       injectedText: "",
-  
+
       semanticHits: 0,
       recencyHits: 0,
       injectedTokens: 0,
@@ -534,278 +533,284 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   //
   // Expected behavior (PR 2 fix): After progress + context_too_large,
   // the system should still attempt compaction before surfacing error.
-  test.todo("context too large after progress triggers compaction retry instead of immediate failure", async () => {
-    const events: ServerMessage[] = [];
-    let reducerCalled = false;
+  test.todo(
+    "context too large after progress triggers compaction retry instead of immediate failure",
+    async () => {
+      const events: ServerMessage[] = [];
+      let reducerCalled = false;
 
-    mockReducerStepFn = (msgs: Message[]) => {
-      reducerCalled = true;
-      return {
-        messages: msgs,
-        tier: "forced_compaction",
-        state: {
-          appliedTiers: ["forced_compaction"],
-          injectionMode: "full",
-          exhausted: false,
-        },
-        estimatedTokens: 50_000,
-        compactionResult: {
-          compacted: true,
+      mockReducerStepFn = (msgs: Message[]) => {
+        reducerCalled = true;
+        return {
           messages: msgs,
-          compactedPersistedMessages: 5,
-          summaryText: "Summary",
-          previousEstimatedInputTokens: 190_000,
-          estimatedInputTokens: 50_000,
-          maxInputTokens: 200_000,
-          thresholdTokens: 160_000,
-          compactedMessages: 10,
-          summaryCalls: 1,
-          summaryInputTokens: 500,
-          summaryOutputTokens: 200,
-          summaryModel: "mock-model",
-        },
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 50_000,
+          compactionResult: {
+            compacted: true,
+            messages: msgs,
+            compactedPersistedMessages: 5,
+            summaryText: "Summary",
+            previousEstimatedInputTokens: 190_000,
+            estimatedInputTokens: 50_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 10,
+            summaryCalls: 1,
+            summaryInputTokens: 500,
+            summaryOutputTokens: 200,
+            summaryModel: "mock-model",
+          },
+        };
       };
-    };
 
-    let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
-      agentLoopCallCount++;
-      if (agentLoopCallCount === 1) {
-        // Simulate: agent makes progress (tool calls + results added)
-        // then hits context_too_large on next LLM call
-        const progressMessages: Message[] = [
-          ...messages,
-          {
-            role: "assistant" as const,
-            content: [
-              { type: "text", text: "Let me check that." },
-              {
-                type: "tool_use",
-                id: "tu-progress",
-                name: "bash",
-                input: { command: "ls" },
-              },
-            ] as ContentBlock[],
-          },
-          {
-            role: "user" as const,
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "tu-progress",
-                content: "file1.ts\nfile2.ts",
-                is_error: false,
-              },
-            ] as ContentBlock[],
-          },
-        ];
+      let agentLoopCallCount = 0;
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        agentLoopCallCount++;
+        if (agentLoopCallCount === 1) {
+          // Simulate: agent makes progress (tool calls + results added)
+          // then hits context_too_large on next LLM call
+          const progressMessages: Message[] = [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [
+                { type: "text", text: "Let me check that." },
+                {
+                  type: "tool_use",
+                  id: "tu-progress",
+                  name: "bash",
+                  input: { command: "ls" },
+                },
+              ] as ContentBlock[],
+            },
+            {
+              role: "user" as const,
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-progress",
+                  content: "file1.ts\nfile2.ts",
+                  is_error: false,
+                },
+              ] as ContentBlock[],
+            },
+          ];
 
-        // Emit events for the progress that was made
-        onEvent({
-          type: "tool_use",
-          id: "tu-progress",
-          name: "bash",
-          input: { command: "ls" },
-        });
-        onEvent({
-          type: "tool_result",
-          toolUseId: "tu-progress",
-          content: "file1.ts\nfile2.ts",
-          isError: false,
-        });
+          // Emit events for the progress that was made
+          onEvent({
+            type: "tool_use",
+            id: "tu-progress",
+            name: "bash",
+            input: { command: "ls" },
+          });
+          onEvent({
+            type: "tool_result",
+            toolUseId: "tu-progress",
+            content: "file1.ts\nfile2.ts",
+            isError: false,
+          });
+          onEvent({
+            type: "message_complete",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Let me check that." },
+                {
+                  type: "tool_use",
+                  id: "tu-progress",
+                  name: "bash",
+                  input: { command: "ls" },
+                },
+              ],
+            },
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 50,
+            model: "test-model",
+            providerDurationMs: 100,
+          });
+
+          // Then context_too_large error occurs on the *next* LLM call
+          onEvent({
+            type: "error",
+            error: new Error(
+              "prompt is too long: 242201 tokens > 200000 maximum",
+            ),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 10,
+          });
+
+          // Return the history WITH progress (more messages than input)
+          return progressMessages;
+        }
+
+        // Second call (after compaction): succeed
         onEvent({
           type: "message_complete",
           message: {
             role: "assistant",
-            content: [
-              { type: "text", text: "Let me check that." },
-              {
-                type: "tool_use",
-                id: "tu-progress",
-                name: "bash",
-                input: { command: "ls" },
-              },
-            ],
+            content: [{ type: "text", text: "recovered after compaction" }],
           },
         });
         onEvent({
           type: "usage",
-          inputTokens: 100,
-          outputTokens: 50,
+          inputTokens: 50,
+          outputTokens: 25,
           model: "test-model",
           providerDurationMs: 100,
         });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: "recovered after compaction" },
+            ] as ContentBlock[],
+          },
+        ];
+      };
 
-        // Then context_too_large error occurs on the *next* LLM call
-        onEvent({
-          type: "error",
-          error: new Error(
-            "prompt is too long: 242201 tokens > 200000 maximum",
-          ),
-        });
-        onEvent({
-          type: "usage",
-          inputTokens: 0,
-          outputTokens: 0,
-          model: "test-model",
-          providerDurationMs: 10,
-        });
-
-        // Return the history WITH progress (more messages than input)
-        return progressMessages;
-      }
-
-      // Second call (after compaction): succeed
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "recovered after compaction" }],
-        },
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 50,
-        outputTokens: 25,
-        model: "test-model",
-        providerDurationMs: 100,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [
-            { type: "text", text: "recovered after compaction" },
-          ] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => ({ compacted: false }),
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      // BUG: Currently the reducer is NOT called when progress was made before
+      // context_too_large. The error is surfaced immediately.
+      // After PR 2 fix, the reducer SHOULD be called to attempt compaction.
+      expect(reducerCalled).toBe(true);
 
-    // BUG: Currently the reducer is NOT called when progress was made before
-    // context_too_large. The error is surfaced immediately.
-    // After PR 2 fix, the reducer SHOULD be called to attempt compaction.
-    expect(reducerCalled).toBe(true);
-
-    // BUG: Currently a session_error IS emitted instead of retrying.
-    // After PR 2 fix, there should be no session_error.
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-  });
+      // BUG: Currently a session_error IS emitted instead of retrying.
+      // After PR 2 fix, there should be no session_error.
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+    },
+  );
 
   // ── Test 2 ────────────────────────────────────────────────────────
   // When estimation says we're within budget but the provider rejects,
   // the post-run convergence loop should kick in and recover.
   // This test should PASS against current code (when no progress is made).
-  test.todo("overflow recovery compacts below limit even when estimation underestimates", async () => {
-    const events: ServerMessage[] = [];
-    let callCount = 0;
-    let reducerCalled = false;
+  test.todo(
+    "overflow recovery compacts below limit even when estimation underestimates",
+    async () => {
+      const events: ServerMessage[] = [];
+      let callCount = 0;
+      let reducerCalled = false;
 
-    // Estimator says 185k (below 190k budget = 200k * 0.95)
-    mockEstimateTokens = 185_000;
+      // Estimator says 185k (below 190k budget = 200k * 0.95)
+      mockEstimateTokens = 185_000;
 
-    // Reducer successfully compacts
-    mockReducerStepFn = (msgs: Message[]) => {
-      reducerCalled = true;
-      return {
-        messages: msgs,
-        tier: "forced_compaction",
-        state: {
-          appliedTiers: ["forced_compaction"],
-          injectionMode: "full",
-          exhausted: false,
-        },
-        estimatedTokens: 100_000,
-        compactionResult: {
-          compacted: true,
+      // Reducer successfully compacts
+      mockReducerStepFn = (msgs: Message[]) => {
+        reducerCalled = true;
+        return {
           messages: msgs,
-          compactedPersistedMessages: 10,
-          summaryText: "Summary",
-          previousEstimatedInputTokens: 185_000,
-          estimatedInputTokens: 100_000,
-          maxInputTokens: 200_000,
-          thresholdTokens: 160_000,
-          compactedMessages: 20,
-          summaryCalls: 1,
-          summaryInputTokens: 800,
-          summaryOutputTokens: 300,
-          summaryModel: "mock-model",
-        },
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 100_000,
+          compactionResult: {
+            compacted: true,
+            messages: msgs,
+            compactedPersistedMessages: 10,
+            summaryText: "Summary",
+            previousEstimatedInputTokens: 185_000,
+            estimatedInputTokens: 100_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 20,
+            summaryCalls: 1,
+            summaryInputTokens: 800,
+            summaryOutputTokens: 300,
+            summaryModel: "mock-model",
+          },
+        };
       };
-    };
 
-    const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
-      callCount++;
-      if (callCount === 1) {
-        // Provider rejects with "prompt is too long: 242201 tokens > 200000"
-        // even though estimator said 185k
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        if (callCount === 1) {
+          // Provider rejects with "prompt is too long: 242201 tokens > 200000"
+          // even though estimator said 185k
+          onEvent({
+            type: "error",
+            error: new Error(
+              "prompt is too long: 242201 tokens > 200000 maximum",
+            ),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 10,
+          });
+          // No progress — return same messages
+          return messages;
+        }
+        // Second call succeeds
         onEvent({
-          type: "error",
-          error: new Error(
-            "prompt is too long: 242201 tokens > 200000 maximum",
-          ),
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
         });
         onEvent({
           type: "usage",
-          inputTokens: 0,
-          outputTokens: 0,
+          inputTokens: 80_000,
+          outputTokens: 200,
           model: "test-model",
-          providerDurationMs: 10,
+          providerDurationMs: 500,
         });
-        // No progress — return same messages
-        return messages;
-      }
-      // Second call succeeds
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "recovered" }],
-        },
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 80_000,
-        outputTokens: 200,
-        model: "test-model",
-        providerDurationMs: 500,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [{ type: "text", text: "recovered" }] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => ({ compacted: false }),
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
-
-    // The reducer should be called in the convergence loop
-    expect(reducerCalled).toBe(true);
-    // Should recover without session_error
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-    expect(callCount).toBe(2);
-  });
+      // The reducer should be called in the convergence loop
+      expect(reducerCalled).toBe(true);
+      // Should recover without session_error
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+      expect(callCount).toBe(2);
+    },
+  );
 
   // ── Test 3 ────────────────────────────────────────────────────────
   // BUG: When the provider rejection reveals actual token count (e.g.,
@@ -824,216 +829,219 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // inaccuracy. For example: 190k / 1.31 ≈ 145k.
   // Planned fix: targetInputTokensOverride should be adjusted based on
   // the ratio between estimated and actual tokens.
-  test.todo("forced compaction targets a lower budget when estimation has been inaccurate", async () => {
-    const events: ServerMessage[] = [];
-    let callCount = 0;
-    let capturedTargetTokens: number | undefined;
+  test.todo(
+    "forced compaction targets a lower budget when estimation has been inaccurate",
+    async () => {
+      const events: ServerMessage[] = [];
+      let callCount = 0;
+      let capturedTargetTokens: number | undefined;
 
-    // Estimator says 185k (below 190k budget = 200k * 0.95)
-    mockEstimateTokens = 185_000;
+      // Estimator says 185k (below 190k budget = 200k * 0.95)
+      mockEstimateTokens = 185_000;
 
-    // Reducer captures the targetTokens from the config
-    mockReducerStepFn = (
-      msgs: Message[],
-      cfg: unknown,
-    ) => {
-      capturedTargetTokens = (cfg as { targetTokens: number }).targetTokens;
-      return {
-        messages: msgs,
-        tier: "forced_compaction",
-        state: {
-          appliedTiers: ["forced_compaction"],
-          injectionMode: "full",
-          exhausted: false,
-        },
-        estimatedTokens: 100_000,
-        compactionResult: {
-          compacted: true,
+      // Reducer captures the targetTokens from the config
+      mockReducerStepFn = (msgs: Message[], cfg: unknown) => {
+        capturedTargetTokens = (cfg as { targetTokens: number }).targetTokens;
+        return {
           messages: msgs,
-          compactedPersistedMessages: 10,
-          summaryText: "Summary",
-          previousEstimatedInputTokens: 185_000,
-          estimatedInputTokens: 100_000,
-          maxInputTokens: 200_000,
-          thresholdTokens: 160_000,
-          compactedMessages: 20,
-          summaryCalls: 1,
-          summaryInputTokens: 800,
-          summaryOutputTokens: 300,
-          summaryModel: "mock-model",
-        },
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 100_000,
+          compactionResult: {
+            compacted: true,
+            messages: msgs,
+            compactedPersistedMessages: 10,
+            summaryText: "Summary",
+            previousEstimatedInputTokens: 185_000,
+            estimatedInputTokens: 100_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: 20,
+            summaryCalls: 1,
+            summaryInputTokens: 800,
+            summaryOutputTokens: 300,
+            summaryModel: "mock-model",
+          },
+        };
       };
-    };
 
-    const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
-      callCount++;
-      if (callCount === 1) {
-        // Provider rejects: actual tokens 242201, way above estimate of 185k
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        if (callCount === 1) {
+          // Provider rejects: actual tokens 242201, way above estimate of 185k
+          onEvent({
+            type: "error",
+            error: new Error(
+              "prompt is too long: 242201 tokens > 200000 maximum",
+            ),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 10,
+          });
+          // No progress — return same messages
+          return messages;
+        }
+        // Second call succeeds after compaction
         onEvent({
-          type: "error",
-          error: new Error(
-            "prompt is too long: 242201 tokens > 200000 maximum",
-          ),
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
         });
         onEvent({
           type: "usage",
-          inputTokens: 0,
-          outputTokens: 0,
+          inputTokens: 80_000,
+          outputTokens: 200,
           model: "test-model",
-          providerDurationMs: 10,
+          providerDurationMs: 500,
         });
-        // No progress — return same messages
-        return messages;
-      }
-      // Second call succeeds after compaction
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "recovered" }],
-        },
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 80_000,
-        outputTokens: 200,
-        model: "test-model",
-        providerDurationMs: 500,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [{ type: "text", text: "recovered" }] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => ({ compacted: false }),
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      // The reducer should have been called with a corrected target
+      expect(capturedTargetTokens).toBeDefined();
 
-    // The reducer should have been called with a corrected target
-    expect(capturedTargetTokens).toBeDefined();
+      // preflightBudget = 200_000 * 0.95 = 190_000
+      // estimationErrorRatio = 242201 / 185000 ≈ 1.309
+      // correctedTarget = floor(190000 / 1.309) ≈ 145_130
+      // The corrected target must be LESS than the uncorrected preflightBudget
+      const preflightBudget = 190_000;
+      expect(capturedTargetTokens!).toBeLessThan(preflightBudget);
 
-    // preflightBudget = 200_000 * 0.95 = 190_000
-    // estimationErrorRatio = 242201 / 185000 ≈ 1.309
-    // correctedTarget = floor(190000 / 1.309) ≈ 145_130
-    // The corrected target must be LESS than the uncorrected preflightBudget
-    const preflightBudget = 190_000;
-    expect(capturedTargetTokens!).toBeLessThan(preflightBudget);
+      // Verify the approximate corrected value (190000 / (242201/185000))
+      const expectedCorrectedTarget = Math.floor(
+        preflightBudget / (242201 / 185_000),
+      );
+      expect(capturedTargetTokens!).toBe(expectedCorrectedTarget);
 
-    // Verify the approximate corrected value (190000 / (242201/185000))
-    const expectedCorrectedTarget = Math.floor(
-      preflightBudget / (242201 / 185_000),
-    );
-    expect(capturedTargetTokens!).toBe(expectedCorrectedTarget);
-
-    // Should recover without session_error
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-    expect(callCount).toBe(2);
-  });
+      // Should recover without session_error
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+      expect(callCount).toBe(2);
+    },
+  );
 
   // ── Test 4 ────────────────────────────────────────────────────────
   // A realistic 75+ message conversation with many tool calls where
   // token estimation underestimates. This test should PASS against
   // current code because the agent loop returns same-length history
   // (no progress), so the convergence loop kicks in.
-  test.todo("overflow recovery succeeds for 75+ message conversation with many tool calls", async () => {
-    const events: ServerMessage[] = [];
-    const longHistory = buildLongConversation(75);
-    let callCount = 0;
-    let reducerCalled = false;
+  test.todo(
+    "overflow recovery succeeds for 75+ message conversation with many tool calls",
+    async () => {
+      const events: ServerMessage[] = [];
+      const longHistory = buildLongConversation(75);
+      let callCount = 0;
+      let reducerCalled = false;
 
-    // Estimator says ~195k — just above budget so preflight reducer runs
-    mockEstimateTokens = 195_000;
+      // Estimator says ~195k — just above budget so preflight reducer runs
+      mockEstimateTokens = 195_000;
 
-    // Reducer reduces to under budget
-    mockReducerStepFn = (msgs: Message[]) => {
-      reducerCalled = true;
-      return {
-        messages: msgs.slice(-10), // Keep only last 10 messages
-        tier: "forced_compaction",
-        state: {
-          appliedTiers: ["forced_compaction"],
-          injectionMode: "full",
-          exhausted: false,
-        },
-        estimatedTokens: 50_000,
-        compactionResult: {
-          compacted: true,
-          messages: msgs.slice(-10),
-          compactedPersistedMessages: msgs.length - 10,
-          summaryText: "Long conversation summary",
-          previousEstimatedInputTokens: 195_000,
-          estimatedInputTokens: 50_000,
-          maxInputTokens: 200_000,
-          thresholdTokens: 160_000,
-          compactedMessages: msgs.length - 10,
-          summaryCalls: 2,
-          summaryInputTokens: 2000,
-          summaryOutputTokens: 500,
-          summaryModel: "mock-model",
-        },
+      // Reducer reduces to under budget
+      mockReducerStepFn = (msgs: Message[]) => {
+        reducerCalled = true;
+        return {
+          messages: msgs.slice(-10), // Keep only last 10 messages
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 50_000,
+          compactionResult: {
+            compacted: true,
+            messages: msgs.slice(-10),
+            compactedPersistedMessages: msgs.length - 10,
+            summaryText: "Long conversation summary",
+            previousEstimatedInputTokens: 195_000,
+            estimatedInputTokens: 50_000,
+            maxInputTokens: 200_000,
+            thresholdTokens: 160_000,
+            compactedMessages: msgs.length - 10,
+            summaryCalls: 2,
+            summaryInputTokens: 2000,
+            summaryOutputTokens: 500,
+            summaryModel: "mock-model",
+          },
+        };
       };
-    };
 
-    const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
-      callCount++;
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "Here's the analysis..." }],
-        },
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        callCount++;
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Here's the analysis..." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 50_000,
+          outputTokens: 300,
+          model: "test-model",
+          providerDurationMs: 800,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: "Here's the analysis..." },
+            ] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        messages: longHistory,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 50_000,
-        outputTokens: 300,
-        model: "test-model",
-        providerDurationMs: 800,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [
-            { type: "text", text: "Here's the analysis..." },
-          ] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      messages: longHistory,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => ({ compacted: false }),
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "analyze this", "msg-1", (msg) =>
+        events.push(msg),
+      );
 
-    await runAgentLoopImpl(ctx, "analyze this", "msg-1", (msg) =>
-      events.push(msg),
-    );
-
-    // Preflight should trigger the reducer since 195k > 190k budget
-    expect(reducerCalled).toBe(true);
-    // Should succeed
-    expect(callCount).toBe(1);
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-    const complete = events.find((e) => e.type === "message_complete");
-    expect(complete).toBeDefined();
-  });
+      // Preflight should trigger the reducer since 195k > 190k budget
+      expect(reducerCalled).toBe(true);
+      // Should succeed
+      expect(callCount).toBe(1);
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+      const complete = events.find((e) => e.type === "message_complete");
+      expect(complete).toBeDefined();
+    },
+  );
 
   // ── Test 5 ────────────────────────────────────────────────────────
   // BUG: When all 4 reducer tiers have been applied, then the agent
@@ -1044,184 +1052,187 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // Expected behavior (PR 2 fix): Even after all tiers are exhausted,
   // if progress was made, attempt emergency compaction with
   // `minKeepRecentUserTurns: 0` as a last resort.
-  test.todo("exhausted reducer tiers with progress still attempts emergency compaction", async () => {
-    const events: ServerMessage[] = [];
-    let emergencyCompactCalled = false;
+  test.todo(
+    "exhausted reducer tiers with progress still attempts emergency compaction",
+    async () => {
+      const events: ServerMessage[] = [];
+      let emergencyCompactCalled = false;
 
-    // Start with reducer already exhausted
-    mockReducerStepFn = (msgs: Message[]) => {
-      return {
-        messages: msgs,
-        tier: "injection_downgrade",
-        state: {
-          appliedTiers: [
-            "forced_compaction",
-            "tool_result_truncation",
-            "media_stubbing",
-            "injection_downgrade",
-          ],
-          injectionMode: "minimal",
-          exhausted: true,
-        },
-        estimatedTokens: 195_000,
+      // Start with reducer already exhausted
+      mockReducerStepFn = (msgs: Message[]) => {
+        return {
+          messages: msgs,
+          tier: "injection_downgrade",
+          state: {
+            appliedTiers: [
+              "forced_compaction",
+              "tool_result_truncation",
+              "media_stubbing",
+              "injection_downgrade",
+            ],
+            injectionMode: "minimal",
+            exhausted: true,
+          },
+          estimatedTokens: 195_000,
+        };
       };
-    };
 
-    let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
-      agentLoopCallCount++;
-      if (agentLoopCallCount === 1) {
-        // Agent makes progress (tool calls succeed, messages grow)
-        const progressMessages: Message[] = [
-          ...messages,
-          {
-            role: "assistant" as const,
-            content: [
-              { type: "text", text: "Running analysis..." },
-              {
-                type: "tool_use",
-                id: "tu-1",
-                name: "bash",
-                input: { command: "find . -name '*.ts'" },
-              },
-            ] as ContentBlock[],
-          },
-          {
-            role: "user" as const,
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "tu-1",
-                content: "file1.ts\nfile2.ts\nfile3.ts",
-                is_error: false,
-              },
-            ] as ContentBlock[],
-          },
-        ];
+      let agentLoopCallCount = 0;
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        agentLoopCallCount++;
+        if (agentLoopCallCount === 1) {
+          // Agent makes progress (tool calls succeed, messages grow)
+          const progressMessages: Message[] = [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [
+                { type: "text", text: "Running analysis..." },
+                {
+                  type: "tool_use",
+                  id: "tu-1",
+                  name: "bash",
+                  input: { command: "find . -name '*.ts'" },
+                },
+              ] as ContentBlock[],
+            },
+            {
+              role: "user" as const,
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-1",
+                  content: "file1.ts\nfile2.ts\nfile3.ts",
+                  is_error: false,
+                },
+              ] as ContentBlock[],
+            },
+          ];
 
-        onEvent({
-          type: "tool_use",
-          id: "tu-1",
-          name: "bash",
-          input: { command: "find . -name '*.ts'" },
-        });
-        onEvent({
-          type: "tool_result",
-          toolUseId: "tu-1",
-          content: "file1.ts\nfile2.ts\nfile3.ts",
-          isError: false,
-        });
+          onEvent({
+            type: "tool_use",
+            id: "tu-1",
+            name: "bash",
+            input: { command: "find . -name '*.ts'" },
+          });
+          onEvent({
+            type: "tool_result",
+            toolUseId: "tu-1",
+            content: "file1.ts\nfile2.ts\nfile3.ts",
+            isError: false,
+          });
+          onEvent({
+            type: "message_complete",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Running analysis..." },
+                {
+                  type: "tool_use",
+                  id: "tu-1",
+                  name: "bash",
+                  input: { command: "find . -name '*.ts'" },
+                },
+              ],
+            },
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 190_000,
+            outputTokens: 100,
+            model: "test-model",
+            providerDurationMs: 200,
+          });
+
+          // Then context_too_large on the next LLM call within the loop
+          onEvent({
+            type: "error",
+            error: new Error("context_length_exceeded"),
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 0,
+            outputTokens: 0,
+            model: "test-model",
+            providerDurationMs: 10,
+          });
+
+          return progressMessages;
+        }
+
+        // After emergency compaction, succeed
         onEvent({
           type: "message_complete",
           message: {
             role: "assistant",
-            content: [
-              { type: "text", text: "Running analysis..." },
-              {
-                type: "tool_use",
-                id: "tu-1",
-                name: "bash",
-                input: { command: "find . -name '*.ts'" },
-              },
-            ],
+            content: [{ type: "text", text: "recovered" }],
           },
         });
         onEvent({
           type: "usage",
-          inputTokens: 190_000,
+          inputTokens: 50_000,
           outputTokens: 100,
           model: "test-model",
           providerDurationMs: 200,
         });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
 
-        // Then context_too_large on the next LLM call within the loop
-        onEvent({
-          type: "error",
-          error: new Error("context_length_exceeded"),
-        });
-        onEvent({
-          type: "usage",
-          inputTokens: 0,
-          outputTokens: 0,
-          model: "test-model",
-          providerDurationMs: 10,
-        });
-
-        return progressMessages;
-      }
-
-      // After emergency compaction, succeed
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "recovered" }],
-        },
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async (
+            _msgs: Message[],
+            _signal: AbortSignal,
+            opts?: Record<string, unknown>,
+          ) => {
+            if (opts?.force && opts?.minKeepRecentUserTurns === 0) {
+              emergencyCompactCalled = true;
+              return {
+                compacted: true,
+                messages: [
+                  {
+                    role: "user",
+                    content: [{ type: "text", text: "Hello" }],
+                  },
+                ] as Message[],
+                compactedPersistedMessages: 50,
+                summaryText: "Emergency summary",
+                previousEstimatedInputTokens: 195_000,
+                estimatedInputTokens: 50_000,
+                maxInputTokens: 200_000,
+                thresholdTokens: 160_000,
+                compactedMessages: 50,
+                summaryCalls: 1,
+                summaryInputTokens: 1000,
+                summaryOutputTokens: 300,
+                summaryModel: "mock-model",
+              };
+            }
+            return { compacted: false };
+          },
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 50_000,
-        outputTokens: 100,
-        model: "test-model",
-        providerDurationMs: 200,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [{ type: "text", text: "recovered" }] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async (
-          _msgs: Message[],
-          _signal: AbortSignal,
-          opts?: Record<string, unknown>,
-        ) => {
-          if (opts?.force && opts?.minKeepRecentUserTurns === 0) {
-            emergencyCompactCalled = true;
-            return {
-              compacted: true,
-              messages: [
-                {
-                  role: "user",
-                  content: [{ type: "text", text: "Hello" }],
-                },
-              ] as Message[],
-              compactedPersistedMessages: 50,
-              summaryText: "Emergency summary",
-              previousEstimatedInputTokens: 195_000,
-              estimatedInputTokens: 50_000,
-              maxInputTokens: 200_000,
-              thresholdTokens: 160_000,
-              compactedMessages: 50,
-              summaryCalls: 1,
-              summaryInputTokens: 1000,
-              summaryOutputTokens: 300,
-              summaryModel: "mock-model",
-            };
-          }
-          return { compacted: false };
-        },
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      // BUG: Currently when progress was made + all tiers exhausted,
+      // emergency compaction is NOT attempted. The error is surfaced directly.
+      // After PR 2 fix, emergency compaction should be attempted.
+      expect(emergencyCompactCalled).toBe(true);
 
-    // BUG: Currently when progress was made + all tiers exhausted,
-    // emergency compaction is NOT attempted. The error is surfaced directly.
-    // After PR 2 fix, emergency compaction should be attempted.
-    expect(emergencyCompactCalled).toBe(true);
-
-    // BUG: Currently a session_error IS emitted.
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-  });
+      // BUG: Currently a session_error IS emitted.
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+    },
+  );
 
   // ── Test 6 ────────────────────────────────────────────────────────
   // Tests mid-loop budget check via onCheckpoint.
@@ -1229,356 +1240,362 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
   // When estimate exceeds the mid-loop threshold (85% of budget),
   // it returns "yield" to break the agent loop.
   // The session-agent-loop then runs compaction and re-enters the agent loop.
-  test.todo("onCheckpoint yields when token estimate exceeds mid-loop budget threshold", async () => {
-    const events: ServerMessage[] = [];
-    let compactionCalled = false;
+  test.todo(
+    "onCheckpoint yields when token estimate exceeds mid-loop budget threshold",
+    async () => {
+      const events: ServerMessage[] = [];
+      let compactionCalled = false;
 
-    // estimatePromptTokens is called:
-    // 1. During preflight budget check (low value, below budget)
-    // 2. During onCheckpoint mid-loop check (high value, above 85% threshold)
-    // Budget = 200_000 * 0.95 = 190_000
-    // Mid-loop threshold = 190_000 * 0.85 = 161_500
-    let estimateCallCount = 0;
-    mockEstimateTokens = () => {
-      estimateCallCount++;
-      // First call: preflight check — below budget
-      if (estimateCallCount === 1) return 100_000;
-      // Subsequent calls: mid-loop check — above 85% threshold
-      return 170_000;
-    };
+      // estimatePromptTokens is called:
+      // 1. During preflight budget check (low value, below budget)
+      // 2. During onCheckpoint mid-loop check (high value, above 85% threshold)
+      // Budget = 200_000 * 0.95 = 190_000
+      // Mid-loop threshold = 190_000 * 0.85 = 161_500
+      let estimateCallCount = 0;
+      mockEstimateTokens = () => {
+        estimateCallCount++;
+        // First call: preflight check — below budget
+        if (estimateCallCount === 1) return 100_000;
+        // Subsequent calls: mid-loop check — above 85% threshold
+        return 170_000;
+      };
 
-    let agentLoopCallCount = 0;
-    const agentLoopRun: AgentLoopRun = async (
-      messages,
-      onEvent,
-      _signal,
-      _requestId,
-      onCheckpoint,
-    ) => {
-      agentLoopCallCount++;
+      let agentLoopCallCount = 0;
+      const agentLoopRun: AgentLoopRun = async (
+        messages,
+        onEvent,
+        _signal,
+        _requestId,
+        onCheckpoint,
+      ) => {
+        agentLoopCallCount++;
 
-      if (agentLoopCallCount === 1) {
-        // Simulate a tool round: assistant calls a tool, results come back
-        const withProgress: Message[] = [
-          ...messages,
-          {
-            role: "assistant" as const,
-            content: [
-              { type: "text", text: "Let me check." },
-              {
-                type: "tool_use",
-                id: "tu-1",
-                name: "bash",
-                input: { command: "ls" },
-              },
-            ] as ContentBlock[],
-          },
-          {
-            role: "user" as const,
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "tu-1",
-                content: "file1.ts\nfile2.ts",
-                is_error: false,
-              },
-            ] as ContentBlock[],
-          },
-        ];
+        if (agentLoopCallCount === 1) {
+          // Simulate a tool round: assistant calls a tool, results come back
+          const withProgress: Message[] = [
+            ...messages,
+            {
+              role: "assistant" as const,
+              content: [
+                { type: "text", text: "Let me check." },
+                {
+                  type: "tool_use",
+                  id: "tu-1",
+                  name: "bash",
+                  input: { command: "ls" },
+                },
+              ] as ContentBlock[],
+            },
+            {
+              role: "user" as const,
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-1",
+                  content: "file1.ts\nfile2.ts",
+                  is_error: false,
+                },
+              ] as ContentBlock[],
+            },
+          ];
 
+          onEvent({
+            type: "message_complete",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Let me check." },
+                {
+                  type: "tool_use",
+                  id: "tu-1",
+                  name: "bash",
+                  input: { command: "ls" },
+                },
+              ],
+            },
+          });
+          onEvent({
+            type: "usage",
+            inputTokens: 100,
+            outputTokens: 50,
+            model: "test-model",
+            providerDurationMs: 100,
+          });
+
+          // Call onCheckpoint — this should trigger the mid-loop budget check
+          // which sees 170_000 > 161_500 and returns "yield"
+          if (onCheckpoint) {
+            const decision = onCheckpoint({
+              turnIndex: 0,
+              toolCount: 1,
+              hasToolUse: true,
+              history: withProgress,
+            });
+            if (decision === "yield") {
+              // Agent loop stops when checkpoint yields
+              return withProgress;
+            }
+          }
+
+          return withProgress;
+        }
+
+        // Second call (after compaction): complete successfully
         onEvent({
           type: "message_complete",
           message: {
             role: "assistant",
-            content: [
-              { type: "text", text: "Let me check." },
-              {
-                type: "tool_use",
-                id: "tu-1",
-                name: "bash",
-                input: { command: "ls" },
-              },
-            ],
+            content: [{ type: "text", text: "done after compaction" }],
           },
         });
         onEvent({
           type: "usage",
-          inputTokens: 100,
-          outputTokens: 50,
+          inputTokens: 50,
+          outputTokens: 25,
           model: "test-model",
           providerDurationMs: 100,
         });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: "done after compaction" },
+            ] as ContentBlock[],
+          },
+        ];
+      };
 
-        // Call onCheckpoint — this should trigger the mid-loop budget check
-        // which sees 170_000 > 161_500 and returns "yield"
-        if (onCheckpoint) {
-          const decision = onCheckpoint({
-            turnIndex: 0,
-            toolCount: 1,
-            hasToolUse: true,
-            history: withProgress,
-          });
-          if (decision === "yield") {
-            // Agent loop stops when checkpoint yields
-            return withProgress;
-          }
-        }
-
-        return withProgress;
-      }
-
-      // Second call (after compaction): complete successfully
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "done after compaction" }],
-        },
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => {
+            compactionCalled = true;
+            return {
+              compacted: true,
+              messages: [
+                {
+                  role: "user" as const,
+                  content: [{ type: "text", text: "Hello" }],
+                },
+              ] as Message[],
+              compactedPersistedMessages: 5,
+              summaryText: "Mid-loop compaction summary",
+              previousEstimatedInputTokens: 170_000,
+              estimatedInputTokens: 80_000,
+              maxInputTokens: 200_000,
+              thresholdTokens: 160_000,
+              compactedMessages: 10,
+              summaryCalls: 1,
+              summaryInputTokens: 500,
+              summaryOutputTokens: 200,
+              summaryModel: "mock-model",
+            };
+          },
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 50,
-        outputTokens: 25,
-        model: "test-model",
-        providerDurationMs: 100,
-      });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [
-            { type: "text", text: "done after compaction" },
-          ] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => {
-          compactionCalled = true;
-          return {
-            compacted: true,
-            messages: [
-              {
-                role: "user" as const,
-                content: [{ type: "text", text: "Hello" }],
-              },
-            ] as Message[],
-            compactedPersistedMessages: 5,
-            summaryText: "Mid-loop compaction summary",
-            previousEstimatedInputTokens: 170_000,
-            estimatedInputTokens: 80_000,
-            maxInputTokens: 200_000,
-            thresholdTokens: 160_000,
-            compactedMessages: 10,
-            summaryCalls: 1,
-            summaryInputTokens: 500,
-            summaryOutputTokens: 200,
-            summaryModel: "mock-model",
-          };
-        },
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+      // The mid-loop budget check should have triggered compaction
+      expect(compactionCalled).toBe(true);
 
-    // The mid-loop budget check should have triggered compaction
-    expect(compactionCalled).toBe(true);
+      // Agent loop should have been called twice: once before yield, once after compaction
+      expect(agentLoopCallCount).toBe(2);
 
-    // Agent loop should have been called twice: once before yield, once after compaction
-    expect(agentLoopCallCount).toBe(2);
+      // No session_error should be emitted
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
 
-    // No session_error should be emitted
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-
-    // A context_compacted event should have been emitted
-    const compacted = events.find((e) => e.type === "context_compacted");
-    expect(compacted).toBeDefined();
-  });
+      // A context_compacted event should have been emitted
+      const compacted = events.find((e) => e.type === "context_compacted");
+      expect(compacted).toBeDefined();
+    },
+  );
 
   // ── Test 7 ────────────────────────────────────────────────────────
   // Tests that mid-loop budget check prevents context_too_large entirely.
   // Agent loop runs tool calls with growing history. After the estimate
   // exceeds the mid-loop threshold, the loop yields, compaction runs,
   // and the loop resumes. The provider NEVER rejects with context_too_large.
-  test.todo("mid-loop budget check prevents context_too_large when tools produce large results", async () => {
-    const events: ServerMessage[] = [];
-    let compactionCalled = false;
+  test.todo(
+    "mid-loop budget check prevents context_too_large when tools produce large results",
+    async () => {
+      const events: ServerMessage[] = [];
+      let compactionCalled = false;
 
-    // Budget = 200_000 * 0.95 = 190_000
-    // Mid-loop threshold = 190_000 * 0.85 = 161_500
-    // Simulate token growth: preflight = 50k, then each checkpoint call
-    // returns a growing estimate. By tool call 3, we exceed the threshold.
-    let estimateCallCount = 0;
-    mockEstimateTokens = () => {
-      estimateCallCount++;
-      // First call: preflight — well below budget
-      if (estimateCallCount === 1) return 50_000;
-      // Checkpoint calls grow with each tool round
-      if (estimateCallCount === 2) return 100_000; // tool 1
-      if (estimateCallCount === 3) return 140_000; // tool 2
-      // Tool 3: exceeds 161_500 threshold
-      return 175_000;
-    };
+      // Budget = 200_000 * 0.95 = 190_000
+      // Mid-loop threshold = 190_000 * 0.85 = 161_500
+      // Simulate token growth: preflight = 50k, then each checkpoint call
+      // returns a growing estimate. By tool call 3, we exceed the threshold.
+      let estimateCallCount = 0;
+      mockEstimateTokens = () => {
+        estimateCallCount++;
+        // First call: preflight — well below budget
+        if (estimateCallCount === 1) return 50_000;
+        // Checkpoint calls grow with each tool round
+        if (estimateCallCount === 2) return 100_000; // tool 1
+        if (estimateCallCount === 3) return 140_000; // tool 2
+        // Tool 3: exceeds 161_500 threshold
+        return 175_000;
+      };
 
-    let agentLoopCallCount = 0;
-    let contextTooLargeEmitted = false;
+      let agentLoopCallCount = 0;
+      let contextTooLargeEmitted = false;
 
-    const agentLoopRun: AgentLoopRun = async (
-      messages,
-      onEvent,
-      _signal,
-      _requestId,
-      onCheckpoint,
-    ) => {
-      agentLoopCallCount++;
+      const agentLoopRun: AgentLoopRun = async (
+        messages,
+        onEvent,
+        _signal,
+        _requestId,
+        onCheckpoint,
+      ) => {
+        agentLoopCallCount++;
 
-      if (agentLoopCallCount === 1) {
-        const currentHistory = [...messages];
+        if (agentLoopCallCount === 1) {
+          const currentHistory = [...messages];
 
-        // Simulate 5 tool rounds — but the checkpoint should yield at round 3
-        for (let i = 0; i < 5; i++) {
-          const toolId = `tu-${i}`;
-          const assistantMsg: Message = {
-            role: "assistant" as const,
-            content: [
-              { type: "text", text: `Step ${i}` },
-              {
-                type: "tool_use",
-                id: toolId,
-                name: "bash",
-                input: { command: `cmd-${i}` },
-              },
-            ] as ContentBlock[],
-          };
-          const resultMsg: Message = {
-            role: "user" as const,
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: toolId,
-                content: "x".repeat(10_000),
-                is_error: false,
-              },
-            ] as ContentBlock[],
-          };
-          currentHistory.push(assistantMsg, resultMsg);
+          // Simulate 5 tool rounds — but the checkpoint should yield at round 3
+          for (let i = 0; i < 5; i++) {
+            const toolId = `tu-${i}`;
+            const assistantMsg: Message = {
+              role: "assistant" as const,
+              content: [
+                { type: "text", text: `Step ${i}` },
+                {
+                  type: "tool_use",
+                  id: toolId,
+                  name: "bash",
+                  input: { command: `cmd-${i}` },
+                },
+              ] as ContentBlock[],
+            };
+            const resultMsg: Message = {
+              role: "user" as const,
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: toolId,
+                  content: "x".repeat(10_000),
+                  is_error: false,
+                },
+              ] as ContentBlock[],
+            };
+            currentHistory.push(assistantMsg, resultMsg);
 
-          onEvent({
-            type: "message_complete",
-            message: assistantMsg,
-          });
-          onEvent({
-            type: "usage",
-            inputTokens: 50_000 + i * 20_000,
-            outputTokens: 50,
-            model: "test-model",
-            providerDurationMs: 100,
-          });
-
-          if (onCheckpoint) {
-            const decision = onCheckpoint({
-              turnIndex: i,
-              toolCount: 1,
-              hasToolUse: true,
-              history: currentHistory,
+            onEvent({
+              type: "message_complete",
+              message: assistantMsg,
             });
-            if (decision === "yield") {
-              return currentHistory;
+            onEvent({
+              type: "usage",
+              inputTokens: 50_000 + i * 20_000,
+              outputTokens: 50,
+              model: "test-model",
+              providerDurationMs: 100,
+            });
+
+            if (onCheckpoint) {
+              const decision = onCheckpoint({
+                turnIndex: i,
+                toolCount: 1,
+                hasToolUse: true,
+                history: currentHistory,
+              });
+              if (decision === "yield") {
+                return currentHistory;
+              }
             }
           }
+
+          return currentHistory;
         }
 
-        return currentHistory;
-      }
+        // Second call (after compaction): complete
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "completed after mid-loop compaction" },
+            ],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 60_000,
+          outputTokens: 100,
+          model: "test-model",
+          providerDurationMs: 200,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [
+              { type: "text", text: "completed after mid-loop compaction" },
+            ] as ContentBlock[],
+          },
+        ];
+      };
 
-      // Second call (after compaction): complete
-      onEvent({
-        type: "message_complete",
-        message: {
-          role: "assistant",
-          content: [
-            { type: "text", text: "completed after mid-loop compaction" },
-          ],
-        },
+      const ctx = makeCtx({
+        agentLoopRun,
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => {
+            compactionCalled = true;
+            return {
+              compacted: true,
+              messages: [
+                {
+                  role: "user" as const,
+                  content: [{ type: "text", text: "Hello" }],
+                },
+              ] as Message[],
+              compactedPersistedMessages: 8,
+              summaryText: "Compacted large tool results",
+              previousEstimatedInputTokens: 175_000,
+              estimatedInputTokens: 60_000,
+              maxInputTokens: 200_000,
+              thresholdTokens: 160_000,
+              compactedMessages: 15,
+              summaryCalls: 1,
+              summaryInputTokens: 800,
+              summaryOutputTokens: 300,
+              summaryModel: "mock-model",
+            };
+          },
+        } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
-      onEvent({
-        type: "usage",
-        inputTokens: 60_000,
-        outputTokens: 100,
-        model: "test-model",
-        providerDurationMs: 200,
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => {
+        events.push(msg);
+        // Track if context_too_large was ever emitted
+        if (
+          msg.type === "session_error" &&
+          "code" in msg &&
+          msg.code === "SESSION_PROCESSING_FAILED"
+        ) {
+          contextTooLargeEmitted = true;
+        }
       });
-      return [
-        ...messages,
-        {
-          role: "assistant" as const,
-          content: [
-            { type: "text", text: "completed after mid-loop compaction" },
-          ] as ContentBlock[],
-        },
-      ];
-    };
 
-    const ctx = makeCtx({
-      agentLoopRun,
-      contextWindowManager: {
-        shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
-        maybeCompact: async () => {
-          compactionCalled = true;
-          return {
-            compacted: true,
-            messages: [
-              {
-                role: "user" as const,
-                content: [{ type: "text", text: "Hello" }],
-              },
-            ] as Message[],
-            compactedPersistedMessages: 8,
-            summaryText: "Compacted large tool results",
-            previousEstimatedInputTokens: 175_000,
-            estimatedInputTokens: 60_000,
-            maxInputTokens: 200_000,
-            thresholdTokens: 160_000,
-            compactedMessages: 15,
-            summaryCalls: 1,
-            summaryInputTokens: 800,
-            summaryOutputTokens: 300,
-            summaryModel: "mock-model",
-          };
-        },
-      } as unknown as AgentLoopSessionContext["contextWindowManager"],
-    });
+      // Compaction should have been triggered by mid-loop budget check
+      expect(compactionCalled).toBe(true);
 
-    await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => {
-      events.push(msg);
-      // Track if context_too_large was ever emitted
-      if (
-        msg.type === "session_error" &&
-        "code" in msg &&
-        msg.code === "SESSION_PROCESSING_FAILED"
-      ) {
-        contextTooLargeEmitted = true;
-      }
-    });
+      // The provider should NEVER have rejected with context_too_large
+      expect(contextTooLargeEmitted).toBe(false);
 
-    // Compaction should have been triggered by mid-loop budget check
-    expect(compactionCalled).toBe(true);
+      // Agent loop called twice: once (yielded at tool 3), once after compaction
+      expect(agentLoopCallCount).toBe(2);
 
-    // The provider should NEVER have rejected with context_too_large
-    expect(contextTooLargeEmitted).toBe(false);
-
-    // Agent loop called twice: once (yielded at tool 3), once after compaction
-    expect(agentLoopCallCount).toBe(2);
-
-    // No session_error
-    const sessionError = events.find((e) => e.type === "session_error");
-    expect(sessionError).toBeUndefined();
-  });
+      // No session_error
+      const sessionError = events.find((e) => e.type === "session_error");
+      expect(sessionError).toBeUndefined();
+    },
+  );
 
   // ── Test 8 ────────────────────────────────────────────────────────
   // When mid-loop compaction exhausts maxAttempts but the agent loop

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -39,7 +39,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     workspaceGit: { turnCommitMaxWaitMs: 10 },
     ui: {},
   }),
@@ -180,7 +179,7 @@ mock.module("../daemon/session-memory.js", () => ({
       enabled: false,
       degraded: false,
       injectedText: "",
-  
+
       semanticHits: 0,
       recencyHits: 0,
       injectedTokens: 0,

--- a/assistant/src/__tests__/session-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/session-confirmation-signals.test.ts
@@ -81,7 +81,6 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     timeouts: { permissionTimeoutSec: 1 },
-    apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },
   }),

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -47,7 +47,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -35,8 +35,9 @@ mock.module("../config/loader.js", () => ({
     contextWindow: {
       enabled: true,
       maxInputTokens: 100000,
-      targetBudgetRatio: 0.30,
-      compactThreshold: 0.8,      summaryBudgetRatio: 0.05,
+      targetBudgetRatio: 0.3,
+      compactThreshold: 0.8,
+      summaryBudgetRatio: 0.05,
       overflowRecovery: {
         enabled: true,
         safetyMarginRatio: 0.05,
@@ -46,7 +47,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -72,7 +72,6 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
     timeouts: { permissionTimeoutSec: 1 },
-    apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     permissions: { mode: "workspace" },
     sandbox: { enabled: false },

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -54,7 +54,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -54,7 +54,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -54,7 +54,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/session-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/session-workspace-cache-state.test.ts
@@ -36,7 +36,6 @@ mock.module("../config/loader.js", () => ({
       summaryBudgetRatio: 0.05,
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     memory: { enabled: false },
   }),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -57,7 +57,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     memory: { enabled: false },
     daemon: {
       startupSocketWaitMs: 5000,

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -55,7 +55,6 @@ mock.module("../config/loader.js", () => ({
       },
     },
     rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
-    apiKeys: {},
     memory: { enabled: false },
     daemon: {
       startupSocketWaitMs: 5000,

--- a/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
+++ b/assistant/src/__tests__/shell-tool-proxy-mode.test.ts
@@ -27,7 +27,6 @@ mock.module("node:child_process", () => ({
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
+++ b/assistant/src/__tests__/skill-script-runner-sandbox.test.ts
@@ -10,7 +10,6 @@ import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -37,7 +37,6 @@ mock.module("../config/loader.js", () => ({
 
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: "test-key" },
     swarm: {
       enabled: true,
       maxWorkers: 3,

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -18,7 +18,6 @@ mock.module("../hooks/manager.js", () => ({
 }));
 
 let swarmEnabled = true;
-let hasApiKey = true;
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
@@ -26,7 +25,6 @@ mock.module("../config/loader.js", () => ({
 
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: hasApiKey ? "test-key" : "" },
     swarm: {
       enabled: swarmEnabled,
       maxWorkers: 2,
@@ -103,7 +101,6 @@ describe("swarm through AgentLoop", () => {
   beforeEach(() => {
     _resetSwarmActive();
     swarmEnabled = true;
-    hasApiKey = true;
   });
 
   test("agent loop calls swarm_delegate and receives tool result", async () => {
@@ -253,7 +250,6 @@ describe("swarm regression tests", () => {
   beforeEach(() => {
     _resetSwarmActive();
     swarmEnabled = true;
-    hasApiKey = true;
   });
 
   test("swarm_delegate returns graceful message when disabled", async () => {
@@ -298,8 +294,6 @@ describe("swarm regression tests", () => {
   });
 
   test("worker backend reports unavailable when no API key", async () => {
-    hasApiKey = false;
-
     const result = await swarmDelegateTool.execute(
       { objective: "Task without key" },
       makeContext(),
@@ -308,7 +302,6 @@ describe("swarm regression tests", () => {
     // The tool should still complete — the orchestrator handles backend failures
     // The result may show failed tasks but shouldn't throw
     expect(result.content).toBeTruthy();
-    hasApiKey = true;
   });
 
   test("progress chunks stream through onOutput", async () => {

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -17,7 +17,6 @@ mock.module("../config/loader.js", () => ({
 
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: "test-key" },
     swarm: {
       enabled: true,
       maxWorkers: 3,
@@ -32,7 +31,6 @@ mock.module("../config/loader.js", () => ({
   getSwarmDisabledConfig: () => ({
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: "test-key" },
     swarm: {
       enabled: false,
       maxWorkers: 3,

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -25,7 +25,6 @@ mock.module("../config/loader.js", () => ({
 
     provider: "anthropic",
     model: "test",
-    apiKeys: {},
     maxTokens: 4096,
     dataDir: "/tmp",
     timeouts: {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -8,7 +8,6 @@ import type {
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/tool-executor-shell-integration.test.ts
+++ b/assistant/src/__tests__/tool-executor-shell-integration.test.ts
@@ -17,7 +17,6 @@ import type { ToolContext } from "../tools/types.js";
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -26,7 +26,6 @@ import type {
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -120,7 +120,6 @@ mock.module("../util/logger.js", () => ({
 const mockConfigObj = {
   model: "test",
   provider: "test",
-  apiKeys: {},
   memory: { enabled: false },
   rateLimit: { maxRequestsPerMinute: 0, maxTokensPerSession: 0 },
   secretDetection: { enabled: false },

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -19,7 +19,6 @@ import type {
 const mockConfig = {
   provider: "anthropic",
   model: "test",
-  apiKeys: {},
   maxTokens: 4096,
   dataDir: "/tmp",
   timeouts: {

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -55,7 +55,6 @@ mock.module("../config/loader.js", () => ({
 
     provider: "anthropic",
     providerOrder: ["anthropic"],
-    apiKeys: { anthropic: "test-key" },
     calls: {
       enabled: true,
       provider: "twilio",

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -87,13 +87,10 @@ Examples:
       const configKey = await getSecureKeyAsync(provider);
       const envVar = providerEnvVar[provider];
       const envKey = envVar ? process.env[envVar] : undefined;
-      const plaintextKey = (
-        raw.apiKeys as Record<string, string> | undefined
-      )?.[provider];
 
       if (provider === "ollama") {
         pass("Provider configured (Ollama; API key optional)");
-      } else if (envKey || configKey || plaintextKey) {
+      } else if (envKey || configKey) {
         pass("API key configured");
       } else {
         fail(

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -1,10 +1,10 @@
 import { dirname, join } from "node:path";
 
-import { getConfig } from "../../../../config/loader.js";
 import {
   getKeyframesForAsset,
   getMediaAssetById,
 } from "../../../../memory/media-store.js";
+import { getSecureKeyAsync } from "../../../../security/secure-keys.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -31,8 +31,7 @@ export async function run(
 
   let openaiApiKey: string | undefined;
   if (includeAudio && (!transcriptionMode || transcriptionMode === "api")) {
-    const config = getConfig();
-    openaiApiKey = config.apiKeys.openai;
+    openaiApiKey = (await getSecureKeyAsync("openai")) ?? undefined;
   }
 
   const options: PreprocessOptions = {

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -7,11 +7,6 @@ import {
 } from "node:fs";
 import { dirname } from "node:path";
 
-import {
-  deleteSecureKey,
-  getSecureKey,
-  setSecureKey,
-} from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -162,7 +157,6 @@ export function deepMergeMissing(
 /**
  * Read the existing config.json from disk, merge any missing schema-default
  * keys, and rewrite only when there is an effective change.
- * Preserves exclusions: apiKeys and dataDir are never written.
  */
 function backfillConfigDefaults(
   configPath: string,
@@ -197,9 +191,9 @@ function backfillConfigDefaults(
 export function loadConfig(): AssistantConfig {
   if (cached) return cached;
 
-  // Re-entrancy guard: log calls during loading (e.g. file-mode warning,
-  // invalid apiKeys) can trigger loadConfig again. Return defaults to
-  // break the cycle instead of recursing to stack overflow.
+  // Re-entrancy guard: log calls during loading (e.g. file-mode warning)
+  // can trigger loadConfig again. Return defaults to break the cycle
+  // instead of recursing to stack overflow.
   if (loading) return cloneDefaultConfig();
   loading = true;
 
@@ -230,67 +224,6 @@ export function loadConfig(): AssistantConfig {
       configFileExisted = false;
     }
 
-    // Pre-validate apiKeys shape before migration (must be a plain object)
-    if (
-      fileConfig.apiKeys !== undefined &&
-      (typeof fileConfig.apiKeys !== "object" ||
-        fileConfig.apiKeys == null ||
-        Array.isArray(fileConfig.apiKeys))
-    ) {
-      log.warn(
-        "Invalid apiKeys in config file: must be an object with string values. Ignoring.",
-      );
-      delete fileConfig.apiKeys;
-    }
-
-    // Auto-migrate plaintext apiKeys from config.json to secure storage
-    if (fileConfig.apiKeys && typeof fileConfig.apiKeys === "object") {
-      const apiKeysObj = fileConfig.apiKeys as Record<string, unknown>;
-      const plaintextKeys = Object.entries(apiKeysObj).filter(
-        ([, v]) => typeof v === "string" && (v as string).length > 0,
-      );
-      if (plaintextKeys.length > 0) {
-        const migratedProviders: string[] = [];
-        for (const [provider, value] of plaintextKeys) {
-          if (setSecureKey(provider, value as string)) {
-            migratedProviders.push(provider);
-          } else {
-            log.warn(
-              `Failed to migrate API key for "${provider}" to secure storage`,
-            );
-          }
-        }
-        if (migratedProviders.length > 0) {
-          // Rewrite config.json without successfully migrated apiKeys
-          try {
-            const rawJson = JSON.parse(readFileSync(configPath, "utf-8"));
-            for (const p of migratedProviders) {
-              delete rawJson.apiKeys[p];
-            }
-            if (Object.keys(rawJson.apiKeys).length === 0) {
-              delete rawJson.apiKeys;
-            }
-            writeFileSync(configPath, JSON.stringify(rawJson, null, 2) + "\n");
-            log.info(
-              `Migrated ${migratedProviders.length} API key(s) from config.json to secure storage`,
-            );
-          } catch (err) {
-            log.warn(
-              { err },
-              "Failed to remove migrated keys from config.json",
-            );
-          }
-        }
-        // Clear only migrated keys from fileConfig so failed keys still flow into config
-        for (const p of migratedProviders) {
-          delete apiKeysObj[p];
-        }
-        if (Object.keys(apiKeysObj).length === 0) {
-          delete fileConfig.apiKeys;
-        }
-      }
-    }
-
     // Validate and apply defaults via Zod schema
     const config = validateWithSchema(fileConfig);
 
@@ -303,8 +236,8 @@ export function loadConfig(): AssistantConfig {
       if (!existsSync(dir)) {
         mkdirSync(dir, { recursive: true });
       }
-      // Strip apiKeys (managed in secure storage) and dataDir (runtime-derived)
-      const { apiKeys: _, dataDir: _d, ...persistable } = config;
+      // Strip dataDir (runtime-derived) from the persisted config
+      const { dataDir: _, ...persistable } = config;
 
       if (!configFileExisted) {
         writeFileSync(configPath, JSON.stringify(persistable, null, 2) + "\n");
@@ -316,47 +249,7 @@ export function loadConfig(): AssistantConfig {
       log.warn({ err }, "Failed to write/backfill config file");
     }
 
-    // Set cached before secure-key/env overrides so re-entrant calls
-    // return the in-flight config instead of bare defaults.
     cached = config;
-
-    // Secure storage keys override plaintext config file
-    try {
-      for (const provider of API_KEY_PROVIDERS) {
-        const secureKey = getSecureKey(provider);
-        if (secureKey) {
-          config.apiKeys[provider] = secureKey;
-        }
-      }
-    } catch (err) {
-      log.debug({ err }, "Failed to load keys from secure storage");
-    }
-
-    // Environment variables override everything
-    if (process.env.ANTHROPIC_API_KEY) {
-      config.apiKeys.anthropic = process.env.ANTHROPIC_API_KEY;
-    }
-    if (process.env.OPENAI_API_KEY) {
-      config.apiKeys.openai = process.env.OPENAI_API_KEY;
-    }
-    if (process.env.GEMINI_API_KEY) {
-      config.apiKeys.gemini = process.env.GEMINI_API_KEY;
-    }
-    if (process.env.OLLAMA_API_KEY) {
-      config.apiKeys.ollama = process.env.OLLAMA_API_KEY;
-    }
-    if (process.env.FIREWORKS_API_KEY) {
-      config.apiKeys.fireworks = process.env.FIREWORKS_API_KEY;
-    }
-    if (process.env.OPENROUTER_API_KEY) {
-      config.apiKeys.openrouter = process.env.OPENROUTER_API_KEY;
-    }
-    if (process.env.BRAVE_API_KEY) {
-      config.apiKeys.brave = process.env.BRAVE_API_KEY;
-    }
-    if (process.env.PERPLEXITY_API_KEY) {
-      config.apiKeys.perplexity = process.env.PERPLEXITY_API_KEY;
-    }
 
     loading = false;
     return config;
@@ -372,25 +265,7 @@ export function saveConfig(config: AssistantConfig): void {
   ensureMigratedDataDir();
   const configPath = getConfigPath();
 
-  // Route apiKeys to secure storage, write config without them
-  for (const [provider, value] of Object.entries(config.apiKeys)) {
-    if (typeof value === "string" && value.length > 0) {
-      if (!setSecureKey(provider, value)) {
-        throw new ConfigError(
-          `Failed to save API key for "${provider}" to secure storage`,
-        );
-      }
-    }
-  }
-  // Delete secure keys for providers no longer in apiKeys or with empty values
-  for (const provider of API_KEY_PROVIDERS) {
-    const value = config.apiKeys[provider];
-    if (!value || (typeof value === "string" && value.length === 0)) {
-      deleteSecureKey(provider);
-    }
-  }
-  const { apiKeys: _, ...rest } = config;
-  writeFileSync(configPath, JSON.stringify(rest, null, 2) + "\n");
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
   cached = config;
 }
@@ -428,10 +303,7 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   ensureMigratedDataDir();
   const configPath = getConfigPath();
 
-  // Strip apiKeys from plaintext config — secure storage is managed
-  // by saveConfig() and `assistant keys` commands, not here.
-  const { apiKeys: _, ...rest } = config;
-  writeFileSync(configPath, JSON.stringify(rest, null, 2) + "\n");
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
   cached = null; // invalidate cache
 }

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -232,12 +232,6 @@ export const AssistantConfigSchema = z
     imageGenModel: z
       .string({ error: "imageGenModel must be a string" })
       .default("gemini-2.5-flash-image"),
-    apiKeys: z
-      .record(
-        z.string(),
-        z.string({ error: "Each apiKeys value must be a string" }),
-      )
-      .default({} as Record<string, string>),
     webSearchProvider: z
       .enum(VALID_WEB_SEARCH_PROVIDERS, {
         error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
@@ -255,7 +256,7 @@ export function selectEmbeddingBackend(
         config.memory.embeddings.ollamaModel,
         () =>
           new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
-            apiKey: config.apiKeys.ollama,
+            apiKey: getSecureKey("ollama") ?? undefined,
           }),
       ),
       reason: null,
@@ -283,29 +284,32 @@ export function selectEmbeddingBackend(
           ),
           reason: null,
         };
-      case "openai":
-        if (!config.apiKeys.openai) continue;
+      case "openai": {
+        const openaiKey = getSecureKey("openai");
+        if (!openaiKey) continue;
         return {
           backend: getCachedOrCreate(
             "openai",
             config.memory.embeddings.openaiModel,
             () =>
               new OpenAIEmbeddingBackend(
-                config.apiKeys.openai,
+                openaiKey,
                 config.memory.embeddings.openaiModel,
               ),
           ),
           reason: null,
         };
-      case "gemini":
-        if (!config.apiKeys.gemini) continue;
+      }
+      case "gemini": {
+        const geminiKey = getSecureKey("gemini");
+        if (!geminiKey) continue;
         return {
           backend: getCachedOrCreate(
             "gemini",
             config.memory.embeddings.geminiModel,
             () =>
               new GeminiEmbeddingBackend(
-                config.apiKeys.gemini,
+                geminiKey,
                 config.memory.embeddings.geminiModel,
                 {
                   taskType: config.memory.embeddings.geminiTaskType,
@@ -316,6 +320,7 @@ export function selectEmbeddingBackend(
           ),
           reason: null,
         };
+      }
       case "ollama":
         if (!isOllamaConfigured(config)) continue;
         return {
@@ -324,7 +329,7 @@ export function selectEmbeddingBackend(
             config.memory.embeddings.ollamaModel,
             () =>
               new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
-                apiKey: config.apiKeys.ollama,
+                apiKey: getSecureKey("ollama") ?? undefined,
               }),
           ),
           reason: null,
@@ -530,30 +535,33 @@ function selectFallbackBackends(
   for (const provider of order) {
     if (provider === exclude) continue;
     switch (provider) {
-      case "openai":
-        if (config.apiKeys.openai) {
+      case "openai": {
+        const openaiKey = getSecureKey("openai");
+        if (openaiKey) {
           backends.push(
             getCachedOrCreate(
               "openai",
               config.memory.embeddings.openaiModel,
               () =>
                 new OpenAIEmbeddingBackend(
-                  config.apiKeys.openai,
+                  openaiKey,
                   config.memory.embeddings.openaiModel,
                 ),
             ),
           );
         }
         break;
-      case "gemini":
-        if (config.apiKeys.gemini) {
+      }
+      case "gemini": {
+        const geminiKey = getSecureKey("gemini");
+        if (geminiKey) {
           backends.push(
             getCachedOrCreate(
               "gemini",
               config.memory.embeddings.geminiModel,
               () =>
                 new GeminiEmbeddingBackend(
-                  config.apiKeys.gemini,
+                  geminiKey,
                   config.memory.embeddings.geminiModel,
                   {
                     taskType: config.memory.embeddings.geminiTaskType,
@@ -565,6 +573,7 @@ function selectFallbackBackends(
           );
         }
         break;
+      }
       case "ollama":
         if (isOllamaConfigured(config)) {
           backends.push(
@@ -575,7 +584,7 @@ function selectFallbackBackends(
                 new OllamaEmbeddingBackend(
                   config.memory.embeddings.ollamaModel,
                   {
-                    apiKey: config.apiKeys.ollama,
+                    apiKey: getSecureKey("ollama") ?? undefined,
                   },
                 ),
             ),
@@ -614,7 +623,7 @@ export function selectedBackendSupportsMultimodal(
 function isOllamaConfigured(config: AssistantConfig): boolean {
   return (
     config.provider === "ollama" ||
-    Boolean(config.apiKeys.ollama) ||
+    Boolean(getSecureKey("ollama")) ||
     Boolean(getOllamaBaseUrlEnv())
   );
 }

--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -374,7 +374,14 @@ describe("Memory Retriever Pipeline", () => {
     const convId = "conv-superseded";
 
     insertConversation(db, convId, now - 60_000);
-    insertMessage(db, "msg-s1", convId, "user", "test superseded", now - 50_000);
+    insertMessage(
+      db,
+      "msg-s1",
+      convId,
+      "user",
+      "test superseded",
+      now - 50_000,
+    );
 
     insertSegment(
       db,
@@ -535,12 +542,6 @@ describe("Memory Retriever Pipeline", () => {
 
     const requiredEmbedConfig: AssistantConfig = {
       ...TEST_CONFIG,
-      apiKeys: {
-        ...TEST_CONFIG.apiKeys,
-        openai: "",
-        gemini: "",
-        ollama: "",
-      },
       memory: {
         ...TEST_CONFIG.memory,
         embeddings: {
@@ -595,7 +596,8 @@ describe("Memory Retriever Pipeline", () => {
       role: "user" | "assistant";
       content: Array<{ type: string; text?: string }>;
     };
-    const recallText = "<memory_context>\n\n<relevant_context>\nsome context\n</relevant_context>\n\n</memory_context>";
+    const recallText =
+      "<memory_context>\n\n<relevant_context>\nsome context\n</relevant_context>\n\n</memory_context>";
 
     const msgs: Msg[] = [
       {
@@ -615,7 +617,9 @@ describe("Memory Retriever Pipeline", () => {
     const cleaned = stripMemoryRecallMessages(msgs, recallText);
     expect(cleaned).toHaveLength(1);
     expect(cleaned[0].role).toBe("user");
-    expect(cleaned[0].content[0].text).toBe("Hello, what do you know about me?");
+    expect(cleaned[0].content[0].text).toBe(
+      "Hello, what do you know about me?",
+    );
   });
 
   test("stripMemoryRecallMessages: handles <memory_context> with slightly different content", () => {
@@ -623,8 +627,10 @@ describe("Memory Retriever Pipeline", () => {
       role: "user" | "assistant";
       content: Array<{ type: string; text?: string }>;
     };
-    const originalRecall = "<memory_context>\n\n<relevant_context>\noriginal\n</relevant_context>\n\n</memory_context>";
-    const actualRecall = "<memory_context>\n\n<relevant_context>\nslightly different\n</relevant_context>\n\n</memory_context>";
+    const originalRecall =
+      "<memory_context>\n\n<relevant_context>\noriginal\n</relevant_context>\n\n</memory_context>";
+    const actualRecall =
+      "<memory_context>\n\n<relevant_context>\nslightly different\n</relevant_context>\n\n</memory_context>";
 
     const msgs: Msg[] = [
       {
@@ -663,7 +669,8 @@ describe("Memory Retriever Pipeline", () => {
       },
     ];
 
-    const recallText = "<memory_context>\n\n<relevant_context>\ntest\n</relevant_context>\n\n</memory_context>";
+    const recallText =
+      "<memory_context>\n\n<relevant_context>\ntest\n</relevant_context>\n\n</memory_context>";
     const result = injectMemoryRecallAsSeparateMessage(msgs, recallText);
 
     expect(result).toHaveLength(3);

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,4 +1,5 @@
 import { wrapWithLogfire } from "../logfire.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
@@ -135,7 +136,6 @@ export function getDefaultModel(providerName: string): string {
 }
 
 export interface ProvidersConfig {
-  apiKeys: Record<string, string>;
   provider: string;
   model: string;
   webSearchProvider?: string;
@@ -211,13 +211,14 @@ export function initializeProviders(config: ProvidersConfig): void {
   const streamTimeoutMs =
     (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
 
-  if (config.apiKeys.anthropic) {
+  const anthropicKey = getSecureKey("anthropic");
+  if (anthropicKey) {
     const model = resolveModel(config, "anthropic");
     registerProvider(
       "anthropic",
       new RetryProvider(
         wrapWithLogfire(
-          new AnthropicProvider(config.apiKeys.anthropic, model, {
+          new AnthropicProvider(anthropicKey, model, {
             useNativeWebSearch: config.webSearchProvider === "anthropic-native",
             streamTimeoutMs,
           }),
@@ -247,13 +248,14 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("anthropic", "managed-proxy");
     }
   }
-  if (config.apiKeys.openai) {
+  const openaiKey = getSecureKey("openai");
+  if (openaiKey) {
     const model = resolveModel(config, "openai");
     registerProvider(
       "openai",
       new RetryProvider(
         wrapWithLogfire(
-          new OpenAIProvider(config.apiKeys.openai, model, { streamTimeoutMs }),
+          new OpenAIProvider(openaiKey, model, { streamTimeoutMs }),
         ),
       ),
     );
@@ -277,13 +279,14 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("openai", "managed-proxy");
     }
   }
-  if (config.apiKeys.gemini) {
+  const geminiKey = getSecureKey("gemini");
+  if (geminiKey) {
     const model = resolveModel(config, "gemini");
     registerProvider(
       "gemini",
       new RetryProvider(
         wrapWithLogfire(
-          new GeminiProvider(config.apiKeys.gemini, model, { streamTimeoutMs }),
+          new GeminiProvider(geminiKey, model, { streamTimeoutMs }),
         ),
       ),
     );
@@ -308,14 +311,15 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("gemini", "managed-proxy");
     }
   }
-  if (config.provider === "ollama" || config.apiKeys.ollama) {
+  const ollamaKey = getSecureKey("ollama");
+  if (config.provider === "ollama" || ollamaKey) {
     const model = resolveModel(config, "ollama");
     registerProvider(
       "ollama",
       new RetryProvider(
         wrapWithLogfire(
           new OllamaProvider(model, {
-            apiKey: config.apiKeys.ollama,
+            apiKey: ollamaKey ?? undefined,
             streamTimeoutMs,
           }),
         ),
@@ -323,13 +327,14 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("ollama", "user-key");
   }
-  if (config.apiKeys.fireworks) {
+  const fireworksKey = getSecureKey("fireworks");
+  if (fireworksKey) {
     const model = resolveModel(config, "fireworks");
     registerProvider(
       "fireworks",
       new RetryProvider(
         wrapWithLogfire(
-          new FireworksProvider(config.apiKeys.fireworks, model, {
+          new FireworksProvider(fireworksKey, model, {
             streamTimeoutMs,
           }),
         ),
@@ -355,13 +360,14 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("fireworks", "managed-proxy");
     }
   }
-  if (config.apiKeys.openrouter) {
+  const openrouterKey = getSecureKey("openrouter");
+  if (openrouterKey) {
     const model = resolveModel(config, "openrouter");
     registerProvider(
       "openrouter",
       new RetryProvider(
         wrapWithLogfire(
-          new OpenRouterProvider(config.apiKeys.openrouter, model, {
+          new OpenRouterProvider(openrouterKey, model, {
             streamTimeoutMs,
           }),
         ),

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -254,14 +254,6 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
     const raw = readFileSync(configPath, "utf-8");
     const config = JSON.parse(raw) as Record<string, unknown>;
 
-    // Strip API key values — preserve which providers have keys configured
-    if (config.apiKeys && typeof config.apiKeys === "object") {
-      const keys = config.apiKeys as Record<string, unknown>;
-      config.apiKeys = Object.fromEntries(
-        Object.keys(keys).map((k) => [k, redactStringValue(keys[k])]),
-      );
-    }
-
     // Strip ingress webhook secret
     if (config.ingress && typeof config.ingress === "object") {
       const ingress = config.ingress as Record<string, unknown>;

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -2,9 +2,9 @@ import {
   getCCCommand,
   loadCCCommandTemplate,
 } from "../../commands/cc-command-registry.js";
-import { getConfig } from "../../config/loader.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import type { WorkerProfile } from "../../swarm/worker-backend.js";
 import { getProfilePolicy } from "../../swarm/worker-backend.js";
 import { getLogger } from "../../util/logger.js";
@@ -203,8 +203,8 @@ export const claudeCodeTool: Tool = {
     const profilePolicy = getProfilePolicy(profileName);
 
     // Validate API key
-    const config = getConfig();
-    const apiKey = config.apiKeys.anthropic ?? process.env.ANTHROPIC_API_KEY;
+    const apiKey =
+      (await getSecureKeyAsync("anthropic")) ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       return {
         content:


### PR DESCRIPTION
## Summary
- Remove `apiKeys` from `AssistantConfigSchema` and the `loadConfig` pipeline entirely — all consumers now read keys from secure storage via `getSecureKey`/`getSecureKeyAsync`
- Clean up `loadConfig`: remove plaintext migration, secure storage merge, env var overrides for API keys
- Update all production consumers (`registry.ts`, `embedding-backend.ts`, `claude-code.ts`, `extract-keyframes.ts`, `doctor.ts`) and ~65 test files to stop referencing `config.apiKeys`

Part of plan: rm-config-apikeys.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
