### PR TITLE
feat: show Telegram bot username and bot ID on connected assistant Telegram card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -140,11 +140,37 @@ struct AssistantChannelsDetailView: View {
             }
         } content: {
             if status == "ready" {
-                VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
-                    store.clearTelegramCredentials()
-                    telegramBotTokenText = ""
-                    telegramSetupExpanded = false
-                    store.channelSetupStatus["telegram"] = "not_configured"
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    if let username = store.telegramBotUsername {
+                        if let url = URL(string: "https://t.me/\(username)") {
+                            Link("@\(username)", destination: url)
+                                .font(VFont.body)
+                                .lineLimit(1)
+                                .pointerCursor()
+                        } else {
+                            Text("@\(username)")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.contentDefault)
+                                .lineLimit(1)
+                        }
+                    }
+                    if let botId = store.telegramBotId {
+                        HStack(spacing: 0) {
+                            Text("Bot ID: ")
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                            Text(botId)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.contentTertiary)
+                                .lineLimit(1)
+                        }
+                    }
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
+                        store.clearTelegramCredentials()
+                        telegramBotTokenText = ""
+                        telegramSetupExpanded = false
+                        store.channelSetupStatus["telegram"] = "not_configured"
+                    }
                 }
             } else if (status == "incomplete" && store.telegramHasBotToken) || telegramSetupExpanded {
                 telegramCredentialEntry


### PR DESCRIPTION
## Summary
- Add @botUsername (linked to https://t.me/username) and Bot ID display to connected Telegram card
- Follows same identity display pattern as the Slack card (PR 7)
- Card degrades gracefully when username or bot ID is unavailable

Part of plan: contact-channels-ui-cleanup.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
