### PR TITLE
fix: include botId in setupTelegram success response

### DIFF
--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -404,6 +404,7 @@ export async function setupTelegram(
 
   return {
     ...commandsResult,
+    botId: setResult.botId,
     botUsername: setResult.botUsername,
   };
 }


### PR DESCRIPTION
## Summary
- Fix setupTelegram success path to include botId from setResult (was being dropped because commandsResult doesn't include it)
- The failure path already correctly spreads setResult which includes botId

Part of plan: contact-channels-ui-cleanup.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
