### PR TITLE
fix: backfill Telegram botId for existing installations with cached username

### DIFF
--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -18,7 +18,10 @@ import {
 } from "../../config/loader.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
-import { getTelegramBotUsername } from "../../telegram/bot-username.js";
+import {
+  getTelegramBotId,
+  getTelegramBotUsername,
+} from "../../telegram/bot-username.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelInviteAdapter,
@@ -37,8 +40,8 @@ import type {
  * gap so that invite share links can be generated.
  */
 export async function ensureTelegramBotUsernameResolved(): Promise<void> {
-  if (getTelegramBotUsername()) {
-    return; // Username already cached in config
+  if (getTelegramBotUsername() && getTelegramBotId()) {
+    return; // Username and bot ID already cached in config
   }
 
   const token = await getSecureKeyAsync(credentialKey("telegram", "bot_token"));


### PR DESCRIPTION
## Summary
- Fix ensureTelegramBotUsernameResolved to also check for botId before early-returning
- Existing installations with a cached bot username but no botId will now re-fetch via getMe to populate both fields

Part of plan: contact-channels-ui-cleanup.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
