### PR TITLE
fix: rename remaining 'Revoke Access' to 'Revoke' and add empty string guards

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -141,7 +141,7 @@ struct AssistantChannelsDetailView: View {
         } content: {
             if status == "ready" {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    if let username = store.telegramBotUsername {
+                    if let username = store.telegramBotUsername, !username.isEmpty {
                         if let url = URL(string: "https://t.me/\(username)") {
                             Link("@\(username)", destination: url)
                                 .font(VFont.body)
@@ -154,7 +154,7 @@ struct AssistantChannelsDetailView: View {
                                 .lineLimit(1)
                         }
                     }
-                    if let botId = store.telegramBotId {
+                    if let botId = store.telegramBotId, !botId.isEmpty {
                         HStack(spacing: 0) {
                             Text("Bot ID: ")
                                 .font(VFont.caption)
@@ -238,13 +238,13 @@ struct AssistantChannelsDetailView: View {
         } content: {
             if status == "ready" {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    if let username = store.slackChannelBotUsername {
+                    if let username = store.slackChannelBotUsername, !username.isEmpty {
                         Text("@\(username)")
                             .font(VFont.body)
                             .foregroundColor(VColor.contentDefault)
                             .lineLimit(1)
                     }
-                    if let botUserId = store.slackChannelBotUserId {
+                    if let botUserId = store.slackChannelBotUserId, !botUserId.isEmpty {
                         HStack(spacing: 0) {
                             Text("Bot ID: ")
                                 .font(VFont.caption)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -799,7 +799,7 @@ struct ContactDetailView: View {
                         initiateVerification(for: channel)
                     }
                     VButton(
-                        label: "Revoke Access",
+                        label: "Revoke",
                         style: .dangerOutline,
                         isDisabled: anyActionInFlight
                     ) {


### PR DESCRIPTION
## Summary
- Rename 'Revoke Access' to 'Revoke' for unverified/pending channels in ContactDetailView (was missed in PR 4)
- Add empty string guards to Assistant identity fields to prevent rendering 'Bot ID: ' with no value

Part of plan: contact-channels-ui-cleanup.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
