### PR TITLE
fix: update tests for apiKeys removal and convergence loop changes

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // Mock state — mutable variables control per-test behavior
 // ---------------------------------------------------------------------------
 
+let mockGeminiKey: string | undefined = "test-gemini-key";
 let mockWorkspaceDir = "/tmp/test-workspace-e2e";
 
 const mkdirSyncFn = mock(() => {});
@@ -28,6 +29,12 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     imageGenModel: "gemini-2.5-flash-image",
   }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (name: string) =>
+    name === "gemini" ? mockGeminiKey : null,
+  getSecureKey: () => null,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -134,6 +141,7 @@ describe("avatar E2E integration", () => {
   const originalGeminiKey = process.env.GEMINI_API_KEY;
 
   beforeEach(() => {
+    mockGeminiKey = "test-gemini-key";
     mockWorkspaceDir = "/tmp/test-workspace-e2e";
 
     mkdirSyncFn.mockClear();
@@ -196,6 +204,8 @@ describe("avatar E2E integration", () => {
   // -----------------------------------------------------------------------
 
   test("no Gemini key — error surfaced", async () => {
+    mockGeminiKey = undefined;
+
     const result = await executeAvatar("a whimsical owl");
 
     expect(result.isError).toBe(true);

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -32,6 +32,12 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (name: string) =>
+    name === "anthropic" ? "fake-anthropic-key" : null,
+  getSecureKey: () => null,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -36,6 +36,13 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+// Mock secure-keys — provide a fake Anthropic API key
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (name: string) =>
+    name === "anthropic" ? "fake-anthropic-key" : null,
+  getSecureKey: () => null,
+}));
+
 import { claudeCodeTool } from "../tools/claude-code/claude-code.js";
 import type { ToolContext } from "../tools/types.js";
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -237,6 +237,20 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "cli/commands/oauth/connections.ts", // CLI OAuth connection delete (legacy credential cleanup)
       "oauth/manual-token-connection.ts", // manual-token provider backfill (keychain credential existence check)
       "cli/commands/doctor.ts", // CLI diagnostic API key verification via secure storage
+      "swarm/backend-claude-code.ts", // Claude Code swarm backend API key lookup
+      "workspace/provider-commit-message-generator.ts", // commit message generation provider key lookup
+      "config/bundled-skills/transcribe/tools/transcribe-media.ts", // transcription tool API key lookup
+      "config/bundled-skills/image-studio/tools/media-generate-image.ts", // image generation tool API key lookup
+      "config/bundled-skills/media-processing/tools/analyze-keyframes.ts", // keyframe analysis tool API key lookup
+      "config/bundled-skills/media-processing/tools/extract-keyframes.ts", // keyframe extraction tool API key lookup
+      "providers/registry.ts", // provider registry API key lookup for initialization
+      "media/app-icon-generator.ts", // app icon generation API key lookup
+      "media/avatar-router.ts", // avatar generation API key lookup
+      "memory/embedding-backend.ts", // embedding backend API key lookup
+      "daemon/handlers/config-model.ts", // model config handler API key lookup
+      "daemon/session-slash.ts", // session slash command API key lookup
+      "daemon/session-process.ts", // session process API key lookup
+      "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/session-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/session-agent-loop-overflow.test.ts
@@ -1744,11 +1744,11 @@ describe("session-agent-loop overflow recovery (JARVIS-110)", () => {
 
     await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
 
-    // Mid-loop compaction should have been called maxAttempts (3) times
-    expect(compactionCallCount).toBe(3);
+    // 1 initial auto-compact + 3 mid-loop compaction attempts = 4 total
+    expect(compactionCallCount).toBe(4);
 
-    // Agent loop: 1 initial + 3 mid-loop re-entries = 4 calls
-    expect(agentLoopCallCount).toBe(4);
+    // Agent loop: 1 initial + 3 mid-loop re-entries + 1 convergence re-run = 5 calls
+    expect(agentLoopCallCount).toBe(5);
 
     // After exhausting mid-loop attempts, the convergence loop should
     // have been triggered (contextTooLargeDetected set to true)

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -352,6 +352,7 @@ function makeCtx(
 
     agentLoop: {
       run: agentLoopRun,
+      getToolTokenBudget: () => 0,
     } as unknown as AgentLoopSessionContext["agentLoop"],
     provider: {
       name: "mock-provider",

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -292,7 +292,15 @@ mock.module("../agent/loop.js", () => ({
         return history; // Progress was made — history grew
       }
 
-      if (agentLoopRunCount === 1 && firstRunErrorMode !== "none") {
+      // Context-too-large modes: keep failing when compaction can't help
+      const isContextTooLargeMode =
+        firstRunErrorMode !== "none" && firstRunErrorMode !== "ordering";
+      const shouldError =
+        firstRunErrorMode !== "none" &&
+        (agentLoopRunCount === 1 ||
+          (isContextTooLargeMode && !forceCompactionEnabled));
+
+      if (shouldError) {
         onEvent({
           type: "usage",
           inputTokens: 0,
@@ -498,18 +506,15 @@ describe("provider ordering error retry", () => {
       (msg) => events.push(msg as unknown as Record<string, unknown>),
     );
 
-    // No retry — the mock reducer returns exhausted:true without successful
-    // compaction, so the convergence loop breaks out. Emergency compaction
-    // also fails (forceCompactionEnabled=false), and the overflow policy
-    // is fail_gracefully, so the error surfaces.
-    expect(agentLoopRunCount).toBe(1);
-    // Three maybeCompact calls: initial auto-compact (force:false),
-    // reducer's compactFn (force:true), emergency compaction (force:true).
-    expect(maybeCompactCalls).toEqual([
-      { force: false },
-      { force: true },
-      { force: true },
-    ]);
+    // The convergence loop enters and applies the reducer (which returns
+    // exhausted:true). With the early-break removed, the loop still re-runs
+    // the agent loop once after the reducer. Since compaction didn't help
+    // (forceCompactionEnabled=false), the second run also fails with
+    // context_too_large. The overflow policy (fail_gracefully) surfaces error.
+    expect(agentLoopRunCount).toBe(2);
+    // Two maybeCompact calls: initial auto-compact (force:false),
+    // reducer's compactFn (force:true).
+    expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
 
     expect(events.some((e) => e.type === "session_error")).toBe(true);
   });
@@ -526,14 +531,9 @@ describe("provider ordering error retry", () => {
       events.push(msg as unknown as Record<string, unknown>),
     );
 
-    // Reducer exhausted without successful compaction, emergency compaction
-    // also fails — error surfaces via overflow policy (fail_gracefully).
-    expect(agentLoopRunCount).toBe(1);
-    expect(maybeCompactCalls).toEqual([
-      { force: false },
-      { force: true },
-      { force: true },
-    ]);
+    // Same as above — convergence loop re-runs agent loop, which also fails.
+    expect(agentLoopRunCount).toBe(2);
+    expect(maybeCompactCalls).toEqual([{ force: false }, { force: true }]);
     expect(events.some((e) => e.type === "session_error")).toBe(true);
   });
 
@@ -594,8 +594,10 @@ describe("provider ordering error retry", () => {
       (msg) => events.push(msg as unknown as Record<string, unknown>),
     );
 
-    // Only one agent loop run — the retry path is skipped because progress was made.
-    expect(agentLoopRunCount).toBe(1);
+    // Two agent loop runs — first makes progress then 413, convergence loop
+    // re-runs after reducer (which returns exhausted). Second run also fails
+    // since compaction didn't help (forceCompactionEnabled=false).
+    expect(agentLoopRunCount).toBe(2);
 
     // The error must be surfaced to clients via session_error, not silently swallowed.
     const sessionError = events.find((e) => e.type === "session_error") as


### PR DESCRIPTION
## Summary
- Add `getSecureKeyAsync` mock to avatar-e2e, claude-code-tool-profiles, and claude-code-skill-regression tests after `apiKeys` was removed from config
- Fix session-agent-loop, overflow, and provider-retry-repair test expectations to match convergence loop behavior changes (early break removal, initial auto-compact)
- Add 14 new authorized importers to credential-security-invariants after modules migrated from config apiKeys to secure-keys

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/23077571624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
