### PR TITLE
fix: phone channel shows number directly instead of display name, use contextual ID labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
@@ -23,7 +23,7 @@ struct ChannelVerificationState {
 
     /// The most user-friendly display name for the verified identity.
     /// For telegram/slack: prefers @username, falls back to display name, then raw identity.
-    /// For voice: prefers display name, falls back to identity.
+    /// For phone: shows the phone number directly (identity), not the display name.
     var primaryIdentity: String? {
         if channel == "telegram" || channel == "slack" {
             if let username = username?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -34,17 +34,12 @@ struct ChannelVerificationState {
                !displayName.isEmpty {
                 return displayName
             }
-        } else if channel == "phone" {
-            if let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !displayName.isEmpty {
-                return displayName
-            }
         }
         return identity
     }
 
     /// A secondary identifier shown when it differs from the primary.
-    /// Returns "ID: <identity>" when the raw identity is distinct from primaryIdentity.
+    /// Uses a channel-contextual label (e.g. "Telegram ID:", "Slack ID:", "Phone Number:").
     func secondaryIdentity(primary: String?) -> String? {
         guard let identity = identity?.trimmingCharacters(in: .whitespacesAndNewlines),
               !identity.isEmpty else {
@@ -56,7 +51,14 @@ struct ChannelVerificationState {
                 return nil
             }
         }
-        return "ID: \(identity)"
+        let label: String
+        switch channel {
+        case "telegram": label = "Telegram ID"
+        case "slack": label = "Slack ID"
+        case "phone": label = "Phone Number"
+        default: label = "ID"
+        }
+        return "\(label): \(identity)"
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove display name preference for phone channels in `primaryIdentity` — phone cards now show the phone number directly instead of the guardian's name
- Make `secondaryIdentity` labels contextual per channel type: "Telegram ID:", "Slack ID:", "Phone Number:" instead of generic "ID:"

Part of plan: contact-channels-ui-cleanup.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
