### PR TITLE
feat: give LLM verification context for post-verification guardian greeting

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -50,6 +50,7 @@ import {
   ASK_GUARDIAN_CAPTURE_REGEX,
   CALL_OPENING_ACK_MARKER,
   CALL_OPENING_MARKER,
+  CALL_VERIFICATION_COMPLETE_MARKER,
   couldBeControlMarker,
   END_CALL_MARKER,
   extractBalancedJson,
@@ -207,6 +208,21 @@ export class CallController {
     this.resetSilenceTimer();
     this.lastSentWasOpener = true;
     await this.runTurn(CALL_OPENING_MARKER);
+  }
+
+  /**
+   * Kick off the first utterance after the guardian has completed outbound
+   * phone verification. Sends a verification-aware marker so the LLM can
+   * greet naturally with context that verification just happened.
+   */
+  async startPostVerificationGreeting(): Promise<void> {
+    if (this.initialGreetingStarted) return;
+    if (this.state !== "idle") return;
+
+    this.initialGreetingStarted = true;
+    this.resetSilenceTimer();
+    this.lastSentWasOpener = true;
+    await this.runTurn(CALL_VERIFICATION_COMPLETE_MARKER);
   }
 
   /**

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -992,9 +992,6 @@ export class RelayConnection {
       }
 
       if (isOutbound) {
-        // Send short verification confirmation TTS
-        this.sendTextToken(result.ttsMessage!, true);
-
         // Keep the pointer message back to the initiating conversation
         const successSession = getCallSession(this.callSessionId);
         if (successSession?.initiatedFromConversationId) {
@@ -1027,10 +1024,18 @@ export class RelayConnection {
           );
         }
 
-        // Mark session as in-progress and transition to normal call flow
+        // Mark session as in-progress and transition to guardian conversation
+        // with verification context so the LLM greets naturally.
         updateCallSession(this.callSessionId, { status: "in_progress" });
         if (this.controller) {
-          this.startNormalCallFlow(this.controller, false);
+          this.controller
+            .startPostVerificationGreeting()
+            .catch((err) =>
+              log.error(
+                { err, callSessionId: this.callSessionId },
+                "Failed to start post-verification greeting",
+              ),
+            );
         }
       } else if (result.verificationType === "trusted_contact") {
         this.continueCallAfterTrustedContactActivation({

--- a/assistant/src/calls/voice-control-protocol.ts
+++ b/assistant/src/calls/voice-control-protocol.ts
@@ -11,6 +11,7 @@
 
 export const CALL_OPENING_MARKER = "[CALL_OPENING]";
 export const CALL_OPENING_ACK_MARKER = "[CALL_OPENING_ACK]";
+export const CALL_VERIFICATION_COMPLETE_MARKER = "[CALL_VERIFICATION_COMPLETE]";
 export const END_CALL_MARKER = "[END_CALL]";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -24,7 +24,10 @@ import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { IngressBlockedError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import { CALL_OPENING_MARKER } from "./voice-control-protocol.js";
+import {
+  CALL_OPENING_MARKER,
+  CALL_VERIFICATION_COMPLETE_MARKER,
+} from "./voice-control-protocol.js";
 
 const log = getLogger("voice-session-bridge");
 
@@ -192,14 +195,20 @@ function buildVoiceCallControlPrompt(opts: {
       "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.",
     );
   } else {
-    const disclosureReminder =
-      disclosureEnabled && disclosureText
-        ? " However, the disclosure text from rule 0 is separate from self-introduction and must always be included in your opening greeting, even if the Task does not mention introducing yourself."
-        : "";
-    lines.push(
-      `7. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction.${disclosureReminder} Vary the wording naturally; do not use a fixed template.`,
-      "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.",
-    );
+    if (opts.isCallerGuardian) {
+      lines.push(
+        '7. If the latest user turn is "(guardian verification completed — transitioning into conversation)", your guardian just completed a phone verification code challenge on this call. Greet them naturally and ask if there is anything you can help with. Keep it casual and brief — they already know who you are.',
+      );
+    } else {
+      const disclosureReminder =
+        disclosureEnabled && disclosureText
+          ? " However, the disclosure text from rule 0 is separate from self-introduction and must always be included in your opening greeting, even if the Task does not mention introducing yourself."
+          : "";
+      lines.push(
+        `7. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction.${disclosureReminder} Vary the wording naturally; do not use a fixed template.`,
+        "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.",
+      );
+    }
   }
 
   lines.push(
@@ -269,7 +278,9 @@ export async function startVoiceTurn(
   const persistedContent =
     opts.content === CALL_OPENING_MARKER
       ? "(call connected — deliver opening greeting)"
-      : opts.content;
+      : opts.content === CALL_VERIFICATION_COMPLETE_MARKER
+        ? "(guardian verification completed — transitioning into conversation)"
+        : opts.content;
 
   // Build the call-control protocol prompt so the model knows how to emit
   // control markers (ASK_GUARDIAN, END_CALL, etc.) and recognize opener turns.


### PR DESCRIPTION
## Summary
- Add a `CALL_VERIFICATION_COMPLETE_MARKER` and `startPostVerificationGreeting()` on `CallController` so the LLM knows a verification code challenge just completed when generating its greeting
- Add a verification-aware rule in the voice call control prompt: "your guardian just completed a phone verification code challenge — greet them naturally and ask if there is anything you can help with"
- Replace `startNormalCallFlow` (context-free `CALL_OPENING_MARKER`) with the new verification-aware path in the outbound success handler

## Original prompt
After successful outbound guardian phone verification, the LLM currently has no context that verification just happened — it greets as if picking up a fresh call. Instead, the LLM should know verification was completed and greet naturally with that context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
