### PR TITLE
fix: remove stale env var references from web-search error message

### DIFF
--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -332,7 +332,7 @@ class WebSearchTool implements Tool {
       } else {
         return {
           content:
-            "Error: No web search API key configured. Set a PERPLEXITY_API_KEY or BRAVE_API_KEY environment variable, or configure it from the Settings page under API Keys.",
+            "Error: No web search API key configured. Set it via `keys set perplexity <key>` or `keys set brave <key>`, or configure it from the Settings page under API Keys.",
           isError: true,
         };
       }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-config-apikeys.md.

**Gap:** web-search.ts error message references env vars no longer honored
**What was expected:** Error message should only reference valid ways to configure keys
**What was found:** Message still mentions PERPLEXITY_API_KEY/BRAVE_API_KEY env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
