### PR TITLE
fix: remove stale env var guidance from ProviderNotConfiguredError handler

### DIFF
--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -32,10 +32,9 @@ export async function withErrorHandling(
     }
     if (err instanceof ProviderNotConfiguredError) {
       log.warn({ err, endpoint }, "No LLM provider configured");
-      const envVar = `${err.requestedProvider.toUpperCase()}_API_KEY`;
       return httpError(
         "UNPROCESSABLE_ENTITY",
-        `No API key configured. Set ${envVar} in your environment or run \`vellum hatch\` to set up your assistant.`,
+        `No API key configured for ${err.requestedProvider}. Run \`keys set ${err.requestedProvider} <key>\` or configure it from the Settings page under API Keys.`,
         422,
       );
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-config-apikeys.md.

**Gap:** error-handler.ts suggests setting env vars that are no longer honored
**What was expected:** Error message should reference valid configuration methods
**What was found:** Message constructs PROVIDER_API_KEY env var names and tells users to set them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
