### PR TITLE
fix: show pointing hand cursor on all animated avatar hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -23,14 +23,13 @@ struct AnimatedAvatarView: View {
                                  isHovered: isHovered)
             .frame(width: size, height: size)
             .accessibilityHidden(true)
+            .contentShape(Rectangle())
             .onHover { hovering in
                 isHovered = hovering
-                if pokeEnabled {
-                    if hovering {
-                        NSCursor.pointingHand.push()
-                    } else {
-                        NSCursor.pop()
-                    }
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
                 }
             }
     }


### PR DESCRIPTION
## Summary
- Remove `pokeEnabled` guard from cursor push/pop — the hand cursor should show whenever hovering over any animated avatar
- Add `.contentShape(Rectangle())` to ensure the full avatar frame registers as a hit-test target for hover events

## Original prompt
We no longer seem to change the mouse to a little hand when hovering over the animated character, but we should in all cases when its animated. Help me fix this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
