### PR TITLE
fix: doctor command checks secure storage instead of stale env vars

### DIFF
--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -35,7 +35,7 @@ Output symbols:
 
 Diagnostic checks performed:
   1.  Bun is installed           Verifies bun is available in PATH
-  2.  API key configured         Checks for a valid provider API key in config or env
+  2.  API key configured         Checks for a valid provider API key in secure storage
   3.  Assistant reachable         HTTP health check against the assistant server
   4.  Database exists/readable   Opens the SQLite database and runs a test query
   5.  Directory structure        Verifies required ~/.vellum/ directories exist
@@ -76,29 +76,14 @@ Examples:
       const raw = loadRawConfig();
       const provider =
         typeof raw.provider === "string" ? raw.provider : "anthropic";
-      const providerEnvVar: Record<string, string> = {
-        anthropic: "ANTHROPIC_API_KEY",
-        openai: "OPENAI_API_KEY",
-        gemini: "GEMINI_API_KEY",
-        ollama: "OLLAMA_API_KEY",
-        fireworks: "FIREWORKS_API_KEY",
-        openrouter: "OPENROUTER_API_KEY",
-      };
       const configKey = await getSecureKeyAsync(provider);
-      const envVar = providerEnvVar[provider];
-      const envKey = envVar ? process.env[envVar] : undefined;
 
       if (provider === "ollama") {
         pass("Provider configured (Ollama; API key optional)");
-      } else if (envKey || configKey) {
+      } else if (configKey) {
         pass("API key configured");
       } else {
-        fail(
-          "API key configured",
-          envVar
-            ? `set ${envVar} or run: assistant keys set ${provider} <key>`
-            : `set API key for provider "${provider}"`,
-        );
+        fail("API key configured", `run: assistant keys set ${provider} <key>`);
       }
 
       // 3. Daemon reachable (HTTP health check)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-config-apikeys.md.

**Gap:** doctor.ts reports false positive when only env var is set
**What was expected:** Doctor should check secure storage (getSecureKeyAsync), matching the runtime's actual key resolution
**What was found:** Doctor checks process.env which is no longer honored by the runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
