### PR TITLE
fix: make post-verification greeting generic across caller trust classes

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -211,7 +211,7 @@ export class CallController {
   }
 
   /**
-   * Kick off the first utterance after the guardian has completed outbound
+   * Kick off the first utterance after the caller has completed outbound
    * phone verification. Sends a verification-aware marker so the LLM can
    * greet naturally with context that verification just happened.
    */

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -195,20 +195,15 @@ function buildVoiceCallControlPrompt(opts: {
       "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the caller acknowledging your greeting and continue the conversation naturally.",
     );
   } else {
-    if (opts.isCallerGuardian) {
-      lines.push(
-        '7. If the latest user turn is "(guardian verification completed — transitioning into conversation)", your guardian just completed a phone verification code challenge on this call. Greet them naturally and ask if there is anything you can help with. Keep it casual and brief — they already know who you are.',
-      );
-    } else {
-      const disclosureReminder =
-        disclosureEnabled && disclosureText
-          ? " However, the disclosure text from rule 0 is separate from self-introduction and must always be included in your opening greeting, even if the Task does not mention introducing yourself."
-          : "";
-      lines.push(
-        `7. If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction.${disclosureReminder} Vary the wording naturally; do not use a fixed template.`,
-        "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.",
-      );
-    }
+    const disclosureReminder =
+      disclosureEnabled && disclosureText
+        ? " However, the disclosure text from rule 0 is separate from self-introduction and must always be included in your opening greeting, even if the Task does not mention introducing yourself."
+        : "";
+    lines.push(
+      '7. If the latest user turn is "(verification completed — transitioning into conversation)", the caller just completed a phone verification code challenge on this call. Greet them naturally and ask if there is anything you can help with. Keep it casual and brief.',
+      `If the latest user turn is "(call connected — deliver opening greeting)", deliver your opening greeting based solely on the Task context above. The Task already describes how to open the call — follow it directly without adding any extra introduction on top. If the Task says to introduce yourself, do so once. If the Task does not mention introducing yourself, skip the introduction.${disclosureReminder} Vary the wording naturally; do not use a fixed template.`,
+      "8. If the latest user turn includes [CALL_OPENING_ACK], treat it as the callee acknowledging your opener and continue the conversation naturally without re-introducing yourself or repeating the initial check-in question.",
+    );
   }
 
   lines.push(
@@ -279,7 +274,7 @@ export async function startVoiceTurn(
     opts.content === CALL_OPENING_MARKER
       ? "(call connected — deliver opening greeting)"
       : opts.content === CALL_VERIFICATION_COMPLETE_MARKER
-        ? "(guardian verification completed — transitioning into conversation)"
+        ? "(verification completed — transitioning into conversation)"
         : opts.content;
 
   // Build the call-control protocol prompt so the model knows how to emit


### PR DESCRIPTION
## Summary
- Remove `isCallerGuardian` gate from the verification-complete prompt rule so it applies to all callers (guardian and trusted contact alike)
- Change persisted content text from "guardian verification completed" to "verification completed" — not guardian-specific
- Update call-controller JSDoc to say "caller" instead of "guardian"

## Original prompt
The post-verification greeting rule in the voice control prompt is currently gated on `isCallerGuardian`, so trusted contacts who complete verification get the wrong greeting. Fix it so the verification-complete rule applies regardless of caller trust class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
