### PR TITLE
fix: update failing CI tests for error messages, telegram mock, and oauth2 loopback

### DIFF
--- a/assistant/src/__tests__/error-handler-friendly-messages.test.ts
+++ b/assistant/src/__tests__/error-handler-friendly-messages.test.ts
@@ -15,8 +15,7 @@ describe("withErrorHandling – friendly error messages", () => {
     };
     expect(body.error.code).toBe("UNPROCESSABLE_ENTITY");
     expect(body.error.message).toContain("No API key configured");
-    expect(body.error.message).toContain("ANTHROPIC_API_KEY");
-    expect(body.error.message).toContain("vellum hatch");
+    expect(body.error.message).toContain("keys set anthropic");
   });
 
   test("ProviderNotConfiguredError tailors env var to requested provider", async () => {
@@ -28,8 +27,8 @@ describe("withErrorHandling – friendly error messages", () => {
     const body = (await response.json()) as {
       error: { code: string; message: string };
     };
-    expect(body.error.message).toContain("OPENAI_API_KEY");
-    expect(body.error.message).not.toContain("ANTHROPIC_API_KEY");
+    expect(body.error.message).toContain("keys set openai");
+    expect(body.error.message).not.toContain("keys set anthropic");
   });
 
   test("generic ConfigError still returns its own message", async () => {

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -185,6 +185,7 @@ describe("OAuth2 gateway transport", () => {
       // The auth URL should contain the gateway redirect_uri, not a loopback one
       expect(capturedAuthUrl).toContain("redirect_uri=");
       expect(capturedAuthUrl).not.toContain("127.0.0.1");
+      expect(capturedAuthUrl).not.toMatch(/localhost:\d+/);
       expect(capturedAuthUrl).toContain(
         encodeURIComponent("https://gw.example.com"),
       );
@@ -212,9 +213,9 @@ describe("OAuth2 gateway transport", () => {
       // Give the loopback server time to start
       await new Promise((r) => setTimeout(r, 50));
 
-      // Auth URL should use a 127.0.0.1 redirect_uri
+      // Auth URL should use a localhost redirect_uri
       expect(capturedAuthUrl).toContain("redirect_uri=");
-      expect(capturedAuthUrl).toContain("127.0.0.1");
+      expect(capturedAuthUrl).toMatch(/localhost|127\.0\.0\.1/);
       expect(capturedAuthUrl).toContain(encodeURIComponent("/oauth/callback"));
 
       // Extract the redirect_uri and simulate the callback
@@ -277,7 +278,7 @@ describe("OAuth2 gateway transport", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       // Should use loopback redirect even though gateway URL is available
-      expect(capturedAuthUrl).toContain("127.0.0.1");
+      expect(capturedAuthUrl).toMatch(/localhost|127\.0\.0\.1/);
       expect(capturedAuthUrl).not.toContain("gw.example.com");
 
       // Simulate callback to loopback server
@@ -395,7 +396,7 @@ describe("OAuth2 gateway transport", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(capturedAuthUrl).toContain("redirect_uri=");
-      expect(capturedAuthUrl).toContain("127.0.0.1");
+      expect(capturedAuthUrl).toMatch(/localhost|127\.0\.0\.1/);
       expect(capturedAuthUrl).toContain("code_challenge=");
       expect(capturedAuthUrl).toContain("code_challenge_method=S256");
 

--- a/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
+++ b/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
@@ -21,6 +21,7 @@ let mockConfigWriteCalls: Array<{
 
 mock.module("../telegram/bot-username.js", () => ({
   getTelegramBotUsername: () => mockBotUsername,
+  getTelegramBotId: () => (mockBotUsername ? "123456" : undefined),
 }));
 
 mock.module("../config/loader.js", () => ({


### PR DESCRIPTION
## Summary
- Update error-handler-friendly-messages test to match the current error message format which uses keys set provider instead of env var names
- Add missing getTelegramBotId export to the mock in telegram-bot-username-resolution test
- Update oauth2-gateway-transport test to accept both localhost and 127.0.0.1 in loopback redirect URIs

## Original prompt
help me fix the CI errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/23078097334/job/67042175723

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
