### PR TITLE
fix(build): restore real-time stderr streaming with wait-based sync in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -37,12 +37,12 @@ swift_with_retry() {
     _stderr_log=$(mktemp)
     trap "rm -f '$_stderr_log'" RETURN
     while true; do
-        # Redirect stderr to log file, capture exit code, then replay stderr
-        # to the terminal. Avoids process substitution race where grep could
-        # read an incomplete log.
+        # Stream stderr to terminal in real time via tee, also capturing to
+        # log file.  `wait` ensures the tee process substitution has flushed
+        # before grep reads the log.
         local _cmd_exit=0
-        "$@" 2>"$_stderr_log" || _cmd_exit=$?
-        cat "$_stderr_log" >&2
+        "$@" 2> >(tee "$_stderr_log" >&2) || _cmd_exit=$?
+        wait
         if [ "$_cmd_exit" -eq 0 ]; then
             return 0
         fi


### PR DESCRIPTION
Addresses review feedback from PR #16417:

- Restore tee-based stderr streaming so developers see real-time output during long swift build commands
- Add wait after command completion to ensure process substitution finishes writing before grep reads the log
- Removes the buffered redirect + cat replay pattern that suppressed output until completion

Part of build tooling review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
