### PR TITLE
fix(ios): preserve memory list state on reload failure and use strict query encoding

### DIFF
--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -31,8 +31,10 @@ public final class MemoryItemsStore: ObservableObject {
             sort: sortField,
             order: sortOrder
         )
-        items = response?.items ?? []
-        total = response?.total ?? 0
+        if let response {
+            items = response.items
+            total = response.total
+        }
         isLoading = false
     }
 

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2466,9 +2466,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         var queryParts = ["limit=\(limit)", "offset=\(offset)"]
-        if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+        if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? kind)") }
         if let status { queryParts.append("status=\(status)") }
-        if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+        if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? search)") }
         if let sort { queryParts.append("sort=\(sort)") }
         if let order { queryParts.append("order=\(order)") }
         let qs = queryParts.joined(separator: "&")

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -850,9 +850,9 @@ public final class HTTPTransport {
         // Memory Items
         case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
             var queryParts = ["limit=\(limit)", "offset=\(offset)"]
-            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? kind)") }
             if let status { queryParts.append("status=\(status)") }
-            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? search)") }
             if let sort { queryParts.append("sort=\(sort)") }
             if let order { queryParts.append("order=\(order)") }
             return ("/v1/memory-items", queryParts.joined(separator: "&"))
@@ -1261,9 +1261,9 @@ public final class HTTPTransport {
         // Memory Items
         case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
             var queryParts = ["limit=\(limit)", "offset=\(offset)"]
-            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? kind)") }
+            if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? kind)") }
             if let status { queryParts.append("status=\(status)") }
-            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? search)") }
+            if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? search)") }
             if let sort { queryParts.append("sort=\(sort)") }
             if let order { queryParts.append("order=\(order)") }
             return ("\(prefix)/memory-items/", queryParts.joined(separator: "&"))


### PR DESCRIPTION
Addresses review feedback from PR #16124:

- Only overwrite items/total in MemoryItemsStore when fetchMemoryItems returns a non-nil response, preventing UI from appearing empty on transient network failures
- Replace .urlQueryAllowed with a stricter character set for encoding search and kind query parameters, properly escaping &, =, + and other reserved characters

Part of memories-tab review feedback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
