### PR TITLE
fix: app sharing fails for single-file HTML apps

### DIFF
--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -74,34 +74,51 @@ export async function packageApp(
     content_id: contentId,
   };
 
-  // Compile the app and bundle the dist/ output.
+  // Compile the app and bundle the output.
   const compiledFiles: { name: string; data: Buffer }[] = [];
 
   const appDir = join(getAppsDir(), appId);
-  const compileResult = await compileApp(appDir);
-  if (!compileResult.ok) {
-    const messages = compileResult.errors
-      .map((e) => {
-        const loc = e.location
-          ? ` (${e.location.file}:${e.location.line}:${e.location.column})`
-          : "";
-        return `${e.text}${loc}`;
-      })
-      .join("\n");
-    throw new Error(`Compilation failed for app "${app.name}":\n${messages}`);
-  }
+  const srcDir = join(appDir, "src");
+  const hasSrc = existsSync(srcDir);
 
-  const distDir = join(appDir, "dist");
-  const indexHtml = await readFile(join(distDir, "index.html"), "utf-8");
-  const mainJs = await readFile(join(distDir, "main.js"));
+  if (hasSrc) {
+    // Multi-file TSX app: compile src/ -> dist/
+    const compileResult = await compileApp(appDir);
+    if (!compileResult.ok) {
+      const messages = compileResult.errors
+        .map((e) => {
+          const loc = e.location
+            ? ` (${e.location.file}:${e.location.line}:${e.location.column})`
+            : "";
+          return `${e.text}${loc}`;
+        })
+        .join("\n");
+      throw new Error(`Compilation failed for app "${app.name}":\n${messages}`);
+    }
 
-  compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
-  compiledFiles.push({ name: "main.js", data: mainJs });
+    const distDir = join(appDir, "dist");
+    const indexHtml = await readFile(join(distDir, "index.html"), "utf-8");
+    const mainJs = await readFile(join(distDir, "main.js"));
 
-  // main.css is optional — only produced when the app imports CSS
-  const cssPath = join(distDir, "main.css");
-  if (existsSync(cssPath)) {
-    compiledFiles.push({ name: "main.css", data: await readFile(cssPath) });
+    compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
+    compiledFiles.push({ name: "main.js", data: mainJs });
+
+    // main.css is optional — only produced when the app imports CSS
+    const cssPath = join(distDir, "main.css");
+    if (existsSync(cssPath)) {
+      compiledFiles.push({ name: "main.css", data: await readFile(cssPath) });
+    }
+  } else {
+    // Single-file HTML app: bundle index.html directly
+    const indexHtmlPath = join(appDir, "index.html");
+    if (!existsSync(indexHtmlPath)) {
+      throw new Error(
+        `App "${app.name}" has no src/ directory and no index.html`,
+      );
+    }
+    const indexHtml = await readFile(indexHtmlPath, "utf-8");
+    compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
+    manifest.entry = "index.html";
   }
 
   // Create the zip archive

--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import archiver from "archiver";
 import JSZip from "jszip";
 
-import { getApp, getAppsDir } from "../memory/app-store.js";
+import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
 import { computeContentId } from "../util/content-id.js";
 import { getLogger } from "../util/logger.js";
 import { compileApp } from "./app-compiler.js";
@@ -60,8 +60,10 @@ export async function packageApp(
   const version = app.version ?? "1.0.0";
   const contentId = computeContentId(app.name);
 
+  const multifile = isMultifileApp(app);
+
   const manifest: AppManifest = {
-    format_version: 2,
+    format_version: multifile ? 2 : 1,
     name: app.name,
     ...(app.description ? { description: app.description } : {}),
     ...(app.icon ? { icon: app.icon } : {}),
@@ -78,10 +80,8 @@ export async function packageApp(
   const compiledFiles: { name: string; data: Buffer }[] = [];
 
   const appDir = join(getAppsDir(), appId);
-  const srcDir = join(appDir, "src");
-  const hasSrc = existsSync(srcDir);
 
-  if (hasSrc) {
+  if (multifile) {
     // Multi-file TSX app: compile src/ -> dist/
     const compileResult = await compileApp(appDir);
     if (!compileResult.ok) {
@@ -118,7 +118,6 @@ export async function packageApp(
     }
     const indexHtml = await readFile(indexHtmlPath, "utf-8");
     compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
-    manifest.entry = "index.html";
   }
 
   // Create the zip archive

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -862,6 +862,7 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
         try {
           const result = await packageApp(params.id);
           return Response.json({
+            type: "bundle_app_response",
             bundlePath: result.bundlePath,
             iconImageBase64: result.iconImageBase64,
             manifest: result.manifest,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -179,6 +179,16 @@ struct AppsGridView: View {
                                     .aspectRatio(contentMode: .fill)
                             )
                             .clipped()
+                    } else if let icon = app.icon, !icon.isEmpty,
+                              let nsImage = MainWindowView.buildAppIcon(iconBase64: nil, emojiIcon: icon, appName: app.name) {
+                        Color.clear
+                            .aspectRatio(16.0 / 10.0, contentMode: .fit)
+                            .overlay(
+                                Image(nsImage: nsImage)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                            )
+                            .clipped()
                     } else {
                         ZStack {
                             VColor.surfaceBase


### PR DESCRIPTION
## Summary
- Bundler now handles single-file HTML apps that have no `src/` directory — bundles `index.html` directly instead of trying to compile TSX
- Added missing `type: "bundle_app_response"` to the bundle HTTP endpoint so the Swift client can decode the response

## Test plan
- [x] Manually verified sharing a single-file HTML app works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
