### PR TITLE
fix: use resetCursorRects for pointing hand on avatar hover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -26,11 +26,6 @@ struct AnimatedAvatarView: View {
             .contentShape(Rectangle())
             .onHover { hovering in
                 isHovered = hovering
-                if hovering {
-                    NSCursor.pointingHand.push()
-                } else {
-                    NSCursor.pop()
-                }
             }
     }
 }
@@ -102,6 +97,10 @@ class AvatarLayerView: NSView {
     }
 
     required init?(coder: NSCoder) { fatalError() }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
 
     /// Called from SwiftUI's `.onHover` via the representable bridge.
     /// Animates eye paths between widened (hovered) and normal (not hovered).


### PR DESCRIPTION
## Summary
- Replace `NSCursor.pointingHand.push()`/`NSCursor.pop()` in `.onHover` with `resetCursorRects()` override on `AvatarLayerView`
- The push/pop approach was silently overridden by SwiftUI's cursor management, so the pointing hand cursor never appeared even though hover detection worked (eye-widen animation fires)
- `resetCursorRects()` + `addCursorRect(bounds, cursor: .pointingHand)` registers with the window server and is respected by the NSViewRepresentable bridge

## Original prompt
fix: use resetCursorRects for pointing hand on avatar hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
