### PR TITLE
fix: update claude-code error message to reference keys set command

### DIFF
--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -208,7 +208,7 @@ export const claudeCodeTool: Tool = {
     if (!apiKey) {
       return {
         content:
-          "Error: No Anthropic API key configured. Set it via config or ANTHROPIC_API_KEY environment variable.",
+          "Error: No Anthropic API key configured. Set it via `keys set anthropic <key>` or configure it from the Settings page under API Keys.",
         isError: true,
       };
     }


### PR DESCRIPTION
## Summary
Updates the error message in claude-code.ts to reference `keys set` CLI command instead of stale env var/config guidance.

**Gap:** Error message references "config or ANTHROPIC_API_KEY environment variable" which is no longer the primary configuration method
**Fix:** Updated to reference `keys set anthropic <key>` and Settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
