### PR TITLE
fix: add env var fallback to swarm backend and fix no-key test

### DIFF
--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -54,9 +54,10 @@ const mockTestProvider = {
     };
   },
 };
+let mockAnthropicKey: string | undefined = "test-api-key";
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKeyAsync: async () => "test-api-key",
-  getSecureKey: () => "test-api-key",
+  getSecureKeyAsync: async () => mockAnthropicKey,
+  getSecureKey: () => mockAnthropicKey,
 }));
 
 mock.module("../providers/registry.js", () => ({
@@ -299,14 +300,26 @@ describe("swarm regression tests", () => {
   });
 
   test("worker backend reports unavailable when no API key", async () => {
-    const result = await swarmDelegateTool.execute(
-      { objective: "Task without key" },
-      makeContext(),
-    );
+    const prevKey = mockAnthropicKey;
+    const prevEnv = process.env.ANTHROPIC_API_KEY;
+    mockAnthropicKey = undefined;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const result = await swarmDelegateTool.execute(
+        { objective: "Task without key" },
+        makeContext(),
+      );
 
-    // The tool should still complete — the orchestrator handles backend failures
-    // The result may show failed tasks but shouldn't throw
-    expect(result.content).toBeTruthy();
+      // The tool should still complete — the orchestrator handles backend failures
+      // Tasks should fail because no backend is available
+      expect(result.content).toBeTruthy();
+      expect(result.content).toContain("failed");
+    } finally {
+      mockAnthropicKey = prevKey;
+      if (prevEnv !== undefined) {
+        process.env.ANTHROPIC_API_KEY = prevEnv;
+      }
+    }
   });
 
   test("progress chunks stream through onOutput", async () => {

--- a/assistant/src/swarm/backend-claude-code.ts
+++ b/assistant/src/swarm/backend-claude-code.ts
@@ -29,7 +29,8 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
     name: "claude_code",
 
     async isAvailable(): Promise<boolean> {
-      const apiKey = await getSecureKeyAsync("anthropic");
+      const apiKey =
+        (await getSecureKeyAsync("anthropic")) ?? process.env.ANTHROPIC_API_KEY;
       return !!apiKey;
     },
 
@@ -38,7 +39,9 @@ export function createClaudeCodeBackend(): SwarmWorkerBackend {
       const stderrLines: string[] = [];
       try {
         const { query } = await import("@anthropic-ai/claude-agent-sdk");
-        const apiKey = await getSecureKeyAsync("anthropic");
+        const apiKey =
+          (await getSecureKeyAsync("anthropic")) ??
+          process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
           return {
             success: false,


### PR DESCRIPTION
## Summary
Fixes two related gaps from rm-config-apikeys.md plan review:

1. **Swarm backend env var fallback**: Adds `process.env.ANTHROPIC_API_KEY` fallback to `backend-claude-code.ts` for consistency with the Claude Code tool path
2. **No-key test**: Makes the `getSecureKeyAsync` mock mutable in `swarm-session-integration.test.ts` so the "no API key" test actually exercises the unavailable path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
