### PR TITLE
feat: add Equatable conformance to ContactPayload and ContactChannelPayload

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2844,6 +2844,38 @@ extension ContactPayload: Identifiable {}
 
 extension ContactChannelPayload: Identifiable {}
 
+extension ContactChannelPayload: Equatable {
+    public static func == (lhs: ContactChannelPayload, rhs: ContactChannelPayload) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.type == rhs.type &&
+        lhs.address == rhs.address &&
+        lhs.isPrimary == rhs.isPrimary &&
+        lhs.externalUserId == rhs.externalUserId &&
+        lhs.status == rhs.status &&
+        lhs.policy == rhs.policy &&
+        lhs.verifiedAt == rhs.verifiedAt &&
+        lhs.verifiedVia == rhs.verifiedVia &&
+        lhs.lastSeenAt == rhs.lastSeenAt &&
+        lhs.interactionCount == rhs.interactionCount &&
+        lhs.lastInteraction == rhs.lastInteraction &&
+        lhs.revokedReason == rhs.revokedReason &&
+        lhs.blockedReason == rhs.blockedReason
+    }
+}
+
+extension ContactPayload: Equatable {
+    public static func == (lhs: ContactPayload, rhs: ContactPayload) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.displayName == rhs.displayName &&
+        lhs.role == rhs.role &&
+        lhs.notes == rhs.notes &&
+        lhs.contactType == rhs.contactType &&
+        lhs.lastInteraction == rhs.lastInteraction &&
+        lhs.interactionCount == rhs.interactionCount &&
+        lhs.channels == rhs.channels
+    }
+}
+
 // MARK: - Work Item Helpers
 
 extension WorkItemsListResponseItem {


### PR DESCRIPTION
## Summary
- Add `Equatable` conformance to `ContactChannelPayload` and `ContactPayload`
- Manual `==` implementations required since types are declared in a generated file (`GeneratedAPITypes.swift`) and Swift cannot auto-synthesize Equatable across file boundaries
- Enables `.onChange(of: contact)` in detail views (used by PRs 2 and 3)

Part of plan: guardian-contact-refresh.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
