### PR TITLE
fix: Contact detail view reacts to contact data refreshes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -85,16 +85,17 @@ struct ContactDetailView: View {
         } message: {
             Text("This will permanently delete this contact and all their channels. This action cannot be undone.")
         }
-        .onAppear {
-            currentContact = contact
-        }
         .onChange(of: contact.id) { _, _ in
+            currentContact = nil
             inviteCodeRevealed = false
             inviteHandleInput = ""
             inviteExpanded = []
             inviteResult = nil
             inviteError = nil
             inviteErrorChannel = nil
+        }
+        .onChange(of: contact) { _, _ in
+            currentContact = nil
         }
         .onDisappear {
             verificationTimeoutTask?.cancel()


### PR DESCRIPTION
## Summary
- Remove stale `currentContact = contact` caching in `.onAppear` so the view uses fresh parent data by default
- Add `.onChange(of: contact)` to clear local override when SSE-driven refresh updates the parent
- Add `currentContact = nil` to the existing `.onChange(of: contact.id)` handler so navigating between contacts also resets stale state

Part of plan: guardian-contact-refresh.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
