### PR TITLE
fix: Guardian channels view reacts to contact data refreshes and checks verification state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -82,11 +82,13 @@ struct GuardianChannelsDetailView: View {
             .padding(VSpacing.lg)
         }
         .onAppear {
-            currentContact = contact
             startVerificationCountdownTimer()
             for channel in Self.verificationSupportedChannels {
                 store?.refreshChannelVerificationStatus(channel: channel)
             }
+        }
+        .onChange(of: contact) { _, _ in
+            currentContact = nil
         }
         .onDisappear {
             stopVerificationCountdownTimer()
@@ -110,6 +112,8 @@ struct GuardianChannelsDetailView: View {
                 ?? existingChannels.first
             if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
                 VBadge(style: .label("Verified"), color: VColor.systemPositiveStrong)
+            } else if store?.channelVerificationState(for: type).verified == true {
+                VBadge(style: .label("Verified"), color: VColor.systemPositiveStrong)
             }
         } content: {
             let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
@@ -122,7 +126,9 @@ struct GuardianChannelsDetailView: View {
             if let channel = activeChannel, channel.status == "active", channel.verifiedAt != nil {
                 // Verified channel — show rich identity + disconnect
                 verifiedChannelContent(channel: channel, type: type)
-            } else if (!existingChannels.isEmpty && !dismissedChannels.contains(type)) || setupExpanded.contains(type) {
+            } else if store?.channelVerificationState(for: type).verified == true
+                || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
+                || setupExpanded.contains(type) {
                 // Existing unverified channel or user clicked "Set Up" — show verification flow
                 verificationFlowContent(for: type)
             } else {


### PR DESCRIPTION
## Summary
- Remove stale `currentContact = contact` caching in `.onAppear` so the view uses fresh parent data by default
- Add `.onChange(of: contact)` to clear local override when SSE-driven refresh updates the parent
- Add SettingsStore verification fallback in both badge slot and card content so verified state appears immediately
- The "Set Up" button is bypassed when SettingsStore already knows the channel is verified

Part of plan: guardian-contact-refresh.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
