### PR TITLE
fix(build): restore VellumAssistantShared import in AssistantUpgradeSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import VellumAssistantShared
 
 /// Upgrade section for managed/remote assistants.
 ///


### PR DESCRIPTION
## Summary
- Restores the `import VellumAssistantShared` that was accidentally removed from `AssistantUpgradeSection.swift` in #16393
- This import is required for `VSpacing`, `VFont`, `VColor`, and `VButton` which are all defined in the shared module

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23078473269/job/67043149795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
