### PR TITLE
fix: add getSecureKey mock to provider-registry-ollama test

### DIFF
--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock secure-keys so tests don't depend on the developer's local secure storage.
+const actualSecureKeys = await import("../security/secure-keys.js");
+mock.module("../security/secure-keys.js", () => ({
+  ...actualSecureKeys,
+  getSecureKey: () => undefined,
+}));
 
 import {
   getProvider,


### PR DESCRIPTION
## Summary
Adds missing `getSecureKey` mock to `provider-registry-ollama.test.ts` so tests don't depend on the developer's local secure storage state.

Part of plan: rm-config-apikeys.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
