### PR TITLE
remove managed LLM providers

### DIFF
--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -106,24 +106,21 @@ describe("buildManagedBaseUrl", () => {
   });
 
   test("builds correct URL for managed providers", async () => {
-    expect(await buildManagedBaseUrl("openai")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/openai",
-    );
     expect(await buildManagedBaseUrl("anthropic")).toBe(
       "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
     expect(await buildManagedBaseUrl("gemini")).toBe(
       "https://platform.example.com/v1/runtime-proxy/vertex",
     );
-    expect(await buildManagedBaseUrl("fireworks")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/fireworks",
-    );
-    expect(await buildManagedBaseUrl("openrouter")).toBe(
-      "https://platform.example.com/v1/runtime-proxy/openrouter",
+    expect(await buildManagedBaseUrl("vertex")).toBe(
+      "https://platform.example.com/v1/runtime-proxy/vertex",
     );
   });
 
-  test("returns undefined for non-managed provider (ollama)", async () => {
+  test("returns undefined for non-managed providers", async () => {
+    expect(await buildManagedBaseUrl("openai")).toBeUndefined();
+    expect(await buildManagedBaseUrl("fireworks")).toBeUndefined();
+    expect(await buildManagedBaseUrl("openrouter")).toBeUndefined();
     expect(await buildManagedBaseUrl("ollama")).toBeUndefined();
   });
 
@@ -134,7 +131,8 @@ describe("buildManagedBaseUrl", () => {
   test("returns undefined when prerequisites are missing", async () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
-    expect(await buildManagedBaseUrl("openai")).toBeUndefined();
+    expect(await buildManagedBaseUrl("anthropic")).toBeUndefined();
+    expect(await buildManagedBaseUrl("vertex")).toBeUndefined();
   });
 });
 
@@ -144,9 +142,10 @@ describe("managedFallbackEnabledFor", () => {
     mockAssistantApiKey = "sk-test-key";
   });
 
-  test("returns true for managed providers with prerequisites", async () => {
-    expect(await managedFallbackEnabledFor("openai")).toBe(true);
+  test("returns true only for managed fallback providers with prerequisites", async () => {
     expect(await managedFallbackEnabledFor("anthropic")).toBe(true);
+    expect(await managedFallbackEnabledFor("gemini")).toBe(true);
+    expect(await managedFallbackEnabledFor("openai")).toBe(false);
   });
 
   test("returns false for non-managed provider", async () => {
@@ -160,6 +159,7 @@ describe("managedFallbackEnabledFor", () => {
   test("returns false when prerequisites are missing", async () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
-    expect(await managedFallbackEnabledFor("openai")).toBe(false);
+    expect(await managedFallbackEnabledFor("anthropic")).toBe(false);
+    expect(await managedFallbackEnabledFor("gemini")).toBe(false);
   });
 });

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -848,15 +848,15 @@ describe("OpenAIProvider", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Managed proxy initialization
+// Custom baseURL initialization
 // ---------------------------------------------------------------------------
 
-describe("managed proxy initialization", () => {
+describe("custom baseURL initialization", () => {
   beforeEach(() => {
     lastConstructorOptions = null;
   });
 
-  test("OpenAIProvider initializes with managed proxy base URL", () => {
+  test("OpenAIProvider forwards a custom baseURL", () => {
     const managed = new OpenAIProvider("ast-key-123", "gpt-4o", {
       baseURL: "https://platform.example.com/v1/runtime-proxy/openai",
     });
@@ -877,7 +877,7 @@ describe("managed proxy initialization", () => {
     });
   });
 
-  test("FireworksProvider initializes with managed proxy base URL", () => {
+  test("FireworksProvider forwards a custom baseURL", () => {
     const managed = new FireworksProvider(
       "ast-key-123",
       "accounts/fireworks/models/llama-v3p1-70b-instruct",
@@ -893,7 +893,7 @@ describe("managed proxy initialization", () => {
     });
   });
 
-  test("FireworksProvider without managed baseURL uses default Fireworks URL", () => {
+  test("FireworksProvider without custom baseURL uses default Fireworks URL", () => {
     new FireworksProvider(
       "fw-user-key",
       "accounts/fireworks/models/llama-v3p1-70b-instruct",
@@ -905,7 +905,7 @@ describe("managed proxy initialization", () => {
     });
   });
 
-  test("OpenRouterProvider initializes with managed proxy base URL", () => {
+  test("OpenRouterProvider forwards a custom baseURL", () => {
     const managed = new OpenRouterProvider("ast-key-123", "openai/gpt-4o", {
       baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
     });
@@ -917,7 +917,7 @@ describe("managed proxy initialization", () => {
     });
   });
 
-  test("OpenRouterProvider without managed baseURL uses default OpenRouter URL", () => {
+  test("OpenRouterProvider without custom baseURL uses default OpenRouter URL", () => {
     new OpenRouterProvider("or-user-key", "openai/gpt-4o");
 
     expect(lastConstructorOptions).toEqual({

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -31,6 +31,7 @@ mock.module("../security/secure-keys.js", () => ({
 
 import {
   getFailoverProvider,
+  getProviderRoutingSource,
   initializeProviders,
   listProviders,
   resolveProviderSelection,
@@ -181,7 +182,7 @@ describe("managed proxy fallback", () => {
     mockAssistantApiKey = "";
   }
 
-  test("openai registered via managed fallback when no user key but proxy context is valid", async () => {
+  test("anthropic and gemini are registered via managed fallback when no user key but proxy context is valid", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key" };
@@ -190,15 +191,13 @@ describe("managed proxy fallback", () => {
         model: "test-model",
       });
       const registered = listProviders();
-      expect(registered).toContain("openai");
-      expect(registered).toContain("fireworks");
-      expect(registered).toContain("openrouter");
+      expect(registered).toEqual(["anthropic", "gemini"]);
     } finally {
       disableManagedProxy();
     }
   });
 
-  test("user key takes precedence over managed fallback", async () => {
+  test("user key takes precedence and managed fallback only fills anthropic and gemini", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key", openai: "user-openai-key" };
@@ -206,12 +205,12 @@ describe("managed proxy fallback", () => {
         provider: "anthropic",
         model: "test-model",
       });
-      // openai should be registered (via user key, not managed)
       const registered = listProviders();
       expect(registered).toContain("openai");
-      // fireworks/openrouter should also be registered via managed fallback
-      expect(registered).toContain("fireworks");
-      expect(registered).toContain("openrouter");
+      expect(registered).toContain("anthropic");
+      expect(registered).toContain("gemini");
+      expect(registered).not.toContain("fireworks");
+      expect(registered).not.toContain("openrouter");
     } finally {
       disableManagedProxy();
     }
@@ -225,12 +224,17 @@ describe("managed proxy fallback", () => {
       model: "test-model",
     });
     const registered = listProviders();
+    // Anthropic is registered via user-key, not managed proxy.
+    expect(registered).toContain("anthropic");
+    expect(getProviderRoutingSource("anthropic")).toBe("user-key");
+    // No other providers are registered — managed fallback is off.
+    expect(registered).not.toContain("gemini");
     expect(registered).not.toContain("openai");
     expect(registered).not.toContain("fireworks");
     expect(registered).not.toContain("openrouter");
   });
 
-  test("managed providers participate in failover selection", async () => {
+  test("managed anthropic and gemini participate in failover selection", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key" };
@@ -240,13 +244,10 @@ describe("managed proxy fallback", () => {
       });
       const selection = resolveProviderSelection("anthropic", [
         "openai",
+        "gemini",
         "fireworks",
       ]);
-      expect(selection.availableProviders).toEqual([
-        "anthropic",
-        "openai",
-        "fireworks",
-      ]);
+      expect(selection.availableProviders).toEqual(["anthropic", "gemini"]);
       expect(selection.selectedPrimary).toBe("anthropic");
       expect(selection.usedFallbackPrimary).toBe(false);
     } finally {
@@ -254,7 +255,7 @@ describe("managed proxy fallback", () => {
     }
   });
 
-  test("managed provider selected as primary when configured primary unavailable", async () => {
+  test("managed gemini can be selected as fallback primary when configured primary is unavailable", async () => {
     enableManagedProxy();
     try {
       // No anthropic key, no gemini key — only managed providers available
@@ -263,9 +264,12 @@ describe("managed proxy fallback", () => {
         provider: "openai",
         model: "test-model",
       });
-      const selection = resolveProviderSelection("openai", ["fireworks"]);
-      expect(selection.selectedPrimary).toBe("openai");
-      expect(selection.usedFallbackPrimary).toBe(false);
+      const selection = resolveProviderSelection("openai", [
+        "gemini",
+        "anthropic",
+      ]);
+      expect(selection.selectedPrimary).toBe("gemini");
+      expect(selection.usedFallbackPrimary).toBe(true);
     } finally {
       disableManagedProxy();
     }

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -68,13 +68,14 @@ import {
 const PLATFORM_BASE = "https://platform.example.com";
 const MANAGED_API_KEY = "ast-managed-key-123";
 
-const MANAGED_PROVIDERS: string[] = [
+const DIRECT_OR_MANAGED_PROVIDER_KEYS: string[] = [
   "openai",
   "anthropic",
   "gemini",
   "fireworks",
   "openrouter",
 ];
+const MANAGED_FALLBACK_PROVIDERS: string[] = ["anthropic", "gemini"];
 
 function enableManagedProxy() {
   mockPlatformBaseUrl = PLATFORM_BASE;
@@ -108,7 +109,7 @@ beforeEach(() => {
 
 describe("managed proxy integration — credential precedence", () => {
   describe("user keys present → providers use direct connections (not proxy)", () => {
-    test.each(MANAGED_PROVIDERS)(
+    test.each(DIRECT_OR_MANAGED_PROVIDER_KEYS)(
       "%s routes via user-key when user key is provided regardless of managed context",
       async (provider: string) => {
         enableManagedProxy();
@@ -122,15 +123,15 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("all five managed providers route via user-key with user keys", async () => {
+    test("all five configured providers route via user-key when user keys exist", async () => {
       enableManagedProxy();
-      setUserKeysFor(...MANAGED_PROVIDERS);
+      setUserKeysFor(...DIRECT_OR_MANAGED_PROVIDER_KEYS);
       await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
       const registered = listProviders();
-      for (const p of MANAGED_PROVIDERS) {
+      for (const p of DIRECT_OR_MANAGED_PROVIDER_KEYS) {
         expect(registered).toContain(p);
         expect(getProviderRoutingSource(p)).toBe("user-key");
       }
@@ -138,13 +139,13 @@ describe("managed proxy integration — credential precedence", () => {
 
     test("user keys still route via user-key when managed context is disabled", async () => {
       disableManagedProxy();
-      setUserKeysFor(...MANAGED_PROVIDERS);
+      setUserKeysFor(...DIRECT_OR_MANAGED_PROVIDER_KEYS);
       await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
       const registered = listProviders();
-      for (const p of MANAGED_PROVIDERS) {
+      for (const p of DIRECT_OR_MANAGED_PROVIDER_KEYS) {
         expect(registered).toContain(p);
         expect(getProviderRoutingSource(p)).toBe("user-key");
       }
@@ -152,14 +153,13 @@ describe("managed proxy integration — credential precedence", () => {
   });
 
   describe("user keys absent + managed context available → providers use managed proxy", () => {
-    test.each(MANAGED_PROVIDERS)(
+    test.each(MANAGED_FALLBACK_PROVIDERS)(
       "%s routes via managed-proxy when no user key",
       async (provider: string) => {
         enableManagedProxy();
         mockProviderKeys = {};
         await initializeProviders({
-          // For ollama, provider selection does not trigger managed proxy
-          provider: provider === "openai" ? "openai" : "anthropic",
+          provider: "anthropic",
           model: "test-model",
         });
         expect(listProviders()).toContain(provider);
@@ -167,21 +167,22 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("all five managed providers route via managed-proxy simultaneously", async () => {
+    test("managed bootstrap registers anthropic and gemini only", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
       await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
-      const registered = listProviders();
-      for (const p of MANAGED_PROVIDERS) {
-        expect(registered).toContain(p);
-        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
+      expect(listProviders()).toEqual(["anthropic", "gemini"]);
+      expect(getProviderRoutingSource("anthropic")).toBe("managed-proxy");
+      expect(getProviderRoutingSource("gemini")).toBe("managed-proxy");
+      for (const p of ["openai", "fireworks", "openrouter"]) {
+        expect(getProviderRoutingSource(p)).toBeUndefined();
       }
     });
 
-    test("managed anthropic uses vertex proxy path instead of anthropic proxy path", async () => {
+    test("managed anthropic uses anthropic proxy path", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
       await initializeProviders({
@@ -204,7 +205,7 @@ describe("managed proxy integration — credential precedence", () => {
       expect(baseURL).toContain("/v1/runtime-proxy/anthropic");
     });
 
-    test("managed gemini uses vertex proxy path instead of gemini proxy path", async () => {
+    test("managed gemini uses vertex proxy path", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
       await initializeProviders({
@@ -212,8 +213,6 @@ describe("managed proxy integration — credential precedence", () => {
         model: "test-model",
       });
 
-      // The GoogleGenAI constructor was captured by the mock — verify it
-      // received httpOptions.baseUrl pointing at the vertex proxy path.
       expect(lastGeminiConstructorOpts).toBeDefined();
       const httpOptions = lastGeminiConstructorOpts!.httpOptions as
         | { baseUrl?: string }
@@ -225,7 +224,7 @@ describe("managed proxy integration — credential precedence", () => {
   });
 
   describe("neither user keys nor managed context → providers not initialized", () => {
-    test.each(MANAGED_PROVIDERS)(
+    test.each(DIRECT_OR_MANAGED_PROVIDER_KEYS)(
       "%s is NOT registered when no user key and no managed context",
       async (provider: string) => {
         disableManagedProxy();
@@ -251,7 +250,7 @@ describe("managed proxy integration — credential precedence", () => {
   });
 
   describe("mixed: some user keys + managed fallback fills gaps", () => {
-    test("user key for anthropic routes direct, managed fallback fills remaining four via proxy", async () => {
+    test("user key for anthropic routes direct and managed fallback only fills gemini", async () => {
       enableManagedProxy();
       setUserKeysFor("anthropic");
       await initializeProviders({
@@ -261,13 +260,15 @@ describe("managed proxy integration — credential precedence", () => {
       const registered = listProviders();
       expect(registered).toContain("anthropic");
       expect(getProviderRoutingSource("anthropic")).toBe("user-key");
-      for (const p of ["openai", "gemini", "fireworks", "openrouter"]) {
-        expect(registered).toContain(p);
-        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
+      expect(registered).toContain("gemini");
+      expect(getProviderRoutingSource("gemini")).toBe("managed-proxy");
+      for (const p of ["openai", "fireworks", "openrouter"]) {
+        expect(registered).not.toContain(p);
+        expect(getProviderRoutingSource(p)).toBeUndefined();
       }
     });
 
-    test("user key for openai routes direct, managed fallback fills remaining four via proxy", async () => {
+    test("user key for openai routes direct while anthropic and gemini still bootstrap via managed proxy", async () => {
       enableManagedProxy();
       setUserKeysFor("openai");
       await initializeProviders({
@@ -277,9 +278,13 @@ describe("managed proxy integration — credential precedence", () => {
       const registered = listProviders();
       expect(registered).toContain("openai");
       expect(getProviderRoutingSource("openai")).toBe("user-key");
-      for (const p of ["anthropic", "gemini", "fireworks", "openrouter"]) {
-        expect(registered).toContain(p);
-        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
+      expect(registered).toContain("anthropic");
+      expect(getProviderRoutingSource("anthropic")).toBe("managed-proxy");
+      expect(registered).toContain("gemini");
+      expect(getProviderRoutingSource("gemini")).toBe("managed-proxy");
+      for (const p of ["fireworks", "openrouter"]) {
+        expect(registered).not.toContain(p);
+        expect(getProviderRoutingSource(p)).toBeUndefined();
       }
     });
   });
@@ -325,8 +330,8 @@ describe("managed proxy integration — ollama exclusion", () => {
 });
 
 describe("managed proxy integration — constants integrity", () => {
-  test("all five managed providers have metadata with managed=true and a proxyPath", () => {
-    for (const provider of MANAGED_PROVIDERS) {
+  test("anthropic, gemini, and vertex have metadata with managed=true and a proxyPath", () => {
+    for (const provider of ["anthropic", "gemini", "vertex"]) {
       const meta = MANAGED_PROVIDER_META[provider];
       expect(meta).toBeDefined();
       expect(meta.managed).toBe(true);
@@ -347,15 +352,10 @@ describe("managed proxy integration — constants integrity", () => {
     );
   });
 
-  test("other providers use their own proxy paths", () => {
-    expect(MANAGED_PROVIDER_META.openai.proxyPath).toBe(
-      "/v1/runtime-proxy/openai",
-    );
-    expect(MANAGED_PROVIDER_META.fireworks.proxyPath).toBe(
-      "/v1/runtime-proxy/fireworks",
-    );
-    expect(MANAGED_PROVIDER_META.openrouter.proxyPath).toBe(
-      "/v1/runtime-proxy/openrouter",
-    );
+  test("openai-compatible providers are not managed proxy capable", () => {
+    for (const provider of ["openai", "fireworks", "openrouter"]) {
+      expect(MANAGED_PROVIDER_META[provider].managed).toBe(false);
+      expect(MANAGED_PROVIDER_META[provider].proxyPath).toBeUndefined();
+    }
   });
 });

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -9,13 +9,7 @@ const metadataDeletes: Array<{ service: string; field: string }> = [];
 
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
-const MANAGED_PROVIDERS = [
-  "anthropic",
-  "openai",
-  "gemini",
-  "fireworks",
-  "openrouter",
-] as const;
+const MANAGED_PROVIDERS = ["anthropic", "gemini"] as const;
 
 const mockConfig = {
   provider: "anthropic",
@@ -136,7 +130,7 @@ describe("secret routes managed proxy registry sync", () => {
     await initializeProviders(mockConfig);
   });
 
-  test("adding vellum:assistant_api_key bootstraps managed providers immediately", async () => {
+  test("adding vellum:assistant_api_key bootstraps managed fallback providers immediately", async () => {
     expect(listProviders()).toEqual([]);
 
     const res = await handleAddSecret(
@@ -158,7 +152,7 @@ describe("secret routes managed proxy registry sync", () => {
     expect(lastGeminiConstructorOpts).toBeDefined();
   });
 
-  test("deleting vellum:assistant_api_key clears managed providers immediately", async () => {
+  test("deleting vellum:assistant_api_key clears managed fallback providers immediately", async () => {
     secureKeyStore[ASSISTANT_API_KEY_PATH] = "ast-managed-key";
     await initializeProviders(mockConfig);
 

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -19,12 +19,16 @@ export interface ManagedProviderMeta {
  * Explicit provider metadata for all known providers.
  * Managed providers get a deterministic proxy path; non-managed providers
  * are marked accordingly and have no proxy path.
+ *
+ * This table describes managed proxy routing capability only. It does not
+ * control which providers auto-bootstrap into the text-model registry when
+ * managed credentials are present; that policy lives in the registry/context
+ * fallback allowlists.
  */
 export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   openai: {
     name: "openai",
-    managed: true,
-    proxyPath: "/v1/runtime-proxy/openai",
+    managed: false,
   },
   anthropic: {
     name: "anthropic",
@@ -38,13 +42,11 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   },
   fireworks: {
     name: "fireworks",
-    managed: true,
-    proxyPath: "/v1/runtime-proxy/fireworks",
+    managed: false,
   },
   openrouter: {
     name: "openrouter",
-    managed: true,
-    proxyPath: "/v1/runtime-proxy/openrouter",
+    managed: false,
   },
   vertex: {
     name: "vertex",

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -56,7 +56,3 @@ export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
   ollama: { name: "ollama", managed: false },
 };
 
-/** Provider names that support managed proxy routing. */
-export const MANAGED_PROVIDER_NAMES = Object.entries(MANAGED_PROVIDER_META)
-  .filter(([, meta]) => meta.managed)
-  .map(([name]) => name);

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -343,24 +343,6 @@ export async function initializeProviders(
       ),
     );
     routingSources.set("fireworks", "user-key");
-  } else {
-    const managedBaseUrl = await buildManagedBaseUrl("fireworks");
-    if (managedBaseUrl) {
-      const ctx = await resolveManagedProxyContext();
-      const model = resolveModel(config, "fireworks");
-      registerProvider(
-        "fireworks",
-        new RetryProvider(
-          wrapWithLogfire(
-            new FireworksProvider(ctx.assistantApiKey, model, {
-              baseURL: managedBaseUrl,
-              streamTimeoutMs,
-            }),
-          ),
-        ),
-      );
-      routingSources.set("fireworks", "managed-proxy");
-    }
   }
   const openrouterKey = await getSecureKeyAsync("openrouter");
   if (openrouterKey) {
@@ -376,23 +358,5 @@ export async function initializeProviders(
       ),
     );
     routingSources.set("openrouter", "user-key");
-  } else {
-    const managedBaseUrl = await buildManagedBaseUrl("openrouter");
-    if (managedBaseUrl) {
-      const ctx = await resolveManagedProxyContext();
-      const model = resolveModel(config, "openrouter");
-      registerProvider(
-        "openrouter",
-        new RetryProvider(
-          wrapWithLogfire(
-            new OpenRouterProvider(ctx.assistantApiKey, model, {
-              baseURL: managedBaseUrl,
-              streamTimeoutMs,
-            }),
-          ),
-        ),
-      );
-      routingSources.set("openrouter", "managed-proxy");
-    }
   }
 }


### PR DESCRIPTION
We only plan to support managed anthropic API keys as a first pass.

Keeping gemini + vertex in for compatibility, but we'll eventually kill vertex (see https://github.com/vellum-ai/vellum-assistant-platform/pull/2235) and add billing info for gemini image gen

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
