### PR TITLE
Remove claude-opus-4-6-fast model

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -23,17 +23,6 @@ describe("resolvePricing", () => {
       expect(result.estimatedCostUsd).toBe(5 + 25);
     });
 
-    test("returns priced for claude-opus-4-6-fast", () => {
-      const result = resolvePricing(
-        "anthropic",
-        "claude-opus-4-6-fast",
-        1_000_000,
-        1_000_000,
-      );
-      expect(result.pricingStatus).toBe("priced");
-      expect(result.estimatedCostUsd).toBe(30 + 150);
-    });
-
     test("returns priced for claude-opus-4", () => {
       const result = resolvePricing(
         "anthropic",

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -59,14 +59,12 @@ export interface SlashContext {
 
 const AVAILABLE_MODELS = [
   "claude-opus-4-6",
-  "claude-opus-4-6-fast",
   "claude-sonnet-4-6",
   "claude-haiku-4-5-20251001",
 ] as const;
 
 const MODEL_DISPLAY_NAMES: Record<string, string> = {
   "claude-opus-4-6": "Claude Opus 4.6",
-  "claude-opus-4-6-fast": "Claude Opus 4.6 Fast",
   "claude-sonnet-4-6": "Claude Sonnet 4.6",
   "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
 };
@@ -80,11 +78,6 @@ const PROVIDER_MODEL_SHORTCUTS: Record<
     provider: "anthropic",
     model: "claude-opus-4-6",
     displayName: "Claude Opus 4.6",
-  },
-  "opus-fast": {
-    provider: "anthropic",
-    model: "claude-opus-4-6-fast",
-    displayName: "Claude Opus 4.6 Fast",
   },
   sonnet: {
     provider: "anthropic",

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -20,7 +20,6 @@ const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
     "claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
     "claude-opus-4": { inputPer1M: 15, outputPer1M: 75 },
-    "claude-opus-4-6-fast": { inputPer1M: 30, outputPer1M: 150 },
     "claude-sonnet-4": { inputPer1M: 3, outputPer1M: 15 },
     "claude-haiku-4": { inputPer1M: 0.8, outputPer1M: 4 },
   },

--- a/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ModelSelectionStepView.swift
@@ -14,7 +14,6 @@ struct ModelSelectionStepView: View {
 
     private static let models: [(id: String, name: String, detail: String)] = [
         ("claude-opus-4-6", "Opus 4.6", "Most capable"),
-        ("claude-opus-4-6-fast", "Opus 4.6 Fast", "Fastest Opus"),
         ("claude-sonnet-4-6", "Sonnet 4.6", "Balanced"),
         ("claude-haiku-4-5-20251001", "Haiku 4.5", "Fastest"),
     ]

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -42,14 +42,12 @@ public final class SettingsStore: ObservableObject {
 
     static let availableModels: [String] = [
         "claude-opus-4-6",
-        "claude-opus-4-6-fast",
         "claude-sonnet-4-6",
         "claude-haiku-4-5-20251001",
     ]
 
     static let modelDisplayNames: [String: String] = [
         "claude-opus-4-6": "Claude Opus 4.6",
-        "claude-opus-4-6-fast": "Claude Opus 4.6 Fast",
         "claude-sonnet-4-6": "Claude Sonnet 4.6",
         "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
     ]

--- a/clients/shared/Features/Chat/ModelListBubble.swift
+++ b/clients/shared/Features/Chat/ModelListBubble.swift
@@ -20,7 +20,6 @@ public struct ModelListBubble: View {
     /// Anthropic model shortcuts, exposed for use by ModelPickerBubble on iOS.
     public static let anthropicModels: [(cmd: String, model: String, display: String)] = [
         ("opus", "claude-opus-4-6", "Claude Opus 4.6"),
-        ("opus-fast", "claude-opus-4-6-fast", "Claude Opus 4.6 Fast"),
         ("sonnet", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
         ("haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
     ]


### PR DESCRIPTION
## Summary
- Remove all references to the `claude-opus-4-6-fast` model from the assistant codebase
- This model is not supported by the platform's rate card validation and causes "The AI provider rejected the request" errors

## Original prompt
get rid of this model both from this repo and the companion repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
