### PR TITLE
fix: clean up stale env var references in comments and test strings

### DIFF
--- a/assistant/src/__tests__/error-handler-friendly-messages.test.ts
+++ b/assistant/src/__tests__/error-handler-friendly-messages.test.ts
@@ -18,7 +18,7 @@ describe("withErrorHandling – friendly error messages", () => {
     expect(body.error.message).toContain("keys set anthropic");
   });
 
-  test("ProviderNotConfiguredError tailors env var to requested provider", async () => {
+  test("ProviderNotConfiguredError tailors keys set command to requested provider", async () => {
     const response = await withErrorHandling("test", async () => {
       throw new ProviderNotConfiguredError("openai", []);
     });

--- a/assistant/src/__tests__/web-search.test.ts
+++ b/assistant/src/__tests__/web-search.test.ts
@@ -548,7 +548,7 @@ async function executeWebSearch(
   if (!apiKey) {
     return {
       content:
-        "Error: No web search API key configured. Provide a PERPLEXITY_API_KEY or BRAVE_API_KEY here in the chat using the secure credential prompt, or set it from the Settings page.",
+        "Error: No web search API key configured. Set it via `keys set perplexity <key>` or `keys set brave <key>`, or configure it from the Settings page under API Keys.",
       isError: true,
     };
   }

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -37,8 +37,8 @@ function getBroker(): KeychainBrokerClient {
  *
  * @deprecated Use `getSecureKeyAsync` instead. This sync variant only reads
  * from the encrypted file store, bypassing the keychain broker. Retained only
- * for startup code paths in `config/loader.ts` and `providers/managed-proxy/context.ts`
- * that cannot do async I/O.
+ * for sync code paths in `providers/registry.ts`, `providers/managed-proxy/context.ts`,
+ * and `memory/embedding-backend.ts` that cannot do async I/O.
  */
 export function getSecureKey(account: string): string | undefined {
   return encryptedStore.getKey(account);
@@ -50,8 +50,8 @@ export function getSecureKey(account: string): string | undefined {
  *
  * @deprecated Use `setSecureKeyAsync` instead. This sync variant only writes
  * to the encrypted file store, bypassing the keychain broker. Retained only
- * for startup code paths in `config/loader.ts` and `providers/managed-proxy/context.ts`
- * that cannot do async I/O.
+ * for sync code paths in `providers/registry.ts`, `providers/managed-proxy/context.ts`,
+ * and `memory/embedding-backend.ts` that cannot do async I/O.
  */
 export function setSecureKey(account: string, value: string): boolean {
   return encryptedStore.setKey(account, value);


### PR DESCRIPTION
## Summary
Cleans up residual stale references from the rm-config-apikeys migration:
- Updates inline error message in web-search test to match production
- Updates @deprecated JSDoc in secure-keys.ts to list actual sync callers
- Updates test description in error-handler test

Part of plan: rm-config-apikeys.md (review fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
