### PR TITLE
feat: add pendingMemoryId transient state to MainWindowState

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -57,6 +57,10 @@ public final class MainWindowState: ObservableObject {
     @Published var avatarCustomizationReturnPanel: SidePanelType = .intelligence
 
     @Published var selectedSubagentId: String?
+
+    /// Transient memory ID to deep-link into when the Intelligence panel opens.
+    /// Consumed once by IntelligencePanel/MemoriesPanel, then set back to nil.
+    @Published var pendingMemoryId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var hasAPIKey: Bool
@@ -218,6 +222,12 @@ public final class MainWindowState: ObservableObject {
     func showPanel(_ panel: SidePanelType) {
         selection = .panel(panel)
         lastActivePanelString = String(describing: panel)
+    }
+
+    /// Navigate to the Intelligence panel and deep-link to a specific memory.
+    func showMemory(id: String) {
+        pendingMemoryId = id
+        showPanel(.intelligence)
     }
 
     func refreshAPIKeyStatus(isConnected: Bool) {


### PR DESCRIPTION
## Summary
- Add pendingMemoryId published property to MainWindowState for memory deep-link coordination
- Add showMemory(id:) convenience method that sets the pending ID and navigates to the Intelligence panel

Part of plan: search-deep-link.md (PR 2 of 5)

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
