### PR TITLE
fix: navigate to conversations from search results via sessionId lookup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -351,6 +351,14 @@ extension AppDelegate {
             self?.mainWindow?.threadManager.selectThread(id: threadId)
         }
 
+        window.onSelectSearchConversation = { [weak self] sessionId in
+            self?.mainWindow?.threadManager.selectThreadBySessionId(sessionId)
+            // Also ensure we're showing the thread view (not a panel)
+            if let threadId = self?.mainWindow?.threadManager.activeThreadId {
+                self?.mainWindow?.windowState.selection = .thread(threadId)
+            }
+        }
+
         // Wire runtime HTTP resolver for server search
         window.runtimeHTTPResolver = {
             let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -19,8 +19,11 @@ final class CommandPaletteWindow {
     private var isDismissing = false
     private let viewModel = CommandPaletteViewModel()
 
-    /// Callback invoked when the user selects a conversation to navigate to.
+    /// Callback invoked when the user selects a recent conversation to navigate to.
     var onSelectConversation: ((UUID) -> Void)?
+
+    /// Callback invoked when the user selects a search result conversation (by daemon session ID).
+    var onSelectSearchConversation: ((String) -> Void)?
 
     /// Static actions to show in the palette.
     var actions: [CommandPaletteAction] = []
@@ -60,8 +63,7 @@ final class CommandPaletteWindow {
                 self?.onSelectConversation?(threadId)
             },
             onSelectConversation: { [weak self] convId in
-                guard let uuid = UUID(uuidString: convId) else { return }
-                self?.onSelectConversation?(uuid)
+                self?.onSelectSearchConversation?(convId)
             }
         )
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -705,6 +705,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    /// Select a thread by its daemon conversation ID (sessionId).
+    /// Falls back to no-op if no matching thread is found.
+    func selectThreadBySessionId(_ sessionId: String) {
+        guard let thread = threads.first(where: { $0.sessionId == sessionId }) else { return }
+        selectThread(id: thread.id)
+    }
+
     // MARK: - Render Cache Management
 
     /// Clears static render caches used by chat bubble and markdown views.


### PR DESCRIPTION
## Summary
- Add `selectThreadBySessionId` method to ThreadManager for looking up threads by daemon conversation ID
- Add `onSelectSearchConversation` callback to CommandPaletteWindow that passes raw session ID strings
- Wire the new callback in AppDelegate so clicking a search result conversation navigates correctly

Part of plan: search-deep-link.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
