### PR TITLE
feat: allow IntelligencePanel to open directly to Memories tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -92,7 +92,8 @@ extension MainWindowView {
                     }
                     windowState.selection = nil
                 },
-                daemonClient: daemonClient
+                daemonClient: daemonClient,
+                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil
             )
         case .usageDashboard:
             UsageDashboardPanel(
@@ -462,7 +463,8 @@ extension MainWindowView {
                     }
                     windowState.dismissOverlay()
                 },
-                daemonClient: daemonClient
+                daemonClient: daemonClient,
+                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -7,8 +7,17 @@ struct IntelligencePanel: View {
     var onClose: () -> Void
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
+    var initialTab: String? = nil
 
-    @State private var selectedTab: IntelligenceTab = .identity
+    @State private var selectedTab: IntelligenceTab
+
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient, initialTab: String? = nil) {
+        self.onClose = onClose
+        self.onInvokeSkill = onInvokeSkill
+        self.daemonClient = daemonClient
+        self.initialTab = initialTab
+        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
+    }
 
     private enum IntelligenceTab: String, CaseIterable {
         case identity = "Identity"


### PR DESCRIPTION
## Summary
- Add `initialTab` parameter to IntelligencePanel that accepts a tab name string
- When `pendingMemoryId` is set on MainWindowState, pass `initialTab: "Memories"` from PanelCoordinator
- Default behavior unchanged — panel opens to Identity tab when no initialTab is specified

Part of plan: search-deep-link.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
