### PR TITLE
feat: auto-open memory detail sheet from pendingMemoryId

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -93,7 +93,8 @@ extension MainWindowView {
                     windowState.selection = nil
                 },
                 daemonClient: daemonClient,
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil
+                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
+                pendingMemoryId: $windowState.pendingMemoryId
             )
         case .usageDashboard:
             UsageDashboardPanel(
@@ -464,7 +465,8 @@ extension MainWindowView {
                     windowState.dismissOverlay()
                 },
                 daemonClient: daemonClient,
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil
+                initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
+                pendingMemoryId: $windowState.pendingMemoryId
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -8,14 +8,16 @@ struct IntelligencePanel: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
     let daemonClient: DaemonClient
     var initialTab: String? = nil
+    @Binding var pendingMemoryId: String?
 
     @State private var selectedTab: IntelligenceTab
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient, initialTab: String? = nil) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, daemonClient: DaemonClient, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.daemonClient = daemonClient
         self.initialTab = initialTab
+        _pendingMemoryId = pendingMemoryId
         _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
     }
 
@@ -111,7 +113,7 @@ struct IntelligencePanel: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:
-            MemoriesPanel(daemonClient: daemonClient)
+            MemoriesPanel(daemonClient: daemonClient, focusedMemoryId: $pendingMemoryId)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -44,6 +44,7 @@ private enum MemoryStatusFilter: String, CaseIterable {
 
 struct MemoriesPanel: View {
     let daemonClient: DaemonClient
+    @Binding var focusedMemoryId: String?
     @StateObject private var store: MemoryItemsStore
     @State private var showCreateSheet = false
     @State private var selectedItem: MemoryItemPayload?
@@ -52,8 +53,9 @@ struct MemoriesPanel: View {
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.daemonClient = daemonClient
+        _focusedMemoryId = focusedMemoryId
         _store = StateObject(wrappedValue: MemoryItemsStore(daemonClient: daemonClient))
     }
 
@@ -64,6 +66,13 @@ struct MemoriesPanel: View {
             contentView
         }
         .task { await store.loadItems() }
+        .task(id: focusedMemoryId) {
+            guard let memoryId = focusedMemoryId else { return }
+            if let item = await store.fetchDetail(id: memoryId) {
+                selectedItem = item
+            }
+            focusedMemoryId = nil
+        }
         .onDisappear {
             searchDebounceTask?.cancel()
             searchDebounceTask = nil


### PR DESCRIPTION
## Summary
- Add `focusedMemoryId` binding to MemoriesPanel that auto-fetches and opens a memory's detail sheet
- Thread `pendingMemoryId` binding from PanelCoordinator through IntelligencePanel to MemoriesPanel
- Consume the pending ID after processing to prevent re-triggers

Part of plan: search-deep-link.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
