### PR TITLE
fix(build): use FIFO for bash 3.2-safe real-time stderr streaming in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -35,14 +35,20 @@ swift_with_retry() {
     local _pch_cleaned=0
     local _stderr_log
     _stderr_log=$(mktemp)
-    trap "rm -f '$_stderr_log'" RETURN
+    # FIFO for stderr streaming. Process substitutions (2> >(tee ...)) are
+    # not tracked by `wait` in bash < 4.4 (macOS ships 3.2), so tee could
+    # still be writing when grep reads the log. A named pipe with an explicit
+    # tee PID gives correct synchronization on all bash versions.
+    local _fifo
+    _fifo=$(mktemp -u)
+    mkfifo "$_fifo"
+    trap "rm -f '$_stderr_log' '$_fifo'" RETURN
     while true; do
-        # Stream stderr to terminal in real time via tee, also capturing to
-        # log file.  `wait` ensures the tee process substitution has flushed
-        # before grep reads the log.
         local _cmd_exit=0
-        "$@" 2> >(tee "$_stderr_log" >&2) || _cmd_exit=$?
-        wait
+        tee "$_stderr_log" >&2 < "$_fifo" &
+        local _tee_pid=$!
+        "$@" 2>"$_fifo" || _cmd_exit=$?
+        wait "$_tee_pid"
         if [ "$_cmd_exit" -eq 0 ]; then
             return 0
         fi


### PR DESCRIPTION
Addresses review feedback from PR #16544.

## Summary
- Replace process substitution with named pipe (FIFO) in swift_with_retry
- Background tee with explicit PID tracking for correct wait synchronization
- Preserves real-time stderr streaming while fixing bash 3.2 race condition

## Context
PR #16544 restored real-time stderr streaming via process substitution + wait,
but Devin correctly identified that bash 3.2 (macOS default) doesn't track
process substitutions as background jobs — wait returns immediately. A FIFO
with an explicit tee background process gives both real-time output and
correct synchronization on all bash versions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
