### PR TITLE
feat: deep link to memory detail from command palette search results

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -359,6 +359,10 @@ extension AppDelegate {
             }
         }
 
+        window.onSelectMemory = { [weak self] memoryId in
+            self?.mainWindow?.windowState.showMemory(id: memoryId)
+        }
+
         // Wire runtime HTTP resolver for server search
         window.runtimeHTTPResolver = {
             let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -7,6 +7,7 @@ struct CommandPaletteView: View {
     var onDismiss: () -> Void
     var onSelectRecent: ((UUID) -> Void)?
     var onSelectConversation: ((String) -> Void)?
+    var onSelectMemory: ((String) -> Void)?
 
     @FocusState private var isSearchFocused: Bool
 
@@ -182,6 +183,10 @@ struct CommandPaletteView: View {
             sectionHeader("Memories")
             ForEach(Array(memories.enumerated()), id: \.element.id) { index, memory in
                 memoryRow(memory, isSelected: viewModel.selectedIndex == memOffset + index)
+                    .onTapGesture {
+                        onSelectMemory?(memory.id)
+                        onDismiss()
+                    }
             }
             let _ = (offset += memories.count)
         }
@@ -424,7 +429,10 @@ struct CommandPaletteView: View {
         case .conversation(let conv):
             onSelectConversation?(conv.id)
             onDismiss()
-        case .memory, .schedule, .contact:
+        case .memory(let memory):
+            onSelectMemory?(memory.id)
+            onDismiss()
+        case .schedule, .contact:
             // Non-navigable results — no action on Enter
             break
         }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -25,6 +25,9 @@ final class CommandPaletteWindow {
     /// Callback invoked when the user selects a search result conversation (by daemon session ID).
     var onSelectSearchConversation: ((String) -> Void)?
 
+    /// Callback invoked when the user selects a memory search result (by memory ID).
+    var onSelectMemory: ((String) -> Void)?
+
     /// Static actions to show in the palette.
     var actions: [CommandPaletteAction] = []
 
@@ -64,6 +67,9 @@ final class CommandPaletteWindow {
             },
             onSelectConversation: { [weak self] convId in
                 self?.onSelectSearchConversation?(convId)
+            },
+            onSelectMemory: { [weak self] memoryId in
+                self?.onSelectMemory?(memoryId)
             }
         )
 


### PR DESCRIPTION
## Summary
- Add `onSelectMemory` callback to CommandPaletteView and CommandPaletteWindow
- Make memory search result rows clickable (both tap and Enter key)
- Wire callback in AppDelegate to call `windowState.showMemory(id:)` for full deep link flow

Part of plan: search-deep-link.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
