### PR TITLE
fix: add HTTP route for ingress config to fix iOS pairing

### DIFF
--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -30,6 +30,29 @@ export function computeGatewayTarget(): string {
 }
 
 /**
+ * Read the current ingress config from the raw workspace config file.
+ * Extracted so it can be called from both the daemon message handler
+ * and the HTTP route handler.
+ */
+export function getIngressConfigResult(): {
+  enabled: boolean;
+  publicBaseUrl: string;
+  localGatewayTarget: string;
+  success: boolean;
+} {
+  const raw = loadRawConfig();
+  const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+  const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
+  const enabled = (ingress.enabled as boolean | undefined) ?? false;
+  return {
+    enabled,
+    publicBaseUrl,
+    localGatewayTarget: computeGatewayTarget(),
+    success: true,
+  };
+}
+
+/**
  * Best-effort Twilio webhook sync helper.
  *
  * Computes the voice and status-callback webhook URLs from the current
@@ -80,16 +103,10 @@ export async function handleIngressConfig(
   const localGatewayTarget = computeGatewayTarget();
   try {
     if (msg.action === "get") {
-      const raw = loadRawConfig();
-      const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-      const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
-      const enabled = (ingress.enabled as boolean | undefined) ?? false;
+      const result = getIngressConfigResult();
       ctx.send({
         type: "ingress_config_response",
-        enabled,
-        publicBaseUrl,
-        localGatewayTarget,
-        success: true,
+        ...result,
       });
     } else if (msg.action === "set") {
       const value = (msg.publicBaseUrl ?? "").trim().replace(/\/+$/, "");

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -413,6 +413,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // OAuth / integrations
   { endpoint: "integrations/oauth/start", scopes: ["settings.write"] },
 
+  // Ingress config
+  { endpoint: "integrations/ingress/config:GET", scopes: ["settings.read"] },
+  { endpoint: "integrations/ingress/config", scopes: ["settings.write"] },
+
   // Workspace files
   { endpoint: "workspace-files", scopes: ["settings.read"] },
   { endpoint: "workspace-files/read", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -10,7 +10,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { setIngressPublicBaseUrl } from "../../config/env.js";
+import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import { loadSkillCatalog } from "../../config/skills.js";
+import {
+  computeGatewayTarget,
+  getIngressConfigResult,
+} from "../../daemon/handlers/config-ingress.js";
 import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import {
@@ -693,6 +699,53 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       method: "GET",
       policyKey: "diagnostics/env-vars",
       handler: () => handleEnvVars(),
+    },
+
+    // Ingress config (GET / PUT)
+    {
+      endpoint: "integrations/ingress/config",
+      method: "GET",
+      policyKey: "integrations/ingress/config:GET",
+      handler: () => Response.json(getIngressConfigResult()),
+    },
+    {
+      endpoint: "integrations/ingress/config",
+      method: "PUT",
+      policyKey: "integrations/ingress/config",
+      handler: async ({ req }) => {
+        try {
+          const body = (await req.json()) as {
+            publicBaseUrl?: string;
+            enabled?: boolean;
+          };
+          const value = (body.publicBaseUrl ?? "").trim().replace(/\/+$/, "");
+          const raw = loadRawConfig();
+          const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+          ingress.publicBaseUrl = value || undefined;
+          if (body.enabled !== undefined) {
+            ingress.enabled = body.enabled;
+          }
+          saveRawConfig({ ...raw, ingress });
+
+          const isEnabled = (ingress.enabled as boolean | undefined) ?? false;
+          if (value && isEnabled) {
+            setIngressPublicBaseUrl(value);
+          } else {
+            setIngressPublicBaseUrl(undefined);
+          }
+
+          return Response.json({
+            enabled: isEnabled,
+            publicBaseUrl: value,
+            localGatewayTarget: computeGatewayTarget(),
+            success: true,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          log.error({ err }, "Failed to update ingress config via HTTP");
+          return httpError("INTERNAL_ERROR", message, 500);
+        }
+      },
     },
   ];
 }

--- a/clients/shared/Network/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Settings.swift
@@ -151,8 +151,16 @@ extension HTTPTransport {
                 Task { await self.sendEncodablePost(.integrationsSlackConfig, body: msg, label: "slack_webhook_config") }
                 return true
             }
-            // ingress_config and platform_config do not have HTTP routes yet;
-            // they continue to use SSE message handlers and are not dispatched here.
+            if let msg = message as? IngressConfigRequestMessage {
+                if msg.action == "get" {
+                    Task { await self.sendEncodablePostAndDispatch(.integrationsIngressConfig, body: msg, method: "GET", messageType: "ingress_config_response", label: "ingress_config_get") }
+                } else {
+                    Task { await self.sendEncodablePostAndDispatch(.integrationsIngressConfig, body: msg, method: "PUT", messageType: "ingress_config_response", label: "ingress_config_set") }
+                }
+                return true
+            }
+            // platform_config does not have HTTP routes yet;
+            // it continues to use SSE message handlers and is not dispatched here.
             if let msg = message as? VercelApiConfigRequestMessage {
                 Task { await self.sendEncodablePost(.integrationsVercelConfig, body: msg, label: "vercel_api_config") }
                 return true

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -381,6 +381,7 @@ public final class HTTPTransport {
         case integrationsSlackConfig
         case integrationsVercelConfig
         case integrationsTelegramConfig
+        case integrationsIngressConfig
 
         // Surface Undo
         case surfaceUndo(surfaceId: String)
@@ -787,6 +788,8 @@ public final class HTTPTransport {
             return ("/v1/integrations/vercel/config", nil)
         case .integrationsTelegramConfig:
             return ("/v1/integrations/telegram/config", nil)
+        case .integrationsIngressConfig:
+            return ("/v1/integrations/ingress/config", nil)
         // Surface Undo
         case .surfaceUndo(let surfaceId):
             let encoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
@@ -1198,6 +1201,8 @@ public final class HTTPTransport {
             return ("\(prefix)/integrations/vercel/config/", nil)
         case .integrationsTelegramConfig:
             return ("\(prefix)/integrations/telegram/config/", nil)
+        case .integrationsIngressConfig:
+            return ("\(prefix)/integrations/ingress/config/", nil)
         // Surface Undo
         case .surfaceUndo(let surfaceId):
             let encoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId


### PR DESCRIPTION
## Summary
- **Root cause**: The macOS app HTTP transport silently dropped `IngressConfigRequestMessage` because no HTTP route existed for `ingress_config`. This left `ingressPublicBaseUrl` as empty string, so the pairing sheet sent `gatewayUrl=""` in the registration body, causing the daemon to return HTTP 400.
- Extracted `getIngressConfigResult()` from the daemon handler and added `GET/PUT /v1/integrations/ingress/config` HTTP routes in `settings-routes.ts`
- Wired up `IngressConfigRequestMessage` dispatch in `HTTPDaemonClient+Settings.swift` using `sendEncodablePostAndDispatch` so the ingress config response flows through `onIngressConfigResponse` to populate `ingressPublicBaseUrl` and fix the pairing flow

## Original prompt
Fix iOS pairing Registration failed (HTTP 400) by adding an HTTP route for ingress config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
