### PR TITLE
fix: make avatar twitch animation more subtle and randomly bidirectional

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -295,7 +295,9 @@ class AvatarLayerView: NSView {
         rootLayer.removeAnimation(forKey: "twitch")
 
         let animation = CAKeyframeAnimation(keyPath: "transform.rotation.z")
-        let angle: CGFloat = .pi / 60  // ~3 degrees
+        let baseAngle: CGFloat = .random(in: (.pi / 150)...(.pi / 90))  // ~1.2° to ~2°
+        let sign: CGFloat = Bool.random() ? 1.0 : -1.0  // Random CW or CCW start
+        let angle = baseAngle * sign
         animation.values = [0, angle, -angle * 0.6, angle * 0.3, 0]
         animation.keyTimes = [0, 0.2, 0.5, 0.75, 1.0]
         animation.duration = 0.4


### PR DESCRIPTION
## Summary
- Replace fixed ~3 degree twitch angle with random range of ~1.2-2 degrees for subtlety
- Add random direction (clockwise or counterclockwise) via Bool.random() sign flip
- Angle magnitude varies per-twitch for more organic feel

Part of plan: avatar-animation-fixes.md (PR 2 of 2)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
