### PR TITLE
fix: only navigate to thread after successful sessionId lookup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -352,9 +352,9 @@ extension AppDelegate {
         }
 
         window.onSelectSearchConversation = { [weak self] sessionId in
-            self?.mainWindow?.threadManager.selectThreadBySessionId(sessionId)
-            // Also ensure we're showing the thread view (not a panel)
-            if let threadId = self?.mainWindow?.threadManager.activeThreadId {
+            let found = self?.mainWindow?.threadManager.selectThreadBySessionId(sessionId) ?? false
+            // Only navigate if the lookup succeeded — otherwise the user stays on their current view
+            if found, let threadId = self?.mainWindow?.threadManager.activeThreadId {
                 self?.mainWindow?.windowState.selection = .thread(threadId)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -706,10 +706,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     }
 
     /// Select a thread by its daemon conversation ID (sessionId).
-    /// Falls back to no-op if no matching thread is found.
-    func selectThreadBySessionId(_ sessionId: String) {
-        guard let thread = threads.first(where: { $0.sessionId == sessionId }) else { return }
+    /// Returns `true` if a matching thread was found and selected, `false` otherwise.
+    @discardableResult
+    func selectThreadBySessionId(_ sessionId: String) -> Bool {
+        guard let thread = threads.first(where: { $0.sessionId == sessionId }) else { return false }
         selectThread(id: thread.id)
+        return true
     }
 
     // MARK: - Render Cache Management


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for search-deep-link.md.

**Gap:** Conversation deep link navigates to wrong thread on lookup failure
**What was expected:** Clicking a search result for an unloaded conversation should be a graceful no-op
**What was found:** `onSelectSearchConversation` unconditionally navigates to `activeThreadId` even when `selectThreadBySessionId` found no matching thread

Changes `selectThreadBySessionId` to return `@discardableResult Bool` and guards the navigation in AppDelegate on a successful lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
