### PR TITLE
fix: reactively switch IntelligencePanel to Memories tab on pendingMemoryId change

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -59,6 +59,11 @@ struct IntelligencePanel: View {
             tabContent
         }
         .padding(VSpacing.xl)
+        .onChange(of: pendingMemoryId) {
+            if pendingMemoryId != nil {
+                withAnimation(VAnimation.fast) { selectedTab = .memories }
+            }
+        }
     }
 
     // MARK: - Tab Button


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for search-deep-link.md.

**Gap:** IntelligencePanel does not switch to Memories tab when already displayed
**What was expected:** Selecting a memory from the command palette while the Intelligence panel is already open should switch to the Memories tab
**What was found:** `@State selectedTab` only takes its initial value on first view creation; subsequent `pendingMemoryId` changes don't reactively switch the tab

Adds `.onChange(of: pendingMemoryId)` modifier to reactively switch `selectedTab` to `.memories` when a non-nil `pendingMemoryId` arrives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
