### PR TITLE
fix: persist 'Show hidden files' workspace toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -33,7 +33,7 @@ final class WorkspaceBrowserState {
     var pendingSwitchPath: String?
     var pendingHiddenFilesToggle: Bool?
     var showingDirtyAlert: Bool = false
-    var showHiddenFiles: Bool = false
+    var showHiddenFiles: Bool = UserDefaults.standard.bool(forKey: "showHiddenFiles")
 
     func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
         if let response = await daemonClient.fetchWorkspaceTree(path: dirPath, showHidden: showHiddenFiles) {
@@ -149,6 +149,7 @@ struct WorkspacePanel: View {
 
     private func applyHiddenFilesToggle(_ newValue: Bool) {
         state.showHiddenFiles = newValue
+        UserDefaults.standard.set(newValue, forKey: "showHiddenFiles")
         state.directoryCache.removeAll()
         state.expandedDirs.removeAll()
         state.selectedFilePath = nil


### PR DESCRIPTION
## Summary
- Persist the "Show hidden files" toggle in the workspace file browser to UserDefaults so it survives app restarts
- Read saved value on `WorkspaceBrowserState` init; write on toggle

## Original prompt
I want the app to remember my setting for "Show hidden files"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
