### PR TITLE
refactor: convert initializeProviders and managed-proxy context to async getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -222,7 +222,7 @@ describe("ConfigWatcher workspace file handlers", () => {
 
   test("config.json change calls refreshConfigFromSources", async () => {
     let refreshCalled = false;
-    watcher.refreshConfigFromSources = () => {
+    watcher.refreshConfigFromSources = async () => {
       refreshCalled = true;
       return false; // no change, so onSessionEvict should NOT be called
     };
@@ -237,7 +237,7 @@ describe("ConfigWatcher workspace file handlers", () => {
   });
 
   test("config.json change triggers onSessionEvict when config actually changed", async () => {
-    watcher.refreshConfigFromSources = () => true;
+    watcher.refreshConfigFromSources = async () => true;
 
     watcher.start(onSessionEvict);
     simulateFileChange(WORKSPACE_DIR, "config.json");
@@ -248,7 +248,7 @@ describe("ConfigWatcher workspace file handlers", () => {
 
   test("config.json change is suppressed when suppressConfigReload is true", async () => {
     let refreshCalled = false;
-    watcher.refreshConfigFromSources = () => {
+    watcher.refreshConfigFromSources = async () => {
       refreshCalled = true;
       return true;
     };

--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -19,7 +19,7 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => {
+  getSecureKeyAsync: async (key: string) => {
     if (key === credentialKey("vellum", "assistant_api_key")) {
       return mockAssistantApiKey;
     }
@@ -40,44 +40,44 @@ describe("resolveManagedProxyContext", () => {
     mockAssistantApiKey = null;
   });
 
-  test("returns disabled when platform URL is empty", () => {
+  test("returns disabled when platform URL is empty", async () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = "sk-test-key";
 
-    const ctx = resolveManagedProxyContext();
+    const ctx = await resolveManagedProxyContext();
     expect(ctx.enabled).toBe(false);
     expect(ctx.platformBaseUrl).toBe("");
   });
 
-  test("returns disabled when assistant API key is missing", () => {
+  test("returns disabled when assistant API key is missing", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = null;
 
-    const ctx = resolveManagedProxyContext();
+    const ctx = await resolveManagedProxyContext();
     expect(ctx.enabled).toBe(false);
     expect(ctx.assistantApiKey).toBe("");
   });
 
-  test("returns disabled when both are missing", () => {
-    const ctx = resolveManagedProxyContext();
+  test("returns disabled when both are missing", async () => {
+    const ctx = await resolveManagedProxyContext();
     expect(ctx.enabled).toBe(false);
   });
 
-  test("returns enabled when both platform URL and API key are present", () => {
+  test("returns enabled when both platform URL and API key are present", async () => {
     mockPlatformBaseUrl = "https://platform.example.com/";
     mockAssistantApiKey = "sk-test-key";
 
-    const ctx = resolveManagedProxyContext();
+    const ctx = await resolveManagedProxyContext();
     expect(ctx.enabled).toBe(true);
     expect(ctx.platformBaseUrl).toBe("https://platform.example.com");
     expect(ctx.assistantApiKey).toBe("sk-test-key");
   });
 
-  test("strips trailing slashes from platform URL", () => {
+  test("strips trailing slashes from platform URL", async () => {
     mockPlatformBaseUrl = "https://platform.example.com///";
     mockAssistantApiKey = "sk-test-key";
 
-    const ctx = resolveManagedProxyContext();
+    const ctx = await resolveManagedProxyContext();
     expect(ctx.platformBaseUrl).toBe("https://platform.example.com");
   });
 });
@@ -88,14 +88,14 @@ describe("hasManagedProxyPrereqs", () => {
     mockAssistantApiKey = null;
   });
 
-  test("returns false when prerequisites are missing", () => {
-    expect(hasManagedProxyPrereqs()).toBe(false);
+  test("returns false when prerequisites are missing", async () => {
+    expect(await hasManagedProxyPrereqs()).toBe(false);
   });
 
-  test("returns true when prerequisites are satisfied", () => {
+  test("returns true when prerequisites are satisfied", async () => {
     mockPlatformBaseUrl = "https://platform.example.com";
     mockAssistantApiKey = "sk-test-key";
-    expect(hasManagedProxyPrereqs()).toBe(true);
+    expect(await hasManagedProxyPrereqs()).toBe(true);
   });
 });
 
@@ -105,36 +105,36 @@ describe("buildManagedBaseUrl", () => {
     mockAssistantApiKey = "sk-test-key";
   });
 
-  test("builds correct URL for managed providers", () => {
-    expect(buildManagedBaseUrl("openai")).toBe(
+  test("builds correct URL for managed providers", async () => {
+    expect(await buildManagedBaseUrl("openai")).toBe(
       "https://platform.example.com/v1/runtime-proxy/openai",
     );
-    expect(buildManagedBaseUrl("anthropic")).toBe(
+    expect(await buildManagedBaseUrl("anthropic")).toBe(
       "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
-    expect(buildManagedBaseUrl("gemini")).toBe(
+    expect(await buildManagedBaseUrl("gemini")).toBe(
       "https://platform.example.com/v1/runtime-proxy/vertex",
     );
-    expect(buildManagedBaseUrl("fireworks")).toBe(
+    expect(await buildManagedBaseUrl("fireworks")).toBe(
       "https://platform.example.com/v1/runtime-proxy/fireworks",
     );
-    expect(buildManagedBaseUrl("openrouter")).toBe(
+    expect(await buildManagedBaseUrl("openrouter")).toBe(
       "https://platform.example.com/v1/runtime-proxy/openrouter",
     );
   });
 
-  test("returns undefined for non-managed provider (ollama)", () => {
-    expect(buildManagedBaseUrl("ollama")).toBeUndefined();
+  test("returns undefined for non-managed provider (ollama)", async () => {
+    expect(await buildManagedBaseUrl("ollama")).toBeUndefined();
   });
 
-  test("returns undefined for unknown provider", () => {
-    expect(buildManagedBaseUrl("unknown-provider")).toBeUndefined();
+  test("returns undefined for unknown provider", async () => {
+    expect(await buildManagedBaseUrl("unknown-provider")).toBeUndefined();
   });
 
-  test("returns undefined when prerequisites are missing", () => {
+  test("returns undefined when prerequisites are missing", async () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
-    expect(buildManagedBaseUrl("openai")).toBeUndefined();
+    expect(await buildManagedBaseUrl("openai")).toBeUndefined();
   });
 });
 
@@ -144,22 +144,22 @@ describe("managedFallbackEnabledFor", () => {
     mockAssistantApiKey = "sk-test-key";
   });
 
-  test("returns true for managed providers with prerequisites", () => {
-    expect(managedFallbackEnabledFor("openai")).toBe(true);
-    expect(managedFallbackEnabledFor("anthropic")).toBe(true);
+  test("returns true for managed providers with prerequisites", async () => {
+    expect(await managedFallbackEnabledFor("openai")).toBe(true);
+    expect(await managedFallbackEnabledFor("anthropic")).toBe(true);
   });
 
-  test("returns false for non-managed provider", () => {
-    expect(managedFallbackEnabledFor("ollama")).toBe(false);
+  test("returns false for non-managed provider", async () => {
+    expect(await managedFallbackEnabledFor("ollama")).toBe(false);
   });
 
-  test("returns false for unknown provider", () => {
-    expect(managedFallbackEnabledFor("unknown")).toBe(false);
+  test("returns false for unknown provider", async () => {
+    expect(await managedFallbackEnabledFor("unknown")).toBe(false);
   });
 
-  test("returns false when prerequisites are missing", () => {
+  test("returns false when prerequisites are missing", async () => {
     mockPlatformBaseUrl = "";
     mockAssistantApiKey = null;
-    expect(managedFallbackEnabledFor("openai")).toBe(false);
+    expect(await managedFallbackEnabledFor("openai")).toBe(false);
   });
 });

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -55,8 +55,8 @@ let mockManagedProxyContext = {
 };
 
 mock.module("../providers/managed-proxy/context.js", () => ({
-  buildManagedBaseUrl: () => mockManagedBaseUrl,
-  resolveManagedProxyContext: () => mockManagedProxyContext,
+  buildManagedBaseUrl: async () => mockManagedBaseUrl,
+  resolveManagedProxyContext: async () => mockManagedProxyContext,
 }));
 
 let mockAttachments: Array<{

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -21,7 +21,7 @@ mock.module("../config/env.js", () => ({
 const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
   ...actualSecureKeys,
-  getSecureKey: (key: string) => {
+  getSecureKeyAsync: async (key: string) => {
     if (key === credentialKey("vellum", "assistant_api_key")) {
       return mockAssistantApiKey || null;
     }
@@ -44,50 +44,50 @@ import { ProviderNotConfiguredError } from "../util/errors.js";
  */
 
 /** Initialize registry with anthropic + openai for most tests. */
-function setupTwoProviders() {
+async function setupTwoProviders() {
   mockProviderKeys = { anthropic: "test-key", openai: "test-key" };
-  initializeProviders({
+  await initializeProviders({
     provider: "anthropic",
     model: "test-model",
   });
 }
 
 /** Initialize registry with no providers (empty keys, non-registerable primary). */
-function setupNoProviders() {
+async function setupNoProviders() {
   mockProviderKeys = {};
-  initializeProviders({
+  await initializeProviders({
     provider: "gemini",
     model: "test-model",
   });
 }
 
 describe("resolveProviderSelection", () => {
-  test("configured primary available → selected as primary", () => {
-    setupTwoProviders();
+  test("configured primary available → selected as primary", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("anthropic", ["openai"]);
     expect(result.selectedPrimary).toBe("anthropic");
     expect(result.usedFallbackPrimary).toBe(false);
     expect(result.availableProviders).toEqual(["anthropic", "openai"]);
   });
 
-  test("configured primary unavailable + alternate available → alternate selected", () => {
-    setupTwoProviders();
+  test("configured primary unavailable + alternate available → alternate selected", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("gemini", ["anthropic", "openai"]);
     expect(result.selectedPrimary).toBe("anthropic");
     expect(result.usedFallbackPrimary).toBe(true);
     expect(result.availableProviders).toEqual(["anthropic", "openai"]);
   });
 
-  test("configured primary unavailable + first alternate also unavailable → second alternate selected", () => {
-    setupTwoProviders();
+  test("configured primary unavailable + first alternate also unavailable → second alternate selected", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("gemini", ["fireworks", "openai"]);
     expect(result.selectedPrimary).toBe("openai");
     expect(result.usedFallbackPrimary).toBe(true);
     expect(result.availableProviders).toEqual(["openai"]);
   });
 
-  test("deduplicates entries in providerOrder", () => {
-    setupTwoProviders();
+  test("deduplicates entries in providerOrder", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("anthropic", [
       "anthropic",
       "openai",
@@ -96,8 +96,8 @@ describe("resolveProviderSelection", () => {
     expect(result.availableProviders).toEqual(["anthropic", "openai"]);
   });
 
-  test("unknown entries in providerOrder are filtered out", () => {
-    setupTwoProviders();
+  test("unknown entries in providerOrder are filtered out", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("anthropic", [
       "nonexistent",
       "openai",
@@ -105,24 +105,24 @@ describe("resolveProviderSelection", () => {
     expect(result.availableProviders).toEqual(["anthropic", "openai"]);
   });
 
-  test("no available providers → null selectedPrimary", () => {
-    setupTwoProviders();
+  test("no available providers → null selectedPrimary", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("gemini", ["fireworks", "ollama"]);
     expect(result.selectedPrimary).toBeNull();
     expect(result.usedFallbackPrimary).toBe(false);
     expect(result.availableProviders).toEqual([]);
   });
 
-  test("empty providerOrder with available primary → primary only", () => {
-    setupTwoProviders();
+  test("empty providerOrder with available primary → primary only", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("anthropic", []);
     expect(result.selectedPrimary).toBe("anthropic");
     expect(result.usedFallbackPrimary).toBe(false);
     expect(result.availableProviders).toEqual(["anthropic"]);
   });
 
-  test("empty providerOrder with unavailable primary → null", () => {
-    setupTwoProviders();
+  test("empty providerOrder with unavailable primary → null", async () => {
+    await setupTwoProviders();
     const result = resolveProviderSelection("gemini", []);
     expect(result.selectedPrimary).toBeNull();
     expect(result.availableProviders).toEqual([]);
@@ -130,20 +130,20 @@ describe("resolveProviderSelection", () => {
 });
 
 describe("getFailoverProvider (fail-open)", () => {
-  test("returns provider when primary is available", () => {
-    setupTwoProviders();
+  test("returns provider when primary is available", async () => {
+    await setupTwoProviders();
     const provider = getFailoverProvider("anthropic", ["openai"]);
     expect(provider).toBeDefined();
   });
 
-  test("returns provider when primary is unavailable but alternate exists", () => {
-    setupTwoProviders();
+  test("returns provider when primary is unavailable but alternate exists", async () => {
+    await setupTwoProviders();
     const provider = getFailoverProvider("gemini", ["anthropic", "openai"]);
     expect(provider).toBeDefined();
   });
 
-  test("throws ProviderNotConfiguredError when no providers are available", () => {
-    setupNoProviders();
+  test("throws ProviderNotConfiguredError when no providers are available", async () => {
+    await setupNoProviders();
     expect(() => getFailoverProvider("gemini", ["fireworks"])).toThrow(
       ProviderNotConfiguredError,
     );
@@ -158,8 +158,8 @@ describe("getFailoverProvider (fail-open)", () => {
     }
   });
 
-  test("single available provider returns it directly (no failover wrapper)", () => {
-    setupTwoProviders();
+  test("single available provider returns it directly (no failover wrapper)", async () => {
+    await setupTwoProviders();
     const provider = getFailoverProvider("gemini", ["anthropic"]);
     // Should be a RetryProvider wrapping AnthropicProvider, not a FailoverProvider
     expect(provider.name).not.toBe("failover");
@@ -181,11 +181,11 @@ describe("managed proxy fallback", () => {
     mockAssistantApiKey = "";
   }
 
-  test("openai registered via managed fallback when no user key but proxy context is valid", () => {
+  test("openai registered via managed fallback when no user key but proxy context is valid", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key" };
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -198,11 +198,11 @@ describe("managed proxy fallback", () => {
     }
   });
 
-  test("user key takes precedence over managed fallback", () => {
+  test("user key takes precedence over managed fallback", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key", openai: "user-openai-key" };
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -217,10 +217,10 @@ describe("managed proxy fallback", () => {
     }
   });
 
-  test("managed fallback not activated when proxy context is disabled", () => {
+  test("managed fallback not activated when proxy context is disabled", async () => {
     disableManagedProxy();
     mockProviderKeys = { anthropic: "test-key" };
-    initializeProviders({
+    await initializeProviders({
       provider: "anthropic",
       model: "test-model",
     });
@@ -230,11 +230,11 @@ describe("managed proxy fallback", () => {
     expect(registered).not.toContain("openrouter");
   });
 
-  test("managed providers participate in failover selection", () => {
+  test("managed providers participate in failover selection", async () => {
     enableManagedProxy();
     try {
       mockProviderKeys = { anthropic: "test-key" };
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -254,12 +254,12 @@ describe("managed proxy fallback", () => {
     }
   });
 
-  test("managed provider selected as primary when configured primary unavailable", () => {
+  test("managed provider selected as primary when configured primary unavailable", async () => {
     enableManagedProxy();
     try {
       // No anthropic key, no gemini key — only managed providers available
       mockProviderKeys = {};
-      initializeProviders({
+      await initializeProviders({
         provider: "openai",
         model: "test-model",
       });

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -46,7 +46,7 @@ mock.module("../config/env.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => {
+  getSecureKeyAsync: async (key: string) => {
     if (key === credentialKey("vellum", "assistant_api_key")) {
       return mockAssistantApiKey;
     }
@@ -110,10 +110,10 @@ describe("managed proxy integration — credential precedence", () => {
   describe("user keys present → providers use direct connections (not proxy)", () => {
     test.each(MANAGED_PROVIDERS)(
       "%s routes via user-key when user key is provided regardless of managed context",
-      (provider: string) => {
+      async (provider: string) => {
         enableManagedProxy();
         setUserKeysFor(provider);
-        initializeProviders({
+        await initializeProviders({
           provider,
           model: "test-model",
         });
@@ -122,10 +122,10 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("all five managed providers route via user-key with user keys", () => {
+    test("all five managed providers route via user-key with user keys", async () => {
       enableManagedProxy();
       setUserKeysFor(...MANAGED_PROVIDERS);
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -136,10 +136,10 @@ describe("managed proxy integration — credential precedence", () => {
       }
     });
 
-    test("user keys still route via user-key when managed context is disabled", () => {
+    test("user keys still route via user-key when managed context is disabled", async () => {
       disableManagedProxy();
       setUserKeysFor(...MANAGED_PROVIDERS);
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -154,10 +154,10 @@ describe("managed proxy integration — credential precedence", () => {
   describe("user keys absent + managed context available → providers use managed proxy", () => {
     test.each(MANAGED_PROVIDERS)(
       "%s routes via managed-proxy when no user key",
-      (provider: string) => {
+      async (provider: string) => {
         enableManagedProxy();
         mockProviderKeys = {};
-        initializeProviders({
+        await initializeProviders({
           // For ollama, provider selection does not trigger managed proxy
           provider: provider === "openai" ? "openai" : "anthropic",
           model: "test-model",
@@ -167,10 +167,10 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("all five managed providers route via managed-proxy simultaneously", () => {
+    test("all five managed providers route via managed-proxy simultaneously", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -181,10 +181,10 @@ describe("managed proxy integration — credential precedence", () => {
       }
     });
 
-    test("managed anthropic uses vertex proxy path instead of anthropic proxy path", () => {
+    test("managed anthropic uses vertex proxy path instead of anthropic proxy path", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "claude-opus-4-6",
       });
@@ -204,10 +204,10 @@ describe("managed proxy integration — credential precedence", () => {
       expect(baseURL).toContain("/v1/runtime-proxy/anthropic");
     });
 
-    test("managed gemini uses vertex proxy path instead of gemini proxy path", () => {
+    test("managed gemini uses vertex proxy path instead of gemini proxy path", async () => {
       enableManagedProxy();
       mockProviderKeys = {};
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -227,10 +227,10 @@ describe("managed proxy integration — credential precedence", () => {
   describe("neither user keys nor managed context → providers not initialized", () => {
     test.each(MANAGED_PROVIDERS)(
       "%s is NOT registered when no user key and no managed context",
-      (provider: string) => {
+      async (provider: string) => {
         disableManagedProxy();
         mockProviderKeys = {};
-        initializeProviders({
+        await initializeProviders({
           provider: "anthropic",
           model: "test-model",
         });
@@ -239,10 +239,10 @@ describe("managed proxy integration — credential precedence", () => {
       },
     );
 
-    test("registry is empty when no keys and no managed context (non-ollama primary)", () => {
+    test("registry is empty when no keys and no managed context (non-ollama primary)", async () => {
       disableManagedProxy();
       mockProviderKeys = {};
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -251,10 +251,10 @@ describe("managed proxy integration — credential precedence", () => {
   });
 
   describe("mixed: some user keys + managed fallback fills gaps", () => {
-    test("user key for anthropic routes direct, managed fallback fills remaining four via proxy", () => {
+    test("user key for anthropic routes direct, managed fallback fills remaining four via proxy", async () => {
       enableManagedProxy();
       setUserKeysFor("anthropic");
-      initializeProviders({
+      await initializeProviders({
         provider: "anthropic",
         model: "test-model",
       });
@@ -267,10 +267,10 @@ describe("managed proxy integration — credential precedence", () => {
       }
     });
 
-    test("user key for openai routes direct, managed fallback fills remaining four via proxy", () => {
+    test("user key for openai routes direct, managed fallback fills remaining four via proxy", async () => {
       enableManagedProxy();
       setUserKeysFor("openai");
-      initializeProviders({
+      await initializeProviders({
         provider: "openai",
         model: "test-model",
       });
@@ -286,30 +286,30 @@ describe("managed proxy integration — credential precedence", () => {
 });
 
 describe("managed proxy integration — ollama exclusion", () => {
-  test("ollama is never registered via managed proxy fallback", () => {
+  test("ollama is never registered via managed proxy fallback", async () => {
     enableManagedProxy();
     mockProviderKeys = {};
-    initializeProviders({
+    await initializeProviders({
       provider: "anthropic",
       model: "test-model",
     });
     expect(listProviders()).not.toContain("ollama");
   });
 
-  test("ollama registers only when explicitly configured as provider", () => {
+  test("ollama registers only when explicitly configured as provider", async () => {
     enableManagedProxy();
     mockProviderKeys = {};
-    initializeProviders({
+    await initializeProviders({
       provider: "ollama",
       model: "test-model",
     });
     expect(listProviders()).toContain("ollama");
   });
 
-  test("ollama registers with explicit API key", () => {
+  test("ollama registers with explicit API key", async () => {
     enableManagedProxy();
     mockProviderKeys = { ollama: "ollama-key" };
-    initializeProviders({
+    await initializeProviders({
       provider: "anthropic",
       model: "test-model",
     });

--- a/assistant/src/__tests__/provider-registry-ollama.test.ts
+++ b/assistant/src/__tests__/provider-registry-ollama.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, mock, test } from "bun:test";
 const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
   ...actualSecureKeys,
-  getSecureKey: () => undefined,
+  getSecureKeyAsync: async () => undefined,
 }));
 
 import {
@@ -14,8 +14,8 @@ import {
 } from "../providers/registry.js";
 
 describe("provider registry (ollama)", () => {
-  test("registers ollama when selected provider has no API key", () => {
-    initializeProviders({
+  test("registers ollama when selected provider has no API key", async () => {
+    await initializeProviders({
       provider: "ollama",
       model: "claude-opus-4-6",
     });

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -129,12 +129,12 @@ function makeDeleteCredentialRequest(name: string): Request {
 }
 
 describe("secret routes managed proxy registry sync", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     secureKeyStore = {};
     metadataUpserts.length = 0;
     metadataDeletes.length = 0;
     lastGeminiConstructorOpts = null;
-    initializeProviders(mockConfig);
+    await initializeProviders(mockConfig);
   });
 
   test("adding vellum:assistant_api_key bootstraps managed providers immediately", async () => {
@@ -161,7 +161,7 @@ describe("secret routes managed proxy registry sync", () => {
 
   test("deleting vellum:assistant_api_key clears managed providers immediately", async () => {
     secureKeyStore[ASSISTANT_API_KEY_PATH] = "ast-managed-key";
-    initializeProviders(mockConfig);
+    await initializeProviders(mockConfig);
 
     for (const provider of MANAGED_PROVIDERS) {
       expect(listProviders()).toContain(provider);

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -59,9 +59,9 @@ export async function run(
   if (apiKey) {
     credentials = { type: "direct", apiKey };
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       credentials = {
         type: "managed-proxy",
         assistantApiKey: ctx.assistantApiKey,

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -88,7 +88,7 @@ export class ConfigWatcher {
    * when effective config values (including API keys) have changed.
    * Returns true if config actually changed.
    */
-  refreshConfigFromSources(): boolean {
+  async refreshConfigFromSources(): Promise<boolean> {
     invalidateConfigCache();
     const config = getConfig();
     const fingerprint = this.configFingerprint(config);
@@ -98,7 +98,7 @@ export class ConfigWatcher {
     clearTrustCache();
     clearEmbeddingBackendCache();
     const isFirstInit = this.lastFingerprint === "";
-    initializeProviders(config);
+    await initializeProviders(config);
     this.lastFingerprint = fingerprint;
     return !isFirstInit;
   }
@@ -113,12 +113,12 @@ export class ConfigWatcher {
     const protectedDir = join(getRootDir(), "protected");
 
     const workspaceHandlers: Record<string, () => void> = {
-      "config.json": () => {
+      "config.json": async () => {
         if (this.suppressReload) return;
         try {
           const prevConfig = getConfig();
           const prevMcpFingerprint = JSON.stringify(prevConfig.mcp ?? {});
-          const changed = this.refreshConfigFromSources();
+          const changed = await this.refreshConfigFromSources();
           if (changed) {
             onSessionEvict();
             const newConfig = getConfig();

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -116,7 +116,7 @@ export async function setModel(
 
   // Re-initialize provider with the new model so LLM calls use it
   const config = getConfig();
-  initializeProviders(config);
+  await initializeProviders(config);
 
   // Evict idle sessions immediately; mark busy ones as stale so they
   // get recreated with the new provider once they finish processing.

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -21,7 +21,7 @@ export async function initializeProvidersAndTools(
   config: AssistantConfig,
 ): Promise<void> {
   log.info("Daemon startup: initializing providers and tools");
-  initializeProviders(config);
+  await initializeProviders(config);
   await initializeTools();
 
   // Start MCP servers and register their tools

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -378,7 +378,7 @@ export class DaemonServer {
 
   async start(): Promise<void> {
     const config = getConfig();
-    initializeProviders(config);
+    await initializeProviders(config);
     this.configWatcher.initFingerprint(config);
 
     this.evictor.start();
@@ -468,8 +468,8 @@ export class DaemonServer {
     this.configWatcher.lastFingerprint = value;
   }
 
-  refreshConfigFromSources(): boolean {
-    const changed = this.configWatcher.refreshConfigFromSources();
+  async refreshConfigFromSources(): Promise<boolean> {
+    const changed = await this.configWatcher.refreshConfigFromSources();
     if (changed) this.evictSessionsForReload();
     return changed;
   }

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -190,7 +190,7 @@ async function resolveProviderModelCommand(
 
   // Re-initialize providers with new config
   const newConfig = getConfig();
-  initializeProviders(newConfig);
+  await initializeProviders(newConfig);
 
   const switchedMsg = name
     ? `Switched ${name} to **${displayName}**. New conversations will use this model.`
@@ -306,7 +306,7 @@ async function resolveModelCommand(
   raw.model = matched;
   saveRawConfig(raw);
   const config = getConfig();
-  initializeProviders(config);
+  await initializeProviders(config);
 
   const displayName = MODEL_DISPLAY_NAMES[matched] ?? matched;
   const switchedMsg = name

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -43,9 +43,9 @@ export async function generateAppIcon(
   if (apiKey) {
     credentials = { type: "direct", apiKey };
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       credentials = {
         type: "managed-proxy",
         assistantApiKey: ctx.assistantApiKey,

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -20,9 +20,9 @@ export async function generateAvatar(
   if (geminiKey) {
     credentials = { type: "direct", apiKey: geminiKey };
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       credentials = {
         type: "managed-proxy",
         assistantApiKey: ctx.assistantApiKey,

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -11,7 +11,7 @@
 
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
-import { getSecureKey } from "../../security/secure-keys.js";
+import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { MANAGED_PROVIDER_META } from "./constants.js";
 
 /** Storage key for the assistant API key credential. */
@@ -35,9 +35,10 @@ export interface ManagedProxyContext {
  * Returns an enabled context only when both the platform base URL and
  * the assistant API key are present. Otherwise returns a disabled context.
  */
-export function resolveManagedProxyContext(): ManagedProxyContext {
+export async function resolveManagedProxyContext(): Promise<ManagedProxyContext> {
   const platformBaseUrl = getPlatformBaseUrl().replace(/\/+$/, "");
-  const assistantApiKey = getSecureKey(ASSISTANT_API_KEY_STORAGE_KEY) ?? "";
+  const assistantApiKey =
+    (await getSecureKeyAsync(ASSISTANT_API_KEY_STORAGE_KEY)) ?? "";
 
   const enabled = !!platformBaseUrl && !!assistantApiKey;
 
@@ -48,8 +49,8 @@ export function resolveManagedProxyContext(): ManagedProxyContext {
  * Check whether managed proxy prerequisites are available.
  * Shorthand for checking that both platform URL and assistant API key exist.
  */
-export function hasManagedProxyPrereqs(): boolean {
-  return resolveManagedProxyContext().enabled;
+export async function hasManagedProxyPrereqs(): Promise<boolean> {
+  return (await resolveManagedProxyContext()).enabled;
 }
 
 /**
@@ -58,11 +59,13 @@ export function hasManagedProxyPrereqs(): boolean {
  * Combines the platform base URL with the provider's deterministic proxy path.
  * Returns undefined if the provider is not managed or prerequisites are missing.
  */
-export function buildManagedBaseUrl(provider: string): string | undefined {
+export async function buildManagedBaseUrl(
+  provider: string,
+): Promise<string | undefined> {
   const meta = MANAGED_PROVIDER_META[provider];
   if (!meta?.managed || !meta.proxyPath) return undefined;
 
-  const ctx = resolveManagedProxyContext();
+  const ctx = await resolveManagedProxyContext();
   if (!ctx.enabled) return undefined;
 
   return `${ctx.platformBaseUrl}${meta.proxyPath}`;
@@ -74,8 +77,10 @@ export function buildManagedBaseUrl(provider: string): string | undefined {
  * Returns true when the provider supports managed proxy routing and
  * all prerequisites (platform URL + assistant API key) are satisfied.
  */
-export function managedFallbackEnabledFor(provider: string): boolean {
+export async function managedFallbackEnabledFor(
+  provider: string,
+): Promise<boolean> {
   const meta = MANAGED_PROVIDER_META[provider];
   if (!meta?.managed) return false;
-  return hasManagedProxyPrereqs();
+  return await hasManagedProxyPrereqs();
 }

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,5 +1,5 @@
 import { wrapWithLogfire } from "../logfire.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
@@ -202,7 +202,9 @@ export function getProviderDebugStatus(
   };
 }
 
-export function initializeProviders(config: ProvidersConfig): void {
+export async function initializeProviders(
+  config: ProvidersConfig,
+): Promise<void> {
   providers.clear();
   routingSources.clear();
   cachedFailoverProvider = null;
@@ -211,7 +213,7 @@ export function initializeProviders(config: ProvidersConfig): void {
   const streamTimeoutMs =
     (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
 
-  const anthropicKey = getSecureKey("anthropic");
+  const anthropicKey = await getSecureKeyAsync("anthropic");
   if (anthropicKey) {
     const model = resolveModel(config, "anthropic");
     registerProvider(
@@ -228,9 +230,9 @@ export function initializeProviders(config: ProvidersConfig): void {
     routingSources.set("anthropic", "user-key");
   } else {
     // No user Anthropic key — route through managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("anthropic");
+    const managedBaseUrl = await buildManagedBaseUrl("anthropic");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       const model = resolveModel(config, "anthropic");
       registerProvider(
         "anthropic",
@@ -248,7 +250,7 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("anthropic", "managed-proxy");
     }
   }
-  const openaiKey = getSecureKey("openai");
+  const openaiKey = await getSecureKeyAsync("openai");
   if (openaiKey) {
     const model = resolveModel(config, "openai");
     registerProvider(
@@ -261,9 +263,9 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openai", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("openai");
+    const managedBaseUrl = await buildManagedBaseUrl("openai");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       const model = resolveModel(config, "openai");
       registerProvider(
         "openai",
@@ -279,7 +281,7 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("openai", "managed-proxy");
     }
   }
-  const geminiKey = getSecureKey("gemini");
+  const geminiKey = await getSecureKeyAsync("gemini");
   if (geminiKey) {
     const model = resolveModel(config, "gemini");
     registerProvider(
@@ -293,9 +295,9 @@ export function initializeProviders(config: ProvidersConfig): void {
     routingSources.set("gemini", "user-key");
   } else {
     // No user Gemini key — route through Vertex managed proxy
-    const managedBaseUrl = buildManagedBaseUrl("vertex");
+    const managedBaseUrl = await buildManagedBaseUrl("vertex");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       const model = resolveModel(config, "gemini");
       registerProvider(
         "gemini",
@@ -311,7 +313,7 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("gemini", "managed-proxy");
     }
   }
-  const ollamaKey = getSecureKey("ollama");
+  const ollamaKey = await getSecureKeyAsync("ollama");
   if (config.provider === "ollama" || ollamaKey) {
     const model = resolveModel(config, "ollama");
     registerProvider(
@@ -327,7 +329,7 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("ollama", "user-key");
   }
-  const fireworksKey = getSecureKey("fireworks");
+  const fireworksKey = await getSecureKeyAsync("fireworks");
   if (fireworksKey) {
     const model = resolveModel(config, "fireworks");
     registerProvider(
@@ -342,9 +344,9 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("fireworks", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("fireworks");
+    const managedBaseUrl = await buildManagedBaseUrl("fireworks");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       const model = resolveModel(config, "fireworks");
       registerProvider(
         "fireworks",
@@ -360,7 +362,7 @@ export function initializeProviders(config: ProvidersConfig): void {
       routingSources.set("fireworks", "managed-proxy");
     }
   }
-  const openrouterKey = getSecureKey("openrouter");
+  const openrouterKey = await getSecureKeyAsync("openrouter");
   if (openrouterKey) {
     const model = resolveModel(config, "openrouter");
     registerProvider(
@@ -375,9 +377,9 @@ export function initializeProviders(config: ProvidersConfig): void {
     );
     routingSources.set("openrouter", "user-key");
   } else {
-    const managedBaseUrl = buildManagedBaseUrl("openrouter");
+    const managedBaseUrl = await buildManagedBaseUrl("openrouter");
     if (managedBaseUrl) {
-      const ctx = resolveManagedProxyContext();
+      const ctx = await resolveManagedProxyContext();
       const model = resolveModel(config, "openrouter");
       registerProvider(
         "openrouter",

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -73,7 +73,7 @@ export async function handleAddSecret(req: Request): Promise<Response> {
         );
       }
       invalidateConfigCache();
-      initializeProviders(getConfig());
+      await initializeProviders(getConfig());
       log.info({ provider: name }, "API key updated via HTTP");
       return Response.json({ success: true, type, name }, { status: 201 });
     }
@@ -101,7 +101,7 @@ export async function handleAddSecret(req: Request): Promise<Response> {
       }
       upsertCredentialMetadata(service, field, {});
       if (isManagedProxyCredential(service, field)) {
-        initializeProviders(getConfig());
+        await initializeProviders(getConfig());
       }
       log.info({ service, field }, "Credential added via HTTP");
       return Response.json({ success: true, type, name }, { status: 201 });
@@ -162,7 +162,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
         );
       }
       invalidateConfigCache();
-      initializeProviders(getConfig());
+      await initializeProviders(getConfig());
       log.info({ provider: name }, "API key deleted via HTTP");
       return Response.json({ success: true, type, name });
     }
@@ -196,7 +196,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       }
       deleteCredentialMetadata(service, field);
       if (isManagedProxyCredential(service, field)) {
-        initializeProviders(getConfig());
+        await initializeProviders(getConfig());
       }
       log.info({ service, field }, "Credential deleted via HTTP");
       return Response.json({ success: true, type, name });


### PR DESCRIPTION
## Summary
- Convert initializeProviders to async, replacing all 6 getSecureKey calls with getSecureKeyAsync
- Convert managed-proxy context functions (resolveManagedProxyContext, buildManagedBaseUrl, hasManagedProxyPrereqs, managedFallbackEnabledFor) to async
- Add await at all caller sites (config-watcher, providers-setup, server, config-model, session-slash, secret-routes)
- Add await at additional caller sites discovered via type-checking (media-generate-image, app-icon-generator, avatar-router)
- Update test files that call these functions directly

Part of plan: async-secure-final.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
