### PR TITLE
refactor: convert all test files from sync to async secure-key functions

### DIFF
--- a/assistant/src/__tests__/credential-broker-browser-fill.test.ts
+++ b/assistant/src/__tests__/credential-broker-browser-fill.test.ts
@@ -50,7 +50,7 @@ mock.module("../tools/registry.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { credentialKey } from "../security/credential-key.js";
-import { setSecureKey } from "../security/secure-keys.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
@@ -93,7 +93,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     let filledValue: string | undefined;
     const result = await broker.browserFill({
@@ -115,7 +115,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -168,7 +168,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -194,8 +194,8 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "password", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "username"), "octocat");
-    setSecureKey(credentialKey("github", "password"), "hunter2");
+    await setSecureKeyAsync(credentialKey("github", "username"), "octocat");
+    await setSecureKeyAsync(credentialKey("github", "password"), "hunter2");
 
     const filled: Record<string, string> = {};
 
@@ -228,7 +228,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -246,7 +246,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -264,7 +264,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -287,7 +287,7 @@ describe("CredentialBroker.browserFill", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -306,7 +306,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     // No domain provided and no allowedDomains policy — should succeed
     const result = await broker.browserFill({
@@ -323,7 +323,7 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["other_tool"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     let fillCalled = false;
     const result = await broker.browserFill({
@@ -344,7 +344,7 @@ describe("CredentialBroker.browserFill", () => {
 
   test("denies fill when allowedTools is empty (fail-closed)", async () => {
     upsertCredentialMetadata("github", "token", { allowedTools: [] });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -363,7 +363,10 @@ describe("CredentialBroker.browserFill", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_supersecret");
+    await setSecureKeyAsync(
+      credentialKey("github", "token"),
+      "ghp_supersecret",
+    );
 
     const result = await broker.browserFill({
       service: "github",
@@ -389,7 +392,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["s3_upload", "cloudfront_invalidate"],
         allowedDomains: [],
       });
-      setSecureKey(credentialKey("aws", "access_key"), "AKIA_test");
+      await setSecureKeyAsync(credentialKey("aws", "access_key"), "AKIA_test");
 
       let fillCalled = false;
       const result = await broker.browserFill({
@@ -414,7 +417,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["browser_fill_credential"],
         allowedDomains: ["github.com"],
       });
-      setSecureKey(credentialKey("github", "pat"), "ghp_fill_test");
+      await setSecureKeyAsync(credentialKey("github", "pat"), "ghp_fill_test");
 
       let fillCalled = false;
       const result = await broker.browserFill({
@@ -438,7 +441,7 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["slack_post"],
         allowedDomains: ["slack.com"],
       });
-      setSecureKey(credentialKey("slack", "bot_token"), "xoxb-test");
+      await setSecureKeyAsync(credentialKey("slack", "bot_token"), "xoxb-test");
 
       const result = await broker.browserFill({
         service: "slack",
@@ -461,7 +464,7 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("custom", "key", {
         allowedTools: [],
       });
-      setSecureKey(credentialKey("custom", "key"), "secret");
+      await setSecureKeyAsync(credentialKey("custom", "key"), "secret");
 
       const result = await broker.browserFill({
         service: "custom",
@@ -491,7 +494,7 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("github", "token", {
         allowedTools: ["browser_fill_credential"],
       });
-      setSecureKey(credentialKey("github", "token"), "ghp_updated");
+      await setSecureKeyAsync(credentialKey("github", "token"), "ghp_updated");
 
       let filledValue: string | undefined;
       const result = await broker.browserFill({
@@ -515,8 +518,8 @@ describe("CredentialBroker.browserFill", () => {
       upsertCredentialMetadata("github", "password", {
         allowedTools: ["other_tool"],
       });
-      setSecureKey(credentialKey("github", "username"), "octocat");
-      setSecureKey(credentialKey("github", "password"), "hunter2");
+      await setSecureKeyAsync(credentialKey("github", "username"), "octocat");
+      await setSecureKeyAsync(credentialKey("github", "password"), "hunter2");
 
       // username allows browser_fill_credential
       const r1 = await broker.browserFill({
@@ -549,8 +552,8 @@ describe("CredentialBroker.browserFill", () => {
         allowedTools: ["browser_fill_credential"],
         allowedDomains: ["gitlab.com"],
       });
-      setSecureKey(credentialKey("github", "token"), "gh_tok");
-      setSecureKey(credentialKey("gitlab", "token"), "gl_tok");
+      await setSecureKeyAsync(credentialKey("github", "token"), "gh_tok");
+      await setSecureKeyAsync(credentialKey("gitlab", "token"), "gl_tok");
 
       // github credential on github.com succeeds
       let filled1 = "";

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -49,7 +49,7 @@ mock.module("../tools/registry.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { credentialKey } from "../security/credential-key.js";
-import { setSecureKey } from "../security/secure-keys.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
@@ -86,7 +86,10 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -110,7 +113,10 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -162,7 +168,10 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -183,7 +192,10 @@ describe("CredentialBroker.serverUse", () => {
     upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["publish_page"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -202,7 +214,10 @@ describe("CredentialBroker.serverUse", () => {
       allowedTools: ["publish_page"],
       allowedDomains: ["vercel.com"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -223,7 +238,10 @@ describe("CredentialBroker.serverUse", () => {
       allowedTools: ["publish_page"],
       allowedDomains: [],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUse({
       service: "vercel",
@@ -248,7 +266,7 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("aws", "access_key", {
         allowedTools: ["deploy_lambda", "s3_upload"],
       });
-      setSecureKey(credentialKey("aws", "access_key"), "AKIA_test");
+      await setSecureKeyAsync(credentialKey("aws", "access_key"), "AKIA_test");
 
       const result = await broker.serverUse({
         service: "aws",
@@ -271,7 +289,10 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("stripe", "secret_key", {
         allowedTools: [],
       });
-      setSecureKey(credentialKey("stripe", "secret_key"), "sk_test_xyz");
+      await setSecureKeyAsync(
+        credentialKey("stripe", "secret_key"),
+        "sk_test_xyz",
+      );
 
       const result = await broker.serverUse({
         service: "stripe",
@@ -292,7 +313,10 @@ describe("CredentialBroker.serverUse", () => {
         allowedTools: ["git_push"],
         allowedDomains: ["github.com"],
       });
-      setSecureKey(credentialKey("github", "oauth_token"), "gho_test");
+      await setSecureKeyAsync(
+        credentialKey("github", "oauth_token"),
+        "gho_test",
+      );
 
       const result = await broker.serverUse({
         service: "github",
@@ -323,7 +347,10 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("vercel", "api_token", {
         allowedTools: ["publish_page", "unpublish_page"],
       });
-      setSecureKey(credentialKey("vercel", "api_token"), "tok_updated");
+      await setSecureKeyAsync(
+        credentialKey("vercel", "api_token"),
+        "tok_updated",
+      );
 
       const result = await broker.serverUse({
         service: "vercel",
@@ -343,8 +370,11 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("vercel", "deploy_hook", {
         allowedTools: ["trigger_deploy"],
       });
-      setSecureKey(credentialKey("vercel", "api_token"), "tok_api");
-      setSecureKey(credentialKey("vercel", "deploy_hook"), "hook_secret");
+      await setSecureKeyAsync(credentialKey("vercel", "api_token"), "tok_api");
+      await setSecureKeyAsync(
+        credentialKey("vercel", "deploy_hook"),
+        "hook_secret",
+      );
 
       // api_token should deny trigger_deploy
       const r1 = await broker.serverUse({
@@ -378,8 +408,8 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("gitlab", "api_token", {
         allowedTools: ["gitlab_api"],
       });
-      setSecureKey(credentialKey("github", "api_token"), "gh_tok");
-      setSecureKey(credentialKey("gitlab", "api_token"), "gl_tok");
+      await setSecureKeyAsync(credentialKey("github", "api_token"), "gh_tok");
+      await setSecureKeyAsync(credentialKey("gitlab", "api_token"), "gl_tok");
 
       // github credential should not serve gitlab tool
       const r1 = await broker.serverUseById({
@@ -396,8 +426,8 @@ describe("CredentialBroker.serverUse", () => {
       upsertCredentialMetadata("gitlab", "api_token", {
         allowedTools: ["gitlab_api"],
       });
-      setSecureKey(credentialKey("github", "api_token"), "gh_tok");
-      setSecureKey(credentialKey("gitlab", "api_token"), "gl_tok");
+      await setSecureKeyAsync(credentialKey("github", "api_token"), "gh_tok");
+      await setSecureKeyAsync(credentialKey("gitlab", "api_token"), "gl_tok");
 
       // github credential should not serve gitlab tool
       const r1 = await broker.serverUse({
@@ -459,7 +489,7 @@ describe("CredentialBroker.serverUseById", () => {
         },
       ],
     });
-    setSecureKey(credentialKey("fal", "api_key"), "fal-secret-key");
+    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,
@@ -484,7 +514,7 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("fal", "api_key", {
       allowedTools: ["media_proxy"],
     });
-    setSecureKey(credentialKey("fal", "api_key"), "fal-secret-key");
+    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,
@@ -515,7 +545,7 @@ describe("CredentialBroker.serverUseById", () => {
       allowedTools: ["media_proxy"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "oauth_token"), "gho_test");
+    await setSecureKeyAsync(credentialKey("github", "oauth_token"), "gho_test");
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,
@@ -532,7 +562,10 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("vercel", "api_token", {
       allowedTools: ["media_proxy"],
     });
-    setSecureKey(credentialKey("vercel", "api_token"), "test-vercel-token");
+    await setSecureKeyAsync(
+      credentialKey("vercel", "api_token"),
+      "test-vercel-token",
+    );
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,
@@ -548,7 +581,10 @@ describe("CredentialBroker.serverUseById", () => {
     const meta = upsertCredentialMetadata("stripe", "secret_key", {
       allowedTools: [],
     });
-    setSecureKey(credentialKey("stripe", "secret_key"), "sk_test_xyz");
+    await setSecureKeyAsync(
+      credentialKey("stripe", "secret_key"),
+      "sk_test_xyz",
+    );
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -65,7 +65,10 @@ mock.module("../tools/registry.js", () => ({
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { credentialKey } from "../security/credential-key.js";
 import { redactSensitiveFields } from "../security/redaction.js";
-import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
+import {
+  getSecureKeyAsync,
+  setSecureKeyAsync,
+} from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
@@ -438,7 +441,7 @@ describe("Invariant 4: credentials only used for allowed purpose", () => {
         allowedTools: tc.allowedTools,
         allowedDomains: tc.allowedDomains,
       });
-      setSecureKey(
+      await setSecureKeyAsync(
         credentialKey(tc.credentialId, "token"),
         "test-secret-value",
       );
@@ -466,7 +469,7 @@ describe("Invariant 4: credentials only used for allowed purpose", () => {
       allowedTools: ["browser_fill_credential"],
       allowedDomains: ["github.com"],
     });
-    setSecureKey(credentialKey("github", "token"), "ghp_secret123");
+    await setSecureKeyAsync(credentialKey("github", "token"), "ghp_secret123");
 
     const result = await broker.browserFill({
       service: "github",
@@ -530,8 +533,8 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
     expect("oauth2ClientId" in record).toBe(false);
   });
 
-  test("client secret is read from secure store, not metadata", () => {
-    setSecureKey(
+  test("client secret is read from secure store, not metadata", async () => {
+    await setSecureKeyAsync(
       credentialKey("integration:google", "client_secret"),
       "my-secret",
     );
@@ -548,7 +551,9 @@ describe("Invariant 6: oauth2ClientSecret not in metadata, only in secure store"
 
     // Secret is in secure store
     expect(
-      getSecureKey(credentialKey("integration:google", "client_secret")),
+      await getSecureKeyAsync(
+        credentialKey("integration:google", "client_secret"),
+      ),
     ).toBe("my-secret");
   });
 

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -105,7 +105,10 @@ mock.module("../security/oauth2.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKey, setSecureKey } from "../security/secure-keys.js";
+import {
+  getSecureKeyAsync,
+  setSecureKeyAsync,
+} from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
@@ -205,7 +208,7 @@ describe("CredentialBroker transient credentials", () => {
     upsertCredentialMetadata("github", "token", {
       allowedTools: ["browser_fill_credential"],
     });
-    setSecureKey(credentialKey("github", "token"), "stored-value");
+    await setSecureKeyAsync(credentialKey("github", "token"), "stored-value");
     broker.injectTransient("github", "token", "transient-value");
 
     // First fill uses transient
@@ -468,9 +471,9 @@ describe("credential_store tool — prompt action", () => {
     expect(result.content).not.toContain("prompt-secret-val");
 
     // Verify stored
-    expect(getSecureKey(credentialKey("test-prompt", "api_key"))).toBe(
-      "prompt-secret-val",
-    );
+    expect(
+      await getSecureKeyAsync(credentialKey("test-prompt", "api_key")),
+    ).toBe("prompt-secret-val");
   });
 
   test("prompt with policy fields persists metadata", async () => {
@@ -702,7 +705,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       callbackTransport: "loopback",
       loopbackPort: 8756,
     }));
-    setSecureKey("oauth_app/test-app-id/client_secret", "test-secret");
+    await setSecureKeyAsync(
+      "oauth_app/test-app-id/client_secret",
+      "test-secret",
+    );
 
     const result = await credentialStoreTool.execute(
       {
@@ -756,7 +762,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       callbackTransport: "loopback",
       loopbackPort: 8756,
     }));
-    setSecureKey("oauth_app/matched-app-id/client_secret", "matched-secret");
+    await setSecureKeyAsync(
+      "oauth_app/matched-app-id/client_secret",
+      "matched-secret",
+    );
 
     const result = await credentialStoreTool.execute(
       {
@@ -797,7 +806,10 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       callbackTransport: "loopback",
       loopbackPort: 8756,
     }));
-    setSecureKey("oauth_app/recent-app-id/client_secret", "recent-secret");
+    await setSecureKeyAsync(
+      "oauth_app/recent-app-id/client_secret",
+      "recent-secret",
+    );
 
     const result = await credentialStoreTool.execute(
       {
@@ -1024,7 +1036,9 @@ describe("credential_store tool — store validation edge cases", () => {
     );
 
     // Verify stored
-    expect(getSecureKey(credentialKey("del-test", "key"))).toBe("secret");
+    expect(await getSecureKeyAsync(credentialKey("del-test", "key"))).toBe(
+      "secret",
+    );
     const { getCredentialMetadata } =
       await import("../tools/credentials/metadata-store.js");
     expect(getCredentialMetadata("del-test", "key")).toBeDefined();
@@ -1041,7 +1055,9 @@ describe("credential_store tool — store validation edge cases", () => {
     expect(result.isError).toBe(false);
 
     // Both should be gone
-    expect(getSecureKey(credentialKey("del-test", "key"))).toBeUndefined();
+    expect(
+      await getSecureKeyAsync(credentialKey("del-test", "key")),
+    ).toBeUndefined();
     expect(getCredentialMetadata("del-test", "key")).toBeUndefined();
   });
 });
@@ -1130,7 +1146,7 @@ describe("CredentialBroker — serverUseById edge cases", () => {
         },
       ],
     });
-    setSecureKey(credentialKey("multi", "api_key"), "multi-secret");
+    await setSecureKeyAsync(credentialKey("multi", "api_key"), "multi-secret");
 
     const result = await broker.serverUseById({
       credentialId: meta.credentialId,

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -132,13 +132,13 @@ mock.module("../oauth/oauth-store.js", () => {
 // Import the module under test
 // ---------------------------------------------------------------------------
 
-// getCredentialValue is no longer exported (sealed in PR 17) — use getSecureKey directly
+// getCredentialValue is no longer exported (sealed in PR 17) — use getSecureKeyAsync directly
 
 import { credentialKey } from "../security/credential-key.js";
 import {
-  deleteSecureKey,
-  getSecureKey,
-  setSecureKey,
+  deleteSecureKeyAsync,
+  getSecureKeyAsync,
+  setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import {
   _resetInflightRefreshes,
@@ -210,7 +210,7 @@ async function executeVault(
       }
 
       const key = credentialKey(service, field);
-      const ok = setSecureKey(key, value);
+      const ok = await setSecureKeyAsync(key, value);
       if (!ok) {
         return { content: "Error: failed to store credential", isError: true };
       }
@@ -241,7 +241,7 @@ async function executeVault(
       }
 
       const key = credentialKey(service, field);
-      const result = deleteSecureKey(key);
+      const result = await deleteSecureKeyAsync(key);
       if (result !== "deleted") {
         return {
           content: `Error: credential ${service}/${field} not found`,
@@ -645,7 +645,7 @@ describe("credential_store tool", () => {
 
       // Delete the secret directly without going through the tool (simulates
       // a divergence where metadata write failed after secret deletion)
-      deleteSecureKey(credentialKey("svc-a", "key"));
+      await deleteSecureKeyAsync(credentialKey("svc-a", "key"));
 
       const result = await credentialStoreTool.execute(
         { action: "list" },
@@ -688,7 +688,7 @@ describe("credential_store tool", () => {
   // -----------------------------------------------------------------------
   describe("delete action", () => {
     test("deletes a stored credential", async () => {
-      setSecureKey(credentialKey("gmail", "password"), "secret");
+      await setSecureKeyAsync(credentialKey("gmail", "password"), "secret");
 
       const result = await executeVault({
         action: "delete",
@@ -699,7 +699,9 @@ describe("credential_store tool", () => {
       expect(result.content).toBe("Deleted credential for gmail/password.");
 
       // Verify it's actually gone
-      expect(getSecureKey(credentialKey("gmail", "password"))).toBeUndefined();
+      expect(
+        await getSecureKeyAsync(credentialKey("gmail", "password")),
+      ).toBeUndefined();
     });
 
     test("returns error for non-existent credential", async () => {
@@ -773,14 +775,16 @@ describe("credential_store tool", () => {
   // Credential value access (sealed — only via secure-keys internally)
   // -----------------------------------------------------------------------
   describe("credential value access", () => {
-    test("credential values are stored via secure keys", () => {
-      setSecureKey(credentialKey("github", "token"), "ghp_abc123");
-      expect(getSecureKey(credentialKey("github", "token"))).toBe("ghp_abc123");
+    test("credential values are stored via secure keys", async () => {
+      await setSecureKeyAsync(credentialKey("github", "token"), "ghp_abc123");
+      expect(await getSecureKeyAsync(credentialKey("github", "token"))).toBe(
+        "ghp_abc123",
+      );
     });
 
-    test("returns undefined for non-existent credential", () => {
+    test("returns undefined for non-existent credential", async () => {
       expect(
-        getSecureKey(credentialKey("nonexistent", "field")),
+        await getSecureKeyAsync(credentialKey("nonexistent", "field")),
       ).toBeUndefined();
     });
   });
@@ -1226,10 +1230,10 @@ describe("credential_store tool", () => {
         value: "github-pass",
       });
 
-      expect(getSecureKey(credentialKey("gmail", "password"))).toBe(
+      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toBe(
         "gmail-pass",
       );
-      expect(getSecureKey(credentialKey("github", "password"))).toBe(
+      expect(await getSecureKeyAsync(credentialKey("github", "password"))).toBe(
         "github-pass",
       );
     });
@@ -1248,10 +1252,12 @@ describe("credential_store tool", () => {
         value: "backup@example.com",
       });
 
-      expect(getSecureKey(credentialKey("gmail", "password"))).toBe("pass123");
-      expect(getSecureKey(credentialKey("gmail", "recovery_email"))).toBe(
-        "backup@example.com",
+      expect(await getSecureKeyAsync(credentialKey("gmail", "password"))).toBe(
+        "pass123",
       );
+      expect(
+        await getSecureKeyAsync(credentialKey("gmail", "recovery_email")),
+      ).toBe("backup@example.com");
     });
   });
 });
@@ -1303,7 +1309,7 @@ describe("withValidToken refresh deduplication", () => {
    * OAuth-specific fields (tokenUrl, clientId, expiresAt) are now stored
    * in the SQLite oauth-store. The mock maps simulate the DB layer.
    */
-  function setupService(
+  async function setupService(
     service: string,
     opts?: { expired?: boolean; accessToken?: string },
   ) {
@@ -1315,7 +1321,10 @@ describe("withValidToken refresh deduplication", () => {
 
     // Store access token under the oauth_connection key path that
     // withValidToken reads (not the legacy credentialKey path).
-    setSecureKey(`oauth_connection/${connId}/access_token`, accessToken);
+    await setSecureKeyAsync(
+      `oauth_connection/${connId}/access_token`,
+      accessToken,
+    );
     mockProviders.set(service, {
       key: service,
       tokenUrl: "https://oauth.example.com/token",
@@ -1335,15 +1344,18 @@ describe("withValidToken refresh deduplication", () => {
         : Date.now() + 3600_000, // expires in 1 hour
     });
     // Store refresh token and client_secret in secure keys (token-manager reads them)
-    setSecureKey(
+    await setSecureKeyAsync(
       `oauth_connection/${connId}/refresh_token`,
       "valid-refresh-token",
     );
-    setSecureKey(`oauth_app/${appId}/client_secret`, "test-client-secret");
+    await setSecureKeyAsync(
+      `oauth_app/${appId}/client_secret`,
+      "test-client-secret",
+    );
   }
 
   test("3 concurrent 401 refreshes for the same service call doRefresh exactly once", async () => {
-    setupService("integration:google");
+    await setupService("integration:google");
 
     let resolveRefresh!: (value: {
       accessToken: string;
@@ -1391,8 +1403,8 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("concurrent refreshes for different services proceed independently", async () => {
-    setupService("integration:google");
-    setupService("integration:slack");
+    await setupService("integration:google");
+    await setupService("integration:slack");
 
     let resolveGmail!: (value: {
       accessToken: string;
@@ -1455,7 +1467,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication cleans up after refresh completes, allowing subsequent refreshes", async () => {
-    setupService("integration:google");
+    await setupService("integration:google");
 
     let refreshCount = 0;
     mockRefreshOAuth2Token.mockImplementation(() => {
@@ -1495,7 +1507,7 @@ describe("withValidToken refresh deduplication", () => {
   });
 
   test("deduplication propagates refresh errors to all waiting callers", async () => {
-    setupService("integration:google");
+    await setupService("integration:google");
 
     mockRefreshOAuth2Token.mockImplementation(() =>
       Promise.reject(

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -71,14 +71,11 @@ import { _setStorePath } from "../security/encrypted-store.js";
 import {
   _resetBackend,
   _setBackend,
-  deleteSecureKey,
   deleteSecureKeyAsync,
   getBackendType,
-  getSecureKey,
   getSecureKeyAsync,
   isDowngradedFromKeychain,
   listSecureKeys,
-  setSecureKey,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 
@@ -141,68 +138,35 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // CRUD operations (via encrypted store backend — sync)
+  // CRUD operations (via encrypted store backend — async)
   // -----------------------------------------------------------------------
-  describe("CRUD with encrypted backend (sync)", () => {
-    test("set and get a key", () => {
-      setSecureKey("openai", "sk-openai-789");
-      expect(getSecureKey("openai")).toBe("sk-openai-789");
+  describe("CRUD with encrypted backend (async)", () => {
+    test("set and get a key", async () => {
+      await setSecureKeyAsync("openai", "sk-openai-789");
+      expect(await getSecureKeyAsync("openai")).toBe("sk-openai-789");
     });
 
-    test("get returns undefined for nonexistent key", () => {
-      expect(getSecureKey("nonexistent")).toBeUndefined();
+    test("get returns undefined for nonexistent key", async () => {
+      expect(await getSecureKeyAsync("nonexistent")).toBeUndefined();
     });
 
-    test("delete removes a key", () => {
-      setSecureKey("gemini", "gem-key");
-      expect(deleteSecureKey("gemini")).toBe("deleted");
-      expect(getSecureKey("gemini")).toBeUndefined();
+    test("delete removes a key", async () => {
+      await setSecureKeyAsync("gemini", "gem-key");
+      expect(await deleteSecureKeyAsync("gemini")).toBe("deleted");
+      expect(await getSecureKeyAsync("gemini")).toBeUndefined();
     });
 
-    test("delete returns not-found for nonexistent key", () => {
-      expect(deleteSecureKey("missing")).toBe("not-found");
+    test("delete returns not-found for nonexistent key", async () => {
+      expect(await deleteSecureKeyAsync("missing")).toBe("not-found");
     });
 
-    test("listSecureKeys returns all keys", () => {
-      setSecureKey("anthropic", "val1");
-      setSecureKey("openai", "val2");
+    test("listSecureKeys returns all keys", async () => {
+      await setSecureKeyAsync("anthropic", "val1");
+      await setSecureKeyAsync("openai", "val2");
       const keys = listSecureKeys();
       expect(keys).toContain("anthropic");
       expect(keys).toContain("openai");
       expect(keys.length).toBe(2);
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // Sync variants always use encrypted store even when broker is available
-  // -----------------------------------------------------------------------
-  describe("sync variants ignore broker", () => {
-    test("getSecureKey uses encrypted store even when broker is available", () => {
-      mockBrokerAvailable = true;
-      mockBrokerStore.set("api-key", "broker-value");
-      // Sync getter should not see broker-only keys
-      expect(getSecureKey("api-key")).toBeUndefined();
-      // But encrypted store keys should work
-      setSecureKey("api-key", "encrypted-value");
-      expect(getSecureKey("api-key")).toBe("encrypted-value");
-    });
-
-    test("setSecureKey uses encrypted store even when broker is available", () => {
-      mockBrokerAvailable = true;
-      setSecureKey("api-key", "encrypted-value");
-      expect(getSecureKey("api-key")).toBe("encrypted-value");
-      // Should not have written to broker
-      expect(mockBrokerStore.has("api-key")).toBe(false);
-    });
-
-    test("deleteSecureKey uses encrypted store even when broker is available", () => {
-      mockBrokerAvailable = true;
-      mockBrokerStore.set("api-key", "broker-value");
-      setSecureKey("api-key", "encrypted-value");
-      deleteSecureKey("api-key");
-      expect(getSecureKey("api-key")).toBeUndefined();
-      // Broker value should be untouched
-      expect(mockBrokerStore.has("api-key")).toBe(true);
     });
   });
 
@@ -213,7 +177,7 @@ describe("secure-keys", () => {
     test("getSecureKeyAsync returns encrypted store value when both stores have key", async () => {
       mockBrokerAvailable = true;
       mockBrokerStore.set("api-key", "broker-value");
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       // Encrypted store is checked first — broker is never called
       expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
       expect(mockBrokerGetCalled).toBe(false);
@@ -223,7 +187,7 @@ describe("secure-keys", () => {
       mockBrokerAvailable = true;
       // Only encrypted store has the key — broker has nothing.
       // Encrypted store is checked first, so broker.get() is never called.
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
       expect(mockBrokerGetCalled).toBe(false);
     });
@@ -239,7 +203,7 @@ describe("secure-keys", () => {
       mockBrokerGetError = true;
       // Encrypted store hit short-circuits — broker is never called, so
       // the broker error flag is irrelevant.
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
       expect(mockBrokerGetCalled).toBe(false);
     });
@@ -249,8 +213,8 @@ describe("secure-keys", () => {
       const result = await setSecureKeyAsync("api-key", "new-value");
       expect(result).toBe(true);
       expect(mockBrokerStore.get("api-key")).toBe("new-value");
-      // Also persisted to encrypted store for sync callers
-      expect(getSecureKey("api-key")).toBe("new-value");
+      // Also persisted to encrypted store
+      expect(await getSecureKeyAsync("api-key")).toBe("new-value");
     });
 
     test("setSecureKeyAsync returns false on broker set error (no silent fallback)", async () => {
@@ -262,29 +226,29 @@ describe("secure-keys", () => {
       expect(result).toBe(false);
       expect(mockBrokerStore.has("api-key")).toBe(false);
       // Encrypted store should NOT have been written either.
-      expect(getSecureKey("api-key")).toBeUndefined();
+      expect(await getSecureKeyAsync("api-key")).toBeUndefined();
     });
 
     test("deleteSecureKeyAsync deletes from broker and encrypted store", async () => {
       mockBrokerAvailable = true;
       mockBrokerStore.set("api-key", "broker-value");
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("deleted");
       expect(mockBrokerStore.has("api-key")).toBe(false);
-      expect(getSecureKey("api-key")).toBeUndefined();
+      expect(await getSecureKeyAsync("api-key")).toBeUndefined();
     });
 
     test("deleteSecureKeyAsync returns error on broker del error (no silent fallback)", async () => {
       mockBrokerAvailable = true;
       mockBrokerDelError = true;
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       const result = await deleteSecureKeyAsync("api-key");
       // Must return "error" — falling through to encrypted-only delete would
       // leave the broker with the key, and async readers would still see it.
       expect(result).toBe("error");
       // Encrypted store should NOT have been modified either.
-      expect(getSecureKey("api-key")).toBe("encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
     });
   });
 
@@ -293,7 +257,7 @@ describe("secure-keys", () => {
   // -----------------------------------------------------------------------
   describe("async variants with broker unavailable", () => {
     test("getSecureKeyAsync uses encrypted store", async () => {
-      setSecureKey("api-key", "encrypted-value");
+      await setSecureKeyAsync("api-key", "encrypted-value");
       expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
     });
 
@@ -304,14 +268,14 @@ describe("secure-keys", () => {
     test("setSecureKeyAsync uses encrypted store", async () => {
       const result = await setSecureKeyAsync("api-key", "new-value");
       expect(result).toBe(true);
-      expect(getSecureKey("api-key")).toBe("new-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("new-value");
     });
 
     test("deleteSecureKeyAsync uses encrypted store", async () => {
-      setSecureKey("api-key", "value");
+      await setSecureKeyAsync("api-key", "value");
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("deleted");
-      expect(getSecureKey("api-key")).toBeUndefined();
+      expect(await getSecureKeyAsync("api-key")).toBeUndefined();
     });
   });
 
@@ -321,7 +285,7 @@ describe("secure-keys", () => {
   describe("encrypted-store-first read order", () => {
     test("returns value from encrypted store without calling broker", async () => {
       mockBrokerAvailable = true;
-      setSecureKey("test-account", "test-secret");
+      await setSecureKeyAsync("test-account", "test-secret");
       mockBrokerStore.set("test-account", "broker-secret");
 
       const result = await getSecureKeyAsync("test-account");
@@ -369,7 +333,7 @@ describe("secure-keys", () => {
       mockBrokerAvailable = true;
       // Simulate broker holding an old value
       mockBrokerStore.set("api-key", "old-broker-value");
-      setSecureKey("api-key", "old-encrypted-value");
+      await setSecureKeyAsync("api-key", "old-encrypted-value");
 
       // Update via async path (writes both broker + encrypted)
       const ok = await setSecureKeyAsync("api-key", "new-value");
@@ -380,13 +344,13 @@ describe("secure-keys", () => {
       expect(value).toBe("new-value");
       // Both stores should agree
       expect(mockBrokerStore.get("api-key")).toBe("new-value");
-      expect(getSecureKey("api-key")).toBe("new-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("new-value");
     });
 
     test("deleteSecureKeyAsync removes from both stores so read returns undefined", async () => {
       mockBrokerAvailable = true;
       mockBrokerStore.set("api-key", "old-broker-value");
-      setSecureKey("api-key", "old-encrypted-value");
+      await setSecureKeyAsync("api-key", "old-encrypted-value");
 
       // Delete via async path (deletes from both broker + encrypted)
       const result = await deleteSecureKeyAsync("api-key");
@@ -397,15 +361,14 @@ describe("secure-keys", () => {
       expect(value).toBeUndefined();
     });
 
-    test("sync setSecureKey updates encrypted store — encrypted-store-first read returns fresh value", async () => {
+    test("setSecureKeyAsync updates encrypted store — encrypted-store-first read returns fresh value", async () => {
       mockBrokerAvailable = true;
       mockBrokerStore.set("api-key", "old-broker-value");
 
-      // Sync write only updates encrypted store, NOT broker
-      setSecureKey("api-key", "new-encrypted-value");
+      // Async write updates both broker and encrypted store
+      await setSecureKeyAsync("api-key", "new-encrypted-value");
 
-      // Encrypted-store-first read returns the fresh encrypted value,
-      // bypassing the stale broker entirely.
+      // Encrypted-store-first read returns the fresh encrypted value
       const value = await getSecureKeyAsync("api-key");
       expect(value).toBe("new-encrypted-value");
       expect(mockBrokerGetCalled).toBe(false);
@@ -415,28 +378,33 @@ describe("secure-keys", () => {
       mockBrokerAvailable = true;
       mockBrokerSetError = true;
       mockBrokerStore.set("api-key", "original-value");
-      setSecureKey("api-key", "original-value");
+      // Pre-seed encrypted store directly via broker mock bypass:
+      // We need the encrypted store to have the value before testing failure.
+      // Temporarily disable broker error to seed, then re-enable.
+      mockBrokerSetError = false;
+      await setSecureKeyAsync("api-key", "original-value");
+      mockBrokerSetError = true;
 
       const ok = await setSecureKeyAsync("api-key", "new-value");
       expect(ok).toBe(false);
 
       // Both stores should retain original value — no partial update
       expect(mockBrokerStore.get("api-key")).toBe("original-value");
-      expect(getSecureKey("api-key")).toBe("original-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("original-value");
     });
 
     test("deleteSecureKeyAsync failure leaves both stores unchanged", async () => {
       mockBrokerAvailable = true;
-      mockBrokerDelError = true;
       mockBrokerStore.set("api-key", "value");
-      setSecureKey("api-key", "value");
+      await setSecureKeyAsync("api-key", "value");
+      mockBrokerDelError = true;
 
       const result = await deleteSecureKeyAsync("api-key");
       expect(result).toBe("error");
 
       // Both stores should retain the key — no partial deletion
       expect(mockBrokerStore.has("api-key")).toBe(true);
-      expect(getSecureKey("api-key")).toBe("value");
+      expect(await getSecureKeyAsync("api-key")).toBe("value");
     });
   });
 
@@ -444,16 +412,16 @@ describe("secure-keys", () => {
   // _setBackend / _resetBackend (no-ops kept for test compat)
   // -----------------------------------------------------------------------
   describe("_setBackend", () => {
-    test("_setBackend is a no-op but does not throw", () => {
+    test("_setBackend is a no-op but does not throw", async () => {
       _setBackend("encrypted");
-      setSecureKey("test", "value");
+      await setSecureKeyAsync("test", "value");
       expect(existsSync(STORE_PATH)).toBe(true);
     });
 
-    test("_resetBackend is a no-op but does not throw", () => {
+    test("_resetBackend is a no-op but does not throw", async () => {
       _resetBackend();
-      setSecureKey("test", "value");
-      expect(getSecureKey("test")).toBe("value");
+      await setSecureKeyAsync("test", "value");
+      expect(await getSecureKeyAsync("test")).toBe("value");
     });
   });
 });

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -117,7 +117,7 @@ mock.module("./oauth-store.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { setSecureKey } from "../security/secure-keys.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
 import {
   _resetInflightRefreshes,
   _resetRefreshBreakers,
@@ -183,7 +183,7 @@ afterEach(() => {
   }
 });
 
-function setupCredential(
+async function setupCredential(
   service: string,
   opts?: { expiresAt?: number; grantedScopes?: string[] },
 ) {
@@ -214,13 +214,19 @@ function setupCredential(
     accountInfo: null,
   });
   // Store access token in oauth-store key format
-  setSecureKey(`oauth_connection/${connId}/access_token`, "test-access-token");
+  await setSecureKeyAsync(
+    `oauth_connection/${connId}/access_token`,
+    "test-access-token",
+  );
   // Store refresh token and client_secret in secure keys (token-manager reads them)
-  setSecureKey(
+  await setSecureKeyAsync(
     `oauth_connection/${connId}/refresh_token`,
     "test-refresh-token",
   );
-  setSecureKey(`oauth_app/${appId}/client_secret`, "test-client-secret");
+  await setSecureKeyAsync(
+    `oauth_app/${appId}/client_secret`,
+    "test-client-secret",
+  );
   upsertCredentialMetadata(service, "access_token", {});
 }
 
@@ -242,7 +248,7 @@ function createConnection(service = "integration:google"): BYOOAuthConnection {
 describe("BYOOAuthConnection", () => {
   describe("request()", () => {
     test("makes authenticated request with Bearer token", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       const result = await conn.request({
@@ -266,7 +272,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("appends query parameters", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -282,7 +288,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("uses per-request baseUrl override", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -296,7 +302,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("sends JSON body for POST requests", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -316,7 +322,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries once on 401 response", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       // First call returns 401, second returns 200
@@ -344,7 +350,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles empty response body", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -361,7 +367,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("handles non-JSON response body", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -378,7 +384,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("returns response headers", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       globalThis.fetch = mock(() =>
@@ -402,7 +408,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("includes custom request headers", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       await conn.request({
@@ -421,7 +427,7 @@ describe("BYOOAuthConnection", () => {
   describe("proactive token refresh", () => {
     test("refreshes token when near expiry (within 5-minute buffer)", async () => {
       // Set token to expire in 2 minutes (within 5-min buffer)
-      setupCredential("integration:google", {
+      await setupCredential("integration:google", {
         expiresAt: Date.now() + 2 * 60 * 1000,
       });
       const conn = createConnection();
@@ -445,7 +451,7 @@ describe("BYOOAuthConnection", () => {
 
   describe("withToken()", () => {
     test("provides valid token to callback", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       const result = await conn.withToken(async (token) => {
@@ -456,7 +462,7 @@ describe("BYOOAuthConnection", () => {
     });
 
     test("retries callback on 401 error", async () => {
-      setupCredential("integration:google");
+      await setupCredential("integration:google");
       const conn = createConnection();
 
       let callCount = 0;
@@ -489,7 +495,7 @@ describe("BYOOAuthConnection", () => {
 
 describe("resolveOAuthConnection", () => {
   test("returns a BYOOAuthConnection for valid credential", async () => {
-    setupCredential("integration:google");
+    await setupCredential("integration:google");
     const conn = await resolveOAuthConnection("integration:google");
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
@@ -504,7 +510,7 @@ describe("resolveOAuthConnection", () => {
   });
 
   test("throws when no base URL configured", async () => {
-    setupCredential("integration:custom-service");
+    await setupCredential("integration:custom-service");
     await expect(
       resolveOAuthConnection("integration:custom-service"),
     ).rejects.toThrow(
@@ -541,7 +547,10 @@ describe("resolveOAuthConnection", () => {
       grantedScopes: JSON.stringify(["repo"]),
       accountInfo: null,
     });
-    setSecureKey(`oauth_connection/${connId}/access_token`, "ghp-test-token");
+    await setSecureKeyAsync(
+      `oauth_connection/${connId}/access_token`,
+      "ghp-test-token",
+    );
 
     const conn = await resolveOAuthConnection("integration:github-work");
 


### PR DESCRIPTION
## Summary
- Convert 7 test files from sync getSecureKey/setSecureKey/deleteSecureKey to async variants
- Make helper functions async and propagate await to all call sites
- Remove sync-specific tests that will be obsolete when sync functions are deleted
- Preserve all core functionality tests by converting them to use async API

Part of plan: async-secure-final.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
