### PR TITLE
fix(build): use atomic mktemp -d for FIFO path allocation in build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -39,10 +39,11 @@ swift_with_retry() {
     # not tracked by `wait` in bash < 4.4 (macOS ships 3.2), so tee could
     # still be writing when grep reads the log. A named pipe with an explicit
     # tee PID gives correct synchronization on all bash versions.
-    local _fifo
-    _fifo=$(mktemp -u)
+    local _fifo_dir
+    _fifo_dir=$(mktemp -d)
+    local _fifo="$_fifo_dir/stderr.fifo"
     mkfifo "$_fifo"
-    trap "rm -f '$_stderr_log' '$_fifo'" RETURN
+    trap "rm -rf '$_stderr_log' '$_fifo_dir'" RETURN
     while true; do
         local _cmd_exit=0
         tee "$_stderr_log" >&2 < "$_fifo" &


### PR DESCRIPTION
Addresses Codex feedback on #16565. Replaces non-atomic mktemp -u + mkfifo with mktemp -d + mkfifo inside the directory, eliminating the TOCTOU race where another process could claim the temp path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
