### PR TITLE
fix(ios): encode remaining raw query values in HTTPDaemonClient

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -854,10 +854,10 @@ public final class HTTPTransport {
         case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
             var queryParts = ["limit=\(limit)", "offset=\(offset)"]
             if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? kind)") }
-            if let status { queryParts.append("status=\(status)") }
+            if let status { queryParts.append("status=\(status.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? status)") }
             if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? search)") }
-            if let sort { queryParts.append("sort=\(sort)") }
-            if let order { queryParts.append("order=\(order)") }
+            if let sort { queryParts.append("sort=\(sort.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? sort)") }
+            if let order { queryParts.append("order=\(order.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? order)") }
             return ("/v1/memory-items", queryParts.joined(separator: "&"))
         case .memoryItemGet(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
@@ -1267,10 +1267,10 @@ public final class HTTPTransport {
         case .memoryItemsList(let kind, let status, let search, let sort, let order, let limit, let offset):
             var queryParts = ["limit=\(limit)", "offset=\(offset)"]
             if let kind { queryParts.append("kind=\(kind.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? kind)") }
-            if let status { queryParts.append("status=\(status)") }
+            if let status { queryParts.append("status=\(status.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? status)") }
             if let search, !search.isEmpty { queryParts.append("search=\(search.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? search)") }
-            if let sort { queryParts.append("sort=\(sort)") }
-            if let order { queryParts.append("order=\(order)") }
+            if let sort { queryParts.append("sort=\(sort.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? sort)") }
+            if let order { queryParts.append("order=\(order.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? order)") }
             return ("\(prefix)/memory-items/", queryParts.joined(separator: "&"))
         case .memoryItemGet(let id):
             let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id


### PR DESCRIPTION
Addresses Devin feedback on #16571. Encodes status, sort, and order query parameter values with Self.queryValueAllowed in memoryItemsList, in both buildRuntimeFlatPath and buildPlatformProxyPath, completing the encoding standardization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
