### PR TITLE
refactor: convert embedding backend selection functions to async getSecureKeyAsync

### DIFF
--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -483,7 +483,7 @@ describe("Memory regressions (experimental)", () => {
     );
   });
 
-  test("indexing enqueues embed_segment, extract_items, and build_conversation_summary for user messages", () => {
+  test("indexing enqueues embed_segment, extract_items, and build_conversation_summary for user messages", async () => {
     const db = getDb();
     const createdAt = 2_000;
     db.insert(conversations)
@@ -512,7 +512,7 @@ describe("Memory regressions (experimental)", () => {
       })
       .run();
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-index",
         conversationId: "conv-index",
@@ -535,7 +535,7 @@ describe("Memory regressions (experimental)", () => {
     expect(embedSegmentJobs).toHaveLength(1);
   });
 
-  test("indexing skips durable item extraction for assistant messages when extractFromAssistant is false", () => {
+  test("indexing skips durable item extraction for assistant messages when extractFromAssistant is false", async () => {
     const db = getDb();
     const createdAt = 2_100;
     db.insert(conversations)
@@ -572,7 +572,7 @@ describe("Memory regressions (experimental)", () => {
       },
     };
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-assistant-index",
         conversationId: "conv-assistant-index",

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -178,7 +178,7 @@ describe("Memory regressions", () => {
   }
 
   // Baseline: indexMessageNow without explicit scopeId defaults to 'default'
-  test('baseline: memory segments default to scope "default" when no scopeId given', () => {
+  test('baseline: memory segments default to scope "default" when no scopeId given', async () => {
     const db = getDb();
     const now = Date.now();
     db.insert(conversations)
@@ -208,7 +208,7 @@ describe("Memory regressions", () => {
       .run();
 
     // Index without explicit scopeId — should use 'default'
-    indexMessageNow(
+    await indexMessageNow(
       {
         messageId: "msg-baseline-scope",
         conversationId: "conv-baseline-scope",
@@ -931,7 +931,7 @@ describe("Memory regressions", () => {
     expect(recent[1]?.id).toBe("seg-recent-2");
   });
 
-  test("explicit ollama memory embedding provider is honored without extra ollama config", () => {
+  test("explicit ollama memory embedding provider is honored without extra ollama config", async () => {
     const config = {
       ...DEFAULT_CONFIG,
       provider: "anthropic" as const,
@@ -944,7 +944,7 @@ describe("Memory regressions", () => {
       },
     };
 
-    const selection = selectEmbeddingBackend(config);
+    const selection = await selectEmbeddingBackend(config);
     expect(selection.backend?.provider).toBe("ollama");
     expect(selection.reason).toBeNull();
   });
@@ -1106,7 +1106,7 @@ describe("Memory regressions", () => {
     expect(recentEmbedding).toBeDefined();
   });
 
-  test("memory admin status reports cleanup backlog and 24h throughput metrics", () => {
+  test("memory admin status reports cleanup backlog and 24h throughput metrics", async () => {
     const db = getDb();
     const now = Date.now();
     const yesterday = now - 20 * 60 * 60 * 1000;
@@ -1153,7 +1153,7 @@ describe("Memory regressions", () => {
       ])
       .run();
 
-    const status = getMemorySystemStatus();
+    const status = await getMemorySystemStatus();
     expect(status.cleanup.supersededBacklog).toBe(1);
     expect(status.cleanup.supersededCompleted24h).toBe(1);
   });
@@ -1582,7 +1582,7 @@ describe("Memory regressions", () => {
     expect(item!.scopeId).toBe("project-abc");
   });
 
-  test("scope columns: segments get scopeId from indexer input", () => {
+  test("scope columns: segments get scopeId from indexer input", async () => {
     const db = getDb();
     const now = Date.now();
 
@@ -1612,7 +1612,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    indexMessageNow(
+    await indexMessageNow(
       {
         messageId: "msg-scope-test",
         conversationId: "conv-scope-test",
@@ -2947,7 +2947,7 @@ describe("Memory regressions", () => {
   });
 
   // Backfill preserves private conversation scope on memory segments
-  test("backfillJob preserves private conversation scope during reindex", () => {
+  test("backfillJob preserves private conversation scope during reindex", async () => {
     const db = getDb();
 
     // Create a private conversation with a message
@@ -2984,7 +2984,7 @@ describe("Memory regressions", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    backfillJob(fakeJob, TEST_CONFIG);
+    await backfillJob(fakeJob, TEST_CONFIG);
 
     // Verify the segments were indexed with the private scope
     const segments = db
@@ -2999,7 +2999,7 @@ describe("Memory regressions", () => {
     }
   });
 
-  test("backfillJob preserves provenance trust gating during reindex", () => {
+  test("backfillJob preserves provenance trust gating during reindex", async () => {
     const db = getDb();
 
     const conv = createConversation("Backfill provenance trust gate");
@@ -3032,7 +3032,7 @@ describe("Memory regressions", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
-    backfillJob(fakeJob, TEST_CONFIG);
+    await backfillJob(fakeJob, TEST_CONFIG);
 
     const segments = db
       .select()
@@ -3152,7 +3152,7 @@ describe("Memory regressions", () => {
 
   // ── Trust-aware extraction gating tests (M3) ───────────────────────
 
-  test("untrusted actor messages do not enqueue extract_items", () => {
+  test("untrusted actor messages do not enqueue extract_items", async () => {
     const db = getDb();
     const now = Date.now();
     db.insert(conversations)
@@ -3181,7 +3181,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-untrusted-gate",
         conversationId: "conv-untrusted-gate",
@@ -3211,7 +3211,7 @@ describe("Memory regressions", () => {
     expect(result.enqueuedJobs).toBe(expectedJobs);
   });
 
-  test("trusted guardian messages still enqueue extraction", () => {
+  test("trusted guardian messages still enqueue extraction", async () => {
     const db = getDb();
     const now = Date.now();
     db.insert(conversations)
@@ -3240,7 +3240,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-trusted-gate",
         conversationId: "conv-trusted-gate",
@@ -3270,7 +3270,7 @@ describe("Memory regressions", () => {
     expect(result.enqueuedJobs).toBeGreaterThan(result.indexedSegments + 1);
   });
 
-  test("legacy messages without provenance still enqueue extraction", () => {
+  test("legacy messages without provenance still enqueue extraction", async () => {
     const db = getDb();
     const now = Date.now();
     db.insert(conversations)
@@ -3299,7 +3299,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-legacy-gate",
         conversationId: "conv-legacy-gate",
@@ -3328,7 +3328,7 @@ describe("Memory regressions", () => {
     expect(result.enqueuedJobs).toBeGreaterThan(result.indexedSegments + 1);
   });
 
-  test("unverified_channel messages do not enqueue extract_items", () => {
+  test("unverified_channel messages do not enqueue extract_items", async () => {
     const db = getDb();
     const now = Date.now();
     db.insert(conversations)
@@ -3360,7 +3360,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    const result = indexMessageNow(
+    const result = await indexMessageNow(
       {
         messageId: "msg-unverified-gate",
         conversationId: "conv-unverified-gate",

--- a/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-retrieval.benchmark.test.ts
@@ -57,7 +57,7 @@ mock.module("../memory/search/semantic.js", () => ({
 }));
 
 mock.module("../memory/embedding-backend.js", () => ({
-  getMemoryBackendStatus: (config: { memory: { enabled: boolean } }) => ({
+  getMemoryBackendStatus: async (config: { memory: { enabled: boolean } }) => ({
     enabled: config.memory.enabled,
     degraded: false,
     provider: "local",

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -295,7 +295,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
     }
   });
 
-  test("re-indexing with identical content does not change the stored segment", () => {
+  test("re-indexing with identical content does not change the stored segment", async () => {
     // When an indexer re-processes an already-indexed segment (same id + same
     // content hash), the ON CONFLICT DO UPDATE path must run but the row must
     // remain semantically equivalent to the original.
@@ -308,7 +308,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
 
     const config = TEST_CONFIG.memory;
 
-    const firstResult = indexMessageNow(
+    const firstResult = await indexMessageNow(
       {
         messageId,
         conversationId,
@@ -327,7 +327,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       .all();
 
     // Re-index twice more with the same payload.
-    indexMessageNow(
+    await indexMessageNow(
       {
         messageId,
         conversationId,
@@ -337,7 +337,7 @@ describe("segment UPSERT atomicity under repeated indexer invocations", () => {
       },
       config,
     );
-    indexMessageNow(
+    await indexMessageNow(
       {
         messageId,
         conversationId,

--- a/assistant/src/__tests__/task-compiler.test.ts
+++ b/assistant/src/__tests__/task-compiler.test.ts
@@ -32,7 +32,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("./indexer.js", () => ({
-  indexMessageNow: () => {},
+  indexMessageNow: async () => ({ indexedSegments: 0, enqueuedJobs: 0 }),
 }));
 
 import type { Database } from "bun:sqlite";

--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -58,9 +58,9 @@ Fields shown:
 Examples:
   $ assistant memory status`,
     )
-    .action(() => {
+    .action(async () => {
       initializeDb();
-      const status = getMemorySystemStatus();
+      const status = await getMemorySystemStatus();
       log.info(`Memory enabled: ${status.enabled ? "yes" : "no"}`);
       log.info(`Memory degraded: ${status.degraded ? "yes" : "no"}`);
       if (status.reason) log.info(`Reason: ${status.reason}`);
@@ -112,9 +112,7 @@ Examples:
 
   memory
     .command("cleanup")
-    .description(
-      "Queue cleanup jobs for stale superseded items",
-    )
+    .description("Queue cleanup jobs for stale superseded items")
     .option(
       "--retention-ms <ms>",
       "Optional retention threshold in milliseconds",

--- a/assistant/src/cli/commands/sessions.ts
+++ b/assistant/src/cli/commands/sessions.ts
@@ -227,7 +227,7 @@ Examples:
 
       const config = getConfig();
       const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
-      const embeddingSelection = selectEmbeddingBackend(config);
+      const embeddingSelection = await selectEmbeddingBackend(config);
       const embeddingModel = embeddingSelection.backend
         ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
         : undefined;

--- a/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -164,7 +164,7 @@ export async function run(
       // Index with the original ChatGPT timestamp so memory segments
       // reflect actual message age, not import time
       try {
-        indexMessageNow(
+        await indexMessageNow(
           {
             messageId: dbMessages[i].id,
             conversationId: conversation.id,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -329,7 +329,7 @@ export async function runDaemon(): Promise<void> {
     const qdrantManager = new QdrantManager({ url: qdrantUrl });
     try {
       await qdrantManager.start();
-      const embeddingSelection = selectEmbeddingBackend(config);
+      const embeddingSelection = await selectEmbeddingBackend(config);
       const embeddingModel = embeddingSelection.backend
         ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
         : undefined;

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -35,9 +35,9 @@ interface CleanupStatsRow {
   superseded_completed_24h: number | null;
 }
 
-export function getMemorySystemStatus(): MemorySystemStatus {
+export async function getMemorySystemStatus(): Promise<MemorySystemStatus> {
   const config = getConfig();
-  const backend = getMemoryBackendStatus(config);
+  const backend = await getMemoryBackendStatus(config);
   const counts = {
     segments: countTable("memory_segments"),
     items: countTable("memory_items"),

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -369,7 +369,7 @@ export async function addMessage(
       const provenanceTrustClass = parsed?.success
         ? parsed.data.provenanceTrustClass
         : undefined;
-      indexMessageNow(
+      await indexMessageNow(
         {
           messageId: message.id,
           conversationId: message.conversationId,

--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { getOllamaBaseUrlEnv } from "../config/env.js";
 import type { AssistantConfig } from "../config/types.js";
-import { getSecureKey } from "../security/secure-keys.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
@@ -234,9 +234,9 @@ export interface EmbeddingBackendSelection {
   reason: string | null;
 }
 
-export function selectEmbeddingBackend(
+export async function selectEmbeddingBackend(
   config: AssistantConfig,
-): EmbeddingBackendSelection {
+): Promise<EmbeddingBackendSelection> {
   const requested = config.memory.embeddings.provider;
   if (requested === "local") {
     return {
@@ -250,13 +250,14 @@ export function selectEmbeddingBackend(
     };
   }
   if (requested === "ollama") {
+    const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
     return {
       backend: getCachedOrCreate(
         "ollama",
         config.memory.embeddings.ollamaModel,
         () =>
           new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
-            apiKey: getSecureKey("ollama") ?? undefined,
+            apiKey: ollamaKey,
           }),
       ),
       reason: null,
@@ -285,7 +286,7 @@ export function selectEmbeddingBackend(
           reason: null,
         };
       case "openai": {
-        const openaiKey = getSecureKey("openai");
+        const openaiKey = await getSecureKeyAsync("openai");
         if (!openaiKey) continue;
         return {
           backend: getCachedOrCreate(
@@ -301,7 +302,7 @@ export function selectEmbeddingBackend(
         };
       }
       case "gemini": {
-        const geminiKey = getSecureKey("gemini");
+        const geminiKey = await getSecureKeyAsync("gemini");
         if (!geminiKey) continue;
         return {
           backend: getCachedOrCreate(
@@ -321,19 +322,21 @@ export function selectEmbeddingBackend(
           reason: null,
         };
       }
-      case "ollama":
-        if (!isOllamaConfigured(config)) continue;
+      case "ollama": {
+        if (!(await isOllamaConfigured(config))) continue;
+        const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
         return {
           backend: getCachedOrCreate(
             "ollama",
             config.memory.embeddings.ollamaModel,
             () =>
               new OllamaEmbeddingBackend(config.memory.embeddings.ollamaModel, {
-                apiKey: getSecureKey("ollama") ?? undefined,
+                apiKey: ollamaKey,
               }),
           ),
           reason: null,
         };
+      }
     }
   }
 
@@ -344,13 +347,13 @@ export function selectEmbeddingBackend(
   return { backend: null, reason };
 }
 
-export function getMemoryBackendStatus(config: AssistantConfig): {
+export async function getMemoryBackendStatus(config: AssistantConfig): Promise<{
   enabled: boolean;
   degraded: boolean;
   provider: EmbeddingProviderName | null;
   model: string | null;
   reason: string | null;
-} {
+}> {
   if (!config.memory.enabled) {
     return {
       enabled: false,
@@ -360,7 +363,7 @@ export function getMemoryBackendStatus(config: AssistantConfig): {
       reason: "memory.disabled",
     };
   }
-  const selection = selectEmbeddingBackend(config);
+  const selection = await selectEmbeddingBackend(config);
   if (!selection.backend) {
     return {
       enabled: true,
@@ -388,7 +391,7 @@ export async function embedWithBackend(
   model: string;
   vectors: number[][];
 }> {
-  const selection = selectEmbeddingBackend(config);
+  const selection = await selectEmbeddingBackend(config);
   if (!selection.backend) {
     throw new Error(
       selection.reason ?? "No memory embedding backend configured",
@@ -405,7 +408,7 @@ export async function embedWithBackend(
   const fallbacks: EmbeddingBackend[] =
     config.memory.embeddings.provider === "auto" &&
     selection.backend.provider !== "gemini"
-      ? selectFallbackBackends(config, selection.backend.provider)
+      ? await selectFallbackBackends(config, selection.backend.provider)
       : [];
 
   // ── Compute provider-specific vector cache extras ───────────────
@@ -526,17 +529,17 @@ export function logMemoryEmbeddingWarning(err: unknown, context: string): void {
   log.warn({ err }, `Memory embeddings failed (${context})`);
 }
 
-function selectFallbackBackends(
+async function selectFallbackBackends(
   config: AssistantConfig,
   exclude: EmbeddingProviderName,
-): EmbeddingBackend[] {
+): Promise<EmbeddingBackend[]> {
   const backends: EmbeddingBackend[] = [];
   const order: EmbeddingProviderName[] = ["openai", "gemini", "ollama"];
   for (const provider of order) {
     if (provider === exclude) continue;
     switch (provider) {
       case "openai": {
-        const openaiKey = getSecureKey("openai");
+        const openaiKey = await getSecureKeyAsync("openai");
         if (openaiKey) {
           backends.push(
             getCachedOrCreate(
@@ -553,7 +556,7 @@ function selectFallbackBackends(
         break;
       }
       case "gemini": {
-        const geminiKey = getSecureKey("gemini");
+        const geminiKey = await getSecureKeyAsync("gemini");
         if (geminiKey) {
           backends.push(
             getCachedOrCreate(
@@ -575,7 +578,8 @@ function selectFallbackBackends(
         break;
       }
       case "ollama":
-        if (isOllamaConfigured(config)) {
+        if (await isOllamaConfigured(config)) {
+          const ollamaKey = (await getSecureKeyAsync("ollama")) ?? undefined;
           backends.push(
             getCachedOrCreate(
               "ollama",
@@ -584,7 +588,7 @@ function selectFallbackBackends(
                 new OllamaEmbeddingBackend(
                   config.memory.embeddings.ollamaModel,
                   {
-                    apiKey: getSecureKey("ollama") ?? undefined,
+                    apiKey: ollamaKey,
                   },
                 ),
             ),
@@ -605,25 +609,25 @@ function selectFallbackBackends(
  * available. We check both the primary and fallback backends so that
  * multimodal jobs are still enqueued when Gemini is reachable via fallback.
  */
-export function selectedBackendSupportsMultimodal(
+export async function selectedBackendSupportsMultimodal(
   config: AssistantConfig,
-): boolean {
-  const { backend } = selectEmbeddingBackend(config);
+): Promise<boolean> {
+  const { backend } = await selectEmbeddingBackend(config);
   if (!backend) return false;
   if (backend.provider === "gemini") return true;
 
   // In auto mode, check if Gemini is available as a fallback backend.
   if (config.memory.embeddings.provider === "auto") {
-    const fallbacks = selectFallbackBackends(config, backend.provider);
+    const fallbacks = await selectFallbackBackends(config, backend.provider);
     return fallbacks.some((fb) => fb.provider === "gemini");
   }
   return false;
 }
 
-function isOllamaConfigured(config: AssistantConfig): boolean {
+async function isOllamaConfigured(config: AssistantConfig): Promise<boolean> {
   return (
     config.provider === "ollama" ||
-    Boolean(getSecureKey("ollama")) ||
+    Boolean(await getSecureKeyAsync("ollama")) ||
     Boolean(getOllamaBaseUrlEnv())
   );
 }

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -38,10 +38,10 @@ export interface IndexMessageResult {
   enqueuedJobs: number;
 }
 
-export function indexMessageNow(
+export async function indexMessageNow(
   input: IndexMessageInput,
   config: MemoryConfig,
-): IndexMessageResult {
+): Promise<IndexMessageResult> {
   if (!config.enabled) return { indexedSegments: 0, enqueuedJobs: 0 };
 
   // Provenance-based trust gating: only guardian and legacy (undefined) actors
@@ -70,7 +70,8 @@ export function indexMessageNow(
     (input.role === "assistant" && config.extraction.extractFromAssistant);
   // Check if the resolved embedding backend supports multimodal input.
   // Only enqueue embed_attachment jobs when it does (currently Gemini only).
-  const supportsMultimodal = selectedBackendSupportsMultimodal(getConfig());
+  const supportsMultimodal =
+    await selectedBackendSupportsMultimodal(getConfig());
   const mediaBlocks = supportsMultimodal
     ? extractMediaBlocks(input.content).filter((b) => b.type === "image")
     : [];

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -32,7 +32,10 @@ function parseProvenanceTrustClass(
   }
 }
 
-export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
+export async function backfillJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
   const db = getDb();
   const force = job.payload.force === true;
   if (force) {
@@ -73,7 +76,7 @@ export function backfillJob(job: MemoryJob, config: AssistantConfig): void {
       const provenanceTrustClass = parseProvenanceTrustClass(
         message.metadata ?? null,
       );
-      indexMessageNow(
+      await indexMessageNow(
         {
           messageId: message.id,
           conversationId: message.conversationId,

--- a/assistant/src/memory/job-handlers/index-maintenance.ts
+++ b/assistant/src/memory/job-handlers/index-maintenance.ts
@@ -20,7 +20,7 @@ import {
 
 const log = getLogger("memory-jobs-worker");
 
-export function rebuildIndexJob(): void {
+export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
   db.delete(memoryEmbeddings).run();
 
@@ -52,7 +52,7 @@ export function rebuildIndexJob(): void {
   // Re-enqueue multimodal embedding jobs only when the resolved embedding
   // backend supports multimodal inputs. Without this gate, embed_media and
   // embed_attachment jobs would all fail for text-only backends.
-  if (selectedBackendSupportsMultimodal(getConfig())) {
+  if (await selectedBackendSupportsMultimodal(getConfig())) {
     const assets = db
       .select({ id: mediaAssets.id })
       .from(mediaAssets)

--- a/assistant/src/memory/job-handlers/media-processing.ts
+++ b/assistant/src/memory/job-handlers/media-processing.ts
@@ -34,7 +34,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
       "Skipping media processing pipeline — only video assets are supported",
     );
     updateMediaAssetStatus(mediaAssetId, "indexed");
-    if (selectedBackendSupportsMultimodal(getConfig())) {
+    if (await selectedBackendSupportsMultimodal(getConfig())) {
       enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
     }
     return;
@@ -114,7 +114,7 @@ export async function mediaProcessingJob(job: MemoryJob): Promise<void> {
   }
 
   updateMediaAssetStatus(mediaAssetId, "indexed");
-  if (selectedBackendSupportsMultimodal(getConfig())) {
+  if (await selectedBackendSupportsMultimodal(getConfig())) {
     enqueueMemoryJob("embed_media", { assetId: mediaAssetId });
   }
 }

--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -147,7 +147,7 @@ export async function embedAndUpsert(
   input: EmbeddingInput,
   extraPayload?: Record<string, unknown>,
 ): Promise<void> {
-  const status = getMemoryBackendStatus(config);
+  const status = await getMemoryBackendStatus(config);
   if (!status.provider) {
     throw new BackendUnavailableError(
       `Embedding backend unavailable (${status.reason ?? "no provider"})`,
@@ -279,4 +279,3 @@ export async function embedAndUpsert(
     throw err;
   }
 }
-

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -282,7 +282,7 @@ async function processJob(
       await buildConversationSummaryJob(job, config);
       return;
     case "backfill":
-      backfillJob(job, config);
+      await backfillJob(job, config);
       return;
     case "backfill_entity_relations":
       // Entity relation backfill has been removed — silently drop legacy jobs
@@ -292,7 +292,7 @@ async function processJob(
       // Global summary rollups have been removed — silently drop legacy jobs
       return;
     case "rebuild_index":
-      rebuildIndexJob();
+      await rebuildIndexJob();
       return;
     case "delete_qdrant_vectors":
       await deleteQdrantVectorsJob(job);

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -166,7 +166,7 @@ async function generateQueryEmbedding(
   signal: AbortSignal | undefined,
   start: number,
 ): Promise<EmbeddingResult | { earlyExit: MemoryRecallResult }> {
-  const backendStatus = getMemoryBackendStatus(config);
+  const backendStatus = await getMemoryBackendStatus(config);
   let queryVector: number[] | null = null;
   let provider: string | undefined;
   let model: string | undefined;

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -134,7 +134,7 @@ async function searchMemoriesSemantic(
   existingIds: Set<string>,
 ): Promise<GlobalSearchMemory[]> {
   const config = getConfig();
-  const backendStatus = getMemoryBackendStatus(config);
+  const backendStatus = await getMemoryBackendStatus(config);
   if (!backendStatus.provider) return [];
 
   try {


### PR DESCRIPTION
## Summary
- Convert selectEmbeddingBackend, selectFallbackBackends, getMemoryBackendStatus, selectedBackendSupportsMultimodal, isOllamaConfigured to async with getSecureKeyAsync
- Convert indexMessageNow to async, propagate await through backfillJob, rebuildIndexJob
- Add await at all caller sites (conversation-crud, jobs-worker, job-utils, global-search-routes, media-processing)
- Also update additional callers: retriever, admin, lifecycle, sessions CLI, memory CLI, chatgpt-import
- Update test files that call these functions directly

Part of plan: async-secure-final.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
