### PR TITLE
Remove dead isDowngradedFromKeychain() stub

### DIFF
--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -52,7 +52,6 @@ mock.module("../security/secure-keys.js", () => {
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [...storedKeys.keys()],
     getBackendType: () => "encrypted",
-    isDowngradedFromKeychain: () => false,
   };
 });
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -74,7 +74,6 @@ mock.module("../security/secure-keys.js", () => ({
     return secureKeyStore.get(account);
   },
   getBackendType: (): "broker" | "encrypted" | null => null,
-  isDowngradedFromKeychain: (): boolean => false,
   _resetBackend: (): void => {},
   _setBackend: (): void => {},
 }));

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -165,7 +165,6 @@ mock.module("../security/secure-keys.js", () => ({
   },
   listSecureKeys: () => [...secureKeyStore.keys()],
   getBackendType: () => "encrypted",
-  isDowngradedFromKeychain: () => false,
   _resetBackend: () => {},
   _setBackend: () => {},
 }));

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -51,7 +51,6 @@ mock.module("../security/secure-keys.js", () => {
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [],
     getBackendType: () => "encrypted",
-    isDowngradedFromKeychain: () => false,
   };
 });
 

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -74,7 +74,6 @@ import {
   deleteSecureKeyAsync,
   getBackendType,
   getSecureKeyAsync,
-  isDowngradedFromKeychain,
   listSecureKeys,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
@@ -130,10 +129,6 @@ describe("secure-keys", () => {
     test("returns broker when broker is available", () => {
       mockBrokerAvailable = true;
       expect(getBackendType()).toBe("broker");
-    });
-
-    test("isDowngradedFromKeychain always returns false", () => {
-      expect(isDowngradedFromKeychain()).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -33,7 +33,6 @@ mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: async () => "deleted" as const,
   listSecureKeys: () => [],
   getBackendType: () => null,
-  isDowngradedFromKeychain: () => false,
   _resetBackend: () => {},
   _setBackend: () => {},
 }));

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -110,7 +110,6 @@ mock.module("../security/secure-keys.js", () => {
     deleteSecureKeyAsync: async (account: string) => syncDelete(account),
     listSecureKeys: () => Object.keys(secureKeyStore),
     getBackendType: () => "encrypted",
-    isDowngradedFromKeychain: () => false,
     _resetBackend: () => {},
     _setBackend: () => {},
   };

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -94,14 +94,6 @@ export function getBackendType(): "broker" | "encrypted" | null {
   return getBroker().isAvailable() ? "broker" : "encrypted";
 }
 
-/**
- * Whether the backend was downgraded from keychain to encrypted at runtime.
- * Always returns false now that keychain CLI is removed.
- */
-export function isDowngradedFromKeychain(): boolean {
-  return false;
-}
-
 // ---------------------------------------------------------------------------
 // Async variants — try encrypted store first, fall back to broker
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed `isDowngradedFromKeychain()` from `secure-keys.ts` — it always returned `false` since keychain CLI was removed
- Removed mock entries from 6 test files and the dedicated test case from `secure-keys.test.ts`

## Original prompt
Remove isDowngradedFromKeychain() stub and 7+ test references — secure-keys.ts:101-103, always returns false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
