### PR TITLE
chore: delete _resetAppGitState() no-op

### DIFF
--- a/assistant/src/__tests__/app-git-history.test.ts
+++ b/assistant/src/__tests__/app-git-history.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { _resetAppGitState } from "../memory/app-git-service.js";
 import { _resetGitServiceRegistry } from "../workspace/git-service.js";
 
 // Mock getDataDir to use a temp directory
@@ -35,7 +34,6 @@ describe("App Git History", () => {
     );
     mkdirSync(join(testDataDir, "apps"), { recursive: true });
     _resetGitServiceRegistry();
-    _resetAppGitState();
   });
 
   afterEach(() => {

--- a/assistant/src/__tests__/app-git-service.test.ts
+++ b/assistant/src/__tests__/app-git-service.test.ts
@@ -4,10 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  _resetAppGitState,
-  commitAppTurnChanges,
-} from "../memory/app-git-service.js";
+import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { _resetGitServiceRegistry } from "../workspace/git-service.js";
 
 // Mock getDataDir to use a temp directory
@@ -36,7 +33,6 @@ describe("App Git Service", () => {
     );
     mkdirSync(join(testDataDir, "apps"), { recursive: true });
     _resetGitServiceRegistry();
-    _resetAppGitState();
   });
 
   afterEach(() => {
@@ -128,7 +124,6 @@ describe("App Git Service", () => {
   });
 
   test("commitAppTurnChanges swallows errors gracefully", async () => {
-    _resetAppGitState();
     // This should not throw
     await commitAppTurnChanges("test", 1);
   });

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -341,10 +341,3 @@ export async function restoreAppVersion(
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
-
-/**
- * @internal Test-only: reset module state.
- */
-export function _resetAppGitState(): void {
-  // no-op — kept for test API compatibility
-}


### PR DESCRIPTION
## Summary
- Removed the `_resetAppGitState()` no-op function from `app-git-service.ts`
- Removed all imports and calls from `app-git-service.test.ts` and `app-git-history.test.ts`

## Original prompt
Remove _resetAppGitState() no-op — app-git-service.ts:348-350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
