### PR TITLE
chore: remove _setBackend no-op and all test callsites

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -67,7 +67,6 @@ mock.module("../security/secure-keys.js", () => ({
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},
-  _setBackend: () => {},
 }));
 
 mock.module("../tools/credentials/metadata-store.js", () => ({

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -88,7 +88,6 @@ import {
   loadConfig,
 } from "../config/loader.js";
 import { _setStorePath } from "../security/encrypted-store.js";
-import { _setBackend } from "../security/secure-keys.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -183,13 +182,11 @@ describe("config loader backfill", () => {
     }
     ensureTestDir();
     _setStorePath(join(TEST_DIR, "keys.enc"));
-    _setBackend("encrypted");
     invalidateConfigCache();
   });
 
   afterEach(() => {
     _setStorePath(null);
-    _setBackend(undefined);
     invalidateConfigCache();
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -72,7 +72,6 @@ import {
   DEFAULT_ELEVENLABS_VOICE_ID,
 } from "../config/schema.js";
 import { _setStorePath } from "../security/encrypted-store.js";
-import { _setBackend } from "../security/secure-keys.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -989,13 +988,11 @@ describe("loadConfig with schema validation", () => {
     }
     ensureTestDir();
     _setStorePath(join(TEST_DIR, "keys.enc"));
-    _setBackend("encrypted");
     invalidateConfigCache();
   });
 
   afterEach(() => {
     _setStorePath(null);
-    _setBackend(undefined);
     invalidateConfigCache();
   });
 
@@ -1215,13 +1212,11 @@ describe("Call entrypoint gating", () => {
     }
     ensureTestDir();
     _setStorePath(join(TEST_DIR, "keys.enc"));
-    _setBackend("encrypted");
     invalidateConfigCache();
   });
 
   afterEach(() => {
     _setStorePath(null);
-    _setBackend(undefined);
     invalidateConfigCache();
   });
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -76,7 +76,6 @@ mock.module("../security/secure-keys.js", () => ({
   getBackendType: (): "broker" | "encrypted" | null => null,
   isDowngradedFromKeychain: (): boolean => false,
   _resetBackend: (): void => {},
-  _setBackend: (): void => {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -85,7 +85,6 @@ mock.module("../security/secure-keys.js", () => ({
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},
-  _setBackend: () => {},
 }));
 
 // Stub ensureLocalCA / certs so tests never run openssl

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -167,7 +167,6 @@ mock.module("../security/secure-keys.js", () => ({
   getBackendType: () => "encrypted",
   isDowngradedFromKeychain: () => false,
   _resetBackend: () => {},
-  _setBackend: () => {},
 }));
 
 mock.module("../tools/credentials/metadata-store.js", () => ({

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -41,7 +41,6 @@ mock.module("../security/secure-keys.js", () => ({
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},
-  _setBackend: () => {},
 }));
 
 // Stub ensureLocalCA / certs so tests never run openssl

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -70,7 +70,6 @@ mock.module("../security/keychain-broker-client.js", () => ({
 import { _setStorePath } from "../security/encrypted-store.js";
 import {
   _resetBackend,
-  _setBackend,
   deleteSecureKeyAsync,
   getBackendType,
   getSecureKeyAsync,
@@ -405,23 +404,6 @@ describe("secure-keys", () => {
       // Both stores should retain the key — no partial deletion
       expect(mockBrokerStore.has("api-key")).toBe(true);
       expect(await getSecureKeyAsync("api-key")).toBe("value");
-    });
-  });
-
-  // -----------------------------------------------------------------------
-  // _setBackend / _resetBackend (no-ops kept for test compat)
-  // -----------------------------------------------------------------------
-  describe("_setBackend", () => {
-    test("_setBackend is a no-op but does not throw", async () => {
-      _setBackend("encrypted");
-      await setSecureKeyAsync("test", "value");
-      expect(existsSync(STORE_PATH)).toBe(true);
-    });
-
-    test("_resetBackend is a no-op but does not throw", async () => {
-      _resetBackend();
-      await setSecureKeyAsync("test", "value");
-      expect(await getSecureKeyAsync("test")).toBe("value");
     });
   });
 });

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -35,7 +35,6 @@ mock.module("../security/secure-keys.js", () => ({
   getBackendType: () => null,
   isDowngradedFromKeychain: () => false,
   _resetBackend: () => {},
-  _setBackend: () => {},
 }));
 
 mock.module("../tools/credentials/metadata-store.js", () => ({

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -112,7 +112,6 @@ mock.module("../security/secure-keys.js", () => {
     getBackendType: () => "encrypted",
     isDowngradedFromKeychain: () => false,
     _resetBackend: () => {},
-    _setBackend: () => {},
   };
 });
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -212,10 +212,3 @@ export async function deleteSecureKeyAsync(
 export function _resetBackend(): void {
   _broker = undefined;
 }
-
-/** @internal Test-only: force a specific backend. Pass `undefined` to reset. */
-export function _setBackend(
-  _backend: "keychain" | "encrypted" | "broker" | null | undefined,
-): void {
-  // No-op — kept for test compatibility.
-}


### PR DESCRIPTION
## Summary
- Delete the `_setBackend()` no-op export from `secure-keys.ts`
- Remove all 15 callsites across 9 test files: imports, mock stubs, `beforeEach`/`afterEach` calls, and the dedicated `_setBackend` describe block in `secure-keys.test.ts`

## Original prompt
Remove _setBackend() no-op and 11+ test callsites — secure-keys.ts:217-221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
