### PR TITLE
chore: delete 10 unused exports from media-reuse-fixtures.ts

### DIFF
--- a/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/media-reuse-fixtures.ts
@@ -1,8 +1,8 @@
 /**
  * Shared fixtures for media-reuse testing.
  *
- * Provides deterministic attachment blobs, message links, and approval
- * response helpers used by the proxy and asset tool test suites.
+ * Provides deterministic attachment blobs and approval response helpers
+ * used by the proxy and asset tool test suites.
  */
 
 import type { StoredAttachment } from "../../memory/attachments-store.js";
@@ -15,12 +15,6 @@ import type { UserDecision } from "../../permissions/types.js";
 /** A tiny 1x1 red PNG pixel, base64-encoded. */
 export const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
-
-/** A tiny 1x1 JPEG pixel, base64-encoded. */
-export const TINY_JPEG_BASE64 =
-  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMCwsKCwsM" +
-  "CgwMDQwMCwwMDQsLCwwODQoMEAwMEQ4ODwwLDgz/2wBDAQMEBAUEBQkFBQkMCwkLDAwMDAwMDAwMDAwM" +
-  "DAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AKwA//9k=";
 
 // ---------------------------------------------------------------------------
 // Deterministic attachment records
@@ -39,60 +33,11 @@ export const FAKE_SELFIE_ATTACHMENT: StoredAttachment = {
   createdAt: NOW,
 };
 
-/** A fake document attachment. */
-export const FAKE_DOCUMENT_ATTACHMENT: StoredAttachment = {
-  id: "att-doc-001",
-  originalFilename: "report.pdf",
-  mimeType: "application/pdf",
-  sizeBytes: 4096,
-  kind: "document",
-  thumbnailBase64: null,
-  createdAt: NOW,
-};
-
-/** A fake JPEG photo attachment. */
-export const FAKE_PHOTO_ATTACHMENT: StoredAttachment = {
-  id: "att-photo-001",
-  originalFilename: "photo.jpg",
-  mimeType: "image/jpeg",
-  sizeBytes: Buffer.from(TINY_JPEG_BASE64, "base64").length,
-  kind: "image",
-  thumbnailBase64: null,
-  createdAt: NOW,
-};
-
-// ---------------------------------------------------------------------------
-// Message link helpers
-// ---------------------------------------------------------------------------
-
-export interface FakeMessageLink {
-  messageId: string;
-  attachmentId: string;
-  conversationId: string;
-  position: number;
-}
-
-/** A deterministic message-attachment link for the selfie. */
-export const FAKE_SELFIE_LINK: FakeMessageLink = {
-  messageId: "msg-001",
-  attachmentId: FAKE_SELFIE_ATTACHMENT.id,
-  conversationId: "conv-001",
-  position: 0,
-};
-
-/** A second link showing multiple attachments on one message. */
-export const FAKE_DOCUMENT_LINK: FakeMessageLink = {
-  messageId: "msg-001",
-  attachmentId: FAKE_DOCUMENT_ATTACHMENT.id,
-  conversationId: "conv-001",
-  position: 1,
-};
-
 // ---------------------------------------------------------------------------
 // Approval response helpers
 // ---------------------------------------------------------------------------
 
-export interface FakeApprovalResponse {
+interface FakeApprovalResponse {
   decision: UserDecision;
   /** Pattern for "always allow" decisions (undefined for one-shot allow/deny). */
   pattern?: string;
@@ -108,25 +53,4 @@ export function fakeAllowOnce(): FakeApprovalResponse {
 /** Returns a deny decision. */
 export function fakeDeny(): FakeApprovalResponse {
   return { decision: "deny" };
-}
-
-/** Returns an "always allow" decision with a pattern for the trust rule. */
-export function fakeAlwaysAllow(
-  pattern: string,
-  scope = "/tmp/test-project",
-): FakeApprovalResponse {
-  return { decision: "always_allow", pattern, scope };
-}
-
-/** Returns an "always allow high risk" decision. */
-export function fakeAlwaysAllowHighRisk(
-  pattern: string,
-  scope = "/tmp/test-project",
-): FakeApprovalResponse {
-  return { decision: "always_allow_high_risk", pattern, scope };
-}
-
-/** Returns an "always deny" decision. */
-export function fakeAlwaysDeny(): FakeApprovalResponse {
-  return { decision: "always_deny" };
 }


### PR DESCRIPTION
## Summary
- Removed 10 unused exports from `media-reuse-fixtures.ts`: `TINY_JPEG_BASE64`, `FAKE_DOCUMENT_ATTACHMENT`, `FAKE_PHOTO_ATTACHMENT`, `FakeMessageLink`, `FAKE_SELFIE_LINK`, `FAKE_DOCUMENT_LINK`, `fakeAlwaysAllow`, `fakeAlwaysAllowHighRisk`, `fakeAlwaysDeny`, and de-exported `FakeApprovalResponse` (kept as local interface for remaining functions)
- Only 4 exports are actually imported: `TINY_PNG_BASE64`, `FAKE_SELFIE_ATTACHMENT`, `fakeAllowOnce`, `fakeDeny`

## Original prompt
Remove 10 unused exports from media-reuse-fixtures.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
