### PR TITLE
chore: remove unused type exports from gemini-image-service.ts

### DIFF
--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -2,7 +2,7 @@ import { ApiError, GoogleGenAI } from "@google/genai";
 
 // --- Request / Response types ---
 
-export interface ImageGenerationRequest {
+interface ImageGenerationRequest {
   prompt: string;
   mode: "generate" | "edit";
   /** Base64-encoded source images for edit mode */
@@ -14,13 +14,13 @@ export interface ImageGenerationRequest {
 }
 
 /** Credentials for direct Gemini API access. */
-export interface DirectCredentials {
+interface DirectCredentials {
   type: "direct";
   apiKey: string;
 }
 
 /** Credentials for managed proxy access via Vertex AI. */
-export interface ManagedProxyCredentials {
+interface ManagedProxyCredentials {
   type: "managed-proxy";
   assistantApiKey: string;
   baseUrl: string;
@@ -28,14 +28,14 @@ export interface ManagedProxyCredentials {
 
 export type ImageGenCredentials = DirectCredentials | ManagedProxyCredentials;
 
-export interface GeneratedImage {
+interface GeneratedImage {
   mimeType: string;
   dataBase64: string;
   /** Short title derived from the model's text response, if available. */
   title?: string;
 }
 
-export interface ImageGenerationResult {
+interface ImageGenerationResult {
   images: GeneratedImage[];
   text?: string;
   resolvedModel: string;


### PR DESCRIPTION
## Summary
- Removed `export` from 5 type declarations in `gemini-image-service.ts` that are only used internally: `ImageGenerationRequest`, `DirectCredentials`, `ManagedProxyCredentials`, `GeneratedImage`, `ImageGenerationResult`

## Original prompt
Remove 5 unused type exports from gemini-image-service.ts — ImageGenerationRequest, DirectCredentials, ManagedProxyCredentials, GeneratedImage, ImageGenerationResult.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
