### PR TITLE
refactor: convert resolveConfiguredProvider and getConfiguredProvider to async

### DIFF
--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -38,7 +38,7 @@ let configuredProvider: { sendMessage: () => Promise<unknown> } | null = null;
 let extractedToolUse: unknown = null;
 
 mock.module("../providers/provider-send-message.js", () => ({
-  getConfiguredProvider: () => configuredProvider,
+  getConfiguredProvider: async () => configuredProvider,
   createTimeout: () => ({
     signal: new AbortController().signal,
     cleanup: () => {},

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -82,7 +82,7 @@ let resolvedProvider: {
 };
 
 mock.module("../providers/provider-send-message.js", () => ({
-  resolveConfiguredProvider: () => resolvedProvider,
+  resolveConfiguredProvider: async () => resolvedProvider,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/calls/guardian-question-copy.ts
+++ b/assistant/src/calls/guardian-question-copy.ts
@@ -52,7 +52,7 @@ export async function generateGuardianCopy(
   const fallback = buildFallbackCopy(questionText);
 
   // If no provider is configured, return fallback immediately
-  const resolved = resolveConfiguredProvider();
+  const resolved = await resolveConfiguredProvider();
   if (!resolved) {
     log.debug(
       "No provider available for guardian copy generation, using fallback",

--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -179,7 +179,7 @@ async function sendToClaude(
   model?: string,
   onProgress?: (msg: string) => void,
 ): Promise<ReduceResult> {
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     throw new Error("No LLM provider available. Please configure an API key.");
   }

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1294,7 +1294,7 @@ async function generateSkillIcon(
   name: string,
   description: string,
 ): Promise<string> {
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     throw new Error("Configured provider unavailable for icon generation");
   }

--- a/assistant/src/daemon/classifier.ts
+++ b/assistant/src/daemon/classifier.ts
@@ -28,7 +28,7 @@ export async function classifyInteraction(
     return "text_qa";
   }
 
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     log.warn(
       "No configured provider available, falling back to heuristic classification",

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -584,7 +584,7 @@ export async function draftSkill(
     if (missing.length > 0) {
       let llmGenerated = false;
       try {
-        const provider = getConfiguredProvider();
+        const provider = await getConfiguredProvider();
         if (provider) {
           const { signal, cleanup } = createTimeout(LLM_DRAFT_TIMEOUT_MS);
           try {

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -107,7 +107,7 @@ export async function handleWatchObservation(
 
 async function generateCommentary(session: WatchSession): Promise<void> {
   try {
-    const provider = getConfiguredProvider();
+    const provider = await getConfiguredProvider();
     if (!provider) {
       log.warn(
         { watchId: session.watchId },
@@ -198,7 +198,7 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       },
       "generateSummary starting — calling LLM",
     );
-    const provider = getConfiguredProvider();
+    const provider = await getConfiguredProvider();
     if (!provider) {
       log.warn(
         { watchId: session.watchId },

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -118,7 +118,7 @@ export async function generateAndPersistConversationTitle(
     return { title: conversation.title!, updated: false };
   }
 
-  const provider = params.provider ?? getConfiguredProvider();
+  const provider = params.provider ?? (await getConfiguredProvider());
   if (!provider) {
     // No provider available — fall back to context-derived title or untitled
     const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
@@ -234,7 +234,7 @@ export async function regenerateConversationTitle(
     return { title: conversation?.title ?? UNTITLED_FALLBACK, updated: false };
   }
 
-  const provider = params.provider ?? getConfiguredProvider();
+  const provider = params.provider ?? (await getConfiguredProvider());
   if (!provider) {
     return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
   }

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -269,7 +269,7 @@ async function extractItemsWithLLM(
   extractionConfig: MemoryExtractionConfig,
   scopeId: string,
 ): Promise<ExtractedItem[]> {
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     log.debug(
       "Configured provider unavailable for LLM extraction, falling back to pattern-based",

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -140,7 +140,7 @@ async function summarizeWithLLM(
     return buildFallbackSummary(existingSummary, newContent, label);
   }
 
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     log.debug(
       { label },

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -127,7 +127,7 @@ export async function extractStylePatterns(
     .map((e, i) => `--- Message ${i + 1} ---\n${e}`)
     .join("\n\n");
 
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     return { stylePatterns: [], contactObservations: [] };
   }

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -711,7 +711,7 @@ export async function evaluateSignal(
     );
   }
 
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     log.warn(
       "Configured provider unavailable for notification decision, using fallback",
@@ -767,7 +767,7 @@ async function classifyWithLLM(
   modelIntent: ModelIntent,
   candidateSet?: ThreadCandidateSet,
 ): Promise<NotificationDecision> {
-  const provider = getConfiguredProvider()!;
+  const provider = (await getConfiguredProvider())!;
   const { signal: abortSignal, cleanup } = createTimeout(DECISION_TIMEOUT_MS);
 
   const candidateContext = candidateSet

--- a/assistant/src/notifications/preference-extractor.ts
+++ b/assistant/src/notifications/preference-extractor.ts
@@ -140,7 +140,7 @@ const EXTRACTION_TOOL = {
 export async function extractPreferences(
   message: string,
 ): Promise<ExtractionResult> {
-  const provider = getConfiguredProvider();
+  const provider = await getConfiguredProvider();
   if (!provider) {
     log.debug("No provider available for preference extraction");
     return { detected: false, preferences: [] };

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -40,12 +40,12 @@ let fallbackWarningLogged = false;
  *
  * Returns `null` when no providers are available at all.
  */
-export function resolveConfiguredProvider(): ConfiguredProviderResult | null {
+export async function resolveConfiguredProvider(): Promise<ConfiguredProviderResult | null> {
   const config = getConfig();
 
   if (listProviders().length === 0) {
     try {
-      initializeProviders(config);
+      await initializeProviders(config);
     } catch {
       return null;
     }
@@ -89,8 +89,8 @@ export function resolveConfiguredProvider(): ConfiguredProviderResult | null {
  *
  * Returns `null` when no providers are available.
  */
-export function getConfiguredProvider(): Provider | null {
-  const result = resolveConfiguredProvider();
+export async function getConfiguredProvider(): Promise<Provider | null> {
+  const result = await resolveConfiguredProvider();
   return result?.provider ?? null;
 }
 

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -96,7 +96,7 @@ export async function generateInviteInstruction(params: {
     shareUrl: params.shareUrl,
   });
 
-  const resolved = resolveConfiguredProvider();
+  const resolved = await resolveConfiguredProvider();
   if (!resolved) {
     log.debug(
       "No provider available for invite instruction generation, using fallback",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1116,7 +1116,7 @@ export async function handleGetSuggestion(
     }
 
     // Try LLM suggestion using the configured provider
-    const provider = getConfiguredProvider();
+    const provider = await getConfiguredProvider();
     if (provider) {
       try {
         // Deduplicate concurrent requests

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -684,7 +684,7 @@ async function handleDictation(body: DictationBody): Promise<Response> {
   const transcription = expandSnippets(body.transcription, profile.snippets);
 
   try {
-    const provider = getConfiguredProvider();
+    const provider = await getConfiguredProvider();
     if (!provider) {
       log.warn(
         "Dictation: no provider available, using heuristic + raw transcription",
@@ -843,7 +843,7 @@ async function handleCommandMode(
   const maxTokens = Math.max(1024, computeMaxTokens(inputLength));
 
   try {
-    const provider = getConfiguredProvider();
+    const provider = await getConfiguredProvider();
     if (!provider) {
       log.warn("Command mode: no provider available, returning selected text");
       const normalizedText = applyDictionary(

--- a/assistant/src/workspace/provider-commit-message-generator.ts
+++ b/assistant/src/workspace/provider-commit-message-generator.ts
@@ -141,7 +141,7 @@ export class ProviderCommitMessageGenerator {
     // Step 2: Resolve configured provider using fail-open semantics.
     // If nothing is resolvable, differentiate likely missing-key cases from
     // true registry/init failures.
-    const resolved = resolveConfiguredProvider();
+    const resolved = await resolveConfiguredProvider();
     if (!resolved) {
       const candidates = getProviderCandidates(config);
       const hasAnyKeylessCandidate = candidates.some((name) =>


### PR DESCRIPTION
## Summary
- Convert resolveConfiguredProvider to async (now awaits initializeProviders which is async from PR 1)
- Convert getConfiguredProvider to async (awaits resolveConfiguredProvider)
- Add await at all 16+ caller sites across daemon handlers, routes, memory, notifications, messaging, config, workspace, and calls modules
- Update test mocks to return Promises

Part of plan: async-secure-final.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
