### PR TITLE
chore: rename stale ipcBroadcast variable in http-server.ts

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -271,16 +271,16 @@ export class RuntimeHttpServer {
   }
 
   private get pairingContext(): PairingHandlerContext {
-    const ipcBroadcast = this.pairingBroadcast;
+    const broadcast = this.pairingBroadcast;
     return {
       pairingStore: this.pairingStore,
       bearerToken: this.bearerToken,
       featureFlagToken: this.readFeatureFlagToken(),
-      pairingBroadcast: ipcBroadcast
+      pairingBroadcast: broadcast
         ? (msg) => {
             // Broadcast to all clients via the event hub so HTTP/SSE clients
             // (e.g. macOS app) receive pairing approval requests.
-            ipcBroadcast(msg);
+            broadcast(msg);
             void assistantEventHub.publish(
               buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
             );


### PR DESCRIPTION
## Summary
- Renamed the stale `ipcBroadcast` local variable to `broadcast` in `http-server.ts` — IPC transport was removed but this variable name was never updated.

## Original prompt
Rename stale ipcBroadcast variable — runtime/http-server.ts:274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
