### PR TITLE
chore: rename ipc_decode to message_decode in credential security fixtures

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -341,7 +341,7 @@ describe("Invariant 3: secrets never logged in plaintext", () => {
           "this is fine",
         );
       });
-    } else if (tc.component === "ipc_decode") {
+    } else if (tc.component === "message_decode") {
       // PR 24 — message decode log hygiene: the TS daemon's message parser must
       // not log raw message content that could contain secrets.
       // Logging metadata (line length, error type) is acceptable; logging

--- a/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
+++ b/assistant/src/__tests__/fixtures/credential-security-fixtures.ts
@@ -100,7 +100,7 @@ export const directReadCases: DirectReadCase[] = [
 export interface LogLeakageCase {
   label: string;
   /** Component where logging might leak credentials */
-  component: "daemon_handler" | "prompter" | "tool_executor" | "ipc_decode";
+  component: "daemon_handler" | "prompter" | "tool_executor" | "message_decode";
   /** Description of what log output is checked */
   logCheck: string;
 }
@@ -122,8 +122,8 @@ export const logLeakageCases: LogLeakageCase[] = [
     logCheck: "password/token/value fields masked",
   },
   {
-    label: "IPC decode failure does not dump raw line",
-    component: "ipc_decode",
+    label: "message decode failure does not dump raw line",
+    component: "message_decode",
     logCheck: "malformed line not logged verbatim",
   },
 ];


### PR DESCRIPTION
## Summary
- Renamed `ipc_decode` component to `message_decode` in `LogLeakageCase` type and fixture data to reflect the IPC-to-HTTP transport rename
- Updated the corresponding test comparison in `credential-security-invariants.test.ts`

## Original prompt
Update ipc_decode test fixture — credential-security-fixtures.ts:103,125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
