### PR TITLE
chore: remove kindMigrationMap backward-compat shim

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -40,18 +40,6 @@ export async function handleMemorySave(
     "constraint",
     "event",
   ]);
-  /** Maps old kind names to their new equivalents for backwards compat. */
-  const kindMigrationMap: Record<string, string> = {
-    profile: "identity",
-    fact: "identity",
-    relationship: "identity",
-    opinion: "preference",
-    todo: "project",
-    instruction: "constraint",
-    style: "preference",
-    playbook: "constraint",
-    learning: "identity",
-  };
   if (typeof rawKind !== "string") {
     return {
       content: `Error: kind is required and must be one of: ${[
@@ -60,7 +48,7 @@ export async function handleMemorySave(
       isError: true,
     };
   }
-  const kind = kindMigrationMap[rawKind] ?? rawKind;
+  const kind = rawKind;
   if (!validKinds.has(kind)) {
     return {
       content: `Error: kind is required and must be one of: ${[


### PR DESCRIPTION
## Summary
- Removed the `kindMigrationMap` backward-compat shim in `tools/memory/handlers.ts` that mapped old kind names (profile, fact, relationship, etc.) to new ones
- This removal was attempted in the 03-12 commit but didn't land in the squash

## Original prompt
Remove kindMigrationMap backward-compat shim — tools/memory/handlers.ts:44-54. Removal was attempted in 03-12 commit but didn't land in the squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
