### PR TITLE
chore: delete dead lazy-tool loading machinery

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -2,8 +2,6 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { RiskLevel } from "../permissions/types.js";
 import type { ToolDefinition } from "../providers/types.js";
-// We cannot import the private LazyTool class directly, so we test through
-// registerLazyTool + getTool which exercise the same code path.
 import {
   __clearRegistryForTesting,
   __resetRegistryForTesting,
@@ -13,16 +11,11 @@ import {
   getSkillToolNames,
   getTool,
   initializeTools,
-  registerLazyTool,
   registerSkillTools,
   registerTool,
   unregisterSkillTools,
 } from "../tools/registry.js";
-import {
-  eagerModuleToolNames,
-  explicitTools,
-  lazyTools,
-} from "../tools/tool-manifest.js";
+import { eagerModuleToolNames, explicitTools } from "../tools/tool-manifest.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
 
 // Clean up global registry after this file completes to prevent
@@ -60,48 +53,6 @@ function makeSkillTool(name: string, ownerSkillId: string): Tool {
     ownerSkillId,
   };
 }
-
-describe("LazyTool", () => {
-  test("clears cached promise on load failure so subsequent call can retry", async () => {
-    let callCount = 0;
-
-    registerLazyTool({
-      name: "test-retry-tool",
-      description: "A tool that fails on first load then succeeds",
-      category: "test",
-      defaultRiskLevel: RiskLevel.Low,
-      definition: {
-        name: "test-retry-tool",
-        description: "A tool that fails on first load then succeeds",
-        input_schema: { type: "object", properties: {}, required: [] },
-      },
-      loader: async () => {
-        callCount++;
-        if (callCount === 1) {
-          throw new Error("transient load failure");
-        }
-        return makeFakeTool("test-retry-tool");
-      },
-    });
-
-    const tool = getTool("test-retry-tool")!;
-    expect(tool).toBeDefined();
-
-    const dummyContext = {} as ToolContext;
-
-    // First call should throw the transient error
-    await expect(tool.execute({}, dummyContext)).rejects.toThrow(
-      "transient load failure",
-    );
-    expect(callCount).toBe(1);
-
-    // Second call should retry the loader and succeed
-    const result = await tool.execute({}, dummyContext);
-    expect(result.content).toBe("ok");
-    expect(result.isError).toBe(false);
-    expect(callCount).toBe(2);
-  });
-});
 
 describe("tool registry host tools", () => {
   test("registers host tools and exposes them in tool definitions", async () => {
@@ -157,29 +108,6 @@ describe("tool registry dynamic-tools tools", () => {
 });
 
 describe("tool manifest", () => {
-  test("all manifest lazy tools are registered after init", async () => {
-    await initializeTools();
-    const registered = new Set(getAllTools().map((t) => t.name));
-
-    for (const descriptor of lazyTools) {
-      expect(registered.has(descriptor.name)).toBe(true);
-    }
-  });
-
-  test("manifest declares expected core lazy tools", () => {
-    // bash moved from lazy to eager registration
-    // swarm_delegate moved to the orchestration bundled skill
-    const lazyNames = new Set(lazyTools.map((t) => t.name));
-    expect(lazyNames.has("bash")).toBe(false);
-    expect(lazyNames.has("evaluate_typescript_code")).toBe(false);
-    expect(lazyNames.has("claude_code")).toBe(false);
-    expect(lazyNames.has("swarm_delegate")).toBe(false);
-    // bash is in eager tools; swarm_delegate is now a bundled skill tool
-    expect(eagerModuleToolNames).toContain("bash");
-    expect(eagerModuleToolNames).not.toContain("swarm_delegate");
-    expect(eagerModuleToolNames).not.toContain("version");
-  });
-
   test("eager module tool names list contains expected count", () => {
     expect(eagerModuleToolNames.length).toBe(11);
   });
@@ -193,12 +121,10 @@ describe("tool manifest", () => {
     expect(names).not.toContain("start_screen_watch");
   });
 
-  test("registered tool count is at least eager + lazy + host", async () => {
+  test("registered tool count is at least eager + host", async () => {
     await initializeTools();
     const tools = getAllTools();
-    expect(tools.length).toBeGreaterThanOrEqual(
-      eagerModuleToolNames.length + lazyTools.length,
-    );
+    expect(tools.length).toBeGreaterThanOrEqual(eagerModuleToolNames.length);
   });
 });
 
@@ -252,11 +178,6 @@ describe("baseline characterization: hardcoded tool loading", () => {
     await initializeTools();
     const tool = getTool("claude_code");
     expect(tool).toBeUndefined();
-  });
-
-  test("claude_code is NOT in lazyTools manifest", () => {
-    const lazyNames = lazyTools.map((t) => t.name);
-    expect(lazyNames).not.toContain("claude_code");
   });
 });
 

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -1,4 +1,3 @@
-import { RiskLevel } from "../permissions/types.js";
 import type { ToolDefinition } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import { coreAppProxyTools } from "./apps/definitions.js";
@@ -8,7 +7,7 @@ import { hostFileEditTool } from "./host-filesystem/edit.js";
 import { hostFileReadTool } from "./host-filesystem/read.js";
 import { hostFileWriteTool } from "./host-filesystem/write.js";
 import { hostShellTool } from "./host-terminal/host-shell.js";
-import type { Tool, ToolContext, ToolExecutionResult } from "./types.js";
+import type { Tool } from "./types.js";
 import { allUiSurfaceTools } from "./ui-surface/definitions.js";
 import { registerUiSurfaceTools } from "./ui-surface/registry.js";
 
@@ -26,68 +25,6 @@ let coreToolsSnapshot: Map<string, Tool> | null = null;
 // Tools are only removed from the global registry when this drops to 0.
 const skillRefCount = new Map<string, number>();
 
-export interface LazyToolDescriptor {
-  name: string;
-  description: string;
-  category: string;
-  defaultRiskLevel: RiskLevel;
-  definition: ToolDefinition;
-  loader: () => Promise<Tool>;
-}
-
-/**
- * A tool wrapper that exposes metadata eagerly but defers module loading
- * and execute() initialization until the tool is first invoked.
- */
-class LazyTool implements Tool {
-  name: string;
-  description: string;
-  category: string;
-  defaultRiskLevel: RiskLevel;
-  private definition: ToolDefinition;
-  private loader: () => Promise<Tool>;
-  private resolvedTool: Tool | null = null;
-  private loadPromise: Promise<Tool> | null = null;
-
-  constructor(descriptor: LazyToolDescriptor) {
-    this.name = descriptor.name;
-    this.description = descriptor.description;
-    this.category = descriptor.category;
-    this.defaultRiskLevel = descriptor.defaultRiskLevel;
-    this.definition = descriptor.definition;
-    this.loader = descriptor.loader;
-  }
-
-  getDefinition(): ToolDefinition {
-    return this.definition;
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    if (!this.resolvedTool) {
-      if (!this.loadPromise) {
-        // Assign loadPromise synchronously before the async loader begins,
-        // so concurrent callers see the guard immediately.
-        const promise = this.loader()
-          .then((tool) => {
-            this.resolvedTool = tool;
-            log.info({ name: this.name }, "Lazy tool loaded");
-            return tool;
-          })
-          .catch((err) => {
-            this.loadPromise = null;
-            throw err;
-          });
-        this.loadPromise = promise;
-      }
-      await this.loadPromise;
-    }
-    return this.resolvedTool!.execute(input, context);
-  }
-}
-
 export function registerTool(tool: Tool): void {
   const existing = tools.get(tool.name);
   if (existing) {
@@ -96,11 +33,6 @@ export function registerTool(tool: Tool): void {
   }
   tools.set(tool.name, tool);
   log.info({ name: tool.name, category: tool.category }, "Tool registered");
-}
-
-export function registerLazyTool(descriptor: LazyToolDescriptor): void {
-  const lazy = new LazyTool(descriptor);
-  registerTool(lazy);
 }
 
 export function getTool(name: string): Tool | undefined {
@@ -312,7 +244,7 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  const { loadEagerModules, eagerModuleToolNames, explicitTools, lazyTools } =
+  const { loadEagerModules, eagerModuleToolNames, explicitTools } =
     await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
@@ -343,24 +275,18 @@ export async function initializeTools(): Promise<void> {
   registerUiSurfaceTools();
   registerAppTools();
 
-  // Lazy tools — defer module loading until first invocation.
-  for (const descriptor of lazyTools) {
-    registerLazyTool(descriptor);
-  }
-
   // Snapshot core tools for __resetRegistryForTesting().  We include every
   // non-skill tool that was registered by the manifest, while excluding
   // arbitrary test tools that were registered before init.
   //
   // A pre-existing tool is included only if it is a known manifest tool
-  // (declared in eagerModuleToolNames, explicitTools, lazyTools, or
-  // hostTools).  This handles ESM cache hits where eager-module tools
-  // are already in the registry before init ran.
+  // (declared in eagerModuleToolNames, explicitTools, or hostTools).
+  // This handles ESM cache hits where eager-module tools are already in
+  // the registry before init ran.
   if (!coreToolsSnapshot) {
     const manifestToolNames = new Set<string>([
       ...eagerModuleToolNames,
       ...explicitTools.map((t: Tool) => t.name),
-      ...lazyTools.map((t: LazyToolDescriptor) => t.name),
       ...hostTools.map((t: Tool) => t.name),
       ...allComputerUseTools.map((t: Tool) => t.name),
       ...allUiSurfaceTools.map((t: Tool) => t.name),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -15,7 +15,6 @@ import { fileWriteTool } from "./filesystem/write.js";
 import { memoryManageTool, memoryRecallTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";
-import type { LazyToolDescriptor } from "./registry.js";
 import { skillExecuteTool } from "./skills/execute.js";
 import { skillLoadTool } from "./skills/load.js";
 import { requestSystemPermissionTool } from "./system/request-permission.js";
@@ -85,12 +84,3 @@ export const explicitTools: Tool[] = [
   memoryRecallTool,
   credentialStoreTool,
 ];
-
-// ── Lazy tool descriptors ───────────────────────────────────────────
-// Tools that defer module loading until first invocation.
-// bash was previously lazy but is now eagerly registered via side-effect
-// imports above, preserving its full definition (including the `reason` field)
-// and fixing bun --compile module-not-found crashes.
-// swarm_delegate has been moved to the orchestration bundled skill.
-
-export const lazyTools: LazyToolDescriptor[] = [];


### PR DESCRIPTION
## Summary
- Removed `LazyTool` class, `LazyToolDescriptor` interface, and `registerLazyTool()` from `registry.ts`
- Deleted the empty `lazyTools` export from `tool-manifest.ts`
- Removed all lazy-tool tests and references from `registry.test.ts`

## Original prompt
Remove LazyTool class, registerLazyTool(), and empty lazyTools export — entire lazy-loading machinery is dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
