### PR TITLE
chore: remove 5 unused feature flags

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Gmail"
     user-invocable: true
-    feature-flag: "gmail"
 ---
 
 This skill provides Gmail-specific tools. For cross-platform messaging (send, read, search, reply), use the **messaging** skill. Gmail tools depend on the messaging skill's provider infrastructure — load messaging first if Gmail is not yet connected.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Messaging"
     user-invocable: true
-    feature-flag: "messaging"
 ---
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.

--- a/assistant/src/config/bundled-skills/sequences/SKILL.md
+++ b/assistant/src/config/bundled-skills/sequences/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   vellum:
     display-name: "Email Sequences"
     user-invocable: true
-    feature-flag: "sequences"
 ---
 
 You are an email sequence assistant. Use the sequence tools to help users create and manage automated multi-step email drip campaigns.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "messaging",
-      "scope": "assistant",
-      "key": "feature_flags.messaging.enabled",
-      "label": "Messaging",
-      "description": "Enable messaging skill section in the system prompt",
-      "defaultEnabled": true
-    },
-    {
       "id": "collect-usage-data",
       "scope": "assistant",
       "key": "feature_flags.collect-usage-data.enabled",
@@ -50,14 +42,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "command-palette",
-      "scope": "assistant",
-      "key": "feature_flags.command-palette.enabled",
-      "label": "Command Palette",
-      "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
-      "defaultEnabled": false
-    },
-    {
       "id": "contacts",
       "scope": "assistant",
       "key": "feature_flags.contacts.enabled",
@@ -71,14 +55,6 @@
       "key": "feature_flags.email-channel.enabled",
       "label": "Email Channel",
       "description": "Show the Email channel card on the Contacts page and enable the email-setup skill",
-      "defaultEnabled": false
-    },
-    {
-      "id": "outbound-proxy-sidecar",
-      "scope": "assistant",
-      "key": "feature_flags.outbound-proxy-sidecar.enabled",
-      "label": "Outbound Proxy Sidecar",
-      "description": "Route proxy session management through the sidecar process instead of running in-process",
       "defaultEnabled": false
     },
     {
@@ -104,22 +80,6 @@
       "label": "Mobile Pairing",
       "description": "Show the Mobile (iOS) pairing card in Settings > Account",
       "defaultEnabled": false
-    },
-    {
-      "id": "gmail",
-      "scope": "assistant",
-      "key": "feature_flags.gmail.enabled",
-      "label": "Gmail",
-      "description": "Enable Gmail management skill (archive, label, declutter)",
-      "defaultEnabled": true
-    },
-    {
-      "id": "sequences",
-      "scope": "assistant",
-      "key": "feature_flags.sequences.enabled",
-      "label": "Email Sequences",
-      "description": "Enable email sequence management skill",
-      "defaultEnabled": true
     },
     {
       "id": "settings-developer-nav",


### PR DESCRIPTION
## Summary
- Remove 5 declared-but-unused feature flags from the registry: `messaging`, `command-palette`, `outbound-proxy-sidecar`, `gmail`, `sequences`
- Strip `feature-flag` metadata from the SKILL.md files for messaging, gmail, and sequences (the skills themselves remain; only the unused gate is removed)
- `command-palette` and `outbound-proxy-sidecar` had zero implementation — purely registry declarations

## Original prompt
Remove 5 declared-but-unused feature flags — messaging, command-palette, outbound-proxy-sidecar, gmail, sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
