### PR TITLE
chore: remove deprecated sync secure-key functions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -96,9 +96,9 @@ declare -a SAFE_LINE_PATTERNS=(
     # `clientSecret: config.clientSecret || "real_secret"`.
     "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
     # TS/JS: secret/key variable assigned from a function call.
-    # E.g. `const clientSecret = getSecureKey(keyVault)` or
-    # `getSecureKey('credential:integration:twitter:client_secret')` or
-    # `getSecureKey(credentialKey(service, "client_secret"))`.
+    # E.g. `const clientSecret = getSecureKeyAsync(keyVault)` or
+    # `getSecureKeyAsync('credential:integration:twitter:client_secret')` or
+    # `getSecureKeyAsync(credentialKey(service, "client_secret"))`.
     # Allows: no quoted args, quoted args containing `:` (key paths), or
     # nested function calls like `credentialKey(...)` whose quoted args are
     # short identifier-like strings (field names, not real secrets).
@@ -257,16 +257,16 @@ if [ "${1:-}" = "--self-test" ]; then
     UNSAFE_TS_NULLISH_FALLBACK='clientSecret: config.clientSecret ?? "real_secret_value_1234"'
 
     # Function-call assignments (false positives to whitelist)
-    SAFE_FUNC_CALL_SECRET='const clientSecret = getSecureKey(keyVault)'
+    SAFE_FUNC_CALL_SECRET='const clientSecret = getSecureKeyAsync(keyVault)'
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
     # Function-call with quoted key path (colon-separated identifier) — must be whitelisted
-    SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || undefined;"
+    SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKeyAsync('credential:integration:twitter:client_secret') || undefined;"
     # Function-call with nested credentialKey() call — must be whitelisted
-    SAFE_FUNC_CALL_NESTED='const clientSecret = getSecureKey(credentialKey(service, "client_secret"));'
+    SAFE_FUNC_CALL_NESTED='const clientSecret = getSecureKeyAsync(credentialKey(service, "client_secret"));'
     # Function-call with key path followed by a hardcoded secret fallback — must NOT be whitelisted
-    UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || \"sk_live_12345678901234567890\""
+    UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKeyAsync('credential:integration:twitter:client_secret') || \"sk_live_12345678901234567890\""
     # Function-call with literal secret in args — must NOT be whitelisted
-    UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKey("sk_live_12345678901234567890")'
+    UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKeyAsync("sk_live_12345678901234567890")'
     UNSAFE_FUNC_CALL_SINGLE_QUOTE="const privateKey = loadPrivateKey('real_secret_key_value_12345')"
     # Type-annotated property (false positive to whitelist)
     SAFE_TYPED_PROP_SECRET='  requiresClientSecret: boolean;'

--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -165,32 +165,15 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 
 ### Async-first policy
 
-**All credential access should use the async functions** (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`). The async variants are the primary API: they check the encrypted store first (instant) and fall back to the keychain broker, ensuring secrets stored in the macOS Keychain are always reachable. The sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) are **deprecated** and bypass the keychain broker entirely.
-
-New code must not introduce sync secure-key calls. Existing sync call sites should be converted to async when their surrounding code paths support it.
+All credential access uses `getSecureKeyAsync`, `setSecureKeyAsync`, and `deleteSecureKeyAsync`. These check the encrypted store first (instant) and fall back to the keychain broker, ensuring secrets stored in the macOS Keychain are always reachable.
 
 ### Runtime request handlers (secret-routes, etc.)
 
-All runtime HTTP handlers that write or delete secrets **must** use the async APIs (`setSecureKeyAsync`, `deleteSecureKeyAsync`). These are the primary entry points for macOS app flows and must go through the broker to reach keychain.
+All runtime HTTP handlers that write or delete secrets use the async APIs (`setSecureKeyAsync`, `deleteSecureKeyAsync`). These are the primary entry points for macOS app flows and must go through the broker to reach keychain.
 
 ### Gateway (credential-reader)
 
 The gateway reads credentials via async `readCredential()` which tries the broker first (native async UDS), falling back to the encrypted store. The gateway never writes credentials — that responsibility belongs to the assistant runtime.
-
-### Known sync exceptions
-
-The migration from sync to async secure-key functions is complete for all call sites except provider initialization paths that require synchronous access. The following call sites still use the deprecated sync variants.
-
-#### Provider initialization (must remain sync)
-
-These call sites run in synchronous initialization contexts where async I/O is not feasible:
-
-| File                                               | Sync functions used | Reason                                                                                                                                                                                               |
-| -------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/providers/managed-proxy/context.ts` | `getSecureKey`      | Provider context initialization is synchronous. The managed proxy context must resolve credentials before the first request can be processed, and the initialization path does not support awaiting. |
-| `assistant/src/providers/registry.ts`              | `getSecureKey`      | Provider registry initialization is synchronous. API keys must be resolved at provider construction time, and the call chain from config watcher through to provider init is fully synchronous.      |
-
-Any new sync usage requires explicit justification and should be documented here.
 
 ## Migration
 

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -34,7 +34,6 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "gemini" ? mockGeminiKey : null,
-  getSecureKey: () => null,
 }));
 
 mock.module("../util/platform.js", () => ({

--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -58,11 +58,8 @@ let mockGetSecureKey: ReturnType<typeof mock>;
 let mockGetCredentialMetadata: ReturnType<typeof mock>;
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (...args: unknown[]) => mockGetSecureKey(...args),
   getSecureKeyAsync: async (...args: unknown[]) => mockGetSecureKey(...args),
-  setSecureKey: () => true,
   setSecureKeyAsync: async () => true,
-  deleteSecureKey: () => "deleted",
   deleteSecureKeyAsync: async () => "deleted",
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -114,7 +114,6 @@ mock.module("../calls/twilio-provider.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => null,
   getSecureKeyAsync: async () => null,
 }));
 

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -103,7 +103,6 @@ mock.module("../calls/twilio-config.js", () => ({
 
 // Mock secure keys
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => null,
   getSecureKeyAsync: async () => null,
 }));
 

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -48,7 +48,6 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -48,7 +48,6 @@ mock.module("../email/service.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 

--- a/assistant/src/__tests__/claude-code-skill-regression.test.ts
+++ b/assistant/src/__tests__/claude-code-skill-regression.test.ts
@@ -35,7 +35,6 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "anthropic" ? "fake-anthropic-key" : null,
-  getSecureKey: () => null,
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -40,7 +40,6 @@ mock.module("../config/loader.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (name: string) =>
     name === "anthropic" ? "fake-anthropic-key" : null,
-  getSecureKey: () => null,
 }));
 
 import { claudeCodeTool } from "../tools/claude-code/claude-code.js";

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -43,12 +43,9 @@ mock.module("../security/secure-keys.js", () => {
     return "not-found" as const;
   };
   return {
-    getSecureKey: (key: string) => storedKeys.get(key) ?? null,
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
-    setSecureKey: syncSet,
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
-    deleteSecureKey: syncDelete,
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [...storedKeys.keys()],
     getBackendType: () => "encrypted",

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -31,15 +31,6 @@ let _getMetadataByIdCalls = 0;
 // ---------------------------------------------------------------------------
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string): string | undefined => {
-    _getSecureKeyCalls += 1;
-    return secureKeyStore.get(account);
-  },
-  setSecureKey: (account: string, value: string): boolean => {
-    _setSecureKeyCalls += 1;
-    secureKeyStore.set(account, value);
-    return true;
-  },
   setSecureKeyAsync: async (
     account: string,
     value: string,
@@ -47,14 +38,6 @@ mock.module("../security/secure-keys.js", () => ({
     _setSecureKeyCalls += 1;
     secureKeyStore.set(account, value);
     return true;
-  },
-  deleteSecureKey: (account: string): "deleted" | "not-found" | "error" => {
-    _deleteSecureKeyCalls += 1;
-    if (secureKeyStore.has(account)) {
-      secureKeyStore.delete(account);
-      return "deleted";
-    }
-    return "not-found";
   },
   deleteSecureKeyAsync: async (
     account: string,

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -110,27 +110,7 @@ mock.module("../calls/twilio-provider.js", () => ({
   },
 }));
 
-import { credentialKey } from "../security/credential-key.js";
-
-const secureKeyStore: Record<string, string | undefined> = {
-  [credentialKey("twilio", "account_sid")]: "AC_test",
-  [credentialKey("twilio", "auth_token")]: "test_token",
-};
-
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => secureKeyStore[key] ?? null,
-  setSecureKey: (key: string, value: string) => {
-    secureKeyStore[key] = value;
-    return true;
-  },
-  deleteSecureKey: (key: string) => {
-    if (key in secureKeyStore) {
-      delete secureKeyStore[key];
-      return "deleted";
-    }
-    return "not-found";
-  },
-}));
+mock.module("../security/secure-keys.js", () => ({}));
 
 // NOTE: Do NOT mock '../inbound/public-ingress-urls.js' here.
 // Those are pure functions that derive URLs from the config object returned by

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -51,9 +51,7 @@ mock.module("../calls/twilio-provider.js", () => ({
   },
 }));
 
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => null,
-}));
+mock.module("../security/secure-keys.js", () => ({}));
 
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -9,7 +9,6 @@ let mockTwilioAccountSid: string | undefined;
 const connectedProviders = new Set<string>();
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyValues.get(account),
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
 }));
 

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -26,9 +26,6 @@ mock.module("../util/logger.js", () => ({
 // Prevent ensureTelegramBotUsernameResolved() from reading real credentials
 // and calling the Telegram API.
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => undefined,
-  setSecureKey: () => {},
-  deleteSecureKey: () => {},
   getSecureKeyAsync: async () => undefined,
   setSecureKeyAsync: async () => {},
   deleteSecureKeyAsync: async () => {},

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -78,10 +78,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyValues.get(account),
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
-  setSecureKey: () => true,
-  deleteSecureKey: () => "deleted",
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",
   _resetBackend: () => {},

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -33,7 +33,6 @@ const secureKeyValues = new Map<string, string>();
 mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: mockDeleteSecureKeyAsync,
   setSecureKeyAsync: mockSetSecureKeyAsync,
-  getSecureKey: (account: string) => secureKeyValues.get(account),
   getSecureKeyAsync: (account: string) =>
     Promise.resolve(secureKeyValues.get(account)),
 }));
@@ -314,7 +313,6 @@ describe("provider operations", () => {
           defaultScopes: ["repo"],
           scopePolicy: {},
           callbackTransport: "loopback",
-
         },
       ]);
 

--- a/assistant/src/__tests__/provider-commit-message-generator.test.ts
+++ b/assistant/src/__tests__/provider-commit-message-generator.test.ts
@@ -10,11 +10,8 @@ import type { CommitContext } from "../workspace/commit-message-provider.js";
 // ---------------------------------------------------------------------------
 let mockSecureKeys: Record<string, string> = {};
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (name: string) => mockSecureKeys[name] ?? undefined,
   getSecureKeyAsync: async (name: string) => mockSecureKeys[name] ?? undefined,
-  setSecureKey: () => true,
   setSecureKeyAsync: async () => true,
-  deleteSecureKey: () => "deleted",
   deleteSecureKeyAsync: async () => "deleted" as const,
 }));
 

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -31,12 +31,9 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 let secureKeyValues = new Map<string, string | undefined>();
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyValues.get(account),
   getSecureKeyAsync: (account: string) =>
     Promise.resolve(secureKeyValues.get(account)),
-  setSecureKey: () => true,
   setSecureKeyAsync: () => Promise.resolve(true),
-  deleteSecureKey: () => "deleted",
   deleteSecureKeyAsync: () => Promise.resolve("deleted"),
   listSecureKeys: () => [],
   getBackendType: () => "encrypted",

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -42,12 +42,9 @@ mock.module("../security/secure-keys.js", () => {
     return "not-found" as const;
   };
   return {
-    getSecureKey: (key: string) => storedKeys.get(key) ?? null,
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
-    setSecureKey: syncSet,
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
-    deleteSecureKey: syncDelete,
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [],
     getBackendType: () => "encrypted",

--- a/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-managed-proxy.test.ts
@@ -66,7 +66,6 @@ mock.module("../logfire.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => secureKeyStore[key],
   getSecureKeyAsync: async (key: string) => secureKeyStore[key],
   setSecureKeyAsync: async (key: string, value: string) => {
     secureKeyStore[key] = value;

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -25,11 +25,8 @@ const metadataByKey = new Map<
 >();
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: () => undefined,
-  setSecureKey: setSecureKeyMock,
   setSecureKeyAsync: async (key?: string, value?: string) =>
     setSecureKeyMock(key, value),
-  deleteSecureKey: () => "deleted",
   deleteSecureKeyAsync: async () => "deleted" as const,
   listSecureKeys: () => [],
   getBackendType: () => null,

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -100,11 +100,8 @@ mock.module("../security/secure-keys.js", () => {
     return "not-found" as const;
   };
   return {
-    getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
     getSecureKeyAsync: async (account: string) =>
       secureKeyStore[account] ?? undefined,
-    setSecureKey: syncSet,
-    deleteSecureKey: syncDelete,
     setSecureKeyAsync: async (account: string, value: string) =>
       syncSet(account, value),
     deleteSecureKeyAsync: async (account: string) => syncDelete(account),

--- a/assistant/src/__tests__/swarm-recursion.test.ts
+++ b/assistant/src/__tests__/swarm-recursion.test.ts
@@ -68,7 +68,6 @@ const mockProvider = {
 };
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => "test-api-key",
-  getSecureKey: () => "test-api-key",
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/swarm-session-integration.test.ts
+++ b/assistant/src/__tests__/swarm-session-integration.test.ts
@@ -57,7 +57,6 @@ const mockTestProvider = {
 let mockAnthropicKey: string | undefined = "test-api-key";
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => mockAnthropicKey,
-  getSecureKey: () => mockAnthropicKey,
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/swarm-tool.test.ts
+++ b/assistant/src/__tests__/swarm-tool.test.ts
@@ -63,7 +63,6 @@ const mockProvider = {
 };
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => "test-api-key",
-  getSecureKey: () => "test-api-key",
 }));
 
 mock.module("../providers/registry.js", () => ({

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -13,7 +13,6 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
 }));
 

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -41,11 +41,6 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => {
-    if (key === credentialKey("twilio", "auth_token")) return mockAuthToken;
-    if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;
-    return undefined;
-  },
   getSecureKeyAsync: async (key: string) => {
     if (key === credentialKey("twilio", "auth_token")) return mockAuthToken;
     if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -143,7 +143,6 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => mockSecureKeyStore[key],
   setSecureKeyAsync: async (key: string, value: string) => {
     mockSecureKeyStore[key] = value;
     return true;

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -3,14 +3,8 @@
  * available (macOS app embedded), with transparent fallback to the
  * encrypted-at-rest file store.
  *
- * **Async variants are the primary API.** They try the encrypted store first
- * and fall back to the keychain broker. All new call sites should use
- * `getSecureKeyAsync`, `setSecureKeyAsync`, and `deleteSecureKeyAsync`.
- *
- * Sync variants (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) are
- * **deprecated startup-only exceptions** that bypass the keychain broker
- * entirely. They exist solely for code paths that cannot do async I/O
- * (e.g. `config/loader.ts`, `providers/managed-proxy/context.ts`).
+ * Use `getSecureKeyAsync`, `setSecureKeyAsync`, and `deleteSecureKeyAsync`
+ * for all credential access.
  */
 
 import { getLogger } from "../util/logger.js";
@@ -27,52 +21,8 @@ function getBroker(): KeychainBrokerClient {
   return _broker;
 }
 
-// ---------------------------------------------------------------------------
-// Sync variants — encrypted store only (DEPRECATED — startup-only exceptions)
-// ---------------------------------------------------------------------------
-
-/**
- * Retrieve a secret from secure storage (sync — encrypted store only).
- * Returns `undefined` if the key doesn't exist or on error.
- *
- * @deprecated Use `getSecureKeyAsync` instead. This sync variant only reads
- * from the encrypted file store, bypassing the keychain broker. Retained only
- * for sync code paths in `providers/registry.ts`, `providers/managed-proxy/context.ts`,
- * and `memory/embedding-backend.ts` that cannot do async I/O.
- */
-export function getSecureKey(account: string): string | undefined {
-  return encryptedStore.getKey(account);
-}
-
-/**
- * Store a secret in secure storage (sync — encrypted store only).
- * Returns `true` on success, `false` on failure.
- *
- * @deprecated Use `setSecureKeyAsync` instead. This sync variant only writes
- * to the encrypted file store, bypassing the keychain broker. Retained only
- * for sync code paths in `providers/registry.ts`, `providers/managed-proxy/context.ts`,
- * and `memory/embedding-backend.ts` that cannot do async I/O.
- */
-export function setSecureKey(account: string, value: string): boolean {
-  return encryptedStore.setKey(account, value);
-}
-
 /** Result of a delete operation — distinguishes success, not-found, and error. */
 export type DeleteResult = "deleted" | "not-found" | "error";
-
-/**
- * Delete a secret from secure storage (sync — encrypted store only).
- * Returns `"deleted"` on success, `"not-found"` if key doesn't exist,
- * or `"error"` on failure.
- *
- * @deprecated Use `deleteSecureKeyAsync` instead. This sync variant only
- * deletes from the encrypted file store, bypassing the keychain broker.
- * Retained only for startup code paths in `config/loader.ts` and
- * `providers/managed-proxy/context.ts` that cannot do async I/O.
- */
-export function deleteSecureKey(account: string): DeleteResult {
-  return encryptedStore.deleteKey(account);
-}
 
 /**
  * List all account names in secure storage (sync — encrypted store only).
@@ -95,11 +45,11 @@ export function getBackendType(): "broker" | "encrypted" | null {
 }
 
 // ---------------------------------------------------------------------------
-// Async variants — try encrypted store first, fall back to broker
+// Primary API — try encrypted store first, fall back to broker
 // ---------------------------------------------------------------------------
 
 /**
- * Async version of `getSecureKey`. Checks the encrypted store first
+ * Retrieve a secret from secure storage. Checks the encrypted store first
  * (instant) since `setSecureKeyAsync` always writes to both stores.
  * Falls back to the broker for keys that may exist only in the macOS
  * Keychain. Returns `undefined` if the key is not found in either store.
@@ -125,9 +75,9 @@ export async function getSecureKeyAsync(
 }
 
 /**
- * Async version of `setSecureKey`. When the broker is available the key
- * is written there **and** to the encrypted store so that sync callers
- * have a consistent view. Returns `true` only when both stores succeed.
+ * Store a secret in secure storage. When the broker is available the key
+ * is written there **and** to the encrypted store. Returns `true` only
+ * when all writes succeed.
  *
  * If the broker is available but `broker.set()` fails we return `false`
  * immediately — falling through to an encrypted-store-only write would
@@ -153,7 +103,7 @@ export async function setSecureKeyAsync(
       );
       return false;
     }
-    // Broker succeeded — also persist to encrypted store for sync callers.
+    // Broker succeeded — also persist to encrypted store.
     const encOk = encryptedStore.setKey(account, value);
     if (!encOk) {
       log.warn({ account }, "Encrypted store set failed after broker success");
@@ -168,9 +118,8 @@ export async function setSecureKeyAsync(
 }
 
 /**
- * Async version of `deleteSecureKey`. When the broker is available the
- * key is deleted there **and** from the encrypted store so that sync
- * callers have a consistent view.
+ * Delete a secret from secure storage. When the broker is available the
+ * key is deleted there **and** from the encrypted store.
  *
  * Returns `"deleted"` when the key was removed, `"not-found"` when it
  * didn't exist (idempotent), or `"error"` on a real backend failure.
@@ -186,7 +135,7 @@ export async function deleteSecureKeyAsync(
   if (broker.isAvailable()) {
     const brokerOk = await broker.del(account);
     if (!brokerOk) return "error";
-    // Broker succeeded — also remove from encrypted store for sync callers.
+    // Broker succeeded — also remove from encrypted store.
     const encResult = encryptedStore.deleteKey(account);
     // Broker deletion succeeded; encrypted-store "not-found" is fine
     // (key may only exist in the broker).


### PR DESCRIPTION
## Summary
- Remove 3 deprecated sync functions (`getSecureKey`, `setSecureKey`, `deleteSecureKey`) from `secure-keys.ts` — all callers have been migrated to async variants
- Clean up mock stubs for these functions across 28 test files, and remove the now-unused `secureKeyStore` variable in `gateway-only-enforcement.test.ts`
- Update `keychain-broker.md` to remove the "Known sync exceptions" section and deprecated function references; update pre-commit hook examples to use async function names

## Original prompt
Remove deprecated sync secure-key functions — 3 @deprecated functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
