### PR TITLE
chore: remove 4 unused test-only exports and 2 dead re-exports

### DIFF
--- a/assistant/src/__tests__/email-invite-adapter.test.ts
+++ b/assistant/src/__tests__/email-invite-adapter.test.ts
@@ -22,7 +22,6 @@ mock.module("../email/service.js", () => ({
   }),
   // Re-export other symbols that callers might need
   EmailService: class {},
-  _resetEmailService: () => {},
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -54,7 +54,6 @@ mock.module("../config/assistant-feature-flags.js", () => ({
   },
   loadDefaultsRegistry: () => ({}),
   getAssistantFeatureFlagDefaults: () => ({}),
-  _resetDefaultsCache: () => {},
 }));
 
 mock.module("../config/skill-state.js", () => ({

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -143,10 +143,3 @@ export function isAssistantFeatureFlagEnabled(
 export function getAssistantFeatureFlagDefaults(): FeatureFlagDefaultsRegistry {
   return loadDefaultsRegistry();
 }
-
-/**
- * Reset the cached defaults registry. Intended for tests only.
- */
-export function _resetDefaultsCache(): void {
-  cachedDefaults = undefined;
-}

--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -382,8 +382,3 @@ export function getEmailService(): EmailService {
   }
   return instance;
 }
-
-/** @internal Test-only: reset singleton. */
-export function _resetEmailService(): void {
-  instance = null;
-}

--- a/assistant/src/memory/qdrant-circuit-breaker.ts
+++ b/assistant/src/memory/qdrant-circuit-breaker.ts
@@ -108,11 +108,3 @@ export function _resetQdrantBreaker(): void {
   openedAt = 0;
   halfOpenProbeInFlight = false;
 }
-
-/** @internal Test-only: get breaker state */
-export function _getQdrantBreakerState(): {
-  state: BreakerState;
-  consecutiveFailures: number;
-} {
-  return { state: breakerState, consecutiveFailures };
-}

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -2,11 +2,7 @@ import { inArray } from "drizzle-orm";
 
 import { getLogger } from "../../util/logger.js";
 import { getDb } from "../db.js";
-import {
-  _getQdrantBreakerState,
-  _resetQdrantBreaker,
-  withQdrantBreaker,
-} from "../qdrant-circuit-breaker.js";
+import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import type {
   QdrantSearchResult,
   QdrantSparseVector,
@@ -23,9 +19,6 @@ import { computeRecencyScore } from "./ranking.js";
 import type { Candidate } from "./types.js";
 
 const _log = getLogger("semantic-search");
-
-// Re-export for tests that depend on these from this module
-export { _getQdrantBreakerState, _resetQdrantBreaker };
 
 export async function semanticSearch(
   queryVector: number[],

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -138,13 +138,6 @@ export function _resetInflightRefreshes(): void {
   inflightRefreshes.clear();
 }
 
-/** @internal Test-only: get breaker state for a service */
-export function _getRefreshBreakerState(
-  service: string,
-): RefreshBreakerState | undefined {
-  return refreshBreakers.get(service);
-}
-
 export class TokenExpiredError extends Error {
   constructor(
     public readonly service: string,


### PR DESCRIPTION
## Summary
- Audited all 15 `_reset*` and 6 `_get*` test-only exports across the codebase
- Removed 4 exports that were completely unused or only existed as no-op mock stubs: `_getRefreshBreakerState`, `_getQdrantBreakerState`, `_resetEmailService`, `_resetDefaultsCache`
- Cleaned up dead re-exports of `_getQdrantBreakerState` and `_resetQdrantBreaker` from `semantic.ts` (tests import directly from `qdrant-circuit-breaker.ts`)
- The remaining 11 `_reset*` exports are all actively called in tests for singleton/state isolation and cannot be removed without refactoring the test infrastructure

## Original prompt
Audit 18+ _reset* test-only exports to see what can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
