### PR TITLE
fix: await addMessage in memory regression tests

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -2242,14 +2242,14 @@ describe("Memory regressions", () => {
   });
 
   // PR-18: extract_items jobs carry scopeId through the async pipeline
-  test("extract_items job payload includes scopeId from private conversation", () => {
+  test("extract_items job payload includes scopeId from private conversation", async () => {
     const conv = createConversation({
       title: "Private scope job test",
       threadType: "private",
     });
     expect(conv.memoryScopeId).toMatch(/^private:/);
 
-    addMessage(
+    await addMessage(
       conv.id,
       "user",
       "Important data that should trigger extraction in private scope.",
@@ -2268,14 +2268,14 @@ describe("Memory regressions", () => {
     expect(payload.scopeId).toBe(conv.memoryScopeId);
   });
 
-  test("extract_items job payload defaults scopeId to default for standard conversations", () => {
+  test("extract_items job payload defaults scopeId to default for standard conversations", async () => {
     const conv = createConversation({
       title: "Standard scope job test",
       threadType: "standard",
     });
     expect(conv.memoryScopeId).toBe("default");
 
-    addMessage(
+    await addMessage(
       conv.id,
       "user",
       "Regular content for extraction in default scope.",


### PR DESCRIPTION
## Summary
- Two tests (`extract_items job payload includes scopeId from private conversation` and `extract_items job payload defaults scopeId to default for standard conversations`) were calling the async `addMessage()` without `await`, so `indexMessageNow()` never completed before assertions ran
- Added `async`/`await` to both test callbacks, matching the pattern used by all other `addMessage` tests in the file

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23079493957/job/67045951704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
