### PR TITLE
chore: audit backward-compat tests — remove dead code, relabel defaults

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -1206,7 +1206,7 @@ describe("AgentLoop", () => {
   // Dynamic tool resolver (resolveTools) tests
   // ---------------------------------------------------------------------------
 
-  // 25. Without resolveTools, static tools are used (backward compatible)
+  // 25. Without resolveTools, static tools are used
   test("without resolveTools, static tools are passed to provider", async () => {
     const { provider, calls } = createMockProvider([textResponse("Hi")]);
     const loop = new AgentLoop(provider, "system", {}, dummyTools);

--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -54,7 +54,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1441,7 +1441,7 @@ describe("HTTP handler channel-aware guardian status", () => {
     expect(resp!.guardianDisplayName).toBe("Guardian Name");
   });
 
-  test("status action defaults channel to telegram when omitted (backward compat)", async () => {
+  test("status action defaults channel to telegram when omitted", async () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
@@ -1457,7 +1457,7 @@ describe("HTTP handler channel-aware guardian status", () => {
     expect(resp!.assistantId).toBe("self");
   });
 
-  test("status action defaults assistantId to self when omitted (backward compat)", async () => {
+  test("status action defaults assistantId to self when omitted", async () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
@@ -2282,9 +2282,9 @@ describe("outbound verification sessions", () => {
     expect(result2.success).toBe(false);
   });
 
-  // ── Backward compat: existing inbound-only flow still works ──
+  // ── Inbound-only verification flow ──
 
-  test("backward compat: inbound-only challenge without expected identity still works", () => {
+  test("inbound-only challenge without expected identity still works", () => {
     const { secret } = createInboundVerificationSession("telegram");
 
     const result = validateAndConsumeVerification(

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -1947,7 +1947,7 @@ describe("Permission Checker", () => {
       ).toHaveLength(0);
     });
 
-    test("returns directory options when toolName is omitted (backward compat)", () => {
+    test("returns directory options when toolName is omitted", () => {
       const options = generateScopeOptions("/home/user/project");
       expect(options).toHaveLength(3);
       expect(options[0].scope).toBe("/home/user/project");
@@ -2121,11 +2121,11 @@ describe("Permission Checker", () => {
     });
   });
 
-  // ── backward compat: addRule basics (PR 2/40) ──
+  // ── addRule basics ──
   // These tests verify that addRule() creates standard rules that
   // match by tool name, pattern glob, and scope prefix.
 
-  describe("backward compat: addRule basics (PR 2/40)", () => {
+  describe("addRule basics", () => {
     test("rule matches by tool/pattern/scope", async () => {
       addRule("skill_test_tool", "skill_test_tool:*", "/tmp", "allow", 2000);
       const result = await check("skill_test_tool", {}, "/tmp");
@@ -2174,7 +2174,7 @@ describe("Permission Checker", () => {
       expect(v2Result.matchedRule?.id).toBe(v1Result.matchedRule?.id);
     });
 
-    test("findHighestPriorityRule works without policy context (backward compat)", () => {
+    test("findHighestPriorityRule works without policy context", () => {
       // Calling findHighestPriorityRule without the optional 4th ctx
       // parameter still works — wildcard rules match any caller.
       addRule("skill_test_tool", "skill_test_tool:*", "/tmp", "allow", 2000);
@@ -2199,14 +2199,14 @@ describe("Permission Checker", () => {
     });
   });
 
-  // ── checker policy context backward compat (PR 17) ─────────────
+  // ── optional policyContext parameter ─────────────
 
-  describe("checker policy context backward compat (PR 17)", () => {
-    test("check() without policyContext still works (backward compatible)", async () => {
-      addRule("bash", "echo backward-compat", "/tmp", "allow", 2000);
+  describe("optional policyContext parameter", () => {
+    test("check() without policyContext still works", async () => {
+      addRule("bash", "echo test-optional-ctx", "/tmp", "allow", 2000);
       const result = await check(
         "bash",
-        { command: "echo backward-compat" },
+        { command: "echo test-optional-ctx" },
         "/tmp",
       );
       expect(result.decision).toBe("allow");

--- a/assistant/src/__tests__/claude-code-tool-profiles.test.ts
+++ b/assistant/src/__tests__/claude-code-tool-profiles.test.ts
@@ -88,7 +88,7 @@ describe("claude_code tool profile support", () => {
     }
   });
 
-  test("omitted profile defaults to general (backward compat)", async () => {
+  test("omitted profile defaults to general", async () => {
     const result = await claudeCodeTool.execute(
       { prompt: "test" },
       makeContext(),

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -846,9 +846,8 @@ describe("AssistantConfigSchema", () => {
     expect(result.calls.callerIdentity.userNumber).toBe("+14155559999");
   });
 
-  test("legacy defaultMode field is silently stripped by schema", () => {
-    // Backward compatibility: existing configs with defaultMode should parse
-    // without error — Zod strips unrecognized keys by default.
+  test("unknown defaultMode field is silently stripped by schema", () => {
+    // Zod strips unrecognized keys by default.
     const result = AssistantConfigSchema.parse({
       calls: {
         callerIdentity: {
@@ -1101,7 +1100,7 @@ describe("loadConfig with schema validation", () => {
     expect(config.sandbox.enabled).toBe(true);
   });
 
-  test("loads sandbox with only enabled (backward compatibility)", () => {
+  test("loads sandbox with only enabled field", () => {
     writeConfig({ sandbox: { enabled: false } });
     const config = loadConfig();
     expect(config.sandbox.enabled).toBe(false);

--- a/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
+++ b/assistant/src/__tests__/guardian-action-conversation-turn.test.ts
@@ -34,8 +34,8 @@ import {
   createGuardianActionDelivery,
   createGuardianActionRequest,
   finalizeFollowup,
+  getFollowupDeliveriesByConversation,
   getFollowupDeliveriesByDestination,
-  getFollowupDeliveryByConversation,
   getGuardianActionRequest,
   markTimedOutWithReason,
   progressFollowupState,
@@ -391,7 +391,7 @@ describe("guardian-action-conversation-turn", () => {
     expect(deliveries).toHaveLength(0);
   });
 
-  test("getFollowupDeliveryByConversation returns delivery in awaiting_guardian_choice", () => {
+  test("getFollowupDeliveriesByConversation returns delivery in awaiting_guardian_choice", () => {
     const { delivery, deliveryConvId } = createAwaitingChoiceRequest(
       "conv-turn-4",
       {
@@ -399,18 +399,18 @@ describe("guardian-action-conversation-turn", () => {
       },
     );
 
-    const found = getFollowupDeliveryByConversation(deliveryConvId);
-    expect(found).not.toBeNull();
-    expect(found!.id).toBe(delivery.id);
+    const found = getFollowupDeliveriesByConversation(deliveryConvId);
+    expect(found).toHaveLength(1);
+    expect(found[0].id).toBe(delivery.id);
   });
 
-  test("getFollowupDeliveryByConversation returns null for non-matching conversation", () => {
+  test("getFollowupDeliveriesByConversation returns empty for non-matching conversation", () => {
     createAwaitingChoiceRequest("conv-turn-5", {
       conversationId: "mac-conv-2",
     });
 
-    const found = getFollowupDeliveryByConversation("nonexistent-conv");
-    expect(found).toBeNull();
+    const found = getFollowupDeliveriesByConversation("nonexistent-conv");
+    expect(found).toHaveLength(0);
   });
 
   // ── State transitions from conversation engine results ──────────────

--- a/assistant/src/__tests__/guardian-action-late-reply.test.ts
+++ b/assistant/src/__tests__/guardian-action-late-reply.test.ts
@@ -41,7 +41,6 @@ import {
   expireGuardianActionRequest,
   getExpiredDeliveriesByConversation,
   getExpiredDeliveriesByDestination,
-  getExpiredDeliveryByConversation,
   getFollowupDeliveriesByConversation,
   getGuardianActionRequest,
   getPendingDeliveriesByConversation,
@@ -180,34 +179,34 @@ describe("guardian-action-late-reply", () => {
     expect(deliveries).toHaveLength(0);
   });
 
-  // ── getExpiredDeliveryByConversation ───────────────────────────────
+  // ── getExpiredDeliveriesByConversation (singular-to-plural migration) ──
 
-  test("getExpiredDeliveryByConversation returns expired delivery for mac channel", () => {
+  test("getExpiredDeliveriesByConversation returns expired delivery for mac channel", () => {
     const { delivery, deliveryConvId } = createExpiredRequest("conv-late-4", {
       conversationId: "mac-conv-1",
     });
 
-    const found = getExpiredDeliveryByConversation(deliveryConvId);
-    expect(found).not.toBeNull();
-    expect(found!.id).toBe(delivery.id);
+    const found = getExpiredDeliveriesByConversation(deliveryConvId);
+    expect(found).toHaveLength(1);
+    expect(found[0].id).toBe(delivery.id);
   });
 
-  test("getExpiredDeliveryByConversation returns null for non-matching conversation", () => {
+  test("getExpiredDeliveriesByConversation returns empty for non-matching conversation", () => {
     createExpiredRequest("conv-late-5", { conversationId: "mac-conv-2" });
 
-    const found = getExpiredDeliveryByConversation("nonexistent-conv");
-    expect(found).toBeNull();
+    const found = getExpiredDeliveriesByConversation("nonexistent-conv");
+    expect(found).toHaveLength(0);
   });
 
-  test("getExpiredDeliveryByConversation returns null when followup already started", () => {
+  test("getExpiredDeliveriesByConversation returns empty when followup already started", () => {
     const { request, deliveryConvId } = createExpiredRequest("conv-late-6", {
       conversationId: "mac-conv-3",
     });
 
     startFollowupFromExpiredRequest(request.id, "already answered");
 
-    const found = getExpiredDeliveryByConversation(deliveryConvId);
-    expect(found).toBeNull();
+    const found = getExpiredDeliveriesByConversation(deliveryConvId);
+    expect(found).toHaveLength(0);
   });
 
   // ── startFollowupFromExpiredRequest ───────────────────────────────
@@ -309,8 +308,8 @@ describe("guardian-action-late-reply", () => {
     );
     expect(expiredByDest).toHaveLength(0);
 
-    const expiredByConv = getExpiredDeliveryByConversation(answeredConvId);
-    expect(expiredByConv).toBeNull();
+    const expiredByConv = getExpiredDeliveriesByConversation(answeredConvId);
+    expect(expiredByConv).toHaveLength(0);
   });
 
   // ── Composed follow-up text verification ──────────────────────────

--- a/assistant/src/__tests__/guardian-action-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-store.test.ts
@@ -35,12 +35,9 @@ import {
   expireGuardianActionRequest,
   getDeliveriesByRequestId,
   getExpiredDeliveriesByConversation,
-  getExpiredDeliveryByConversation,
   getFollowupDeliveriesByConversation,
-  getFollowupDeliveryByConversation,
   getGuardianActionRequest,
   getPendingDeliveriesByConversation,
-  getPendingDeliveryByConversation,
   startFollowupFromExpiredRequest,
   updateDeliveryStatus,
 } from "../memory/guardian-action-store.js";
@@ -153,17 +150,6 @@ describe("guardian-action-store", () => {
     expect(deliveries[0].requestId).toBe(request.id);
   });
 
-  test("getPendingDeliveryByConversation returns first from multiple (backward compat)", () => {
-    const convId = "compat-pending-conv";
-    ensureConversation(convId);
-
-    createPendingRequestWithDelivery("source-conv-compat-p1", convId);
-    createPendingRequestWithDelivery("source-conv-compat-p2", convId);
-
-    const single = getPendingDeliveryByConversation(convId);
-    expect(single).not.toBeNull();
-  });
-
   test("getPendingDeliveriesByConversation returns empty for non-matching conversation", () => {
     ensureConversation("other-conv");
     createPendingRequestWithDelivery("source-conv-no-match", "other-conv");
@@ -196,26 +182,6 @@ describe("guardian-action-store", () => {
     const requestIds = deliveries.map((d) => d.requestId);
     expect(requestIds).toContain(req1.id);
     expect(requestIds).toContain(req2.id);
-  });
-
-  test("getExpiredDeliveryByConversation returns first from multiple (backward compat)", () => {
-    const convId = "compat-expired-conv";
-    ensureConversation(convId);
-
-    const { request: req1 } = createPendingRequestWithDelivery(
-      "source-conv-compat-e1",
-      convId,
-    );
-    const { request: req2 } = createPendingRequestWithDelivery(
-      "source-conv-compat-e2",
-      convId,
-    );
-
-    expireGuardianActionRequest(req1.id, "sweep_timeout");
-    expireGuardianActionRequest(req2.id, "sweep_timeout");
-
-    const single = getExpiredDeliveryByConversation(convId);
-    expect(single).not.toBeNull();
   });
 
   test("getExpiredDeliveriesByConversation excludes deliveries with followup already started", () => {
@@ -269,29 +235,6 @@ describe("guardian-action-store", () => {
     const requestIds = deliveries.map((d) => d.requestId);
     expect(requestIds).toContain(req1.id);
     expect(requestIds).toContain(req2.id);
-  });
-
-  test("getFollowupDeliveryByConversation returns first from multiple (backward compat)", () => {
-    const convId = "compat-followup-conv";
-    ensureConversation(convId);
-
-    const { request: req1 } = createPendingRequestWithDelivery(
-      "source-conv-compat-f1",
-      convId,
-    );
-    const { request: req2 } = createPendingRequestWithDelivery(
-      "source-conv-compat-f2",
-      convId,
-    );
-
-    expireGuardianActionRequest(req1.id, "sweep_timeout");
-    expireGuardianActionRequest(req2.id, "sweep_timeout");
-
-    startFollowupFromExpiredRequest(req1.id, "late 1");
-    startFollowupFromExpiredRequest(req2.id, "late 2");
-
-    const single = getFollowupDeliveryByConversation(convId);
-    expect(single).not.toBeNull();
   });
 
   test("getFollowupDeliveriesByConversation returns empty for non-matching conversation", () => {

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -298,7 +298,7 @@ describe("startOutbound", () => {
     expect(voiceCallInitCalls[0].phoneNumber).toBe("+15559876543");
   });
 
-  test("voice: succeeds without originConversationId (backward compat)", async () => {
+  test("voice: succeeds without originConversationId", async () => {
     voiceCallInitCalls.length = 0;
     const result = await startOutbound({
       channel: "phone",

--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -2324,7 +2324,7 @@ describe("Memory regressions", () => {
       })
       .run();
 
-    // Call without scopeId — backward compat: should work exactly as before
+    // Call without scopeId — optional parameter omitted
     const withoutScope =
       await extractAndUpsertMemoryItemsForMessage("msg-scope-pass");
     expect(withoutScope).toBeGreaterThan(0);
@@ -3308,14 +3308,14 @@ describe("Memory regressions", () => {
           { type: "text", text: "Legacy message with no provenance info." },
         ]),
         createdAt: now,
-        // provenanceTrustClass is intentionally omitted (undefined) for backwards compat
+        // provenanceTrustClass is intentionally omitted (undefined) to test default behavior
       },
       DEFAULT_CONFIG.memory,
     );
 
     expect(result.indexedSegments).toBeGreaterThan(0);
 
-    // extract_items job should still be enqueued for legacy messages (backwards compat)
+    // extract_items job should still be enqueued for messages without provenance
     const extractJobs = db
       .select()
       .from(memoryJobs)

--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -98,7 +98,7 @@ describe("getPublicBaseUrl", () => {
     ).toThrow(/Public ingress is disabled/);
   });
 
-  test("returns URL when enabled is undefined (backward compat)", () => {
+  test("returns URL when enabled is undefined", () => {
     const result = getPublicBaseUrl({
       ingress: { enabled: undefined, publicBaseUrl: "https://example.com" },
     });

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -17,7 +17,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/session-confirmation-signals.test.ts
@@ -56,7 +56,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -15,7 +15,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -15,7 +15,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -39,7 +39,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));
@@ -621,8 +620,7 @@ describe("Session message queue", () => {
     const sessionErr = events.find((e) => e.type === "session_error");
     expect(sessionErr).toBeDefined();
 
-    // Should also emit generic error for backward compatibility
-    // (callers rely on error events to detect failures)
+    // Should also emit generic error (callers rely on error events to detect failures)
     const genericErr = events.find((e) => e.type === "error");
     expect(genericErr).toBeDefined();
   });
@@ -1674,7 +1672,7 @@ describe("Regression: cancel semantics and error channel split", () => {
     const sessionErr = allEvents.find((e) => e.type === "session_error");
     expect(sessionErr).toBeDefined();
 
-    // Should also get generic error for backward compatibility
+    // Should also get generic error
     const genericErr = allEvents.find((e) => e.type === "error");
     expect(genericErr).toBeDefined();
   });

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -22,7 +22,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -22,7 +22,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -22,7 +22,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -25,7 +25,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -23,7 +23,6 @@ mock.module("../util/platform.js", () => ({
 }));
 
 mock.module("../memory/guardian-action-store.js", () => ({
-  getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,
   resolveGuardianActionRequest: () => {},
 }));

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -196,7 +196,7 @@ describe("ToolExecutor allowedToolNames gating", () => {
     }
   });
 
-  test("executes normally when allowedToolNames is not set (backward compat)", async () => {
+  test("executes normally when allowedToolNames is not set", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "file_read",

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1461,10 +1461,10 @@ describe("Trust Store", () => {
       });
     });
 
-    // ── backward compatibility ────────────────────────────────────
+    // ── optional ctx parameter ────────────────────────────────────
 
-    describe("backward compatibility", () => {
-      test("existing callers without ctx parameter still work", () => {
+    describe("optional ctx parameter", () => {
+      test("callers without ctx parameter still work", () => {
         addRule("bash", "git *", "/tmp", "allow", 200);
         // Calling without the 4th argument — must still match
         const match = findHighestPriorityRule("bash", ["git status"], "/tmp");

--- a/assistant/src/config/bundled-skills/claude-code/SKILL.md
+++ b/assistant/src/config/bundled-skills/claude-code/SKILL.md
@@ -46,7 +46,7 @@ Do NOT delegate when:
 
 Claude Code supports scoped worker profiles that restrict tool access:
 
-- **general** (default) — Full access to all tools. Backward-compatible with existing behavior.
+- **general** (default) — Full access to all tools.
 - **researcher** — Read-only access. Can search, read files, and browse the web but cannot write or execute commands.
 - **coder** — Full read/write/execute access optimized for implementation tasks.
 - **reviewer** — Read-only access tailored for code review, with emphasis on analysis and feedback.

--- a/assistant/src/config/bundled-skills/claude-code/TOOLS.json
+++ b/assistant/src/config/bundled-skills/claude-code/TOOLS.json
@@ -36,7 +36,7 @@
           "profile": {
             "type": "string",
             "enum": ["general", "researcher", "coder", "reviewer"],
-            "description": "Worker profile that scopes tool access. Defaults to general (backward compatible)."
+            "description": "Worker profile that scopes tool access. Defaults to general."
           }
         }
       },

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -218,8 +218,7 @@ export async function runDaemon(): Promise<void> {
       });
 
       // DEPRECATED: The http-token file is deprecated. Readers will be
-      // migrated to use the credential store instead. This write is kept
-      // for backward compatibility until all consumers are updated.
+      // migrated to use the credential store instead.
       const httpTokenPath = join(getRootDir(), "http-token");
       writeFileSync(httpTokenPath, credentials.accessToken, { mode: 0o600 });
       chmodSync(httpTokenPath, 0o600);

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -723,16 +723,6 @@ export function getPendingDeliveriesByDestination(
 }
 
 /**
- * Look up a pending delivery by destination conversation ID (for mac channel routing).
- */
-export function getPendingDeliveryByConversation(
-  conversationId: string,
-): GuardianActionDelivery | null {
-  const all = getPendingDeliveriesByConversation(conversationId);
-  return all.length > 0 ? all[0] : null;
-}
-
-/**
  * Look up all pending deliveries by destination conversation ID.
  * Used for disambiguation when a reused vellum thread has multiple active
  * guardian requests.
@@ -809,16 +799,6 @@ export function getExpiredDeliveriesByDestination(
     }
     throw err;
   }
-}
-
-/**
- * Look up an expired delivery by destination conversation ID (for mac channel routing).
- */
-export function getExpiredDeliveryByConversation(
-  conversationId: string,
-): GuardianActionDelivery | null {
-  const all = getExpiredDeliveriesByConversation(conversationId);
-  return all.length > 0 ? all[0] : null;
 }
 
 /**
@@ -900,17 +880,6 @@ export function getFollowupDeliveriesByDestination(
     }
     throw err;
   }
-}
-
-/**
- * Look up a delivery for a request in `awaiting_guardian_choice` follow-up
- * state by destination conversation ID (for mac channel routing).
- */
-export function getFollowupDeliveryByConversation(
-  conversationId: string,
-): GuardianActionDelivery | null {
-  const all = getFollowupDeliveriesByConversation(conversationId);
-  return all.length > 0 ? all[0] : null;
 }
 
 /**

--- a/assistant/src/memory/migrations/032-guardian-delivery-conversation-index.ts
+++ b/assistant/src/memory/migrations/032-guardian-delivery-conversation-index.ts
@@ -3,8 +3,8 @@ import type { DrizzleDb } from "../db-connection.js";
 /**
  * Add index on guardian_action_deliveries.destination_conversation_id.
  *
- * Several lookup paths (getPendingDeliveryByConversation,
- * getExpiredDeliveryByConversation, getFollowupDeliveryByConversation)
+ * Several lookup paths (getPendingDeliveriesByConversation,
+ * getExpiredDeliveriesByConversation, getFollowupDeliveriesByConversation)
  * filter deliveries by destination_conversation_id. Without an index
  * these degrade to full table scans as delivery history grows.
  */

--- a/assistant/src/memory/migrations/110-channel-guardian.ts
+++ b/assistant/src/memory/migrations/110-channel-guardian.ts
@@ -89,7 +89,6 @@ export function createChannelGuardianTables(database: DrizzleDb): void {
   );
 
   // Migration: add assistant_id column to scope approval requests by assistant.
-  // Existing rows default to 'self' for backward compatibility.
   try {
     database.run(
       /*sql*/ `ALTER TABLE channel_guardian_approval_requests ADD COLUMN assistant_id TEXT NOT NULL DEFAULT 'self'`,

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -45,7 +45,7 @@ export interface OAuth2Config {
    * How the client authenticates at the token endpoint when a clientSecret is present.
    * - `client_secret_post`: Send client_id and client_secret in the POST body (default).
    * - `client_secret_basic`: Send an HTTP Basic Auth header with base64(client_id:client_secret).
-   * Defaults to `client_secret_post` for backward compatibility.
+   * Defaults to `client_secret_post`.
    */
   tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
 }

--- a/assistant/src/tools/claude-code/claude-code.ts
+++ b/assistant/src/tools/claude-code/claude-code.ts
@@ -121,7 +121,7 @@ export const claudeCodeTool: Tool = {
             type: "string",
             enum: ["general", "researcher", "coder", "reviewer"],
             description:
-              "Worker profile that scopes tool access. Defaults to general (backward compatible).",
+              "Worker profile that scopes tool access. Defaults to general.",
           },
         },
       },
@@ -261,7 +261,7 @@ export const claudeCodeTool: Tool = {
           return { behavior: "allow" as const };
         }
 
-        // Auto-approve safe read-only tools (backward compat for general profile)
+        // Auto-approve safe read-only tools (general profile default)
         if (AUTO_APPROVE_TOOLS.has(toolName)) {
           return { behavior: "allow" as const };
         }


### PR DESCRIPTION
## Summary
- **Removed 3 dead singular getter functions** (`getPendingDeliveryByConversation`, `getExpiredDeliveryByConversation`, `getFollowupDeliveryByConversation`) from `guardian-action-store.ts` — zero production callers, purely backward-compat wrappers around the plural versions
- **Removed 3 backward-compat test cases** and updated 6 test files that used the removed functions to call the plural APIs directly
- **Cleaned up 11 session test mocks** that referenced the removed `getPendingDeliveryByConversation`
- **Relabeled ~20 test cases/comments** that were incorrectly tagged as "backward compat" but actually test standard optional parameter defaults (e.g., omitting `toolName`, `policyContext`, `profile`)
- **Cleaned up production comments/metadata** in oauth2.ts, claude-code tool, lifecycle.ts, SKILL.md, TOOLS.json, and migration files

## Original prompt
Audit ~40 backward-compat test cases to see what can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
