### PR TITLE
chore: remove deprecated http-token file write and reader chain

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,6 @@ Each named instance gets its own directory tree under `~/.vellum/instances/<name
 │   │       ├── vellum.pid        # Daemon PID
 │   │       ├── gateway.pid       # Gateway PID
 │   │       ├── outbound-proxy.pid
-│   │       ├── http-token        # Bearer token for gateway auth
 │   │       ├── session-token
 │   │       └── workspace/
 │   │           ├── config.json

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -42,11 +42,10 @@ Diagnostic checks performed:
   6.  Disk space                 Ensures at least 100MB free on the data partition
   7.  Log file size              Warns if the log file exceeds 50MB
   8.  Database integrity         Runs SQLite PRAGMA integrity_check
-  9.  HTTP token permissions     Verifies the http-token file has 0600 or 0700 mode
-  10. Trust rule syntax          Validates trust.json structure and rule fields
-  11. WASM files                 Checks that tree-sitter WASM binaries are present
-  12. Browser runtime            Verifies Playwright and Chromium availability
-  13. Sandbox diagnostics        Reports sandbox backend status and configuration
+  9.  Trust rule syntax          Validates trust.json structure and rule fields
+  10. WASM files                 Checks that tree-sitter WASM binaries are present
+  11. Browser runtime            Verifies Playwright and Chromium availability
+  12. Sandbox diagnostics        Reports sandbox backend status and configuration
 
 Examples:
   $ assistant doctor`,
@@ -216,30 +215,7 @@ Examples:
         fail("Database integrity check", "database file not found");
       }
 
-      // 9. HTTP token
-      const tokenPath = `${rootDir}/http-token`;
-      if (existsSync(tokenPath)) {
-        try {
-          const tokenStat = statSync(tokenPath);
-          const mode = tokenStat.mode & 0o777;
-          if (mode === 0o600 || mode === 0o700) {
-            pass(
-              `HTTP token permissions (${mode.toString(8).padStart(4, "0")})`,
-            );
-          } else {
-            fail(
-              "HTTP token permissions",
-              `expected 0600 or 0700, got 0${mode.toString(8)}`,
-            );
-          }
-        } catch {
-          fail("HTTP token permissions", "could not stat http-token file");
-        }
-      } else {
-        pass("HTTP token (not present — assistant not running)");
-      }
-
-      // 10. Trust rule syntax
+      // 9. Trust rule syntax
       const trustPath = `${rootDir}/protected/trust.json`;
       if (existsSync(trustPath)) {
         try {
@@ -279,7 +255,7 @@ Examples:
         pass("Trust rule syntax (no trust.json yet)");
       }
 
-      // 11. WASM files
+      // 10. WASM files
       const wasmFiles = [
         { pkg: "web-tree-sitter", file: "web-tree-sitter.wasm" },
         { pkg: "tree-sitter-bash", file: "tree-sitter-bash.wasm" },
@@ -321,7 +297,7 @@ Examples:
         fail("WASM files", missingWasm.join(", "));
       }
 
-      // 12. Browser runtime (Playwright + Chromium)
+      // 11. Browser runtime (Playwright + Chromium)
       const { checkBrowserRuntime } =
         await import("../../tools/browser/runtime-check.js");
       const browserStatus = await checkBrowserRuntime();
@@ -339,7 +315,7 @@ Examples:
         );
       }
 
-      // 13. Sandbox backend diagnostics
+      // 12. Sandbox backend diagnostics
       const { runSandboxDiagnostics } =
         await import("../../tools/terminal/sandbox-diagnostics.js");
       const sandbox = runSandboxDiagnostics();

--- a/assistant/src/cli/http-client.ts
+++ b/assistant/src/cli/http-client.ts
@@ -5,25 +5,35 @@
  * Patterns are adapted from `cli/src/lib/http-client.ts` (external CLI).
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { getRuntimeHttpPort } from "../config/env.js";
-import { getRootDir } from "../util/platform.js";
+import { CURRENT_POLICY_EPOCH } from "../runtime/auth/policy.js";
+import {
+  initAuthSigningKey,
+  isSigningKeyInitialized,
+  loadOrCreateSigningKey,
+  mintToken,
+} from "../runtime/auth/token-service.js";
 
 // ---------------------------------------------------------------------------
 // Token
 // ---------------------------------------------------------------------------
 
 /**
- * Read the HTTP bearer token from `<rootDir>/http-token`.
- * Returns undefined if the token file doesn't exist or is empty.
+ * Mint a short-lived CLI JWT from the signing key on disk.
+ * Returns undefined if the signing key cannot be loaded.
  */
-export function readHttpToken(): string | undefined {
-  const tokenPath = join(getRootDir(), "http-token");
+export function mintCliToken(): string | undefined {
   try {
-    const token = readFileSync(tokenPath, "utf-8").trim();
-    return token || undefined;
+    if (!isSigningKeyInitialized()) {
+      initAuthSigningKey(loadOrCreateSigningKey());
+    }
+    return mintToken({
+      aud: "vellum-gateway",
+      sub: "svc:cli:local",
+      scope_profile: "actor_client_v1",
+      policy_epoch: CURRENT_POLICY_EPOCH,
+      ttlSeconds: 300,
+    });
   } catch {
     return undefined;
   }
@@ -53,7 +63,7 @@ export async function httpSend(
   path: string,
   init: RequestInit = {},
 ): Promise<Response> {
-  const token = readHttpToken();
+  const token = mintCliToken();
   const url = `${getHttpBaseUrl()}${path}`;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { chmodSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
@@ -210,21 +209,13 @@ export async function runDaemon(): Promise<void> {
       const hashedDeviceId = createHash("sha256")
         .update(cliDeviceId)
         .digest("hex");
-      const credentials = mintCredentialPair({
+      mintCredentialPair({
         platform: "cli",
         deviceId: cliDeviceId,
         guardianPrincipalId,
         hashedDeviceId,
       });
-
-      // DEPRECATED: The http-token file is deprecated. Readers will be
-      // migrated to use the credential store instead.
-      const httpTokenPath = join(getRootDir(), "http-token");
-      writeFileSync(httpTokenPath, credentials.accessToken, { mode: 0o600 });
-      chmodSync(httpTokenPath, 0o600);
-      log.info(
-        "Daemon startup: CLI edge token written to credential store and http-token",
-      );
+      log.info("Daemon startup: CLI edge token written to credential store");
     } else {
       log.warn("No guardian principal available — CLI edge token not written");
     }
@@ -477,8 +468,7 @@ export async function runDaemon(): Promise<void> {
 
     const hostname = getRuntimeHttpHost();
 
-    // Mint a JWT bearer token for the pairing flow. This replaces the
-    // old static http-token that was removed — the pairing handler
+    // Mint a JWT bearer token for the pairing flow. The pairing handler
     // and HTTP auto-approve logic both guard on a non-empty bearer token.
     const pairingBearerToken = mintPairingBearerToken();
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -40,6 +40,7 @@ import {
 } from "../lib/constants";
 import type { RemoteHost, Species } from "../lib/constants";
 import { hatchDocker } from "../lib/docker";
+import { mintLocalBearerToken } from "../lib/jwt";
 import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import {
@@ -794,17 +795,9 @@ async function hatchLocal(
     delete process.env.BASE_DATA_DIR;
   }
 
-  // Read the bearer token (JWT) written by the daemon so the CLI can
-  // with the gateway (which requires auth by default). The daemon writes under
-  // getRootDir() which resolves to <instanceDir>/.vellum/.
-  let bearerToken: string | undefined;
-  try {
-    const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
-    const token = readFileSync(tokenPath, "utf-8").trim();
-    if (token) bearerToken = token;
-  } catch {
-    // Token file may not exist if daemon started without HTTP server
-  }
+  // Mint a JWT from the signing key so the CLI can authenticate with the
+  // daemon/gateway (which requires auth by default).
+  const bearerToken = mintLocalBearerToken(resources.instanceDir);
 
   const localEntry: AssistantEntry = {
     assistantId: instanceName,

--- a/cli/src/lib/jwt.ts
+++ b/cli/src/lib/jwt.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal JWT minting for the external CLI.
+ *
+ * Loads the shared HMAC signing key from disk and mints short-lived JWTs
+ * so the CLI can authenticate with the daemon's HTTP server without reading
+ * the deprecated http-token file.
+ */
+
+import { createHmac, randomBytes } from "crypto";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function base64urlEncode(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  return buf.toString("base64url");
+}
+
+const JWT_HEADER = base64urlEncode(
+  JSON.stringify({ alg: "HS256", typ: "JWT" }),
+);
+
+/**
+ * Mint a short-lived JWT bearer token for the given instance directory.
+ *
+ * Reads the signing key from `<instanceDir>/.vellum/protected/actor-token-signing-key`
+ * and mints a 5-minute JWT with `aud=vellum-gateway`.
+ *
+ * Returns undefined if the signing key doesn't exist yet (daemon not started).
+ */
+export function mintLocalBearerToken(instanceDir: string): string | undefined {
+  try {
+    const keyPath = join(
+      instanceDir,
+      ".vellum",
+      "protected",
+      "actor-token-signing-key",
+    );
+    const key = readFileSync(keyPath);
+    if (key.length !== 32) return undefined;
+
+    const now = Math.floor(Date.now() / 1000);
+    const claims = {
+      iss: "vellum-auth",
+      aud: "vellum-gateway",
+      sub: "svc:cli:local",
+      scope_profile: "actor_client_v1",
+      exp: now + 300,
+      policy_epoch: 1,
+      iat: now,
+      jti: randomBytes(16).toString("hex"),
+    };
+
+    const payload = base64urlEncode(JSON.stringify(claims));
+    const sigInput = JWT_HEADER + "." + payload;
+    const sig = createHmac("sha256", key).update(sigInput).digest();
+    return sigInput + "." + base64urlEncode(sig);
+  } catch {
+    return undefined;
+  }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -215,8 +215,7 @@ extension AppDelegate {
             if success {
                 log.info("Initial actor token bootstrap succeeded")
                 // Push the new actor token to the HTTP transport so SSE and
-                // API requests authenticate with the full-scope JWT instead
-                // of the http-token file (which may lack required scopes).
+                // API requests authenticate with the full-scope JWT.
                 if let token = ActorTokenManager.getToken(), !token.isEmpty {
                     daemonClient.updateTransportBearerToken(token)
                 }

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -45,13 +45,6 @@ private func resolveInstanceDirFromLockfile() -> String? {
     return instanceDir
 }
 
-/// Resolve the runtime HTTP bearer token path.
-/// Uses BASE_DATA_DIR when set to match daemon root resolution.
-/// Available on all platforms since HTTP transport is used on both macOS and iOS.
-public func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
-    return resolveVellumDir(environment: environment) + "/http-token"
-}
-
 /// Resolve the feature-flag bearer token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 public func resolveFeatureFlagTokenPath(environment: [String: String]? = nil) -> String {

--- a/clients/shared/Network/DaemonConnection.swift
+++ b/clients/shared/Network/DaemonConnection.swift
@@ -25,16 +25,9 @@ extension DaemonClient {
 
         log.info("connect: establishing HTTP transport to \(baseURL, privacy: .public)")
 
-        // The bearer token may be nil at config time (e.g. managed mode or
-        // local HTTP where the token isn't known until bootstrap).
-        // Resolve lazily from disk so connections started after a previous
-        // bootstrap carry the persisted JWT.
-        let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
-        let resolvedToken = bearerToken ?? (try? String(contentsOfFile: resolveHttpTokenPath(environment: tokenEnv), encoding: .utf8)).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-
         let transport = HTTPTransport(
             baseURL: baseURL,
-            bearerToken: resolvedToken,
+            bearerToken: bearerToken,
             conversationKey: conversationKey,
             transportMetadata: config.transportMetadata
         )

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -1448,10 +1448,10 @@ public final class HTTPTransport {
                         }
                     }
                     if statusCode == 403 {
-                        // 403 during assistant switch: the http-token (gateway_service_v1
-                        // profile) may lack chat.read scope needed for SSE. The actor
-                        // token is still bootstrapping. Use a short retry delay so SSE
-                        // reconnects quickly once the actor token is available.
+                        // 403 during assistant switch: the bearer token may lack
+                        // chat.read scope needed for SSE. The actor token is still
+                        // bootstrapping. Use a short retry delay so SSE reconnects
+                        // quickly once the actor token is available.
                         self.sseReconnectDelay = 1.0
                     }
                     self.handleSSEDisconnect()
@@ -2899,8 +2899,8 @@ public final class HTTPTransport {
                     }
                 }
                 // 403 during assistant switch: the actor token hasn't been
-                // bootstrapped yet (http-token lacks chat.read scope). Retry
-                // a few times with a delay to let ensureActorCredentials() finish.
+                // bootstrapped yet. Retry a few times with a delay to let
+                // ensureActorCredentials() finish.
                 if statusCode == 403 && authRetryCount < 6 {
                     log.info("Session list fetch got 403 — waiting for actor token (attempt \(authRetryCount + 1)/6)")
                     try? await Task.sleep(nanoseconds: 2_000_000_000)

--- a/skills/doordash/scripts/lib/shared/platform.ts
+++ b/skills/doordash/scripts/lib/shared/platform.ts
@@ -3,6 +3,7 @@
  * Subset of assistant/src/util/platform.ts — kept minimal.
  */
 
+import { createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -38,17 +39,41 @@ export function buildDaemonUrl(port?: number): string {
   return `http://127.0.0.1:${port ?? getHttpPort()}`;
 }
 
+function base64urlEncode(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  return buf.toString("base64url");
+}
+
+const JWT_HEADER = base64urlEncode(
+  JSON.stringify({ alg: "HS256", typ: "JWT" }),
+);
+
 /**
- * Read the HTTP bearer token from `<rootDir>/http-token`.
- * Returns null if the token file doesn't exist or is empty.
+ * Mint a short-lived JWT bearer token from the signing key on disk.
+ * Returns null if the signing key doesn't exist.
  */
 export function readHttpToken(): string | null {
   try {
-    const token = readFileSync(
-      join(getRootDir(), "http-token"),
-      "utf-8",
-    ).trim();
-    return token || null;
+    const keyPath = join(getRootDir(), "protected", "actor-token-signing-key");
+    const key = readFileSync(keyPath);
+    if (key.length !== 32) return null;
+
+    const now = Math.floor(Date.now() / 1000);
+    const claims = {
+      iss: "vellum-auth",
+      aud: "vellum-gateway",
+      sub: "svc:cli:local",
+      scope_profile: "actor_client_v1",
+      exp: now + 300,
+      policy_epoch: 1,
+      iat: now,
+      jti: randomBytes(16).toString("hex"),
+    };
+
+    const payload = base64urlEncode(JSON.stringify(claims));
+    const sigInput = JWT_HEADER + "." + payload;
+    const sig = createHmac("sha256", key).update(sigInput).digest();
+    return sigInput + "." + base64urlEncode(sig);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Removes the deprecated `http-token` file write from daemon startup and all file-based readers across the codebase (built-in CLI, external CLI, macOS/iOS clients, doordash skill, doctor diagnostic)
- Consumers now mint short-lived JWTs directly from the shared signing key on disk (`~/.vellum/protected/actor-token-signing-key`) instead of reading a persisted token file
- The `.gitignore` migration in `git-service.ts` is intentionally preserved to clean up existing workspace gitignore files

## Original prompt
Remove deprecated http-token file write and reader chain — lifecycle.ts:220-225 plus readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
