### PR TITLE
chore: remove 5 unused type exports from clawhub.ts

### DIFF
--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -160,14 +160,14 @@ export function verifyAndRecordSkillHash(slug: string): void {
   saveIntegrityManifest(manifest);
 }
 
-export interface ClawhubInstallResult {
+interface ClawhubInstallResult {
   success: boolean;
   skillName?: string;
   version?: string;
   error?: string;
 }
 
-export interface ClawhubSearchResultItem {
+interface ClawhubSearchResultItem {
   name: string;
   slug: string;
   description: string;
@@ -180,17 +180,17 @@ export interface ClawhubSearchResultItem {
   source: "vellum" | "clawhub";
 }
 
-export interface ClawhubSearchResult {
+interface ClawhubSearchResult {
   skills: ClawhubSearchResultItem[];
 }
 
-export interface ClawhubUpdateResult {
+interface ClawhubUpdateResult {
   success: boolean;
   updatedVersion?: string;
   error?: string;
 }
 
-export interface ClawhubUpdateCheckItem {
+interface ClawhubUpdateCheckItem {
   name: string;
   installedVersion: string;
   latestVersion: string;


### PR DESCRIPTION
Remove ClawhubInstallResult, ClawhubSearchResultItem, ClawhubSearchResult, ClawhubUpdateResult, ClawhubUpdateCheckItem — exported but never imported anywhere.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
