### PR TITLE
chore: remove 4 unused type exports from work-item-store.ts

### DIFF
--- a/assistant/src/work-items/work-item-store.ts
+++ b/assistant/src/work-items/work-item-store.ts
@@ -147,7 +147,7 @@ export function deleteWorkItem(id: string): void {
 
 // ── Queue Removal ───────────────────────────────────────────────────
 
-export interface RemoveWorkItemResult {
+interface RemoveWorkItemResult {
   success: boolean;
   title: string;
   message: string;
@@ -177,7 +177,7 @@ export function removeWorkItemFromQueue(id: string): RemoveWorkItemResult {
 
 // ── Selectors / Helpers ─────────────────────────────────────────────
 
-export interface WorkItemSelector {
+interface WorkItemSelector {
   workItemId?: string;
   taskId?: string;
   title?: string;
@@ -356,9 +356,9 @@ export function resolveWorkItem(
 
 // ── Entity Identification ───────────────────────────────────────────
 
-export type EntityType = "task_template" | "work_item" | "unknown";
+type EntityType = "task_template" | "work_item" | "unknown";
 
-export interface EntityIdentification {
+interface EntityIdentification {
   type: EntityType;
   id: string;
   title?: string;


### PR DESCRIPTION
Remove RemoveWorkItemResult, WorkItemSelector, EntityType, EntityIdentification — exported but never imported anywhere.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
