### PR TITLE
chore: remove 4 unused type exports from managed-store.ts

### DIFF
--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -47,7 +47,7 @@ function getSkillsIndexPath(): string {
 
 // ─── SKILL.md generation ─────────────────────────────────────────────────────
 
-export interface BuildSkillMarkdownInput {
+interface BuildSkillMarkdownInput {
   name: string;
   description: string;
   bodyMarkdown: string;
@@ -195,7 +195,7 @@ export function readSkillVersion(id: string): string | null {
 
 // ─── Create / Delete ─────────────────────────────────────────────────────────
 
-export interface CreateManagedSkillParams {
+interface CreateManagedSkillParams {
   id: string;
   name: string;
   description: string;
@@ -209,7 +209,7 @@ export interface CreateManagedSkillParams {
   version?: string;
 }
 
-export interface CreateManagedSkillResult {
+interface CreateManagedSkillResult {
   created: boolean;
   path: string;
   indexUpdated: boolean;
@@ -295,7 +295,7 @@ export function createManagedSkill(
   return { created: true, path: skillFilePath, indexUpdated };
 }
 
-export interface DeleteManagedSkillResult {
+interface DeleteManagedSkillResult {
   deleted: boolean;
   indexUpdated: boolean;
   error?: string;


### PR DESCRIPTION
Remove BuildSkillMarkdownInput, CreateManagedSkillParams, CreateManagedSkillResult, DeleteManagedSkillResult — exported but never imported anywhere.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
