### PR TITLE
chore: remove unused RATE_LIMIT_ERROR enum member

### DIFF
--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -20,9 +20,6 @@ export enum ErrorCode {
   // WASM integrity check failures
   INTEGRITY_ERROR = "INTEGRITY_ERROR",
 
-  // Rate limit exceeded
-  RATE_LIMIT_ERROR = "RATE_LIMIT_ERROR",
-
   // Secret detected in inbound content
   INGRESS_BLOCKED = "INGRESS_BLOCKED",
 


### PR DESCRIPTION
Remove ErrorCode.RATE_LIMIT_ERROR — defined but never referenced anywhere in the codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
