### PR TITLE
chore: remove unused isPhoneChannel() export

### DIFF
--- a/assistant/src/util/canonicalize-identity.ts
+++ b/assistant/src/util/canonicalize-identity.ts
@@ -44,12 +44,3 @@ export function canonicalizeInboundIdentity(
 
   return trimmed;
 }
-
-/**
- * Check whether a channel uses phone-number-based identity.
- * Useful for call sites that need to know whether E.164 normalization
- * applies without re-importing the channel set.
- */
-export function isPhoneChannel(channel: ChannelId): boolean {
-  return PHONE_CHANNELS.has(channel);
-}


### PR DESCRIPTION
Remove isPhoneChannel() from canonicalize-identity.ts — never called; PHONE_CHANNELS is used directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
