### PR TITLE
chore: remove obsolete cli/src/types/sh.d.ts

### DIFF
--- a/cli/src/types/sh.d.ts
+++ b/cli/src/types/sh.d.ts
@@ -1,4 +1,0 @@
-declare module "*.sh" {
-  const content: string;
-  export default content;
-}


### PR DESCRIPTION
Remove sh.d.ts module declaration — superseded by 'with { type: "text" }' import syntax.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
