### PR TITLE
chore: remove unused expectToolNamesEqual from browser-skill-harness.ts

### DIFF
--- a/assistant/src/__tests__/test-support/browser-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/browser-skill-harness.ts
@@ -62,24 +62,6 @@ export function buildSkillLoadHistory(
 }
 
 /**
- * Assert that a set of tool names is exactly the expected set (order-independent).
- */
-export function expectToolNamesEqual(
-  actual: string[],
-  expected: readonly string[],
-): void {
-  const sorted = [...actual].sort();
-  const expectedSorted = [...expected].sort();
-  if (JSON.stringify(sorted) !== JSON.stringify(expectedSorted)) {
-    throw new Error(
-      `Tool names mismatch.\nExpected: ${JSON.stringify(
-        expectedSorted,
-      )}\nActual: ${JSON.stringify(sorted)}`,
-    );
-  }
-}
-
-/**
  * Assert that all browser tool names are present in a given set.
  */
 export function assertBrowserToolsPresent(toolNames: string[]): void {


### PR DESCRIPTION
Remove expectToolNamesEqual — exported but never imported by any test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
