### PR TITLE
chore: remove 3 dead exports from computer-use-skill-harness.ts

### DIFF
--- a/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
+++ b/assistant/src/__tests__/test-support/computer-use-skill-harness.ts
@@ -17,28 +17,5 @@ export const COMPUTER_USE_TOOL_NAMES = [
   "computer_use_respond",
 ] as const;
 
-/** The skill ID for the bundled computer-use skill (used in later PRs). */
-export const COMPUTER_USE_SKILL_ID = "computer-use";
-
 /** Number of computer_use_* tools. */
 export const COMPUTER_USE_TOOL_COUNT = COMPUTER_USE_TOOL_NAMES.length; // 11
-
-import { expect } from "bun:test";
-
-/**
- * Assert that every COMPUTER_USE_TOOL_NAMES entry is present in `names`.
- */
-export function assertComputerUseToolsPresent(names: string[]): void {
-  for (const name of COMPUTER_USE_TOOL_NAMES) {
-    expect(names).toContain(name);
-  }
-}
-
-/**
- * Assert that no COMPUTER_USE_TOOL_NAMES entry is present in `names`.
- */
-export function assertComputerUseToolsAbsent(names: string[]): void {
-  for (const name of COMPUTER_USE_TOOL_NAMES) {
-    expect(names).not.toContain(name);
-  }
-}


### PR DESCRIPTION
Remove assertComputerUseToolsPresent, assertComputerUseToolsAbsent, COMPUTER_USE_SKILL_ID — never imported by any test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
