### PR TITLE
chore: un-export 3 internal-only functions in browser-relay-websocket.ts

### DIFF
--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -10,7 +10,7 @@ const log = getLogger("browser-relay-ws");
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
-export function isPrivateAddress(addr: string): boolean {
+function isPrivateAddress(addr: string): boolean {
   const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
   const normalized = v4Mapped ? v4Mapped[1] : addr;
 
@@ -39,7 +39,7 @@ export function isPrivateAddress(addr: string): boolean {
   return false;
 }
 
-export function isPrivateNetworkPeer(
+function isPrivateNetworkPeer(
   server: import("bun").Server<unknown>,
   req: Request,
 ): boolean {
@@ -53,7 +53,7 @@ export function isPrivateNetworkPeer(
  * Use this instead of isPrivateNetworkPeer for endpoints that must be
  * restricted to the local machine (e.g. token minting).
  */
-export function isLoopbackAddress(addr: string): boolean {
+function isLoopbackAddress(addr: string): boolean {
   const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
   const normalized = v4Mapped ? v4Mapped[1] : addr;
 


### PR DESCRIPTION
Remove unnecessary export from isPrivateAddress, isPrivateNetworkPeer, isLoopbackAddress — used only within the same file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
