### PR TITLE
fix: restore cli/src/types/sh.d.ts needed by gcp.ts shell import

### DIFF
--- a/cli/src/types/sh.d.ts
+++ b/cli/src/types/sh.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sh" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- Restores `cli/src/types/sh.d.ts` which was incorrectly removed in #16613
- The `*.sh` module declaration is still needed by `cli/src/lib/gcp.ts` which imports `../adapters/install.sh` with `{ type: "text" }`
- Fixes CI type-check failure: `error TS2307: Cannot find module '../adapters/install.sh'`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23079904227/job/67047035921

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
