### PR TITLE
feat: gate Sign in button behind env var

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
@@ -5,8 +5,9 @@ enum OnboardingManagedContinuationAction: Equatable {
     case bootstrap
 }
 
-func onboardingPrimaryButtonTitle(isAuthenticated: Bool) -> String {
-    isAuthenticated ? "Talk to your assistant" : "Sign in"
+func onboardingPrimaryButtonTitle(isAuthenticated: Bool, managedSignInEnabled: Bool) -> String {
+    if isAuthenticated { return "Talk to your assistant" }
+    return managedSignInEnabled ? "Sign in" : "Coming Soon"
 }
 
 func onboardingManagedContinuationAction(isAuthenticated: Bool) -> OnboardingManagedContinuationAction {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -30,8 +30,12 @@ struct WakeUpStepView: View {
         return NSImage(contentsOf: url)
     }()
 
+    private var managedSignInEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("managed_sign_in_enabled")
+    }
+
     private var primaryButtonTitle: String {
-        onboardingPrimaryButtonTitle(isAuthenticated: authManager?.isAuthenticated == true)
+        onboardingPrimaryButtonTitle(isAuthenticated: authManager?.isAuthenticated == true, managedSignInEnabled: managedSignInEnabled)
     }
 
     // MARK: - Body
@@ -80,6 +84,7 @@ struct WakeUpStepView: View {
                 OnboardingButton(title: primaryButtonTitle, style: .primary) {
                     onContinueWithVellum()
                 }
+                .disabled(!managedSignInEnabled && authManager?.isAuthenticated != true)
                 .accessibilityLabel("Sign in")
             }
 


### PR DESCRIPTION
## Summary
- Gate the onboarding "Sign in" button behind `VELLUM_FLAG_MANAGED_SIGN_IN_ENABLED`
- When unset (default): button shows "Coming Soon" and is disabled
- When set to `true`: button shows "Sign in" and works as before
- No feature flag registry entry — env-var-only, hidden from Settings UI

## Original prompt
Gate the "Sign in" button on the desktop behind an env var. Disabled by default showing "Coming Soon", functional when the env var is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
