### PR TITLE
chore: remove dead getRegisteredProviderIds

### DIFF
--- a/assistant/src/messaging/registry.ts
+++ b/assistant/src/messaging/registry.ts
@@ -33,8 +33,3 @@ export async function getConnectedProviders(): Promise<MessagingProvider[]> {
   }
   return results;
 }
-
-/** Return all registered provider IDs. */
-export function getRegisteredProviderIds(): string[] {
-  return Array.from(providers.keys());
-}


### PR DESCRIPTION
Delete unused getRegisteredProviderIds function from messaging provider code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
