### PR TITLE
chore: un-export ~10 route handler functions

### DIFF
--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -101,7 +101,7 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
   return new Response(null, { status: 204 });
 }
 
-export function handleGetAttachment(attachmentId: string): Response {
+function handleGetAttachment(attachmentId: string): Response {
   const attachment = attachmentsStore.getAttachmentById(attachmentId);
   if (!attachment) {
     return httpError("NOT_FOUND", "Attachment not found", 404);

--- a/assistant/src/runtime/routes/brain-graph-routes.ts
+++ b/assistant/src/runtime/routes/brain-graph-routes.ts
@@ -34,7 +34,7 @@ function getMemoryKindColor(kind: string): string {
   }
 }
 
-export function handleGetBrainGraph(): Response {
+function handleGetBrainGraph(): Response {
   try {
     const db = getDb();
 

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -148,7 +148,7 @@ export async function handleStartCall(
 /**
  * GET /v1/calls/:callSessionId
  */
-export function handleGetCallStatus(callSessionId: string): Response {
+function handleGetCallStatus(callSessionId: string): Response {
   const result = getCallStatus(callSessionId);
 
   if (!result.ok) {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1169,7 +1169,7 @@ export async function handleGetSuggestion(
  * Full-text search across all conversation threads (message content + titles).
  * Returns ranked results grouped by conversation, each with matching message excerpts.
  */
-export function handleSearchConversations(url: URL): Response {
+function handleSearchConversations(url: URL): Response {
   const query = url.searchParams.get("q") ?? "";
   if (!query.trim()) {
     return httpError("BAD_REQUEST", "q query parameter is required", 400);

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -35,7 +35,7 @@ function getMemoryItemCount(): number {
   }
 }
 
-export function handleDebug(): Response {
+function handleDebug(): Response {
   const now = Date.now();
   const uptimeSeconds = Math.floor((now - startedAt) / 1000);
 

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -27,7 +27,7 @@ type DocumentListRow = Omit<DocumentRow, "content">;
 // Shared business logic (used by both message handlers and HTTP routes)
 // ---------------------------------------------------------------------------
 
-export function saveDocument(params: {
+function saveDocument(params: {
   surfaceId: string;
   conversationId: string;
   title: string;
@@ -66,7 +66,7 @@ export function saveDocument(params: {
   }
 }
 
-export function loadDocument(surfaceId: string):
+function loadDocument(surfaceId: string):
   | {
       success: true;
       surfaceId: string;
@@ -112,7 +112,7 @@ export function loadDocument(surfaceId: string):
   }
 }
 
-export function listDocuments(conversationId?: string): Array<{
+function listDocuments(conversationId?: string): Array<{
   surfaceId: string;
   conversationId: string;
   title: string;

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -19,7 +19,6 @@ import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { mintCredentialPair } from "../auth/credential-service.js";
 import { httpError } from "../http-errors.js";
-import type { RouteDefinition } from "../http-router.js";
 
 /** Bun server shape needed for requestIP -- avoids importing the full Bun type. */
 type ServerWithRequestIP = {
@@ -153,23 +152,4 @@ export async function handleGuardianBootstrap(
     log.error({ err }, "Guardian bootstrap failed");
     return httpError("INTERNAL_ERROR", "Internal server error", 500);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Route definitions
-// ---------------------------------------------------------------------------
-
-/**
- * Guardian bootstrap is a pre-auth endpoint (handled before JWT auth in
- * http-server.ts), so these definitions are exported for completeness but
- * are not added to the authenticated route table.
- */
-export function guardianBootstrapRouteDefinitions(): RouteDefinition[] {
-  return [
-    {
-      endpoint: "guardian/init",
-      method: "POST",
-      handler: async ({ req, server }) => handleGuardianBootstrap(req, server),
-    },
-  ];
 }

--- a/assistant/src/runtime/routes/guardian-refresh-routes.ts
+++ b/assistant/src/runtime/routes/guardian-refresh-routes.ts
@@ -8,7 +8,6 @@
 import { getLogger } from "../../util/logger.js";
 import { rotateCredentials } from "../auth/credential-service.js";
 import { httpError } from "../http-errors.js";
-import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("guardian-refresh");
 
@@ -77,23 +76,4 @@ export async function handleGuardianRefresh(req: Request): Promise<Response> {
     log.error({ err }, "Guardian refresh failed");
     return httpError("INTERNAL_ERROR", "Internal server error", 500);
   }
-}
-
-// ---------------------------------------------------------------------------
-// Route definitions
-// ---------------------------------------------------------------------------
-
-/**
- * Guardian refresh is a pre-auth endpoint (handled before JWT auth in
- * http-server.ts), so these definitions are exported for completeness but
- * are not added to the authenticated route table.
- */
-export function guardianRefreshRouteDefinitions(): RouteDefinition[] {
-  return [
-    {
-      endpoint: "guardian/refresh",
-      method: "POST",
-      handler: async ({ req }) => handleGuardianRefresh(req),
-    },
-  ];
 }

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -20,7 +20,7 @@ const log = getLogger("trust-rules-routes");
 /**
  * GET /v1/trust-rules/manage — list all trust rules.
  */
-export function handleListTrustRules(): Response {
+function handleListTrustRules(): Response {
   const rules = getAllRules();
   return Response.json({ type: "trust_rules_list_response", rules });
 }


### PR DESCRIPTION
Remove export keyword from route handlers that are only called within their own route definition function. Delete 2 entirely unused route definition functions (guardianBootstrapRouteDefinitions, guardianRefreshRouteDefinitions).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
