### PR TITLE
chore: remove dead sequence module exports

### DIFF
--- a/assistant/src/sequence/guardrails.ts
+++ b/assistant/src/sequence/guardrails.ts
@@ -45,10 +45,6 @@ export function setGuardrailConfig(
   return { ...config };
 }
 
-export function resetGuardrailConfig(): void {
-  config = { ...DEFAULT_CONFIG };
-}
-
 // ── Send tracking (in-memory, resets on daemon restart) ─────────────
 
 interface SendRecord {

--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -28,7 +28,6 @@ import type {
   Sequence,
   SequenceEnrollment,
   SequenceStep,
-  SequenceStore,
   UpdateSequenceInput,
 } from "./types.js";
 
@@ -376,21 +375,3 @@ export function updateEnrollmentThreadId(id: string, threadId: string): void {
     .where(eq(sequenceEnrollments.id, id))
     .run();
 }
-
-// ── Aggregate export matching the SequenceStore interface ───────────
-
-export const sqliteSequenceStore: SequenceStore = {
-  createSequence,
-  getSequence,
-  listSequences,
-  updateSequence,
-  deleteSequence,
-  enrollContact,
-  getEnrollment,
-  listEnrollments,
-  claimDueEnrollments,
-  advanceEnrollment,
-  exitEnrollment,
-  findActiveEnrollmentsByEmail,
-  countActiveEnrollments,
-};


### PR DESCRIPTION
Delete unused resetGuardrailConfig from guardrails.ts and sqliteSequenceStore from store.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
