### PR TITLE
chore: remove dead memory store exports

### DIFF
--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -177,16 +177,6 @@ export function getBindingByChannelChat(
 }
 
 /**
- * Remove an external binding for a conversation.
- */
-export function deleteBinding(conversationId: string): void {
-  const db = getDb();
-  db.delete(externalConversationBindings)
-    .where(eq(externalConversationBindings.conversationId, conversationId))
-    .run();
-}
-
-/**
  * Remove an external binding by channel + external chat ID.
  * Used when disconnecting a synced thread by its channel identifiers.
  */
@@ -203,26 +193,6 @@ export function deleteBindingByChannelChat(
       ),
     )
     .run();
-}
-
-/**
- * List all external bindings, optionally filtered by sourceChannel.
- */
-export function listBindings(options?: {
-  sourceChannel?: string;
-}): ExternalConversationBinding[] {
-  const db = getDb();
-  const query = db.select().from(externalConversationBindings);
-
-  if (options?.sourceChannel) {
-    return query
-      .where(
-        eq(externalConversationBindings.sourceChannel, options.sourceChannel),
-      )
-      .all();
-  }
-
-  return query.all();
 }
 
 /**

--- a/assistant/src/memory/guardian-approvals.ts
+++ b/assistant/src/memory/guardian-approvals.ts
@@ -6,7 +6,7 @@
  * channel requester.
  */
 
-import { and, count, desc, eq, gt, lte } from "drizzle-orm";
+import { and, desc, eq, gt, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "./db.js";
@@ -406,59 +406,4 @@ export function resolveApprovalRequest(
     decidedByExternalUserId: decidedByExternalUserId ?? null,
     updatedAt: now,
   });
-}
-
-/**
- * Count pending approval requests for a given conversation.
- * Used by thread state projection to compute `pending_escalation_count`.
- */
-export function countPendingByConversation(conversationId: string): number {
-  const db = getDb();
-
-  const result = db
-    .select({ count: count() })
-    .from(channelGuardianApprovalRequests)
-    .where(
-      and(
-        eq(channelGuardianApprovalRequests.conversationId, conversationId),
-        eq(channelGuardianApprovalRequests.status, "pending"),
-      ),
-    )
-    .get();
-
-  return result?.count ?? 0;
-}
-
-/**
- * @internal Test-only helper. Production code should query canonical guardian
- * requests via `listCanonicalGuardianRequests` in canonical-guardian-store.ts.
- * Retained for existing test fixtures that check legacy approval dedup.
- */
-export function findPendingAccessRequestForRequester(
-  channel: string,
-  requesterExternalUserId: string,
-  toolName: string,
-): GuardianApprovalRequest | null {
-  const db = getDb();
-  const now = Date.now();
-
-  const row = db
-    .select()
-    .from(channelGuardianApprovalRequests)
-    .where(
-      and(
-        eq(channelGuardianApprovalRequests.channel, channel),
-        eq(
-          channelGuardianApprovalRequests.requesterExternalUserId,
-          requesterExternalUserId,
-        ),
-        eq(channelGuardianApprovalRequests.toolName, toolName),
-        eq(channelGuardianApprovalRequests.status, "pending"),
-        gt(channelGuardianApprovalRequests.expiresAt, now),
-      ),
-    )
-    .orderBy(desc(channelGuardianApprovalRequests.createdAt))
-    .get();
-
-  return row ? rowToApprovalRequest(row) : null;
 }

--- a/assistant/src/memory/shared-app-links-store.ts
+++ b/assistant/src/memory/shared-app-links-store.ts
@@ -104,21 +104,6 @@ export function getSharedAppLink(
   };
 }
 
-export function deleteSharedAppLink(id: string): boolean {
-  const db = getDb();
-  const existing = db
-    .select({ id: sharedAppLinks.id })
-    .from(sharedAppLinks)
-    .where(eq(sharedAppLinks.id, id))
-    .get();
-
-  if (!existing) return false;
-
-  db.delete(sharedAppLinks).where(eq(sharedAppLinks.id, id)).run();
-
-  return true;
-}
-
 export function deleteSharedAppLinkByToken(shareToken: string): boolean {
   const db = getDb();
   const existing = db


### PR DESCRIPTION
Delete unused functions: deleteSharedAppLink, deleteBinding, listBindings, countPendingByConversation, findPendingAccessRequestForRequester from their respective store files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
