### PR TITLE
fix: silence 'var was never mutated' warning in DaemonClient

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -2546,7 +2546,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
-        guard var request = buildLocalRequest(target: .daemon, path: "v1/memory-items/\(encoded)", method: "DELETE") else { return false }
+        guard let request = buildLocalRequest(target: .daemon, path: "v1/memory-items/\(encoded)", method: "DELETE") else { return false }
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)


### PR DESCRIPTION
## Summary
- Changed `guard var request` to `guard let request` in `deleteMemoryItem` since the request is never mutated after creation

## Original prompt
Fix Swift compiler warning: variable 'request' was never mutated; consider changing to 'let' constant (DaemonClient.swift:2549)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
