### PR TITLE
chore: remove dead notification exports

### DIFF
--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -117,19 +117,8 @@ export function buildAccessRequestIdentityLine(
   return `${parts.join(" ")} is requesting access to the assistant.`;
 }
 
-export function buildAccessRequestDecisionDirective(
-  requestCode: string,
-): string {
-  const code = requestCode.toUpperCase();
-  return `Reply "${code} approve" to grant access or "${code} reject" to deny.`;
-}
-
 export function buildAccessRequestInviteDirective(): string {
   return 'Reply "open invite flow" to start Trusted Contacts invite flow.';
-}
-
-export function buildAccessRequestRevokedNote(): string {
-  return "Note: this user was previously revoked.";
 }
 
 /**
@@ -222,10 +211,13 @@ export function buildAccessRequestContractText(
   const lines: string[] = [];
   lines.push(buildAccessRequestIdentityLine(payload));
   if (previousMemberStatus === "revoked") {
-    lines.push(buildAccessRequestRevokedNote());
+    lines.push("Note: this user was previously revoked.");
   }
   if (requestCode) {
-    lines.push(buildAccessRequestDecisionDirective(requestCode));
+    const code = requestCode.toUpperCase();
+    lines.push(
+      `Reply "${code} approve" to grant access or "${code} reject" to deny.`,
+    );
   }
   lines.push(buildAccessRequestInviteDirective());
   return lines.join("\n");

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -159,45 +159,6 @@ export function updateDeliveryStatus(
   return rawChanges() > 0;
 }
 
-/**
- * Update a delivery record with the client-side outcome of posting the
- * notification via UNUserNotificationCenter.add().
- *
- * Returns true if a row was updated, false otherwise (e.g. unknown deliveryId).
- */
-export function updateDeliveryClientOutcome(
-  deliveryId: string,
-  success: boolean,
-  error?: { code?: string; message?: string },
-): boolean {
-  const db = getDb();
-  const now = Date.now();
-
-  const updates: Record<string, unknown> = {
-    clientDeliveryStatus: success ? "delivered" : "client_failed",
-    clientDeliveryAt: now,
-    updatedAt: now,
-  };
-
-  if (success) {
-    // Clear any stale error from previous failed attempts
-    updates.clientDeliveryError = null;
-  } else if (error?.message) {
-    updates.clientDeliveryError = error.code
-      ? `[${error.code}] ${error.message}`
-      : error.message;
-  } else if (error?.code) {
-    updates.clientDeliveryError = error.code;
-  }
-
-  db.update(notificationDeliveries)
-    .set(updates)
-    .where(eq(notificationDeliveries.id, deliveryId))
-    .run();
-
-  return rawChanges() > 0;
-}
-
 /** Check whether a delivery already exists for a given decision+channel pair. */
 export function findDeliveryByDecisionAndChannel(
   decisionId: string,

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -6,15 +6,11 @@
  * fields like `toolName`.
  */
 
-export const GUARDIAN_QUESTION_REQUEST_KINDS = {
-  pending_question: "pending_question",
-  tool_approval: "tool_approval",
-  tool_grant_request: "tool_grant_request",
-  access_request: "access_request",
-} as const;
-
 export type GuardianQuestionRequestKind =
-  keyof typeof GUARDIAN_QUESTION_REQUEST_KINDS;
+  | "pending_question"
+  | "tool_approval"
+  | "tool_grant_request"
+  | "access_request";
 export type GuardianQuestionInstructionMode = "approval" | "answer";
 
 interface GuardianRequestKindModeConfig {
@@ -151,7 +147,7 @@ function nonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function parseGuardianQuestionRequestKind(
+function parseGuardianQuestionRequestKind(
   payload: Record<string, unknown>,
 ): GuardianQuestionRequestKind | null {
   const raw = nonEmptyString(payload.requestKind);
@@ -241,7 +237,7 @@ export function parseGuardianQuestionPayload(
   }
 }
 
-export function resolveGuardianInstructionModeForRequestKind(
+function resolveGuardianInstructionModeForRequestKind(
   requestKind: GuardianQuestionRequestKind,
   toolName?: string | null,
 ): GuardianQuestionInstructionMode {


### PR DESCRIPTION
Delete unused exports (GUARDIAN_QUESTION_REQUEST_KINDS, buildAccessRequestDecisionDirective, buildAccessRequestRevokedNote, updateDeliveryClientOutcome). Un-export 2 internally-used functions in guardian-question-mode.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
