### PR TITLE
fix: update onboarding tests for managedSignInEnabled param

### DIFF
--- a/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
@@ -2,12 +2,16 @@ import XCTest
 @testable import VellumAssistantLib
 
 final class OnboardingManagedAuthStateTests: XCTestCase {
-    func testPrimaryButtonTitleShowsSignInWhenUnauthenticated() {
-        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false), "Sign in")
+    func testPrimaryButtonTitleShowsSignInWhenUnauthenticatedAndManagedEnabled() {
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false, managedSignInEnabled: true), "Sign in")
+    }
+
+    func testPrimaryButtonTitleShowsComingSoonWhenUnauthenticatedAndManagedDisabled() {
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false, managedSignInEnabled: false), "Coming Soon")
     }
 
     func testPrimaryButtonTitleShowsContinueLabelWhenAuthenticated() {
-        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: true), "Talk to your assistant")
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: true, managedSignInEnabled: true), "Talk to your assistant")
     }
 
     func testContinuationActionStartsLoginWhenUnauthenticated() {


### PR DESCRIPTION
## Summary
- Update `OnboardingManagedAuthStateTests` to pass the new `managedSignInEnabled` parameter to `onboardingPrimaryButtonTitle`
- Add test coverage for the `managedSignInEnabled: false` → "Coming Soon" branch

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23080937551/job/67050046234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
