### PR TITLE
chore: remove dead gateway exports

### DIFF
--- a/gateway/src/channels/transport-hints.ts
+++ b/gateway/src/channels/transport-hints.ts
@@ -16,16 +16,6 @@ export function buildTelegramTransportMetadata(): {
   };
 }
 
-export const SLACK_CHANNEL_TRANSPORT_HINTS = [
-  "chat-first-medium",
-  "threaded-channel",
-  "mention-triggered",
-  "defer-dashboard-only-tasks",
-] as const;
-
-export const SLACK_CHANNEL_TRANSPORT_UX_BRIEF =
-  "Slack is a threaded channel medium. Replies should stay in-thread when a thread_ts is present. Use plain text or Slack mrkdwn formatting; avoid markdown tables and complex block layouts.";
-
 export const WHATSAPP_CHANNEL_TRANSPORT_HINTS = [
   "chat-first-medium",
   "channel-safe-onboarding",


### PR DESCRIPTION
Delete unused constants SLACK_CHANNEL_TRANSPORT_HINTS and SLACK_CHANNEL_TRANSPORT_UX_BRIEF from gateway.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
