### PR TITLE
fix: show Sign in with Coming Soon subtitle when flag is off

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingManagedAuthState.swift
@@ -5,9 +5,8 @@ enum OnboardingManagedContinuationAction: Equatable {
     case bootstrap
 }
 
-func onboardingPrimaryButtonTitle(isAuthenticated: Bool, managedSignInEnabled: Bool) -> String {
-    if isAuthenticated { return "Talk to your assistant" }
-    return managedSignInEnabled ? "Sign in" : "Coming Soon"
+func onboardingPrimaryButtonTitle(isAuthenticated: Bool) -> String {
+    isAuthenticated ? "Talk to your assistant" : "Sign in"
 }
 
 func onboardingManagedContinuationAction(isAuthenticated: Bool) -> OnboardingManagedContinuationAction {

--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -35,7 +35,7 @@ struct WakeUpStepView: View {
     }
 
     private var primaryButtonTitle: String {
-        onboardingPrimaryButtonTitle(isAuthenticated: authManager?.isAuthenticated == true, managedSignInEnabled: managedSignInEnabled)
+        onboardingPrimaryButtonTitle(isAuthenticated: authManager?.isAuthenticated == true)
     }
 
     // MARK: - Body
@@ -81,11 +81,19 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else {
-                OnboardingButton(title: primaryButtonTitle, style: .primary) {
-                    onContinueWithVellum()
+                VStack(spacing: VSpacing.xs) {
+                    OnboardingButton(title: primaryButtonTitle, style: .primary) {
+                        onContinueWithVellum()
+                    }
+                    .disabled(!managedSignInEnabled && authManager?.isAuthenticated != true)
+                    .accessibilityLabel("Sign in")
+
+                    if !managedSignInEnabled && authManager?.isAuthenticated != true {
+                        Text("Coming Soon")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.contentTertiary)
+                    }
                 }
-                .disabled(!managedSignInEnabled && authManager?.isAuthenticated != true)
-                .accessibilityLabel("Sign in")
             }
 
             OnboardingButton(title: "Self-host", style: .tertiary) {


### PR DESCRIPTION
## Summary
- Keep the button title as "Sign in" instead of replacing it with "Coming Soon"
- Add a smaller "Coming Soon" caption text below the disabled button when the flag is off
- Revert the `managedSignInEnabled` parameter from `onboardingPrimaryButtonTitle` since the title is always "Sign in" now

## Original prompt
Instead of just saying "Coming Soon" let's keep "Sign In" and put "Coming Soon" in smaller text below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
