### PR TITLE
chore: remove dead runtime/guardian exports

### DIFF
--- a/assistant/src/runtime/actor-token-store.ts
+++ b/assistant/src/runtime/actor-token-store.ts
@@ -156,29 +156,6 @@ export function revokeByDeviceBinding(
 }
 
 /**
- * Find all active actor token records for a given guardianPrincipalId.
- * Used for multi-device guardian fanout — returns all bound devices (macOS, iOS, etc.)
- * so notification targeting can reach every device for the same guardian identity.
- */
-export function findActiveByGuardianPrincipalId(
-  guardianPrincipalId: string,
-): ActorTokenRecord[] {
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(actorTokenRecords)
-    .where(
-      and(
-        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
-        eq(actorTokenRecords.status, "active"),
-      ),
-    )
-    .all();
-
-  return rows.map(rowToRecord);
-}
-
-/**
  * Revoke a single token by its hash.
  */
 export function revokeByTokenHash(tokenHash: string): boolean {

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -24,49 +24,6 @@ const GENERATION_TIMEOUT_MS = 5_000;
 const MAX_INSTRUCTION_LENGTH = 500;
 
 // ---------------------------------------------------------------------------
-// Channel display label
-// ---------------------------------------------------------------------------
-
-/** Human-readable label for a channel type. */
-export function channelDisplayLabel(type: string): string {
-  switch (type) {
-    case "telegram":
-      return "Telegram";
-    case "email":
-      return "Email";
-    case "slack":
-      return "Slack";
-    case "phone":
-      return "Voice";
-    default:
-      return type.charAt(0).toUpperCase() + type.slice(1);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Deterministic fallback
-// ---------------------------------------------------------------------------
-
-/**
- * Build a deterministic fallback instruction when the LLM is unavailable.
- */
-export function buildFallbackInstruction(params: {
-  contactName?: string;
-  channelLabel: string;
-  channelHandle?: string;
-  shareUrl?: string;
-}): string {
-  const contact = params.contactName || "the contact";
-  const handle = params.channelHandle
-    ? ` at ${params.channelHandle}`
-    : ` on ${params.channelLabel}`;
-  if (params.shareUrl) {
-    return `Send ${contact} this link: ${params.shareUrl} — or tell them to message me${handle} with the code below.`;
-  }
-  return `Tell ${contact} to message me${handle} with the code below.`;
-}
-
-// ---------------------------------------------------------------------------
 // LLM-powered generation
 // ---------------------------------------------------------------------------
 
@@ -88,13 +45,30 @@ export async function generateInviteInstruction(params: {
    */
   shareUrl?: string;
 }): Promise<string> {
-  const channelLabel = channelDisplayLabel(params.channelType);
-  const fallback = buildFallbackInstruction({
-    contactName: params.contactName,
-    channelLabel,
-    channelHandle: params.channelHandle,
-    shareUrl: params.shareUrl,
-  });
+  const channelLabel = (() => {
+    switch (params.channelType) {
+      case "telegram":
+        return "Telegram";
+      case "email":
+        return "Email";
+      case "slack":
+        return "Slack";
+      case "phone":
+        return "Voice";
+      default:
+        return (
+          params.channelType.charAt(0).toUpperCase() +
+          params.channelType.slice(1)
+        );
+    }
+  })();
+  const contact = params.contactName || "the contact";
+  const handle = params.channelHandle
+    ? ` at ${params.channelHandle}`
+    : ` on ${channelLabel}`;
+  const fallback = params.shareUrl
+    ? `Send ${contact} this link: ${params.shareUrl} — or tell them to message me${handle} with the code below.`
+    : `Tell ${contact} to message me${handle} with the code below.`;
 
   const resolved = await resolveConfiguredProvider();
   if (!resolved) {

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -34,8 +34,6 @@ import {
 } from "./channel-invite-transport.js";
 import { generateInviteInstruction } from "./invite-instruction-generator.js";
 import {
-  type InviteRedemptionOutcome,
-  redeemInvite as redeemInviteTyped,
   redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
   type VoiceRedemptionOutcome,
 } from "./invite-redemption-service.js";
@@ -370,25 +368,6 @@ export function redeemIngressInvite(params: {
     return { ok: false, error: "Invite not found after redemption" };
   }
   return { ok: true, data: inviteToResponse(inv) };
-}
-
-// ---------------------------------------------------------------------------
-// Typed invite redemption — preferred entry point for new callers
-// ---------------------------------------------------------------------------
-
-export { type InviteRedemptionOutcome } from "./invite-redemption-service.js";
-export { type VoiceRedemptionOutcome } from "./invite-redemption-service.js";
-
-export function redeemIngressInviteTyped(params: {
-  rawToken: string;
-  sourceChannel: string;
-  externalUserId?: string;
-  externalChatId?: string;
-  displayName?: string;
-  username?: string;
-  assistantId?: string;
-}): InviteRedemptionOutcome {
-  return redeemInviteTyped(params);
 }
 
 export function redeemVoiceInviteCode(params: {


### PR DESCRIPTION
Delete unused functions: redeemIngressInviteTyped, channelDisplayLabel, buildFallbackInstruction, findActiveByGuardianPrincipalId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
