### PR TITLE
fix: rename Self-host to Self Host on onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -96,10 +96,10 @@ struct WakeUpStepView: View {
                 }
             }
 
-            OnboardingButton(title: "Self-host", style: .tertiary) {
+            OnboardingButton(title: "Self Host", style: .tertiary) {
                 onStartWithAPIKey()
             }
-            .accessibilityLabel("Self-host")
+            .accessibilityLabel("Self Host")
 
             // Auth error message
             if let error = authManager?.errorMessage {


### PR DESCRIPTION
## Summary
- Change "Self-host" button label to "Self Host" on the onboarding welcome screen

## Original prompt
Let's change "Self-host" to "Self Host"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
