### PR TITLE
fix: update onboarding tests to match simplified function signature

### DIFF
--- a/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingManagedAuthStateTests.swift
@@ -2,16 +2,12 @@ import XCTest
 @testable import VellumAssistantLib
 
 final class OnboardingManagedAuthStateTests: XCTestCase {
-    func testPrimaryButtonTitleShowsSignInWhenUnauthenticatedAndManagedEnabled() {
-        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false, managedSignInEnabled: true), "Sign in")
-    }
-
-    func testPrimaryButtonTitleShowsComingSoonWhenUnauthenticatedAndManagedDisabled() {
-        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false, managedSignInEnabled: false), "Coming Soon")
+    func testPrimaryButtonTitleShowsSignInWhenUnauthenticated() {
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: false), "Sign in")
     }
 
     func testPrimaryButtonTitleShowsContinueLabelWhenAuthenticated() {
-        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: true, managedSignInEnabled: true), "Talk to your assistant")
+        XCTAssertEqual(onboardingPrimaryButtonTitle(isAuthenticated: true), "Talk to your assistant")
     }
 
     func testContinuationActionStartsLoginWhenUnauthenticated() {


### PR DESCRIPTION
## Summary
- Updated `OnboardingManagedAuthStateTests` to match the current `onboardingPrimaryButtonTitle(isAuthenticated:)` signature (the `managedSignInEnabled` parameter was removed in #16637)
- Removed the now-obsolete "Coming Soon" test case since the function no longer branches on managed sign-in state

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23081067010/job/67050380358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
