### PR TITLE
feat: on-demand fetch and navigate to conversations not in local sidebar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -352,10 +352,11 @@ extension AppDelegate {
         }
 
         window.onSelectSearchConversation = { [weak self] sessionId in
-            let found = self?.mainWindow?.threadManager.selectThreadBySessionId(sessionId) ?? false
-            // Only navigate if the lookup succeeded — otherwise the user stays on their current view
-            if found, let threadId = self?.mainWindow?.threadManager.activeThreadId {
-                self?.mainWindow?.windowState.selection = .thread(threadId)
+            Task { @MainActor in
+                let found = await self?.mainWindow?.threadManager.selectThreadBySessionIdAsync(sessionId) ?? false
+                if found, let threadId = self?.mainWindow?.threadManager.activeThreadId {
+                    self?.mainWindow?.windowState.selection = .thread(threadId)
+                }
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -714,6 +714,62 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         return true
     }
 
+    /// Select a thread by session ID, fetching it on-demand from the server if not locally available.
+    /// Returns `true` if the thread was found (or fetched) and selected, `false` on failure.
+    func selectThreadBySessionIdAsync(_ sessionId: String) async -> Bool {
+        // Fast path: already loaded locally
+        if selectThreadBySessionId(sessionId) {
+            return true
+        }
+
+        // Slow path: fetch the conversation from the daemon and insert it locally
+        guard let session = await daemonClient.fetchConversationById(sessionId) else {
+            return false
+        }
+
+        // Don't insert external-channel or private threads into the main sidebar
+        if session.threadType == "private" || session.channelBinding?.sourceChannel != nil {
+            return false
+        }
+
+        let effectiveCreatedAt = session.createdAt ?? session.updatedAt
+        let thread = ThreadModel(
+            title: session.title,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
+            sessionId: session.id,
+            isPinned: session.isPinned ?? false,
+            pinnedOrder: (session.isPinned ?? false) ? session.displayOrder.map { Int($0) } : nil,
+            displayOrder: session.displayOrder.map { Int($0) },
+            lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+            kind: .standard,
+            source: session.source,
+            scheduleJobId: session.scheduleJobId,
+            hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
+            latestAssistantMessageAt: session.assistantAttention?.latestAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            },
+            lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+        )
+
+        let viewModel = makeViewModel()
+        viewModel.sessionId = session.id
+        // Leave isHistoryLoaded false so history is fetched when the thread activates
+        viewModel.startMessageLoop()
+
+        threads.insert(thread, at: 0)
+        chatViewModels[thread.id] = viewModel
+        subscribeToBusyState(for: thread.id, viewModel: viewModel)
+        subscribeToAssistantActivity(for: thread.id, viewModel: viewModel)
+        subscribeToInteractionState(for: thread.id, viewModel: viewModel)
+        touchVMAccessOrder(thread.id)
+        evictStaleCachedViewModels()
+
+        selectThread(id: thread.id)
+        return true
+    }
+
     // MARK: - Render Cache Management
 
     /// Clears static render caches used by chat bubble and markdown views.

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -852,6 +852,21 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         return await executeLocalRequest(path: "v1/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10)
     }
 
+    // MARK: - Single Conversation Lookup
+
+    /// Fetch a single conversation by its daemon ID.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    /// Returns `nil` if the conversation doesn't exist (404) or the request fails.
+    public func fetchConversationById(_ conversationId: String) async -> ConversationsListResponse.Session? {
+        if let httpTransport {
+            return await httpTransport.fetchConversationById(conversationId)
+        }
+
+        let encoded = conversationId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? conversationId
+        let response: SingleConversationResponse? = await executeLocalRequest(path: "v1/conversations/\(encoded)", timeout: 10)
+        return response?.session
+    }
+
     // MARK: - BTW Side-Chain
 
     /// Send a /btw side-chain question and stream the response text.

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -21,24 +21,24 @@ struct AssistantEvent: Decodable {
 // MARK: - Conversations List Response
 
 /// Response shape from `GET /v1/conversations`.
-struct ConversationsListResponse: Decodable {
-    struct Session: Decodable {
-        let id: String
-        let title: String
-        let createdAt: Int?
-        let updatedAt: Int
-        let threadType: String?
-        let source: String?
-        let scheduleJobId: String?
-        let channelBinding: ChannelBinding?
-        let conversationOriginChannel: String?
-        let conversationOriginInterface: String?
-        let assistantAttention: AssistantAttention?
-        let displayOrder: Double?
-        let isPinned: Bool?
+public struct ConversationsListResponse: Decodable {
+    public struct Session: Decodable {
+        public let id: String
+        public let title: String
+        public let createdAt: Int?
+        public let updatedAt: Int
+        public let threadType: String?
+        public let source: String?
+        public let scheduleJobId: String?
+        public let channelBinding: ChannelBinding?
+        public let conversationOriginChannel: String?
+        public let conversationOriginInterface: String?
+        public let assistantAttention: AssistantAttention?
+        public let displayOrder: Double?
+        public let isPinned: Bool?
     }
-    let sessions: [Session]
-    let hasMore: Bool?
+    public let sessions: [Session]
+    public let hasMore: Bool?
 }
 
 /// Response shape from `GET /v1/conversations/:id`.


### PR DESCRIPTION
## Summary
- Adds `selectThreadBySessionIdAsync` to ThreadManager that fetches conversations on-demand from the daemon when not found locally
- Updates command palette conversation navigation to use the async variant, enabling navigation to any conversation regardless of pagination state
- Filters out private and external-channel threads from on-demand insertion
- Adds `fetchConversationById` forwarding method to DaemonClient for local daemon support
- Makes `ConversationsListResponse` public for cross-module access

Part of plan: on-demand-conv-load.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
