### PR TITLE
fix: add 401 auth-retry to fetchConversationById matching peer methods

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2942,7 +2942,7 @@ public final class HTTPTransport {
 
     /// Fetch a single conversation by its daemon ID.
     /// Returns `nil` if the conversation doesn't exist (404) or the request fails.
-    func fetchConversationById(_ conversationId: String) async -> ConversationsListResponse.Session? {
+    func fetchConversationById(_ conversationId: String, isRetry: Bool = false) async -> ConversationsListResponse.Session? {
         guard let url = buildURL(for: .conversationById(id: conversationId)) else { return nil }
 
         var request = URLRequest(url: url)
@@ -2951,6 +2951,14 @@ public final class HTTPTransport {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                if statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchConversationById(conversationId, isRetry: true)
+                    }
+                }
+                log.error("Fetch conversation \(conversationId) failed (HTTP \(statusCode))")
                 return nil
             }
             let decoded = try decoder.decode(SingleConversationResponse.self, from: data)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for on-demand-conv-load.md.

**Gap:** fetchConversationById lacks 401 auth-retry logic
**What was expected:** Method should follow the same auth patterns as fetchSessionList
**What was found:** Returns nil on any non-200 without attempting token refresh on 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
