### PR TITLE
fix: improve CredentialBackend error handling and resolve circular import

### DIFF
--- a/assistant/src/security/credential-backend.ts
+++ b/assistant/src/security/credential-backend.ts
@@ -7,7 +7,13 @@
 import * as encryptedStore from "./encrypted-store.js";
 import type { KeychainBrokerClient } from "./keychain-broker-client.js";
 import { createBrokerClient } from "./keychain-broker-client.js";
-import type { DeleteResult } from "./secure-keys.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Result of a delete operation — distinguishes success, not-found, and error. */
+export type DeleteResult = "deleted" | "not-found" | "error";
 
 // ---------------------------------------------------------------------------
 // Interface
@@ -68,6 +74,8 @@ export class KeychainBackend implements CredentialBackend {
   async delete(account: string): Promise<DeleteResult> {
     try {
       const ok = await this.client.del(account);
+      // The keychain broker returns a boolean — it does not distinguish
+      // "not found" from a genuine error, so we map false → "error".
       return ok ? "deleted" : "error";
     } catch {
       return "error";
@@ -95,19 +103,35 @@ export class EncryptedStoreBackend implements CredentialBackend {
   }
 
   async get(account: string): Promise<string | undefined> {
-    return encryptedStore.getKey(account);
+    try {
+      return encryptedStore.getKey(account);
+    } catch {
+      return undefined;
+    }
   }
 
   async set(account: string, value: string): Promise<boolean> {
-    return encryptedStore.setKey(account, value);
+    try {
+      return encryptedStore.setKey(account, value);
+    } catch {
+      return false;
+    }
   }
 
   async delete(account: string): Promise<DeleteResult> {
-    return encryptedStore.deleteKey(account);
+    try {
+      return encryptedStore.deleteKey(account);
+    } catch {
+      return "error";
+    }
   }
 
   async list(): Promise<string[]> {
-    return encryptedStore.listKeys();
+    try {
+      return encryptedStore.listKeys();
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -12,12 +12,14 @@
  */
 
 import { getLogger } from "../util/logger.js";
-import type { CredentialBackend } from "./credential-backend.js";
+import type { CredentialBackend, DeleteResult } from "./credential-backend.js";
 import {
   createEncryptedStoreBackend,
   createKeychainBackend,
 } from "./credential-backend.js";
 import * as encryptedStore from "./encrypted-store.js";
+
+export type { DeleteResult } from "./credential-backend.js";
 
 const log = getLogger("secure-keys");
 
@@ -45,9 +47,6 @@ function resolveBackend(): CredentialBackend {
   }
   return getEncryptedStoreBackend();
 }
-
-/** Result of a delete operation — distinguishes success, not-found, and error. */
-export type DeleteResult = "deleted" | "not-found" | "error";
 
 /**
  * List all account names in secure storage (sync — encrypted store only).


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for single-writer-secure-keys.md.

**Gap A:** Add try/catch to all EncryptedStoreBackend methods for consistent error handling
**Gap B:** Move DeleteResult type from secure-keys.ts to credential-backend.ts to resolve circular import
**Gap C:** Document KeychainBackend.delete() limitation (broker returns boolean, can't distinguish not-found from error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
