### PR TITLE
fix: memoize resolveBackend, add listSecureKeysAsync, clean up getBackendType return type

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -52,11 +52,14 @@ mock.module("../security/secure-keys.js", () => ({
   listSecureKeys: (): string[] => {
     return [...secureKeyStore.keys()];
   },
+  listSecureKeysAsync: async (): Promise<string[]> => {
+    return [...secureKeyStore.keys()];
+  },
   getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
     _getSecureKeyCalls += 1;
     return secureKeyStore.get(account);
   },
-  getBackendType: (): "broker" | "encrypted" | null => null,
+  getBackendType: (): "broker" | "encrypted" => "encrypted",
   _resetBackend: (): void => {},
 }));
 

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -29,7 +29,8 @@ mock.module("../security/secure-keys.js", () => ({
     setSecureKeyMock(key, value),
   deleteSecureKeyAsync: async () => "deleted" as const,
   listSecureKeys: () => [],
-  getBackendType: () => null,
+  listSecureKeysAsync: async () => [],
+  getBackendType: (): "broker" | "encrypted" => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -23,6 +23,7 @@ const log = getLogger("secure-keys");
 
 let _keychain: CredentialBackend | undefined;
 let _encryptedStore: CredentialBackend | undefined;
+let _resolvedBackend: CredentialBackend | undefined;
 
 function getKeychainBackend(): CredentialBackend {
   if (!_keychain) _keychain = createKeychainBackend();
@@ -38,12 +39,19 @@ function getEncryptedStoreBackend(): CredentialBackend {
  * Resolve the primary credential backend for this process.
  * Production (VELLUM_DEV unset or "0") uses keychain when available.
  * Dev mode (VELLUM_DEV=1) always uses the encrypted file store.
+ *
+ * Once resolved, the backend does not change during the process lifetime.
+ * Call `_resetBackend()` in tests to clear the cached resolution.
  */
 function resolveBackend(): CredentialBackend {
-  if (process.env.VELLUM_DEV !== "1" && getKeychainBackend().isAvailable()) {
-    return getKeychainBackend();
+  if (!_resolvedBackend) {
+    if (process.env.VELLUM_DEV !== "1" && getKeychainBackend().isAvailable()) {
+      _resolvedBackend = getKeychainBackend();
+    } else {
+      _resolvedBackend = getEncryptedStoreBackend();
+    }
   }
-  return getEncryptedStoreBackend();
+  return _resolvedBackend;
 }
 
 /** Result of a delete operation — distinguishes success, not-found, and error. */
@@ -52,9 +60,35 @@ export type DeleteResult = "deleted" | "not-found" | "error";
 /**
  * List all account names in secure storage (sync — encrypted store only).
  * Throws if the store file exists but cannot be read.
+ *
+ * @deprecated Use {@link listSecureKeysAsync} instead, which merges keys from
+ * both the primary backend and the encrypted store for completeness.
  */
 export function listSecureKeys(): string[] {
   return encryptedStore.listKeys();
+}
+
+/**
+ * List all account names across both backends (async).
+ *
+ * When the primary backend is the keychain, this merges keys from the keychain
+ * and the encrypted store (for legacy keys that haven't been migrated). The
+ * result is deduplicated. When the primary backend is already the encrypted
+ * store, only that store is queried.
+ */
+export async function listSecureKeysAsync(): Promise<string[]> {
+  const backend = resolveBackend();
+  const primaryKeys = await backend.list();
+
+  // If primary backend is NOT the encrypted store, also check
+  // the encrypted store for legacy keys that haven't been migrated.
+  if (backend !== getEncryptedStoreBackend()) {
+    const encKeys = await getEncryptedStoreBackend().list();
+    const merged = new Set([...primaryKeys, ...encKeys]);
+    return Array.from(merged);
+  }
+
+  return primaryKeys;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +100,7 @@ export function listSecureKeys(): string[] {
  * Returns `"broker"` when VELLUM_DEV !== "1" and keychain backend is available,
  * `"encrypted"` otherwise.
  */
-export function getBackendType(): "broker" | "encrypted" | null {
+export function getBackendType(): "broker" | "encrypted" {
   const backend = resolveBackend();
   return backend.name === "keychain" ? "broker" : "encrypted";
 }
@@ -148,4 +182,5 @@ export async function deleteSecureKeyAsync(
 export function _resetBackend(): void {
   _keychain = undefined;
   _encryptedStore = undefined;
+  _resolvedBackend = undefined;
 }

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -21,7 +21,7 @@ import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
   getSecureKeyAsync,
-  listSecureKeys,
+  listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
@@ -368,9 +368,11 @@ class CredentialStoreTool implements Tool {
         const allMetadata = listCredentialMetadata();
         // Verify secrets still exist by reading all key names once (instead of
         // per-entry getSecureKeyAsync calls that each re-read/re-derive the store).
+        // Uses the async variant to include keys from both the primary backend
+        // (e.g. keychain) and the encrypted store (legacy keys).
         let secureKeySet: Set<string> | undefined;
         try {
-          secureKeySet = new Set(listSecureKeys());
+          secureKeySet = new Set(await listSecureKeysAsync());
         } catch (err) {
           log.error(
             { err },


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for single-writer-secure-keys.md.

**Gap A:** Memoize resolveBackend() so backend selection is stable for the process lifetime
**Gap B:** Remove unreachable | null from getBackendType() return type, update test mocks
**Gap C:** Add listSecureKeysAsync() that merges keys from both backends; update vault.ts caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
