### PR TITLE
fix: guard against duplicate thread insertion in selectThreadBySessionIdAsync

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -727,6 +727,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             return false
         }
 
+        // Re-check after await — another code path (e.g. SSE session-list response)
+        // may have inserted this thread while we were waiting on the network.
+        if selectThreadBySessionId(sessionId) {
+            return true
+        }
+
         // Don't insert external-channel or private threads into the main sidebar
         if session.threadType == "private" || session.channelBinding?.sourceChannel != nil {
             return false


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for on-demand-conv-load.md.

**Gap:** Race condition — duplicate thread insertion in `selectThreadBySessionIdAsync`
**What was expected:** Re-check for local thread after `await` to prevent duplicates
**What was found:** Missing re-check after network fetch suspension point

After `await daemonClient.fetchConversationById(sessionId)` returns, another `@MainActor` code path (e.g. SSE session-list response) may have already inserted the same thread during the suspension point. The fix adds a re-check using the existing `selectThreadBySessionId()` method before proceeding with insertion, matching the guard pattern used by peer methods like `createNotificationThread` and `createTaskRunThread`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
