### PR TITLE
refactor: remove unused getBackendType helper from secure-keys

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -62,7 +62,6 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async () => "deleted",
   listSecureKeys: () => [],
-  getBackendType: () => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -49,7 +49,6 @@ mock.module("../security/secure-keys.js", () => {
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [...storedKeys.keys()],
     listSecureKeysAsync: async () => [...storedKeys.keys()],
-    getBackendType: () => "encrypted",
   };
 });
 

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -59,7 +59,6 @@ mock.module("../security/secure-keys.js", () => ({
     _getSecureKeyCalls += 1;
     return secureKeyStore.get(account);
   },
-  getBackendType: (): "broker" | "encrypted" => "encrypted",
   _resetBackend: (): void => {},
 }));
 

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -80,7 +80,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
   listSecureKeys: () => [],
-  getBackendType: () => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -164,7 +164,6 @@ mock.module("../security/secure-keys.js", () => ({
     return "not-found" as const;
   },
   listSecureKeys: () => [...secureKeyStore.keys()],
-  getBackendType: () => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -36,7 +36,6 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: () => Promise.resolve(true),
   deleteSecureKeyAsync: () => Promise.resolve("deleted"),
   listSecureKeys: () => [],
-  getBackendType: () => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -47,7 +47,6 @@ mock.module("../security/secure-keys.js", () => {
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [],
-    getBackendType: () => "encrypted",
   };
 });
 

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -74,7 +74,6 @@ import { _setStorePath } from "../security/encrypted-store.js";
 import {
   _resetBackend,
   deleteSecureKeyAsync,
-  getBackendType,
   getSecureKeyAsync,
   listSecureKeys,
   listSecureKeysAsync,
@@ -124,34 +123,6 @@ describe("secure-keys", () => {
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
     }
-  });
-
-  // -----------------------------------------------------------------------
-  // Backend selection
-  // -----------------------------------------------------------------------
-  describe("backend selection", () => {
-    test("returns encrypted when broker is unavailable", () => {
-      expect(getBackendType()).toBe("encrypted");
-    });
-
-    test("returns broker when broker is available and VELLUM_DEV is not set", () => {
-      mockBrokerAvailable = true;
-      expect(getBackendType()).toBe("broker");
-    });
-
-    test("returns encrypted when VELLUM_DEV=1 even if broker is available", () => {
-      process.env.VELLUM_DEV = "1";
-      mockBrokerAvailable = true;
-      _resetBackend();
-      expect(getBackendType()).toBe("encrypted");
-    });
-
-    test("returns broker when VELLUM_DEV=0 and broker is available", () => {
-      process.env.VELLUM_DEV = "0";
-      mockBrokerAvailable = true;
-      _resetBackend();
-      expect(getBackendType()).toBe("broker");
-    });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -30,7 +30,6 @@ mock.module("../security/secure-keys.js", () => ({
   deleteSecureKeyAsync: async () => "deleted" as const,
   listSecureKeys: () => [],
   listSecureKeysAsync: async () => [],
-  getBackendType: (): "broker" | "encrypted" => "encrypted",
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -106,7 +106,6 @@ mock.module("../security/secure-keys.js", () => {
       syncSet(account, value),
     deleteSecureKeyAsync: async (account: string) => syncDelete(account),
     listSecureKeys: () => Object.keys(secureKeyStore),
-    getBackendType: () => "encrypted",
     _resetBackend: () => {},
   };
 });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -91,20 +91,6 @@ export async function listSecureKeysAsync(): Promise<string[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Backend introspection
-// ---------------------------------------------------------------------------
-
-/**
- * Return the currently resolved backend type.
- * Returns `"broker"` when VELLUM_DEV !== "1" and keychain backend is available,
- * `"encrypted"` otherwise.
- */
-export function getBackendType(): "broker" | "encrypted" {
-  const backend = resolveBackend();
-  return backend.name === "keychain" ? "broker" : "encrypted";
-}
-
-// ---------------------------------------------------------------------------
 // Async CRUD — single-writer routing
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove `getBackendType()` from `secure-keys.ts` — it had zero production callers and was a legacy mapping layer translating `CredentialBackend.name` to old `"broker"` / `"encrypted"` strings
- Remove `getBackendType` from all 9 test mock objects that provided it
- Remove the 4-test `backend selection` describe block from `secure-keys.test.ts`

## Original prompt
lets delete it entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
