### PR TITLE
fix: add listSecureKeysAsync mock to secret-onetime-send test

### DIFF
--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -47,6 +47,7 @@ mock.module("../security/secure-keys.js", () => {
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeys: () => [],
+    listSecureKeysAsync: async () => [],
     getBackendType: () => "encrypted",
   };
 });


### PR DESCRIPTION
## Summary
- Add missing `listSecureKeysAsync` mock to `secret-onetime-send.test.ts`, fixing the `SyntaxError: Export named 'listSecureKeysAsync' not found` CI failure

## Original prompt
fix CI errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/23089777060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
