### PR TITLE
fix: remove deprecated sync listSecureKeys, fix CI

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -61,7 +61,7 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (...args: unknown[]) => mockGetSecureKey(...args),
   setSecureKeyAsync: async () => true,
   deleteSecureKeyAsync: async () => "deleted",
-  listSecureKeys: () => [],
+  listSecureKeysAsync: async () => [],
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -47,7 +47,6 @@ mock.module("../security/secure-keys.js", () => {
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
-    listSecureKeys: () => [...storedKeys.keys()],
     listSecureKeysAsync: async () => [...storedKeys.keys()],
   };
 });

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -49,9 +49,6 @@ mock.module("../security/secure-keys.js", () => ({
     }
     return "not-found";
   },
-  listSecureKeys: (): string[] => {
-    return [...secureKeyStore.keys()];
-  },
   listSecureKeysAsync: async (): Promise<string[]> => {
     return [...secureKeyStore.keys()];
   },

--- a/assistant/src/__tests__/media-reuse-story.e2e.test.ts
+++ b/assistant/src/__tests__/media-reuse-story.e2e.test.ts
@@ -79,7 +79,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
-  listSecureKeys: () => [],
+  listSecureKeysAsync: async () => [],
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -163,7 +163,7 @@ mock.module("../security/secure-keys.js", () => ({
     }
     return "not-found" as const;
   },
-  listSecureKeys: () => [...secureKeyStore.keys()],
+  listSecureKeysAsync: async () => [...secureKeyStore.keys()],
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -35,7 +35,7 @@ mock.module("../security/secure-keys.js", () => ({
     Promise.resolve(secureKeyValues.get(account)),
   setSecureKeyAsync: () => Promise.resolve(true),
   deleteSecureKeyAsync: () => Promise.resolve("deleted"),
-  listSecureKeys: () => [],
+  listSecureKeysAsync: async () => [],
   _resetBackend: () => {},
 }));
 

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -46,7 +46,7 @@ mock.module("../security/secure-keys.js", () => {
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
-    listSecureKeys: () => [],
+    listSecureKeysAsync: async () => [],
   };
 });
 

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -75,7 +75,6 @@ import {
   _resetBackend,
   deleteSecureKeyAsync,
   getSecureKeyAsync,
-  listSecureKeys,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
@@ -146,15 +145,6 @@ describe("secure-keys", () => {
 
     test("delete returns not-found for nonexistent key", async () => {
       expect(await deleteSecureKeyAsync("missing")).toBe("not-found");
-    });
-
-    test("listSecureKeys returns all keys", async () => {
-      await setSecureKeyAsync("anthropic", "val1");
-      await setSecureKeyAsync("openai", "val2");
-      const keys = listSecureKeys();
-      expect(keys).toContain("anthropic");
-      expect(keys).toContain("openai");
-      expect(keys.length).toBe(2);
     });
   });
 

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -28,7 +28,6 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: async (key?: string, value?: string) =>
     setSecureKeyMock(key, value),
   deleteSecureKeyAsync: async () => "deleted" as const,
-  listSecureKeys: () => [],
   listSecureKeysAsync: async () => [],
   _resetBackend: () => {},
 }));

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -105,7 +105,7 @@ mock.module("../security/secure-keys.js", () => {
     setSecureKeyAsync: async (account: string, value: string) =>
       syncSet(account, value),
     deleteSecureKeyAsync: async (account: string) => syncDelete(account),
-    listSecureKeys: () => Object.keys(secureKeyStore),
+    listSecureKeysAsync: async () => Object.keys(secureKeyStore),
     _resetBackend: () => {},
   };
 });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -17,7 +17,6 @@ import {
   createEncryptedStoreBackend,
   createKeychainBackend,
 } from "./credential-backend.js";
-import * as encryptedStore from "./encrypted-store.js";
 
 export type { DeleteResult } from "./credential-backend.js";
 
@@ -54,17 +53,6 @@ function resolveBackend(): CredentialBackend {
     }
   }
   return _resolvedBackend;
-}
-
-/**
- * List all account names in secure storage (sync — encrypted store only).
- * Throws if the store file exists but cannot be read.
- *
- * @deprecated Use {@link listSecureKeysAsync} instead, which merges keys from
- * both the primary backend and the encrypted store for completeness.
- */
-export function listSecureKeys(): string[] {
-  return encryptedStore.listKeys();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove the deprecated sync `listSecureKeys()` from `secure-keys.ts` (no production callers)
- Replace `listSecureKeys` with `listSecureKeysAsync` in all test mocks, fixing the `secret-onetime-send.test.ts` CI failure
- Remove the now-unused `import * as encryptedStore` from `secure-keys.ts`

## Original prompt
fix CI errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/23089777060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
