### PR TITLE
feat: wire UsageTelemetryReporter into daemon startup and shutdown

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -61,6 +61,7 @@ import {
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
   ensureDataDir,
@@ -284,6 +285,13 @@ export async function runDaemon(): Promise<void> {
     );
     if (!collectUsageData) {
       await closeSentry();
+    }
+
+    let telemetryReporter: UsageTelemetryReporter | null = null;
+    if (collectUsageData) {
+      telemetryReporter = new UsageTelemetryReporter();
+      telemetryReporter.start();
+      log.info("Usage telemetry reporter started");
     }
 
     // If Logfire observability is not explicitly enabled, disable it so
@@ -827,6 +835,7 @@ export async function runDaemon(): Promise<void> {
       memoryWorker,
       qdrantManager,
       mcpManager,
+      telemetryReporter,
       cleanupPidFile,
     });
   } catch (err) {

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -24,6 +24,7 @@ export interface ShutdownDeps {
   memoryWorker: { stop(): void };
   qdrantManager: QdrantManager;
   mcpManager: McpServerManager | null;
+  telemetryReporter: { stop(): Promise<void> } | null;
   cleanupPidFile: () => void;
 }
 
@@ -85,6 +86,14 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
       await getEnrichmentService().shutdown();
     } catch (err) {
       log.warn({ err }, "Enrichment service shutdown failed (non-fatal)");
+    }
+
+    if (deps.telemetryReporter) {
+      try {
+        await deps.telemetryReporter.stop();
+      } catch (err) {
+        log.warn({ err }, "Telemetry reporter shutdown failed (non-fatal)");
+      }
     }
 
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();


### PR DESCRIPTION
## Summary
- Start UsageTelemetryReporter during daemon init when collect-usage-data flag is enabled
- Add telemetryReporter to ShutdownDeps for graceful stop before SQLite WAL checkpoint

Part of plan: usage-telemetry.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
