### PR TITLE
fix: add telemetry reporter auth guard, consume response body, use gte watermark

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -1,4 +1,4 @@
-import { asc, desc, gt } from "drizzle-orm";
+import { asc, desc, gte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type {
@@ -106,7 +106,7 @@ export function queryUnreportedUsageEvents(
   const rows = db
     .select()
     .from(llmUsageEvents)
-    .where(gt(llmUsageEvents.createdAt, afterCreatedAt))
+    .where(gte(llmUsageEvents.createdAt, afterCreatedAt))
     .orderBy(asc(llmUsageEvents.createdAt))
     .limit(limit)
     .all();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -102,8 +102,11 @@ export class UsageTelemetryReporter {
       const events = queryUnreportedUsageEvents(watermark, BATCH_SIZE);
       if (events.length === 0) return;
 
-      // Resolve auth context
+      // Resolve auth context — skip flush when neither auth mode is viable
       const proxyCtx = await resolveManagedProxyContext();
+      if (!proxyCtx.enabled && !getTelemetryAppToken()) {
+        return;
+      }
 
       let url: string;
       let authHeaders: Record<string, string>;
@@ -143,12 +146,14 @@ export class UsageTelemetryReporter {
       });
 
       if (!resp.ok) {
+        await resp.text(); // consume body to release connection
         log.warn(
           { status: resp.status, url },
           "Usage telemetry POST failed — will retry next cycle",
         );
         return;
       }
+      await resp.text(); // consume body to release connection
 
       // Advance watermark
       setMemoryCheckpoint(


### PR DESCRIPTION
## Summary
Fixes three gaps found during plan review:
- Skip telemetry flush when neither managed proxy nor app token is configured (prevents silent 401s every 5 min)
- Consume fetch response body to avoid holding TCP connections
- Use gte instead of gt for watermark query to avoid skipping events with identical timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)