### PR TITLE
Fix: make authManager and performLogout public for cross-module access

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -111,7 +111,7 @@ extension AppDelegate {
         }
     }
 
-    @objc func performLogout() {
+    @objc public func performLogout() {
         Task {
             await authManager.logout()
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -71,7 +71,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     var onboardingWindow: OnboardingWindow?
     var authWindow: NSWindow?
-    var authManager: AuthManager { services.authManager }
+    public var authManager: AuthManager { services.authManager }
     public var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
 


### PR DESCRIPTION
## Summary
- Make `authManager` property on `AppDelegate` `public` so it's accessible from the executable target
- Make `performLogout()` `public` for the same reason — it's called from the Sign Out button in `VellumAssistantApp.swift`
- Fixes the macOS CI build failure introduced by the Sign Out menu item PR (#16677)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23091529419/job/67076843331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
