### PR TITLE
fix: use strict greater-than in queryUnreportedUsageEvents

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -1,4 +1,4 @@
-import { asc, desc, gte } from "drizzle-orm";
+import { asc, desc, gt } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type {
@@ -106,7 +106,7 @@ export function queryUnreportedUsageEvents(
   const rows = db
     .select()
     .from(llmUsageEvents)
-    .where(gte(llmUsageEvents.createdAt, afterCreatedAt))
+    .where(gt(llmUsageEvents.createdAt, afterCreatedAt))
     .orderBy(asc(llmUsageEvents.createdAt))
     .limit(limit)
     .all();


### PR DESCRIPTION
## Summary
- Fixed `queryUnreportedUsageEvents` to use `gt` (strict greater-than) instead of `gte` (greater-than-or-equal) when filtering by `afterCreatedAt`, so events at exactly the watermark timestamp are correctly excluded.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23091747020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
