### PR TITLE
fix: revert gte to gt in watermark query, fix reporter test auth setup

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -120,7 +120,7 @@ beforeEach(() => {
     assistantApiKey: "",
   });
   mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.vellum.ai");
-  mockGetTelemetryAppToken.mockReturnValue("");
+  mockGetTelemetryAppToken.mockReturnValue("default-test-token");
 
   mockFetch = mock(() =>
     Promise.resolve(new Response('{"accepted":0}', { status: 200 })),


### PR DESCRIPTION
## Summary
- Revert queryUnreportedUsageEvents from gte back to gt to prevent duplicate event reporting
- Fix reporter tests to configure a default telemetry app token so auth guard doesn't short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
