### PR TITLE
fix: move hooks directory outside sandbox boundary

### DIFF
--- a/assistant/src/__tests__/hooks-blocking.test.ts
+++ b/assistant/src/__tests__/hooks-blocking.test.ts
@@ -45,7 +45,7 @@ describe("Blocking Hooks", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-config.test.ts
+++ b/assistant/src/__tests__/hooks-config.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe("Hooks Config", () => {
   beforeEach(() => {
-    const hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    const hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
   });
 
@@ -38,13 +38,7 @@ describe("Hooks Config", () => {
   });
 
   test("loadHooksConfig reads existing config", () => {
-    const configPath = join(
-      testDir,
-      ".vellum",
-      "workspace",
-      "hooks",
-      "config.json",
-    );
+    const configPath = join(testDir, ".vellum", "hooks", "config.json");
     writeFileSync(
       configPath,
       JSON.stringify({
@@ -58,13 +52,7 @@ describe("Hooks Config", () => {
   });
 
   test("loadHooksConfig returns defaults for invalid JSON", () => {
-    const configPath = join(
-      testDir,
-      ".vellum",
-      "workspace",
-      "hooks",
-      "config.json",
-    );
+    const configPath = join(testDir, ".vellum", "hooks", "config.json");
     writeFileSync(configPath, "NOT VALID JSON {{{");
 
     const config = loadHooksConfig();
@@ -73,13 +61,7 @@ describe("Hooks Config", () => {
   });
 
   test("loadHooksConfig returns defaults for invalid structure", () => {
-    const configPath = join(
-      testDir,
-      ".vellum",
-      "workspace",
-      "hooks",
-      "config.json",
-    );
+    const configPath = join(testDir, ".vellum", "hooks", "config.json");
     writeFileSync(configPath, JSON.stringify({ foo: "bar" }));
 
     const config = loadHooksConfig();
@@ -91,13 +73,7 @@ describe("Hooks Config", () => {
     const config = { version: 1, hooks: { "test-hook": { enabled: true } } };
     saveHooksConfig(config);
 
-    const configPath = join(
-      testDir,
-      ".vellum",
-      "workspace",
-      "hooks",
-      "config.json",
-    );
+    const configPath = join(testDir, ".vellum", "hooks", "config.json");
     expect(existsSync(configPath)).toBe(true);
     const read = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(read.hooks["test-hook"].enabled).toBe(true);

--- a/assistant/src/__tests__/hooks-discovery.test.ts
+++ b/assistant/src/__tests__/hooks-discovery.test.ts
@@ -29,7 +29,7 @@ describe("Hooks Discovery", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-integration.test.ts
+++ b/assistant/src/__tests__/hooks-integration.test.ts
@@ -43,7 +43,7 @@ describe("Hooks Integration", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-manager.test.ts
+++ b/assistant/src/__tests__/hooks-manager.test.ts
@@ -41,7 +41,7 @@ describe("HookManager", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     resetHookManager();
   });

--- a/assistant/src/__tests__/hooks-runner.test.ts
+++ b/assistant/src/__tests__/hooks-runner.test.ts
@@ -40,7 +40,7 @@ describe("Hook Runner", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-settings.test.ts
+++ b/assistant/src/__tests__/hooks-settings.test.ts
@@ -22,7 +22,7 @@ describe("Hook Settings", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/hooks-templates.test.ts
+++ b/assistant/src/__tests__/hooks-templates.test.ts
@@ -45,7 +45,7 @@ describe("Hook Templates", () => {
   let hooksDir: string;
 
   beforeEach(() => {
-    hooksDir = join(testDir, ".vellum", "workspace", "hooks");
+    hooksDir = join(testDir, ".vellum", "hooks");
     mkdirSync(hooksDir, { recursive: true });
   });
 

--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -69,11 +69,22 @@ describe("baseline path characterization (pre-migration)", () => {
     expect(getSandboxRootDir()).toBe(join(data, "sandbox"));
     expect(getSandboxWorkingDir()).toBe(join(root, "workspace"));
 
-    // Now resolves under workspace/hooks
-    expect(getHooksDir()).toBe(join(root, "workspace", "hooks"));
+    // Hooks remain outside the workspace sandbox boundary
+    expect(getHooksDir()).toBe(join(root, "hooks"));
 
     // STAYS ROOT — runtime files remain at ~/.vellum/
     expect(getPidPath()).toBe(join(root, "vellum.pid"));
+  });
+
+  test("hooks directory is outside the sandbox boundary", () => {
+    const base = join(
+      tmpdir(),
+      `platform-test-${randomBytes(4).toString("hex")}`,
+    );
+    process.env.BASE_DATA_DIR = base;
+    const hooksDir = getHooksDir();
+    const sandboxDir = getSandboxWorkingDir();
+    expect(hooksDir.startsWith(sandboxDir)).toBe(false);
   });
 
   test("ensureDataDir creates all expected directories", () => {
@@ -98,7 +109,7 @@ describe("baseline path characterization (pre-migration)", () => {
 
     // Workspace dirs
     expect(existsSync(ws)).toBe(true);
-    expect(existsSync(join(ws, "hooks"))).toBe(true);
+    expect(existsSync(join(getRootDir(), "hooks"))).toBe(true);
     expect(existsSync(join(ws, "skills"))).toBe(true);
 
     // Data sub-dirs under workspace
@@ -113,7 +124,6 @@ describe("baseline path characterization (pre-migration)", () => {
 
     // Legacy dirs should NOT be created
     expect(existsSync(join(getRootDir(), "skills"))).toBe(false);
-    expect(existsSync(join(getRootDir(), "hooks"))).toBe(false);
     expect(existsSync(join(getRootDir(), "data", "sandbox"))).toBe(false);
     expect(existsSync(join(getRootDir(), "data", "sandbox", "fs"))).toBe(false);
 

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -10,10 +10,10 @@ import { isHttpHealthy } from "../../daemon/daemon-control.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import {
   getDbPath,
+  getHooksDir,
   getLogPath,
   getRootDir,
   getWorkspaceDir,
-  getWorkspaceHooksDir,
   getWorkspaceSkillsDir,
 } from "../../util/platform.js";
 import { log } from "../logger.js";
@@ -133,7 +133,7 @@ Examples:
         `${dataDir}/db`,
         `${dataDir}/logs`,
         getWorkspaceSkillsDir(),
-        getWorkspaceHooksDir(),
+        getHooksDir(),
         `${rootDir}/protected`,
       ];
       const missing = requiredDirs.filter((d) => !existsSync(d));

--- a/assistant/src/hooks/templates.ts
+++ b/assistant/src/hooks/templates.ts
@@ -18,7 +18,7 @@ const log = getLogger("hooks-templates");
 
 /**
  * Install bundled hook templates into the user's hooks directory.
- * Templates are copied from `assistant/hook-templates/` to `~/.vellum/workspace/hooks/`.
+ * Templates are copied from `assistant/hook-templates/` to `~/.vellum/hooks/`.
  * - Never overwrites existing hooks (user modifications are preserved).
  * - Newly installed hooks are disabled by default.
  */

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -321,7 +321,7 @@ export function getHistoryPath(): string {
 }
 
 export function getHooksDir(): string {
-  return getWorkspaceHooksDir();
+  return join(getRootDir(), "hooks");
 }
 
 // --- Workspace path primitives ---
@@ -369,7 +369,7 @@ export function ensureDataDir(): void {
     join(root, "protected"),
     // Workspace dirs
     workspace,
-    join(workspace, "hooks"),
+    join(root, "hooks"),
     join(workspace, "skills"),
     join(workspace, "embedding-models"),
     // Data sub-dirs under workspace


### PR DESCRIPTION
## Summary
- **Security fix**: `getHooksDir()` previously resolved to `~/.vellum/workspace/hooks`, inside the sandbox working directory (`~/.vellum/workspace`). Sandboxed `file_write` could plant hook scripts that execute on the host via `spawn()` — a sandbox escape.
- Moves hooks to `~/.vellum/hooks` (root-level, alongside `protected/`), outside the tool-writable boundary.
- Adds a guard test ensuring hooks directory never falls inside the sandbox boundary.

Codex finding: https://chatgpt.com/codex/security/archives/d50ad41170248191a213310a6bad0ba6

## Original prompt
Security Fix: Move hooks directory outside sandbox boundary — getHooksDir() resolves inside the sandbox working directory, enabling sandboxed file writes to install hooks that execute on the host.

## Test plan
- [x] All 13 platform tests pass
- [x] All 66 hook tests pass (blocking, config, discovery, integration, manager, runner, settings, templates)
- [x] New guard test: `hooks directory is outside the sandbox boundary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
