### PR TITLE
chore: bake telemetry app token default for prod

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -161,7 +161,10 @@ export function getTelemetryPlatformUrl(): string {
 }
 
 export function getTelemetryAppToken(): string {
-  return str("TELEMETRY_APP_TOKEN") ?? "";
+  return (
+    str("TELEMETRY_APP_TOKEN") ??
+    "e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed"
+  );
 }
 
 // ── Startup validation ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Set default TELEMETRY_APP_TOKEN so the daemon can send anonymous telemetry without env var configuration
- Token is a non-secret abuse deterrent (like a Segment write key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
