### PR TITLE
feat: add developer-menu-items feature flag, restructure menu bar

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -306,17 +306,17 @@ extension AppDelegate {
         sendLogsItem.image = VIcon.upload.nsImage
         menu.addItem(sendLogsItem)
 
-        menu.addItem(NSMenuItem.separator())
+        if MacOSClientFeatureFlagManager.shared.isEnabled("developer-menu-items") {
+            menu.addItem(NSMenuItem.separator())
 
-        let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")
-        onboardingItem.target = self
-        menu.addItem(onboardingItem)
+            let onboardingItem = NSMenuItem(title: "Replay Onboarding", action: #selector(replayOnboarding), keyEquivalent: "")
+            onboardingItem.target = self
+            menu.addItem(onboardingItem)
 
-        #if DEBUG
-        let galleryItem = NSMenuItem(title: "Component Gallery", action: #selector(showComponentGallery), keyEquivalent: "")
-        galleryItem.target = self
-        menu.addItem(galleryItem)
-        #endif
+            let galleryItem = NSMenuItem(title: "Component Gallery", action: #selector(showComponentGallery), keyEquivalent: "")
+            galleryItem.target = self
+            menu.addItem(galleryItem)
+        }
 
         menu.addItem(NSMenuItem.separator())
 
@@ -329,8 +329,6 @@ extension AppDelegate {
         restartItem.target = self
         restartItem.image = VIcon.refreshCw.nsImage
         menu.addItem(restartItem)
-
-        menu.addItem(NSMenuItem.separator())
 
         let logoutItem = NSMenuItem(title: "Sign Out", action: #selector(performLogout), keyEquivalent: "")
         logoutItem.target = self

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -90,6 +90,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "developer-menu-items",
+      "scope": "macos",
+      "key": "developer_menu_items_enabled",
+      "label": "Developer Menu Items",
+      "description": "Show Component Gallery and Replay Onboarding in the menu bar",
+      "defaultEnabled": false
+    },
+    {
       "id": "logfire",
       "scope": "assistant",
       "key": "feature_flags.logfire.enabled",


### PR DESCRIPTION
## Summary
- Add `developer-menu-items` macOS feature flag (default off) to gate Component Gallery and Replay Onboarding menu items behind a runtime toggle in Settings > Developer
- Remove `#if DEBUG` compile-time gate on Component Gallery — now controlled by the feature flag at runtime
- Merge Settings and Restart into the Sign Out / Quit section, removing the separator between them

## Original prompt
the plan we just mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)