### PR TITLE
M1: Add daemon app sync on macOS Things panel appear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -44,7 +44,7 @@ struct AppsGridView: View {
 
     var body: some View {
         Group {
-            if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared {
+            if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared && hasFetchedLocalApps {
                 noAppsEmptyState
             } else {
                 VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -538,7 +538,10 @@ struct AppsGridView: View {
             let stream = daemonClient.subscribe()
             do {
                 try daemonClient.sendAppsList()
-            } catch { return }
+            } catch {
+                hasFetchedLocalApps = true
+                return
+            }
             for await message in stream {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
@@ -553,6 +556,8 @@ struct AppsGridView: View {
                     return
                 }
             }
+            // Stream ended without a response (e.g. daemon disconnected)
+            hasFetchedLocalApps = true
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -27,6 +27,10 @@ struct AppsGridView: View {
     @State private var sharedAppsTask: Task<Void, Never>?
     @State private var sharedAppsTaskGeneration = 0
 
+    // Local apps fetched from daemon
+    @State private var hasFetchedLocalApps = false
+    @State private var localAppsTask: Task<Void, Never>?
+
     /// Cache of lazily-loaded preview screenshots keyed by app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
     @State private var previewCache: [String: String] = [:]
@@ -63,10 +67,13 @@ struct AppsGridView: View {
         .background(VColor.surfaceBase)
         .onAppear {
             if !hasFetchedShared { fetchSharedApps() }
+            if !hasFetchedLocalApps { refreshLocalAppsFromDaemon() }
         }
         .onDisappear {
             sharedAppsTask?.cancel()
             sharedAppsTask = nil
+            localAppsTask?.cancel()
+            localAppsTask = nil
             for task in previewTasks.values { task.cancel() }
             previewTasks.removeAll()
         }
@@ -523,6 +530,30 @@ struct AppsGridView: View {
             }
         }
         sharedAppsTask = task
+    }
+
+    private func refreshLocalAppsFromDaemon() {
+        localAppsTask?.cancel()
+        localAppsTask = Task { @MainActor in
+            let stream = daemonClient.subscribe()
+            do {
+                try daemonClient.sendAppsList()
+            } catch { return }
+            for await message in stream {
+                guard !Task.isCancelled else { return }
+                if case .appsListResponse(let response) = message {
+                    let daemonItems = response.apps.map {
+                        AppListManager.AppItem_Daemon(
+                            id: $0.id, name: $0.name, description: $0.description,
+                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                        )
+                    }
+                    appListManager.syncFromDaemon(daemonItems)
+                    hasFetchedLocalApps = true
+                    return
+                }
+            }
+        }
     }
 
     // MARK: - Sections


### PR DESCRIPTION
## Summary
- Adds `refreshLocalAppsFromDaemon()` method to `AppsGridView` that subscribes to the daemon message stream, sends an apps list request, and syncs the response into `AppListManager`
- Calls `refreshLocalAppsFromDaemon()` from `.onAppear` (gated by `hasFetchedLocalApps`) alongside the existing `fetchSharedApps()` call
- Tracks the async task in `localAppsTask` and cancels it in `.onDisappear`

Previously, local apps only appeared via inline preview clicks or `appFilesChanged` broadcasts — if either path failed, the Things panel showed stale/empty data with no recovery.

Closes #16696

## Test plan
- [ ] Open the Things panel and verify local apps from the daemon appear alongside shared apps
- [ ] Navigate away and back — verify apps are not re-fetched (guard prevents redundant calls)
- [ ] Verify existing shared apps and preview fetching still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
