### PR TITLE
fix: align accessibility label with dynamic button title in onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -89,7 +89,7 @@ struct WakeUpStepView: View {
                         onContinueWithVellum()
                     }
                     .disabled(!managedSignInEnabled && authManager?.isAuthenticated != true)
-                    .accessibilityLabel("Sign in")
+                    .accessibilityLabel(primaryButtonTitle)
 
                     if !managedSignInEnabled && authManager?.isAuthenticated != true {
                         Text("Coming Soon")


### PR DESCRIPTION
Fixes from review of PR #16619: accessibility label now uses primaryButtonTitle instead of hardcoded 'Sign in', so VoiceOver correctly announces 'Coming Soon' when managed sign-in is disabled.