### PR TITLE
chore: remove orphaned SequenceStore interface and stale comments

### DIFF
--- a/assistant/src/sequence/store.ts
+++ b/assistant/src/sequence/store.ts
@@ -1,5 +1,5 @@
 /**
- * SQLite-backed implementation of the SequenceStore interface.
+ * SQLite-backed sequence store.
  *
  * Follows the same patterns as schedule-store.ts:
  * - Flat exported functions (no class)

--- a/assistant/src/sequence/types.ts
+++ b/assistant/src/sequence/types.ts
@@ -1,9 +1,5 @@
 /**
- * Email sequencing types and store interface.
- *
- * The SequenceStore interface is the contract that the engine, tools, and CLI
- * program against. The SQLite implementation is the first backend; a hosted
- * backend can be added later without touching any consumers.
+ * Email sequencing domain types and input shapes.
  */
 
 // ── Domain Types ────────────────────────────────────────────────────
@@ -92,34 +88,3 @@ export type EnrollmentExitReason =
   | "replied"
   | "cancelled"
   | "failed";
-
-// ── Store Interface ─────────────────────────────────────────────────
-
-export interface SequenceStore {
-  // Sequence CRUD
-  createSequence(input: CreateSequenceInput): Sequence;
-  getSequence(id: string): Sequence | undefined;
-  listSequences(filter?: ListSequencesFilter): Sequence[];
-  updateSequence(id: string, patch: UpdateSequenceInput): Sequence | undefined;
-  deleteSequence(id: string): void;
-
-  // Enrollment CRUD
-  enrollContact(input: EnrollContactInput): SequenceEnrollment;
-  getEnrollment(id: string): SequenceEnrollment | undefined;
-  listEnrollments(filter?: ListEnrollmentsFilter): SequenceEnrollment[];
-  /**
-   * Atomically claim enrollments that are due for processing.
-   * Uses optimistic locking to prevent double-sends in concurrent environments.
-   */
-  claimDueEnrollments(now: number, limit?: number): SequenceEnrollment[];
-  advanceEnrollment(
-    id: string,
-    threadId?: string,
-    nextStepAt?: number | null,
-  ): SequenceEnrollment | undefined;
-  exitEnrollment(id: string, reason: EnrollmentExitReason): void;
-
-  // Query helpers
-  findActiveEnrollmentsByEmail(email: string): SequenceEnrollment[];
-  countActiveEnrollments(sequenceId: string): number;
-}


### PR DESCRIPTION
Follows up on PR #16625: removes the now-unused SequenceStore interface definition from types.ts and updates stale comments in store.ts that referenced it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
