### PR TITLE
chore: remove dead MAX_BACKOFF_MS export from watcher constants

### DIFF
--- a/assistant/src/watcher/constants.ts
+++ b/assistant/src/watcher/constants.ts
@@ -1,8 +1,4 @@
 /** Default poll interval for watchers (60 seconds). */
 export const DEFAULT_POLL_INTERVAL_MS = 60_000;
-
-/** Maximum backoff delay (1 hour). */
-export const MAX_BACKOFF_MS = 60 * 60 * 1000;
-
 /** Disable watcher after this many consecutive errors. */
 export const MAX_CONSECUTIVE_ERRORS = 5;


### PR DESCRIPTION
Follows up on PR #16640: removes the unused MAX_BACKOFF_MS export that was left behind when BACKOFF_BASE_MS was removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
