### PR TITLE
fix: correct JWT subject pattern and TTL in CLI bearer tokens

### DIFF
--- a/assistant/src/cli/http-client.ts
+++ b/assistant/src/cli/http-client.ts
@@ -29,7 +29,7 @@ function mintCliToken(): string | undefined {
     }
     return mintToken({
       aud: "vellum-gateway",
-      sub: "svc:cli:local",
+      sub: "local:cli:cli",
       scope_profile: "actor_client_v1",
       policy_epoch: CURRENT_POLICY_EPOCH,
       ttlSeconds: 300,

--- a/cli/src/lib/jwt.ts
+++ b/cli/src/lib/jwt.ts
@@ -10,6 +10,8 @@ import { createHmac, randomBytes } from "crypto";
 import { readFileSync } from "fs";
 import { join } from "path";
 
+import { CURRENT_POLICY_EPOCH } from "./policy.js";
+
 function base64urlEncode(data: Buffer | string): string {
   const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
   return buf.toString("base64url");
@@ -23,7 +25,7 @@ const JWT_HEADER = base64urlEncode(
  * Mint a short-lived JWT bearer token for the given instance directory.
  *
  * Reads the signing key from `<instanceDir>/.vellum/protected/actor-token-signing-key`
- * and mints a 5-minute JWT with `aud=vellum-gateway`.
+ * and mints a 30-day JWT with `aud=vellum-gateway`.
  *
  * Returns undefined if the signing key doesn't exist yet (daemon not started).
  */
@@ -42,10 +44,10 @@ export function mintLocalBearerToken(instanceDir: string): string | undefined {
     const claims = {
       iss: "vellum-auth",
       aud: "vellum-gateway",
-      sub: "svc:cli:local",
+      sub: "local:cli:cli",
       scope_profile: "actor_client_v1",
-      exp: now + 300,
-      policy_epoch: 1,
+      exp: now + 30 * 24 * 60 * 60,
+      policy_epoch: CURRENT_POLICY_EPOCH,
       iat: now,
       jti: randomBytes(16).toString("hex"),
     };

--- a/cli/src/lib/policy.ts
+++ b/cli/src/lib/policy.ts
@@ -1,0 +1,7 @@
+/**
+ * Policy epoch constant for the external CLI.
+ *
+ * Must stay in sync with assistant/src/runtime/auth/policy.ts.
+ * When the daemon bumps CURRENT_POLICY_EPOCH, update this value too.
+ */
+export const CURRENT_POLICY_EPOCH = 1;

--- a/skills/doordash/scripts/lib/shared/platform.ts
+++ b/skills/doordash/scripts/lib/shared/platform.ts
@@ -39,6 +39,9 @@ export function buildDaemonUrl(port?: number): string {
   return `http://127.0.0.1:${port ?? getHttpPort()}`;
 }
 
+/** Must stay in sync with assistant/src/runtime/auth/policy.ts. */
+const CURRENT_POLICY_EPOCH = 1;
+
 function base64urlEncode(data: Buffer | string): string {
   const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
   return buf.toString("base64url");
@@ -62,10 +65,10 @@ export function readHttpToken(): string | null {
     const claims = {
       iss: "vellum-auth",
       aud: "vellum-gateway",
-      sub: "svc:cli:local",
+      sub: "local:cli:cli",
       scope_profile: "actor_client_v1",
       exp: now + 300,
-      policy_epoch: 1,
+      policy_epoch: CURRENT_POLICY_EPOCH,
       iat: now,
       jti: randomBytes(16).toString("hex"),
     };


### PR DESCRIPTION
Fixes from review of PR #16604:

1. **Invalid JWT subject**: Changed `sub: "svc:cli:local"` to `sub: "local:cli:cli"` — the auth parser only accepts `actor:`, `svc:gateway:`, `svc:daemon:`, or `local:` patterns. Fixed in all three locations (assistant CLI, external CLI, DoorDash skill).

2. **5-minute TTL too short**: Increased `mintLocalBearerToken` TTL from 5 minutes to 30 days in `cli/src/lib/jwt.ts`, matching the previous `ACCESS_TOKEN_TTL_SECONDS`. The lockfile token is used by `ps`, `client`, and other commands hours/days after `hatch`.

3. **Hardcoded policy_epoch**: Replaced hardcoded `policy_epoch: 1` with `CURRENT_POLICY_EPOCH` constant in `cli/src/lib/jwt.ts` (via new `cli/src/lib/policy.ts`) and `skills/doordash/scripts/lib/shared/platform.ts` (inline constant). Both include sync comments pointing to the canonical source.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
