### PR TITLE
fix: add staleness check before removing .git/index.lock

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1,5 +1,11 @@
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -252,17 +258,30 @@ export class WorkspaceGitService {
     );
   }
 
+  /** Age threshold (ms) beyond which an index.lock is considered stale. */
+  private static readonly LOCK_STALE_THRESHOLD_MS = 30_000;
+
   /**
-   * Remove stale `.git/index.lock` left by a crashed or timed-out git process.
-   * Safe to call while holding the mutex — the lock guarantees no other
-   * service-initiated git operation is running, so any existing lock file
-   * must be stale.
+   * Remove `.git/index.lock` only if it is stale — older than
+   * {@link LOCK_STALE_THRESHOLD_MS}. A recently-created lock may belong to a
+   * concurrent git process outside our mutex (e.g. a user-initiated CLI
+   * command), so we leave it alone.
    */
   private cleanStaleLockFile(): void {
+    const lockPath = join(this.workspaceDir, ".git", "index.lock");
     try {
-      unlinkSync(join(this.workspaceDir, ".git", "index.lock"));
+      const stat = statSync(lockPath);
+      const ageMs = Date.now() - stat.mtimeMs;
+      if (ageMs < GitService.LOCK_STALE_THRESHOLD_MS) {
+        log.debug(
+          `index.lock exists but is only ${Math.round(ageMs / 1000)}s old — leaving it`,
+        );
+        return;
+      }
+      unlinkSync(lockPath);
+      log.debug(`Removed stale index.lock (${Math.round(ageMs / 1000)}s old)`);
     } catch {
-      // File doesn't exist or can't be removed — either way, move on.
+      // File doesn't exist or can't be stat'd/removed — move on.
     }
   }
 


### PR DESCRIPTION
Follows up on PR #16636: instead of unconditionally deleting index.lock, now checks if the lock file is stale (older than 30s) before removing, to avoid breaking concurrent git operations.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
