### PR TITLE
fix: strengthen stop() flush test to verify additional flush call

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -304,11 +304,15 @@ describe("UsageTelemetryReporter", () => {
 
     const reporter = new UsageTelemetryReporter();
     reporter.start();
+
+    // Wait a tick so start()'s immediate flush settles.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const callsBeforeStop = mockFetch.mock.calls.length;
+
     await reporter.stop();
 
-    // start() triggers an immediate flush, and stop() performs a final flush.
-    // At minimum fetch should have been called once.
-    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(1);
+    // stop() must trigger at least one additional flush beyond what start() did.
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBeforeStop);
   });
 
   test("payload shape is correct", async () => {


### PR DESCRIPTION
Follows up on PR #16682: the stop() test was too lenient — it passed even if stop() never flushed because start() already triggered one flush. Now records the fetch count after start() settles, then verifies stop() triggers an additional flush beyond that baseline.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
