### PR TITLE
fix: add timeout to telemetry flush during shutdown

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -90,7 +90,13 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     if (deps.telemetryReporter) {
       try {
-        await deps.telemetryReporter.stop();
+        const timeout = new Promise<void>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Telemetry flush timed out")),
+            3_000,
+          ),
+        );
+        await Promise.race([deps.telemetryReporter.stop(), timeout]);
       } catch (err) {
         log.warn({ err }, "Telemetry reporter shutdown failed (non-fatal)");
       }


### PR DESCRIPTION
Follows up on PR #16681: wraps the telemetry reporter stop() in a Promise.race with a 3s timeout during shutdown to prevent slow/unreachable telemetry endpoints from blocking critical cleanup like Qdrant stop and SQLite WAL checkpoint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
