### PR TITLE
fix: use compound cursor (createdAt, id) for telemetry watermark

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -642,7 +642,7 @@ describe("queryUnreportedUsageEvents", () => {
     insertEventAt(3000, { model: "model-c" });
 
     // afterCreatedAt = 1000 should exclude the event at exactly 1000
-    const events = queryUnreportedUsageEvents(1000, 100);
+    const events = queryUnreportedUsageEvents(1000, undefined, 100);
     expect(events).toHaveLength(2);
     expect(events[0].model).toBe("model-b");
     expect(events[0].createdAt).toBe(2000);
@@ -655,7 +655,7 @@ describe("queryUnreportedUsageEvents", () => {
     insertEventAt(2000, { model: "model-b" });
     insertEventAt(3000, { model: "model-c" });
 
-    const events = queryUnreportedUsageEvents(0, 2);
+    const events = queryUnreportedUsageEvents(0, undefined, 2);
     expect(events).toHaveLength(2);
     // Should return the earliest two due to ASC ordering
     expect(events[0].model).toBe("model-a");
@@ -665,12 +665,12 @@ describe("queryUnreportedUsageEvents", () => {
   test("returns empty array when no events match", () => {
     insertEventAt(1000, { model: "model-a" });
 
-    const events = queryUnreportedUsageEvents(2000, 100);
+    const events = queryUnreportedUsageEvents(2000, undefined, 100);
     expect(events).toHaveLength(0);
   });
 
   test("returns empty array when table is empty", () => {
-    const events = queryUnreportedUsageEvents(0, 100);
+    const events = queryUnreportedUsageEvents(0, undefined, 100);
     expect(events).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -1,4 +1,4 @@
-import { asc, desc, gt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type {
@@ -100,14 +100,25 @@ export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
 
 export function queryUnreportedUsageEvents(
   afterCreatedAt: number,
+  afterId: string | undefined,
   limit: number,
 ): UsageEvent[] {
   const db = getDb();
   const rows = db
     .select()
     .from(llmUsageEvents)
-    .where(gt(llmUsageEvents.createdAt, afterCreatedAt))
-    .orderBy(asc(llmUsageEvents.createdAt))
+    .where(
+      afterId
+        ? or(
+            gt(llmUsageEvents.createdAt, afterCreatedAt),
+            and(
+              eq(llmUsageEvents.createdAt, afterCreatedAt),
+              gt(llmUsageEvents.id, afterId),
+            ),
+          )
+        : gt(llmUsageEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(llmUsageEvents.createdAt), asc(llmUsageEvents.id))
     .limit(limit)
     .all();
   return rows.map(rowToUsageEvent);

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -192,8 +192,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("watermark advances on successful upload", async () => {
     const events = [
-      makeUsageEvent({ createdAt: 1700000001000 }),
-      makeUsageEvent({ createdAt: 1700000002000 }),
+      makeUsageEvent({ id: "evt-w1", createdAt: 1700000001000 }),
+      makeUsageEvent({ id: "evt-w2", createdAt: 1700000002000 }),
     ];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
     mockFetch.mockImplementation(() =>
@@ -211,6 +211,13 @@ describe("UsageTelemetryReporter", () => {
     expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
       String(1700000002000),
     );
+
+    // The compound cursor ID should also be set to the last event's id
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:usage:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe("evt-w2");
   });
 
   test("watermark stays on failed upload", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -30,6 +30,7 @@ const log = getLogger("usage-telemetry");
 // ---------------------------------------------------------------------------
 
 const CHECKPOINT_KEY_WATERMARK = "telemetry:usage:last_reported_at";
+const CHECKPOINT_KEY_WATERMARK_ID = "telemetry:usage:last_reported_id";
 const CHECKPOINT_KEY_INSTALL_ID = "telemetry:installation_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
@@ -93,13 +94,19 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
-      // Read watermark
+      // Read watermark (compound cursor: createdAt + id)
       const watermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK) ?? "0",
       );
+      const watermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID) ?? undefined;
 
       // Query unreported events
-      const events = queryUnreportedUsageEvents(watermark, BATCH_SIZE);
+      const events = queryUnreportedUsageEvents(
+        watermark,
+        watermarkId,
+        BATCH_SIZE,
+      );
       if (events.length === 0) return;
 
       // Resolve auth context — skip flush when neither auth mode is viable
@@ -155,11 +162,13 @@ export class UsageTelemetryReporter {
       }
       await resp.text(); // consume body to release connection
 
-      // Advance watermark
+      // Advance watermark (compound cursor)
+      const lastEvent = events[events.length - 1];
       setMemoryCheckpoint(
         CHECKPOINT_KEY_WATERMARK,
-        String(events[events.length - 1].createdAt),
+        String(lastEvent.createdAt),
       );
+      setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, lastEvent.id);
 
       // If we got a full batch, there may be more events — recurse
       if (events.length === BATCH_SIZE) {


### PR DESCRIPTION
Fixes review feedback from PRs #16678, #16679, #16688: the telemetry watermark tracked only createdAt, which could skip events sharing a timestamp at batch boundaries. Now uses a compound (createdAt, id) cursor matching the pattern in backfill.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
