### PR TITLE
M2: Fix silent HTTP failure in fetchAppsList causing hung subscriptions

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -102,7 +102,13 @@ extension HTTPTransport {
     // MARK: - Apps HTTP Endpoints
 
     private func fetchAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsList) else { return }
+        guard let url = buildURL(for: .appsList) else {
+            onMessage?(.appsListResponse(AppsListResponse(
+                type: "apps_list_response",
+                apps: []
+            )))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -113,11 +119,22 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchAppsList(isRetry: true)
+                    } else {
+                        onMessage?(.appsListResponse(AppsListResponse(
+                            type: "apps_list_response",
+                            apps: []
+                        )))
+                    }
                     return
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch apps list failed (\(http.statusCode))")
+                    onMessage?(.appsListResponse(AppsListResponse(
+                        type: "apps_list_response",
+                        apps: []
+                    )))
                     return
                 }
             }
@@ -141,6 +158,10 @@ extension HTTPTransport {
             )))
         } catch {
             log.error("Fetch apps list error: \(error.localizedDescription)")
+            onMessage?(.appsListResponse(AppsListResponse(
+                type: "apps_list_response",
+                apps: []
+            )))
         }
     }
 
@@ -527,7 +548,13 @@ extension HTTPTransport {
     }
 
     private func fetchSharedAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsShared) else { return }
+        guard let url = buildURL(for: .appsShared) else {
+            onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                type: "shared_apps_list_response",
+                apps: []
+            )))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -538,7 +565,14 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchSharedAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchSharedAppsList(isRetry: true)
+                    } else {
+                        onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                            type: "shared_apps_list_response",
+                            apps: []
+                        )))
+                    }
                     return
                 }
                 if http.statusCode == 404 {
@@ -551,6 +585,10 @@ extension HTTPTransport {
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch shared apps list failed (\(http.statusCode))")
+                    onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                        type: "shared_apps_list_response",
+                        apps: []
+                    )))
                     return
                 }
             }
@@ -579,6 +617,10 @@ extension HTTPTransport {
             )))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
+            onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                type: "shared_apps_list_response",
+                apps: []
+            )))
         }
     }
 


### PR DESCRIPTION
## Summary
- When `fetchAppsList()` or `fetchSharedAppsList()` encounter HTTP errors (auth failure, non-200 status, network error, decode error), they now send an empty response via `onMessage` before returning
- Previously, error paths returned silently without calling `onMessage`, causing any subscriber waiting for the response to hang indefinitely

## Test plan
- [ ] Verify apps list loads normally when daemon is running
- [ ] Simulate a 401 auth failure where re-auth fails and confirm the UI shows empty apps (not hung)
- [ ] Simulate a network error and confirm the UI recovers gracefully

Closes #16697

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
