### PR TITLE
fix: use correct class name in cleanStaleLockFile

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -272,7 +272,7 @@ export class WorkspaceGitService {
     try {
       const stat = statSync(lockPath);
       const ageMs = Date.now() - stat.mtimeMs;
-      if (ageMs < GitService.LOCK_STALE_THRESHOLD_MS) {
+      if (ageMs < WorkspaceGitService.LOCK_STALE_THRESHOLD_MS) {
         log.debug(
           `index.lock exists but is only ${Math.round(ageMs / 1000)}s old — leaving it`,
         );


### PR DESCRIPTION
## Summary
- Fix `TS2304: Cannot find name 'GitService'` by changing `GitService.LOCK_STALE_THRESHOLD_MS` to `WorkspaceGitService.LOCK_STALE_THRESHOLD_MS` in `cleanStaleLockFile()`
- The class was renamed to `WorkspaceGitService` but this one reference was missed

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23092335763/job/67078966990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
