### PR TITLE
M3: Forward broadcastToAllClients to subagent sessions

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -279,6 +279,7 @@ export class DaemonServer {
   constructor() {
     this.evictor = new SessionEvictor(this.sessions);
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
+    getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
     this.evictor.onEvict = (sessionId: string) => {
       getSubagentManager().abortAllForParent(sessionId);
     };

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -87,6 +87,13 @@ export class SubagentManager {
    */
   sharedRequestTimestamps: number[] = [];
 
+  /**
+   * Broadcast callback from the daemon server.
+   * Set by DaemonServer at startup so subagent sessions can broadcast
+   * to all connected clients (e.g. app_files_changed side-effects).
+   */
+  broadcastToAllClients?: (msg: ServerMessage) => void;
+
   // ── Spawn ───────────────────────────────────────────────────────────
 
   /**
@@ -184,7 +191,7 @@ export class SubagentManager {
       maxTokens,
       wrappedSendToClient,
       workingDir,
-      undefined, // no broadcastToAllClients for subagents
+      this.broadcastToAllClients, // forward parent's broadcast so tool side-effects (e.g. app_files_changed) reach all clients
       memoryPolicy,
     );
 


### PR DESCRIPTION
## Summary
- Subagent sessions were created with `broadcastToAllClients` set to `undefined`, which meant apps created by subagents (via `app_create` tool) never triggered `app_files_changed` broadcasts to connected clients.
- Added a `broadcastToAllClients` property to `SubagentManager`, wired from `DaemonServer` at startup, and forwarded when creating subagent `Session` instances.
- Tool side-effects like app creation, update, and deletion now properly notify all connected clients even when triggered by subagents.

Closes #16698

## Test plan
- [ ] Verify subagent-created apps trigger `app_files_changed` broadcasts to connected clients
- [ ] Verify existing parent session broadcasts still work as before
- [ ] Verify subagent `sendToClient` still correctly wraps messages in subagent envelope (not affected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
