### PR TITLE
Fix: Apps/websites built not showing up in macOS Things panel

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -279,6 +279,7 @@ export class DaemonServer {
   constructor() {
     this.evictor = new SessionEvictor(this.sessions);
     getSubagentManager().sharedRequestTimestamps = this.sharedRequestTimestamps;
+    getSubagentManager().broadcastToAllClients = (msg) => this.broadcast(msg);
     this.evictor.onEvict = (sessionId: string) => {
       getSubagentManager().abortAllForParent(sessionId);
     };

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -87,6 +87,13 @@ export class SubagentManager {
    */
   sharedRequestTimestamps: number[] = [];
 
+  /**
+   * Broadcast callback from the daemon server.
+   * Set by DaemonServer at startup so subagent sessions can broadcast
+   * to all connected clients (e.g. app_files_changed side-effects).
+   */
+  broadcastToAllClients?: (msg: ServerMessage) => void;
+
   // ── Spawn ───────────────────────────────────────────────────────────
 
   /**
@@ -184,7 +191,7 @@ export class SubagentManager {
       maxTokens,
       wrappedSendToClient,
       workingDir,
-      undefined, // no broadcastToAllClients for subagents
+      this.broadcastToAllClients, // forward parent's broadcast so tool side-effects (e.g. app_files_changed) reach all clients
       memoryPolicy,
     );
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -457,14 +457,16 @@ extension AppDelegate {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
                     self.cachedApps = response.apps
-                    // Sync daemon apps into the sidebar list so pre-existing apps appear
-                    let daemonItems = response.apps.map {
-                        AppListManager.AppItem_Daemon(
-                            id: $0.id, name: $0.name, description: $0.description,
-                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                        )
+                    // Only sync if daemon returned apps — empty response may indicate an error
+                    if !response.apps.isEmpty {
+                        let daemonItems = response.apps.map {
+                            AppListManager.AppItem_Daemon(
+                                id: $0.id, name: $0.name, description: $0.description,
+                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                            )
+                        }
+                        self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     }
-                    self.mainWindow?.appListManager.syncFromDaemon(daemonItems)
                     return
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -557,7 +557,7 @@ struct AppsGridView: View {
                 }
             }
             // Stream ended without a response (e.g. daemon disconnected)
-            hasFetchedLocalApps = true
+            if !Task.isCancelled { hasFetchedLocalApps = true }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -27,6 +27,10 @@ struct AppsGridView: View {
     @State private var sharedAppsTask: Task<Void, Never>?
     @State private var sharedAppsTaskGeneration = 0
 
+    // Local apps fetched from daemon
+    @State private var hasFetchedLocalApps = false
+    @State private var localAppsTask: Task<Void, Never>?
+
     /// Cache of lazily-loaded preview screenshots keyed by app ID.
     /// Empty string is used as a sentinel for "fetched but no preview available".
     @State private var previewCache: [String: String] = [:]
@@ -40,7 +44,7 @@ struct AppsGridView: View {
 
     var body: some View {
         Group {
-            if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared {
+            if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared && hasFetchedLocalApps {
                 noAppsEmptyState
             } else {
                 VStack(alignment: .leading, spacing: 0) {
@@ -63,10 +67,13 @@ struct AppsGridView: View {
         .background(VColor.surfaceBase)
         .onAppear {
             if !hasFetchedShared { fetchSharedApps() }
+            if !hasFetchedLocalApps { refreshLocalAppsFromDaemon() }
         }
         .onDisappear {
             sharedAppsTask?.cancel()
             sharedAppsTask = nil
+            localAppsTask?.cancel()
+            localAppsTask = nil
             for task in previewTasks.values { task.cancel() }
             previewTasks.removeAll()
         }
@@ -523,6 +530,35 @@ struct AppsGridView: View {
             }
         }
         sharedAppsTask = task
+    }
+
+    private func refreshLocalAppsFromDaemon() {
+        localAppsTask?.cancel()
+        localAppsTask = Task { @MainActor in
+            let stream = daemonClient.subscribe()
+            do {
+                try daemonClient.sendAppsList()
+            } catch {
+                hasFetchedLocalApps = true
+                return
+            }
+            for await message in stream {
+                guard !Task.isCancelled else { return }
+                if case .appsListResponse(let response) = message {
+                    let daemonItems = response.apps.map {
+                        AppListManager.AppItem_Daemon(
+                            id: $0.id, name: $0.name, description: $0.description,
+                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                        )
+                    }
+                    appListManager.syncFromDaemon(daemonItems)
+                    hasFetchedLocalApps = true
+                    return
+                }
+            }
+            // Stream ended without a response (e.g. daemon disconnected)
+            hasFetchedLocalApps = true
+        }
     }
 
     // MARK: - Sections

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -545,13 +545,16 @@ struct AppsGridView: View {
             for await message in stream {
                 guard !Task.isCancelled else { return }
                 if case .appsListResponse(let response) = message {
-                    let daemonItems = response.apps.map {
-                        AppListManager.AppItem_Daemon(
-                            id: $0.id, name: $0.name, description: $0.description,
-                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
-                        )
+                    // Only sync if daemon returned apps — empty response may indicate an error
+                    if !response.apps.isEmpty {
+                        let daemonItems = response.apps.map {
+                            AppListManager.AppItem_Daemon(
+                                id: $0.id, name: $0.name, description: $0.description,
+                                icon: $0.icon, appType: nil, createdAt: $0.createdAt
+                            )
+                        }
+                        appListManager.syncFromDaemon(daemonItems)
                     }
-                    appListManager.syncFromDaemon(daemonItems)
                     hasFetchedLocalApps = true
                     return
                 }

--- a/clients/shared/Features/Directory/DirectoryStore.swift
+++ b/clients/shared/Features/Directory/DirectoryStore.swift
@@ -58,7 +58,10 @@ public final class DirectoryStore: ObservableObject {
                 }
                 return nil
             }
-            self.localApps = result ?? self.localApps
+            // Only replace if we got actual apps — empty response may be an error fallback
+            if let apps = result, !apps.isEmpty {
+                self.localApps = apps
+            }
             isLoadingApps = false
         }
     }

--- a/clients/shared/Network/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Apps.swift
@@ -102,7 +102,13 @@ extension HTTPTransport {
     // MARK: - Apps HTTP Endpoints
 
     private func fetchAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsList) else { return }
+        guard let url = buildURL(for: .appsList) else {
+            onMessage?(.appsListResponse(AppsListResponse(
+                type: "apps_list_response",
+                apps: []
+            )))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -113,11 +119,22 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchAppsList(isRetry: true)
+                    } else {
+                        onMessage?(.appsListResponse(AppsListResponse(
+                            type: "apps_list_response",
+                            apps: []
+                        )))
+                    }
                     return
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch apps list failed (\(http.statusCode))")
+                    onMessage?(.appsListResponse(AppsListResponse(
+                        type: "apps_list_response",
+                        apps: []
+                    )))
                     return
                 }
             }
@@ -141,6 +158,10 @@ extension HTTPTransport {
             )))
         } catch {
             log.error("Fetch apps list error: \(error.localizedDescription)")
+            onMessage?(.appsListResponse(AppsListResponse(
+                type: "apps_list_response",
+                apps: []
+            )))
         }
     }
 
@@ -527,7 +548,13 @@ extension HTTPTransport {
     }
 
     private func fetchSharedAppsList(isRetry: Bool = false) async {
-        guard let url = buildURL(for: .appsShared) else { return }
+        guard let url = buildURL(for: .appsShared) else {
+            onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                type: "shared_apps_list_response",
+                apps: []
+            )))
+            return
+        }
 
         var request = URLRequest(url: url)
         applyAuth(&request)
@@ -538,7 +565,14 @@ extension HTTPTransport {
             if let http = response as? HTTPURLResponse {
                 if http.statusCode == 401 && !isRetry {
                     let result = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = result { await fetchSharedAppsList(isRetry: true) }
+                    if case .success = result {
+                        await fetchSharedAppsList(isRetry: true)
+                    } else {
+                        onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                            type: "shared_apps_list_response",
+                            apps: []
+                        )))
+                    }
                     return
                 }
                 if http.statusCode == 404 {
@@ -551,6 +585,10 @@ extension HTTPTransport {
                 }
                 guard http.statusCode == 200 else {
                     log.error("Fetch shared apps list failed (\(http.statusCode))")
+                    onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                        type: "shared_apps_list_response",
+                        apps: []
+                    )))
                     return
                 }
             }
@@ -579,6 +617,10 @@ extension HTTPTransport {
             )))
         } catch {
             log.error("Fetch shared apps list error: \(error.localizedDescription)")
+            onMessage?(.sharedAppsListResponse(SharedAppsListResponse(
+                type: "shared_apps_list_response",
+                apps: []
+            )))
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes apps created by the assistant not appearing in the macOS Things panel. The root cause was that the Things panel had no mechanism to fetch apps from the daemon when it became visible — it relied entirely on `appFilesChanged` SSE broadcasts, which could silently fail due to HTTP error handling bugs and subagent broadcast gaps.

## Changes
- **M1: Add daemon app sync on macOS Things panel appear** — `AppsGridView` now fetches local apps from the daemon via HTTP on `.onAppear`, ensuring apps always show up when the user navigates to Things. Includes proper error handling and empty-state gating.
- **M2: Fix silent HTTP failure in fetchAppsList** — `fetchAppsList()` and `fetchSharedAppsList()` now send empty responses via `onMessage` on all error paths (auth failure, non-200 status, network error), preventing subscribers from hanging indefinitely.
- **M3: Forward broadcastToAllClients to subagent sessions** — Subagent sessions now share the parent's broadcast callback, so apps created by subagents properly trigger `app_files_changed` notifications to all connected clients.

## Milestone PRs (merged into feature branch)
- #16699: M1: Add daemon app sync on macOS Things panel appear
- #16712: M2: Fix silent HTTP failure in fetchAppsList causing hung subscriptions
- #16715: M3: Forward broadcastToAllClients to subagent sessions

## Project issue
Closes #16695

## Test plan
- [ ] Ask assistant to build a weather app, navigate to Things panel — app should appear
- [ ] Kill daemon briefly during Things panel load, verify empty state shows (not blank/stuck)
- [ ] Create app via subagent, verify it appears in Things without manual refresh
- [ ] Pull-to-refresh on Things panel should recover from any transient failure

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
