### PR TITLE
fix: restore inline images for assistant messages in chat history

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -352,16 +352,37 @@ export function handleListMessages(
           });
         }
       } else {
-        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
+        const linked =
+          attachmentsStore.getAttachmentMetadataForMessage(m.id);
         if (linked.length > 0) {
-          msgAttachments = linked.map((a) => ({
-            id: a.id,
-            filename: a.originalFilename,
-            mimeType: a.mimeType,
-            sizeBytes: a.sizeBytes,
-            kind: a.kind,
-            ...(a.thumbnailBase64 ? { thumbnailData: a.thumbnailBase64 } : {}),
-          }));
+          msgAttachments = linked.map((a) => {
+            if (a.mimeType.startsWith("image/")) {
+              const full = attachmentsStore.getAttachmentById(a.id);
+              return {
+                id: a.id,
+                filename: a.originalFilename,
+                mimeType: a.mimeType,
+                sizeBytes: a.sizeBytes,
+                kind: a.kind,
+                ...(full?.dataBase64
+                  ? { data: full.dataBase64 }
+                  : {}),
+                ...(a.thumbnailBase64
+                  ? { thumbnailData: a.thumbnailBase64 }
+                  : {}),
+              };
+            }
+            return {
+              id: a.id,
+              filename: a.originalFilename,
+              mimeType: a.mimeType,
+              sizeBytes: a.sizeBytes,
+              kind: a.kind,
+              ...(a.thumbnailBase64
+                ? { thumbnailData: a.thumbnailBase64 }
+                : {}),
+            };
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix assistant-generated images not displaying inline after app relaunch
- The history endpoint (`handleListMessages`) only fetched attachment metadata for assistant-role messages, omitting the `dataBase64` needed for inline image rendering
- Apply the same `getAttachmentById()` lookup for `image/*` attachments that already works for user-role messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
