### PR TITLE
fix: update attachment test to match assistant image data behavior

### DIFF
--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -4,7 +4,7 @@
  * Verifies that:
  * - User message image attachments include base64 data for client thumbnail generation
  * - User message non-image attachments stay metadata-only (no base64 blob)
- * - Assistant message attachments remain metadata-only
+ * - Assistant message image attachments include base64 data (same as user messages)
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -140,7 +140,7 @@ describe("handleListMessages attachments", () => {
     expect(attachments![0].data).toBeUndefined();
   });
 
-  test("assistant message attachments remain metadata-only", async () => {
+  test("assistant message image attachments include base64 data", async () => {
     const conv = createConversation();
     const msg = await addMessage(
       conv.id,
@@ -158,8 +158,8 @@ describe("handleListMessages attachments", () => {
     expect(attachments).toBeDefined();
     expect(attachments).toHaveLength(1);
     expect(attachments![0].mimeType).toBe("image/png");
-    // Assistant attachments should NOT include base64 data (metadata-only)
-    expect(attachments![0].data).toBeUndefined();
+    // Assistant image attachments include base64 data for inline rendering
+    expect(attachments![0].data).toBe(IMAGE_BASE64);
   });
 
   test("user message with mixed attachments only inlines images", async () => {


### PR DESCRIPTION
## Summary
- Updated `list-messages-attachments.test.ts` to expect base64 data on assistant image attachments, aligning with the behavior change in #16717 that includes image data for inline rendering on history restore.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23092756012/job/67080078094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
