### PR TITLE
fix: cache primaryButtonTitle to avoid redundant lockfile reads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/WakeUpStepView.swift
@@ -84,12 +84,13 @@ struct WakeUpStepView: View {
                 }
                 .frame(height: 36)
             } else {
+                let buttonTitle = primaryButtonTitle
                 VStack(spacing: VSpacing.xs) {
-                    OnboardingButton(title: primaryButtonTitle, style: .primary) {
+                    OnboardingButton(title: buttonTitle, style: .primary) {
                         onContinueWithVellum()
                     }
                     .disabled(!managedSignInEnabled && authManager?.isAuthenticated != true)
-                    .accessibilityLabel(primaryButtonTitle)
+                    .accessibilityLabel(buttonTitle)
 
                     if !managedSignInEnabled && authManager?.isAuthenticated != true {
                         Text("Coming Soon")


### PR DESCRIPTION
Follows up on PR #16702. Codex noted that primaryButtonTitle is a computed property that reads/parses the lockfile, and using it twice per render (button title + accessibility label) causes double filesystem I/O. Now computed once in a local let and reused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
