### PR TITLE
fix: resolve Swift 6 build warnings in macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/SVGPathParser.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/SVGPathParser.swift
@@ -99,7 +99,6 @@ private func isCommandLetter(_ ch: Character) -> Bool {
 private func scanNumber(_ chars: [Character], from start: Int) -> (Double?, Int) {
     var i = start
     var hasDigits = false
-    var hasDot = false
 
     // Optional leading sign
     if i < chars.count && (chars[i] == "-" || chars[i] == "+") {
@@ -114,7 +113,6 @@ private func scanNumber(_ chars: [Character], from start: Int) -> (Double?, Int)
 
     // Fractional part
     if i < chars.count && chars[i] == "." {
-        hasDot = true
         i += 1
         while i < chars.count && chars[i].isNumber {
             hasDigits = true

--- a/clients/macos/vellum-assistant/Features/Terminal/TerminalSessionManager.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/TerminalSessionManager.swift
@@ -103,7 +103,7 @@ final class TerminalSessionManager: ObservableObject {
     func sendResize(cols: Int, rows: Int) {
         lastDimensions = (cols, rows)
 
-        guard status == .connected, let sessionId else { return }
+        guard status == .connected, sessionId != nil else { return }
 
         pendingResize = (cols, rows)
         resizeTimer?.invalidate()

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -116,7 +116,7 @@ enum LogExporter {
             event.fingerprint = ["log_report", formData.reason.rawValue, categoryComponent]
 
             // User-provided context (message, email, category) is sent via
-            // Sentry's UserFeedback API, linked to the event. This keeps PII
+            // Sentry's Feedback API, linked to the event. This keeps PII
             // out of event tags/extras and lets us use Sentry's built-in
             // feedback UI for triage.
             let feedback = MetricKitManager.UserFeedbackData(
@@ -243,7 +243,7 @@ enum LogExporter {
 
         // 9. Report metadata — reason and message from the log report form.
         // Email is excluded from the archive since it's already sent via
-        // Sentry's UserFeedback API (linked to the event).
+        // Sentry's Feedback API (linked to the event).
         if let formData {
             var metadata: [String: String] = [
                 "reason": formData.reason.rawValue,

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -41,5 +41,5 @@ struct LogReportFormData: Sendable {
     var reason: LogReportReason
     var name: String
     var message: String
-    var email: String  // Required — used for follow-up via Sentry UserFeedback
+    var email: String  // Required — used for follow-up via Sentry Feedback
 }

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -46,8 +46,8 @@ import os
         }
     }
 
-    /// Data for Sentry's User Feedback API, attached to the captured event.
-    /// Sent via `SentrySDK.capture(userFeedback:)` so it appears in Sentry's
+    /// Data for Sentry's Feedback API, attached to the captured event.
+    /// Sent via `SentrySDK.capture(feedback:)` so it appears in Sentry's
     /// "User Feedback" section linked to the event.
     struct UserFeedbackData: Sendable {
         let comments: String?
@@ -59,12 +59,12 @@ import os
     /// but workspace files included in log archives can exceed that. Sentry's
     /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
     /// provides sufficient headroom.
-    static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
+    nonisolated(unsafe) static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
     /// Default DSN for the macOS app Sentry project.
-    static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+    nonisolated(unsafe) static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
     /// DSN for the assistant/brain Sentry project.
-    static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+    nonisolated(unsafe) static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
 
     /// Sends a manual problem report unconditionally, even when the user has
     /// opted out of automatic crash reporting.  The SDK is temporarily started
@@ -126,11 +126,14 @@ import os
             // (message, email, category) with the event without embedding PII in
             // event tags or extras.
             if let feedbackData = userFeedback {
-                let feedback = Sentry.UserFeedback(eventId: eventId)
-                feedback.comments = feedbackData.comments ?? ""
-                feedback.email = feedbackData.email ?? ""
-                feedback.name = feedbackData.name ?? ""
-                SentrySDK.capture(userFeedback: feedback)
+                let feedback = SentryFeedback(
+                    message: feedbackData.comments ?? "",
+                    name: feedbackData.name,
+                    email: feedbackData.email,
+                    source: .custom,
+                    associatedEventId: eventId
+                )
+                SentrySDK.capture(feedback: feedback)
             }
 
             // Clean up attachments so they don't leak into subsequent events.


### PR DESCRIPTION
## Summary
- Mark `macosDSN`, `brainDSN`, and `sentryMaxAttachmentSize` as `nonisolated(unsafe)` to fix `@MainActor`-isolated static property warnings when accessed from nonisolated contexts (these are compile-time constants, safe to read from any context)
- Migrate from deprecated `Sentry.UserFeedback` / `SentrySDK.capture(userFeedback:)` to `SentryFeedback` / `SentrySDK.capture(feedback:)` (deprecated since Sentry 8.46.0)
- Remove unused `hasDot` variable in `SVGPathParser.scanNumber`
- Replace unused `let sessionId` binding with `sessionId != nil` nil check in `TerminalSessionManager.sendResize`

## Test plan
- [ ] Build macOS client in Xcode — verify zero warnings in the changed files
- [ ] Send a manual problem report (Settings > Send Logs) — verify feedback appears in Sentry's User Feedback section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
