### PR TITLE
fix: stop assistant from leaking IDENTITY.md internals to user

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -466,7 +466,7 @@ function buildToolPermissionSection(): string {
     "",
     "### Always-Available Tools (No Approval Required)",
     "",
-    "- **file_read** on your workspace directory — You can freely read any file under your `.vellum` workspace at any time. Use this proactively to check files, load context, and inform your responses without asking. **Always use `file_read` for workspace files (IDENTITY.md, USER.md, SOUL.md, etc.), never `host_file_read`.**",
+    "- **file_read** on your workspace directory — You can freely read any file under your `.vellum` workspace at any time. Use this proactively to check files, load context, and inform your responses without asking. **Always use `file_read` for workspace files, never `host_file_read`.** Note: your core prompt files (IDENTITY.md, SOUL.md, USER.md) are already loaded into your system prompt — no need to re-read them at the start of a conversation.",
     "- **web_search** — You can search the web at any time without approval. Use this to look up documentation, current information, or anything you need.",
   ].join("\n");
 }

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -34,7 +34,7 @@ You are your own entity, with an identity that’s still forming. You can have t
 
 ## Continuity
 
-Each session, you wake up fresh. Your workspace files and saved memories are your continuity — they're how you persist across conversations. Read them. Update them. Save what matters.
+Each session, you wake up fresh. Your workspace files and saved memories are your continuity — they're how you persist across conversations. Your core prompt files (IDENTITY.md, SOUL.md, USER.md) are already loaded into this conversation — you don't need to read them again. Update them when things change. Save what matters.
 
 If you change this file, tell your user — it's your soul, and they should know.
 


### PR DESCRIPTION
## Summary
- Clarify in SOUL.md's Continuity section that core prompt files are already loaded — no need to re-read them
- Update the file_read tool description in system-prompt.ts to note the same, preventing the model from announcing "I haven't read my IDENTITY.md yet"

## Original prompt
The assistant sometimes starts conversations by telling the user "Heads up - I haven't read my IDENTITY.md yet to know my personality. Let me check." — leaking internal implementation details. Root cause: SOUL.md says "Read them" and the file_read description encourages proactive reading, but the files are already injected into the system prompt by buildSystemPrompt().

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
