### PR TITLE
feat: persist pinned threads via HTTP reorder endpoint

### DIFF
--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -7,8 +7,10 @@
  * POST   /v1/conversations/:id/cancel     — cancel generation
  * POST   /v1/conversations/:id/undo       — undo last message
  * POST   /v1/conversations/:id/regenerate — regenerate last assistant response
+ * POST   /v1/sessions/reorder             — reorder / pin sessions
  */
 
+import { batchSetDisplayOrders } from "../../memory/conversation-crud.js";
 import { setConversationKeyIfAbsent } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -157,6 +159,31 @@ export function sessionManagementRouteDefinitions(
             500,
           );
         }
+      },
+    },
+    {
+      endpoint: "sessions/reorder",
+      method: "POST",
+      policyKey: "sessions/reorder",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          updates?: Array<{
+            sessionId: string;
+            displayOrder?: number;
+            isPinned?: boolean;
+          }>;
+        };
+        if (!Array.isArray(body.updates)) {
+          return httpError("BAD_REQUEST", "Missing updates array", 400);
+        }
+        batchSetDisplayOrders(
+          body.updates.map((u) => ({
+            id: u.sessionId,
+            displayOrder: u.displayOrder ?? null,
+            isPinned: u.isPinned ?? false,
+          })),
+        );
+        return Response.json({ ok: true });
       },
     },
   ];

--- a/clients/shared/Network/HTTPDaemonClient+Sessions.swift
+++ b/clients/shared/Network/HTTPDaemonClient+Sessions.swift
@@ -58,6 +58,9 @@ extension HTTPTransport {
             } else if let msg = message as? DeleteQueuedMessageMessage {
                 Task { await self.deleteQueuedMessage(sessionId: msg.sessionId, requestId: msg.requestId) }
                 return true
+            } else if let msg = message as? ReorderThreadsRequest {
+                Task { await self.reorderThreads(updates: msg.updates) }
+                return true
             }
 
             return false

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -341,6 +341,7 @@ public final class HTTPTransport {
         case conversationSearch(query: String, limit: Int?, maxMessagesPerConversation: Int?)
         case messageContent(id: String, sessionId: String?)
         case deleteQueuedMessage(id: String, sessionId: String)
+        case sessionsReorder
         // Skill management
         case skillsList
         case skillEnable(id: String)
@@ -716,6 +717,8 @@ public final class HTTPTransport {
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = sessionId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? sessionId
             return ("/v1/messages/queued/\(idEncoded)", "sessionId=\(sEncoded)")
+        case .sessionsReorder:
+            return ("/v1/sessions/reorder", nil)
         // Skill management
         case .skillsList:
             return ("/v1/skills", nil)
@@ -1132,6 +1135,8 @@ public final class HTTPTransport {
             let idEncoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
             let sEncoded = sessionId.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? sessionId
             return ("\(prefix)/messages/queued/\(idEncoded)/", "sessionId=\(sEncoded)")
+        case .sessionsReorder:
+            return ("\(prefix)/sessions/reorder/", nil)
         // Skill management
         case .skillsList:
             return ("\(prefix)/skills/", nil)
@@ -3857,6 +3862,48 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Delete queued message error: \(error.localizedDescription)")
+        }
+    }
+
+    func reorderThreads(updates: [ReorderThreadsRequestUpdate], isRetry: Bool = false) async {
+        guard let url = buildURL(for: .sessionsReorder) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = [
+            "updates": updates.map { u in
+                var entry: [String: Any] = [
+                    "sessionId": u.sessionId,
+                    "isPinned": u.isPinned
+                ]
+                if let order = u.displayOrder {
+                    entry["displayOrder"] = order
+                }
+                return entry
+            }
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse else { return }
+
+            if http.statusCode == 200 {
+                // Success — no response event needed
+            } else if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                if case .success = refreshResult {
+                    await reorderThreads(updates: updates, isRetry: true)
+                }
+            } else {
+                log.error("Reorder threads failed (HTTP \(http.statusCode))")
+            }
+        } catch {
+            log.error("Reorder threads error: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `POST /v1/sessions/reorder` HTTP endpoint that calls existing `batchSetDisplayOrders()` to persist pin state
- Wire `ReorderThreadsRequest` in `HTTPDaemonClient+Sessions.swift` so the Swift client dispatches to the new endpoint
- Fixes pinned threads being lost on app restart (the HTTP dispatcher had no handler for this message type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
