### PR TITLE
fix: resolve gateway port from lockfile in DaemonClient

### DIFF
--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1646,7 +1646,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     private enum LocalHTTPTarget {
         /// The daemon runtime HTTP server (port from httpPort, default 7821).
         case daemon
-        /// The gateway server (port from GATEWAY_PORT env, default 7830).
+        /// The gateway server (port resolved via LockfilePaths: env > lockfile > 7830).
         case gateway
     }
 
@@ -1673,8 +1673,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             guard let port = httpPort else { return nil }
             baseURL = "http://localhost:\(port)"
         case .gateway:
-            let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-                .flatMap(Int.init) ?? 7830
+            let port = LockfilePaths.resolveGatewayPort()
             baseURL = "http://127.0.0.1:\(port)"
         }
 


### PR DESCRIPTION
## Summary
- `DaemonClient.buildLocalRequest(target: .gateway)` was hardcoding the gateway port fallback to 7830 via env var, ignoring the lockfile's `resources.gatewayPort` for the active assistant
- When multiple assistants are hatched with dynamically allocated ports (e.g. 7831), the Privacy tab and other gateway-routed requests would fail with "Could not connect to the server"
- Replaced with `LockfilePaths.resolveGatewayPort()` which already exists and correctly resolves: env var → lockfile → default 7830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
