### PR TITLE
fix: prevent empty snapshot required_tools from bypassing approvals

### DIFF
--- a/assistant/src/runtime/routes/work-items-routes.test.ts
+++ b/assistant/src/runtime/routes/work-items-routes.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for empty required_tools snapshot bypass.
+ *
+ * Verifies that an explicitly empty `requiredTools: "[]"` snapshot on a work
+ * item falls back to the task-level required tools instead of silently
+ * skipping permission checks.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "work-items-routes-test-"));
+
+mock.module("../../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../permissions/checker.js", () => ({
+  check: async () => ({ decision: "prompt" }),
+  classifyRisk: async () => "high",
+}));
+
+import { initializeDb, resetDb } from "../../memory/db.js";
+import { createTask } from "../../tasks/task-store.js";
+import { createWorkItem } from "../../work-items/work-item-store.js";
+import type { RouteContext } from "../http-router.js";
+import {
+  preflightWorkItem,
+  workItemRouteDefinitions,
+} from "./work-items-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("empty required_tools snapshot bypass", () => {
+  test("falls back to task required tools when snapshot requiredTools is empty", async () => {
+    const task = createTask({
+      title: "Test task",
+      template: "Do something",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Test work item",
+      requiredTools: JSON.stringify([]),
+    });
+
+    const result = await preflightWorkItem(workItem.id);
+    expect(result.success).toBe(true);
+    expect(result.permissions).toHaveLength(1);
+    expect(result.permissions![0].tool).toBe("host_bash");
+  });
+
+  test("rejects run when snapshot requiredTools is empty but task tools are unapproved", async () => {
+    const task = createTask({
+      title: "Test task for run",
+      template: "Do something",
+      requiredTools: ["host_bash"],
+    });
+
+    const workItem = createWorkItem({
+      taskId: task.id,
+      title: "Test work item for run",
+      requiredTools: JSON.stringify([]),
+    });
+
+    const routes = workItemRouteDefinitions();
+    const runRoute = routes.find(
+      (r) => r.endpoint === "work-items/:id/run" && r.method === "POST",
+    )!;
+
+    const response = await runRoute.handler({
+      params: { id: workItem.id },
+      req: new Request(
+        "http://localhost/v1/work-items/" + workItem.id + "/run",
+        {
+          method: "POST",
+        },
+      ),
+      url: new URL("http://localhost/v1/work-items/" + workItem.id + "/run"),
+    } as unknown as RouteContext);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -24,6 +24,7 @@ import {
   getWorkItem,
   listWorkItems,
   updateWorkItem,
+  type WorkItem,
   type WorkItemStatus,
 } from "../../work-items/work-item-store.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -61,6 +62,22 @@ function broadcastWorkItemStatus(id: string): void {
       },
     });
   }
+}
+
+function resolveRequiredTools(
+  workItem: WorkItem,
+  taskRequiredTools: string[],
+): string[] {
+  if (workItem.requiredTools == null) {
+    return taskRequiredTools;
+  }
+
+  const snapshotTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
+  if (snapshotTools.length > 0) {
+    return snapshotTools;
+  }
+
+  return taskRequiredTools;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,21 +338,17 @@ export async function preflightWorkItem(
     return { success: false, error: "Work item not found" };
   }
 
-  let requiredTools: string[];
-  if (workItem.requiredTools != null) {
-    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-  } else {
-    const task = getTask(workItem.taskId);
-    if (!task) {
-      return {
-        success: false,
-        error: `Associated task not found: ${workItem.taskId}`,
-      };
-    }
-    requiredTools = task.requiredTools
-      ? sanitizeToolList(JSON.parse(task.requiredTools))
-      : getRegisteredToolNames();
+  const task = getTask(workItem.taskId);
+  if (!task) {
+    return {
+      success: false,
+      error: `Associated task not found: ${workItem.taskId}`,
+    };
   }
+  const taskRequiredTools = task.requiredTools
+    ? sanitizeToolList(JSON.parse(task.requiredTools))
+    : getRegisteredToolNames();
+  let requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
   if (requiredTools.length === 0) {
     return { success: true, permissions: [] };
@@ -648,15 +661,10 @@ export function workItemRouteDefinitions(
           );
         }
 
-        // Compute required tools
-        let requiredTools: string[];
-        if (workItem.requiredTools != null) {
-          requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-        } else {
-          requiredTools = task.requiredTools
-            ? sanitizeToolList(JSON.parse(task.requiredTools))
-            : getRegisteredToolNames();
-        }
+        const taskRequiredTools = task.requiredTools
+          ? sanitizeToolList(JSON.parse(task.requiredTools))
+          : getRegisteredToolNames();
+        const requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
 
         // Permission checkpoint
         let approvedTools: string[] | undefined;


### PR DESCRIPTION
## Summary

- An explicitly empty `required_tools: []` snapshot on a work item suppressed both the preflight permission dialog and the run endpoint's permission checkpoint, while `runTask()` still fell back to the task template's `requiredTools` to build ephemeral allow rules — enabling tool execution without user approval.
- Added `resolveRequiredTools()` helper that falls back to task-level tools when the snapshot is null or sanitizes to empty, closing the bypass on both preflight and run paths.
- Added regression tests covering both the preflight and run endpoint for the empty-snapshot scenario.

Codex finding: https://chatgpt.com/codex/security/findings/92d2aa34cd908191a30e0b593891162e?sev=critical%2Chigh%2Cmedium%2Clow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
