### PR TITLE
fix: disable git hooks for workspace auto-commits

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -1222,6 +1223,52 @@ describe("WorkspaceGitService", () => {
       const now = Date.now();
       // Use a deadline slightly in the past to avoid timing flakes
       expect(isDeadlineExpired(now - 1)).toBe(true);
+    });
+  });
+
+  describe("git hook hardening", () => {
+    test("does not execute pre-commit hooks during commitChanges", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const hookPath = join(testDir, ".git", "hooks", "pre-commit");
+      const markerPath = join(testDir, "hook-ran.txt");
+      writeFileSync(
+        hookPath,
+        `#!/bin/sh\necho hook-ran > "${markerPath}"\nexit 1\n`,
+      );
+      chmodSync(hookPath, 0o755);
+
+      writeFileSync(join(testDir, "test.txt"), "content");
+      await service.commitChanges("Add file safely");
+
+      expect(existsSync(markerPath)).toBe(false);
+    });
+
+    test("does not execute hooks configured via core.hooksPath during commitIfDirty", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      const hooksDir = join(testDir, "custom-hooks");
+      mkdirSync(hooksDir, { recursive: true });
+      const markerPath = join(testDir, "core-hooks-ran.txt");
+      const hookPath = join(hooksDir, "pre-commit");
+      writeFileSync(
+        hookPath,
+        `#!/bin/sh\necho core-hooks-ran > "${markerPath}"\nexit 1\n`,
+      );
+      chmodSync(hookPath, 0o755);
+      execFileSync("git", ["config", "core.hooksPath", hooksDir], {
+        cwd: testDir,
+      });
+
+      writeFileSync(join(testDir, "dirty.txt"), "dirty");
+      const result = await service.commitIfDirty(() => ({
+        message: "commit if dirty",
+      }));
+
+      expect(result.committed).toBe(true);
+      expect(existsSync(markerPath)).toBe(false);
     });
   });
 });

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -456,7 +456,9 @@ export class WorkspaceGitService {
             ? "Initial commit: migrated existing workspace"
             : "Initial commit: new workspace";
 
-          await this.execGit(["commit", "-m", message, "--allow-empty"]);
+          await this.execGit(
+            this.buildSafeCommitArgs(["-m", message, "--allow-empty"]),
+          );
 
           this.initialized = true;
           this.recordInitSuccess();
@@ -494,7 +496,9 @@ export class WorkspaceGitService {
       }
 
       // Commit (will succeed even if no changes)
-      await this.execGit(["commit", "-m", fullMessage, "--allow-empty"]);
+      await this.execGit(
+        this.buildSafeCommitArgs(["-m", fullMessage, "--allow-empty"]),
+      );
     });
   }
 
@@ -634,7 +638,7 @@ export class WorkspaceGitService {
               .join("\n");
         }
 
-        await this.execGit(["commit", "-m", fullMessage]);
+        await this.execGit(this.buildSafeCommitArgs(["-m", fullMessage]));
         return { committed: true, status, didRunGit: true as const };
       });
       if (result.didRunGit) {
@@ -868,6 +872,16 @@ export class WorkspaceGitService {
       (enhanced as ExecError).code = gitErr.code;
       throw enhanced;
     }
+  }
+
+  /**
+   * Build commit args that disable all git hook execution.
+   *
+   * Workspace contents are model-writable, so hooks in `.git/hooks` (or via
+   * `core.hooksPath`) are untrusted. Auto-commit paths must not execute them.
+   */
+  private buildSafeCommitArgs(args: string[]): string[] {
+    return ["-c", "core.hooksPath=/dev/null", "commit", "--no-verify", ...args];
   }
 
   /**

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -910,7 +910,13 @@ export class WorkspaceGitService {
     await this.ensureInitialized();
     await this.mutex.withLock(async () => {
       this.cleanStaleLockFile();
-      await fn((args) => this.execGit(args));
+      await fn((args) => {
+        // Intercept commit commands to enforce hook hardening.
+        if (args[0] === "commit") {
+          return this.execGit(this.buildSafeCommitArgs(args.slice(1)));
+        }
+        return this.execGit(args);
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

- Auto-commit logic in `WorkspaceGitService` invoked `git commit` without disabling hooks, allowing untrusted `.git/hooks` scripts to execute with daemon privileges during turn-boundary, heartbeat, or shutdown commits
- Added `buildSafeCommitArgs()` helper that prepends `-c core.hooksPath=/dev/null` and `--no-verify` to all 3 commit call sites (init, `commitChanges`, `commitIfDirty`)
- Added regression tests verifying hooks in `.git/hooks/` and via `core.hooksPath` are not executed during commits

Codex finding: https://chatgpt.com/codex/security/findings/ab8e0f9aecfc8191a5db98fa99d21786?sev=critical%2Chigh%2Cmedium%2Clow

## Original prompt

Fix: Disable git hooks for workspace auto-commits (security). Auto-commit logic in WorkspaceGitService invokes `git commit` without disabling hooks. Since workspace files are writable via tools, an attacker could place a malicious hook script in `.git/hooks/` within the workspace. When the automatic commit runs, the hook executes with daemon privileges, bypassing tool permissions/sandboxing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
