### PR TITLE
fix: always register bash signal handler so disabled-mode error reaches CLI

### DIFF
--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -20,7 +20,7 @@ import {
   resetAllowlist,
   validateAllowlistFile,
 } from "../security/secret-allowlist.js";
-import { handleBashSignal, isDebugMode } from "../signals/bash.js";
+import { handleBashSignal } from "../signals/bash.js";
 import { handleCancelSignal } from "../signals/cancel.js";
 import { handleConfirmationSignal } from "../signals/confirm.js";
 import { handleConversationUndoSignal } from "../signals/conversation-undo.js";
@@ -237,7 +237,7 @@ export class ConfigWatcher {
     };
 
     const prefixSignalHandlers: Record<string, (filename: string) => void> = {
-      ...(isDebugMode() ? { "bash.": handleBashSignal } : {}),
+      "bash.": handleBashSignal,
     };
 
     try {


### PR DESCRIPTION
## Summary
- Always register the bash handler in prefixSignalHandlers instead of conditionally spreading it
- The inner guard in handleBashSignal already handles the debug-mode-off case by writing an error result
- Removes the isDebugMode import from config-watcher.ts since it's no longer needed there

Addresses feedback from PR #16722.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
