### PR TITLE
security: move signals dir outside sandbox-writable workspace

### DIFF
--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -38,6 +38,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(WORKSPACE_DIR, "data", "logs", "vellum.log"),
   getHistoryPath: () => join(WORKSPACE_DIR, "data", "history"),
   getHooksDir: () => join(WORKSPACE_DIR, "hooks"),
+  getSignalsDir: () => join(TEST_DIR, "signals"),
 
   getSandboxRootDir: () => join(WORKSPACE_DIR, "data", "sandbox"),
   getSandboxWorkingDir: () => WORKSPACE_DIR,

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -41,7 +41,7 @@ import {
   formatSessionForExport,
 } from "./util/clipboard.js";
 import { formatDiff, formatNewFileDiff } from "./util/diff.js";
-import { getHistoryPath, getWorkspaceDir } from "./util/platform.js";
+import { getHistoryPath, getSignalsDir } from "./util/platform.js";
 import { Spinner } from "./util/spinner.js";
 import { timeAgo } from "./util/time.js";
 import { truncate } from "./util/truncate.js";
@@ -241,7 +241,7 @@ export async function startCli(): Promise<void> {
   /** Send a confirmation decision via signal file (read by the daemon). */
   function sendConfirmation(requestId: string, decision: string): void {
     try {
-      const signalsDir = join(getWorkspaceDir(), "signals");
+      const signalsDir = getSignalsDir();
       mkdirSync(signalsDir, { recursive: true });
       writeFileSync(
         join(signalsDir, "confirm"),
@@ -262,7 +262,7 @@ export async function startCli(): Promise<void> {
     options?: { allowHighRisk?: boolean },
   ): void {
     try {
-      const signalsDir = join(getWorkspaceDir(), "signals");
+      const signalsDir = getSignalsDir();
       mkdirSync(signalsDir, { recursive: true });
       const resultPath = join(signalsDir, "trust-rule.result");
       writeFileSync(
@@ -1276,7 +1276,7 @@ export async function startCli(): Promise<void> {
         return;
       }
       try {
-        const signalsDir = join(getWorkspaceDir(), "signals");
+        const signalsDir = getSignalsDir();
         mkdirSync(signalsDir, { recursive: true });
         const resultPath = join(signalsDir, "conversation-undo.result");
         try {
@@ -1412,7 +1412,7 @@ export async function startCli(): Promise<void> {
     spinner.stop();
     if (generating && sessionId) {
       try {
-        const signalsDir = join(getWorkspaceDir(), "signals");
+        const signalsDir = getSignalsDir();
         mkdirSync(signalsDir, { recursive: true });
         writeFileSync(
           join(signalsDir, "cancel"),

--- a/assistant/src/cli/commands/bash.ts
+++ b/assistant/src/cli/commands/bash.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 import type { Command } from "commander";
 
-import { getWorkspaceDir } from "../../util/platform.js";
+import { getSignalsDir } from "../../util/platform.js";
 import { log } from "../logger.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -73,7 +73,7 @@ Examples:
       }
 
       const requestId = randomUUID();
-      const signalsDir = join(getWorkspaceDir(), "signals");
+      const signalsDir = getSignalsDir();
 
       try {
         mkdirSync(signalsDir, { recursive: true });

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -14,7 +14,7 @@ import {
   deleteMcpOAuthCredentials,
   McpOAuthProvider,
 } from "../../mcp/mcp-oauth-provider.js";
-import { getWorkspaceDir } from "../../util/platform.js";
+import { getSignalsDir } from "../../util/platform.js";
 import { log } from "../logger.js";
 
 export const HEALTH_CHECK_TIMEOUT_MS = 10_000;
@@ -61,7 +61,7 @@ export async function checkServerHealth(
  */
 function signalMcpReload(): void {
   try {
-    const signalsDir = join(getWorkspaceDir(), "signals");
+    const signalsDir = getSignalsDir();
     mkdirSync(signalsDir, { recursive: true });
     writeFileSync(join(signalsDir, "mcp-reload"), "");
   } catch {

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -30,6 +30,7 @@ import { DebouncerMap } from "../util/debounce.js";
 import { getLogger } from "../util/logger.js";
 import {
   getRootDir,
+  getSignalsDir,
   getWorkspaceDir,
   getWorkspaceSkillsDir,
 } from "../util/platform.js";
@@ -219,7 +220,7 @@ export class ConfigWatcher {
   }
 
   private startSignalsWatcher(): void {
-    const signalsDir = join(getWorkspaceDir(), "signals");
+    const signalsDir = getSignalsDir();
     try {
       if (!existsSync(signalsDir)) {
         mkdirSync(signalsDir, { recursive: true });

--- a/assistant/src/signals/bash.ts
+++ b/assistant/src/signals/bash.ts
@@ -21,7 +21,7 @@ import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getSignalsDir, getWorkspaceDir } from "../util/platform.js";
 
 const log = getLogger("signal:bash");
 
@@ -51,7 +51,7 @@ interface BashSignalResult {
 function writeResult(requestId: string, result: BashSignalResult): void {
   try {
     writeFileSync(
-      join(getWorkspaceDir(), "signals", `bash.${requestId}.result`),
+      join(getSignalsDir(), `bash.${requestId}.result`),
       JSON.stringify(result),
     );
   } catch (err) {
@@ -86,7 +86,7 @@ export function handleBashSignal(filename: string): void {
     return;
   }
 
-  const signalPath = join(getWorkspaceDir(), "signals", filename);
+  const signalPath = join(getSignalsDir(), filename);
   let raw: string;
   try {
     raw = readFileSync(signalPath, "utf-8");

--- a/assistant/src/signals/cancel.ts
+++ b/assistant/src/signals/cancel.ts
@@ -14,7 +14,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getSignalsDir } from "../util/platform.js";
 
 const log = getLogger("signal:cancel");
 
@@ -40,10 +40,7 @@ export function registerCancelCallback(cb: CancelCallback): void {
  */
 export function handleCancelSignal(): void {
   try {
-    const content = readFileSync(
-      join(getWorkspaceDir(), "signals", "cancel"),
-      "utf-8",
-    );
+    const content = readFileSync(join(getSignalsDir(), "cancel"), "utf-8");
     const parsed = JSON.parse(content) as { sessionId?: string };
     const { sessionId } = parsed;
 

--- a/assistant/src/signals/confirm.ts
+++ b/assistant/src/signals/confirm.ts
@@ -13,7 +13,7 @@ import { join } from "node:path";
 import type { UserDecision } from "../permissions/types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getSignalsDir } from "../util/platform.js";
 
 const log = getLogger("signal:confirm");
 
@@ -38,10 +38,7 @@ function isUserDecision(value: string): value is UserDecision {
  */
 export function handleConfirmationSignal(): void {
   try {
-    const content = readFileSync(
-      join(getWorkspaceDir(), "signals", "confirm"),
-      "utf-8",
-    );
+    const content = readFileSync(join(getSignalsDir(), "confirm"), "utf-8");
     const parsed = JSON.parse(content) as {
       requestId?: string;
       decision?: string;

--- a/assistant/src/signals/conversation-undo.ts
+++ b/assistant/src/signals/conversation-undo.ts
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getSignalsDir } from "../util/platform.js";
 
 const log = getLogger("signal:conversation-undo");
 
@@ -46,11 +46,7 @@ export function registerConversationUndoCallback(cb: UndoCallback): void {
  * file is written.
  */
 export async function handleConversationUndoSignal(): Promise<void> {
-  const resultPath = join(
-    getWorkspaceDir(),
-    "signals",
-    "conversation-undo.result",
-  );
+  const resultPath = join(getSignalsDir(), "conversation-undo.result");
 
   const writeResult = (
     data:
@@ -68,7 +64,7 @@ export async function handleConversationUndoSignal(): Promise<void> {
 
   try {
     const content = readFileSync(
-      join(getWorkspaceDir(), "signals", "conversation-undo"),
+      join(getSignalsDir(), "conversation-undo"),
       "utf-8",
     );
     const parsed = JSON.parse(content) as {

--- a/assistant/src/signals/trust-rule.ts
+++ b/assistant/src/signals/trust-rule.ts
@@ -16,7 +16,7 @@ import { addRule } from "../permissions/trust-store.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { getTool } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getSignalsDir } from "../util/platform.js";
 
 const log = getLogger("signal:trust-rule");
 
@@ -27,7 +27,7 @@ const VALID_TRUST_DECISIONS: ReadonlySet<string> = new Set(["allow", "deny"]);
  * Called by ConfigWatcher when the signal file is written or modified.
  */
 export function handleTrustRuleSignal(): void {
-  const resultPath = join(getWorkspaceDir(), "signals", "trust-rule.result");
+  const resultPath = join(getSignalsDir(), "trust-rule.result");
 
   const writeError = (requestId: string | undefined, error: string): void => {
     writeFileSync(
@@ -39,10 +39,7 @@ export function handleTrustRuleSignal(): void {
   let parsedRequestId: string | undefined;
 
   try {
-    const content = readFileSync(
-      join(getWorkspaceDir(), "signals", "trust-rule"),
-      "utf-8",
-    );
+    const content = readFileSync(join(getSignalsDir(), "trust-rule"), "utf-8");
     const parsed = JSON.parse(content) as {
       requestId?: string;
       pattern?: string;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -341,6 +341,17 @@ export function getHooksDir(): string {
   return join(getRootDir(), "hooks");
 }
 
+/**
+ * Returns ~/.vellum/signals — the directory for IPC signal files.
+ *
+ * Placed under getRootDir() (not getWorkspaceDir()) so that sandboxed tools
+ * — whose write access is limited to the workspace directory — cannot write
+ * signal files to bypass guardian authorization.
+ */
+export function getSignalsDir(): string {
+  return join(getRootDir(), "signals");
+}
+
 // --- Workspace path primitives ---
 // These will become the canonical paths after workspace migration.
 // Currently not used by call-sites; wired in later PRs.


### PR DESCRIPTION
## Summary
- Moves the signals directory from `~/.vellum/workspace/signals/` to `~/.vellum/signals/` (under `getRootDir()` instead of `getWorkspaceDir()`)
- Adds `getSignalsDir()` helper to `platform.ts` and updates all references in `cli.ts`, `config-watcher.ts`, and signal handler files
- Prevents sandboxed tools from writing confirmation signal files to bypass guardian authorization, since the sandbox only allows writes to the workspace directory

Codex finding: https://chatgpt.com/codex/security/findings/14ae412196888191bfe3ce6c4e98a049

## Original prompt
Security fix: Move signals directory outside sandbox-writable workspace to prevent sandboxed tools from writing confirmation signal files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
