### PR TITLE
fix: apply empty required_tools bypass fix to work-item-runner

### DIFF
--- a/assistant/src/runtime/routes/work-items-routes.ts
+++ b/assistant/src/runtime/routes/work-items-routes.ts
@@ -19,12 +19,12 @@ import {
 } from "../../tasks/tool-sanitizer.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
+import { resolveRequiredTools } from "../../work-items/resolve-required-tools.js";
 import {
   deleteWorkItem,
   getWorkItem,
   listWorkItems,
   updateWorkItem,
-  type WorkItem,
   type WorkItemStatus,
 } from "../../work-items/work-item-store.js";
 import { buildAssistantEvent } from "../assistant-event.js";
@@ -62,22 +62,6 @@ function broadcastWorkItemStatus(id: string): void {
       },
     });
   }
-}
-
-function resolveRequiredTools(
-  workItem: WorkItem,
-  taskRequiredTools: string[],
-): string[] {
-  if (workItem.requiredTools == null) {
-    return taskRequiredTools;
-  }
-
-  const snapshotTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-  if (snapshotTools.length > 0) {
-    return snapshotTools;
-  }
-
-  return taskRequiredTools;
 }
 
 // ---------------------------------------------------------------------------
@@ -348,7 +332,10 @@ export async function preflightWorkItem(
   const taskRequiredTools = task.requiredTools
     ? sanitizeToolList(JSON.parse(task.requiredTools))
     : getRegisteredToolNames();
-  let requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
+  let requiredTools = resolveRequiredTools(
+    workItem.requiredTools,
+    taskRequiredTools,
+  );
 
   if (requiredTools.length === 0) {
     return { success: true, permissions: [] };
@@ -664,7 +651,10 @@ export function workItemRouteDefinitions(
         const taskRequiredTools = task.requiredTools
           ? sanitizeToolList(JSON.parse(task.requiredTools))
           : getRegisteredToolNames();
-        const requiredTools = resolveRequiredTools(workItem, taskRequiredTools);
+        const requiredTools = resolveRequiredTools(
+          workItem.requiredTools,
+          taskRequiredTools,
+        );
 
         // Permission checkpoint
         let approvedTools: string[] | undefined;

--- a/assistant/src/work-items/resolve-required-tools.ts
+++ b/assistant/src/work-items/resolve-required-tools.ts
@@ -1,0 +1,26 @@
+import { sanitizeToolList } from "../tasks/tool-sanitizer.js";
+
+/**
+ * Resolve the effective required tools for a work item, falling back to
+ * task-level tools when the snapshot is null or sanitizes to empty.
+ *
+ * This prevents an explicitly empty `required_tools: []` snapshot from
+ * suppressing the task's actual tool requirements — closing a permission
+ * bypass where preflight/run would skip authorization while runTask still
+ * builds ephemeral allow rules from the task template's requiredTools.
+ */
+export function resolveRequiredTools(
+  snapshotRequiredTools: string | null,
+  taskRequiredTools: string[],
+): string[] {
+  if (snapshotRequiredTools == null) {
+    return taskRequiredTools;
+  }
+
+  const snapshotTools = sanitizeToolList(JSON.parse(snapshotRequiredTools));
+  if (snapshotTools.length > 0) {
+    return snapshotTools;
+  }
+
+  return taskRequiredTools;
+}

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -10,11 +10,9 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Session } from "../daemon/session.js";
 import { runTask } from "../tasks/task-runner.js";
 import { getTask } from "../tasks/task-store.js";
-import {
-  getRegisteredToolNames,
-  sanitizeToolList,
-} from "../tasks/tool-sanitizer.js";
+import { getRegisteredToolNames } from "../tasks/tool-sanitizer.js";
 import { getLogger } from "../util/logger.js";
+import { resolveRequiredTools } from "./resolve-required-tools.js";
 import {
   getWorkItem,
   updateWorkItem,
@@ -117,15 +115,15 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
     };
   }
 
-  // Resolve required tools
-  let requiredTools: string[];
-  if (workItem.requiredTools != null) {
-    requiredTools = sanitizeToolList(JSON.parse(workItem.requiredTools));
-  } else {
-    requiredTools = task.requiredTools
-      ? sanitizeToolList(JSON.parse(task.requiredTools))
-      : getRegisteredToolNames();
-  }
+  // Resolve required tools — falls back to task-level tools when the
+  // snapshot is empty, preventing an empty-snapshot permission bypass.
+  const taskRequiredTools = task.requiredTools
+    ? JSON.parse(task.requiredTools)
+    : getRegisteredToolNames();
+  const requiredTools = resolveRequiredTools(
+    workItem.requiredTools,
+    taskRequiredTools,
+  );
 
   // Auto-approve all required tools for chat-initiated runs.
   // The user explicitly asked to run the task, so we treat that as consent.


### PR DESCRIPTION
## Summary

- The previous fix (#16735) closed the empty `required_tools` snapshot bypass in `work-items-routes.ts` but missed the identical pattern in `work-item-runner.ts` (used for chat-initiated work item runs).
- Extracted `resolveRequiredTools()` into a shared module (`work-items/resolve-required-tools.ts`) used by both code paths.
- Removed the duplicate local function from `work-items-routes.ts`.

Codex finding: https://chatgpt.com/codex/security/findings/92d2aa34cd908191a30e0b593891162e?sev=critical%2Chigh%2Cmedium%2Clow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
