### PR TITLE
fix: scope notification icon files per assistant for multi-assistant support

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -339,20 +339,25 @@ final class AvatarAppearanceManager {
     /// The destination path is derived from `connectedAssistantId` in
     /// UserDefaults, matching the same resolution used by `customAvatarURL`.
     ///
-    /// Writes to `{baseDataDir}/workspace/data/avatar/notification-icon.png`.
+    /// Writes to `{avatarDir}/notification-icon-{assistantId}.png`.
     /// Returns the file URL on success, nil on failure.
     func exportNotificationIcon() -> URL? {
         // 1. Resolve the destination path from the connected assistant
+        guard let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              !assistantId.isEmpty else {
+            return nil
+        }
+
         let destURL: URL
-        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
-           let assistant = LockfileAssistant.loadByName(assistantId),
+        if let assistant = LockfileAssistant.loadByName(assistantId),
            let baseDataDir = assistant.baseDataDir {
             destURL = URL(fileURLWithPath: baseDataDir)
-                .appendingPathComponent("workspace/data/avatar/notification-icon.png")
+                .appendingPathComponent("workspace/data/avatar/notification-icon-\(assistantId).png")
         } else {
-            // No assistant-scoped path available — return nil to avoid
-            // writing to a shared location that could serve the wrong avatar.
-            return nil
+            // Fall back to default workspace path with assistant-scoped filename
+            destURL = Self.workspaceCustomAvatarURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("notification-icon-\(assistantId).png")
         }
 
         // 2. Get the current avatar image (chatAvatarImage handles all fallbacks)

--- a/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
+++ b/clients/macos/vellum-assistant/Services/NotificationIconProvider.swift
@@ -11,15 +11,18 @@ protocol NotificationIconProviding {
 @MainActor
 final class NotificationIconProvider: NotificationIconProviding {
     func notificationIconURL(for assistantId: String) -> URL? {
+        guard !assistantId.isEmpty else { return nil }
+
         let iconURL: URL
         if let assistant = LockfileAssistant.loadByName(assistantId),
            let baseDataDir = assistant.baseDataDir {
             iconURL = URL(fileURLWithPath: baseDataDir)
-                .appendingPathComponent("workspace/data/avatar/notification-icon.png")
+                .appendingPathComponent("workspace/data/avatar/notification-icon-\(assistantId).png")
         } else {
-            // No assistant-scoped path available — return nil to avoid
-            // serving another assistant's notification icon.
-            return nil
+            // Fall back to default workspace path with assistant-scoped filename
+            iconURL = AvatarAppearanceManager.workspaceCustomAvatarURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("notification-icon-\(assistantId).png")
         }
 
         guard FileManager.default.fileExists(atPath: iconURL.path) else {


### PR DESCRIPTION
## Summary
- Change notification icon filename from `notification-icon.png` to `notification-icon-{assistantId}.png` so each assistant's icon is isolated
- Restore workspace fallback path for assistants without `baseDataDir` (common for local assistants) — previously returned nil, now uses the default workspace path with the scoped filename
- Prevents assistant avatar cross-contamination when switching between multiple assistants

## Original prompt
this plan then

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
