### PR TITLE
chore: add migration to drop orphaned media tables

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -57,6 +57,7 @@ import {
   migrateDropLegacyMemberGuardianTables,
   migrateDropLoopbackPortColumn,
   migrateDropMemorySegmentFts,
+  migrateDropOrphanedMediaTables,
   migrateDropRemindersTable,
   migrateDropUsageCompositeIndexes,
   migrateFkCascadeRebuilds,
@@ -387,6 +388,9 @@ export function initializeDb(): void {
 
   // 63. Drop loopback_port column from oauth_providers (moved to code-side behavior registry)
   migrateDropLoopbackPortColumn(database);
+
+  // 64. Drop orphaned media tables (CREATE TABLE removed in #16739, clean up existing databases)
+  migrateDropOrphanedMediaTables(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/161-drop-orphaned-media-tables.ts
+++ b/assistant/src/memory/migrations/161-drop-orphaned-media-tables.ts
@@ -1,0 +1,18 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Drop orphaned media tables that are no longer used.
+ *
+ * These tables were previously created by 111-media-assets.ts but the CREATE
+ * TABLE statements were removed in PR #16739. This migration cleans up
+ * existing databases that still have them.
+ */
+export function migrateDropOrphanedMediaTables(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS media_vision_outputs`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS media_timelines`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS media_events`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS media_tracking_profiles`);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS media_event_feedback`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -102,6 +102,7 @@ export { migrateInviteContactId } from "./157-invite-contact-id.js";
 export { migrateChannelInteractionColumns } from "./158-channel-interaction-columns.js";
 export { migrateDropContactInteractionColumns } from "./159-drop-contact-interaction-columns.js";
 export { migrateDropLoopbackPortColumn } from "./160-drop-loopback-port-column.js";
+export { migrateDropOrphanedMediaTables } from "./161-drop-orphaned-media-tables.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Adds a new migration (161) to DROP TABLE IF EXISTS for 5 orphaned media tables
- Tables: media_vision_outputs, media_timelines, media_events, media_tracking_profiles, media_event_feedback
- Follows established codebase convention (see 153-drop-entity-tables.ts, 145-drop-accounts-table.ts)
- Cleans up existing databases that still have these tables from before #16739

Addresses feedback from PR #16739.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
