### PR TITLE
fix: add sanitizeToolList to runner + tests for resolveRequiredTools

### DIFF
--- a/assistant/src/work-items/resolve-required-tools.test.ts
+++ b/assistant/src/work-items/resolve-required-tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveRequiredTools } from "./resolve-required-tools.js";
+
+describe("resolveRequiredTools", () => {
+  const taskTools = ["tool_a", "tool_b"];
+
+  test("returns task tools when snapshot is null", () => {
+    expect(resolveRequiredTools(null, taskTools)).toEqual(taskTools);
+  });
+
+  test("returns snapshot tools when snapshot is non-empty", () => {
+    const snapshot = JSON.stringify(["tool_x", "tool_y"]);
+    expect(resolveRequiredTools(snapshot, taskTools)).toEqual([
+      "tool_x",
+      "tool_y",
+    ]);
+  });
+
+  test("falls back to task tools when snapshot is empty array", () => {
+    const snapshot = JSON.stringify([]);
+    expect(resolveRequiredTools(snapshot, taskTools)).toEqual(taskTools);
+  });
+
+  test("falls back to task tools when snapshot contains only invalid entries", () => {
+    const snapshot = JSON.stringify(["", "", ""]);
+    expect(resolveRequiredTools(snapshot, taskTools)).toEqual(taskTools);
+  });
+
+  test("deduplicates and sorts snapshot tools", () => {
+    const snapshot = JSON.stringify(["tool_b", "tool_a", "tool_b"]);
+    expect(resolveRequiredTools(snapshot, taskTools)).toEqual([
+      "tool_a",
+      "tool_b",
+    ]);
+  });
+});

--- a/assistant/src/work-items/work-item-runner.ts
+++ b/assistant/src/work-items/work-item-runner.ts
@@ -10,7 +10,10 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Session } from "../daemon/session.js";
 import { runTask } from "../tasks/task-runner.js";
 import { getTask } from "../tasks/task-store.js";
-import { getRegisteredToolNames } from "../tasks/tool-sanitizer.js";
+import {
+  getRegisteredToolNames,
+  sanitizeToolList,
+} from "../tasks/tool-sanitizer.js";
 import { getLogger } from "../util/logger.js";
 import { resolveRequiredTools } from "./resolve-required-tools.js";
 import {
@@ -118,7 +121,7 @@ export function runWorkItemInBackground(workItemId: string): RunWorkItemResult {
   // Resolve required tools — falls back to task-level tools when the
   // snapshot is empty, preventing an empty-snapshot permission bypass.
   const taskRequiredTools = task.requiredTools
-    ? JSON.parse(task.requiredTools)
+    ? sanitizeToolList(JSON.parse(task.requiredTools))
     : getRegisteredToolNames();
   const requiredTools = resolveRequiredTools(
     workItem.requiredTools,


### PR DESCRIPTION
## Summary
- Adds missing `sanitizeToolList` call on `task.requiredTools` in `work-item-runner.ts` to match `work-items-routes.ts`
- Adds unit tests for `resolve-required-tools.ts` covering all three branches (null, non-empty, empty snapshot)
- Fixes behavioral regression where unsanitized tool lists could contain duplicates or empty strings

Addresses feedback from PR #16741.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
