### PR TITLE
fix: scope gateway port resolution to connected assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -417,7 +417,8 @@ extension AppDelegate {
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
     /// Port resolution: env var > lockfile > default 7830.
     func isGatewayHealthy() async -> Bool {
-        let port = LockfilePaths.resolveGatewayPort()
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let port = LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId)
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -535,7 +535,8 @@ struct InlineVideoAttachmentView: View {
 
 /// Resolve the local gateway base URL: env var > lockfile > default 7830.
 private func resolveGatewayBaseUrl() -> String {
-    "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
+    let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+    return "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId))"
 }
 
 /// Fetch raw attachment bytes via the gateway's runtime proxy.

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -179,7 +179,8 @@ struct PairingQRCodeSheet: View {
 
     /// Resolve the local gateway base URL: env var > lockfile > default 7830.
     private var resolvedGatewayBaseUrl: String {
-        "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        return "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId))"
     }
 
     private func registerWithDaemon() {
@@ -276,7 +277,8 @@ struct PairingQRCodeSheet: View {
 
     private func computeLocalLanUrl() -> String? {
         guard let lanIP = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(lanIP):\(LockfilePaths.resolveGatewayPort())"
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        return "http://\(lanIP):\(LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId))"
     }
 
     /// LAN pairing uses plaintext HTTP and can expose bearer tokens on a local

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1913,7 +1913,8 @@ public final class SettingsStore: ObservableObject {
     /// LAN pairing URL for the gateway, or nil if no LAN IP available.
     var lanPairingUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(ip):\(LockfilePaths.resolveGatewayPort())"
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        return "http://\(ip):\(LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId))"
     }
 
     // MARK: - Dev Mode Actions

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -340,7 +340,8 @@ enum LogExporter {
     /// log files, then writes them into `directory`. Silently skips if the
     /// gateway is unreachable or returns an error.
     private nonisolated static func fetchDaemonExports(into directory: URL) async {
-        let baseURL = LockfilePaths.resolveGatewayUrl()
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let baseURL = LockfilePaths.resolveGatewayUrl(connectedAssistantId: connectedId)
 
         guard let token = ActorTokenManager.getToken(), !token.isEmpty else {
             log.warning("No actor token available — skipping daemon exports")

--- a/clients/macos/vellum-assistant/Services/GatewayHTTPClient.swift
+++ b/clients/macos/vellum-assistant/Services/GatewayHTTPClient.swift
@@ -134,7 +134,7 @@ enum GatewayHTTPClient {
                 }
                 baseURL = runtimeUrl
             } else {
-                let port = assistant.gatewayPort ?? LockfilePaths.resolveGatewayPort()
+                let port = assistant.gatewayPort ?? LockfilePaths.resolveGatewayPort(connectedAssistantId: assistant.assistantId)
                 baseURL = "http://127.0.0.1:\(port)"
             }
             authHeader = ("Authorization", "Bearer \(token)")

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1673,7 +1673,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             guard let port = httpPort else { return nil }
             baseURL = "http://localhost:\(port)"
         case .gateway:
-            let port = LockfilePaths.resolveGatewayPort()
+            let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            let port = LockfilePaths.resolveGatewayPort(connectedAssistantId: connectedId)
             baseURL = "http://127.0.0.1:\(port)"
         }
 

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -30,20 +30,31 @@ public enum LockfilePaths {
     }
 
     /// Resolve the local gateway port: env var > lockfile > default 7830.
-    public static func resolveGatewayPort() -> Int {
+    ///
+    /// When `connectedAssistantId` is provided the port is read from that
+    /// specific lockfile entry instead of the most-recently-hatched one.
+    /// This prevents multi-instance scenarios from targeting the wrong gateway.
+    public static func resolveGatewayPort(connectedAssistantId: String? = nil) -> Int {
         if let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
             ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) }),
            let port = Int(envPort) {
             return port
         }
         if let json = read(),
-           let assistants = json["assistants"] as? [[String: Any]],
-           let latest = assistants.max(by: {
-               ($0["hatchedAt"] as? String ?? "") < ($1["hatchedAt"] as? String ?? "")
-           }),
-           let resources = latest["resources"] as? [String: Any],
-           let port = resources["gatewayPort"] as? Int {
-            return port
+           let assistants = json["assistants"] as? [[String: Any]] {
+            let entry: [String: Any]?
+            if let id = connectedAssistantId {
+                entry = assistants.first(where: { ($0["assistantId"] as? String) == id })
+            } else {
+                entry = assistants.max(by: {
+                    ($0["hatchedAt"] as? String ?? "") < ($1["hatchedAt"] as? String ?? "")
+                })
+            }
+            if let entry,
+               let resources = entry["resources"] as? [String: Any],
+               let port = resources["gatewayPort"] as? Int {
+                return port
+            }
         }
         return 7830
     }
@@ -74,6 +85,6 @@ public enum LockfilePaths {
             }
         }
 
-        return "http://127.0.0.1:\(resolveGatewayPort())"
+        return "http://127.0.0.1:\(resolveGatewayPort(connectedAssistantId: connectedAssistantId))"
     }
 }


### PR DESCRIPTION
## Summary
- Adds `connectedAssistantId` parameter to `LockfilePaths.resolveGatewayPort()`, mirroring the existing pattern in `resolveGatewayUrl()`
- Updates all call sites (`DaemonClient`, `GatewayHTTPClient`, `AppDelegate`, `PairingQRCodeSheet`, `SettingsStore`, `LogExporter`, `InlineVideoAttachmentView`) to pass the connected assistant ID from UserDefaults
- Prevents gateway-routed requests from being sent to the wrong assistant when a user keeps an older assistant selected after hatching a newer one

Addresses feedback from PR #16733.

## Test plan
- [ ] Verify single-instance scenario still works (no behavior change when only one assistant in lockfile)
- [ ] Verify multi-instance scenario: select an older assistant, hatch a newer one, confirm gateway requests still route to the selected assistant's port
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
