### PR TITLE
security: redact legacy top-level apiKeys in log export configSnapshot

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -171,7 +171,13 @@ writeFileSync(
 // config.json at workspace root — should be skipped (already in configSnapshot)
 writeFileSync(
   join(testWorkspaceDir, "config.json"),
-  JSON.stringify({ provider: "anthropic" }),
+  JSON.stringify({
+    provider: "anthropic",
+    apiKeys: {
+      anthropic: "anthropic-secret",
+      openai: "",
+    },
+  }),
 );
 
 // Symlink pointing outside workspace — should be skipped
@@ -284,6 +290,24 @@ describe("POST /v1/export — tar.gz archive", () => {
     try {
       const files = listFiles(join(dir, "workspace"));
       expect(files).not.toContain("sneaky-link.txt");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("redacts legacy top-level apiKeys in config-snapshot.json", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const configContent = readFileSync(
+        join(dir, "config-snapshot.json"),
+        "utf-8",
+      );
+      const parsed = JSON.parse(configContent) as Record<string, unknown>;
+      const apiKeys = parsed.apiKeys as Record<string, unknown> | undefined;
+      expect(apiKeys).toBeDefined();
+      expect(apiKeys?.anthropic).toBe("(set)");
+      expect(apiKeys?.openai).toBe("(empty)");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -444,6 +444,14 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
       }
     }
 
+    // Strip legacy top-level apiKeys values
+    if (config.apiKeys && typeof config.apiKeys === "object") {
+      const apiKeys = config.apiKeys as Record<string, unknown>;
+      config.apiKeys = Object.fromEntries(
+        Object.keys(apiKeys).map((k) => [k, redactStringValue(apiKeys[k])]),
+      );
+    }
+
     // Strip Twilio accountSid
     if (config.twilio && typeof config.twilio === "object") {
       const twilio = config.twilio as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- `readSanitizedConfig()` in `log-export-routes.ts` was missing redaction of legacy top-level `apiKeys`, allowing plaintext API keys to leak via `POST /v1/export`
- Added redaction block using the existing `redactStringValue` helper, matching the pattern of all other sensitive field redaction in the same function
- Added regression test that seeds a legacy-style `apiKeys` object in `config.json` and asserts the export redacts values to `(set)` / `(empty)`

Codex finding: https://chatgpt.com/codex/security/findings/7117038b379c8191ac64e29447dc06f0

## Test plan

- [x] Existing log-export-workspace tests pass (9/9)
- [x] New test verifies `apiKeys.anthropic` → `(set)` and `apiKeys.openai` → `(empty)` in `config-snapshot.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
