### PR TITLE
fix: vertically center stop button in composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -436,7 +436,7 @@ struct ComposerView: View {
     @ViewBuilder
     private var textEntryComposer: some View {
         standardComposerShell {
-            HStack(alignment: .bottom, spacing: VSpacing.xs) {
+            HStack(alignment: isSending ? .center : .bottom, spacing: VSpacing.xs) {
                 composerTextField
                     .frame(minHeight: composerActionButtonSize)
                 composerActionButtons


### PR DESCRIPTION
## Summary
- Change composer HStack alignment from `.bottom` to `.center` when `isSending` is true, so the stop button is vertically centered in the composer during generation
- When not sending, buttons remain bottom-aligned to stay flush with the last line of multi-line text input

## Original prompt
fix the stop button in the composer to match the mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
