### PR TITLE
security: quote client-id placeholders in OAuth skills to prevent shell injection

### DIFF
--- a/skills/airtable-oauth-setup/SKILL.md
+++ b/skills/airtable-oauth-setup/SKILL.md
@@ -118,7 +118,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id <client-id> --client-secret-credential-path "integration:airtable:oauth_secret"
+    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:airtable:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."
@@ -134,7 +137,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:airtable --client-id <client-id>
+    assistant oauth connections connect integration:airtable --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -146,7 +152,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:airtable --client-id <client-id>)" "https://api.airtable.com/v0/meta/whoami" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:airtable --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.airtable.com/v0/meta/whoami" | python3 -m json.tool
 ```
 
 **On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."

--- a/skills/airtable-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/airtable-oauth-setup/references/path-b-manual-setup.md
@@ -113,13 +113,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:airtable --client-id <client-id> --client-secret-credential-path "integration:airtable:oauth_secret"
+    assistant oauth apps upsert --provider integration:airtable --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:airtable:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:airtable --client-id <client-id>
+    assistant oauth connections connect integration:airtable --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.

--- a/skills/asana-oauth-setup/SKILL.md
+++ b/skills/asana-oauth-setup/SKILL.md
@@ -102,7 +102,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id <client-id> --client-secret-credential-path "integration:asana:oauth_secret"
+    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:asana:oauth_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved — just the authorization step left."
@@ -118,7 +121,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:asana --client-id <client-id>
+    assistant oauth connections connect integration:asana --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -130,7 +136,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:asana --client-id <client-id>)" "https://app.asana.com/api/1.0/users/me" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:asana --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://app.asana.com/api/1.0/users/me" | python3 -m json.tool
 ```
 
 **On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."

--- a/skills/asana-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/asana-oauth-setup/references/path-b-manual-setup.md
@@ -101,13 +101,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:asana --client-id <client-id> --client-secret-credential-path "integration:asana:oauth_secret"
+    assistant oauth apps upsert --provider integration:asana --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:asana:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:asana --client-id <client-id>
+    assistant oauth connections connect integration:asana --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.

--- a/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
+++ b/skills/collaborative-oauth-flow/references/collaborative-guided-flow.md
@@ -145,7 +145,10 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "credential/<provider-key>/client_secret"
+    assistant oauth apps upsert --provider <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/<provider-key>/client_secret"
 ```
 
 ---
@@ -155,7 +158,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect <provider-key> --client-id <client-id>
+    assistant oauth connections connect <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 The command prints an authorization URL. Send it to the user. Wait for completion.
@@ -171,7 +177,10 @@ If a ping URL is available:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id <client-id>)" "<provider-ping-url>"
+    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "<provider-ping-url>"
 ```
 
 ---

--- a/skills/discord-oauth-setup/SKILL.md
+++ b/skills/discord-oauth-setup/SKILL.md
@@ -123,7 +123,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id <client-id> --client-secret-credential-path "integration:discord:oauth_secret"
+    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:discord:oauth_secret"
 ```
 
 **Milestone (7 of 9):** "Credentials saved — just the authorization step left."
@@ -139,7 +142,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:discord --client-id <client-id> --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connections connect integration:discord --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --scopes identify guilds guilds.members.read messages.read
 ```
 
 ---
@@ -151,7 +157,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:discord --client-id <client-id>)" "https://discord.com/api/v10/users/@me" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:discord --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://discord.com/api/v10/users/@me" | python3 -m json.tool
 ```
 
 **On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."

--- a/skills/discord-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/discord-oauth-setup/references/path-b-manual-setup.md
@@ -111,13 +111,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:discord --client-id <client-id> --client-secret-credential-path "integration:discord:oauth_secret"
+    assistant oauth apps upsert --provider integration:discord --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:discord:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:discord --client-id <client-id> --scopes identify guilds guilds.members.read messages.read
+    assistant oauth connections connect integration:discord --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --scopes identify guilds guilds.members.read messages.read
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.

--- a/skills/dropbox-oauth-setup/SKILL.md
+++ b/skills/dropbox-oauth-setup/SKILL.md
@@ -142,7 +142,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id <app-key> --client-secret-credential-path "integration:dropbox:oauth_secret"
+    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    <app-key>
+    EOF
+    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
 ```
 
 **Milestone (8 of 11):** "Credentials saved — just the authorization step left."
@@ -158,7 +161,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:dropbox --client-id <app-key>
+    assistant oauth connections connect integration:dropbox --client-id $(cat <<'EOF'
+    <app-key>
+    EOF
+    )
 ```
 
 ---
@@ -170,7 +176,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Authorization: Bearer $(assistant oauth connections token integration:dropbox --client-id <app-key>)" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
+    curl -s -X POST -H "Authorization: Bearer $(assistant oauth connections token integration:dropbox --client-id $(cat <<'EOF'
+    <app-key>
+    EOF
+    ))" "https://api.dropboxapi.com/2/users/get_current_account" | python3 -m json.tool
 ```
 
 **On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."

--- a/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/dropbox-oauth-setup/references/path-b-manual-setup.md
@@ -115,13 +115,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:dropbox --client-id <app-key> --client-secret-credential-path "integration:dropbox:oauth_secret"
+    assistant oauth apps upsert --provider integration:dropbox --client-id $(cat <<'EOF'
+    <app-key>
+    EOF
+    ) --client-secret-credential-path "integration:dropbox:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:dropbox --client-id <app-key>
+    assistant oauth connections connect integration:dropbox --client-id $(cat <<'EOF'
+    <app-key>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.

--- a/skills/figma-oauth-setup/SKILL.md
+++ b/skills/figma-oauth-setup/SKILL.md
@@ -123,7 +123,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id <client-id> --client-secret-credential-path "integration:figma:oauth_secret"
+    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:figma:oauth_secret"
 ```
 
 **Milestone (6 of 7):** "Credentials saved — just the authorization step left."
@@ -139,7 +142,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:figma --client-id <client-id>
+    assistant oauth connections connect integration:figma --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 After authorization completes, verify the connection:
@@ -147,7 +153,10 @@ After authorization completes, verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:figma --client-id <client-id>)" "https://api.figma.com/v1/me" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:figma --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.figma.com/v1/me" | python3 -m json.tool
 ```
 
 **On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."

--- a/skills/figma-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/figma-oauth-setup/references/path-b-manual-setup.md
@@ -104,13 +104,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:figma --client-id <client-id> --client-secret-credential-path "integration:figma:oauth_secret"
+    assistant oauth apps upsert --provider integration:figma --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:figma:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:figma --client-id <client-id>
+    assistant oauth connections connect integration:figma --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -118,7 +118,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id <client-id> --client-secret-credential-path "integration:github:<secret-field>"
+    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:github:<secret-field>"
 ```
 
 **Milestone (5 of 8):** "Credentials saved — just the authorization step left."
@@ -146,7 +149,10 @@ These scopes are passed during the authorization step below.
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:github --client-id <client-id> --scopes repo read:user notifications
+    assistant oauth connections connect integration:github --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --scopes repo read:user notifications
 ```
 
 **Milestone (7 of 8):** "Authorization complete — let's verify it works."
@@ -160,7 +166,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:github --client-id <client-id>)" "https://api.github.com/user" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:github --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.github.com/user" | python3 -m json.tool
 ```
 
 **On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."

--- a/skills/github-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/github-oauth-setup/references/path-b-manual-setup.md
@@ -92,13 +92,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:github --client-id <client-id> --client-secret-credential-path "integration:github:<secret-field>"
+    assistant oauth apps upsert --provider integration:github --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:github:<secret-field>"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:github --client-id <client-id> --scopes repo read:user notifications
+    assistant oauth connections connect integration:github --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --scopes repo read:user notifications
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.

--- a/skills/hubspot-oauth-setup/SKILL.md
+++ b/skills/hubspot-oauth-setup/SKILL.md
@@ -136,7 +136,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id <client-id> --client-secret-credential-path "integration:hubspot:oauth_secret"
+    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
 ```
 
 Then authorize:
@@ -148,7 +151,10 @@ Then authorize:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:hubspot --client-id <client-id>
+    assistant oauth connections connect integration:hubspot --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 **Milestone (9 of 10):** "Credentials saved and authorized — let's verify."
@@ -162,7 +168,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:hubspot --client-id <client-id>)" "https://api.hubapi.com/crm/v3/objects/contacts?limit=1" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:hubspot --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.hubapi.com/crm/v3/objects/contacts?limit=1" | python3 -m json.tool
 ```
 
 **On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."

--- a/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/hubspot-oauth-setup/references/path-b-manual-setup.md
@@ -115,13 +115,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:hubspot --client-id <client-id> --client-secret-credential-path "integration:hubspot:oauth_secret"
+    assistant oauth apps upsert --provider integration:hubspot --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:hubspot:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:hubspot --client-id <client-id>
+    assistant oauth connections connect integration:hubspot --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.

--- a/skills/linear-oauth-setup/SKILL.md
+++ b/skills/linear-oauth-setup/SKILL.md
@@ -119,7 +119,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id <client-id> --client-secret-credential-path "integration:linear:oauth_secret"
+    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:linear:oauth_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."
@@ -135,7 +138,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:linear --client-id <client-id>
+    assistant oauth connections connect integration:linear --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -147,7 +153,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth connections token integration:linear --client-id <client-id>)" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
+    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $(assistant oauth connections token integration:linear --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" -d '{"query":"{ viewer { id name email } }"}' "https://api.linear.app/graphql" | python3 -m json.tool
 ```
 
 **On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."

--- a/skills/linear-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/linear-oauth-setup/references/path-b-manual-setup.md
@@ -86,13 +86,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:linear --client-id <client-id> --client-secret-credential-path "integration:linear:oauth_secret"
+    assistant oauth apps upsert --provider integration:linear --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:linear:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:linear --client-id <client-id>
+    assistant oauth connections connect integration:linear --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.

--- a/skills/notion-oauth-setup/SKILL.md
+++ b/skills/notion-oauth-setup/SKILL.md
@@ -141,7 +141,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id <client-id>)" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:notion --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.notion.com/v1/users/me" -H "Notion-Version: 2022-06-28"
 ```
 
 **On success:** "Notion is connected! You can now ask me to read and write pages and databases in your Notion workspace."

--- a/skills/oauth-setup/SKILL.md
+++ b/skills/oauth-setup/SKILL.md
@@ -149,13 +149,19 @@ credential_store prompt:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "credential/<provider-key>/client_secret"
+    assistant oauth apps upsert --provider <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/<provider-key>/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect <provider-key> --client-id <client-id>
+    assistant oauth connections connect <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 If the service shows an "unverified app" or consent warning, tell the user how to proceed.
@@ -169,7 +175,10 @@ If a ping URL is available, verify:
 ```
 bash:
   command: |
-    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id <client-id>)" "<provider-ping-url>"
+    curl -H "Authorization: Bearer $(assistant oauth connections token <provider-key> --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "<provider-ping-url>"
 ```
 
 **On success:** "**{setup.displayName} is connected!** You're all set."

--- a/skills/slack-oauth-setup/SKILL.md
+++ b/skills/slack-oauth-setup/SKILL.md
@@ -152,7 +152,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "credential/integration:slack/client_secret"
+    assistant oauth apps upsert --provider integration:slack --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/integration:slack/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."
@@ -168,7 +171,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:slack --client-id <client-id>
+    assistant oauth connections connect integration:slack --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -180,7 +186,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:slack --client-id <client-id>)" "https://slack.com/api/auth.test" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:slack --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://slack.com/api/auth.test" | python3 -m json.tool
 ```
 
 **On success:** "Slack is connected! You can now ask me to check your Slack messages, search conversations, send messages, and react to posts."

--- a/skills/slack-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/slack-oauth-setup/references/path-b-manual-setup.md
@@ -117,13 +117,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:slack --client-id <client-id> --client-secret-credential-path "credential/integration:slack/client_secret"
+    assistant oauth apps upsert --provider integration:slack --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/integration:slack/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:slack --client-id <client-id>
+    assistant oauth connections connect integration:slack --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Allow** on the Slack consent page.

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -117,7 +117,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id <client-id> --client-secret-credential-path "integration:spotify:oauth_secret"
+    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:spotify:oauth_secret"
 ```
 
 **Milestone (4 of 7):** "Credentials saved — just the authorization step left."
@@ -133,7 +136,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:spotify --client-id <client-id>
+    assistant oauth connections connect integration:spotify --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 The scopes requested will include:
@@ -157,7 +163,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:spotify --client-id <client-id>)" "https://api.spotify.com/v1/me" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:spotify --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.spotify.com/v1/me" | python3 -m json.tool
 ```
 
 **On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."

--- a/skills/spotify-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/spotify-oauth-setup/references/path-b-manual-setup.md
@@ -92,13 +92,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:spotify --client-id <client-id> --client-secret-credential-path "integration:spotify:oauth_secret"
+    assistant oauth apps upsert --provider integration:spotify --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:spotify:oauth_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:spotify --client-id <client-id>
+    assistant oauth connections connect integration:spotify --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.

--- a/skills/todoist-oauth-setup/SKILL.md
+++ b/skills/todoist-oauth-setup/SKILL.md
@@ -90,7 +90,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id <client-id> --client-secret-credential-path "integration:todoist:app_secret"
+    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:todoist:app_secret"
 ```
 
 **Milestone (5 of 7):** "Credentials saved — just the authorization step left."
@@ -106,7 +109,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:todoist --client-id <client-id>
+    assistant oauth connections connect integration:todoist --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -118,7 +124,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:todoist --client-id <client-id>)" "https://api.todoist.com/rest/v2/projects" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:todoist --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.todoist.com/rest/v2/projects" | python3 -m json.tool
 ```
 
 **On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."

--- a/skills/todoist-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/todoist-oauth-setup/references/path-b-manual-setup.md
@@ -99,13 +99,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:todoist --client-id <client-id> --client-secret-credential-path "integration:todoist:app_secret"
+    assistant oauth apps upsert --provider integration:todoist --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "integration:todoist:app_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:todoist --client-id <client-id>
+    assistant oauth connections connect integration:todoist --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.

--- a/skills/twitter-oauth-setup/SKILL.md
+++ b/skills/twitter-oauth-setup/SKILL.md
@@ -165,7 +165,10 @@ Register the OAuth app:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "credential/integration:twitter/client_secret"
+    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
 ```
 
 **Milestone (6 of 8):** "Credentials saved — just the authorization step left."
@@ -181,7 +184,10 @@ bash:
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:twitter --client-id <client-id>
+    assistant oauth connections connect integration:twitter --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 ---
@@ -193,7 +199,10 @@ Use the ping URL to verify the connection:
 ```
 bash:
   command: |
-    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:twitter --client-id <client-id>)" "https://api.x.com/2/users/me" | python3 -m json.tool
+    curl -s -H "Authorization: Bearer $(assistant oauth connections token integration:twitter --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ))" "https://api.x.com/2/users/me" | python3 -m json.tool
 ```
 
 **On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."

--- a/skills/twitter-oauth-setup/references/path-b-manual-setup.md
+++ b/skills/twitter-oauth-setup/references/path-b-manual-setup.md
@@ -112,13 +112,19 @@ Tell the user:
 ```
 bash:
   command: |
-    assistant oauth apps upsert --provider integration:twitter --client-id <client-id> --client-secret-credential-path "credential/integration:twitter/client_secret"
+    assistant oauth apps upsert --provider integration:twitter --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "credential/integration:twitter/client_secret"
 ```
 
 ```
 bash:
   command: |
-    assistant oauth connections connect integration:twitter --client-id <client-id>
+    assistant oauth connections connect integration:twitter --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    )
 ```
 
 Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.


### PR DESCRIPTION
## Summary

- Wrap all `<client-id>` and `<app-key>` placeholders in OAuth setup skill bash command templates with heredoc literals (`$(cat <<'EOF' ... EOF)`) to prevent shell metacharacter interpretation
- Applied across all 13 provider-specific OAuth skills, their Path B manual setup references, and the shared collaborative-oauth-flow and oauth-setup templates (27 files total)
- Codex finding: https://chatgpt.com/codex/security/findings/c8afa3b336cc8191aeb380825160a905?sev=critical%2Chigh%2Cmedium%2Clow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
