### PR TITLE
fix: exclude BOOTSTRAP.md from BTW system prompt

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -111,6 +111,7 @@ export function isOnboardingComplete(): boolean {
  */
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
+  excludeBootstrap?: boolean;
 }
 
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
@@ -135,7 +136,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   if (identity) parts.push(identity);
   if (soul) parts.push(soul);
   if (user) parts.push(user);
-  if (bootstrap) {
+  if (bootstrap && !options?.excludeBootstrap) {
     parts.push(
       "# First-Run Ritual\n\n" +
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -1,8 +1,10 @@
 /**
  * HTTP route handler for the POST /v1/btw SSE-streaming side-chain endpoint.
  *
- * Runs an ephemeral LLM call that reuses the session's provider, system prompt,
- * tool definitions, and message history for prompt-cache efficiency. The response
+ * Runs an ephemeral LLM call that reuses the session's provider, tool
+ * definitions, and message history for prompt-cache efficiency. Builds its own
+ * system prompt (excluding BOOTSTRAP.md) so first-run onboarding instructions
+ * don't leak into cosmetic UI calls like identity intro generation. The response
  * is streamed as SSE events (`btw_text_delta`, `btw_complete`, `btw_error`).
  *
  * No messages are persisted. `session.processing` is never set or checked.
@@ -10,6 +12,7 @@
 
 import { buildToolDefinitions } from "../../daemon/session-tool-setup.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
+import { buildSystemPrompt } from "../../prompts/system-prompt.js";
 import {
   createTimeout,
   userMessage,
@@ -102,28 +105,28 @@ async function handleBtw(
     start(controller) {
       (async () => {
         try {
-          await session.provider.sendMessage(
-            messages,
-            tools,
-            session.systemPrompt,
-            {
-              config: {
-                max_tokens: 1024,
-                tool_choice: { type: "none" },
-                modelIntent: "latency-optimized",
-              },
-              onEvent: (event) => {
-                if (event.type === "text_delta") {
-                  controller.enqueue(
-                    encoder.encode(
-                      `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
-                    ),
-                  );
-                }
-              },
-              signal: combinedSignal,
+          // Build a system prompt without BOOTSTRAP.md so ephemeral BTW
+          // calls (e.g. identity intro generation) aren't contaminated by
+          // first-run onboarding instructions.
+          const systemPrompt = buildSystemPrompt({ excludeBootstrap: true });
+
+          await session.provider.sendMessage(messages, tools, systemPrompt, {
+            config: {
+              max_tokens: 1024,
+              tool_choice: { type: "none" },
+              modelIntent: "latency-optimized",
             },
-          );
+            onEvent: (event) => {
+              if (event.type === "text_delta") {
+                controller.enqueue(
+                  encoder.encode(
+                    `event: btw_text_delta\ndata: ${JSON.stringify({ text: event.text })}\n\n`,
+                  ),
+                );
+              }
+            },
+            signal: combinedSignal,
+          });
 
           controller.enqueue(
             encoder.encode(`event: btw_complete\ndata: {}\n\n`),


### PR DESCRIPTION
## Summary
- Added `excludeBootstrap` option to `BuildSystemPromptOptions` in `system-prompt.ts`
- BTW route now builds its own system prompt with `excludeBootstrap: true` instead of reusing `session.systemPrompt`
- Prevents first-run onboarding instructions from leaking into ephemeral UI calls (e.g. identity intro generation on the Intelligence panel)

## Original prompt
Exclude BOOTSTRAP.md from the BTW system prompt so identity intro generation doesn't produce bootstrap-flavored responses during first-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
