### PR TITLE
security: validate tar archive paths before extraction in LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -420,6 +420,7 @@ enum LogExporter {
 
     /// Writes tar.gz `data` to a temporary file and extracts it into
     /// `directory/<subdirectory>/` using `/usr/bin/tar`.
+    /// Validates archive member paths before extraction to prevent path traversal.
     private nonisolated static func extractTarGzResponse(
         data: Data,
         into directory: URL,
@@ -433,6 +434,9 @@ enum LogExporter {
         defer {
             try? fileManager.removeItem(at: tarPath)
         }
+
+        // Validate archive contents — reject paths with ".." components or absolute paths
+        try await validateTarContents(at: tarPath)
 
         let extractDir = directory.appendingPathComponent(subdirectory, isDirectory: true)
         try fileManager.createDirectory(at: extractDir, withIntermediateDirectories: true)
@@ -465,6 +469,54 @@ enum LogExporter {
                 try process.run()
             } catch {
                 continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    /// Lists tar archive members and rejects any with path traversal (`..`) or absolute paths.
+    private nonisolated static func validateTarContents(at tarPath: URL) async throws {
+        let entries = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+            process.arguments = ["tzf", tarPath.path]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+
+            let errPipe = Pipe()
+            process.standardError = errPipe
+
+            process.terminationHandler = { proc in
+                if proc.terminationStatus == 0 {
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+                    continuation.resume(returning: output)
+                } else {
+                    let stderr = String(
+                        data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                        encoding: .utf8
+                    ) ?? ""
+                    continuation.resume(throwing: ExportError.tarFailed("Failed to list archive: \(stderr)"))
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+
+        for entry in entries.split(separator: "\n") {
+            let path = String(entry)
+            if path.hasPrefix("/") {
+                log.warning("Rejecting archive with absolute path: \(path)")
+                throw ExportError.unsafeArchivePath(path)
+            }
+            let components = (path as NSString).pathComponents
+            if components.contains("..") {
+                log.warning("Rejecting archive with path traversal: \(path)")
+                throw ExportError.unsafeArchivePath(path)
             }
         }
     }
@@ -702,6 +754,7 @@ enum LogExporter {
     enum ExportError: LocalizedError {
         case noLogsFound
         case tarFailed(String)
+        case unsafeArchivePath(String)
 
         var errorDescription: String? {
             switch self {
@@ -709,6 +762,8 @@ enum LogExporter {
                 return "No log files were found to export."
             case .tarFailed(let detail):
                 return "Failed to create archive: \(detail)"
+            case .unsafeArchivePath(let path):
+                return "Archive contains unsafe path: \(path)"
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add pre-extraction validation of tar.gz archive member paths in `LogExporter.extractTarGzResponse` to prevent path traversal attacks
- New `validateTarContents()` lists archive entries with `tar tzf` and rejects any containing `..` components or starting with `/`
- Restores the defense-in-depth path traversal protection that was present in the prior JSON-based implementation but dropped during the tar.gz refactor (506a85a)

## Original prompt

Fix tar extraction path traversal vulnerability in LogExporter.swift — the `extractTarGzResponse` method extracts tar.gz archives without validating member paths, allowing potential path traversal if archive contents are attacker-controlled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
