### PR TITLE
fix: update btw-routes test and managed-skill-lifecycle timeout for CI

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -65,6 +65,12 @@ mock.module("../security/secret-ingress.js", () => ({
   checkIngressForSecrets: mockCheckIngressForSecrets,
 }));
 
+const MOCK_SYSTEM_PROMPT = "You are a helpful assistant.";
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => MOCK_SYSTEM_PROMPT,
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
@@ -331,8 +337,8 @@ describe("POST /v1/btw", () => {
     // Tools
     expect(tools).toEqual(MOCK_TOOLS);
 
-    // System prompt from session
-    expect(systemPrompt).toBe("You are a helpful assistant.");
+    // System prompt built by buildSystemPrompt({ excludeBootstrap: true })
+    expect(systemPrompt).toBe(MOCK_SYSTEM_PROMPT);
 
     // Options: tool_choice must be "none"
     expect(options!.config!.tool_choice).toEqual({ type: "none" });

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -264,5 +264,5 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
       ctx,
     );
     expect(loadAfterDelete.isError).toBe(true);
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary
- Mock `buildSystemPrompt` in `btw-routes.test.ts` so the test matches the new code path introduced in #16751 (which switched from `session.systemPrompt` to `buildSystemPrompt({ excludeBootstrap: true })`)
- Increase the timeout for the `scaffold → skill_load chain` test from 5s to 15s — loading all bundled skills from disk can exceed 5s on CI runners

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23094606199/job/67084900105

🤖 Generated with [Claude Code](https://claude.com/claude-code)