### PR TITLE
fix: temporary chats not filtered from sidebar after app restart

### DIFF
--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -100,11 +100,15 @@ export function setConversationKeyIfAbsent(
  * Otherwise, creates a new conversation and mapping atomically within a
  * single transaction to prevent race conditions and orphaned rows.
  */
-export function getOrCreateConversation(conversationKey: string): {
+export function getOrCreateConversation(
+  conversationKey: string,
+  opts?: { threadType?: "standard" | "private" },
+): {
   conversationId: string;
   created: boolean;
 } {
   const db = getDb();
+  const threadType = opts?.threadType ?? "standard";
 
   return db.transaction((tx) => {
     const existing = tx
@@ -140,6 +144,8 @@ export function getOrCreateConversation(conversationKey: string): {
 
     const now = Date.now();
     const conversationId = uuid();
+    const memoryScopeId =
+      threadType === "private" ? `private:${conversationId}` : "default";
 
     tx.insert(conversations)
       .values({
@@ -153,6 +159,8 @@ export function getOrCreateConversation(conversationKey: string): {
         contextSummary: null,
         contextCompactedMessageCount: 0,
         contextCompactedAt: null,
+        threadType,
+        memoryScopeId,
       })
       .run();
 

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -33,7 +33,7 @@ export function listConversations(
   const db = getDb();
   const where = includeBackground
     ? undefined
-    : sql`${conversations.threadType} != 'background'`;
+    : sql`${conversations.threadType} NOT IN ('background', 'private')`;
   const query = db
     .select()
     .from(conversations)
@@ -48,7 +48,7 @@ export function countConversations(includeBackground = false): number {
   const db = getDb();
   const where = includeBackground
     ? undefined
-    : sql`${conversations.threadType} != 'background'`;
+    : sql`${conversations.threadType} NOT IN ('background', 'private')`;
   const [{ total }] = db
     .select({ total: count() })
     .from(conversations)

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -352,8 +352,7 @@ export function handleListMessages(
           });
         }
       } else {
-        const linked =
-          attachmentsStore.getAttachmentMetadataForMessage(m.id);
+        const linked = attachmentsStore.getAttachmentMetadataForMessage(m.id);
         if (linked.length > 0) {
           msgAttachments = linked.map((a) => {
             if (a.mimeType.startsWith("image/")) {
@@ -364,9 +363,7 @@ export function handleListMessages(
                 mimeType: a.mimeType,
                 sizeBytes: a.sizeBytes,
                 kind: a.kind,
-                ...(full?.dataBase64
-                  ? { data: full.dataBase64 }
-                  : {}),
+                ...(full?.dataBase64 ? { data: full.dataBase64 } : {}),
                 ...(a.thumbnailBase64
                   ? { thumbnailData: a.thumbnailBase64 }
                   : {}),
@@ -557,6 +554,7 @@ export async function handleSendMessage(
     attachmentIds?: string[];
     sourceChannel?: string;
     interface?: string;
+    threadType?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -655,7 +653,9 @@ export async function handleSendMessage(
     );
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
+  const threadType =
+    body.threadType === "private" ? ("private" as const) : undefined;
+  const mapping = getOrCreateConversation(conversationKey, { threadType });
   const smDeps = deps.sendMessageDeps;
   const session = await smDeps.getOrCreateSession(mapping.conversationId);
 

--- a/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
+++ b/clients/shared/Network/HTTPDaemonClient+ExistingRoutes.swift
@@ -30,6 +30,10 @@ extension HTTPTransport {
                 // acts as the session. Emit a synthetic session_info so ChatViewModel
                 // records the session ID.
                 let sessionId = (msg.correlationId.flatMap { $0.isEmpty ? nil : $0 }) ?? UUID().uuidString
+                // Remember private sessions so sendMessage can pass threadType to the backend.
+                if msg.threadType == "private" {
+                    self.privateSessionIds.insert(sessionId)
+                }
                 let info = ServerMessage.sessionInfo(
                     SessionInfoMessage(sessionId: sessionId, title: msg.title ?? "New Chat", correlationId: msg.correlationId)
                 )

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -186,6 +186,9 @@ public final class HTTPTransport {
     /// Session IDs that originated from this client instance.
     /// Host tool requests are only executed for these session IDs.
     private var locallyOwnedSessionIds: Set<String> = []
+    /// Session IDs that belong to private (temporary) threads.
+    /// Populated when a session_create with threadType "private" is handled locally.
+    private var privateSessionIds: Set<String> = []
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -1714,6 +1717,9 @@ public final class HTTPTransport {
         }
         if !attachmentIds.isEmpty {
             body["attachmentIds"] = attachmentIds
+        }
+        if privateSessionIds.contains(sessionId) {
+            body["threadType"] = "private"
         }
 
         do {


### PR DESCRIPTION
## Summary

- **Client**: When `session_create` arrives with `threadType: "private"`, the HTTP transport now remembers the session ID. Subsequent `POST /v1/messages` calls include `threadType: "private"` in the body so the backend creates the conversation with the correct type and memory scope.
- **Backend**: `getOrCreateConversation()` now accepts an optional `threadType` parameter. When creating a new conversation, it sets both `threadType` and `memoryScopeId` (private threads get `private:<id>` scope for memory isolation).
- **Backend**: `listConversations()` and `countConversations()` now exclude `private` threads (in addition to `background`), fixing pagination counts and preventing private threads from appearing in the session list response.

## Original prompt
Fix temporary chat persistence bug: private threads created via HTTP transport are stored as "standard" because the HTTP session_create handler is local-only and threadType is never passed to the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
