### PR TITLE
fix: widen privateSessionIds access for cross-file extension

### DIFF
--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -188,7 +188,7 @@ public final class HTTPTransport {
     private var locallyOwnedSessionIds: Set<String> = []
     /// Session IDs that belong to private (temporary) threads.
     /// Populated when a session_create with threadType "private" is handled locally.
-    private var privateSessionIds: Set<String> = []
+    var privateSessionIds: Set<String> = []
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()


### PR DESCRIPTION
## Summary
- Changed `privateSessionIds` from `private` to `internal` access in `HTTPDaemonClient.swift` so the extension in `HTTPDaemonClient+ExistingRoutes.swift` can mutate it.
- This fixes the Swift build error introduced in #16758 where the property was added as `private` but used from a separate extension file.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23095032555/job/67085994938

🤖 Generated with [Claude Code](https://claude.com/claude-code)