### PR TITLE
feat: clean up private conversations on toggle-off and startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -30,6 +30,7 @@ import {
   deleteMessageById,
   getConversationThreadType,
   getMessages,
+  purgePrivateConversations,
 } from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db.js";
 import {
@@ -176,6 +177,16 @@ export async function runDaemon(): Promise<void> {
       );
     }
     log.info("Daemon startup: DB initialized");
+
+    // Purge private (temporary) conversations from the previous session.
+    // These are ephemeral by design and should not survive daemon restarts.
+    const purgedCount = purgePrivateConversations();
+    if (purgedCount > 0) {
+      log.info(
+        { purgedCount },
+        `Purged ${purgedCount} private conversation(s) from previous session`,
+      );
+    }
 
     // Expire pending interaction-bound canonical guardian requests left over
     // from before this process started.  Their in-memory pending-interaction

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -272,6 +272,28 @@ export function deleteConversation(id: string): void {
   });
 }
 
+/**
+ * Delete all private (temporary) conversations and their associated data.
+ * Called at daemon startup to clean up ephemeral threads from previous sessions.
+ * Returns the number of conversations purged.
+ */
+export function purgePrivateConversations(): number {
+  const db = getDb();
+  const privateConvs = db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.threadType, "private"))
+    .all();
+
+  if (privateConvs.length === 0) return 0;
+
+  for (const conv of privateConvs) {
+    deleteConversation(conv.id);
+  }
+
+  return privateConvs.length;
+}
+
 export async function addMessage(
   conversationId: string,
   role: string,

--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -4,13 +4,18 @@
  * POST   /v1/conversations/switch         — switch to an existing conversation
  * PATCH  /v1/conversations/:id/name       — rename a conversation
  * DELETE /v1/conversations                 — clear all conversations
+ * DELETE /v1/conversations/:id            — delete a single conversation
  * POST   /v1/conversations/:id/cancel     — cancel generation
  * POST   /v1/conversations/:id/undo       — undo last message
  * POST   /v1/conversations/:id/regenerate — regenerate last assistant response
  * POST   /v1/sessions/reorder             — reorder / pin sessions
  */
 
-import { batchSetDisplayOrders } from "../../memory/conversation-crud.js";
+import {
+  batchSetDisplayOrders,
+  deleteConversation,
+  getConversation,
+} from "../../memory/conversation-crud.js";
 import { setConversationKeyIfAbsent } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -31,7 +36,9 @@ export interface SessionManagementDeps {
   renameSession: (sessionId: string, name: string) => boolean;
   clearAllSessions: () => number;
   cancelGeneration: (sessionId: string) => boolean;
-  undoLastMessage: (sessionId: string) => Promise<{ removedCount: number } | null>;
+  undoLastMessage: (
+    sessionId: string,
+  ) => Promise<{ removedCount: number } | null>;
   regenerateResponse: (
     sessionId: string,
   ) => Promise<{ requestId: string } | null>;
@@ -101,6 +108,24 @@ export function sessionManagementRouteDefinitions(
       policyKey: "conversations",
       handler: () => {
         deps.clearAllSessions();
+        return new Response(null, { status: 204 });
+      },
+    },
+    {
+      endpoint: "conversations/:id",
+      method: "DELETE",
+      policyKey: "conversations",
+      handler: ({ params }) => {
+        const conversation = getConversation(params.id);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+        deleteConversation(params.id);
+        log.info({ conversationId: params.id }, "Deleted conversation");
         return new Response(null, { status: 204 });
       },
     },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -110,7 +110,9 @@ struct MainWindowView: View {
 
     private func toggleTemporaryChat() {
         withAnimation(VAnimation.standard) {
-            if threadManager.activeThread?.kind == .private {
+            if let privateThread = threadManager.activeThread, privateThread.kind == .private {
+                let privateId = privateThread.id
+
                 // Restore the thread the user was on before entering temporary chat.
                 // Fall back to visibleThreads.first only if the stored thread no longer exists.
                 if let savedId = preTemporaryChatThreadId,
@@ -122,6 +124,9 @@ struct MainWindowView: View {
                     threadManager.enterDraftMode()
                 }
                 preTemporaryChatThreadId = nil
+
+                // Delete the private thread and its backend conversation.
+                threadManager.removePrivateThread(id: privateId)
             } else {
                 preTemporaryChatThreadId = threadManager.activeThreadId
                 threadManager.createPrivateThread()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -348,6 +348,29 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         log.info("Created private thread \(thread.id)")
     }
 
+    /// Remove a private (temporary) thread and delete its backend conversation.
+    /// Stops any active generation before cleanup.
+    func removePrivateThread(id: UUID) {
+        guard let index = threads.firstIndex(where: { $0.id == id && $0.kind == .private }) else { return }
+
+        let sessionId = threads[index].sessionId
+
+        // Stop generation and clean up local state
+        chatViewModels[id]?.stopGenerating()
+        threads.remove(at: index)
+        chatViewModels.removeValue(forKey: id)
+        unsubscribeAllForThread(id: id)
+        vmAccessOrder.removeAll { $0 == id }
+        Self.clearRenderCaches()
+
+        // Delete the conversation on the backend (fire-and-forget)
+        if let sessionId {
+            daemonClient.deleteConversation(sessionId)
+        }
+
+        log.info("Removed private thread \(id)")
+    }
+
     /// Create a visible thread bound to an existing task run conversation.
     /// Called when the daemon broadcasts `task_run_thread_created` so the user
     /// can see task execution messages streaming in real-time.

--- a/clients/shared/Network/DaemonClient.swift
+++ b/clients/shared/Network/DaemonClient.swift
@@ -1441,6 +1441,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Sessions
 
+    /// Delete a single conversation on the backend (fire-and-forget).
+    public func deleteConversation(_ conversationId: String) {
+        guard let httpTransport else { return }
+        Task { await httpTransport.deleteConversation(conversationId) }
+    }
+
     /// Request the list of past sessions from the daemon.
     public func sendSessionList(offset: Int? = nil, limit: Int? = nil) throws {
         try send(SessionListRequestMessage(offset: offset, limit: limit))

--- a/clients/shared/Network/HTTPDaemonClient.swift
+++ b/clients/shared/Network/HTTPDaemonClient.swift
@@ -2980,6 +2980,32 @@ public final class HTTPTransport {
         }
     }
 
+    /// Delete a single conversation on the backend (fire-and-forget).
+    func deleteConversation(_ conversationId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .conversationById(id: conversationId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                if case .success = refreshResult {
+                    await deleteConversation(conversationId, isRetry: true)
+                    return
+                }
+            }
+            if statusCode != 204 && statusCode != 200 {
+                log.error("Delete conversation \(conversationId) failed (HTTP \(statusCode))")
+            }
+        } catch {
+            log.error("Delete conversation \(conversationId) error: \(error.localizedDescription)")
+        }
+    }
+
     func fetchHistory(sessionId: String, isRetry: Bool = false) async {
         guard let url = buildURL(for: .getMessages(conversationId: sessionId)) else { return }
 


### PR DESCRIPTION
## Summary

- **Client (toggle-off)**: When the user exits a temporary chat, `removePrivateThread()` stops any active generation, removes the thread locally, and fires `DELETE /v1/conversations/:id` to delete the backend conversation immediately.
- **Backend (startup)**: `purgePrivateConversations()` runs during daemon initialization to delete all private conversations from the previous session — acts as a safety net for crashes or force-quits where the toggle-off cleanup didn't fire.
- **Backend (new endpoint)**: Adds `DELETE /v1/conversations/:id` for single conversation deletion, used by the client cleanup but available for general use.

## Original prompt
Delete private (temporary) chat conversations from the database on toggle-off (option 1) and on daemon startup (option 3), with a guard against deleting mid-generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
