### PR TITLE
Fix Swift 6 nonisolated context warnings in MetricKitManager

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -59,12 +59,12 @@ import os
     /// but workspace files included in log archives can exceed that. Sentry's
     /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
     /// provides sufficient headroom.
-    static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
+    nonisolated(unsafe) static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
     /// Default DSN for the macOS app Sentry project.
-    static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+    nonisolated(unsafe) static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
     /// DSN for the assistant/brain Sentry project.
-    static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+    nonisolated(unsafe) static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
 
     /// Sends a manual problem report unconditionally, even when the user has
     /// opted out of automatic crash reporting.  The SDK is temporarily started


### PR DESCRIPTION
## Summary
- Mark `sentryMaxAttachmentSize`, `macosDSN`, and `brainDSN` static properties as `nonisolated(unsafe)` in `MetricKitManager`
- These are compile-time constants (string literals and constant arithmetic) that are safe to access from any isolation domain
- Eliminates Swift 6 warnings about main actor-isolated static properties referenced from nonisolated contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)