### PR TITLE
Rename 'Things' to 'Library'

### DIFF
--- a/clients/ios/Views/Things/ThingsTabView.swift
+++ b/clients/ios/Views/Things/ThingsTabView.swift
@@ -64,7 +64,7 @@ struct ThingsDisconnectedView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .navigationTitle("Things")
+            .navigationTitle("Library")
         }
     }
 }

--- a/clients/ios/Views/Things/ThingsView.swift
+++ b/clients/ios/Views/Things/ThingsView.swift
@@ -37,7 +37,7 @@ struct ThingsView: View {
                     DocumentsListView(directoryStore: directoryStore)
                 }
             }
-            .navigationTitle("Things")
+            .navigationTitle("Library")
             .onAppear {
                 directoryStore.fetchApps()
                 directoryStore.fetchSharedApps()

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -315,7 +315,7 @@ extension AppDelegate {
             CommandPaletteAction(id: "settings", icon: VIcon.settings.rawValue, label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.settings)
             },
-            CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Things", shortcutHint: nil) { [weak self] in
+            CommandPaletteAction(id: "app-directory", icon: VIcon.layoutGrid.rawValue, label: "Library", shortcutHint: nil) { [weak self] in
                 self?.mainWindow?.windowState.showPanel(.apps)
             },
             CommandPaletteAction(id: "intelligence", icon: VIcon.brain.rawValue, label: "Intelligence", shortcutHint: nil) { [weak self] in

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -194,7 +194,7 @@ extension MainWindowView {
             SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.showPanel(.intelligence)
             }
-            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps)) {
+            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps)) {
                 windowState.showPanel(.apps)
             }
             // Divider between nav items and threads
@@ -476,7 +476,7 @@ extension MainWindowView {
             SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.showPanel(.intelligence)
             }
-            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
+            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Library", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
                 windowState.showPanel(.apps)
             }
             sidebarSectionDivider(isExpanded: false)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -50,7 +50,7 @@ struct AppsGridView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     // Header
                     HStack(alignment: .center) {
-                        Text("Things")
+                        Text("Library")
                             .font(VFont.panelTitle)
                             .foregroundColor(VColor.contentDefault)
                         Spacer()
@@ -155,7 +155,7 @@ struct AppsGridView: View {
     // MARK: - Search Bar
 
     private var searchBar: some View {
-        VSearchBar(placeholder: "Find your things", text: $searchText)
+        VSearchBar(placeholder: "Search your library", text: $searchText)
     }
 
     // MARK: - App Card


### PR DESCRIPTION
## Summary
- Renamed "Things" to "Library" in sidebar nav, page heading, command palette, and iOS navigation titles
- Updated search placeholder from "Find your things" to "Search your library"

## Original prompt
Change "Things" to "Library"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
