### PR TITLE
fix: prevent duplicate update bulletin content across version bumps

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -10,15 +10,3 @@ _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
 
-<!-- vellum-update-release:schedule-reminder-unification -->
-
-### Reminders are now one-shot schedules
-
-The separate reminder system has been unified into the schedule system. What this means:
-
-- **`reminder_create`, `reminder_list`, and `reminder_cancel` tools no longer exist.** Do not attempt to use them.
-- **To set a one-shot reminder**, use `schedule_create` with a `fire_at` parameter (an ISO 8601 timestamp) instead of a recurrence pattern. This replaces `reminder_create`.
-- **To list or cancel reminders**, use `schedule_list` and `schedule_delete` — they now cover both recurring schedules and one-shot reminders.
-- Existing reminders have been automatically migrated into the schedules table as one-shot schedules.
-
-<!-- /vellum-update-release:schedule-reminder-unification -->

--- a/assistant/src/prompts/update-bulletin-format.ts
+++ b/assistant/src/prompts/update-bulletin-format.ts
@@ -41,6 +41,22 @@ export function appendReleaseBlock(
   return `${content}${separator}${block}\n`;
 }
 
+/**
+ * Extracts content-level markers (non-version feature markers) from the
+ * template body. These are markers like `schedule-reminder-unification`
+ * that identify the _content_ rather than the release version.
+ */
+export function extractContentMarkers(body: string): string[] {
+  const ids: string[] = [];
+  const regex = /<!-- vellum-update-release:(.+?) -->/g;
+  let match: RegExpExecArray | null;
+  // eslint-disable-next-line no-restricted-syntax -- RegExp.exec returns null
+  while ((match = regex.exec(body)) !== null) {
+    ids.push(match[1]);
+  }
+  return ids;
+}
+
 /** Extracts all version strings from release markers found in `content`. */
 export function extractReleaseIds(content: string): string[] {
   const ids: string[] = [];

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -13,7 +13,9 @@ import { APP_VERSION } from "../version.js";
 import { stripCommentLines } from "./system-prompt.js";
 import {
   appendReleaseBlock,
+  extractContentMarkers,
   hasReleaseBlock,
+  releaseMarker,
 } from "./update-bulletin-format.js";
 import {
   addActiveRelease,
@@ -103,12 +105,22 @@ export function syncUpdateBulletinOnStartup(): void {
   } else {
     const existing = readFileSync(workspacePath, "utf-8");
     if (!hasReleaseBlock(existing, currentReleaseId)) {
-      const updated = appendReleaseBlock(
-        existing,
-        currentReleaseId,
-        templateContent,
-      );
-      atomicWriteFileSync(workspacePath, updated);
+      // Guard: skip if the template's content markers already exist in the
+      // workspace file. This prevents the same update notes from being
+      // appended on every version bump when the template isn't cleared.
+      const contentMarkers = extractContentMarkers(templateContent);
+      const allContentAlreadyPresent =
+        contentMarkers.length > 0 &&
+        contentMarkers.every((m) => existing.includes(releaseMarker(m)));
+
+      if (!allContentAlreadyPresent) {
+        const updated = appendReleaseBlock(
+          existing,
+          currentReleaseId,
+          templateContent,
+        );
+        atomicWriteFileSync(workspacePath, updated);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Added content-level marker deduplication to `syncUpdateBulletinOnStartup()` — before appending template content, it now checks whether the template's feature markers (e.g. `schedule-reminder-unification`) already exist in the workspace file, preventing the same notes from being repeated on every version bump.
- Cleared the stale `schedule-reminder-unification` content from the UPDATES.md template that had been shipping with every release since 0.4.46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
