### PR TITLE
fix: prevent pipe deadlock in LogExporter tar validation

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -486,24 +486,27 @@ enum LogExporter {
             let errPipe = Pipe()
             process.standardError = errPipe
 
-            process.terminationHandler = { proc in
-                if proc.terminationStatus == 0 {
-                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                    let output = String(data: data, encoding: .utf8) ?? ""
-                    continuation.resume(returning: output)
-                } else {
-                    let stderr = String(
-                        data: errPipe.fileHandleForReading.readDataToEndOfFile(),
-                        encoding: .utf8
-                    ) ?? ""
-                    continuation.resume(throwing: ExportError.tarFailed("Failed to list archive: \(stderr)"))
-                }
-            }
-
             do {
                 try process.run()
             } catch {
                 continuation.resume(throwing: error)
+                return
+            }
+
+            // Read pipe data eagerly BEFORE waiting for process exit.
+            // If reads happen inside terminationHandler, tar blocks on a full
+            // pipe buffer (~64 KB) and never exits — deadlocking the export.
+            let stdoutData = pipe.fileHandleForReading.readDataToEndOfFile()
+            let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+
+            process.waitUntilExit()
+
+            if process.terminationStatus == 0 {
+                let output = String(data: stdoutData, encoding: .utf8) ?? ""
+                continuation.resume(returning: output)
+            } else {
+                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+                continuation.resume(throwing: ExportError.tarFailed("Failed to list archive: \(stderr)"))
             }
         }
 


### PR DESCRIPTION
## Summary
- Reads stdout/stderr data eagerly outside terminationHandler to prevent deadlock when tar listing exceeds pipe buffer (~64KB)
- Uses `waitUntilExit()` after reading pipe data to check exit status synchronously
- Fixes validateTarContents hanging indefinitely for archives with many entries

Addresses feedback from PR #16753.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
