### PR TITLE
fix: preserve systemPromptOverride in BTW handler when excluding bootstrap

### DIFF
--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -2,10 +2,12 @@
  * HTTP route handler for the POST /v1/btw SSE-streaming side-chain endpoint.
  *
  * Runs an ephemeral LLM call that reuses the session's provider, tool
- * definitions, and message history for prompt-cache efficiency. Builds its own
- * system prompt (excluding BOOTSTRAP.md) so first-run onboarding instructions
- * don't leak into cosmetic UI calls like identity intro generation. The response
- * is streamed as SSE events (`btw_text_delta`, `btw_complete`, `btw_error`).
+ * definitions, and message history for prompt-cache efficiency. Uses the
+ * session's system prompt when a conversation-specific override is active;
+ * otherwise builds a fresh prompt excluding BOOTSTRAP.md so first-run
+ * onboarding instructions don't leak into cosmetic UI calls like identity
+ * intro generation. The response is streamed as SSE events (`btw_text_delta`,
+ * `btw_complete`, `btw_error`).
  *
  * No messages are persisted. `session.processing` is never set or checked.
  */
@@ -105,10 +107,14 @@ async function handleBtw(
     start(controller) {
       (async () => {
         try {
-          // Build a system prompt without BOOTSTRAP.md so ephemeral BTW
-          // calls (e.g. identity intro generation) aren't contaminated by
-          // first-run onboarding instructions.
-          const systemPrompt = buildSystemPrompt({ excludeBootstrap: true });
+          // Preserve any conversation-specific systemPromptOverride so
+          // side-chain responses match the active session contract.  Only
+          // fall back to a fresh prompt (excluding BOOTSTRAP.md) for
+          // default sessions where no override was provided.
+          const hasOverride = session.systemPrompt !== buildSystemPrompt();
+          const systemPrompt = hasOverride
+            ? session.systemPrompt
+            : buildSystemPrompt({ excludeBootstrap: true });
 
           await session.provider.sendMessage(messages, tools, systemPrompt, {
             config: {


### PR DESCRIPTION
## Summary
- Fixes BTW handler to check for session-specific systemPromptOverride before falling back to buildSystemPrompt({ excludeBootstrap: true })
- Preserves override-driven session behavior while still excluding bootstrap from default sessions
- Uses the same hasOverride detection pattern as session.ts (comparing against buildSystemPrompt())

Addresses feedback from PR #16751.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
