### PR TITLE
fix: exclude private threads from search and getLatestConversation queries

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -62,7 +62,7 @@ export function getLatestConversation(): ConversationRow | null {
   const row = db
     .select()
     .from(conversations)
-    .where(sql`${conversations.threadType} != 'background'`)
+    .where(sql`${conversations.threadType} NOT IN ('background', 'private')`)
     .orderBy(desc(conversations.updatedAt))
     .limit(1)
     .get();
@@ -164,7 +164,7 @@ export function searchConversations(
         FROM messages_fts f
         JOIN messages m ON m.id = f.message_id
         JOIN conversations c ON c.id = m.conversation_id
-        WHERE messages_fts MATCH ? AND c.thread_type != 'background'
+        WHERE messages_fts MATCH ? AND c.thread_type NOT IN ('background', 'private')
         LIMIT 1000
       `,
         ftsMatch,
@@ -189,7 +189,7 @@ export function searchConversations(
       SELECT DISTINCT m.conversation_id
       FROM messages m
       JOIN conversations c ON c.id = m.conversation_id
-      WHERE m.content LIKE ? ESCAPE '\\' AND c.thread_type != 'background'
+      WHERE m.content LIKE ? ESCAPE '\\' AND c.thread_type NOT IN ('background', 'private')
       LIMIT 1000
     `,
       likePattern,
@@ -203,7 +203,7 @@ export function searchConversations(
     .from(conversations)
     .where(
       and(
-        sql`${conversations.threadType} != 'background'`,
+        sql`${conversations.threadType} NOT IN ('background', 'private')`,
         sql`${conversations.title} LIKE ${titlePattern} ESCAPE '\\'`,
       ),
     )


### PR DESCRIPTION
## Summary
- Updates searchConversations (FTS, LIKE fallback, title match) and getLatestConversation to exclude 'private' threads
- Matches the existing listConversations/countConversations filtering pattern

Addresses feedback from PR #16758.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
