### PR TITLE
fix: assert excludeBootstrap flag in btw-routes test mock

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -66,9 +66,10 @@ mock.module("../security/secret-ingress.js", () => ({
 }));
 
 const MOCK_SYSTEM_PROMPT = "You are a helpful assistant.";
+const mockBuildSystemPrompt = mock(() => MOCK_SYSTEM_PROMPT);
 
 mock.module("../prompts/system-prompt.js", () => ({
-  buildSystemPrompt: () => MOCK_SYSTEM_PROMPT,
+  buildSystemPrompt: mockBuildSystemPrompt,
 }));
 
 // ---------------------------------------------------------------------------
@@ -339,6 +340,9 @@ describe("POST /v1/btw", () => {
 
     // System prompt built by buildSystemPrompt({ excludeBootstrap: true })
     expect(systemPrompt).toBe(MOCK_SYSTEM_PROMPT);
+    expect(mockBuildSystemPrompt).toHaveBeenCalledWith({
+      excludeBootstrap: true,
+    });
 
     // Options: tool_choice must be "none"
     expect(options!.config!.tool_choice).toEqual({ type: "none" });


### PR DESCRIPTION
## Summary
- Updates buildSystemPrompt mock in btw-routes.test.ts to capture call arguments
- Adds assertion that buildSystemPrompt is called with { excludeBootstrap: true }
- Prevents silent regression if the handler stops passing the flag

Addresses feedback from PR #16754.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
