### PR TITLE
Fix chat text disappearing when document/panel opens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -317,6 +317,11 @@ struct MainWindowView: View {
                     let shouldCollapse: Bool = {
                         switch newSelection {
                         case .app, .appEditing: return true
+                        case .panel(let p):
+                            switch p {
+                            case .settings: return false
+                            default: return true
+                            }
                         default: return false
                         }
                     }()

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -193,6 +193,37 @@ extension MainWindowView {
         )
     }
 
+    /// Like `clampedPanelWidth` but reads/writes `sidePanelWidth` (default 400)
+    /// instead of `appPanelWidth`. Used for the document editor and default chat
+    /// side panels.
+    func clampedSidePanelWidth(geometry: GeometryProxy) -> Binding<Double> {
+        let settingsOpen: Bool = {
+            if case .panel(.settings) = windowState.selection { return true }
+            return false
+        }()
+        let sidebarWidth: CGFloat = settingsOpen ? 0 : (sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        let hstackSpacing: CGFloat = 16
+        let outerPadding: CGFloat = 32 // 16 left + 16 right
+        let windowWidth: Double = Double(geometry.size.width) / zoomManager.zoomLevel
+        let availableWidth: Double = windowWidth - Double(sidebarWidth) - Double(hstackSpacing) - Double(outerPadding)
+
+        let preferredMinPanel: Double = 300
+        let preferredMinMain: Double = 300
+        let dividerBudget: Double = Double(VSpacing.xs) + 12
+        let maxPanel: Double = availableWidth - preferredMinMain - dividerBudget
+        let effectiveMinPanel: Double = min(preferredMinPanel, max(maxPanel, 100))
+
+        return Binding<Double>(
+            get: {
+                let raw = sidePanelWidth > 0 ? sidePanelWidth : 400
+                return min(max(raw, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
+            },
+            set: {
+                sidePanelWidth = min(max($0, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
+            }
+        )
+    }
+
     func clampedChatDockWidth(geometry: GeometryProxy) -> Binding<Double> {
         let settingsOpen: Bool = {
             if case .panel(.settings) = windowState.selection { return true }
@@ -225,7 +256,7 @@ extension MainWindowView {
         switch windowState.selection {
         case .thread:
             // Show chat for this thread (threadManager.activeViewModel is synced)
-            defaultChatLayout
+            defaultChatLayout(geometry: geometry)
         case .app(let appId), .appEditing(let appId, _):
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
@@ -281,7 +312,7 @@ extension MainWindowView {
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
-                    panelWidth: $sidePanelWidth,
+                    panelWidth: clampedSidePanelWidth(geometry: geometry),
                     showPanel: documentManager.hasActiveDocument,
                     main: { slotView(for: config.center.content) },
                     panel: {
@@ -319,19 +350,19 @@ extension MainWindowView {
             }
         case nil:
             // Default: show chat for active thread
-            defaultChatLayout
+            defaultChatLayout(geometry: geometry)
         }
     }
 
     /// The default chat layout used when showing a thread or no specific selection.
     @ViewBuilder
-    var defaultChatLayout: some View {
+    func defaultChatLayout(geometry: GeometryProxy) -> some View {
         let config = windowState.layoutConfig
         let showConfigPanel = config.right.visible && config.right.content != .empty
         let showSubagentPanel = windowState.selectedSubagentId != nil && threadManager.activeViewModel != nil
 
         VSplitView(
-            panelWidth: $sidePanelWidth,
+            panelWidth: clampedSidePanelWidth(geometry: geometry),
             showPanel: showConfigPanel || showSubagentPanel,
             mainBackground: VColor.surfaceOverlay,
             mainCornerRadius: 0,

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -22,7 +22,7 @@ public struct VSplitView<Main: View, Panel: View>: View {
             HStack(spacing: 0) {
                 // Main content - styled as panel
                 main
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(minWidth: 300, maxWidth: .infinity, maxHeight: .infinity)
                     .background(mainBackground ?? VColor.surfaceBase)
                     .clipShape(RoundedRectangle(cornerRadius: mainCornerRadius ?? VRadius.lg))
                     .padding([.bottom, .leading], VSpacing.xs)


### PR DESCRIPTION
## Summary
Fix two compounding UI bugs where chat text disappears when a document or generated content panel opens alongside an expanded sidebar. The sidebar wasn't auto-collapsing for panel selections, and the document editor panel width wasn't clamped, causing the chat area to compress to near-zero width.

## Changes
- Extend sidebar auto-collapse to fire for `.panel(...)` selections (excluding `.settings` which has its own mechanism)
- Add `clampedSidePanelWidth(geometry:)` for document editor and default chat layout panel widths
- Add `minWidth: 300` safety net to `VSplitView` main pane

## Milestone PRs (merged into feature branch)
- #16767: fix: prevent chat text from disappearing when panels open (#16766)

## Project issue
Closes #16765

## Test plan
- [ ] Open a document in the side panel — sidebar should auto-collapse and chat text should remain visible
- [ ] Open generated content panel — same behavior
- [ ] Open settings — sidebar should NOT collapse (settings handles this differently)
- [ ] Resize panel divider — main pane should not go below 300px
- [ ] Close panel — layout should return to normal

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
