### PR TITLE
fix: complete private conversation cleanup with session teardown and memory artifact removal

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -180,12 +180,38 @@ export async function runDaemon(): Promise<void> {
 
     // Purge private (temporary) conversations from the previous session.
     // These are ephemeral by design and should not survive daemon restarts.
-    const purgedCount = purgePrivateConversations();
+    const { count: purgedCount, deletedMemory } = purgePrivateConversations();
     if (purgedCount > 0) {
       log.info(
         { purgedCount },
         `Purged ${purgedCount} private conversation(s) from previous session`,
       );
+      // Qdrant may not be ready at startup, so enqueue vector cleanup jobs
+      // rather than attempting direct deletion.
+      for (const segId of deletedMemory.segmentIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "segment",
+          targetId: segId,
+        });
+      }
+      for (const itemId of deletedMemory.orphanedItemIds) {
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "item",
+          targetId: itemId,
+        });
+      }
+      if (
+        deletedMemory.segmentIds.length > 0 ||
+        deletedMemory.orphanedItemIds.length > 0
+      ) {
+        log.info(
+          {
+            segments: deletedMemory.segmentIds.length,
+            orphanedItems: deletedMemory.orphanedItemIds.length,
+          },
+          "Enqueued Qdrant vector cleanup jobs for purged private conversations",
+        );
+      }
     }
 
     // Expire pending interaction-bound canonical guardian requests left over
@@ -541,6 +567,7 @@ export async function runDaemon(): Promise<void> {
         clearAllSessions: () => clearAllSessions(server.getHandlerContext()),
         cancelGeneration: (sessionId) =>
           cancelGeneration(sessionId, server.getHandlerContext()),
+        destroySession: (sessionId) => server.destroySession(sessionId),
         undoLastMessage: (sessionId) =>
           undoLastMessage(sessionId, server.getHandlerContext()),
         regenerateResponse: (sessionId) => {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -501,6 +501,20 @@ export class DaemonServer {
     return count;
   }
 
+  /**
+   * Abort and dispose a single in-memory session, removing it from the session
+   * map. No-op if no session exists for the given ID.
+   */
+  destroySession(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    this.evictor.remove(sessionId);
+    getSubagentManager().abortAllForParent(sessionId);
+    session.dispose();
+    this.sessions.delete(sessionId);
+    this.sessionOptions.delete(sessionId);
+  }
+
   private evictSessionsForReload(): void {
     const subagentManager = getSubagentManager();
     for (const [id, session] of this.sessions) {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -254,30 +254,116 @@ export function getConversationMemoryScopeId(conversationId: string): string {
 }
 
 /**
- * Delete a conversation and all its messages.
- * Used for ephemeral conversations (e.g. secret-redirect placeholders)
- * that should not persist in session history.
+ * Delete a conversation and all its messages, cleaning up orphaned memory
+ * artifacts (items, embeddings). Returns segment and orphaned item IDs so
+ * callers can clean up the corresponding Qdrant vector entries.
  */
-export function deleteConversation(id: string): void {
+export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
+  const result: DeletedMemoryIds = { segmentIds: [], orphanedItemIds: [] };
+
   db.transaction((tx) => {
-    tx.delete(llmRequestLogs)
-      .where(eq(llmRequestLogs.conversationId, id))
-      .run();
-    tx.delete(toolInvocations)
-      .where(eq(toolInvocations.conversationId, id))
-      .run();
-    tx.delete(messages).where(eq(messages.conversationId, id)).run();
+    // Collect all message IDs for this conversation.
+    const messageRows = tx
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.conversationId, id))
+      .all();
+    const messageIds = messageRows.map((r) => r.id);
+
+    if (messageIds.length > 0) {
+      // Collect memory segment IDs linked to these messages before cascade.
+      const linkedSegments = tx
+        .select({ id: memorySegments.id })
+        .from(memorySegments)
+        .where(inArray(memorySegments.messageId, messageIds))
+        .all();
+      result.segmentIds = linkedSegments.map((r) => r.id);
+
+      // Collect memory item IDs linked to these messages before cascade.
+      const linkedItems = tx
+        .select({ memoryItemId: memoryItemSources.memoryItemId })
+        .from(memoryItemSources)
+        .where(inArray(memoryItemSources.messageId, messageIds))
+        .all();
+      const candidateItemIds = [
+        ...new Set(linkedItems.map((r) => r.memoryItemId)),
+      ];
+
+      // Delete non-cascading tables first.
+      tx.delete(llmRequestLogs)
+        .where(eq(llmRequestLogs.conversationId, id))
+        .run();
+      tx.delete(toolInvocations)
+        .where(eq(toolInvocations.conversationId, id))
+        .run();
+      // Cascade deletes memory_segments, memory_item_sources, message_attachments.
+      tx.delete(messages).where(eq(messages.conversationId, id)).run();
+
+      // Clean up segment embeddings.
+      if (result.segmentIds.length > 0) {
+        tx.delete(memoryEmbeddings)
+          .where(
+            and(
+              eq(memoryEmbeddings.targetType, "segment"),
+              inArray(memoryEmbeddings.targetId, result.segmentIds),
+            ),
+          )
+          .run();
+      }
+
+      // Clean up orphaned memory items whose only sources were in this conversation.
+      if (candidateItemIds.length > 0) {
+        const surviving = tx
+          .select({ memoryItemId: memoryItemSources.memoryItemId })
+          .from(memoryItemSources)
+          .where(inArray(memoryItemSources.memoryItemId, candidateItemIds))
+          .all();
+        const survivingIds = new Set(surviving.map((r) => r.memoryItemId));
+        const orphanedIds = candidateItemIds.filter(
+          (itemId) => !survivingIds.has(itemId),
+        );
+        result.orphanedItemIds = orphanedIds;
+
+        if (orphanedIds.length > 0) {
+          tx.delete(memoryEmbeddings)
+            .where(
+              and(
+                eq(memoryEmbeddings.targetType, "item"),
+                inArray(memoryEmbeddings.targetId, orphanedIds),
+              ),
+            )
+            .run();
+          tx.delete(memoryItems)
+            .where(inArray(memoryItems.id, orphanedIds))
+            .run();
+        }
+      }
+    } else {
+      // No messages — just clean up non-message tables.
+      tx.delete(llmRequestLogs)
+        .where(eq(llmRequestLogs.conversationId, id))
+        .run();
+      tx.delete(toolInvocations)
+        .where(eq(toolInvocations.conversationId, id))
+        .run();
+    }
+
     tx.delete(conversations).where(eq(conversations.id, id)).run();
   });
+
+  return result;
 }
 
 /**
  * Delete all private (temporary) conversations and their associated data.
  * Called at daemon startup to clean up ephemeral threads from previous sessions.
- * Returns the number of conversations purged.
+ * Returns the count and aggregated deleted memory IDs for Qdrant cleanup.
  */
-export function purgePrivateConversations(): number {
+export function purgePrivateConversations(): {
+  count: number;
+  deletedMemory: DeletedMemoryIds;
+} {
   const db = getDb();
   const privateConvs = db
     .select({ id: conversations.id })
@@ -285,13 +371,26 @@ export function purgePrivateConversations(): number {
     .where(eq(conversations.threadType, "private"))
     .all();
 
-  if (privateConvs.length === 0) return 0;
-
-  for (const conv of privateConvs) {
-    deleteConversation(conv.id);
+  if (privateConvs.length === 0) {
+    return { count: 0, deletedMemory: { segmentIds: [], orphanedItemIds: [] } };
   }
 
-  return privateConvs.length;
+  const allSegmentIds: string[] = [];
+  const allOrphanedItemIds: string[] = [];
+
+  for (const conv of privateConvs) {
+    const deleted = deleteConversation(conv.id);
+    allSegmentIds.push(...deleted.segmentIds);
+    allOrphanedItemIds.push(...deleted.orphanedItemIds);
+  }
+
+  return {
+    count: privateConvs.length,
+    deletedMemory: {
+      segmentIds: allSegmentIds,
+      orphanedItemIds: allOrphanedItemIds,
+    },
+  };
 }
 
 export async function addMessage(

--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -11,6 +11,7 @@
  * POST   /v1/sessions/reorder             — reorder / pin sessions
  */
 
+import { cleanupQdrantVectors } from "../../daemon/session-history.js";
 import {
   batchSetDisplayOrders,
   deleteConversation,
@@ -36,6 +37,8 @@ export interface SessionManagementDeps {
   renameSession: (sessionId: string, name: string) => boolean;
   clearAllSessions: () => number;
   cancelGeneration: (sessionId: string) => boolean;
+  /** Abort and dispose an active in-memory session (if any) before deletion. */
+  destroySession: (sessionId: string) => void;
   undoLastMessage: (
     sessionId: string,
   ) => Promise<{ removedCount: number } | null>;
@@ -115,7 +118,7 @@ export function sessionManagementRouteDefinitions(
       endpoint: "conversations/:id",
       method: "DELETE",
       policyKey: "conversations",
-      handler: ({ params }) => {
+      handler: async ({ params }) => {
         const conversation = getConversation(params.id);
         if (!conversation) {
           return httpError(
@@ -124,7 +127,27 @@ export function sessionManagementRouteDefinitions(
             404,
           );
         }
-        deleteConversation(params.id);
+        // Tear down the in-memory session (abort + dispose) before removing
+        // persistence so that a running agent loop doesn't write to a deleted
+        // conversation row, tripping FK constraints.
+        deps.destroySession(params.id);
+        const deleted = deleteConversation(params.id);
+        // Clean up Qdrant vectors for orphaned memory data (fire-and-forget).
+        if (
+          deleted.segmentIds.length > 0 ||
+          deleted.orphanedItemIds.length > 0
+        ) {
+          cleanupQdrantVectors(
+            params.id,
+            deleted.segmentIds,
+            deleted.orphanedItemIds,
+          ).catch((err) => {
+            log.warn(
+              { err, conversationId: params.id },
+              "Qdrant cleanup after conversation delete failed (non-fatal)",
+            );
+          });
+        }
         log.info({ conversationId: params.id }, "Deleted conversation");
         return new Response(null, { status: 204 });
       },


### PR DESCRIPTION
## Summary
- DELETE /v1/conversations/:id now aborts and disposes any active in-memory session before deleting the DB row, preventing FK constraint violations when a turn is still running
- deleteConversation now detects and removes orphaned memoryItems and memoryEmbeddings after cascade delete, matching the pattern from deleteMessageById
- purgePrivateConversations returns deleted memory IDs; lifecycle.ts enqueues Qdrant vector cleanup jobs at startup (deferred since Qdrant may not be ready)

Addresses feedback from PR #16761.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
