### PR TITLE
fix: remove maxWidth on workspace sidebar for free resizing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -71,7 +71,7 @@ struct WorkspacePanel: View {
     var body: some View {
         HSplitView {
             WorkspaceTreeSidebar(state: state, daemonClient: daemonClient, onToggleHiddenFiles: applyHiddenFilesToggle)
-                .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
+                .frame(minWidth: 200, idealWidth: 250)
             WorkspaceFileViewer(state: state, daemonClient: daemonClient)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }


### PR DESCRIPTION
## Summary
- Removed the `maxWidth: 300` constraint on the workspace file browser sidebar so it can be resized arbitrarily wide via the HSplitView divider

## Original prompt
This should be arbitrarily resizable left/right, don't give it a small max width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
