### PR TITLE
fix: add rounded corners to workspace file browser sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -288,6 +288,7 @@ private struct WorkspaceTreeSidebar: View {
             return true
         }
         .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .alert("New File", isPresented: $state.showingNewFileAlert) {
             TextField("Filename", text: $state.newItemName)
             Button("Cancel", role: .cancel) {}


### PR DESCRIPTION
## Summary
- Added `.clipShape(RoundedRectangle(cornerRadius: VRadius.lg))` to `WorkspaceTreeSidebar` to match the rounded corner style used by other panels (e.g. `IdentityPanel` sidebar)

## Original prompt
Give this rounded corners like the other UI elements in our app. Make sure to match the style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
