### PR TITLE
fix: narrow default workspace file browser sidebar width

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -71,7 +71,7 @@ struct WorkspacePanel: View {
     var body: some View {
         HSplitView {
             WorkspaceTreeSidebar(state: state, daemonClient: daemonClient, onToggleHiddenFiles: applyHiddenFilesToggle)
-                .frame(minWidth: 200, idealWidth: 250)
+                .frame(minWidth: 140, idealWidth: 180)
             WorkspaceFileViewer(state: state, daemonClient: daemonClient)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }


### PR DESCRIPTION
## Summary
- Reduced workspace file browser sidebar `idealWidth` from 250 → 180 and `minWidth` from 200 → 140
- Gives more horizontal space to the file viewer pane by default

## Original prompt
The default file browser sidebar width should be much narrower

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
