### PR TITLE
fix: remove unnecessary nonisolated(unsafe) from MetricKitManager constants

### DIFF
--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -59,12 +59,12 @@ import os
     /// but workspace files included in log archives can exceed that. Sentry's
     /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
     /// provides sufficient headroom.
-    nonisolated(unsafe) static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
+    static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
     /// Default DSN for the macOS app Sentry project.
-    nonisolated(unsafe) static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
+    static let macosDSN = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
     /// DSN for the assistant/brain Sentry project.
-    nonisolated(unsafe) static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+    static let brainDSN = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
 
     /// Sends a manual problem report unconditionally, even when the user has
     /// opted out of automatic crash reporting.  The SDK is temporarily started


### PR DESCRIPTION
## Summary

- Removed `nonisolated(unsafe)` qualifier from three `static let` constants in `MetricKitManager.swift` (`sentryMaxAttachmentSize`, `macosDSN`, `brainDSN`) — the qualifier is unnecessary for constants with `Sendable` types (`UInt`, `String`) and produces compiler warnings.

## Original prompt

Fix Swift compiler warnings: `'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
