### PR TITLE
fix: allow workspace sidebar to resize freely while defaulting narrow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -71,9 +71,10 @@ struct WorkspacePanel: View {
     var body: some View {
         HSplitView {
             WorkspaceTreeSidebar(state: state, daemonClient: daemonClient, onToggleHiddenFiles: applyHiddenFilesToggle)
-                .frame(minWidth: 140, idealWidth: 180, maxWidth: 240)
+                .frame(minWidth: 140, idealWidth: 180)
             WorkspaceFileViewer(state: state, daemonClient: daemonClient)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .layoutPriority(1)
         }
         .task { await loadRoot() }
         .onDisappear {


### PR DESCRIPTION
## Summary
- Removed `maxWidth: 240` from the sidebar frame so it can be resized to any width
- Added `layoutPriority(1)` to the file viewer so `HSplitView` allocates space to the content area first, keeping the sidebar at its `idealWidth` (180pt) by default

## Original prompt
No I want to be able to resize it to be larger, I just don't want the default to be that large

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
