### PR TITLE
fix: remove black divider line from workspace file browser sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -67,14 +67,42 @@ final class WorkspaceBrowserState {
 struct WorkspacePanel: View {
     let daemonClient: DaemonClient
     @State private var state = WorkspaceBrowserState()
+    @State private var sidebarWidth: CGFloat = 300
+    @State private var dragStartWidth: CGFloat?
+
+    private let minSidebarWidth: CGFloat = 140
+    private let maxSidebarWidth: CGFloat = 500
 
     var body: some View {
-        HSplitView {
+        HStack(spacing: 0) {
             WorkspaceTreeSidebar(state: state, daemonClient: daemonClient, onToggleHiddenFiles: applyHiddenFilesToggle)
-                .frame(minWidth: 140, idealWidth: 300)
+                .frame(width: sidebarWidth)
+
+            // Invisible resize handle
+            Color.clear
+                .frame(width: 6)
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    if hovering {
+                        NSCursor.resizeLeftRight.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            let start = dragStartWidth ?? sidebarWidth
+                            if dragStartWidth == nil { dragStartWidth = sidebarWidth }
+                            sidebarWidth = min(max(start + value.translation.width, minSidebarWidth), maxSidebarWidth)
+                        }
+                        .onEnded { _ in
+                            dragStartWidth = nil
+                        }
+                )
+
             WorkspaceFileViewer(state: state, daemonClient: daemonClient)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .layoutPriority(1)
         }
         .task { await loadRoot() }
         .onDisappear {


### PR DESCRIPTION
## Summary
- Replace native `HSplitView` with `HStack` + invisible 6pt drag handle to remove the black divider line on the right edge of the workspace file browser sidebar
- Preserve drag-to-resize with proper cursor feedback (`resizeLeftRight`) and min/max width constraints (140–500pt)

## Original prompt
What is this weird black line on the right? Can we get rid of it without remove resize functionality?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
