### PR TITLE
fix: show full file names in workspace sidebar with horizontal scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -285,7 +285,7 @@ private struct WorkspaceTreeSidebar: View {
                     Spacer()
                 }
             } else {
-                ScrollView {
+                ScrollView([.vertical, .horizontal]) {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         if let rootEntries = state.directoryCache[""] {
                             ForEach(rootEntries) { entry in
@@ -449,11 +449,8 @@ private struct WorkspaceTreeRow: View {
                         Text(entry.name)
                             .font(VFont.body)
                             .foregroundColor(VColor.contentDefault)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                            .fixedSize(horizontal: true, vertical: false)
                     }
-
-                    Spacer()
                 }
                 .padding(.leading, CGFloat(depth) * 16 + VSpacing.sm)
                 .padding(.trailing, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Enabled horizontal scrolling on the sidebar's `ScrollView` so long file names can be scrolled into view
- Removed `.lineLimit(1)` and `.truncationMode(.middle)` that shortened names like "BOOTSTRAP.md" to "BOO...P.md"
- Used `.fixedSize(horizontal: true, vertical: false)` so text renders at its natural width instead of being compressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
