### PR TITLE
fix: complete Things to Library rename in iOS and macOS views

### DIFF
--- a/clients/ios/Views/ContentView.swift
+++ b/clients/ios/Views/ContentView.swift
@@ -200,7 +200,7 @@ struct ContentView: View {
                 .id(ObjectIdentifier(clientProvider.client as AnyObject))
                 .tag(Tab.things)
                 .tabItem {
-                    Label { Text("Things") } icon: { VIconView(.layoutGrid, size: 12) }
+                    Label { Text("Library") } icon: { VIconView(.layoutGrid, size: 12) }
                 }
 
             IdentityView(onConnectTapped: navigateToConnectSettings)

--- a/clients/ios/Views/Things/ThingsTabView.swift
+++ b/clients/ios/Views/Things/ThingsTabView.swift
@@ -46,7 +46,7 @@ struct ThingsDisconnectedView: View {
                 VIconView(.layoutGrid, size: 48)
                     .foregroundColor(VColor.contentTertiary)
                     .accessibilityHidden(true)
-                Text("Things Require Connection")
+                Text("Library Requires Connection")
                     .font(VFont.title)
                     .foregroundColor(VColor.contentDefault)
                 Text("Connect to your Assistant to browse apps, shared apps, and documents.")

--- a/clients/ios/Views/Things/ThingsView.swift
+++ b/clients/ios/Views/Things/ThingsView.swift
@@ -26,7 +26,7 @@ struct ThingsView: View {
                 .pickerStyle(.segmented)
                 .padding(.horizontal, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
-                .accessibilityLabel("Things section picker")
+                .accessibilityLabel("Library section picker")
 
                 switch selectedSegment {
                 case .myApps:

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -140,7 +140,7 @@ struct AppsGridView: View {
                 .foregroundColor(VColor.contentTertiary)
 
             VStack(spacing: VSpacing.sm) {
-                Text("No things yet")
+                Text("Your library is empty")
                     .font(VFont.bodyBold)
                     .foregroundColor(VColor.contentSecondary)
 


### PR DESCRIPTION
Addresses review feedback from #16768. Updates 4 missed rename locations: iOS tab bar label, disconnected state heading, accessibility label, and macOS empty state text.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
