### PR TITLE
fix: drain tar stdout and stderr concurrently in LogExporter validation

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -493,11 +493,26 @@ enum LogExporter {
                 return
             }
 
-            // Read pipe data eagerly BEFORE waiting for process exit.
-            // If reads happen inside terminationHandler, tar blocks on a full
-            // pipe buffer (~64 KB) and never exits — deadlocking the export.
-            let stdoutData = pipe.fileHandleForReading.readDataToEndOfFile()
-            let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            // Drain both pipes concurrently to prevent deadlock.
+            // Sequential reads can block if tar fills one pipe buffer (~64 KB)
+            // while we're waiting on the other.
+            var stdoutData = Data()
+            var stderrData = Data()
+            let group = DispatchGroup()
+
+            group.enter()
+            DispatchQueue.global(qos: .utility).async {
+                stdoutData = pipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            group.enter()
+            DispatchQueue.global(qos: .utility).async {
+                stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            group.wait()
 
             process.waitUntilExit()
 


### PR DESCRIPTION
Addresses review feedback from #16771. Changes sequential readDataToEndOfFile() calls to concurrent draining using DispatchGroup to prevent deadlock when tar produces large stderr output that fills the pipe buffer while stdout is still being read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
