### PR TITLE
fix: isolate buildSystemPrompt mock assertion in btw-routes test

### DIFF
--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -304,6 +304,8 @@ describe("POST /v1/btw", () => {
   // -- Provider receives correct args --
 
   test("provider receives session messages + btw user message, system prompt, tools, and tool_choice none", async () => {
+    mockBuildSystemPrompt.mockClear();
+
     const provider = makeMockProvider();
     const session = makeMockSession(provider);
     const deps = makeSendMessageDeps(session);


### PR DESCRIPTION
Addresses review feedback from #16774. Clears mockBuildSystemPrompt before the test action to ensure the excludeBootstrap assertion only validates the current test's call, not accumulated calls from earlier tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
