### PR TITLE
fix: use explicit hasSystemPromptOverride flag instead of string comparison in BTW handler

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -206,6 +206,7 @@ export class Session {
   /** @internal */ workspaceTopLevelContext: string | null = null;
   /** @internal */ workspaceTopLevelDirty = true;
   public readonly traceEmitter: TraceEmitter;
+  public readonly hasSystemPromptOverride: boolean;
   public memoryPolicy: SessionMemoryPolicy;
   /** @internal */ streamThinking: boolean;
   /** @internal */ turnCount = 0;
@@ -317,6 +318,7 @@ export class Session {
     // When a systemPromptOverride was provided, use it as-is; otherwise
     // rebuild the full prompt each turn (picks up any workspace file changes).
     const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
+    this.hasSystemPromptOverride = hasSystemPromptOverride;
 
     const resolveSystemPromptCallback = (
       _history: import("../providers/types.js").Message[],

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -111,8 +111,7 @@ async function handleBtw(
           // side-chain responses match the active session contract.  Only
           // fall back to a fresh prompt (excluding BOOTSTRAP.md) for
           // default sessions where no override was provided.
-          const hasOverride = session.systemPrompt !== buildSystemPrompt();
-          const systemPrompt = hasOverride
+          const systemPrompt = session.hasSystemPromptOverride
             ? session.systemPrompt
             : buildSystemPrompt({ excludeBootstrap: true });
 


### PR DESCRIPTION
Addresses review feedback from #16772. Replaces unreliable buildSystemPrompt() string comparison with an explicit boolean flag on Session, preventing false-positive override detection when workspace files change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
