### PR TITLE
fix: balance resize cursor stack on view disappear in WorkspacePanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -69,6 +69,7 @@ struct WorkspacePanel: View {
     @State private var state = WorkspaceBrowserState()
     @State private var sidebarWidth: CGFloat = 300
     @State private var dragStartWidth: CGFloat?
+    @State private var didPushResizeCursor = false
 
     private let minSidebarWidth: CGFloat = 140
     private let maxSidebarWidth: CGFloat = 500
@@ -87,8 +88,16 @@ struct WorkspacePanel: View {
                 .onHover { hovering in
                     if hovering {
                         NSCursor.resizeLeftRight.push()
-                    } else {
+                        didPushResizeCursor = true
+                    } else if didPushResizeCursor {
                         NSCursor.pop()
+                        didPushResizeCursor = false
+                    }
+                }
+                .onDisappear {
+                    if didPushResizeCursor {
+                        NSCursor.pop()
+                        didPushResizeCursor = false
                     }
                 }
                 .gesture(


### PR DESCRIPTION
Addresses review feedback from #16786. Tracks cursor push state and adds onDisappear cleanup to prevent stuck resize cursor when the view is removed while hovering, following the PointerCursorModifier pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
