### PR TITLE
fix: eliminate mutable var captures in concurrent pipe draining for strict concurrency

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -496,8 +496,8 @@ enum LogExporter {
             // Drain both pipes concurrently to prevent deadlock.
             // Sequential reads can block if tar fills one pipe buffer (~64 KB)
             // while we're waiting on the other.
-            var stdoutData = Data()
-            var stderrData = Data()
+            nonisolated(unsafe) var stdoutData = Data()
+            nonisolated(unsafe) var stderrData = Data()
             let group = DispatchGroup()
 
             group.enter()


### PR DESCRIPTION
Addresses Devin review feedback from PR #16790. Refactors the concurrent stdout/stderr pipe draining in LogExporter to avoid capturing mutable vars in @Sendable DispatchQueue closures, which would be diagnosed under Swift 6 strict concurrency. Uses `nonisolated(unsafe)` annotations consistent with the existing pattern in the codebase (e.g. ScreenRecorder.swift).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
