### PR TITLE
fix: correct OAuth provider configs for token exchange and callback URIs

### DIFF
--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -1,14 +1,39 @@
 import { type Command } from "commander";
 
+import { loadConfig } from "../../../config/loader.js";
+import { getOAuthCallbackUrl } from "../../../inbound/public-ingress-urls.js";
 import {
   getProvider,
   listProviders,
   registerProvider,
 } from "../../../oauth/oauth-store.js";
+import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
 const log = getCliLogger("cli");
+
+const LOOPBACK_CALLBACK_PATH = "/oauth/callback";
+
+/** Resolve the redirect URI for a provider based on its callback transport. */
+function resolveRedirectUri(
+  providerKey: string,
+  callbackTransport: string | null,
+): string | null {
+  const transport = callbackTransport ?? "loopback";
+  if (transport === "loopback") {
+    const behavior = getProviderBehavior(providerKey);
+    const port = behavior?.loopbackPort;
+    if (!port) return null;
+    return `http://localhost:${port}${LOOPBACK_CALLBACK_PATH}`;
+  }
+  // Gateway transport — resolve from public ingress config
+  try {
+    return getOAuthCallbackUrl(loadConfig());
+  } catch {
+    return null;
+  }
+}
 
 /** Parse stored JSON string fields into their native types. */
 function parseProviderRow(row: ReturnType<typeof getProvider>) {
@@ -18,6 +43,7 @@ function parseProviderRow(row: ReturnType<typeof getProvider>) {
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
     extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
+    redirectUri: resolveRedirectUri(row.providerKey, row.callbackTransport),
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   };

--- a/assistant/src/oauth/provider-behaviors.ts
+++ b/assistant/src/oauth/provider-behaviors.ts
@@ -192,6 +192,7 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
   },
   "integration:github": {
     service: "integration:github",
+    loopbackPort: 17332,
     injectionTemplates: [
       {
         hostPattern: "api.github.com",
@@ -270,6 +271,7 @@ const PROVIDER_BEHAVIORS: Record<string, OAuthProviderBehavior> = {
 
   "integration:spotify": {
     service: "integration:spotify",
+    loopbackPort: 17333,
     injectionTemplates: [
       {
         hostPattern: "api.spotify.com",

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -93,7 +93,6 @@ const PROVIDER_SEED_DATA: Record<
         "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write",
     },
     callbackTransport: "loopback",
-
   },
 
   "integration:notion": {
@@ -111,7 +110,6 @@ const PROVIDER_SEED_DATA: Record<
     extraParams: { owner: "user" },
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "loopback",
-
   },
 
   "integration:twitter": {
@@ -169,7 +167,6 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { prompt: "consent" },
     callbackTransport: "loopback",
-
   },
 
   "integration:spotify": {
@@ -194,6 +191,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
+    tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "loopback",
   },
 
@@ -210,7 +208,6 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: ["data:delete"],
     },
     callbackTransport: "loopback",
-
   },
 
   "integration:discord": {
@@ -231,7 +228,6 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: [],
     },
     callbackTransport: "loopback",
-
   },
 
   "integration:dropbox": {
@@ -253,7 +249,6 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { token_access_type: "offline" },
     callbackTransport: "loopback",
-
   },
 
   "integration:asana": {
@@ -269,7 +264,6 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: [],
     },
     callbackTransport: "loopback",
-
   },
 
   "integration:airtable": {
@@ -288,9 +282,8 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    tokenEndpointAuthMethod: "client_secret_post",
+    tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "loopback",
-
   },
 
   "integration:hubspot": {
@@ -315,7 +308,6 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: [],
     },
     callbackTransport: "loopback",
-
   },
 
   "integration:figma": {
@@ -330,8 +322,8 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
+    tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "loopback",
-
   },
 
   // Manual-token providers: these don't use OAuth2 flows but need provider

--- a/skills/github-oauth-setup/SKILL.md
+++ b/skills/github-oauth-setup/SKILL.md
@@ -20,7 +20,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 - **Provider key:** `integration:github`
 - **Dashboard:** `https://github.com/settings/developers`
 - **Ping URL:** `https://api.github.com/user`
-- **Callback transport:** Loopback (port 17322)
+- **Callback transport:** Loopback
 - **Requires secret:** Yes (token endpoint needs both client ID and app secret)
 
 ## GitHub-Specific Flow
@@ -58,15 +58,14 @@ After the user clicks:
 Resolve the callback URL:
 
 ```
-credential_store describe:
-  service: "integration:github"
+bash:
+  command: assistant oauth providers get integration:github --json
 ```
 
-Use the `redirectUri` from the response. If it says **"automatic"** or the callback transport is loopback with no ingress requirement, tell the user:
+Use the `redirectUri` from the JSON response:
 
-> For the **Authorization callback URL**, enter: `http://localhost:17322/oauth/callback`
-
-If `redirectUri` mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
+- If it is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the **Authorization callback URL**.
+- If it is `null`, stop and help the user configure public ingress first.
 
 Then:
 

--- a/skills/spotify-oauth-setup/SKILL.md
+++ b/skills/spotify-oauth-setup/SKILL.md
@@ -20,7 +20,7 @@ This skill follows the **Collaborative Guided Flow** pattern from the included `
 - **Provider key:** `integration:spotify`
 - **Dashboard:** `https://developer.spotify.com/dashboard`
 - **Ping URL:** `https://api.spotify.com/v1/me`
-- **Callback transport:** Loopback (port 17322)
+- **Callback transport:** Loopback
 - **Requires secret:** Yes (token endpoint needs both client ID and app secret)
 
 ## Spotify-Specific Flow
@@ -58,13 +58,12 @@ After the user clicks:
 Before providing the redirect URI, resolve it:
 
 ```
-credential_store describe:
-  service: "integration:spotify"
+bash:
+  command: assistant oauth providers get integration:spotify --json
 ```
 
-- If the redirect URI is **"automatic"** or the callback transport is loopback with no ingress requirement, tell the user to enter `http://localhost:17322/callback` as the redirect URI.
-- If the redirect URI mentions `ingress.publicBaseUrl` or says "not currently configured", stop and help the user configure public ingress first.
-- Otherwise, provide the concrete redirect URI from the credential store.
+- If the `redirectUri` is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the redirect URI.
+- If it is `null`, stop and help the user configure public ingress first.
 
 Then:
 


### PR DESCRIPTION
## Summary
- **Token endpoint auth**: Spotify, Airtable, and Figma all require `client_secret_basic` (HTTP Basic auth) for token exchange. Spotify and Figma were missing the setting entirely (defaulting to POST body), and Airtable was explicitly set to `client_secret_post`. All three are corrected to `client_secret_basic`.
- **Loopback ports**: GitHub and Spotify were missing fixed `loopbackPort` values in provider behaviors, causing random OS-assigned ports on each OAuth flow — making it impossible for users to pre-register a stable redirect URI. Added fixed ports (17332, 17333).
- **Dynamic redirect URIs**: Enriched the `assistant oauth providers list/get` CLI output with a computed `redirectUri` field, and updated the GitHub and Spotify setup skills to read it dynamically instead of hard-coding port numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
