### PR TITLE
feat: add binary POST method to GatewayHTTPClient

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -61,6 +61,24 @@ public enum GatewayHTTPClient {
         return try await execute(request)
     }
 
+    /// Performs an authenticated POST with a binary body (`application/octet-stream`).
+    ///
+    /// Use this instead of `post(path:body:timeout:)` when the payload is raw
+    /// binary data (e.g. `.vbundle` archives) rather than JSON.
+    ///
+    /// - Parameters:
+    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{id}/transfer"`).
+    ///   - body: Raw binary data to upload.
+    ///   - timeout: Request timeout in seconds. Defaults to 120 to accommodate large bundle uploads.
+    /// - Returns: A `Response` with the raw data and HTTP status code.
+    /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
+    public static func postBinary(path: String, body: Data, timeout: TimeInterval = 120) async throws -> Response {
+        var request = try buildRequest(path: path, method: "POST", timeout: timeout)
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        return try await execute(request)
+    }
+
     /// Performs an authenticated DELETE request against the gateway.
     ///
     /// - Parameters:


### PR DESCRIPTION
## Summary
- Add `postBinary(path:body:timeout:)` to `GatewayHTTPClient` for uploading raw binary data with `application/octet-stream` content type
- Longer default timeout (120s) to accommodate large `.vbundle` archive uploads
- Existing `post()` method unchanged

Part of plan: asst-transfer-local-managed.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
