### PR TITLE
Style workspace file viewer with card container

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -654,6 +654,16 @@ private struct WorkspaceFileViewer: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let detail = state.selectedFileDetail {
                 fileContent(detail)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                    .background(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(VColor.surfaceBase)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .strokeBorder(VColor.borderBase, lineWidth: 1)
+                    )
+                    .padding(VSpacing.md)
             } else {
                 emptyState
             }


### PR DESCRIPTION
## Summary
- Wrap the file content viewer in WorkspacePanel with a rounded rectangle card style
- Apply `VColor.surfaceBase` background, `VColor.borderBase` stroke border, and `VSpacing.md` padding
- Uses design system tokens (`VRadius.md`, `VColor`, `VSpacing`) for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)