### PR TITLE
[shared] Add private `packages/ces-contracts` for assistant-to-CES wire schemas

### DIFF
--- a/packages/ces-contracts/bun.lock
+++ b/packages/ces-contracts/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/ces-contracts",
+      "dependencies": {
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.4",
+        "typescript": "^5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+  }
+}

--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vellumai/ces-contracts",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/ces-contracts/src/__tests__/contracts.test.ts
+++ b/packages/ces-contracts/src/__tests__/contracts.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for @vellumai/ces-contracts
+ *
+ * These tests verify:
+ * 1. The package can be consumed independently (no assistant/ or CES imports).
+ * 2. All exported schemas parse valid payloads and reject invalid ones.
+ * 3. The transport message union correctly discriminates by `type`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CES_PROTOCOL_VERSION,
+  HandshakeAckSchema,
+  HandshakeRequestSchema,
+  RpcEnvelopeSchema,
+  RpcErrorSchema,
+  ToolRequestBaseSchema,
+  ToolResponseBaseSchema,
+  TransportMessageSchema,
+} from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Independence guard — the package must not pull in assistant or CES modules.
+// ---------------------------------------------------------------------------
+
+describe("package independence", () => {
+  test("does not import from assistant/ or credential-executor/", () => {
+    // Reading our own source is the simplest portable check. If someone
+    // accidentally adds an import, this test will catch it.
+    const src = require("node:fs").readFileSync(
+      require("node:path").resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+    expect(src).not.toMatch(/from\s+['"].*assistant\//);
+    expect(src).not.toMatch(/from\s+['"].*credential-executor\//);
+    expect(src).not.toMatch(/require\(['"].*assistant\//);
+    expect(src).not.toMatch(/require\(['"].*credential-executor\//);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Protocol version
+// ---------------------------------------------------------------------------
+
+describe("CES_PROTOCOL_VERSION", () => {
+  test("is a valid semver string", () => {
+    expect(CES_PROTOCOL_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handshake schemas
+// ---------------------------------------------------------------------------
+
+describe("HandshakeRequestSchema", () => {
+  test("parses a valid handshake request", () => {
+    const result = HandshakeRequestSchema.parse({
+      type: "handshake_request",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: "sess-001",
+    });
+    expect(result.type).toBe("handshake_request");
+    expect(result.protocolVersion).toBe(CES_PROTOCOL_VERSION);
+    expect(result.sessionId).toBe("sess-001");
+  });
+
+  test("rejects a request with wrong type literal", () => {
+    expect(() =>
+      HandshakeRequestSchema.parse({
+        type: "handshake_ack",
+        protocolVersion: CES_PROTOCOL_VERSION,
+        sessionId: "sess-001",
+      }),
+    ).toThrow();
+  });
+
+  test("rejects a request missing sessionId", () => {
+    expect(() =>
+      HandshakeRequestSchema.parse({
+        type: "handshake_request",
+        protocolVersion: CES_PROTOCOL_VERSION,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("HandshakeAckSchema", () => {
+  test("parses an accepted ack", () => {
+    const result = HandshakeAckSchema.parse({
+      type: "handshake_ack",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: "sess-001",
+      accepted: true,
+    });
+    expect(result.accepted).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  test("parses a rejected ack with reason", () => {
+    const result = HandshakeAckSchema.parse({
+      type: "handshake_ack",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: "sess-001",
+      accepted: false,
+      reason: "Unsupported protocol version",
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe("Unsupported protocol version");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RPC envelope
+// ---------------------------------------------------------------------------
+
+describe("RpcEnvelopeSchema", () => {
+  test("parses a valid request envelope", () => {
+    const result = RpcEnvelopeSchema.parse({
+      id: "1",
+      kind: "request",
+      method: "tool.execute",
+      payload: { foo: "bar" },
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.kind).toBe("request");
+    expect(result.method).toBe("tool.execute");
+  });
+
+  test("parses a valid response envelope", () => {
+    const result = RpcEnvelopeSchema.parse({
+      id: "1",
+      kind: "response",
+      method: "tool.execute",
+      payload: { success: true },
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.kind).toBe("response");
+  });
+
+  test("rejects an envelope with invalid kind", () => {
+    expect(() =>
+      RpcEnvelopeSchema.parse({
+        id: "1",
+        kind: "notification",
+        method: "tool.execute",
+        payload: null,
+        timestamp: new Date().toISOString(),
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RPC error
+// ---------------------------------------------------------------------------
+
+describe("RpcErrorSchema", () => {
+  test("parses a minimal error", () => {
+    const result = RpcErrorSchema.parse({
+      code: "CREDENTIAL_EXPIRED",
+      message: "The credential has expired",
+    });
+    expect(result.code).toBe("CREDENTIAL_EXPIRED");
+    expect(result.details).toBeUndefined();
+  });
+
+  test("parses an error with details", () => {
+    const result = RpcErrorSchema.parse({
+      code: "TOOL_FAILED",
+      message: "Execution timed out",
+      details: { timeoutMs: 30000 },
+    });
+    expect(result.details).toEqual({ timeoutMs: 30000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool request / response base shapes
+// ---------------------------------------------------------------------------
+
+describe("ToolRequestBaseSchema", () => {
+  test("parses a valid tool request", () => {
+    const result = ToolRequestBaseSchema.parse({
+      toolName: "browser.navigate",
+      credentialHandle: "cred-abc-123",
+      params: { url: "https://example.com" },
+    });
+    expect(result.toolName).toBe("browser.navigate");
+    expect(result.credentialHandle).toBe("cred-abc-123");
+    expect(result.params).toEqual({ url: "https://example.com" });
+  });
+
+  test("rejects a request missing credentialHandle", () => {
+    expect(() =>
+      ToolRequestBaseSchema.parse({
+        toolName: "browser.navigate",
+        params: {},
+      }),
+    ).toThrow();
+  });
+});
+
+describe("ToolResponseBaseSchema", () => {
+  test("parses a successful response", () => {
+    const result = ToolResponseBaseSchema.parse({
+      success: true,
+      result: { html: "<html></html>" },
+    });
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ html: "<html></html>" });
+  });
+
+  test("parses a failed response with error", () => {
+    const result = ToolResponseBaseSchema.parse({
+      success: false,
+      error: {
+        code: "TOOL_FAILED",
+        message: "Network error",
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("TOOL_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport message union
+// ---------------------------------------------------------------------------
+
+describe("TransportMessageSchema", () => {
+  test("discriminates a handshake request", () => {
+    const msg = TransportMessageSchema.parse({
+      type: "handshake_request",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: "sess-001",
+    });
+    expect(msg.type).toBe("handshake_request");
+  });
+
+  test("discriminates a handshake ack", () => {
+    const msg = TransportMessageSchema.parse({
+      type: "handshake_ack",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: "sess-001",
+      accepted: true,
+    });
+    expect(msg.type).toBe("handshake_ack");
+  });
+
+  test("discriminates an rpc envelope", () => {
+    const msg = TransportMessageSchema.parse({
+      type: "rpc",
+      id: "42",
+      kind: "request",
+      method: "tool.execute",
+      payload: {},
+      timestamp: new Date().toISOString(),
+    });
+    expect(msg.type).toBe("rpc");
+  });
+
+  test("rejects an unknown message type", () => {
+    expect(() =>
+      TransportMessageSchema.parse({
+        type: "unknown",
+        data: {},
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -1,0 +1,120 @@
+/**
+ * @vellumai/ces-contracts
+ *
+ * Neutral wire-protocol contracts for communication between the assistant
+ * daemon and the Credential Execution Service (CES). This package is
+ * intentionally free of imports from `assistant/` or any CES implementation
+ * module so that both sides can depend on it without circular references.
+ */
+
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Transport handshake
+// ---------------------------------------------------------------------------
+
+/** Semantic version of the CES wire protocol. */
+export const CES_PROTOCOL_VERSION = "0.1.0" as const;
+
+/**
+ * Sent by the initiator (assistant) when opening a CES transport channel.
+ * The responder (CES) replies with a HandshakeAck.
+ */
+export const HandshakeRequestSchema = z.object({
+  type: z.literal("handshake_request"),
+  protocolVersion: z.string(),
+  /** Opaque session identifier chosen by the initiator. */
+  sessionId: z.string(),
+});
+export type HandshakeRequest = z.infer<typeof HandshakeRequestSchema>;
+
+export const HandshakeAckSchema = z.object({
+  type: z.literal("handshake_ack"),
+  protocolVersion: z.string(),
+  sessionId: z.string(),
+  /** Whether the responder accepted the requested protocol version. */
+  accepted: z.boolean(),
+  /** Human-readable reason when `accepted` is false. */
+  reason: z.string().optional(),
+});
+export type HandshakeAck = z.infer<typeof HandshakeAckSchema>;
+
+// ---------------------------------------------------------------------------
+// RPC envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Every message on the wire is wrapped in an RpcEnvelope so both sides can
+ * demux by `method`, correlate responses via `id`, and distinguish requests
+ * from responses via `kind`.
+ */
+export const RpcEnvelopeSchema = z.object({
+  /** Monotonically increasing per-session request id. */
+  id: z.string(),
+  kind: z.enum(["request", "response"]),
+  method: z.string(),
+  /** JSON-serialisable payload; schema depends on `method`. */
+  payload: z.unknown(),
+  /** ISO-8601 timestamp of when the message was created. */
+  timestamp: z.string(),
+});
+export type RpcEnvelope = z.infer<typeof RpcEnvelopeSchema>;
+
+// ---------------------------------------------------------------------------
+// RPC error
+// ---------------------------------------------------------------------------
+
+export const RpcErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  /** Optional structured details for debugging. */
+  details: z.record(z.string(), z.unknown()).optional(),
+});
+export type RpcError = z.infer<typeof RpcErrorSchema>;
+
+// ---------------------------------------------------------------------------
+// Tool request / response base shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Base shape for a tool execution request sent from the assistant to CES.
+ * Concrete tool requests extend this with tool-specific `params`.
+ */
+export const ToolRequestBaseSchema = z.object({
+  /** The tool identifier as known to both sides. */
+  toolName: z.string(),
+  /** Opaque handle referencing the credential context for this execution. */
+  credentialHandle: z.string(),
+  /** Tool-specific parameters; schema varies per tool. */
+  params: z.record(z.string(), z.unknown()),
+});
+export type ToolRequestBase = z.infer<typeof ToolRequestBaseSchema>;
+
+/**
+ * Base shape for a tool execution response sent from CES back to the
+ * assistant.
+ */
+export const ToolResponseBaseSchema = z.object({
+  /** Whether the tool executed successfully. */
+  success: z.boolean(),
+  /** Tool output when `success` is true. */
+  result: z.unknown().optional(),
+  /** Structured error when `success` is false. */
+  error: RpcErrorSchema.optional(),
+});
+export type ToolResponseBase = z.infer<typeof ToolResponseBaseSchema>;
+
+// ---------------------------------------------------------------------------
+// Aggregate transport message union
+// ---------------------------------------------------------------------------
+
+/**
+ * Union of all top-level message types that can appear on the transport.
+ * Useful for a single discriminated-union parse at the transport layer.
+ */
+export const TransportMessageSchema = z.discriminatedUnion("type", [
+  HandshakeRequestSchema,
+  HandshakeAckSchema,
+  RpcEnvelopeSchema.extend({ type: z.literal("rpc") }),
+]);
+export type TransportMessage = z.infer<typeof TransportMessageSchema>;

--- a/packages/ces-contracts/tsconfig.json
+++ b/packages/ces-contracts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Create `packages/ces-contracts` as a private local package with its own `package.json`, `tsconfig.json`, and `src/index.ts`
- Add initial wire schema surface for RPC envelope framing, transport handshake versioning, and tool request/response base shapes
- Add tests proving the package is independently consumable with no assistant or CES imports

Part of plan: untrusted-agent-credential-arch.md (PR 3 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
