### PR TITLE
[assistant] Add feature flags for CES tools, CES shell lockdown, and managed sidecar mode

### DIFF
--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for CES (Credential Execution Service) feature gates.
+ *
+ * Verifies:
+ * - All CES flags default to disabled (safe dark-launch).
+ * - Each flag can be enabled independently via config overrides.
+ * - Enabling CES flags does not implicitly change unrelated approval
+ *   behavior or existing feature flags.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  CES_GRANT_AUDIT_FLAG_KEY,
+  CES_MANAGED_SIDECAR_FLAG_KEY,
+  CES_SECURE_INSTALL_FLAG_KEY,
+  CES_SHELL_LOCKDOWN_FLAG_KEY,
+  CES_TOOLS_FLAG_KEY,
+  isCesGrantAuditEnabled,
+  isCesManagedSidecarEnabled,
+  isCesSecureInstallEnabled,
+  isCesShellLockdownEnabled,
+  isCesToolsEnabled,
+} from "../credential-execution/feature-gates.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal AssistantConfig with optional feature flag values. */
+function makeConfig(flagOverrides?: Record<string, boolean>): AssistantConfig {
+  return {
+    ...(flagOverrides ? { assistantFeatureFlagValues: flagOverrides } : {}),
+  } as AssistantConfig;
+}
+
+/** All CES flag keys for iteration. */
+const ALL_CES_FLAG_KEYS = [
+  CES_TOOLS_FLAG_KEY,
+  CES_SHELL_LOCKDOWN_FLAG_KEY,
+  CES_SECURE_INSTALL_FLAG_KEY,
+  CES_GRANT_AUDIT_FLAG_KEY,
+  CES_MANAGED_SIDECAR_FLAG_KEY,
+] as const;
+
+/** All CES predicate functions paired with their flag keys. */
+const ALL_CES_PREDICATES = [
+  { name: "isCesToolsEnabled", fn: isCesToolsEnabled, key: CES_TOOLS_FLAG_KEY },
+  {
+    name: "isCesShellLockdownEnabled",
+    fn: isCesShellLockdownEnabled,
+    key: CES_SHELL_LOCKDOWN_FLAG_KEY,
+  },
+  {
+    name: "isCesSecureInstallEnabled",
+    fn: isCesSecureInstallEnabled,
+    key: CES_SECURE_INSTALL_FLAG_KEY,
+  },
+  {
+    name: "isCesGrantAuditEnabled",
+    fn: isCesGrantAuditEnabled,
+    key: CES_GRANT_AUDIT_FLAG_KEY,
+  },
+  {
+    name: "isCesManagedSidecarEnabled",
+    fn: isCesManagedSidecarEnabled,
+    key: CES_MANAGED_SIDECAR_FLAG_KEY,
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Key format validation
+// ---------------------------------------------------------------------------
+
+describe("CES flag key format", () => {
+  for (const key of ALL_CES_FLAG_KEYS) {
+    test(`${key} uses canonical feature_flags.<id>.enabled format`, () => {
+      expect(key).toMatch(/^feature_flags\.[a-z0-9][a-z0-9_-]*\.enabled$/);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Default-safe: all CES flags disabled by default
+// ---------------------------------------------------------------------------
+
+describe("CES flags default safely (all disabled)", () => {
+  const config = makeConfig();
+
+  for (const { name, fn } of ALL_CES_PREDICATES) {
+    test(`${name} returns false with no config overrides`, () => {
+      expect(fn(config)).toBe(false);
+    });
+  }
+
+  for (const key of ALL_CES_FLAG_KEYS) {
+    test(`isAssistantFeatureFlagEnabled('${key}') returns false with no overrides`, () => {
+      expect(isAssistantFeatureFlagEnabled(key, config)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Independent enablement: each flag can be enabled without affecting others
+// ---------------------------------------------------------------------------
+
+describe("CES flags can be enabled independently", () => {
+  for (const { name, fn, key } of ALL_CES_PREDICATES) {
+    test(`enabling ${key} makes ${name} return true`, () => {
+      const config = makeConfig({ [key]: true });
+      expect(fn(config)).toBe(true);
+    });
+
+    test(`enabling ${key} does not enable other CES flags`, () => {
+      const config = makeConfig({ [key]: true });
+      for (const { fn: otherFn, key: otherKey } of ALL_CES_PREDICATES) {
+        if (otherKey === key) continue;
+        expect(otherFn(config)).toBe(false);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Config override: explicit false overrides registry
+// ---------------------------------------------------------------------------
+
+describe("CES flags respect explicit false overrides", () => {
+  for (const { name, fn, key } of ALL_CES_PREDICATES) {
+    test(`${name} returns false when explicitly set to false`, () => {
+      const config = makeConfig({ [key]: false });
+      expect(fn(config)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Non-interference: CES flags do not affect unrelated flags
+// ---------------------------------------------------------------------------
+
+describe("CES flags do not affect unrelated flags", () => {
+  test("enabling all CES flags does not change browser flag (defaultEnabled: true)", () => {
+    const overrides: Record<string, boolean> = {};
+    for (const key of ALL_CES_FLAG_KEYS) {
+      overrides[key] = true;
+    }
+    const config = makeConfig(overrides);
+
+    // browser defaults to true in the registry and should stay true
+    expect(
+      isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
+    ).toBe(true);
+  });
+
+  test("enabling all CES flags does not change hatch-new-assistant flag (defaultEnabled: false)", () => {
+    const overrides: Record<string, boolean> = {};
+    for (const key of ALL_CES_FLAG_KEYS) {
+      overrides[key] = true;
+    }
+    const config = makeConfig(overrides);
+
+    // hatch-new-assistant defaults to false in the registry and should stay false
+    expect(
+      isAssistantFeatureFlagEnabled(
+        "feature_flags.hatch-new-assistant.enabled",
+        config,
+      ),
+    ).toBe(false);
+  });
+
+  test("enabling all CES flags does not change collect-usage-data flag (defaultEnabled: true)", () => {
+    const overrides: Record<string, boolean> = {};
+    for (const key of ALL_CES_FLAG_KEYS) {
+      overrides[key] = true;
+    }
+    const config = makeConfig(overrides);
+
+    expect(
+      isAssistantFeatureFlagEnabled(
+        "feature_flags.collect-usage-data.enabled",
+        config,
+      ),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -1,0 +1,75 @@
+/**
+ * CES (Credential Execution Service) feature gates.
+ *
+ * Single source of truth for whether each CES capability is enabled.
+ * All checks delegate to the unified feature-flag resolver so that
+ * config overrides and registry defaults are respected uniformly.
+ *
+ * Flag keys follow the canonical `feature_flags.<id>.enabled` format
+ * and are declared in `meta/feature-flags/feature-flag-registry.json`.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+// ---------------------------------------------------------------------------
+// Canonical flag keys (must match the registry)
+// ---------------------------------------------------------------------------
+
+/** Gate for CES tool registration (credential-grant, credential-revoke, credential-list). */
+export const CES_TOOLS_FLAG_KEY = "feature_flags.ces-tools.enabled" as const;
+
+/** Gate for untrusted-agent shell lockdown when CES credentials are active. */
+export const CES_SHELL_LOCKDOWN_FLAG_KEY =
+  "feature_flags.ces-shell-lockdown.enabled" as const;
+
+/** Gate for secure tool/command installation via CES. */
+export const CES_SECURE_INSTALL_FLAG_KEY =
+  "feature_flags.ces-secure-install.enabled" as const;
+
+/** Gate for credential grant and audit inspection surfaces. */
+export const CES_GRANT_AUDIT_FLAG_KEY =
+  "feature_flags.ces-grant-audit.enabled" as const;
+
+/** Gate for managed sidecar transport in containerized environments. */
+export const CES_MANAGED_SIDECAR_FLAG_KEY =
+  "feature_flags.ces-managed-sidecar.enabled" as const;
+
+// ---------------------------------------------------------------------------
+// Public API — predicate functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether CES tools should be registered in the agent loop.
+ */
+export function isCesToolsEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(CES_TOOLS_FLAG_KEY, config);
+}
+
+/**
+ * Whether untrusted-agent shell lockdown is active.
+ */
+export function isCesShellLockdownEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(CES_SHELL_LOCKDOWN_FLAG_KEY, config);
+}
+
+/**
+ * Whether secure tool/command installation via CES is enabled.
+ */
+export function isCesSecureInstallEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(CES_SECURE_INSTALL_FLAG_KEY, config);
+}
+
+/**
+ * Whether credential grant and audit inspection surfaces are available.
+ */
+export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(CES_GRANT_AUDIT_FLAG_KEY, config);
+}
+
+/**
+ * Whether managed sidecar transport should be used for CES communication.
+ */
+export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(CES_MANAGED_SIDECAR_FLAG_KEY, config);
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -104,6 +104,46 @@
       "label": "Logfire LLM Observability",
       "description": "Enable Logfire tracing for LLM request/response telemetry when LOGFIRE_TOKEN is set",
       "defaultEnabled": false
+    },
+    {
+      "id": "ces-tools",
+      "scope": "assistant",
+      "key": "feature_flags.ces-tools.enabled",
+      "label": "CES Tool Exposure",
+      "description": "Register Credential Execution Service tools (credential-grant, credential-revoke, credential-list) in the agent loop",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-shell-lockdown",
+      "scope": "assistant",
+      "key": "feature_flags.ces-shell-lockdown.enabled",
+      "label": "CES Shell Lockdown",
+      "description": "Enforce untrusted-agent shell lockdown when CES credentials are active, restricting direct shell access to credentialed services",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-secure-install",
+      "scope": "assistant",
+      "key": "feature_flags.ces-secure-install.enabled",
+      "label": "CES Secure Command Installation",
+      "description": "Enable secure tool/command installation via CES instead of direct shell execution for untrusted agents",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-grant-audit",
+      "scope": "assistant",
+      "key": "feature_flags.ces-grant-audit.enabled",
+      "label": "CES Grant & Audit Inspection",
+      "description": "Surface credential grant and audit inspection endpoints for reviewing active grants and access logs",
+      "defaultEnabled": false
+    },
+    {
+      "id": "ces-managed-sidecar",
+      "scope": "assistant",
+      "key": "feature_flags.ces-managed-sidecar.enabled",
+      "label": "CES Managed Sidecar Transport",
+      "description": "Use managed sidecar transport for CES communication when running in a containerized environment",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add five assistant-scoped feature flags for CES tool exposure, shell lockdown, secure command installation, grant/audit inspection, and managed sidecar transport
- Add feature-gates.ts as single source of truth for CES feature flag checks
- Add tests proving flags default safely and can be enabled independently

Part of plan: untrusted-agent-credential-arch.md (PR 2 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)