### PR TITLE
[shared] Add private `packages/egress-proxy` for controlled command egress

### DIFF
--- a/packages/egress-proxy/bun.lock
+++ b/packages/egress-proxy/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/egress-proxy",
+      "devDependencies": {
+        "@types/bun": "^1.2.4",
+        "typescript": "^5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/packages/egress-proxy/package.json
+++ b/packages/egress-proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@vellumai/egress-proxy",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/egress-proxy/src/__tests__/package-boundary.test.ts
+++ b/packages/egress-proxy/src/__tests__/package-boundary.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Package boundary tests for @vellumai/egress-proxy.
+ *
+ * These tests ensure the egress-proxy package remains isolated from
+ * assistant runtime and CES server implementation modules. If a direct
+ * import of those modules is introduced, these tests will fail.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const PKG_SRC = resolve(import.meta.dir, "..");
+
+/** Recursively collect all .ts source files (excluding tests and declaration files). */
+async function collectSourceFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      files.push(...(await collectSourceFiles(fullPath)));
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".ts") &&
+      !entry.name.endsWith(".d.ts") &&
+      !entry.name.endsWith(".test.ts")
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/** Read file content as UTF-8. */
+async function readSource(filePath: string): Promise<string> {
+  return Bun.file(filePath).text();
+}
+
+/**
+ * Forbidden import patterns — if any source file in packages/egress-proxy
+ * imports from these paths, the package boundary has been violated.
+ */
+const FORBIDDEN_PATTERNS = [
+  // Assistant runtime internals
+  /from\s+['"].*\/assistant\/src\//,
+  /from\s+['"]@vellumai\/assistant/,
+  /import\s*\(.*\/assistant\/src\//,
+  /require\s*\(.*\/assistant\/src\//,
+
+  // CES server modules (future — reserve the boundary now)
+  /from\s+['"].*\/ces\/src\//,
+  /from\s+['"]@vellumai\/ces/,
+  /import\s*\(.*\/ces\/src\//,
+  /require\s*\(.*\/ces\/src\//,
+
+  // Gateway internals
+  /from\s+['"].*\/gateway\/src\//,
+  /from\s+['"]@vellumai\/vellum-gateway/,
+  /import\s*\(.*\/gateway\/src\//,
+  /require\s*\(.*\/gateway\/src\//,
+];
+
+describe("package boundary", () => {
+  test("source files do not import assistant, CES, or gateway modules", async () => {
+    const sourceFiles = await collectSourceFiles(PKG_SRC);
+    expect(sourceFiles.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+
+    for (const filePath of sourceFiles) {
+      const content = await readSource(filePath);
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        const match = content.match(pattern);
+        if (match) {
+          const relativePath = filePath.replace(PKG_SRC + "/", "");
+          violations.push(`${relativePath}: ${match[0]}`);
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(
+        `Package boundary violated — egress-proxy must not import assistant, CES, or gateway modules:\n` +
+          violations.map((v) => `  - ${v}`).join("\n"),
+      );
+    }
+  });
+
+  test("package.json has no dependencies on assistant, CES, or gateway", async () => {
+    const pkgJsonPath = resolve(PKG_SRC, "..", "package.json");
+    const pkgJson = JSON.parse(await Bun.file(pkgJsonPath).text());
+
+    const allDeps = {
+      ...pkgJson.dependencies,
+      ...pkgJson.devDependencies,
+      ...pkgJson.peerDependencies,
+    };
+
+    const forbidden = [
+      "@vellumai/assistant",
+      "@vellumai/ces",
+      "@vellumai/vellum-gateway",
+    ];
+
+    for (const dep of forbidden) {
+      expect(allDeps).not.toHaveProperty(
+        dep,
+        `package.json must not depend on ${dep}`,
+      );
+    }
+  });
+
+  test("exports the expected egress control primitives", async () => {
+    const mod = await import("../index.js");
+
+    // The module should export only types at this stage.
+    // TypeScript types are erased at runtime, so we verify the module
+    // loads without error and doesn't unexpectedly export runtime values
+    // that would indicate coupling to implementation modules.
+    //
+    // The key assertion is that the module exists and is importable
+    // without pulling in assistant/CES/gateway runtime code.
+    expect(mod).toBeDefined();
+  });
+});

--- a/packages/egress-proxy/src/index.ts
+++ b/packages/egress-proxy/src/index.ts
@@ -1,0 +1,179 @@
+/**
+ * @vellumai/egress-proxy — Reusable outbound proxy and request-policy core.
+ *
+ * This package defines the portable primitives shared by the legacy
+ * trusted-session shell proxy flows (assistant/src/outbound-proxy) and the
+ * CES secure command egress enforcement layer. It intentionally has zero
+ * dependencies on assistant runtime or CES server modules.
+ */
+
+// ---------------------------------------------------------------------------
+// Session identity
+// ---------------------------------------------------------------------------
+
+/** Unique identifier for a proxy session (opaque string, typically a UUID). */
+export type ProxySessionId = string;
+
+/** Lifecycle states a proxy session progresses through. */
+export type ProxySessionStatus = "starting" | "active" | "stopping" | "stopped";
+
+// ---------------------------------------------------------------------------
+// Environment injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Environment variables injected into a subprocess so its HTTP(S) traffic
+ * is routed through an egress proxy session.
+ */
+export interface ProxyEnvVars {
+  HTTP_PROXY: string;
+  HTTPS_PROXY: string;
+  NO_PROXY: string;
+  /** Extra CA certs path for Node.js / Bun TLS (proxy CA cert). */
+  NODE_EXTRA_CA_CERTS?: string;
+  /** Combined CA bundle (system roots + proxy CA) for non-Node TLS clients. */
+  SSL_CERT_FILE?: string;
+}
+
+/** How a credential value is injected into an outbound proxied request. */
+export type CredentialInjectionType = "header" | "query";
+
+/**
+ * Describes where and how to inject a credential into proxied requests
+ * matching a specific host pattern.
+ */
+export interface CredentialInjectionTemplate {
+  /** Glob pattern for matching request hosts (e.g. "*.fal.ai"). */
+  hostPattern: string;
+  /** Where the credential value is injected. */
+  injectionType: CredentialInjectionType;
+  /** Header name when injectionType is 'header' (e.g. "Authorization"). */
+  headerName?: string;
+  /** Prefix prepended to the secret value (e.g. "Key ", "Bearer "). */
+  valuePrefix?: string;
+  /** Query parameter name when injectionType is 'query'. */
+  queryParamName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Request target context
+// ---------------------------------------------------------------------------
+
+/**
+ * Context about an outbound request target, used by the policy engine and
+ * approval prompts.
+ */
+export interface RequestTargetContext {
+  hostname: string;
+  port: number | null;
+  path: string;
+  /** The protocol scheme of the original request ('http' or 'https'). */
+  scheme: "http" | "https";
+}
+
+// ---------------------------------------------------------------------------
+// Policy decisions
+// ---------------------------------------------------------------------------
+
+/** A single credential matched — inject it. */
+export interface PolicyDecisionMatched {
+  kind: "matched";
+  credentialId: string;
+  template: CredentialInjectionTemplate;
+}
+
+/** Multiple credentials match — caller must disambiguate. */
+export interface PolicyDecisionAmbiguous {
+  kind: "ambiguous";
+  candidates: Array<{
+    credentialId: string;
+    template: CredentialInjectionTemplate;
+  }>;
+}
+
+/** No credential matches the target host/path. */
+export interface PolicyDecisionMissing {
+  kind: "missing";
+}
+
+/** No credential_ids were requested — pass-through. */
+export interface PolicyDecisionUnauthenticated {
+  kind: "unauthenticated";
+}
+
+/**
+ * The target host matches a known credential template pattern, but the
+ * session has no credential bound for it.
+ */
+export interface PolicyDecisionAskMissingCredential {
+  kind: "ask_missing_credential";
+  target: RequestTargetContext;
+  /** Host patterns from the known registry that matched the target. */
+  matchingPatterns: string[];
+}
+
+/**
+ * The request doesn't match any known credential template and the session
+ * has no credentials.
+ */
+export interface PolicyDecisionAskUnauthenticated {
+  kind: "ask_unauthenticated";
+  target: RequestTargetContext;
+}
+
+/** Union of all possible policy evaluation outcomes. */
+export type PolicyDecision =
+  | PolicyDecisionMatched
+  | PolicyDecisionAmbiguous
+  | PolicyDecisionMissing
+  | PolicyDecisionUnauthenticated
+  | PolicyDecisionAskMissingCredential
+  | PolicyDecisionAskUnauthenticated;
+
+// ---------------------------------------------------------------------------
+// Policy callback shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Callback invoked by the proxy HTTP forwarder for each outbound request.
+ * Returns injected headers on allow, or `null` to block the request.
+ */
+export type PolicyCallback = (
+  hostname: string,
+  port: number | null,
+  path: string,
+  scheme: "http" | "https",
+) => Promise<Record<string, string> | null>;
+
+/**
+ * Payload passed to the approval callback when the policy engine emits an
+ * `ask_missing_credential` or `ask_unauthenticated` decision.
+ */
+export interface ProxyApprovalRequest {
+  /** The policy decision that triggered the approval prompt. */
+  decision:
+    | PolicyDecisionAskMissingCredential
+    | PolicyDecisionAskUnauthenticated;
+  /** The proxy session ID that originated the request. */
+  sessionId: ProxySessionId;
+}
+
+/**
+ * Callback signature for proxy approval prompts. Returns `true` if the
+ * user approves, `false` if denied.
+ */
+export type ProxyApprovalCallback = (
+  request: ProxyApprovalRequest,
+) => Promise<boolean>;
+
+// ---------------------------------------------------------------------------
+// Session configuration
+// ---------------------------------------------------------------------------
+
+/** Tuning knobs for a proxy session. */
+export interface ProxySessionConfig {
+  /** How long (ms) an idle session stays alive before auto-stopping. */
+  idleTimeoutMs: number;
+  /** Maximum concurrent sessions per conversation. */
+  maxSessionsPerConversation: number;
+}

--- a/packages/egress-proxy/tsconfig.json
+++ b/packages/egress-proxy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Create packages/egress-proxy as a private local package for reusable outbound proxy and request-policy core
- Define initial package surface around session ids, env injection types, request target context, and policy callback shapes
- Add package boundary tests ensuring no assistant or CES imports leak in

Part of plan: untrusted-agent-credential-arch.md (PR 5 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
