### PR TITLE
Fix CI: add daemon/lifecycle.ts to secure-keys allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -253,6 +253,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-model.ts", // model config handler API key lookup
       "daemon/session-slash.ts", // session slash command API key lookup
       "daemon/session-process.ts", // session process API key lookup
+      "daemon/lifecycle.ts", // CLI edge token persistence at startup
       "tools/claude-code/claude-code.ts", // Claude Code tool API key lookup
     ]);
 


### PR DESCRIPTION
## Summary
- `daemon/lifecycle.ts` imports `setSecureKeyAsync` to persist the CLI edge token at startup, but was missing from the `ALLOWED_IMPORTERS` set in `credential-security-invariants.test.ts`
- Added it to the allowlist to fix the failing guard test

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23099572059/job/67097809830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
