### PR TITLE
fix: remove dead code from assistant transfer feature

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -14,8 +14,6 @@ import VellumAssistantShared
 @MainActor
 struct AssistantTransferSection: View {
     let assistant: LockfileAssistant
-    let store: SettingsStore
-    let authManager: AuthManager
     let onClose: () -> Void
 
     @State private var isTransferring = false
@@ -23,7 +21,6 @@ struct AssistantTransferSection: View {
     @State private var showingConfirmation = false
     @State private var showingManagedConfirmation = false
     @State private var errorMessage: String?
-    @State private var successMessage: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
@@ -53,12 +50,6 @@ struct AssistantTransferSection: View {
                 Text(error)
                     .font(VFont.caption)
                     .foregroundColor(VColor.systemNegativeStrong)
-            }
-
-            if let success = successMessage {
-                Text(success)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.systemPositiveStrong)
             }
         }
         .padding(VSpacing.lg)
@@ -127,7 +118,6 @@ struct AssistantTransferSection: View {
     private func transferLocalToManaged() async {
         isTransferring = true
         errorMessage = nil
-        successMessage = nil
         defer {
             isTransferring = false
             currentStep = nil
@@ -169,14 +159,7 @@ struct AssistantTransferSection: View {
             // Step 5 — Retire local assistant (fire-and-forget)
             currentStep = "Cleaning up..."
             let localName = assistant.assistantId
-            var retireWarning: String?
-            do {
-                try await AppDelegate.shared?.assistantCli.retire(name: localName)
-            } catch {
-                retireWarning = " Note: the source assistant could not be retired automatically."
-            }
-
-            successMessage = "Transfer complete. You are now using the cloud assistant.\(retireWarning ?? "")"
+            try? await AppDelegate.shared?.assistantCli.retire(name: localName)
         } catch {
             errorMessage = "Transfer failed: \(error.localizedDescription)"
         }
@@ -187,7 +170,6 @@ struct AssistantTransferSection: View {
     private func transferManagedToLocal() async {
         isTransferring = true
         errorMessage = nil
-        successMessage = nil
         defer {
             isTransferring = false
             currentStep = nil
@@ -325,7 +307,6 @@ struct AssistantTransferSection: View {
 
             // Step 9 — Retire managed assistant (fire-and-forget with pre-saved auth)
             currentStep = "Cleaning up..."
-            var retireWarning: String?
             if let token = savedSessionToken {
                 let retireUrlString = "\(savedPlatformUrl)/v1/assistants/\(managedAssistantId)/retire/"
                 if let retireURL = URL(string: retireUrlString) {
@@ -336,22 +317,9 @@ struct AssistantTransferSection: View {
                     if let orgId = savedOrgId {
                         retireRequest.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
                     }
-                    let retireResult = try? await URLSession.shared.data(for: retireRequest)
-                    if let (_, retireResponse) = retireResult,
-                       let httpRetire = retireResponse as? HTTPURLResponse,
-                       (200..<300).contains(httpRetire.statusCode) {
-                        // Retire succeeded
-                    } else {
-                        retireWarning = " Note: the source assistant could not be retired automatically."
-                    }
-                } else {
-                    retireWarning = " Note: the source assistant could not be retired automatically."
+                    _ = try? await URLSession.shared.data(for: retireRequest)
                 }
-            } else {
-                retireWarning = " Note: the source assistant could not be retired automatically."
             }
-
-            successMessage = "Transfer complete. You are now using a local assistant.\(retireWarning ?? "")"
         } catch {
             errorMessage = "Transfer failed: \(error.localizedDescription)"
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -85,8 +85,6 @@ struct SettingsDeveloperTab: View {
                !assistant.isRemote || assistant.isManaged {
                 AssistantTransferSection(
                     assistant: assistant,
-                    store: store,
-                    authManager: authManager,
                     onClose: onClose
                 )
             }

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -61,24 +61,6 @@ public enum GatewayHTTPClient {
         return try await execute(request)
     }
 
-    /// Performs an authenticated POST with a binary body (`application/octet-stream`).
-    ///
-    /// Use this instead of `post(path:body:timeout:)` when the payload is raw
-    /// binary data (e.g. `.vbundle` archives) rather than JSON.
-    ///
-    /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{id}/transfer"`).
-    ///   - body: Raw binary data to upload.
-    ///   - timeout: Request timeout in seconds. Defaults to 120 to accommodate large bundle uploads.
-    /// - Returns: A `Response` with the raw data and HTTP status code.
-    /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func postBinary(path: String, body: Data, timeout: TimeInterval = 120) async throws -> Response {
-        var request = try buildRequest(path: path, method: "POST", timeout: timeout)
-        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        request.httpBody = body
-        return try await execute(request)
-    }
-
     /// Performs an authenticated DELETE request against the gateway.
     ///
     /// - Parameters:


### PR DESCRIPTION
## Summary
Fixes three dead code gaps from plan review for asst-transfer-local-managed.md:

- Remove `GatewayHTTPClient.postBinary` — zero callers, manual URLRequests are correct for the transfer use cases
- Remove unused `store` and `authManager` properties from `AssistantTransferSection`
- Remove unreachable `successMessage` assignments that occur after `onClose()` dismisses the view, and the now-dead `successMessage` property and display block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
