### PR TITLE
fix: top-align workspace file tree

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -311,6 +311,7 @@ private struct WorkspaceTreeSidebar: View {
                     }
                     .padding(.vertical, VSpacing.xs)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 .background {
                     GeometryReader { geo in
                         Color.clear


### PR DESCRIPTION
## Summary
- Add `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)` to the workspace file tree ScrollView so files appear at the top of the panel instead of vertically centered

## Original prompt
The files should show up at the top of this section not be centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
