### PR TITLE
feat: add workspace migration registry with 001-avatar-rename migration

### DIFF
--- a/assistant/src/workspace/migrations/001-avatar-rename.ts
+++ b/assistant/src/workspace/migrations/001-avatar-rename.ts
@@ -1,0 +1,25 @@
+import { existsSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const avatarRenameMigration: WorkspaceMigration = {
+  id: "001-avatar-rename",
+  description:
+    "Rename custom-avatar.png → avatar-image.png and avatar-components.json → character-traits.json",
+  run(workspaceDir: string): void {
+    const avatarDir = join(workspaceDir, "data", "avatar");
+
+    const oldImage = join(avatarDir, "custom-avatar.png");
+    const newImage = join(avatarDir, "avatar-image.png");
+    if (existsSync(oldImage) && !existsSync(newImage)) {
+      renameSync(oldImage, newImage);
+    }
+
+    const oldTraits = join(avatarDir, "avatar-components.json");
+    const newTraits = join(avatarDir, "character-traits.json");
+    if (existsSync(oldTraits) && !existsSync(newTraits)) {
+      renameSync(oldTraits, newTraits);
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,0 +1,10 @@
+import { avatarRenameMigration } from "./001-avatar-rename.js";
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Ordered list of all workspace data migrations.
+ * New migrations are appended to the end. Never reorder or remove entries.
+ */
+export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
+  avatarRenameMigration,
+];


### PR DESCRIPTION
## Summary
- Add 001-avatar-rename migration (renames custom-avatar.png → avatar-image.png and avatar-components.json → character-traits.json)
- Add workspace migration registry with ordered migration list

Part of plan: workspace-migration-framework.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
