### PR TITLE
[assistant+ces] Add `credential-executor/` package scaffold and bundled local dependency layout

### DIFF
--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -1,0 +1,103 @@
+name: CI Main Credential Executor Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'credential-executor/**'
+      - 'packages/ces-contracts/**'
+      - 'packages/credential-storage/**'
+      - 'packages/egress-proxy/**'
+      - '.github/workflows/ci-main-credential-executor.yaml'
+
+jobs:
+  checks:
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: credential-executor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+
+  notify-credential-executor:
+    name: Slack Notification (Credential Executor)
+    needs: [checks]
+    if: always()
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Slack ID
+        id: slack-id
+        run: |
+          GITHUB_USER="${{ github.actor }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" ]]; then
+            STATUS="failure"
+          elif [[ "${{ needs.checks.result }}" == "cancelled" ]]; then
+            STATUS="cancelled"
+          elif [[ "${{ needs.checks.result }}" == "skipped" ]]; then
+            STATUS="skipped"
+          else
+            STATUS="success"
+          fi
+
+          SLACK_ID=$(yq ".github_to_slack_all_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+
+          if [ "$SLACK_ID" = "null" ]; then
+            case $STATUS in
+              failure)
+                SLACK_ID=$(yq ".github_to_slack_failure_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              success)
+                SLACK_ID=$(yq ".github_to_slack_success_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+              cancelled)
+                SLACK_ID=$(yq ".github_to_slack_cancelled_notifications.[\"$GITHUB_USER\"]" .github/config/github_slack_mapping.yaml)
+                ;;
+            esac
+          fi
+
+          if [ "$SLACK_ID" = "null" ]; then
+            SLACK_ID="$GITHUB_USER"
+          fi
+
+          if [ "$SLACK_ID" = "$GITHUB_USER" ]; then
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+          fi
+          echo "id=$SLACK_ID" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+
+      - uses: act10ns/slack@v2
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USER_ID: ${{ steps.slack-id.outputs.id }}
+          SHOULD_TAG: ${{ steps.slack-id.outputs.should_tag }}
+        with:
+          status: ${{ steps.slack-id.outputs.status }}
+          channel: "#build-alerts"
+          config: .github/config/slack.yaml

--- a/.github/workflows/pr-credential-executor.yaml
+++ b/.github/workflows/pr-credential-executor.yaml
@@ -1,0 +1,42 @@
+name: PR Credential Executor Checks
+
+on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+    paths:
+      - 'credential-executor/**'
+      - 'packages/ces-contracts/**'
+      - 'packages/credential-storage/**'
+      - 'packages/egress-proxy/**'
+      - '.github/workflows/pr-credential-executor.yaml'
+
+concurrency:
+  group: pr-credential-executor-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    name: Type Check & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: credential-executor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -16,6 +16,11 @@ RUN apt-get update && apt-get install -y \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
+# Copy shared packages needed by assistant's repo-local dependencies
+COPY packages/ces-contracts ./packages/ces-contracts
+COPY packages/credential-storage ./packages/credential-storage
+COPY packages/egress-proxy ./packages/egress-proxy
+
 # Install assistant dependencies first for cache reuse
 COPY assistant/package.json assistant/bun.lock ./assistant/
 RUN cd /app/assistant && bun install --frozen-lockfile

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -29,6 +29,9 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.40.0",
+    "@vellumai/ces-contracts": "file:../packages/ces-contracts",
+    "@vellumai/credential-storage": "file:../packages/credential-storage",
+    "@vellumai/egress-proxy": "file:../packages/egress-proxy",
     "@modelcontextprotocol/sdk": "^1.15.1",
     "@qdrant/js-client-rest": "^1.16.2",
     "@sentry/node": "^10.38.0",
@@ -58,6 +61,11 @@
   "engines": {
     "node": ">=20.12.0"
   },
+  "bundledDependencies": [
+    "@vellumai/ces-contracts",
+    "@vellumai/credential-storage",
+    "@vellumai/egress-proxy"
+  ],
   "devDependencies": {
     "@pydantic/logfire-node": "^0.13.0",
     "@types/archiver": "^7.0.0",

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -1,0 +1,54 @@
+# Build stage
+FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Copy shared packages first (needed for repo-local dependencies)
+COPY packages/ces-contracts ./packages/ces-contracts
+COPY packages/credential-storage ./packages/credential-storage
+COPY packages/egress-proxy ./packages/egress-proxy
+
+# Install credential-executor dependencies with local package resolution
+COPY credential-executor/package.json credential-executor/bun.lock* ./credential-executor/
+RUN cd /app/credential-executor && bun install --frozen-lockfile
+
+# Copy credential-executor source
+COPY credential-executor ./credential-executor
+
+# Runtime stage
+FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430 AS runner
+
+WORKDIR /app/credential-executor
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy bun binary from builder
+COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
+RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
+
+# Create non-root user
+RUN groupadd --system --gid 1001 ces && \
+    useradd --system --uid 1001 --gid ces --create-home ces
+
+# Copy built app from builder
+COPY --from=builder --chown=ces:ces /app /app
+
+USER ces
+
+EXPOSE 7840
+
+ENV CES_PORT=7840
+
+CMD ["bun", "run", "src/index.ts"]

--- a/credential-executor/package.json
+++ b/credential-executor/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vellumai/credential-executor",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "credential-executor": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "@vellumai/ces-contracts": "file:../packages/ces-contracts",
+    "@vellumai/credential-storage": "file:../packages/credential-storage",
+    "@vellumai/egress-proxy": "file:../packages/egress-proxy"
+  },
+  "bundledDependencies": [
+    "@vellumai/ces-contracts",
+    "@vellumai/credential-storage",
+    "@vellumai/egress-proxy"
+  ],
+  "devDependencies": {
+    "@types/bun": "^1.2.4",
+    "typescript": "^5.7.3"
+  }
+}

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+/**
+ * @vellumai/credential-executor
+ *
+ * Credential Execution Service (CES) — an isolated runtime that executes
+ * credential-bearing tool operations on behalf of untrusted agents. The CES
+ * receives RPC requests from the assistant daemon, materialises credentials
+ * from the local credential store, executes the requested operation through
+ * the egress proxy, and returns sanitised results.
+ *
+ * This entrypoint bootstraps the CES process and starts listening for
+ * incoming transport connections from the assistant.
+ */
+
+import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+
+const PORT = parseInt(process.env["CES_PORT"] ?? "7840", 10);
+
+console.log(
+  `[credential-executor] Starting CES v${CES_PROTOCOL_VERSION} on port ${PORT}`,
+);
+
+// Placeholder — the server implementation will be added in subsequent PRs.
+const server = Bun.serve({
+  port: PORT,
+  fetch(_req) {
+    return new Response(
+      JSON.stringify({
+        service: "credential-executor",
+        protocolVersion: CES_PROTOCOL_VERSION,
+        status: "ok",
+      }),
+      {
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  },
+});
+
+console.log(`[credential-executor] Listening on http://localhost:${server.port}`);

--- a/credential-executor/tsconfig.json
+++ b/credential-executor/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Create top-level credential-executor/ package with package.json, tsconfig.json, Dockerfile, and bin entrypoint
- Wire repo-local bundled dependencies to packages/ces-contracts, credential-storage, and egress-proxy
- Update assistant/package.json and assistant/Dockerfile for local package resolution
- Add PR and main CI workflows for credential-executor

Part of plan: untrusted-agent-credential-arch.md (PR 6 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)