### PR TITLE
feat: run workspace migrations on daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -70,12 +70,15 @@ import {
   ensureDataDir,
   getInterfacesDir,
   getRootDir,
+  getWorkspaceDir,
 } from "../util/platform.js";
 import {
   listWorkItems,
   updateWorkItem,
 } from "../work-items/work-item-store.js";
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import {
   createApprovalConversationGenerator,
   createApprovalCopyGenerator,
@@ -141,6 +144,7 @@ export async function runDaemon(): Promise<void> {
     await initLogfire();
 
     ensureDataDir();
+    runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
 
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the


### PR DESCRIPTION
## Summary
- Wire workspace migration framework into daemon startup in lifecycle.ts
- Runs after ensureDataDir() and before DB initialization
- Enables one-time file/data migrations on every daemon start

Part of plan: workspace-migration-framework.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
