### PR TITLE
test: add unit tests for 001-avatar-rename workspace migration

### DIFF
--- a/assistant/src/__tests__/workspace-migration-avatar-rename.test.ts
+++ b/assistant/src/__tests__/workspace-migration-avatar-rename.test.ts
@@ -56,8 +56,14 @@ describe("001-avatar-rename migration", () => {
     avatarRenameMigration.run(WORKSPACE_DIR);
 
     expect(renameSyncFn).toHaveBeenCalledTimes(2);
-    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_IMAGE, NEW_IMAGE]);
-    expect(renameSyncFn.mock.calls[1]).toEqual([OLD_TRAITS, NEW_TRAITS]);
+    expect(renameSyncFn.mock.calls[0] as unknown[]).toEqual([
+      OLD_IMAGE,
+      NEW_IMAGE,
+    ]);
+    expect(renameSyncFn.mock.calls[1] as unknown[]).toEqual([
+      OLD_TRAITS,
+      NEW_TRAITS,
+    ]);
   });
 
   test("no-op when new files already exist", () => {
@@ -97,7 +103,10 @@ describe("001-avatar-rename migration", () => {
     avatarRenameMigration.run(WORKSPACE_DIR);
 
     expect(renameSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_IMAGE, NEW_IMAGE]);
+    expect(renameSyncFn.mock.calls[0] as unknown[]).toEqual([
+      OLD_IMAGE,
+      NEW_IMAGE,
+    ]);
   });
 
   test("partial rename — only traits exist", () => {
@@ -111,6 +120,9 @@ describe("001-avatar-rename migration", () => {
     avatarRenameMigration.run(WORKSPACE_DIR);
 
     expect(renameSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_TRAITS, NEW_TRAITS]);
+    expect(renameSyncFn.mock.calls[0] as unknown[]).toEqual([
+      OLD_TRAITS,
+      NEW_TRAITS,
+    ]);
   });
 });

--- a/assistant/src/__tests__/workspace-migration-avatar-rename.test.ts
+++ b/assistant/src/__tests__/workspace-migration-avatar-rename.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const existsSyncFn = mock((_path: string): boolean => false);
+const renameSyncFn = mock(() => {});
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs", () => ({
+  existsSync: existsSyncFn,
+  renameSync: renameSyncFn,
+}));
+
+// Import after mocking
+import { avatarRenameMigration } from "../workspace/migrations/001-avatar-rename.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = "/tmp/test-workspace";
+const AVATAR_DIR = `${WORKSPACE_DIR}/data/avatar`;
+
+const OLD_IMAGE = `${AVATAR_DIR}/custom-avatar.png`;
+const NEW_IMAGE = `${AVATAR_DIR}/avatar-image.png`;
+const OLD_TRAITS = `${AVATAR_DIR}/avatar-components.json`;
+const NEW_TRAITS = `${AVATAR_DIR}/character-traits.json`;
+
+function setupExistsSync(mapping: Record<string, boolean>) {
+  existsSyncFn.mockImplementation((path: string) => mapping[path] ?? false);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("001-avatar-rename migration", () => {
+  beforeEach(() => {
+    existsSyncFn.mockClear();
+    renameSyncFn.mockClear();
+  });
+
+  test("renames both files when old names exist", () => {
+    setupExistsSync({
+      [OLD_IMAGE]: true,
+      [NEW_IMAGE]: false,
+      [OLD_TRAITS]: true,
+      [NEW_TRAITS]: false,
+    });
+
+    avatarRenameMigration.run(WORKSPACE_DIR);
+
+    expect(renameSyncFn).toHaveBeenCalledTimes(2);
+    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_IMAGE, NEW_IMAGE]);
+    expect(renameSyncFn.mock.calls[1]).toEqual([OLD_TRAITS, NEW_TRAITS]);
+  });
+
+  test("no-op when new files already exist", () => {
+    setupExistsSync({
+      [OLD_IMAGE]: true,
+      [NEW_IMAGE]: true,
+      [OLD_TRAITS]: true,
+      [NEW_TRAITS]: true,
+    });
+
+    avatarRenameMigration.run(WORKSPACE_DIR);
+
+    expect(renameSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no old files exist", () => {
+    setupExistsSync({
+      [OLD_IMAGE]: false,
+      [NEW_IMAGE]: false,
+      [OLD_TRAITS]: false,
+      [NEW_TRAITS]: false,
+    });
+
+    avatarRenameMigration.run(WORKSPACE_DIR);
+
+    expect(renameSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("partial rename — only image exists", () => {
+    setupExistsSync({
+      [OLD_IMAGE]: true,
+      [NEW_IMAGE]: false,
+      [OLD_TRAITS]: false,
+      [NEW_TRAITS]: false,
+    });
+
+    avatarRenameMigration.run(WORKSPACE_DIR);
+
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_IMAGE, NEW_IMAGE]);
+  });
+
+  test("partial rename — only traits exist", () => {
+    setupExistsSync({
+      [OLD_IMAGE]: false,
+      [NEW_IMAGE]: false,
+      [OLD_TRAITS]: true,
+      [NEW_TRAITS]: false,
+    });
+
+    avatarRenameMigration.run(WORKSPACE_DIR);
+
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn.mock.calls[0]).toEqual([OLD_TRAITS, NEW_TRAITS]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add five unit tests covering full rename, no-op cases, and partial rename scenarios
- Tests verify idempotency and correct filesystem operations

Part of plan: workspace-migration-framework.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
