### PR TITLE
[shared] Add CES handles, proposal/grant schemas, and approval/audit contracts

### DIFF
--- a/packages/ces-contracts/package.json
+++ b/packages/ces-contracts/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./handles": "./src/handles.ts",
+    "./grants": "./src/grants.ts",
+    "./rpc": "./src/rpc.ts",
+    "./rendering": "./src/rendering.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/ces-contracts/src/__tests__/contracts.test.ts
+++ b/packages/ces-contracts/src/__tests__/contracts.test.ts
@@ -24,18 +24,26 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("package independence", () => {
-  test("does not import from assistant/ or credential-executor/", () => {
-    // Reading our own source is the simplest portable check. If someone
-    // accidentally adds an import, this test will catch it.
-    const src = require("node:fs").readFileSync(
-      require("node:path").resolve(__dirname, "../index.ts"),
-      "utf-8",
-    );
-    expect(src).not.toMatch(/from\s+['"].*assistant\//);
-    expect(src).not.toMatch(/from\s+['"].*credential-executor\//);
-    expect(src).not.toMatch(/require\(['"].*assistant\//);
-    expect(src).not.toMatch(/require\(['"].*credential-executor\//);
-  });
+  const sourceFiles = [
+    "../index.ts",
+    "../handles.ts",
+    "../grants.ts",
+    "../rpc.ts",
+    "../rendering.ts",
+  ];
+
+  for (const file of sourceFiles) {
+    test(`${file} does not import from assistant/ or credential-executor/`, () => {
+      const src = require("node:fs").readFileSync(
+        require("node:path").resolve(__dirname, file),
+        "utf-8",
+      );
+      expect(src).not.toMatch(/from\s+['"].*assistant\//);
+      expect(src).not.toMatch(/from\s+['"].*credential-executor\//);
+      expect(src).not.toMatch(/require\(['"].*assistant\//);
+      expect(src).not.toMatch(/require\(['"].*credential-executor\//);
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ces-contracts/src/__tests__/grants.test.ts
+++ b/packages/ces-contracts/src/__tests__/grants.test.ts
@@ -1,0 +1,661 @@
+/**
+ * Tests for CES grants, proposals, handles, rendering, and RPC contracts.
+ *
+ * Covers:
+ * 1. Handle parsing and construction roundtrips.
+ * 2. Grant proposal schema validation.
+ * 3. Proposal hash determinism — same content, different key order → same hash.
+ * 4. Proposal rendering produces stable, human-readable output.
+ * 5. Persistent grant record and audit record schema validation.
+ * 6. RPC schema validation for all methods.
+ * 7. No raw secret-return fields in any schema.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  AuditRecordSummarySchema,
+  CommandGrantProposalSchema,
+  GrantProposalSchema,
+  HttpGrantProposalSchema,
+  PersistentGrantRecordSchema,
+  TemporaryGrantDecisionSchema,
+} from "../grants.js";
+import {
+  HandleType,
+  localOAuthHandle,
+  localStaticHandle,
+  parseHandle,
+  platformOAuthHandle,
+  CredentialHandleSchema,
+} from "../handles.js";
+import { canonicalJsonSerialize, hashProposal, renderProposal } from "../rendering.js";
+import {
+  ApprovalRequiredSchema,
+  CesRpcMethod,
+  CesRpcSchemas,
+  ListAuditRecordsSchema,
+  ListGrantsSchema,
+  MakeAuthenticatedRequestResponseSchema,
+  MakeAuthenticatedRequestSchema,
+  ManageSecureCommandToolSchema,
+  RecordGrantSchema,
+  RevokeGrantSchema,
+  RunAuthenticatedCommandResponseSchema,
+  RunAuthenticatedCommandSchema,
+} from "../rpc.js";
+
+// ---------------------------------------------------------------------------
+// Handle parsing and construction
+// ---------------------------------------------------------------------------
+
+describe("handles", () => {
+  describe("localStaticHandle", () => {
+    test("constructs the expected format", () => {
+      expect(localStaticHandle("github", "api_key")).toBe(
+        "local_static:github/api_key",
+      );
+    });
+
+    test("roundtrips through parseHandle", () => {
+      const raw = localStaticHandle("fal", "password");
+      const result = parseHandle(raw);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.handle.type).toBe(HandleType.LocalStatic);
+      if (result.handle.type !== HandleType.LocalStatic) return;
+      expect(result.handle.service).toBe("fal");
+      expect(result.handle.field).toBe("password");
+      expect(result.handle.raw).toBe(raw);
+    });
+  });
+
+  describe("localOAuthHandle", () => {
+    test("constructs the expected format", () => {
+      expect(localOAuthHandle("integration:google", "conn-123")).toBe(
+        "local_oauth:integration:google/conn-123",
+      );
+    });
+
+    test("roundtrips with integration: prefix in providerKey", () => {
+      const raw = localOAuthHandle("integration:slack", "conn-abc");
+      const result = parseHandle(raw);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.handle.type).toBe(HandleType.LocalOAuth);
+      if (result.handle.type !== HandleType.LocalOAuth) return;
+      expect(result.handle.providerKey).toBe("integration:slack");
+      expect(result.handle.connectionId).toBe("conn-abc");
+    });
+  });
+
+  describe("platformOAuthHandle", () => {
+    test("constructs the expected format", () => {
+      expect(platformOAuthHandle("plat-conn-456")).toBe(
+        "platform_oauth:plat-conn-456",
+      );
+    });
+
+    test("roundtrips through parseHandle", () => {
+      const raw = platformOAuthHandle("plat-conn-789");
+      const result = parseHandle(raw);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.handle.type).toBe(HandleType.PlatformOAuth);
+      if (result.handle.type !== HandleType.PlatformOAuth) return;
+      expect(result.handle.connectionId).toBe("plat-conn-789");
+    });
+  });
+
+  describe("parseHandle error cases", () => {
+    test("rejects a handle with no colon", () => {
+      const result = parseHandle("no-prefix");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects an unknown prefix", () => {
+      const result = parseHandle("cloud_kms:some-key");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects local_static with no slash", () => {
+      const result = parseHandle("local_static:nofield");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects local_static with empty service", () => {
+      const result = parseHandle("local_static:/field");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects local_static with empty field", () => {
+      const result = parseHandle("local_static:service/");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects local_oauth with no slash", () => {
+      const result = parseHandle("local_oauth:integration:google");
+      expect(result.ok).toBe(false);
+    });
+
+    test("rejects platform_oauth with empty connectionId", () => {
+      const result = parseHandle("platform_oauth:");
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("CredentialHandleSchema", () => {
+    test("accepts valid handles", () => {
+      expect(() =>
+        CredentialHandleSchema.parse("local_static:github/api_key"),
+      ).not.toThrow();
+      expect(() =>
+        CredentialHandleSchema.parse(
+          "local_oauth:integration:google/conn-1",
+        ),
+      ).not.toThrow();
+      expect(() =>
+        CredentialHandleSchema.parse("platform_oauth:conn-2"),
+      ).not.toThrow();
+    });
+
+    test("rejects invalid handles", () => {
+      expect(() => CredentialHandleSchema.parse("bad-handle")).toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grant proposal schemas
+// ---------------------------------------------------------------------------
+
+describe("grant proposals", () => {
+  const httpProposal = {
+    type: "http" as const,
+    credentialHandle: "local_static:github/api_key",
+    method: "GET",
+    url: "https://api.github.com/repos",
+    purpose: "List repositories",
+  };
+
+  const commandProposal = {
+    type: "command" as const,
+    credentialHandle: "local_static:aws/access_key",
+    command: "aws s3 ls",
+    purpose: "List S3 buckets",
+  };
+
+  test("HttpGrantProposalSchema parses valid proposal", () => {
+    const result = HttpGrantProposalSchema.parse(httpProposal);
+    expect(result.type).toBe("http");
+    expect(result.method).toBe("GET");
+  });
+
+  test("HttpGrantProposalSchema accepts optional allowedUrlPatterns", () => {
+    const result = HttpGrantProposalSchema.parse({
+      ...httpProposal,
+      allowedUrlPatterns: ["https://api.github.com/**"],
+    });
+    expect(result.allowedUrlPatterns).toEqual(["https://api.github.com/**"]);
+  });
+
+  test("CommandGrantProposalSchema parses valid proposal", () => {
+    const result = CommandGrantProposalSchema.parse(commandProposal);
+    expect(result.type).toBe("command");
+    expect(result.command).toBe("aws s3 ls");
+  });
+
+  test("GrantProposalSchema discriminates by type", () => {
+    const http = GrantProposalSchema.parse(httpProposal);
+    expect(http.type).toBe("http");
+
+    const cmd = GrantProposalSchema.parse(commandProposal);
+    expect(cmd.type).toBe("command");
+  });
+
+  test("GrantProposalSchema rejects unknown type", () => {
+    expect(() =>
+      GrantProposalSchema.parse({
+        type: "browser_fill",
+        credentialHandle: "local_static:x/y",
+        purpose: "test",
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proposal hash determinism
+// ---------------------------------------------------------------------------
+
+describe("proposal hashing", () => {
+  test("same proposal produces same hash", () => {
+    const proposal = {
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+      method: "POST",
+      url: "https://api.github.com/repos",
+      purpose: "Create repository",
+    };
+    const hash1 = hashProposal(proposal);
+    const hash2 = hashProposal(proposal);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("different key order produces same hash", () => {
+    const proposal1 = {
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos",
+      purpose: "List repos",
+    };
+    // Same content, different key ordering
+    const proposal2 = {
+      purpose: "List repos",
+      url: "https://api.github.com/repos",
+      method: "GET",
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+    };
+    expect(hashProposal(proposal1)).toBe(hashProposal(proposal2));
+  });
+
+  test("different proposals produce different hashes", () => {
+    const proposal1 = {
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos",
+      purpose: "List repos",
+    };
+    const proposal2 = {
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+      method: "POST",
+      url: "https://api.github.com/repos",
+      purpose: "Create repo",
+    };
+    expect(hashProposal(proposal1)).not.toBe(hashProposal(proposal2));
+  });
+
+  test("hash is a 64-char lowercase hex string (SHA-256)", () => {
+    const hash = hashProposal({
+      type: "command" as const,
+      credentialHandle: "local_static:aws/key",
+      command: "aws s3 ls",
+      purpose: "test",
+    });
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical JSON serialization
+// ---------------------------------------------------------------------------
+
+describe("canonicalJsonSerialize", () => {
+  test("sorts keys recursively", () => {
+    const result = canonicalJsonSerialize({ z: 1, a: { c: 3, b: 2 } });
+    expect(result).toBe('{"a":{"b":2,"c":3},"z":1}');
+  });
+
+  test("preserves array order", () => {
+    const result = canonicalJsonSerialize({ items: [3, 1, 2] });
+    expect(result).toBe('{"items":[3,1,2]}');
+  });
+
+  test("preserves null", () => {
+    const result = canonicalJsonSerialize({ a: null });
+    expect(result).toBe('{"a":null}');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proposal rendering
+// ---------------------------------------------------------------------------
+
+describe("renderProposal", () => {
+  test("renders HTTP proposal with expected format", () => {
+    const rendered = renderProposal({
+      type: "http",
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos",
+      purpose: "List repositories",
+    });
+    expect(rendered).toContain("Authenticated HTTP Request");
+    expect(rendered).toContain("Method: GET");
+    expect(rendered).toContain("URL: https://api.github.com/repos");
+    expect(rendered).toContain("Credential: local_static:github/api_key");
+    expect(rendered).toContain("Purpose: List repositories");
+  });
+
+  test("renders HTTP proposal with URL patterns", () => {
+    const rendered = renderProposal({
+      type: "http",
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos",
+      purpose: "test",
+      allowedUrlPatterns: ["https://api.github.com/**"],
+    });
+    expect(rendered).toContain("Allowed URL patterns:");
+    expect(rendered).toContain("- https://api.github.com/**");
+  });
+
+  test("renders command proposal with expected format", () => {
+    const rendered = renderProposal({
+      type: "command",
+      credentialHandle: "local_static:aws/key",
+      command: "aws s3 ls",
+      purpose: "List S3 buckets",
+    });
+    expect(rendered).toContain("Authenticated Command Execution");
+    expect(rendered).toContain("Command: aws s3 ls");
+    expect(rendered).toContain("Purpose: List S3 buckets");
+  });
+
+  test("rendering is deterministic", () => {
+    const proposal = {
+      type: "http" as const,
+      credentialHandle: "local_static:github/api_key",
+      method: "POST",
+      url: "https://api.github.com/repos",
+      purpose: "Create repo",
+    };
+    expect(renderProposal(proposal)).toBe(renderProposal(proposal));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grant decision and record schemas
+// ---------------------------------------------------------------------------
+
+describe("TemporaryGrantDecisionSchema", () => {
+  test("parses an approved decision", () => {
+    const result = TemporaryGrantDecisionSchema.parse({
+      proposal: {
+        type: "http",
+        credentialHandle: "local_static:github/api_key",
+        method: "GET",
+        url: "https://api.github.com/repos",
+        purpose: "List repos",
+      },
+      proposalHash: "abcdef1234567890".repeat(4),
+      decision: "approved",
+      decidedBy: "guardian:user@example.com",
+      decidedAt: new Date().toISOString(),
+      ttl: "PT1H",
+    });
+    expect(result.decision).toBe("approved");
+  });
+
+  test("parses a denied decision with reason", () => {
+    const result = TemporaryGrantDecisionSchema.parse({
+      proposal: {
+        type: "command",
+        credentialHandle: "local_static:aws/key",
+        command: "aws s3 rm --recursive",
+        purpose: "Clean up bucket",
+      },
+      proposalHash: "abcdef1234567890".repeat(4),
+      decision: "denied",
+      decidedBy: "guardian:admin",
+      decidedAt: new Date().toISOString(),
+      reason: "Destructive operation not permitted",
+    });
+    expect(result.decision).toBe("denied");
+    expect(result.reason).toBe("Destructive operation not permitted");
+  });
+});
+
+describe("PersistentGrantRecordSchema", () => {
+  test("parses a valid active grant", () => {
+    const now = new Date().toISOString();
+    const result = PersistentGrantRecordSchema.parse({
+      grantId: "grant-001",
+      sessionId: "sess-001",
+      credentialHandle: "local_static:github/api_key",
+      proposalType: "http",
+      proposalHash: "abcdef1234567890".repeat(4),
+      allowedPurposes: ["https://api.github.com/**"],
+      status: "active",
+      grantedBy: "guardian:user@example.com",
+      createdAt: now,
+      expiresAt: null,
+      consumedAt: null,
+      revokedAt: null,
+    });
+    expect(result.status).toBe("active");
+    expect(result.grantId).toBe("grant-001");
+  });
+
+  test("rejects a grant with unknown status", () => {
+    expect(() =>
+      PersistentGrantRecordSchema.parse({
+        grantId: "grant-001",
+        sessionId: "sess-001",
+        credentialHandle: "local_static:github/api_key",
+        proposalType: "http",
+        proposalHash: "abc",
+        allowedPurposes: [],
+        status: "pending",
+        grantedBy: "guardian:user",
+        createdAt: new Date().toISOString(),
+        expiresAt: null,
+        consumedAt: null,
+        revokedAt: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("AuditRecordSummarySchema", () => {
+  test("parses a valid audit record", () => {
+    const result = AuditRecordSummarySchema.parse({
+      auditId: "audit-001",
+      grantId: "grant-001",
+      credentialHandle: "local_static:github/api_key",
+      toolName: "ces_authenticated_http",
+      target: "https://api.github.com/repos",
+      sessionId: "sess-001",
+      success: true,
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.auditId).toBe("audit-001");
+    expect(result.success).toBe(true);
+  });
+
+  test("parses a failed audit record with error message", () => {
+    const result = AuditRecordSummarySchema.parse({
+      auditId: "audit-002",
+      grantId: "grant-001",
+      credentialHandle: "local_static:github/api_key",
+      toolName: "ces_authenticated_http",
+      target: "https://api.github.com/repos",
+      sessionId: "sess-001",
+      success: false,
+      errorMessage: "Connection timeout",
+      timestamp: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toBe("Connection timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RPC method schemas
+// ---------------------------------------------------------------------------
+
+describe("RPC schemas", () => {
+  test("MakeAuthenticatedRequestSchema parses valid request", () => {
+    const result = MakeAuthenticatedRequestSchema.parse({
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos",
+      purpose: "List repos",
+    });
+    expect(result.method).toBe("GET");
+  });
+
+  test("MakeAuthenticatedRequestResponseSchema parses success", () => {
+    const result = MakeAuthenticatedRequestResponseSchema.parse({
+      success: true,
+      statusCode: 200,
+      responseBody: '{"data": []}',
+      auditId: "audit-001",
+    });
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+
+  test("RunAuthenticatedCommandSchema parses valid request", () => {
+    const result = RunAuthenticatedCommandSchema.parse({
+      credentialHandle: "local_static:aws/key",
+      command: "aws s3 ls",
+      purpose: "List buckets",
+    });
+    expect(result.command).toBe("aws s3 ls");
+  });
+
+  test("RunAuthenticatedCommandResponseSchema parses success", () => {
+    const result = RunAuthenticatedCommandResponseSchema.parse({
+      success: true,
+      exitCode: 0,
+      stdout: "bucket-1\nbucket-2\n",
+      stderr: "",
+      auditId: "audit-002",
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("ManageSecureCommandToolSchema parses register action", () => {
+    const result = ManageSecureCommandToolSchema.parse({
+      action: "register",
+      toolName: "aws-cli",
+      credentialHandle: "local_static:aws/key",
+      commandTemplate: "aws {{credential}} s3 ls",
+      description: "AWS CLI with credentials",
+    });
+    expect(result.action).toBe("register");
+  });
+
+  test("ManageSecureCommandToolSchema parses unregister action", () => {
+    const result = ManageSecureCommandToolSchema.parse({
+      action: "unregister",
+      toolName: "aws-cli",
+    });
+    expect(result.action).toBe("unregister");
+  });
+
+  test("ApprovalRequiredSchema parses valid notification", () => {
+    const result = ApprovalRequiredSchema.parse({
+      proposal: {
+        type: "http",
+        credentialHandle: "local_static:github/api_key",
+        method: "DELETE",
+        url: "https://api.github.com/repos/test",
+        purpose: "Delete repository",
+      },
+      proposalHash: "abcdef1234567890".repeat(4),
+      renderedProposal: "Authenticated HTTP Request\n  Method: DELETE",
+      sessionId: "sess-001",
+    });
+    expect(result.sessionId).toBe("sess-001");
+  });
+
+  test("RecordGrantSchema parses valid grant recording", () => {
+    const result = RecordGrantSchema.parse({
+      decision: {
+        proposal: {
+          type: "http",
+          credentialHandle: "local_static:github/api_key",
+          method: "GET",
+          url: "https://api.github.com/repos",
+          purpose: "List repos",
+        },
+        proposalHash: "abcdef1234567890".repeat(4),
+        decision: "approved",
+        decidedBy: "guardian:user",
+        decidedAt: new Date().toISOString(),
+      },
+      sessionId: "sess-001",
+    });
+    expect(result.sessionId).toBe("sess-001");
+  });
+
+  test("ListGrantsSchema accepts empty filter", () => {
+    const result = ListGrantsSchema.parse({});
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  test("RevokeGrantSchema parses valid revocation", () => {
+    const result = RevokeGrantSchema.parse({
+      grantId: "grant-001",
+      reason: "Session ended",
+    });
+    expect(result.grantId).toBe("grant-001");
+  });
+
+  test("ListAuditRecordsSchema parses with pagination", () => {
+    const result = ListAuditRecordsSchema.parse({
+      sessionId: "sess-001",
+      limit: 50,
+      cursor: "cursor-abc",
+    });
+    expect(result.limit).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract completeness — all methods have schemas
+// ---------------------------------------------------------------------------
+
+describe("CesRpcSchemas completeness", () => {
+  test("every CesRpcMethod has request and response schemas", () => {
+    for (const method of Object.values(CesRpcMethod)) {
+      const entry = CesRpcSchemas[method];
+      expect(entry).toBeDefined();
+      expect(entry.request).toBeDefined();
+      expect(entry.response).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No secret-return fields guard
+// ---------------------------------------------------------------------------
+
+describe("no secret-return fields", () => {
+  test("PersistentGrantRecordSchema does not have secretValue or credential_value fields", () => {
+    const shape = PersistentGrantRecordSchema.shape;
+    expect("secretValue" in shape).toBe(false);
+    expect("credential_value" in shape).toBe(false);
+    expect("secret" in shape).toBe(false);
+    expect("accessToken" in shape).toBe(false);
+    expect("refreshToken" in shape).toBe(false);
+  });
+
+  test("AuditRecordSummarySchema does not have secretValue fields", () => {
+    const shape = AuditRecordSummarySchema.shape;
+    expect("secretValue" in shape).toBe(false);
+    expect("credential_value" in shape).toBe(false);
+    expect("secret" in shape).toBe(false);
+    expect("accessToken" in shape).toBe(false);
+    expect("refreshToken" in shape).toBe(false);
+  });
+
+  test("MakeAuthenticatedRequestResponseSchema does not return secrets", () => {
+    const shape = MakeAuthenticatedRequestResponseSchema.shape;
+    expect("secretValue" in shape).toBe(false);
+    expect("credential_value" in shape).toBe(false);
+    expect("accessToken" in shape).toBe(false);
+  });
+
+  test("RunAuthenticatedCommandResponseSchema does not return secrets", () => {
+    const shape = RunAuthenticatedCommandResponseSchema.shape;
+    expect("secretValue" in shape).toBe(false);
+    expect("credential_value" in shape).toBe(false);
+    expect("accessToken" in shape).toBe(false);
+  });
+});

--- a/packages/ces-contracts/src/grants.ts
+++ b/packages/ces-contracts/src/grants.ts
@@ -1,0 +1,174 @@
+/**
+ * CES grant proposal, grant record, and audit record schemas.
+ *
+ * These schemas define the wire format for:
+ * - HTTP grant proposals (requesting permission to make an authenticated HTTP call)
+ * - Command grant proposals (requesting permission to run an authenticated command)
+ * - Temporary grant decisions (approval/denial from a guardian)
+ * - Persistent grant records (stored by CES after approval)
+ * - Audit record summaries (materialization events)
+ */
+
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Grant proposal types
+// ---------------------------------------------------------------------------
+
+/**
+ * Proposal to make an authenticated HTTP request using a credential.
+ */
+export const HttpGrantProposalSchema = z.object({
+  type: z.literal("http"),
+  /** CES credential handle identifying which credential to use. */
+  credentialHandle: z.string(),
+  /** HTTP method (e.g. "GET", "POST"). */
+  method: z.string(),
+  /** Target URL. */
+  url: z.string(),
+  /** Human-readable description of why this request is needed. */
+  purpose: z.string(),
+  /** Optional constrained set of URL patterns this grant covers. */
+  allowedUrlPatterns: z.array(z.string()).optional(),
+});
+export type HttpGrantProposal = z.infer<typeof HttpGrantProposalSchema>;
+
+/**
+ * Proposal to run an authenticated command using credential environment variables.
+ */
+export const CommandGrantProposalSchema = z.object({
+  type: z.literal("command"),
+  /** CES credential handle identifying which credential to use. */
+  credentialHandle: z.string(),
+  /** The command to execute (without credential values — CES injects those). */
+  command: z.string(),
+  /** Human-readable description of why this command is needed. */
+  purpose: z.string(),
+  /** Optional constrained set of command patterns this grant covers. */
+  allowedCommandPatterns: z.array(z.string()).optional(),
+});
+export type CommandGrantProposal = z.infer<typeof CommandGrantProposalSchema>;
+
+/**
+ * Union of all grant proposal types.
+ */
+export const GrantProposalSchema = z.discriminatedUnion("type", [
+  HttpGrantProposalSchema,
+  CommandGrantProposalSchema,
+]);
+export type GrantProposal = z.infer<typeof GrantProposalSchema>;
+
+// ---------------------------------------------------------------------------
+// Grant decisions (temporary — before persistence)
+// ---------------------------------------------------------------------------
+
+export const GrantDecision = {
+  Approved: "approved",
+  Denied: "denied",
+} as const;
+
+export type GrantDecision = (typeof GrantDecision)[keyof typeof GrantDecision];
+
+/**
+ * A temporary grant decision from a guardian, before CES persists it.
+ */
+export const TemporaryGrantDecisionSchema = z.object({
+  /** The proposal this decision applies to. */
+  proposal: GrantProposalSchema,
+  /** Deterministic hash of the proposal (see rendering.ts). */
+  proposalHash: z.string(),
+  /** The guardian's decision. */
+  decision: z.enum(["approved", "denied"]),
+  /** Who made the decision (guardian identifier). */
+  decidedBy: z.string(),
+  /** ISO-8601 timestamp of the decision. */
+  decidedAt: z.string(),
+  /** Optional human-readable reason for the decision. */
+  reason: z.string().optional(),
+  /** How long the grant should remain valid (ISO-8601 duration, e.g. "PT1H"). */
+  ttl: z.string().optional(),
+});
+export type TemporaryGrantDecision = z.infer<
+  typeof TemporaryGrantDecisionSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Persistent grant records (CES-owned)
+// ---------------------------------------------------------------------------
+
+export const GrantStatus = {
+  Active: "active",
+  Expired: "expired",
+  Revoked: "revoked",
+  Consumed: "consumed",
+} as const;
+
+export type GrantStatus = (typeof GrantStatus)[keyof typeof GrantStatus];
+
+/**
+ * A persistent grant record stored by CES.
+ *
+ * Grants authorize a specific agent session to use a credential for a
+ * constrained purpose. They are never sent to the assistant with secret
+ * values — only metadata.
+ */
+export const PersistentGrantRecordSchema = z.object({
+  /** Unique grant identifier. */
+  grantId: z.string(),
+  /** The agent session that holds this grant. */
+  sessionId: z.string(),
+  /** The credential handle this grant authorizes. */
+  credentialHandle: z.string(),
+  /** The proposal type (http or command). */
+  proposalType: z.enum(["http", "command"]),
+  /** Deterministic hash of the original proposal. */
+  proposalHash: z.string(),
+  /** Constrained purposes — URL patterns for HTTP, command patterns for commands. */
+  allowedPurposes: z.array(z.string()),
+  /** Current grant status. */
+  status: z.enum(["active", "expired", "revoked", "consumed"]),
+  /** Who approved the grant. */
+  grantedBy: z.string(),
+  /** ISO-8601 timestamp when the grant was created. */
+  createdAt: z.string(),
+  /** ISO-8601 timestamp when the grant expires (null if no expiry). */
+  expiresAt: z.string().nullable(),
+  /** ISO-8601 timestamp when the grant was consumed (null if unconsumed). */
+  consumedAt: z.string().nullable(),
+  /** ISO-8601 timestamp when the grant was revoked (null if active). */
+  revokedAt: z.string().nullable(),
+});
+export type PersistentGrantRecord = z.infer<typeof PersistentGrantRecordSchema>;
+
+// ---------------------------------------------------------------------------
+// Audit record summaries
+// ---------------------------------------------------------------------------
+
+/**
+ * Summary of a credential materialization event, as exposed by CES
+ * for audit inspection.
+ *
+ * Audit records never contain secret values — only metadata about what
+ * was accessed, when, by whom, and whether it succeeded.
+ */
+export const AuditRecordSummarySchema = z.object({
+  /** Unique audit record identifier. */
+  auditId: z.string(),
+  /** The grant that authorized this materialization. */
+  grantId: z.string(),
+  /** The credential handle that was materialized. */
+  credentialHandle: z.string(),
+  /** The tool that triggered materialization. */
+  toolName: z.string(),
+  /** Target of the operation (URL for HTTP, command summary for commands). */
+  target: z.string(),
+  /** The agent session that triggered materialization. */
+  sessionId: z.string(),
+  /** Whether the execution succeeded. */
+  success: z.boolean(),
+  /** Error message if execution failed (no secrets). */
+  errorMessage: z.string().optional(),
+  /** ISO-8601 timestamp of the materialization event. */
+  timestamp: z.string(),
+});
+export type AuditRecordSummary = z.infer<typeof AuditRecordSummarySchema>;

--- a/packages/ces-contracts/src/handles.ts
+++ b/packages/ces-contracts/src/handles.ts
@@ -1,0 +1,213 @@
+/**
+ * CES credential handle formats and parser helpers.
+ *
+ * A "handle" is an opaque string that the assistant passes to CES to identify
+ * which credential context should be used for a given execution. Handles never
+ * contain secret material — they are references that CES resolves internally.
+ *
+ * v1 handle formats:
+ *
+ * 1. **Local static** — references a credential stored in the local secure-key
+ *    backend. Format: `local_static:<service>/<field>` (matches the
+ *    `credential/{service}/{field}` key pattern from credential-storage).
+ *
+ * 2. **Local OAuth** — references a locally persisted OAuth connection.
+ *    Format: `local_oauth:<providerKey>/<connectionId>` where providerKey
+ *    uses the existing `integration:*` keys (e.g. `integration:google`).
+ *
+ * 3. **Managed OAuth** — references an OAuth connection managed by the
+ *    platform. Format: `platform_oauth:<connectionId>` where connectionId
+ *    is the platform-assigned connection identifier.
+ */
+
+import { z } from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Handle type discriminator
+// ---------------------------------------------------------------------------
+
+export const HandleType = {
+  LocalStatic: "local_static",
+  LocalOAuth: "local_oauth",
+  PlatformOAuth: "platform_oauth",
+} as const;
+
+export type HandleType = (typeof HandleType)[keyof typeof HandleType];
+
+// ---------------------------------------------------------------------------
+// Parsed handle shapes
+// ---------------------------------------------------------------------------
+
+export interface LocalStaticHandle {
+  type: typeof HandleType.LocalStatic;
+  /** Service name (e.g. "github", "fal"). */
+  service: string;
+  /** Field name within the service (e.g. "api_key", "password"). */
+  field: string;
+  /** The raw handle string. */
+  raw: string;
+}
+
+export interface LocalOAuthHandle {
+  type: typeof HandleType.LocalOAuth;
+  /** Provider key (e.g. "integration:google", "integration:slack"). */
+  providerKey: string;
+  /** Connection identifier. */
+  connectionId: string;
+  /** The raw handle string. */
+  raw: string;
+}
+
+export interface PlatformOAuthHandle {
+  type: typeof HandleType.PlatformOAuth;
+  /** Platform-assigned connection identifier. */
+  connectionId: string;
+  /** The raw handle string. */
+  raw: string;
+}
+
+export type ParsedHandle =
+  | LocalStaticHandle
+  | LocalOAuthHandle
+  | PlatformOAuthHandle;
+
+// ---------------------------------------------------------------------------
+// Handle construction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a local static credential handle from service and field.
+ *
+ * Accepts the same service/field values used in `credentialKey()` from
+ * `@vellumai/credential-storage`.
+ */
+export function localStaticHandle(service: string, field: string): string {
+  return `${HandleType.LocalStatic}:${service}/${field}`;
+}
+
+/**
+ * Build a local OAuth credential handle from a provider key and connection ID.
+ */
+export function localOAuthHandle(
+  providerKey: string,
+  connectionId: string,
+): string {
+  return `${HandleType.LocalOAuth}:${providerKey}/${connectionId}`;
+}
+
+/**
+ * Build a managed (platform) OAuth credential handle from a connection ID.
+ */
+export function platformOAuthHandle(connectionId: string): string {
+  return `${HandleType.PlatformOAuth}:${connectionId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Handle parsing
+// ---------------------------------------------------------------------------
+
+export type ParseHandleResult =
+  | { ok: true; handle: ParsedHandle }
+  | { ok: false; error: string };
+
+/**
+ * Parse a raw handle string into a structured `ParsedHandle`.
+ *
+ * Returns a discriminated result so callers can inspect parse errors
+ * without catching exceptions.
+ */
+export function parseHandle(raw: string): ParseHandleResult {
+  const colonIdx = raw.indexOf(":");
+  if (colonIdx === -1) {
+    return { ok: false, error: `Invalid handle format: missing type prefix in "${raw}"` };
+  }
+
+  const prefix = raw.slice(0, colonIdx);
+  const rest = raw.slice(colonIdx + 1);
+
+  switch (prefix) {
+    case HandleType.LocalStatic: {
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx === -1 || slashIdx === 0 || slashIdx === rest.length - 1) {
+        return {
+          ok: false,
+          error: `Invalid local_static handle: expected "local_static:<service>/<field>", got "${raw}"`,
+        };
+      }
+      return {
+        ok: true,
+        handle: {
+          type: HandleType.LocalStatic,
+          service: rest.slice(0, slashIdx),
+          field: rest.slice(slashIdx + 1),
+          raw,
+        },
+      };
+    }
+
+    case HandleType.LocalOAuth: {
+      // providerKey may itself contain a colon (e.g. "integration:google"),
+      // so we split on the *last* "/" to separate providerKey from connectionId.
+      const lastSlashIdx = rest.lastIndexOf("/");
+      if (
+        lastSlashIdx === -1 ||
+        lastSlashIdx === 0 ||
+        lastSlashIdx === rest.length - 1
+      ) {
+        return {
+          ok: false,
+          error: `Invalid local_oauth handle: expected "local_oauth:<providerKey>/<connectionId>", got "${raw}"`,
+        };
+      }
+      return {
+        ok: true,
+        handle: {
+          type: HandleType.LocalOAuth,
+          providerKey: rest.slice(0, lastSlashIdx),
+          connectionId: rest.slice(lastSlashIdx + 1),
+          raw,
+        },
+      };
+    }
+
+    case HandleType.PlatformOAuth: {
+      if (!rest || rest.length === 0) {
+        return {
+          ok: false,
+          error: `Invalid platform_oauth handle: missing connectionId in "${raw}"`,
+        };
+      }
+      return {
+        ok: true,
+        handle: {
+          type: HandleType.PlatformOAuth,
+          connectionId: rest,
+          raw,
+        },
+      };
+    }
+
+    default:
+      return {
+        ok: false,
+        error: `Unknown handle type prefix "${prefix}" in "${raw}"`,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema for wire validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Zod schema that validates a string as a well-formed CES credential handle.
+ * Useful in RPC schemas where the handle travels on the wire.
+ */
+export const CredentialHandleSchema = z
+  .string()
+  .check(
+    z.refine((val: string) => {
+      const result = parseHandle(val);
+      return result.ok;
+    }, "Must be a valid CES credential handle (local_static:*, local_oauth:*, or platform_oauth:*)"),
+  );

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -118,3 +118,12 @@ export const TransportMessageSchema = z.discriminatedUnion("type", [
   RpcEnvelopeSchema.extend({ type: z.literal("rpc") }),
 ]);
 export type TransportMessage = z.infer<typeof TransportMessageSchema>;
+
+// ---------------------------------------------------------------------------
+// Re-exports from sub-modules
+// ---------------------------------------------------------------------------
+
+export * from "./handles.js";
+export * from "./grants.js";
+export * from "./rpc.js";
+export * from "./rendering.js";

--- a/packages/ces-contracts/src/rendering.ts
+++ b/packages/ces-contracts/src/rendering.ts
@@ -1,0 +1,131 @@
+/**
+ * Canonical proposal rendering and deterministic hashing.
+ *
+ * Both the assistant and CES must produce identical human-readable text and
+ * proposal hashes for the same proposal object. This module provides the
+ * shared implementations so neither side has to duplicate the logic.
+ *
+ * Hashing algorithm:
+ *   1. Recursively sort object keys (depth-first).
+ *   2. Serialize to a canonical JSON string with no whitespace.
+ *   3. SHA-256 hash the UTF-8 bytes and return a lowercase hex digest.
+ *
+ * This matches the algorithm used by `tool-approval-digest.ts` in the
+ * assistant, ensuring consistency across the approval pipeline.
+ */
+
+import { createHash } from "node:crypto";
+import type { GrantProposal } from "./grants.js";
+
+// ---------------------------------------------------------------------------
+// Canonical JSON serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively sort all object keys and return a deterministic JSON string.
+ *
+ * Handles nested objects, arrays (element order preserved), and primitive
+ * values. `undefined` values inside objects are omitted (matching
+ * JSON.stringify semantics). `null` is preserved.
+ */
+export function canonicalJsonSerialize(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (value == null) return value;
+
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+
+  if (typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    for (const key of keys) {
+      sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+
+  // Primitive — number, string, boolean
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a deterministic SHA-256 hex digest for a grant proposal.
+ *
+ * Two proposals with the same canonical content (regardless of key ordering)
+ * will always produce the same hash. This hash is used to match grant
+ * decisions to proposals in the approval pipeline.
+ */
+export function hashProposal(proposal: GrantProposal): string {
+  const canonical = canonicalJsonSerialize(proposal);
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable proposal rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a grant proposal as a human-readable text block suitable for
+ * display in approval UIs and guardian notifications.
+ *
+ * The rendering is deterministic for the same proposal, so both assistant
+ * and CES produce identical text.
+ */
+export function renderProposal(proposal: GrantProposal): string {
+  switch (proposal.type) {
+    case "http":
+      return renderHttpProposal(proposal);
+    case "command":
+      return renderCommandProposal(proposal);
+  }
+}
+
+function renderHttpProposal(proposal: GrantProposal & { type: "http" }): string {
+  const lines: string[] = [
+    `Authenticated HTTP Request`,
+    `  Method: ${proposal.method}`,
+    `  URL: ${proposal.url}`,
+    `  Credential: ${proposal.credentialHandle}`,
+    `  Purpose: ${proposal.purpose}`,
+  ];
+
+  if (proposal.allowedUrlPatterns && proposal.allowedUrlPatterns.length > 0) {
+    lines.push(`  Allowed URL patterns:`);
+    for (const pattern of proposal.allowedUrlPatterns) {
+      lines.push(`    - ${pattern}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderCommandProposal(
+  proposal: GrantProposal & { type: "command" },
+): string {
+  const lines: string[] = [
+    `Authenticated Command Execution`,
+    `  Command: ${proposal.command}`,
+    `  Credential: ${proposal.credentialHandle}`,
+    `  Purpose: ${proposal.purpose}`,
+  ];
+
+  if (
+    proposal.allowedCommandPatterns &&
+    proposal.allowedCommandPatterns.length > 0
+  ) {
+    lines.push(`  Allowed command patterns:`);
+    for (const pattern of proposal.allowedCommandPatterns) {
+      lines.push(`    - ${pattern}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -1,0 +1,369 @@
+/**
+ * CES RPC method contracts.
+ *
+ * Defines the request and response schemas for every RPC method in the
+ * assistant-to-CES wire protocol. Each method has a canonical string
+ * name, a request schema, and a response schema.
+ *
+ * Methods:
+ *
+ * **Tool execution**
+ * - `make_authenticated_request` — Execute an authenticated HTTP request
+ * - `run_authenticated_command` — Execute a command with credential env vars
+ * - `manage_secure_command_tool` — Register/unregister a secure command tool
+ *
+ * **Approval flow**
+ * - `approval_required` — CES notifies the assistant that approval is needed
+ * - `record_grant` — Record a grant decision after guardian approval
+ *
+ * **Grant management**
+ * - `list_grants` — List grants for a session
+ * - `revoke_grant` — Revoke a specific grant
+ *
+ * **Audit**
+ * - `list_audit_records` — List audit records for inspection
+ */
+
+import { z } from "zod/v4";
+import {
+  AuditRecordSummarySchema,
+  GrantProposalSchema,
+  PersistentGrantRecordSchema,
+  TemporaryGrantDecisionSchema,
+} from "./grants.js";
+import { RpcErrorSchema } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Method name constants
+// ---------------------------------------------------------------------------
+
+export const CesRpcMethod = {
+  MakeAuthenticatedRequest: "make_authenticated_request",
+  RunAuthenticatedCommand: "run_authenticated_command",
+  ManageSecureCommandTool: "manage_secure_command_tool",
+  ApprovalRequired: "approval_required",
+  RecordGrant: "record_grant",
+  ListGrants: "list_grants",
+  RevokeGrant: "revoke_grant",
+  ListAuditRecords: "list_audit_records",
+} as const;
+
+export type CesRpcMethod =
+  (typeof CesRpcMethod)[keyof typeof CesRpcMethod];
+
+// ---------------------------------------------------------------------------
+// make_authenticated_request
+// ---------------------------------------------------------------------------
+
+export const MakeAuthenticatedRequestSchema = z.object({
+  /** CES credential handle to use for authentication. */
+  credentialHandle: z.string(),
+  /** HTTP method. */
+  method: z.string(),
+  /** Target URL. */
+  url: z.string(),
+  /** Optional request headers (credential headers are injected by CES). */
+  headers: z.record(z.string(), z.string()).optional(),
+  /** Optional request body (string or JSON-serialisable). */
+  body: z.unknown().optional(),
+  /** Human-readable purpose for audit logging. */
+  purpose: z.string(),
+  /** Existing grant ID to consume, if the caller holds one. */
+  grantId: z.string().optional(),
+});
+export type MakeAuthenticatedRequest = z.infer<
+  typeof MakeAuthenticatedRequestSchema
+>;
+
+export const MakeAuthenticatedRequestResponseSchema = z.object({
+  /** Whether the request was executed (not whether the HTTP call succeeded). */
+  success: z.boolean(),
+  /** HTTP status code returned by the target. */
+  statusCode: z.number().optional(),
+  /** Response headers. */
+  responseHeaders: z.record(z.string(), z.string()).optional(),
+  /** Response body (string). */
+  responseBody: z.string().optional(),
+  /** Structured error if execution failed. */
+  error: RpcErrorSchema.optional(),
+  /** Audit record ID for this execution. */
+  auditId: z.string().optional(),
+});
+export type MakeAuthenticatedRequestResponse = z.infer<
+  typeof MakeAuthenticatedRequestResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// run_authenticated_command
+// ---------------------------------------------------------------------------
+
+export const RunAuthenticatedCommandSchema = z.object({
+  /** CES credential handle to use for environment injection. */
+  credentialHandle: z.string(),
+  /** The command to execute. */
+  command: z.string(),
+  /** Optional environment variable name mappings for credential injection. */
+  envMappings: z.record(z.string(), z.string()).optional(),
+  /** Optional working directory. */
+  cwd: z.string().optional(),
+  /** Human-readable purpose for audit logging. */
+  purpose: z.string(),
+  /** Existing grant ID to consume, if the caller holds one. */
+  grantId: z.string().optional(),
+});
+export type RunAuthenticatedCommand = z.infer<
+  typeof RunAuthenticatedCommandSchema
+>;
+
+export const RunAuthenticatedCommandResponseSchema = z.object({
+  /** Whether the command was executed. */
+  success: z.boolean(),
+  /** Process exit code. */
+  exitCode: z.number().optional(),
+  /** Combined stdout output. */
+  stdout: z.string().optional(),
+  /** Combined stderr output. */
+  stderr: z.string().optional(),
+  /** Structured error if execution failed. */
+  error: RpcErrorSchema.optional(),
+  /** Audit record ID for this execution. */
+  auditId: z.string().optional(),
+});
+export type RunAuthenticatedCommandResponse = z.infer<
+  typeof RunAuthenticatedCommandResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// manage_secure_command_tool
+// ---------------------------------------------------------------------------
+
+export const ManageSecureCommandToolAction = {
+  Register: "register",
+  Unregister: "unregister",
+} as const;
+
+export type ManageSecureCommandToolAction =
+  (typeof ManageSecureCommandToolAction)[keyof typeof ManageSecureCommandToolAction];
+
+export const ManageSecureCommandToolSchema = z.object({
+  /** Whether to register or unregister the tool. */
+  action: z.enum(["register", "unregister"]),
+  /** Tool name to register/unregister. */
+  toolName: z.string(),
+  /** CES credential handle the tool should use (required for register). */
+  credentialHandle: z.string().optional(),
+  /** Command template with `{{credential}}` placeholders (required for register). */
+  commandTemplate: z.string().optional(),
+  /** Human-readable description of the tool (required for register). */
+  description: z.string().optional(),
+});
+export type ManageSecureCommandTool = z.infer<
+  typeof ManageSecureCommandToolSchema
+>;
+
+export const ManageSecureCommandToolResponseSchema = z.object({
+  /** Whether the operation succeeded. */
+  success: z.boolean(),
+  /** Structured error if the operation failed. */
+  error: RpcErrorSchema.optional(),
+});
+export type ManageSecureCommandToolResponse = z.infer<
+  typeof ManageSecureCommandToolResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// approval_required (CES → assistant notification)
+// ---------------------------------------------------------------------------
+
+export const ApprovalRequiredSchema = z.object({
+  /** The proposal that requires approval. */
+  proposal: GrantProposalSchema,
+  /** Deterministic hash of the proposal. */
+  proposalHash: z.string(),
+  /** Human-readable rendering of the proposal. */
+  renderedProposal: z.string(),
+  /** The agent session requesting approval. */
+  sessionId: z.string(),
+});
+export type ApprovalRequired = z.infer<typeof ApprovalRequiredSchema>;
+
+export const ApprovalRequiredResponseSchema = z.object({
+  /** Whether the assistant acknowledged the approval request. */
+  acknowledged: z.boolean(),
+});
+export type ApprovalRequiredResponse = z.infer<
+  typeof ApprovalRequiredResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// record_grant
+// ---------------------------------------------------------------------------
+
+export const RecordGrantSchema = z.object({
+  /** The grant decision from the guardian. */
+  decision: TemporaryGrantDecisionSchema,
+  /** The agent session this grant applies to. */
+  sessionId: z.string(),
+});
+export type RecordGrant = z.infer<typeof RecordGrantSchema>;
+
+export const RecordGrantResponseSchema = z.object({
+  /** Whether the grant was successfully recorded. */
+  success: z.boolean(),
+  /** The persisted grant record (when approved and recorded). */
+  grant: PersistentGrantRecordSchema.optional(),
+  /** Structured error if recording failed. */
+  error: RpcErrorSchema.optional(),
+});
+export type RecordGrantResponse = z.infer<typeof RecordGrantResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// list_grants
+// ---------------------------------------------------------------------------
+
+export const ListGrantsSchema = z.object({
+  /** Filter by session ID. */
+  sessionId: z.string().optional(),
+  /** Filter by credential handle. */
+  credentialHandle: z.string().optional(),
+  /** Filter by grant status. */
+  status: z
+    .enum(["active", "expired", "revoked", "consumed"])
+    .optional(),
+});
+export type ListGrants = z.infer<typeof ListGrantsSchema>;
+
+export const ListGrantsResponseSchema = z.object({
+  /** List of matching grant records. */
+  grants: z.array(PersistentGrantRecordSchema),
+});
+export type ListGrantsResponse = z.infer<typeof ListGrantsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// revoke_grant
+// ---------------------------------------------------------------------------
+
+export const RevokeGrantSchema = z.object({
+  /** The grant to revoke. */
+  grantId: z.string(),
+  /** Human-readable reason for revocation. */
+  reason: z.string().optional(),
+});
+export type RevokeGrant = z.infer<typeof RevokeGrantSchema>;
+
+export const RevokeGrantResponseSchema = z.object({
+  /** Whether the grant was successfully revoked. */
+  success: z.boolean(),
+  /** Structured error if revocation failed. */
+  error: RpcErrorSchema.optional(),
+});
+export type RevokeGrantResponse = z.infer<typeof RevokeGrantResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// list_audit_records
+// ---------------------------------------------------------------------------
+
+export const ListAuditRecordsSchema = z.object({
+  /** Filter by session ID. */
+  sessionId: z.string().optional(),
+  /** Filter by credential handle. */
+  credentialHandle: z.string().optional(),
+  /** Filter by grant ID. */
+  grantId: z.string().optional(),
+  /** Maximum number of records to return. */
+  limit: z.number().optional(),
+  /** Cursor for pagination (opaque string from a previous response). */
+  cursor: z.string().optional(),
+});
+export type ListAuditRecords = z.infer<typeof ListAuditRecordsSchema>;
+
+export const ListAuditRecordsResponseSchema = z.object({
+  /** List of matching audit record summaries. */
+  records: z.array(AuditRecordSummarySchema),
+  /** Cursor for the next page (null if no more results). */
+  nextCursor: z.string().nullable(),
+});
+export type ListAuditRecordsResponse = z.infer<
+  typeof ListAuditRecordsResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Full RPC contract type map
+// ---------------------------------------------------------------------------
+
+/**
+ * Type-level mapping from RPC method names to their request and response
+ * schemas. Useful for building type-safe RPC dispatch layers.
+ */
+export interface CesRpcContract {
+  [CesRpcMethod.MakeAuthenticatedRequest]: {
+    request: MakeAuthenticatedRequest;
+    response: MakeAuthenticatedRequestResponse;
+  };
+  [CesRpcMethod.RunAuthenticatedCommand]: {
+    request: RunAuthenticatedCommand;
+    response: RunAuthenticatedCommandResponse;
+  };
+  [CesRpcMethod.ManageSecureCommandTool]: {
+    request: ManageSecureCommandTool;
+    response: ManageSecureCommandToolResponse;
+  };
+  [CesRpcMethod.ApprovalRequired]: {
+    request: ApprovalRequired;
+    response: ApprovalRequiredResponse;
+  };
+  [CesRpcMethod.RecordGrant]: {
+    request: RecordGrant;
+    response: RecordGrantResponse;
+  };
+  [CesRpcMethod.ListGrants]: {
+    request: ListGrants;
+    response: ListGrantsResponse;
+  };
+  [CesRpcMethod.RevokeGrant]: {
+    request: RevokeGrant;
+    response: RevokeGrantResponse;
+  };
+  [CesRpcMethod.ListAuditRecords]: {
+    request: ListAuditRecords;
+    response: ListAuditRecordsResponse;
+  };
+}
+
+/**
+ * Schema lookup map for runtime validation of RPC payloads.
+ */
+export const CesRpcSchemas = {
+  [CesRpcMethod.MakeAuthenticatedRequest]: {
+    request: MakeAuthenticatedRequestSchema,
+    response: MakeAuthenticatedRequestResponseSchema,
+  },
+  [CesRpcMethod.RunAuthenticatedCommand]: {
+    request: RunAuthenticatedCommandSchema,
+    response: RunAuthenticatedCommandResponseSchema,
+  },
+  [CesRpcMethod.ManageSecureCommandTool]: {
+    request: ManageSecureCommandToolSchema,
+    response: ManageSecureCommandToolResponseSchema,
+  },
+  [CesRpcMethod.ApprovalRequired]: {
+    request: ApprovalRequiredSchema,
+    response: ApprovalRequiredResponseSchema,
+  },
+  [CesRpcMethod.RecordGrant]: {
+    request: RecordGrantSchema,
+    response: RecordGrantResponseSchema,
+  },
+  [CesRpcMethod.ListGrants]: {
+    request: ListGrantsSchema,
+    response: ListGrantsResponseSchema,
+  },
+  [CesRpcMethod.RevokeGrant]: {
+    request: RevokeGrantSchema,
+    response: RevokeGrantResponseSchema,
+  },
+  [CesRpcMethod.ListAuditRecords]: {
+    request: ListAuditRecordsSchema,
+    response: ListAuditRecordsResponseSchema,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Add v1 handle formats and parsers for local static, local OAuth, and managed OAuth handles
- Add canonical schemas for HTTP/command grant proposals, temporary/persistent grants, and audit records
- Add full CES RPC contract and deterministic proposal rendering/hashing helpers

Part of plan: untrusted-agent-credential-arch.md (PR 16 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
