### PR TITLE
fix: skip credential-executor CI test step when no test files exist

### DIFF
--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -39,7 +39,12 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun run test
+        run: |
+          if find src/ -name '*.test.*' -o -name '*.spec.*' | grep -q .; then
+            bun run test
+          else
+            echo "No test files found, skipping"
+          fi
 
   notify-credential-executor:
     name: Slack Notification (Credential Executor)

--- a/.github/workflows/pr-credential-executor.yaml
+++ b/.github/workflows/pr-credential-executor.yaml
@@ -42,4 +42,9 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun run test
+        run: |
+          if find src/ -name '*.test.*' -o -name '*.spec.*' | grep -q .; then
+            bun run test
+          else
+            echo "No test files found, skipping"
+          fi

--- a/credential-executor/bun.lock
+++ b/credential-executor/bun.lock
@@ -1,0 +1,37 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/credential-executor",
+      "dependencies": {
+        "@vellumai/ces-contracts": "file:../packages/ces-contracts",
+        "@vellumai/credential-storage": "file:../packages/credential-storage",
+        "@vellumai/egress-proxy": "file:../packages/egress-proxy",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.4",
+        "typescript": "^5.7.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "dependencies": { "zod": "^4.3.6" }, "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
+
+    "@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
+
+    "@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "devDependencies": { "@types/bun": "^1.2.4", "typescript": "^5.7.3" } }],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+  }
+}


### PR DESCRIPTION
## Summary
- CI test step in credential-executor workflows (`ci-main-credential-executor.yaml`, `pr-credential-executor.yaml`) fails because `bun test src/` exits with code 1 when no test files are found
- credential-executor is a new scaffold package with no test files yet
- Added a check for test files before running `bun test` — skips gracefully when none exist

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23099999792/job/67098984722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
