### PR TITLE
fix: defer avatar rename migration until consumer code is updated

### DIFF
--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,10 +1,12 @@
-import { avatarRenameMigration } from "./001-avatar-rename.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
  * Ordered list of all workspace data migrations.
  * New migrations are appended to the end. Never reorder or remove entries.
+ *
+ * NOTE: avatarRenameMigration (001-avatar-rename.ts) is intentionally not
+ * registered yet. It renames avatar files to new paths, but no consumer code
+ * reads from the new filenames. Re-add it here once the avatar-skill-refactor
+ * plan updates all consumers to use the new paths.
  */
-export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
-  avatarRenameMigration,
-];
+export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for workspace-migration-framework.md.

**Gap:** Avatar rename migration runs on startup but no consumers have been updated to read from the new filenames yet, which would cause existing avatars to disappear.
**Fix:** Remove the migration from the registry (keep the file) until the companion avatar-skill-refactor plan updates all consumers. The migration will be re-registered at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
