### PR TITLE
fix: resolve type check errors from credential-storage extraction

### DIFF
--- a/assistant/src/__tests__/credential-storage-static-compat.test.ts
+++ b/assistant/src/__tests__/credential-storage-static-compat.test.ts
@@ -315,8 +315,12 @@ describe("static credential storage compatibility", () => {
       expect(result!.credentialId).toBe("test-id");
       expect(result!.service).toBe("github");
       // OAuth-specific fields should be stripped
-      expect((result as Record<string, unknown>).expiresAt).toBeUndefined();
-      expect((result as Record<string, unknown>).grantedScopes).toBeUndefined();
+      expect(
+        (result as unknown as Record<string, unknown>).expiresAt,
+      ).toBeUndefined();
+      expect(
+        (result as unknown as Record<string, unknown>).grantedScopes,
+      ).toBeUndefined();
     });
 
     test("filters out refresh_token ghost records during migration", () => {

--- a/assistant/tsconfig.json
+++ b/assistant/tsconfig.json
@@ -12,7 +12,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": "./src",
     "jsx": "react-jsx",
     "types": ["bun-types"],
     "paths": {


### PR DESCRIPTION
## Summary
- Remove explicit `rootDir` from `assistant/tsconfig.json` — it caused TS6059 errors when TypeScript pulled in source files from `packages/credential-storage/` (outside `assistant/src/`). Since we only use `tsc --noEmit` and Bun for runtime, `rootDir` is unnecessary.
- Fix TS2352 cast errors in `credential-storage-static-compat.test.ts` by casting through `unknown` first (the `StaticCredentialRecord` interface lacks an index signature).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100013799/job/67099023494

🤖 Generated with [Claude Code](https://claude.com/claude-code)