### PR TITLE
refactor: update avatar generator and side effects to use avatar-image.png

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -129,7 +129,7 @@ function geminiContentResponse() {
 }
 
 const expectedAvatarPath =
-  "/tmp/test-workspace-e2e/data/avatar/custom-avatar.png";
+  "/tmp/test-workspace-e2e/data/avatar/avatar-image.png";
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -119,7 +119,7 @@ describe("setAvatarTool", () => {
   test("atomic write — file is written to .tmp then renamed", async () => {
     await executeAvatar("a friendly cat");
 
-    const expectedPath = "/tmp/test-workspace/data/avatar/custom-avatar.png";
+    const expectedPath = "/tmp/test-workspace/data/avatar/avatar-image.png";
 
     // Verify mkdirSync was called for the directory
     expect(mkdirSyncFn).toHaveBeenCalledTimes(1);

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -203,7 +203,7 @@ registerHook(
       getWorkspaceDir(),
       "data",
       "avatar",
-      "custom-avatar.png",
+      "avatar-image.png",
     );
     broadcastToAllClients?.({ type: "avatar_updated", avatarPath });
   },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -100,7 +100,7 @@ async function handleGenerateAvatar(description: string): Promise<Response> {
       getWorkspaceDir(),
       "data",
       "avatar",
-      "custom-avatar.png",
+      "avatar-image.png",
     );
     return Response.json({ ok: true, avatarPath });
   } catch (err) {
@@ -176,7 +176,9 @@ async function handleOAuthConnectStart(body: {
     if (dbApp) {
       clientId = dbApp.clientId;
       if (!clientSecret) {
-        clientSecret = await getSecureKeyAsync(dbApp.clientSecretCredentialPath);
+        clientSecret = await getSecureKeyAsync(
+          dbApp.clientSecretCredentialPath,
+        );
       }
     }
   }

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -16,7 +16,7 @@ const TOOL_NAME = "set_avatar";
 
 /** Canonical path where the custom avatar PNG is stored. */
 function getAvatarPath(): string {
-  return join(getWorkspaceDir(), "data", "avatar", "custom-avatar.png");
+  return join(getWorkspaceDir(), "data", "avatar", "avatar-image.png");
 }
 
 export const setAvatarTool: Tool = {

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -1,12 +1,10 @@
+import { avatarRenameMigration } from "./001-avatar-rename.js";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
  * Ordered list of all workspace data migrations.
  * New migrations are appended to the end. Never reorder or remove entries.
- *
- * NOTE: avatarRenameMigration (001-avatar-rename.ts) is intentionally not
- * registered yet. It renames avatar files to new paths, but no consumer code
- * reads from the new filenames. Re-add it here once the avatar-skill-refactor
- * plan updates all consumers to use the new paths.
  */
-export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [];
+export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
+  avatarRenameMigration,
+];


### PR DESCRIPTION
## Summary
- Update all daemon-side references from custom-avatar.png to avatar-image.png
- Re-register the 001-avatar-rename workspace migration now that consumers use new paths
- Update test assertions to match new file paths

Part of plan: avatar-skill-refactor.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
