### PR TITLE
[assistant] Add platform-managed CES handle discovery to assistant CLI commands

### DIFF
--- a/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
+++ b/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+// ---------------------------------------------------------------------------
+// Mock logger
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  getCliLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mutable state for mocks
+// ---------------------------------------------------------------------------
+
+let mockPlatformBaseUrl = "";
+let mockAssistantApiKey: string | null = null;
+
+/** Simulated platform catalog responses keyed by URL. */
+let mockFetchResponses: Map<
+  string,
+  { status: number; body: unknown }
+> = new Map();
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => {
+    if (key === credentialKey("vellum", "assistant_api_key")) {
+      return mockAssistantApiKey;
+    }
+    return null;
+  },
+}));
+
+// Mock global fetch
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  const entry = mockFetchResponses.get(url);
+  if (!entry) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  // Verify the Authorization header never leaks secrets into the request path
+  const authHeader = init?.headers
+    ? (init.headers as Record<string, string>)["Authorization"]
+    : undefined;
+  if (authHeader && !authHeader.startsWith("Api-Key ")) {
+    throw new Error("Unexpected auth header format");
+  }
+
+  return new Response(JSON.stringify(entry.body), {
+    status: entry.status,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Import after mocks are installed
+// ---------------------------------------------------------------------------
+
+import {
+  fetchManagedCatalog,
+  type ManagedCredentialDescriptor,
+} from "../credential-execution/managed-catalog.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("fetchManagedCatalog", () => {
+  beforeEach(() => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+    mockFetchResponses = new Map();
+  });
+
+  test("returns empty descriptors when managed proxy prerequisites are missing", async () => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toEqual([]);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns empty descriptors when platform URL is missing", async () => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = "sk-test-key";
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toEqual([]);
+  });
+
+  test("returns empty descriptors when API key is missing", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = null;
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toEqual([]);
+  });
+
+  test("parses platform catalog response into descriptors with correct handles", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/ces/catalog",
+      {
+        status: 200,
+        body: {
+          connections: [
+            {
+              id: "conn_google_123",
+              provider: "google",
+              account_info: "user@gmail.com",
+              granted_scopes: ["email", "calendar"],
+              status: "active",
+            },
+            {
+              id: "conn_slack_456",
+              provider: "slack",
+              account_info: "workspace-bot",
+              granted_scopes: ["chat:write"],
+              status: "active",
+            },
+          ],
+        },
+      },
+    );
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toHaveLength(2);
+
+    const [google, slack] = result.descriptors;
+    expect(google.handle).toBe("platform_oauth:conn_google_123");
+    expect(google.source).toBe("platform");
+    expect(google.provider).toBe("google");
+    expect(google.connectionId).toBe("conn_google_123");
+    expect(google.accountInfo).toBe("user@gmail.com");
+    expect(google.grantedScopes).toEqual(["email", "calendar"]);
+    expect(google.status).toBe("active");
+
+    expect(slack.handle).toBe("platform_oauth:conn_slack_456");
+    expect(slack.provider).toBe("slack");
+    expect(slack.connectionId).toBe("conn_slack_456");
+  });
+
+  test("handles empty connections list from platform", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/ces/catalog",
+      {
+        status: 200,
+        body: { connections: [] },
+      },
+    );
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toEqual([]);
+  });
+
+  test("handles platform returning HTTP error gracefully", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/ces/catalog",
+      {
+        status: 500,
+        body: { detail: "Internal server error" },
+      },
+    );
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(false);
+    expect(result.descriptors).toEqual([]);
+    expect(result.error).toContain("500");
+  });
+
+  test("handles platform returning unexpected format gracefully", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/ces/catalog",
+      {
+        status: 200,
+        body: { unexpected: "shape" },
+      },
+    );
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("unexpected response format");
+  });
+
+  test("defaults missing optional fields in catalog entries", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+
+    mockFetchResponses.set(
+      "https://platform.example.com/v1/ces/catalog",
+      {
+        status: 200,
+        body: {
+          connections: [
+            {
+              id: "conn_minimal",
+              provider: "github",
+              // account_info, granted_scopes, status all omitted
+            },
+          ],
+        },
+      },
+    );
+
+    const result = await fetchManagedCatalog();
+    expect(result.ok).toBe(true);
+    expect(result.descriptors).toHaveLength(1);
+
+    const descriptor = result.descriptors[0];
+    expect(descriptor.accountInfo).toBeNull();
+    expect(descriptor.grantedScopes).toEqual([]);
+    expect(descriptor.status).toBe("unknown");
+    expect(descriptor.handle).toBe("platform_oauth:conn_minimal");
+  });
+
+  test("error messages never contain API key values", async () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-super-secret-key-12345";
+
+    // Simulate a network error
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error(
+        "Connect failed to https://platform.example.com/v1/ces/catalog with Api-Key sk-super-secret-key-12345",
+      );
+    };
+
+    try {
+      const result = await fetchManagedCatalog();
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeDefined();
+      // Ensure the raw API key is not in the error message
+      expect(result.error).not.toContain("sk-super-secret-key-12345");
+      expect(result.error).toContain("[REDACTED]");
+    } finally {
+      globalThis.fetch = savedFetch;
+    }
+  });
+});
+
+describe("managed credential merging", () => {
+  test("managed descriptors produce correct CES handle format", () => {
+    // Verify the handle format matches what CES tools expect
+    const descriptor: ManagedCredentialDescriptor = {
+      handle: "platform_oauth:conn_test_789",
+      source: "platform",
+      provider: "google",
+      connectionId: "conn_test_789",
+      accountInfo: "test@example.com",
+      grantedScopes: ["email"],
+      status: "active",
+    };
+
+    expect(descriptor.handle).toMatch(/^platform_oauth:/);
+    expect(descriptor.handle).toBe("platform_oauth:conn_test_789");
+    expect(descriptor.source).toBe("platform");
+  });
+
+  test("managed descriptors never expose token values", () => {
+    // A descriptor should only contain non-secret metadata
+    const descriptor: ManagedCredentialDescriptor = {
+      handle: "platform_oauth:conn_abc",
+      source: "platform",
+      provider: "google",
+      connectionId: "conn_abc",
+      accountInfo: "user@example.com",
+      grantedScopes: ["email", "calendar"],
+      status: "active",
+    };
+
+    // Serialize and check for common token patterns
+    const serialized = JSON.stringify(descriptor);
+    expect(serialized).not.toContain("access_token");
+    expect(serialized).not.toContain("refresh_token");
+    expect(serialized).not.toContain("id_token");
+    expect(serialized).not.toContain("Bearer ");
+    expect(serialized).not.toContain("Api-Key ");
+
+    // Verify all properties are the expected non-secret metadata
+    const keys = Object.keys(descriptor);
+    expect(keys).toEqual([
+      "handle",
+      "source",
+      "provider",
+      "connectionId",
+      "accountInfo",
+      "grantedScopes",
+      "status",
+    ]);
+  });
+});

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -1,6 +1,10 @@
 import type { Command } from "commander";
 
 import {
+  fetchManagedCatalog,
+  type ManagedCredentialDescriptor,
+} from "../../credential-execution/managed-catalog.js";
+import {
   disconnectOAuthProvider,
   getConnectionByProvider,
   listConnections,
@@ -147,6 +151,44 @@ function printCredentialHuman(output: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Build a structured output object for a platform-managed credential descriptor.
+ * Never includes token values — only handle references and non-secret metadata.
+ */
+function buildManagedCredentialOutput(
+  descriptor: ManagedCredentialDescriptor,
+): Record<string, unknown> {
+  return {
+    ok: true,
+    source: "platform",
+    handle: descriptor.handle,
+    provider: descriptor.provider,
+    connectionId: descriptor.connectionId,
+    accountInfo: descriptor.accountInfo,
+    grantedScopes: descriptor.grantedScopes,
+    status: descriptor.status,
+  };
+}
+
+/**
+ * Print a human-readable view of a platform-managed credential to the logger.
+ */
+function printManagedCredentialHuman(
+  output: Record<string, unknown>,
+): void {
+  log.info(`  [platform-managed] ${output.provider}`);
+  log.info(`    Handle:      ${output.handle}`);
+  log.info(`    Status:      ${output.status}`);
+  if (output.accountInfo) log.info(`    Account:     ${output.accountInfo}`);
+  if (
+    Array.isArray(output.grantedScopes) &&
+    (output.grantedScopes as string[]).length > 0
+  )
+    log.info(
+      `    Scopes:      ${(output.grantedScopes as string[]).join(", ")}`,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Command registration
 // ---------------------------------------------------------------------------
@@ -257,16 +299,50 @@ Examples:
           }),
         );
 
-        writeOutput(cmd, { ok: true, credentials });
+        // Fetch platform-managed credentials (best-effort — errors do not
+        // break local listing). Filter by search query if provided.
+        const managedResult = await fetchManagedCatalog();
+        let managedOutputs: Record<string, unknown>[] = [];
+        if (managedResult.ok && managedResult.descriptors.length > 0) {
+          let descriptors = managedResult.descriptors;
+          if (opts.search) {
+            const query = opts.search.toLowerCase();
+            descriptors = descriptors.filter(
+              (d) =>
+                d.provider.toLowerCase().includes(query) ||
+                d.handle.toLowerCase().includes(query) ||
+                (d.accountInfo ?? "").toLowerCase().includes(query),
+            );
+          }
+          managedOutputs = descriptors.map(buildManagedCredentialOutput);
+        }
+
+        writeOutput(cmd, {
+          ok: true,
+          credentials,
+          managedCredentials: managedOutputs,
+        });
 
         if (!shouldOutputJson(cmd)) {
-          if (credentials.length === 0) {
+          const totalCount = credentials.length + managedOutputs.length;
+          if (totalCount === 0) {
             log.info("No credentials found");
           } else {
-            log.info(`${credentials.length} credential(s):\n`);
-            for (const cred of credentials) {
-              printCredentialHuman(cred);
-              log.info("");
+            if (credentials.length > 0) {
+              log.info(`${credentials.length} local credential(s):\n`);
+              for (const cred of credentials) {
+                printCredentialHuman(cred);
+                log.info("");
+              }
+            }
+            if (managedOutputs.length > 0) {
+              log.info(
+                `${managedOutputs.length} platform-managed credential(s):\n`,
+              );
+              for (const managed of managedOutputs) {
+                printManagedCredentialHuman(managed);
+                log.info("");
+              }
             }
           }
         }

--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
 
+import {
+  fetchManagedCatalog,
+  type ManagedCredentialDescriptor,
+} from "../../../credential-execution/managed-catalog.js";
 import { orchestrateOAuthConnect } from "../../../oauth/connect-orchestrator.js";
 import {
   disconnectOAuthProvider,
@@ -77,6 +81,25 @@ function formatConnectionRow(row: ReturnType<typeof getConnection>) {
   };
 }
 
+/**
+ * Format a platform-managed credential descriptor into a connection-like
+ * output row. Never includes token values — only handle references and
+ * non-secret metadata.
+ */
+function formatManagedConnectionRow(
+  descriptor: ManagedCredentialDescriptor,
+): Record<string, unknown> {
+  return {
+    source: "platform",
+    handle: descriptor.handle,
+    provider: descriptor.provider,
+    connectionId: descriptor.connectionId,
+    accountInfo: descriptor.accountInfo,
+    grantedScopes: descriptor.grantedScopes,
+    status: descriptor.status,
+  };
+}
+
 export function registerConnectionCommands(oauth: Command): void {
   const connections = oauth
     .command("connections")
@@ -128,23 +151,54 @@ Examples:
   $ assistant oauth connections list --provider integration:google
   $ assistant oauth connections list --client-id abc123`,
     )
-    .action((opts: { provider?: string; clientId?: string }, cmd: Command) => {
-      try {
-        const rows = listConnections(opts.provider, opts.clientId).map(
-          formatConnectionRow,
-        );
+    .action(
+      async (
+        opts: { provider?: string; clientId?: string },
+        cmd: Command,
+      ) => {
+        try {
+          const rows = listConnections(opts.provider, opts.clientId).map(
+            formatConnectionRow,
+          );
 
-        if (!shouldOutputJson(cmd)) {
-          log.info(`Found ${rows.length} connection(s)`);
+          // Fetch platform-managed connections (best-effort — errors do not
+          // break local listing).
+          const managedResult = await fetchManagedCatalog();
+          let managedEntries: Array<Record<string, unknown>> = [];
+          if (managedResult.ok && managedResult.descriptors.length > 0) {
+            let descriptors = managedResult.descriptors;
+            // Apply provider filter if specified
+            if (opts.provider) {
+              const filterKey = opts.provider.toLowerCase();
+              descriptors = descriptors.filter(
+                (d) => d.provider.toLowerCase() === filterKey,
+              );
+            }
+            managedEntries = descriptors.map(
+              formatManagedConnectionRow,
+            );
+          }
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(
+              `Found ${rows.length} local connection(s)` +
+                (managedEntries.length > 0
+                  ? `, ${managedEntries.length} platform-managed`
+                  : ""),
+            );
+          }
+
+          writeOutput(cmd, {
+            connections: rows,
+            managedConnections: managedEntries,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
         }
-
-        writeOutput(cmd, rows);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // connections get

--- a/assistant/src/credential-execution/managed-catalog.ts
+++ b/assistant/src/credential-execution/managed-catalog.ts
@@ -1,0 +1,143 @@
+/**
+ * Managed CES credential catalog.
+ *
+ * Discovers platform-managed OAuth connections by calling the platform's CES
+ * catalog endpoint. Returns displayable descriptors with exact
+ * `platform_oauth:<connection_id>` handles suitable for CES tools.
+ *
+ * This module never reveals token values — it only surfaces handle references
+ * and non-secret metadata (provider, account info, scopes, status).
+ */
+
+import { platformOAuthHandle } from "@vellumai/ces-contracts";
+
+import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("managed-catalog");
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ManagedCredentialDescriptor {
+  /** CES handle string (e.g. `platform_oauth:conn_abc123`). */
+  handle: string;
+  /** Source of the credential — always `"platform"` for managed entries. */
+  source: "platform";
+  /** Provider key on the platform (e.g. `google`, `slack`). */
+  provider: string;
+  /** Platform-assigned connection identifier. */
+  connectionId: string;
+  /** Human-readable account info (e.g. email), if available. */
+  accountInfo: string | null;
+  /** Granted OAuth scopes, if reported by the platform. */
+  grantedScopes: string[];
+  /** Connection status as reported by the platform (e.g. `active`, `expired`). */
+  status: string;
+}
+
+// ---------------------------------------------------------------------------
+// Platform response shape (non-secret subset)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a single connection entry in the platform catalog response.
+ * Only non-secret fields are parsed; token values are never included.
+ */
+interface PlatformCatalogEntry {
+  id: string;
+  provider: string;
+  account_info?: string | null;
+  granted_scopes?: string[];
+  status?: string;
+}
+
+interface PlatformCatalogResponse {
+  connections: PlatformCatalogEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface FetchManagedCatalogResult {
+  ok: boolean;
+  descriptors: ManagedCredentialDescriptor[];
+  error?: string;
+}
+
+/**
+ * Fetch the managed credential catalog from the platform.
+ *
+ * Requires managed proxy prerequisites (platform base URL + assistant API key).
+ * Returns an empty list with `ok: true` when prerequisites are missing —
+ * callers should not treat a missing platform as an error.
+ *
+ * Errors from the platform are captured and returned as `ok: false` with an
+ * error message that never contains secret material.
+ */
+export async function fetchManagedCatalog(): Promise<FetchManagedCatalogResult> {
+  const ctx = await resolveManagedProxyContext();
+
+  if (!ctx.enabled) {
+    return { ok: true, descriptors: [] };
+  }
+
+  const url = `${ctx.platformBaseUrl}/v1/ces/catalog`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Api-Key ${ctx.assistantApiKey}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const statusText = response.statusText || `HTTP ${response.status}`;
+      log.warn(`Platform CES catalog returned ${response.status}: ${statusText}`);
+      return {
+        ok: false,
+        descriptors: [],
+        error: `Platform CES catalog request failed (${response.status})`,
+      };
+    }
+
+    const body = (await response.json()) as PlatformCatalogResponse;
+
+    if (!body.connections || !Array.isArray(body.connections)) {
+      return {
+        ok: false,
+        descriptors: [],
+        error: "Platform CES catalog returned unexpected response format",
+      };
+    }
+
+    const descriptors: ManagedCredentialDescriptor[] = body.connections.map(
+      (entry) => ({
+        handle: platformOAuthHandle(entry.id),
+        source: "platform" as const,
+        provider: entry.provider,
+        connectionId: entry.id,
+        accountInfo: entry.account_info ?? null,
+        grantedScopes: entry.granted_scopes ?? [],
+        status: entry.status ?? "unknown",
+      }),
+    );
+
+    return { ok: true, descriptors };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Ensure the error message does not leak secrets — strip any URL params
+    // that might contain tokens (defensive, since we use Api-Key header).
+    const safeMessage = message.replace(/Api-Key\s+\S+/gi, "Api-Key [REDACTED]");
+    log.warn(`Failed to fetch managed CES catalog: ${safeMessage}`);
+    return {
+      ok: false,
+      descriptors: [],
+      error: `Failed to fetch managed CES catalog: ${safeMessage}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Add managed-catalog.ts calling platform CES catalog endpoint for handle discovery
- Update oauth connections list and credentials list CLI commands to merge managed entries
- Add tests for clean merging, missing prerequisites, and no token value exposure

Part of plan: untrusted-agent-credential-arch.md (PR 18 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
