### PR TITLE
[ces] Add secure command manifests with explicit auth adapters and egress requirements

### DIFF
--- a/credential-executor/src/__tests__/command-validator.test.ts
+++ b/credential-executor/src/__tests__/command-validator.test.ts
@@ -1,0 +1,708 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type SecureCommandManifest,
+  MANIFEST_SCHEMA_VERSION,
+  EgressMode,
+  isDeniedBinary,
+  DENIED_BINARIES,
+} from "../commands/profiles.js";
+import { AuthAdapterType } from "../commands/auth-adapters.js";
+import {
+  validateManifest,
+  validateCommand,
+  matchesArgvPattern,
+} from "../commands/validator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal valid manifest for testing. Override individual fields
+ * by passing partial overrides.
+ */
+function buildManifest(
+  overrides: Partial<SecureCommandManifest> = {},
+): SecureCommandManifest {
+  return {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    bundleDigest: "sha256:abc123def456",
+    bundleId: "gh-cli",
+    version: "2.45.0",
+    entrypoint: "bin/gh",
+    commandProfiles: {
+      "api-read": {
+        description: "Read-only GitHub API calls",
+        allowedArgvPatterns: [
+          {
+            name: "api-get",
+            tokens: ["api", "<endpoint>", "--method", "GET"],
+          },
+        ],
+        deniedSubcommands: ["auth login", "auth logout"],
+        deniedFlags: ["--exec"],
+        allowedNetworkTargets: [
+          {
+            hostPattern: "api.github.com",
+            protocols: ["https"],
+          },
+        ],
+      },
+    },
+    authAdapter: {
+      type: AuthAdapterType.EnvVar,
+      envVarName: "GH_TOKEN",
+    },
+    egressMode: EgressMode.ProxyRequired,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Manifest validation
+// ---------------------------------------------------------------------------
+
+describe("validateManifest", () => {
+  test("accepts a valid manifest", () => {
+    const result = validateManifest(buildManifest());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // -- Denied binaries (entrypoint) -----------------------------------------
+
+  test("rejects curl as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/usr/bin/curl", bundleId: "curl-tool" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("curl"))).toBe(true);
+    expect(
+      result.errors.some((e) => e.includes("structurally denied binary")),
+    ).toBe(true);
+  });
+
+  test("rejects wget as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "bin/wget" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("wget"))).toBe(true);
+  });
+
+  test("rejects httpie as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/usr/local/bin/http" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("http"))).toBe(true);
+  });
+
+  test("rejects python interpreter as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/usr/bin/python3" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("python3"))).toBe(true);
+  });
+
+  test("rejects node interpreter as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/usr/local/bin/node" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("node"))).toBe(true);
+  });
+
+  test("rejects bash shell as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/bin/bash" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("bash"))).toBe(true);
+  });
+
+  test("rejects sh shell as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/bin/sh" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("sh"))).toBe(true);
+  });
+
+  test("rejects env trampoline as entrypoint", () => {
+    const result = validateManifest(
+      buildManifest({ entrypoint: "/usr/bin/env" }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("env"))).toBe(true);
+  });
+
+  test("rejects bundleId matching a denied binary", () => {
+    const result = validateManifest(
+      buildManifest({
+        entrypoint: "bin/my-curl-wrapper",
+        bundleId: "curl",
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) => e.includes("bundleId") && e.includes("curl"),
+      ),
+    ).toBe(true);
+  });
+
+  // -- Missing egress mode ---------------------------------------------------
+
+  test("rejects manifest with missing egressMode", () => {
+    const manifest = buildManifest();
+    // @ts-expect-error testing runtime validation with missing field
+    delete manifest.egressMode;
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("egressMode"))).toBe(true);
+  });
+
+  test("rejects manifest with invalid egressMode", () => {
+    const result = validateManifest(
+      buildManifest({
+        // @ts-expect-error testing invalid value
+        egressMode: "direct",
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) => e.includes("egressMode") && e.includes("direct"),
+      ),
+    ).toBe(true);
+  });
+
+  // -- Missing auth adapter ---------------------------------------------------
+
+  test("rejects manifest with missing authAdapter", () => {
+    const manifest = buildManifest();
+    // @ts-expect-error testing runtime validation with missing field
+    delete manifest.authAdapter;
+    const result = validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("authAdapter"))).toBe(true);
+  });
+
+  // -- Empty command profiles -------------------------------------------------
+
+  test("rejects manifest with no command profiles", () => {
+    const result = validateManifest(
+      buildManifest({ commandProfiles: {} }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.includes("At least one command profile"),
+      ),
+    ).toBe(true);
+  });
+
+  // -- Denied subcommands in profiles -----------------------------------------
+
+  test("rejects profile with empty allowed argv patterns", () => {
+    const result = validateManifest(
+      buildManifest({
+        commandProfiles: {
+          "empty-profile": {
+            description: "A profile with no patterns",
+            allowedArgvPatterns: [],
+            deniedSubcommands: [],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("allowedArgvPattern")),
+    ).toBe(true);
+  });
+
+  // -- Overbroad patterns -----------------------------------------------------
+
+  test("rejects overbroad argv pattern (single rest placeholder)", () => {
+    const result = validateManifest(
+      buildManifest({
+        commandProfiles: {
+          overbroad: {
+            description: "Matches anything",
+            allowedArgvPatterns: [
+              { name: "everything", tokens: ["<args...>"] },
+            ],
+            deniedSubcommands: [],
+            allowedNetworkTargets: [
+              { hostPattern: "api.github.com", protocols: ["https"] },
+            ],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("too broad"))).toBe(true);
+  });
+
+  // -- proxy_required without network targets --------------------------------
+
+  test("rejects proxy_required profile without network targets", () => {
+    const result = validateManifest(
+      buildManifest({
+        egressMode: EgressMode.ProxyRequired,
+        commandProfiles: {
+          "no-targets": {
+            description: "Proxy but no targets",
+            allowedArgvPatterns: [
+              { name: "run", tokens: ["run", "<task>"] },
+            ],
+            deniedSubcommands: [],
+            // No allowedNetworkTargets
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("proxy_required") &&
+          e.includes("allowedNetworkTargets"),
+      ),
+    ).toBe(true);
+  });
+
+  // -- no_network with network targets (contradictory) -----------------------
+
+  test("rejects no_network profile with network targets", () => {
+    const result = validateManifest(
+      buildManifest({
+        egressMode: EgressMode.NoNetwork,
+        commandProfiles: {
+          "contradictory": {
+            description: "No network but has targets",
+            allowedArgvPatterns: [
+              { name: "run", tokens: ["format", "<file>"] },
+            ],
+            deniedSubcommands: [],
+            allowedNetworkTargets: [
+              { hostPattern: "example.com", protocols: ["https"] },
+            ],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) =>
+          e.includes("no_network") && e.includes("contradictory"),
+      ),
+    ).toBe(true);
+  });
+
+  // -- Valid no_network manifest ---------------------------------------------
+
+  test("accepts valid no_network manifest", () => {
+    const result = validateManifest(
+      buildManifest({
+        egressMode: EgressMode.NoNetwork,
+        commandProfiles: {
+          "format": {
+            description: "Format code files",
+            allowedArgvPatterns: [
+              { name: "format-file", tokens: ["format", "<file>"] },
+            ],
+            deniedSubcommands: [],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // -- Rest placeholder not at end -------------------------------------------
+
+  test("rejects rest placeholder not at end of pattern", () => {
+    const result = validateManifest(
+      buildManifest({
+        commandProfiles: {
+          "bad-pattern": {
+            description: "Rest placeholder in wrong position",
+            allowedArgvPatterns: [
+              {
+                name: "bad",
+                tokens: ["cmd", "<args...>", "--flag"],
+              },
+            ],
+            deniedSubcommands: [],
+            allowedNetworkTargets: [
+              { hostPattern: "api.github.com", protocols: ["https"] },
+            ],
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("rest placeholder")),
+    ).toBe(true);
+  });
+
+  // -- Auth adapter validation -----------------------------------------------
+
+  test("rejects auth adapter with empty envVarName", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.EnvVar,
+          envVarName: "",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("envVarName")),
+    ).toBe(true);
+  });
+
+  test("rejects credential_process adapter with empty helperCommand", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.CredentialProcess,
+          helperCommand: "",
+          envVarName: "AWS_CREDENTIALS",
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("helperCommand")),
+    ).toBe(true);
+  });
+
+  test("accepts valid temp_file adapter", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.TempFile,
+          envVarName: "GOOGLE_APPLICATION_CREDENTIALS",
+          fileExtension: ".json",
+          fileMode: 0o400,
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects temp_file adapter with too permissive fileMode", () => {
+    const result = validateManifest(
+      buildManifest({
+        authAdapter: {
+          type: AuthAdapterType.TempFile,
+          envVarName: "GOOGLE_APPLICATION_CREDENTIALS",
+          fileMode: 0o644,
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("fileMode"))).toBe(true);
+  });
+
+  // -- Multiple errors reported exhaustively ----------------------------------
+
+  test("reports multiple errors exhaustively", () => {
+    const result = validateManifest(
+      buildManifest({
+        bundleDigest: "",
+        entrypoint: "/bin/bash",
+        commandProfiles: {},
+        // @ts-expect-error testing invalid value
+        egressMode: "unrestricted",
+      }),
+    );
+    expect(result.valid).toBe(false);
+    // Should have at least 3 errors: bundleDigest, entrypoint, commandProfiles, egressMode
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDeniedBinary
+// ---------------------------------------------------------------------------
+
+describe("isDeniedBinary", () => {
+  test("denies curl by name", () => {
+    expect(isDeniedBinary("curl")).toBe(true);
+  });
+
+  test("denies curl by full path", () => {
+    expect(isDeniedBinary("/usr/bin/curl")).toBe(true);
+  });
+
+  test("denies wget", () => {
+    expect(isDeniedBinary("wget")).toBe(true);
+  });
+
+  test("denies httpie variants", () => {
+    expect(isDeniedBinary("http")).toBe(true);
+    expect(isDeniedBinary("https")).toBe(true);
+    expect(isDeniedBinary("httpie")).toBe(true);
+  });
+
+  test("denies interpreters", () => {
+    expect(isDeniedBinary("python")).toBe(true);
+    expect(isDeniedBinary("python3")).toBe(true);
+    expect(isDeniedBinary("node")).toBe(true);
+    expect(isDeniedBinary("bun")).toBe(true);
+    expect(isDeniedBinary("deno")).toBe(true);
+    expect(isDeniedBinary("ruby")).toBe(true);
+    expect(isDeniedBinary("perl")).toBe(true);
+    expect(isDeniedBinary("php")).toBe(true);
+  });
+
+  test("denies shell trampolines", () => {
+    expect(isDeniedBinary("bash")).toBe(true);
+    expect(isDeniedBinary("sh")).toBe(true);
+    expect(isDeniedBinary("zsh")).toBe(true);
+    expect(isDeniedBinary("env")).toBe(true);
+    expect(isDeniedBinary("xargs")).toBe(true);
+  });
+
+  test("allows legitimate CLIs", () => {
+    expect(isDeniedBinary("gh")).toBe(false);
+    expect(isDeniedBinary("aws")).toBe(false);
+    expect(isDeniedBinary("gcloud")).toBe(false);
+    expect(isDeniedBinary("terraform")).toBe(false);
+    expect(isDeniedBinary("kubectl")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesArgvPattern
+// ---------------------------------------------------------------------------
+
+describe("matchesArgvPattern", () => {
+  test("matches exact literal tokens", () => {
+    const pattern = { name: "list", tokens: ["repo", "list"] };
+    expect(matchesArgvPattern(["repo", "list"], pattern)).toBe(true);
+    expect(matchesArgvPattern(["repo", "create"], pattern)).toBe(false);
+    expect(matchesArgvPattern(["repo"], pattern)).toBe(false);
+    expect(matchesArgvPattern(["repo", "list", "extra"], pattern)).toBe(false);
+  });
+
+  test("matches single placeholder", () => {
+    const pattern = {
+      name: "api-get",
+      tokens: ["api", "<endpoint>", "--method", "GET"],
+    };
+    expect(
+      matchesArgvPattern(["api", "/repos", "--method", "GET"], pattern),
+    ).toBe(true);
+    expect(
+      matchesArgvPattern(["api", "/issues", "--method", "GET"], pattern),
+    ).toBe(true);
+    expect(
+      matchesArgvPattern(["api", "/repos", "--method", "POST"], pattern),
+    ).toBe(false);
+  });
+
+  test("matches rest placeholder", () => {
+    const pattern = {
+      name: "run-args",
+      tokens: ["run", "<args...>"],
+    };
+    expect(matchesArgvPattern(["run", "build"], pattern)).toBe(true);
+    expect(matchesArgvPattern(["run", "build", "--watch"], pattern)).toBe(true);
+    // Rest requires at least one arg
+    expect(matchesArgvPattern(["run"], pattern)).toBe(false);
+  });
+
+  test("empty argv never matches", () => {
+    const pattern = { name: "any", tokens: ["cmd"] };
+    expect(matchesArgvPattern([], pattern)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCommand
+// ---------------------------------------------------------------------------
+
+describe("validateCommand", () => {
+  const manifest = buildManifest();
+
+  test("allows command matching an allowed pattern", () => {
+    const result = validateCommand(manifest, [
+      "api",
+      "/repos/owner/repo",
+      "--method",
+      "GET",
+    ]);
+    expect(result.allowed).toBe(true);
+    expect(result.matchedProfile).toBe("api-read");
+    expect(result.matchedPattern).toBe("api-get");
+  });
+
+  test("denies command with denied subcommand", () => {
+    const result = validateCommand(manifest, ["auth", "login"]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("auth login");
+    expect(result.reason).toContain("denied");
+  });
+
+  test("denies command with denied flag", () => {
+    const result = validateCommand(manifest, [
+      "api",
+      "/repos",
+      "--exec",
+      "GET",
+    ]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("--exec");
+    expect(result.reason).toContain("denied");
+  });
+
+  test("denies command matching no pattern", () => {
+    const result = validateCommand(manifest, [
+      "issue",
+      "create",
+      "--title",
+      "bug",
+    ]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("does not match any allowed pattern");
+  });
+
+  test("denies empty argv", () => {
+    const result = validateCommand(manifest, []);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Empty argv");
+  });
+
+  test("denies undeclared flags even when pattern would match", () => {
+    // The argv without the denied flag would match, but the flag should cause rejection
+    const manifestWithDeniedFlags = buildManifest({
+      commandProfiles: {
+        "api-read": {
+          description: "Read-only GitHub API calls",
+          allowedArgvPatterns: [
+            {
+              name: "api-call",
+              tokens: ["api", "<endpoint>", "<args...>"],
+            },
+          ],
+          deniedSubcommands: [],
+          deniedFlags: ["--unsafe-perm", "--exec"],
+          allowedNetworkTargets: [
+            { hostPattern: "api.github.com", protocols: ["https"] },
+          ],
+        },
+      },
+    });
+
+    const result = validateCommand(manifestWithDeniedFlags, [
+      "api",
+      "/repos",
+      "--unsafe-perm",
+    ]);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("--unsafe-perm");
+  });
+
+  // -- Multi-profile matching ------------------------------------------------
+
+  test("matches across multiple profiles", () => {
+    const multiProfileManifest = buildManifest({
+      commandProfiles: {
+        read: {
+          description: "Read operations",
+          allowedArgvPatterns: [
+            { name: "list", tokens: ["repo", "list"] },
+          ],
+          deniedSubcommands: [],
+          allowedNetworkTargets: [
+            { hostPattern: "api.github.com", protocols: ["https"] },
+          ],
+        },
+        write: {
+          description: "Write operations",
+          allowedArgvPatterns: [
+            { name: "create-issue", tokens: ["issue", "create", "<args...>"] },
+          ],
+          deniedSubcommands: [],
+          allowedNetworkTargets: [
+            { hostPattern: "api.github.com", protocols: ["https"] },
+          ],
+        },
+      },
+    });
+
+    const readResult = validateCommand(multiProfileManifest, [
+      "repo",
+      "list",
+    ]);
+    expect(readResult.allowed).toBe(true);
+    expect(readResult.matchedProfile).toBe("read");
+
+    const writeResult = validateCommand(multiProfileManifest, [
+      "issue",
+      "create",
+      "--title",
+      "bug",
+    ]);
+    expect(writeResult.allowed).toBe(true);
+    expect(writeResult.matchedProfile).toBe("write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Comprehensive denied binary coverage
+// ---------------------------------------------------------------------------
+
+describe("DENIED_BINARIES set", () => {
+  test("contains all expected generic HTTP clients", () => {
+    for (const binary of ["curl", "wget", "http", "https", "httpie"]) {
+      expect(DENIED_BINARIES.has(binary)).toBe(true);
+    }
+  });
+
+  test("contains all expected interpreters", () => {
+    for (const binary of [
+      "python",
+      "python3",
+      "node",
+      "bun",
+      "deno",
+      "ruby",
+      "perl",
+      "lua",
+      "php",
+    ]) {
+      expect(DENIED_BINARIES.has(binary)).toBe(true);
+    }
+  });
+
+  test("contains all expected shell trampolines", () => {
+    for (const binary of [
+      "bash",
+      "sh",
+      "zsh",
+      "fish",
+      "dash",
+      "ksh",
+      "csh",
+      "tcsh",
+      "env",
+      "xargs",
+      "exec",
+      "nohup",
+    ]) {
+      expect(DENIED_BINARIES.has(binary)).toBe(true);
+    }
+  });
+});

--- a/credential-executor/src/commands/auth-adapters.ts
+++ b/credential-executor/src/commands/auth-adapters.ts
@@ -1,0 +1,169 @@
+/**
+ * CES auth adapter definitions for secure command profiles.
+ *
+ * Auth adapters describe how credentials are materialised into a command's
+ * execution environment. Each adapter type has different security properties
+ * and cleanup requirements.
+ *
+ * v1 adapter set:
+ *
+ * - `env_var`            — Inject credential as an environment variable.
+ *                          Lifetime: process scope. Cleaned up on exit.
+ * - `temp_file`          — Write credential to a temporary file and pass
+ *                          the path via an env var. File is deleted after
+ *                          command exits.
+ * - `credential_process` — Spawn a helper process that prints the credential
+ *                          to stdout (AWS credential_process pattern). The
+ *                          helper runs inside CES and is never exposed to the
+ *                          subprocess directly.
+ */
+
+// ---------------------------------------------------------------------------
+// Auth adapter type discriminator
+// ---------------------------------------------------------------------------
+
+export const AuthAdapterType = {
+  /** Inject credential value as an environment variable. */
+  EnvVar: "env_var",
+  /** Write credential to a temp file and set a path env var. */
+  TempFile: "temp_file",
+  /**
+   * Spawn a credential helper process (AWS credential_process-style).
+   * The helper stdout is captured and injected as an env var.
+   */
+  CredentialProcess: "credential_process",
+} as const;
+
+export type AuthAdapterType =
+  (typeof AuthAdapterType)[keyof typeof AuthAdapterType];
+
+/** All valid auth adapter type strings. */
+export const AUTH_ADAPTER_TYPES: readonly AuthAdapterType[] = Object.values(
+  AuthAdapterType,
+) as AuthAdapterType[];
+
+// ---------------------------------------------------------------------------
+// Auth adapter config shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject a credential directly as an environment variable.
+ *
+ * Example: `GH_TOKEN=<secret>` with `envVarName: "GH_TOKEN"`.
+ */
+export interface EnvVarAdapterConfig {
+  type: typeof AuthAdapterType.EnvVar;
+  /** Environment variable name where the credential value is injected. */
+  envVarName: string;
+  /**
+   * Optional prefix prepended to the raw credential value before injection
+   * (e.g. "Bearer " for OAuth tokens).
+   */
+  valuePrefix?: string;
+}
+
+/**
+ * Write the credential to a temporary file and set an env var to the path.
+ *
+ * Example: `GOOGLE_APPLICATION_CREDENTIALS=/tmp/ces-xxx/svc.json`.
+ * The temp file is created in a CES-managed ephemeral directory and deleted
+ * after the command exits.
+ */
+export interface TempFileAdapterConfig {
+  type: typeof AuthAdapterType.TempFile;
+  /** Environment variable name pointing to the temp file path. */
+  envVarName: string;
+  /** File extension for the temp file (e.g. ".json", ".pem"). */
+  fileExtension?: string;
+  /**
+   * File mode (octal) for the temp file. Defaults to 0o600 (owner-only
+   * read/write). Must be <= 0o600.
+   */
+  fileMode?: number;
+}
+
+/**
+ * Spawn a credential helper process, capture its stdout, and inject the
+ * result as an env var.
+ *
+ * Example: AWS `credential_process` that emits JSON with temporary keys.
+ * The helper command runs inside the CES process and is never exposed to
+ * the child command.
+ */
+export interface CredentialProcessAdapterConfig {
+  type: typeof AuthAdapterType.CredentialProcess;
+  /** The helper command to run (e.g. "aws-vault exec <profile> --json"). */
+  helperCommand: string;
+  /** Environment variable name where the helper's stdout is injected. */
+  envVarName: string;
+  /** Timeout in milliseconds for the helper process. Defaults to 10000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Discriminated union of all auth adapter configurations.
+ */
+export type AuthAdapterConfig =
+  | EnvVarAdapterConfig
+  | TempFileAdapterConfig
+  | CredentialProcessAdapterConfig;
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the given string is a valid auth adapter type.
+ */
+export function isValidAuthAdapterType(value: string): value is AuthAdapterType {
+  return (AUTH_ADAPTER_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Validate an auth adapter config shape. Returns a list of error messages
+ * (empty array = valid).
+ */
+export function validateAuthAdapterConfig(
+  config: AuthAdapterConfig,
+): string[] {
+  const errors: string[] = [];
+
+  if (!isValidAuthAdapterType(config.type)) {
+    errors.push(
+      `Unknown auth adapter type "${config.type}". Valid types: ${AUTH_ADAPTER_TYPES.join(", ")}`,
+    );
+    return errors;
+  }
+
+  if (!config.envVarName || config.envVarName.trim().length === 0) {
+    errors.push(`Auth adapter "${config.type}" requires a non-empty envVarName`);
+  }
+
+  switch (config.type) {
+    case AuthAdapterType.TempFile:
+      if (
+        config.fileMode !== undefined &&
+        config.fileMode > 0o600
+      ) {
+        errors.push(
+          `temp_file adapter fileMode must be <= 0600 (owner-only), got ${config.fileMode.toString(8)}`,
+        );
+      }
+      break;
+
+    case AuthAdapterType.CredentialProcess:
+      if (!config.helperCommand || config.helperCommand.trim().length === 0) {
+        errors.push(
+          `credential_process adapter requires a non-empty helperCommand`,
+        );
+      }
+      if (config.timeoutMs !== undefined && config.timeoutMs <= 0) {
+        errors.push(
+          `credential_process adapter timeoutMs must be positive, got ${config.timeoutMs}`,
+        );
+      }
+      break;
+  }
+
+  return errors;
+}

--- a/credential-executor/src/commands/profiles.ts
+++ b/credential-executor/src/commands/profiles.ts
@@ -1,0 +1,282 @@
+/**
+ * Secure command profile manifest schema (v1).
+ *
+ * A secure command profile defines the complete execution boundary for a
+ * credential-bearing command. Profiles are manifest-driven — there is no
+ * default of "run any subcommand on this binary." Every allowed invocation
+ * must be declared explicitly.
+ *
+ * Manifest fields:
+ *
+ * - **bundleDigest**       — SHA-256 digest of the command bundle (for
+ *                            integrity verification).
+ * - **bundleId**           — Unique identifier for the command bundle
+ *                            (e.g. "gh-cli", "aws-cli").
+ * - **version**            — Semantic version of the bundle.
+ * - **entrypoint**         — Path to the executable within the bundle
+ *                            (e.g. "bin/gh").
+ * - **commandProfiles**    — Map of named profiles, each declaring allowed
+ *                            argv grammar, denied subcommands, and network
+ *                            targets.
+ * - **authAdapter**        — How credentials are injected (env_var,
+ *                            temp_file, or credential_process).
+ * - **egressMode**         — Network egress enforcement mode. Must be
+ *                            `proxy_required` unless the command has no
+ *                            network needs.
+ * - **cleanConfigDirs**    — List of config directories to mount as empty
+ *                            tmpfs (prevents the command from reading host
+ *                            config files that could contain secrets).
+ */
+
+import type { AuthAdapterConfig } from "./auth-adapters.js";
+
+// ---------------------------------------------------------------------------
+// Egress mode
+// ---------------------------------------------------------------------------
+
+/**
+ * Network egress enforcement mode for a secure command profile.
+ *
+ * - `proxy_required`  — All network traffic MUST route through the CES
+ *                        egress proxy. The command's environment is
+ *                        configured with HTTP_PROXY/HTTPS_PROXY. Direct
+ *                        connections are blocked.
+ * - `no_network`      — The command has no network requirements. Any
+ *                        network access is blocked entirely.
+ *
+ * There is intentionally no "direct" or "unrestricted" mode. Commands
+ * that need network access must go through the egress proxy so CES can
+ * enforce credential injection and audit logging.
+ */
+export const EgressMode = {
+  ProxyRequired: "proxy_required",
+  NoNetwork: "no_network",
+} as const;
+
+export type EgressMode = (typeof EgressMode)[keyof typeof EgressMode];
+
+/** All valid egress mode strings. */
+export const EGRESS_MODES: readonly EgressMode[] = Object.values(
+  EgressMode,
+) as EgressMode[];
+
+// ---------------------------------------------------------------------------
+// Allowed argv grammar
+// ---------------------------------------------------------------------------
+
+/**
+ * Defines the allowed argument grammar for a command profile.
+ *
+ * Allowed patterns use a simple grammar:
+ * - Literal strings match exactly (e.g. "api", "--json")
+ * - `<param>` matches any single argument (positional placeholder)
+ * - `<param...>` matches one or more remaining arguments (rest placeholder)
+ *
+ * Example: `["api", "<endpoint>", "--method", "<method>"]` allows
+ * `gh api /repos --method GET` but not `gh auth login`.
+ */
+export interface AllowedArgvPattern {
+  /**
+   * Human-readable name for this pattern (e.g. "api-call", "list-repos").
+   * Used in audit logs and error messages.
+   */
+  name: string;
+  /**
+   * Ordered sequence of argv tokens. Each token is either a literal
+   * string or a placeholder (`<name>` or `<name...>`).
+   */
+  tokens: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Network target allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * Declares a network target that the command is allowed to contact.
+ */
+export interface AllowedNetworkTarget {
+  /** Host pattern (glob). E.g. "api.github.com", "*.amazonaws.com". */
+  hostPattern: string;
+  /** Allowed port(s). Null means any port. */
+  ports?: number[];
+  /** Allowed protocol(s). Defaults to ["https"]. */
+  protocols?: Array<"http" | "https">;
+}
+
+// ---------------------------------------------------------------------------
+// Command profile (single named profile within a manifest)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single named command profile within a manifest.
+ *
+ * Each profile defines a narrow slice of allowed behaviour for the command.
+ * A manifest may contain multiple profiles (e.g. "read-repos" and
+ * "create-issue" for the GitHub CLI).
+ */
+export interface CommandProfile {
+  /** Human-readable description of what this profile allows. */
+  description: string;
+
+  /**
+   * Allowed argv patterns. The command is rejected unless its arguments
+   * match at least one pattern.
+   */
+  allowedArgvPatterns: AllowedArgvPattern[];
+
+  /**
+   * Subcommands that are explicitly denied even if they would otherwise
+   * match an argv pattern. This is a safety net against overly broad
+   * patterns.
+   *
+   * Each entry is matched against the first N argv tokens.
+   */
+  deniedSubcommands: string[];
+
+  /**
+   * Flags (argv tokens starting with `-`) that are explicitly denied.
+   * Matched literally (e.g. "--exec", "-e").
+   */
+  deniedFlags?: string[];
+
+  /**
+   * Network targets this profile is allowed to contact. Only relevant
+   * when egressMode is `proxy_required`.
+   */
+  allowedNetworkTargets?: AllowedNetworkTarget[];
+}
+
+// ---------------------------------------------------------------------------
+// Secure command manifest (top-level)
+// ---------------------------------------------------------------------------
+
+/** Current manifest schema version. */
+export const MANIFEST_SCHEMA_VERSION = "1" as const;
+
+/**
+ * v1 secure command manifest.
+ *
+ * This is the top-level schema that defines a complete execution boundary
+ * for a credential-bearing command binary.
+ */
+export interface SecureCommandManifest {
+  /** Manifest schema version. Must be "1". */
+  schemaVersion: typeof MANIFEST_SCHEMA_VERSION;
+
+  /**
+   * SHA-256 hex digest of the command bundle. Used for integrity
+   * verification before execution.
+   */
+  bundleDigest: string;
+
+  /** Unique identifier for the command bundle (e.g. "gh-cli"). */
+  bundleId: string;
+
+  /** Semantic version of the bundle. */
+  version: string;
+
+  /**
+   * Path to the executable entrypoint within the bundle
+   * (e.g. "bin/gh", "bin/aws").
+   */
+  entrypoint: string;
+
+  /**
+   * Named command profiles. Each profile defines a narrow execution
+   * boundary. Keyed by profile name.
+   */
+  commandProfiles: Record<string, CommandProfile>;
+
+  /**
+   * Auth adapter configuration describing how credentials are
+   * materialised into the command's environment.
+   */
+  authAdapter: AuthAdapterConfig;
+
+  /**
+   * Network egress enforcement mode. Must be `proxy_required` for commands
+   * that contact the network, or `no_network` for offline-only commands.
+   */
+  egressMode: EgressMode;
+
+  /**
+   * Config directories to mount as empty tmpfs during execution. Prevents
+   * the command from reading host config files that might contain secrets.
+   *
+   * Map from source path pattern to a description.
+   * E.g. `{ "~/.aws": "AWS CLI config", "~/.config/gh": "GitHub CLI config" }`.
+   */
+  cleanConfigDirs?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Denied binaries — structurally rejected as secure command profiles
+// ---------------------------------------------------------------------------
+
+/**
+ * Binaries that are structurally banned from being registered as secure
+ * command profiles. These are generic HTTP clients, interpreters, and
+ * shell trampolines that would undermine the manifest-driven security
+ * model.
+ *
+ * This list is checked against the entrypoint basename (the last path
+ * segment) and against bundleId.
+ */
+export const DENIED_BINARIES: ReadonlySet<string> = new Set([
+  // Generic HTTP clients
+  "curl",
+  "wget",
+  "http",     // httpie
+  "https",    // httpie alias
+  "httpie",
+
+  // Interpreters
+  "python",
+  "python3",
+  "python3.10",
+  "python3.11",
+  "python3.12",
+  "python3.13",
+  "python3.14",
+  "node",
+  "bun",
+  "deno",
+  "ruby",
+  "perl",
+  "lua",
+  "php",
+
+  // Shell trampolines
+  "bash",
+  "sh",
+  "zsh",
+  "fish",
+  "dash",
+  "ksh",
+  "csh",
+  "tcsh",
+  "env",    // /usr/bin/env can trampoline to any binary
+  "xargs",  // can execute arbitrary commands
+  "exec",
+  "nohup",
+  "strace",
+  "ltrace",
+]);
+
+/**
+ * Returns the basename of a path (last segment after the last `/`).
+ */
+export function pathBasename(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash === -1 ? path : path.slice(lastSlash + 1);
+}
+
+/**
+ * Check if a binary name (basename or full path) is in the denied set.
+ * Matches against the basename portion of the path.
+ */
+export function isDeniedBinary(binaryNameOrPath: string): boolean {
+  const basename = pathBasename(binaryNameOrPath);
+  return DENIED_BINARIES.has(basename);
+}

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -1,0 +1,438 @@
+/**
+ * Secure command manifest validator.
+ *
+ * Validates that a {@link SecureCommandManifest} meets the CES security
+ * invariants before it can be registered. Validation is fail-closed: any
+ * structural issue, missing field, or policy violation results in rejection.
+ *
+ * Invariants enforced:
+ *
+ * 1. The entrypoint and bundleId must not be a denied binary.
+ * 2. At least one command profile must be declared (no empty manifests).
+ * 3. Each profile must have at least one allowed argv pattern.
+ * 4. Denied subcommands and denied flags lists are checked for consistency.
+ * 5. Auth adapter config must be structurally valid.
+ * 6. `egressMode` must be explicitly declared.
+ * 7. When `egressMode` is `proxy_required`, each profile must declare at
+ *    least one allowed network target.
+ * 8. When `egressMode` is `no_network`, profiles must not declare network
+ *    targets (contradictory).
+ * 9. Overbroad patterns (e.g. a single `<param...>` that matches anything)
+ *    are rejected.
+ */
+
+import {
+  validateAuthAdapterConfig,
+} from "./auth-adapters.js";
+import {
+  type SecureCommandManifest,
+  type CommandProfile,
+  type AllowedArgvPattern,
+  MANIFEST_SCHEMA_VERSION,
+  EGRESS_MODES,
+  EgressMode,
+  isDeniedBinary,
+  pathBasename,
+} from "./profiles.js";
+
+// ---------------------------------------------------------------------------
+// Validation result
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  /** Whether the manifest passed all checks. */
+  valid: boolean;
+  /** List of human-readable error messages (empty when valid). */
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Top-level validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a secure command manifest against all CES security invariants.
+ *
+ * Returns a {@link ValidationResult} with `valid: false` and a list of
+ * error messages if any check fails. Validation is exhaustive — all
+ * violations are reported, not just the first.
+ */
+export function validateManifest(
+  manifest: SecureCommandManifest,
+): ValidationResult {
+  const errors: string[] = [];
+
+  // -- Schema version
+  if (manifest.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+    errors.push(
+      `Unsupported schema version "${manifest.schemaVersion}". Expected "${MANIFEST_SCHEMA_VERSION}".`,
+    );
+  }
+
+  // -- Required string fields
+  if (!manifest.bundleDigest || manifest.bundleDigest.trim().length === 0) {
+    errors.push("bundleDigest is required and must be non-empty.");
+  }
+  if (!manifest.bundleId || manifest.bundleId.trim().length === 0) {
+    errors.push("bundleId is required and must be non-empty.");
+  }
+  if (!manifest.version || manifest.version.trim().length === 0) {
+    errors.push("version is required and must be non-empty.");
+  }
+  if (!manifest.entrypoint || manifest.entrypoint.trim().length === 0) {
+    errors.push("entrypoint is required and must be non-empty.");
+  }
+
+  // -- Denied binary check (entrypoint basename and bundleId)
+  if (manifest.entrypoint && isDeniedBinary(manifest.entrypoint)) {
+    errors.push(
+      `Entrypoint "${manifest.entrypoint}" (basename: "${pathBasename(manifest.entrypoint)}") is a structurally denied binary. ` +
+        `Generic HTTP clients, interpreters, and shell trampolines cannot be secure command profiles.`,
+    );
+  }
+  if (manifest.bundleId && isDeniedBinary(manifest.bundleId)) {
+    errors.push(
+      `bundleId "${manifest.bundleId}" matches a structurally denied binary name. ` +
+        `Generic HTTP clients, interpreters, and shell trampolines cannot be secure command profiles.`,
+    );
+  }
+
+  // -- Egress mode
+  if (!manifest.egressMode) {
+    errors.push(
+      `egressMode is required. Valid values: ${EGRESS_MODES.join(", ")}.`,
+    );
+  } else if (!(EGRESS_MODES as readonly string[]).includes(manifest.egressMode)) {
+    errors.push(
+      `Invalid egressMode "${manifest.egressMode}". Valid values: ${EGRESS_MODES.join(", ")}.`,
+    );
+  }
+
+  // -- Auth adapter
+  if (!manifest.authAdapter) {
+    errors.push("authAdapter is required.");
+  } else {
+    const adapterErrors = validateAuthAdapterConfig(manifest.authAdapter);
+    for (const e of adapterErrors) {
+      errors.push(`authAdapter: ${e}`);
+    }
+  }
+
+  // -- Command profiles (must have at least one)
+  if (
+    !manifest.commandProfiles ||
+    Object.keys(manifest.commandProfiles).length === 0
+  ) {
+    errors.push(
+      "At least one command profile must be declared. " +
+        "Secure command profiles cannot default to 'run any subcommand on this binary.'",
+    );
+  } else {
+    for (const [profileName, profile] of Object.entries(
+      manifest.commandProfiles,
+    )) {
+      const profileErrors = validateProfile(
+        profileName,
+        profile,
+        manifest.egressMode,
+      );
+      errors.push(...profileErrors);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Profile-level validation
+// ---------------------------------------------------------------------------
+
+function validateProfile(
+  profileName: string,
+  profile: CommandProfile,
+  egressMode: EgressMode | undefined,
+): string[] {
+  const errors: string[] = [];
+  const prefix = `Profile "${profileName}"`;
+
+  // -- Description
+  if (!profile.description || profile.description.trim().length === 0) {
+    errors.push(`${prefix}: description is required and must be non-empty.`);
+  }
+
+  // -- Allowed argv patterns (must have at least one)
+  if (
+    !profile.allowedArgvPatterns ||
+    profile.allowedArgvPatterns.length === 0
+  ) {
+    errors.push(
+      `${prefix}: at least one allowedArgvPattern is required. ` +
+        "Profiles must explicitly declare what invocations are allowed.",
+    );
+  } else {
+    for (const pattern of profile.allowedArgvPatterns) {
+      const patternErrors = validateArgvPattern(prefix, pattern);
+      errors.push(...patternErrors);
+    }
+  }
+
+  // -- Denied subcommands (optional but must be an array)
+  if (profile.deniedSubcommands) {
+    for (const sub of profile.deniedSubcommands) {
+      if (!sub || sub.trim().length === 0) {
+        errors.push(
+          `${prefix}: deniedSubcommands contains an empty string.`,
+        );
+      }
+    }
+  }
+
+  // -- Denied flags (optional)
+  if (profile.deniedFlags) {
+    for (const flag of profile.deniedFlags) {
+      if (!flag || flag.trim().length === 0) {
+        errors.push(`${prefix}: deniedFlags contains an empty string.`);
+      }
+      if (flag && !flag.startsWith("-")) {
+        errors.push(
+          `${prefix}: deniedFlags entry "${flag}" does not start with "-". ` +
+            "Flags must start with a dash.",
+        );
+      }
+    }
+  }
+
+  // -- Network targets vs egress mode consistency
+  if (egressMode === EgressMode.ProxyRequired) {
+    if (
+      !profile.allowedNetworkTargets ||
+      profile.allowedNetworkTargets.length === 0
+    ) {
+      errors.push(
+        `${prefix}: egressMode is "proxy_required" but no allowedNetworkTargets are declared. ` +
+          "Commands with network egress must declare their allowed network targets.",
+      );
+    }
+  }
+
+  if (egressMode === EgressMode.NoNetwork) {
+    if (
+      profile.allowedNetworkTargets &&
+      profile.allowedNetworkTargets.length > 0
+    ) {
+      errors.push(
+        `${prefix}: egressMode is "no_network" but allowedNetworkTargets are declared. ` +
+          "This is contradictory — remove network targets or change egressMode.",
+      );
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Argv pattern validation
+// ---------------------------------------------------------------------------
+
+function validateArgvPattern(
+  profilePrefix: string,
+  pattern: AllowedArgvPattern,
+): string[] {
+  const errors: string[] = [];
+
+  if (!pattern.name || pattern.name.trim().length === 0) {
+    errors.push(
+      `${profilePrefix}: argv pattern has no name. Each pattern must be named for audit logging.`,
+    );
+  }
+
+  if (!pattern.tokens || pattern.tokens.length === 0) {
+    errors.push(
+      `${profilePrefix}: argv pattern "${pattern.name}" has no tokens. ` +
+        "Empty patterns would match any invocation.",
+    );
+    return errors;
+  }
+
+  // Check for overbroad patterns: a single rest placeholder matches anything
+  if (
+    pattern.tokens.length === 1 &&
+    isRestPlaceholder(pattern.tokens[0]!)
+  ) {
+    errors.push(
+      `${profilePrefix}: argv pattern "${pattern.name}" contains only a rest placeholder ` +
+        `("${pattern.tokens[0]}"). This would match any invocation and is too broad.`,
+    );
+  }
+
+  // Rest placeholder must be last token
+  for (let i = 0; i < pattern.tokens.length; i++) {
+    const token = pattern.tokens[i]!;
+    if (isRestPlaceholder(token) && i < pattern.tokens.length - 1) {
+      errors.push(
+        `${profilePrefix}: argv pattern "${pattern.name}" has a rest placeholder ` +
+          `("${token}") at position ${i}, but rest placeholders must be the last token.`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Argv matching (used by the runtime to check commands against profiles)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the token is a single-value placeholder like `<name>`.
+ */
+function isPlaceholder(token: string): boolean {
+  return token.startsWith("<") && token.endsWith(">") && !token.endsWith("...>");
+}
+
+/**
+ * Returns true if the token is a rest placeholder like `<name...>`.
+ */
+function isRestPlaceholder(token: string): boolean {
+  return token.startsWith("<") && token.endsWith("...>");
+}
+
+/**
+ * Check if a concrete argv array matches an allowed argv pattern.
+ *
+ * Matching rules:
+ * - Literal tokens must match exactly.
+ * - `<name>` matches exactly one argument.
+ * - `<name...>` matches one or more remaining arguments (must be last token).
+ */
+export function matchesArgvPattern(
+  argv: readonly string[],
+  pattern: AllowedArgvPattern,
+): boolean {
+  const { tokens } = pattern;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+
+    if (isRestPlaceholder(token)) {
+      // Rest placeholder: must have at least one remaining arg
+      return argv.length > i;
+    }
+
+    // No more args but still have pattern tokens
+    if (i >= argv.length) return false;
+
+    if (isPlaceholder(token)) {
+      // Single placeholder: matches any single value
+      continue;
+    }
+
+    // Literal: must match exactly
+    if (argv[i] !== token) return false;
+  }
+
+  // All pattern tokens consumed — argv must also be fully consumed
+  return argv.length === tokens.length;
+}
+
+// ---------------------------------------------------------------------------
+// Full command validation against a manifest
+// ---------------------------------------------------------------------------
+
+export interface CommandValidationResult {
+  /** Whether the command is allowed. */
+  allowed: boolean;
+  /** The profile name that matched (undefined when rejected). */
+  matchedProfile?: string;
+  /** The pattern name that matched (undefined when rejected). */
+  matchedPattern?: string;
+  /** Human-readable reason for rejection (undefined when allowed). */
+  reason?: string;
+}
+
+/**
+ * Validate a concrete command invocation (argv array) against a manifest.
+ *
+ * Checks:
+ * 1. The argv is non-empty.
+ * 2. The argv does not contain any denied subcommands (across all profiles).
+ * 3. The argv does not contain any denied flags (across all profiles).
+ * 4. At least one profile's allowed argv patterns matches.
+ *
+ * This function does NOT re-validate the manifest itself — call
+ * {@link validateManifest} separately during registration.
+ */
+export function validateCommand(
+  manifest: SecureCommandManifest,
+  argv: readonly string[],
+): CommandValidationResult {
+  if (argv.length === 0) {
+    return {
+      allowed: false,
+      reason: "Empty argv — no command to validate.",
+    };
+  }
+
+  // Collect all denied subcommands and flags across profiles
+  const allDeniedSubcommands = new Set<string>();
+  const allDeniedFlags = new Set<string>();
+
+  for (const profile of Object.values(manifest.commandProfiles)) {
+    for (const sub of profile.deniedSubcommands) {
+      allDeniedSubcommands.add(sub);
+    }
+    if (profile.deniedFlags) {
+      for (const flag of profile.deniedFlags) {
+        allDeniedFlags.add(flag);
+      }
+    }
+  }
+
+  // Check denied subcommands (match against first N tokens of argv)
+  for (const denied of allDeniedSubcommands) {
+    const deniedParts = denied.split(/\s+/);
+    if (deniedParts.length <= argv.length) {
+      const match = deniedParts.every((part, i) => argv[i] === part);
+      if (match) {
+        return {
+          allowed: false,
+          reason: `Subcommand "${denied}" is explicitly denied.`,
+        };
+      }
+    }
+  }
+
+  // Check denied flags
+  for (const arg of argv) {
+    if (allDeniedFlags.has(arg)) {
+      return {
+        allowed: false,
+        reason: `Flag "${arg}" is explicitly denied.`,
+      };
+    }
+  }
+
+  // Try to match against allowed argv patterns in each profile
+  for (const [profileName, profile] of Object.entries(
+    manifest.commandProfiles,
+  )) {
+    for (const pattern of profile.allowedArgvPatterns) {
+      if (matchesArgvPattern(argv, pattern)) {
+        return {
+          allowed: true,
+          matchedProfile: profileName,
+          matchedPattern: pattern.name,
+        };
+      }
+    }
+  }
+
+  return {
+    allowed: false,
+    reason:
+      "Command argv does not match any allowed pattern in any profile.",
+  };
+}


### PR DESCRIPTION
## Summary
- Add v1 secure command manifest schema with bundle digest, profiles, allowed argv, and egress mode
- Define env_var, temp_file, and credential_process auth adapters with proxy_required egress enforcement
- Ban generic HTTP clients, interpreters, and shell trampolines from secure command profiles with tests

Part of plan: untrusted-agent-credential-arch.md (PR 22 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
