### PR TITLE
refactor: update macOS avatar paths (avatar-image.png, character-traits.json)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -83,7 +83,7 @@ final class AvatarAppearanceManager {
     /// Workspace path for custom avatar -- canonical storage location.
     nonisolated static func workspaceCustomAvatarURL(homeDirectory: String = NSHomeDirectory()) -> URL {
         URL(fileURLWithPath: homeDirectory)
-            .appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+            .appendingPathComponent(".vellum/workspace/data/avatar/avatar-image.png")
     }
 
     /// Legacy Application Support path (pre-workspace migration). Retained for one-time migration on first launch after upgrade.
@@ -102,7 +102,7 @@ final class AvatarAppearanceManager {
            let baseDataDir = assistant.baseDataDir {
             // baseDataDir is the .vellum root (e.g. ~/.local/share/vellum/assistants/foo/.vellum)
             return URL(fileURLWithPath: baseDataDir)
-                .appendingPathComponent("workspace/data/avatar/custom-avatar.png")
+                .appendingPathComponent("workspace/data/avatar/avatar-image.png")
         }
         return Self.workspaceCustomAvatarURL()
     }
@@ -228,7 +228,7 @@ final class AvatarAppearanceManager {
     // MARK: - Avatar Components Persistence
 
     private var avatarComponentsURL: URL {
-        customAvatarURL.deletingLastPathComponent().appendingPathComponent("avatar-components.json")
+        customAvatarURL.deletingLastPathComponent().appendingPathComponent("character-traits.json")
     }
 
     private struct AvatarComponents: Codable {

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerMigrationTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerMigrationTests.swift
@@ -8,7 +8,7 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
-        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/avatar-image.png")
 
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         let testData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
@@ -31,7 +31,7 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
-        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/avatar-image.png")
 
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data([0x01]).write(to: legacyURL)
@@ -59,7 +59,7 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
         }
 
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
-        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/avatar-image.png")
 
         // Set up legacy file
         try FileManager.default.createDirectory(at: legacyURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -82,7 +82,7 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
 
     func testReturnsNilWhenNeitherFileExists() {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/custom-avatar.png")
+        let workspaceURL = tmp.appendingPathComponent(".vellum/workspace/data/avatar/avatar-image.png")
         let legacyURL = tmp.appendingPathComponent("AppSupport/vellum-assistant/custom-avatar.png")
 
         let result = AvatarAppearanceManager.resolveCustomAvatarURL(
@@ -94,7 +94,7 @@ final class AvatarAppearanceManagerMigrationTests: XCTestCase {
 
     func testPathHelpersProduceCorrectURLsForMigration() {
         let workspace = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/Users/test")
-        XCTAssertEqual(workspace.path, "/Users/test/.vellum/workspace/data/avatar/custom-avatar.png")
+        XCTAssertEqual(workspace.path, "/Users/test/.vellum/workspace/data/avatar/avatar-image.png")
 
         let legacy = AvatarAppearanceManager.legacyAppSupportCustomAvatarURL()
         XCTAssertTrue(legacy.path.contains("Application Support/vellum-assistant/custom-avatar.png"))

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerPathTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerPathTests.swift
@@ -5,12 +5,12 @@ final class AvatarAppearanceManagerPathTests: XCTestCase {
 
     func testWorkspacePathUsesVellumWorkspaceDirectory() {
         let url = AvatarAppearanceManager.workspaceCustomAvatarURL(homeDirectory: "/Users/testuser")
-        XCTAssertEqual(url.path, "/Users/testuser/.vellum/workspace/data/avatar/custom-avatar.png")
+        XCTAssertEqual(url.path, "/Users/testuser/.vellum/workspace/data/avatar/avatar-image.png")
     }
 
     func testWorkspacePathDefaultsToRealHomeDirectory() {
         let url = AvatarAppearanceManager.workspaceCustomAvatarURL()
-        XCTAssertTrue(url.path.hasSuffix("/.vellum/workspace/data/avatar/custom-avatar.png"))
+        XCTAssertTrue(url.path.hasSuffix("/.vellum/workspace/data/avatar/avatar-image.png"))
         XCTAssertFalse(url.path.isEmpty)
     }
 

--- a/clients/macos/vellum-assistantTests/AvatarAppearanceManagerStorageTests.swift
+++ b/clients/macos/vellum-assistantTests/AvatarAppearanceManagerStorageTests.swift
@@ -6,7 +6,7 @@ final class AvatarAppearanceManagerStorageTests: XCTestCase {
     func testCustomAvatarURLPointsToWorkspacePath() {
         // The workspace URL should end with the expected workspace suffix
         let url = AvatarAppearanceManager.workspaceCustomAvatarURL()
-        XCTAssertTrue(url.path.hasSuffix("/.vellum/workspace/data/avatar/custom-avatar.png"))
+        XCTAssertTrue(url.path.hasSuffix("/.vellum/workspace/data/avatar/avatar-image.png"))
     }
 
     func testWorkspacePathCreatesParentDirectories() throws {


### PR DESCRIPTION
## Summary
- Update macOS client to read/write avatar-image.png instead of custom-avatar.png
- Update character traits path from avatar-components.json to character-traits.json
- Legacy App Support migration path preserved for backwards compatibility

Part of plan: avatar-skill-refactor.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
