### PR TITLE
[ces] Add CES RPC server, local/managed entrypoints, and private data-root layout

### DIFF
--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -47,8 +47,9 @@ COPY --from=builder --chown=ces:ces /app /app
 
 USER ces
 
-EXPOSE 7840
+EXPOSE 7841
 
-ENV CES_PORT=7840
+ENV CES_MODE=managed
+ENV CES_HEALTH_PORT=7841
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "run", "src/managed-main.ts"]

--- a/credential-executor/package.json
+++ b/credential-executor/package.json
@@ -7,10 +7,12 @@
     ".": "./src/index.ts"
   },
   "bin": {
-    "credential-executor": "./src/index.ts"
+    "credential-executor": "./src/main.ts",
+    "credential-executor-managed": "./src/managed-main.ts"
   },
   "scripts": {
-    "dev": "bun run src/index.ts",
+    "dev": "bun run src/main.ts",
+    "dev:managed": "CES_MODE=managed bun run src/managed-main.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test src/"
   },

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -1,0 +1,388 @@
+/**
+ * CES transport tests.
+ *
+ * Verifies:
+ * 1. The managed entrypoint never opens a general localhost command API —
+ *    the only command transport is via the accepted Unix socket stream.
+ * 2. Health probes are served on a dedicated HTTP port, separate from
+ *    the command transport.
+ * 3. Local stdio transports are not accidentally inherited by shell
+ *    subprocesses (the entrypoint does not open TCP listeners).
+ * 4. The CES RPC server correctly performs handshake and dispatches methods.
+ * 5. CES private data paths are correctly resolved for both modes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { PassThrough } from "node:stream";
+
+import {
+  CES_PROTOCOL_VERSION,
+  type HandshakeAck,
+  type RpcEnvelope,
+} from "@vellumai/ces-contracts";
+
+import { getCesDataRoot, getBootstrapSocketPath, getHealthPort } from "../paths.js";
+import { CesRpcServer, type RpcHandlerRegistry } from "../server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a CesRpcServer wired to in-memory PassThrough streams for testing.
+ */
+function createTestServer(handlers: RpcHandlerRegistry = {}) {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const logs: string[] = [];
+
+  const server = new CesRpcServer({
+    input,
+    output,
+    handlers,
+    logger: {
+      log: (msg: string) => logs.push(`LOG: ${msg}`),
+      warn: (msg: string) => logs.push(`WARN: ${msg}`),
+      error: (msg: string) => logs.push(`ERROR: ${msg}`),
+    },
+  });
+
+  /**
+   * Collect all output lines from the server.
+   */
+  function collectOutputLines(): string[] {
+    const data = output.read();
+    if (!data) return [];
+    const text = typeof data === "string" ? data : data.toString("utf-8");
+    return text.split("\n").filter((l: string) => l.trim().length > 0);
+  }
+
+  /**
+   * Send a JSON message to the server (newline-delimited).
+   */
+  function send(msg: unknown): void {
+    input.write(JSON.stringify(msg) + "\n");
+  }
+
+  /**
+   * Send a handshake request and read the response.
+   */
+  async function handshake(sessionId = "test-session"): Promise<HandshakeAck> {
+    send({
+      type: "handshake_request",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId,
+    });
+    // Give the server a tick to process
+    await new Promise((r) => setTimeout(r, 10));
+    const lines = collectOutputLines();
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    return JSON.parse(lines[0]) as HandshakeAck;
+  }
+
+  /**
+   * Send an RPC request and read the response.
+   */
+  async function rpc(
+    method: string,
+    payload: unknown,
+    id = "1",
+  ): Promise<RpcEnvelope> {
+    send({
+      type: "rpc",
+      id,
+      kind: "request",
+      method,
+      payload,
+      timestamp: new Date().toISOString(),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const lines = collectOutputLines();
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    return JSON.parse(lines[lines.length - 1]) as RpcEnvelope;
+  }
+
+  return { server, input, output, send, collectOutputLines, handshake, rpc, logs };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Managed entrypoint never opens a generic localhost command API
+// ---------------------------------------------------------------------------
+
+describe("managed entrypoint transport isolation", () => {
+  test("managed-main.ts does not call Bun.serve for RPC (only health)", () => {
+    const src = readFileSync(
+      resolve(__dirname, "..", "managed-main.ts"),
+      "utf-8",
+    );
+    // Bun.serve calls in managed-main should only be in startHealthServer
+    const bunServeMatches = src.match(/Bun\.serve\(/g);
+    expect(bunServeMatches).not.toBeNull();
+    // There should be exactly 1 Bun.serve call — for health probes only
+    expect(bunServeMatches!.length).toBe(1);
+  });
+
+  test("managed-main.ts uses createNetServer for Unix socket, not Bun.serve", () => {
+    const src = readFileSync(
+      resolve(__dirname, "..", "managed-main.ts"),
+      "utf-8",
+    );
+    // Uses node:net createServer for the bootstrap socket
+    expect(src).toMatch(/createNetServer/);
+    // The net server never listens on a TCP port (only a socket path)
+    expect(src).not.toMatch(/netServer\.listen\(\d+/);
+  });
+
+  test("managed-main.ts unlinks socket after accepting one connection", () => {
+    const src = readFileSync(
+      resolve(__dirname, "..", "managed-main.ts"),
+      "utf-8",
+    );
+    // Should unlink the socket path after connection
+    expect(src).toMatch(/unlinkSync\(socketPath\)/);
+    // Should close the net server after one connection
+    expect(src).toMatch(/netServer\.close\(\)/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Health probes on dedicated port
+// ---------------------------------------------------------------------------
+
+describe("health probes", () => {
+  test("managed-main.ts serves /healthz and /readyz on a separate port", () => {
+    const src = readFileSync(
+      resolve(__dirname, "..", "managed-main.ts"),
+      "utf-8",
+    );
+    expect(src).toMatch(/\/healthz/);
+    expect(src).toMatch(/\/readyz/);
+    // Health server uses Bun.serve on a dedicated port, not the socket
+    expect(src).toMatch(/startHealthServer\(healthPort/);
+  });
+
+  test("getHealthPort defaults to 7841", () => {
+    // Save and clear env
+    const saved = process.env["CES_HEALTH_PORT"];
+    delete process.env["CES_HEALTH_PORT"];
+    try {
+      expect(getHealthPort()).toBe(7841);
+    } finally {
+      if (saved !== undefined) process.env["CES_HEALTH_PORT"] = saved;
+    }
+  });
+
+  test("getHealthPort respects CES_HEALTH_PORT env var", () => {
+    const saved = process.env["CES_HEALTH_PORT"];
+    process.env["CES_HEALTH_PORT"] = "9999";
+    try {
+      expect(getHealthPort()).toBe(9999);
+    } finally {
+      if (saved !== undefined) {
+        process.env["CES_HEALTH_PORT"] = saved;
+      } else {
+        delete process.env["CES_HEALTH_PORT"];
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Local stdio transport not inherited by subprocesses
+// ---------------------------------------------------------------------------
+
+describe("local entrypoint transport isolation", () => {
+  test("main.ts uses process.stdin/stdout, not TCP listeners", () => {
+    const src = readFileSync(resolve(__dirname, "..", "main.ts"), "utf-8");
+    // Uses stdin/stdout for transport
+    expect(src).toMatch(/process\.stdin/);
+    expect(src).toMatch(/process\.stdout/);
+    // Does not open any TCP or Unix socket listener
+    expect(src).not.toMatch(/Bun\.serve\(/);
+    expect(src).not.toMatch(/createServer\(/);
+    expect(src).not.toMatch(/\.listen\(/);
+  });
+
+  test("main.ts logs to stderr, not stdout (avoids polluting transport)", () => {
+    const src = readFileSync(resolve(__dirname, "..", "main.ts"), "utf-8");
+    // All log output goes to stderr
+    expect(src).toMatch(/process\.stderr\.write/);
+    // Should not use console.log (which writes to stdout)
+    expect(src).not.toMatch(/console\.log\(/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. CES RPC server handshake and dispatch
+// ---------------------------------------------------------------------------
+
+describe("CesRpcServer", () => {
+  test("completes handshake with correct protocol version", async () => {
+    const { server, handshake, input } = createTestServer();
+    const servePromise = server.serve();
+
+    const ack = await handshake();
+    expect(ack.type).toBe("handshake_ack");
+    expect(ack.accepted).toBe(true);
+    expect(ack.protocolVersion).toBe(CES_PROTOCOL_VERSION);
+    expect(ack.sessionId).toBe("test-session");
+    expect(server.isHandshakeComplete).toBe(true);
+    expect(server.currentSessionId).toBe("test-session");
+
+    server.close();
+    input.end();
+  });
+
+  test("rejects handshake with wrong protocol version", async () => {
+    const { server, send, collectOutputLines, input } = createTestServer();
+    const servePromise = server.serve();
+
+    send({
+      type: "handshake_request",
+      protocolVersion: "99.99.99",
+      sessionId: "bad-session",
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    const lines = collectOutputLines();
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const ack = JSON.parse(lines[0]) as HandshakeAck;
+    expect(ack.accepted).toBe(false);
+    expect(ack.reason).toMatch(/Unsupported protocol version/);
+    expect(server.isHandshakeComplete).toBe(false);
+
+    server.close();
+    input.end();
+  });
+
+  test("rejects RPC before handshake", async () => {
+    const { server, send, collectOutputLines, input } = createTestServer();
+    const servePromise = server.serve();
+
+    send({
+      type: "rpc",
+      id: "1",
+      kind: "request",
+      method: "list_grants",
+      payload: {},
+      timestamp: new Date().toISOString(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    const lines = collectOutputLines();
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const resp = JSON.parse(lines[0]);
+    expect(resp.payload.success).toBe(false);
+    expect(resp.payload.error.code).toBe("HANDSHAKE_REQUIRED");
+
+    server.close();
+    input.end();
+  });
+
+  test("dispatches RPC to registered handler", async () => {
+    const handlers: RpcHandlerRegistry = {
+      list_grants: async (req: unknown) => {
+        return { grants: [] };
+      },
+    };
+
+    const { server, handshake, rpc, input } = createTestServer(handlers);
+    const servePromise = server.serve();
+
+    await handshake();
+
+    const resp = await rpc("list_grants", {});
+    expect(resp.kind).toBe("response");
+    expect(resp.method).toBe("list_grants");
+    expect((resp.payload as { grants: unknown[] }).grants).toEqual([]);
+
+    server.close();
+    input.end();
+  });
+
+  test("returns METHOD_NOT_FOUND for unknown methods", async () => {
+    const { server, handshake, rpc, input } = createTestServer();
+    const servePromise = server.serve();
+
+    await handshake();
+
+    const resp = await rpc("nonexistent_method", {});
+    expect(resp.kind).toBe("response");
+    expect((resp.payload as { success: boolean; error: { code: string } }).error.code).toBe(
+      "METHOD_NOT_FOUND",
+    );
+
+    server.close();
+    input.end();
+  });
+
+  test("returns HANDLER_ERROR when handler throws", async () => {
+    const handlers: RpcHandlerRegistry = {
+      fail_method: async () => {
+        throw new Error("Intentional test failure");
+      },
+    };
+
+    const { server, handshake, rpc, input } = createTestServer(handlers);
+    const servePromise = server.serve();
+
+    await handshake();
+
+    const resp = await rpc("fail_method", {});
+    expect(resp.kind).toBe("response");
+    const payload = resp.payload as { success: boolean; error: { code: string; message: string } };
+    expect(payload.error.code).toBe("HANDLER_ERROR");
+    expect(payload.error.message).toMatch(/Intentional test failure/);
+
+    server.close();
+    input.end();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. CES private data paths
+// ---------------------------------------------------------------------------
+
+describe("CES data paths", () => {
+  test("local mode data root includes 'protected/credential-executor'", () => {
+    const root = getCesDataRoot("local");
+    expect(root).toMatch(/protected[/\\]credential-executor$/);
+  });
+
+  test("managed mode data root is /ces-data", () => {
+    expect(getCesDataRoot("managed")).toBe("/ces-data");
+  });
+
+  test("local data root is under the Vellum root, not the workspace", () => {
+    const root = getCesDataRoot("local");
+    // Must be under .vellum/protected/, NOT .vellum/workspace/
+    expect(root).toMatch(/\.vellum[/\\]protected[/\\]/);
+    expect(root).not.toMatch(/workspace/);
+  });
+
+  test("getBootstrapSocketPath defaults to /run/ces/ces.sock", () => {
+    const saved = process.env["CES_BOOTSTRAP_SOCKET"];
+    delete process.env["CES_BOOTSTRAP_SOCKET"];
+    try {
+      expect(getBootstrapSocketPath()).toBe("/run/ces/ces.sock");
+    } finally {
+      if (saved !== undefined) process.env["CES_BOOTSTRAP_SOCKET"] = saved;
+    }
+  });
+
+  test("getBootstrapSocketPath respects CES_BOOTSTRAP_SOCKET env var", () => {
+    const saved = process.env["CES_BOOTSTRAP_SOCKET"];
+    process.env["CES_BOOTSTRAP_SOCKET"] = "/tmp/test-ces.sock";
+    try {
+      expect(getBootstrapSocketPath()).toBe("/tmp/test-ces.sock");
+    } finally {
+      if (saved !== undefined) {
+        process.env["CES_BOOTSTRAP_SOCKET"] = saved;
+      } else {
+        delete process.env["CES_BOOTSTRAP_SOCKET"];
+      }
+    }
+  });
+});

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -8,33 +8,25 @@
  * from the local credential store, executes the requested operation through
  * the egress proxy, and returns sanitised results.
  *
- * This entrypoint bootstraps the CES process and starts listening for
- * incoming transport connections from the assistant.
+ * This module re-exports the public API surface. For entrypoints see:
+ * - `main.ts` — local mode (stdio transport, child process)
+ * - `managed-main.ts` — managed mode (Unix socket transport, sidecar)
  */
 
-import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+export { CesRpcServer, createCesServer } from "./server.js";
+export type {
+  CesServerOptions,
+  RpcHandlerRegistry,
+  RpcMethodHandler,
+} from "./server.js";
 
-const PORT = parseInt(process.env["CES_PORT"] ?? "7840", 10);
-
-console.log(
-  `[credential-executor] Starting CES v${CES_PROTOCOL_VERSION} on port ${PORT}`,
-);
-
-// Placeholder — the server implementation will be added in subsequent PRs.
-const server = Bun.serve({
-  port: PORT,
-  fetch(_req) {
-    return new Response(
-      JSON.stringify({
-        service: "credential-executor",
-        protocolVersion: CES_PROTOCOL_VERSION,
-        status: "ok",
-      }),
-      {
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  },
-});
-
-console.log(`[credential-executor] Listening on http://localhost:${server.port}`);
+export {
+  getCesDataRoot,
+  getCesGrantsDir,
+  getCesAuditDir,
+  getCesToolStoreDir,
+  getCesMode,
+  getBootstrapSocketPath,
+  getHealthPort,
+} from "./paths.js";
+export type { CesMode } from "./paths.js";

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+/**
+ * Local CES entrypoint.
+ *
+ * In local mode the assistant spawns CES as a child process and communicates
+ * over stdin/stdout using newline-delimited JSON. This entrypoint:
+ *
+ * 1. Ensures the CES-private data directories exist.
+ * 2. Starts the RPC server on process.stdin / process.stdout.
+ * 3. Shuts down cleanly when stdin closes (parent exit) or SIGTERM arrives.
+ *
+ * Local mode never opens a TCP listener or Unix socket. All communication
+ * flows through the inherited stdio file descriptors, which are automatically
+ * closed when the parent process exits.
+ *
+ * The stdio transport ensures that shell subprocesses spawned by CES
+ * (e.g. for `run_authenticated_command`) do not accidentally inherit the
+ * command channel — Bun's `Bun.spawn` defaults to "pipe" for stdio on
+ * child processes, so CES's own stdin/stdout are not leaked to subprocesses.
+ */
+
+import { mkdirSync } from "node:fs";
+
+import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+
+import {
+  getCesAuditDir,
+  getCesDataRoot,
+  getCesGrantsDir,
+  getCesToolStoreDir,
+} from "./paths.js";
+import { CesRpcServer, type RpcHandlerRegistry } from "./server.js";
+
+// ---------------------------------------------------------------------------
+// Data directory bootstrap
+// ---------------------------------------------------------------------------
+
+function ensureDataDirs(): void {
+  const dirs = [
+    getCesDataRoot("local"),
+    getCesGrantsDir("local"),
+    getCesAuditDir("local"),
+    getCesToolStoreDir("local"),
+  ];
+  for (const dir of dirs) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stub RPC handlers (real implementations will be added in subsequent PRs)
+// ---------------------------------------------------------------------------
+
+const handlers: RpcHandlerRegistry = {
+  // Placeholder — each RPC method will be wired to its implementation
+  // as the respective PRs land.
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  ensureDataDirs();
+
+  const log = (msg: string) =>
+    process.stderr.write(`[ces-local] ${msg}\n`);
+
+  log(`Starting CES v${CES_PROTOCOL_VERSION} (local mode, stdio transport)`);
+
+  const controller = new AbortController();
+
+  // Graceful shutdown on SIGTERM / SIGINT
+  const shutdown = () => {
+    log("Shutting down...");
+    controller.abort();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  const server = new CesRpcServer({
+    input: process.stdin,
+    output: process.stdout,
+    handlers,
+    logger: {
+      log: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-local] ${msg} ${args.map(String).join(" ")}\n`),
+      warn: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-local] WARN: ${msg} ${args.map(String).join(" ")}\n`),
+      error: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-local] ERROR: ${msg} ${args.map(String).join(" ")}\n`),
+    },
+    signal: controller.signal,
+  });
+
+  await server.serve();
+  log("Server stopped.");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[ces-local] Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env bun
+/**
+ * Managed CES entrypoint.
+ *
+ * In managed (sidecar) mode the CES container:
+ *
+ * 1. Ensures the CES-private data directories exist.
+ * 2. Binds a bootstrap Unix socket on the shared bootstrap volume.
+ * 3. Accepts exactly **one** assistant runtime connection.
+ * 4. Unlinks the socket path immediately after the connection is accepted,
+ *    preventing any second process from connecting.
+ * 5. Serves RPC on the accepted stream only.
+ * 6. Simultaneously serves health probes (`/healthz`, `/readyz`) on a
+ *    dedicated HTTP port for Kubernetes liveness/readiness checks.
+ *
+ * The managed entrypoint never opens a generic TCP or HTTP command API.
+ * All RPC traffic flows exclusively over the accepted Unix socket stream.
+ */
+
+import { mkdirSync, unlinkSync } from "node:fs";
+import { createServer as createNetServer, type Socket } from "node:net";
+import { dirname } from "node:path";
+import { Readable, Writable } from "node:stream";
+
+import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+
+import {
+  getBootstrapSocketPath,
+  getCesAuditDir,
+  getCesDataRoot,
+  getCesGrantsDir,
+  getCesToolStoreDir,
+  getHealthPort,
+} from "./paths.js";
+import { CesRpcServer, type RpcHandlerRegistry } from "./server.js";
+
+// ---------------------------------------------------------------------------
+// Logging (managed always logs to stderr)
+// ---------------------------------------------------------------------------
+
+const log = (msg: string) =>
+  process.stderr.write(`[ces-managed] ${msg}\n`);
+
+const warn = (msg: string) =>
+  process.stderr.write(`[ces-managed] WARN: ${msg}\n`);
+
+// ---------------------------------------------------------------------------
+// Data directory bootstrap
+// ---------------------------------------------------------------------------
+
+function ensureDataDirs(): void {
+  const dirs = [
+    getCesDataRoot("managed"),
+    getCesGrantsDir("managed"),
+    getCesAuditDir("managed"),
+    getCesToolStoreDir("managed"),
+  ];
+  for (const dir of dirs) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stub RPC handlers (real implementations added in subsequent PRs)
+// ---------------------------------------------------------------------------
+
+const handlers: RpcHandlerRegistry = {};
+
+// ---------------------------------------------------------------------------
+// Health server
+// ---------------------------------------------------------------------------
+
+let rpcConnected = false;
+
+function startHealthServer(port: number, signal: AbortSignal): ReturnType<typeof Bun.serve> {
+  const server = Bun.serve({
+    port,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/healthz") {
+        return new Response(
+          JSON.stringify({ status: "ok", version: CES_PROTOCOL_VERSION }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.pathname === "/readyz") {
+        const ready = rpcConnected;
+        return new Response(
+          JSON.stringify({ ready, version: CES_PROTOCOL_VERSION }),
+          {
+            status: ready ? 200 : 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  signal.addEventListener("abort", () => {
+    server.stop(true);
+  }, { once: true });
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap socket server (accepts exactly one connection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Listen on a Unix socket, accept exactly one connection, unlink the
+ * socket path, and return readable/writable streams for the accepted
+ * connection.
+ */
+function acceptOneConnection(
+  socketPath: string,
+  signal: AbortSignal,
+): Promise<{ readable: Readable; writable: Writable; socket: Socket }> {
+  return new Promise((resolve, reject) => {
+    // Ensure the socket directory exists
+    mkdirSync(dirname(socketPath), { recursive: true });
+
+    // Clean up any stale socket file
+    try {
+      unlinkSync(socketPath);
+    } catch {
+      // Ignore — file may not exist
+    }
+
+    const netServer = createNetServer();
+
+    const cleanup = () => {
+      netServer.close();
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Already unlinked or never created
+      }
+    };
+
+    if (signal.aborted) {
+      reject(new Error("Aborted before listening"));
+      return;
+    }
+
+    signal.addEventListener("abort", () => {
+      cleanup();
+      reject(new Error("Aborted while waiting for connection"));
+    }, { once: true });
+
+    netServer.on("error", (err) => {
+      cleanup();
+      reject(err);
+    });
+
+    netServer.listen(socketPath, () => {
+      log(`Bootstrap socket listening at ${socketPath}`);
+    });
+
+    netServer.on("connection", (socket: Socket) => {
+      // Accept exactly one connection, then close the listener and
+      // unlink the socket path so no other process can connect.
+      log("Assistant connected via bootstrap socket");
+      netServer.close();
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Already unlinked
+      }
+      log("Bootstrap socket unlinked (single-connection enforced)");
+
+      const readable = new Readable({
+        read() {
+          // Data is pushed externally
+        },
+      });
+
+      const writable = new Writable({
+        write(chunk, _encoding, callback) {
+          if (socket.writable) {
+            socket.write(chunk, callback);
+          } else {
+            callback(new Error("Socket no longer writable"));
+          }
+        },
+      });
+
+      socket.on("data", (chunk) => {
+        readable.push(chunk);
+      });
+
+      socket.on("end", () => {
+        readable.push(null);
+      });
+
+      socket.on("error", (err) => {
+        readable.destroy(err);
+        writable.destroy(err);
+      });
+
+      resolve({ readable, writable, socket });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  ensureDataDirs();
+
+  log(`Starting CES v${CES_PROTOCOL_VERSION} (managed mode)`);
+
+  const controller = new AbortController();
+
+  // Graceful shutdown
+  const shutdown = () => {
+    log("Shutting down...");
+    controller.abort();
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  // Start health server on dedicated port
+  const healthPort = getHealthPort();
+  const healthServer = startHealthServer(healthPort, controller.signal);
+  log(`Health server listening on port ${healthPort}`);
+
+  // Wait for exactly one assistant connection on the bootstrap socket
+  const socketPath = getBootstrapSocketPath();
+  log(`Waiting for assistant connection on ${socketPath}...`);
+
+  let connection: Awaited<ReturnType<typeof acceptOneConnection>>;
+  try {
+    connection = await acceptOneConnection(socketPath, controller.signal);
+  } catch (err) {
+    if (controller.signal.aborted) {
+      log("Shutdown before assistant connected.");
+      return;
+    }
+    throw err;
+  }
+
+  rpcConnected = true;
+
+  const server = new CesRpcServer({
+    input: connection.readable,
+    output: connection.writable,
+    handlers,
+    logger: {
+      log: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-managed] ${msg} ${args.map(String).join(" ")}\n`),
+      warn: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-managed] WARN: ${msg} ${args.map(String).join(" ")}\n`),
+      error: (msg: string, ...args: unknown[]) =>
+        process.stderr.write(`[ces-managed] ERROR: ${msg} ${args.map(String).join(" ")}\n`),
+    },
+    signal: controller.signal,
+  });
+
+  await server.serve();
+
+  rpcConnected = false;
+  log("RPC session ended. Shutting down...");
+  controller.abort();
+}
+
+main().catch((err) => {
+  process.stderr.write(`[ces-managed] Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -1,0 +1,137 @@
+/**
+ * CES private data-root layout.
+ *
+ * Defines the directory structure for CES-private durable state (grants,
+ * audit logs, tool store). This state is never stored on the assistant-visible
+ * workspace/data root — it lives in a CES-only path that the assistant process
+ * cannot read or write.
+ *
+ * Two modes:
+ *
+ * - **Local**: CES private state lives under the Vellum root's `protected/`
+ *   directory at `<rootDir>/protected/credential-executor/`.
+ *
+ * - **Managed**: CES private state lives at `/ces-data`, a dedicated volume
+ *   mounted only into the CES container. The assistant container never sees
+ *   this volume.
+ *
+ * The assistant-visible data root (where workspace, embeddings, etc. live)
+ * is a separate path and must never be used for CES-private writes.
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Mode detection
+// ---------------------------------------------------------------------------
+
+export type CesMode = "local" | "managed";
+
+/**
+ * Determine the CES operating mode from the environment.
+ *
+ * `CES_MODE=managed` is set explicitly in managed container entrypoints.
+ * Everything else defaults to local.
+ */
+export function getCesMode(): CesMode {
+  return process.env["CES_MODE"] === "managed" ? "managed" : "local";
+}
+
+// ---------------------------------------------------------------------------
+// Root directory helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Vellum root directory, respecting `BASE_DATA_DIR` for
+ * multi-instance deployments. Mirrors the logic in `assistant/src/util/platform.ts`.
+ */
+function getVellumRootDir(): string {
+  const baseDataDir = process.env["BASE_DATA_DIR"]?.trim();
+  return join(baseDataDir || homedir(), ".vellum");
+}
+
+/** Well-known managed CES data root (dedicated volume mount). */
+const MANAGED_CES_DATA_ROOT = "/ces-data";
+
+/**
+ * Return the CES-private data root.
+ *
+ * - Local: `<vellumRoot>/protected/credential-executor/`
+ * - Managed: `/ces-data`
+ */
+export function getCesDataRoot(mode?: CesMode): string {
+  const resolvedMode = mode ?? getCesMode();
+  if (resolvedMode === "managed") {
+    return MANAGED_CES_DATA_ROOT;
+  }
+  return join(getVellumRootDir(), "protected", "credential-executor");
+}
+
+// ---------------------------------------------------------------------------
+// Subdirectory layout
+// ---------------------------------------------------------------------------
+
+/** Directory for CES grant persistence. */
+export function getCesGrantsDir(mode?: CesMode): string {
+  return join(getCesDataRoot(mode), "grants");
+}
+
+/** Directory for CES audit log persistence. */
+export function getCesAuditDir(mode?: CesMode): string {
+  return join(getCesDataRoot(mode), "audit");
+}
+
+/** Directory for CES secure tool store (registered secure command tools). */
+export function getCesToolStoreDir(mode?: CesMode): string {
+  return join(getCesDataRoot(mode), "toolstore");
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap socket path (managed mode only)
+// ---------------------------------------------------------------------------
+
+/** Default directory for the bootstrap Unix socket shared volume. */
+const BOOTSTRAP_SOCKET_DIR = "/run/ces";
+
+/** Default bootstrap socket filename. */
+const BOOTSTRAP_SOCKET_NAME = "ces.sock";
+
+/**
+ * Return the path to the bootstrap Unix socket.
+ *
+ * In managed mode, CES listens on this socket for exactly one assistant
+ * connection, then unlinks it. The path is on a shared `emptyDir` volume
+ * visible to both containers.
+ *
+ * Can be overridden via `CES_BOOTSTRAP_SOCKET` env var.
+ */
+export function getBootstrapSocketPath(): string {
+  return (
+    process.env["CES_BOOTSTRAP_SOCKET"] ??
+    join(BOOTSTRAP_SOCKET_DIR, BOOTSTRAP_SOCKET_NAME)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Health port (managed mode only)
+// ---------------------------------------------------------------------------
+
+/** Default health probe port for managed CES. */
+const DEFAULT_HEALTH_PORT = 7841;
+
+/**
+ * Return the health probe port for managed mode.
+ *
+ * Health probes are served on a dedicated HTTP port, separate from the
+ * Unix socket command transport. This ensures liveness/readiness probes
+ * work without a Unix socket client.
+ */
+export function getHealthPort(): number {
+  const envPort = process.env["CES_HEALTH_PORT"];
+  if (envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_HEALTH_PORT;
+}

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -1,0 +1,309 @@
+/**
+ * CES RPC server.
+ *
+ * Implements the server-side of the CES wire protocol defined in
+ * `@vellumai/ces-contracts`. The server reads newline-delimited JSON
+ * messages from a readable stream, dispatches them through the RPC
+ * contract, and writes responses back to a writable stream.
+ *
+ * Transport-agnostic: callers provide the readable/writable pair.
+ * - Local mode: stdin/stdout
+ * - Managed mode: the accepted Unix socket stream
+ *
+ * The server handles the handshake, validates envelopes, dispatches
+ * method calls, and sends structured responses or errors.
+ */
+
+import type { Readable, Writable } from "node:stream";
+
+import {
+  CES_PROTOCOL_VERSION,
+  type CesRpcMethod,
+  CesRpcSchemas,
+  type HandshakeAck,
+  type HandshakeRequest,
+  type RpcEnvelope,
+  type TransportMessage,
+  TransportMessageSchema,
+} from "@vellumai/ces-contracts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler function for a single RPC method. Receives the validated
+ * request payload and returns the response payload (or throws).
+ */
+export type RpcMethodHandler<TReq = unknown, TRes = unknown> = (
+  request: TReq,
+) => Promise<TRes> | TRes;
+
+/**
+ * Registry of method name to handler function.
+ */
+export type RpcHandlerRegistry = Partial<
+  Record<string, RpcMethodHandler>
+>;
+
+export interface CesServerOptions {
+  /** Readable stream to consume messages from. */
+  input: Readable;
+  /** Writable stream to send responses to. */
+  output: Writable;
+  /** Map of RPC method names to handler functions. */
+  handlers: RpcHandlerRegistry;
+  /** Optional logger (defaults to console). */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+  /** Optional abort signal to shut down the server. */
+  signal?: AbortSignal;
+}
+
+// ---------------------------------------------------------------------------
+// Server implementation
+// ---------------------------------------------------------------------------
+
+export class CesRpcServer {
+  private readonly input: Readable;
+  private readonly output: Writable;
+  private readonly handlers: RpcHandlerRegistry;
+  private readonly logger: Pick<Console, "log" | "warn" | "error">;
+  private readonly signal?: AbortSignal;
+
+  private handshakeComplete = false;
+  private sessionId: string | null = null;
+  private buffer = "";
+  private closed = false;
+
+  constructor(options: CesServerOptions) {
+    this.input = options.input;
+    this.output = options.output;
+    this.handlers = options.handlers;
+    this.logger = options.logger ?? console;
+    this.signal = options.signal;
+  }
+
+  /**
+   * Start serving. Returns a promise that resolves when the input stream
+   * ends or the abort signal fires.
+   */
+  async serve(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (this.signal?.aborted) {
+        this.close();
+        resolve();
+        return;
+      }
+
+      const onAbort = () => {
+        this.close();
+        resolve();
+      };
+
+      if (this.signal) {
+        this.signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      this.input.on("data", (chunk: Buffer | string) => {
+        if (this.closed) return;
+        this.buffer += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+        this.processBuffer();
+      });
+
+      this.input.on("end", () => {
+        if (this.signal) {
+          this.signal.removeEventListener("abort", onAbort);
+        }
+        this.close();
+        resolve();
+      });
+
+      this.input.on("error", (err) => {
+        if (this.signal) {
+          this.signal.removeEventListener("abort", onAbort);
+        }
+        this.close();
+        reject(err);
+      });
+    });
+  }
+
+  /** Whether the server has completed the handshake. */
+  get isHandshakeComplete(): boolean {
+    return this.handshakeComplete;
+  }
+
+  /** The session ID established during handshake (null before handshake). */
+  get currentSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  /** Shut down the server gracefully. */
+  close(): void {
+    this.closed = true;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private processBuffer(): void {
+    let newlineIdx: number;
+    while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, newlineIdx).trim();
+      this.buffer = this.buffer.slice(newlineIdx + 1);
+      if (line.length === 0) continue;
+      this.handleLine(line);
+    }
+  }
+
+  private handleLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.logger.warn("[ces-server] Failed to parse JSON line:", line);
+      return;
+    }
+
+    // Parse as a transport message
+    const msgResult = TransportMessageSchema.safeParse(parsed);
+    if (!msgResult.success) {
+      this.logger.warn(
+        "[ces-server] Invalid transport message:",
+        msgResult.error,
+      );
+      return;
+    }
+
+    const msg = msgResult.data as TransportMessage;
+
+    if (msg.type === "handshake_request") {
+      this.handleHandshake(msg as HandshakeRequest);
+    } else if (msg.type === "rpc") {
+      this.handleRpcEnvelope(msg as unknown as RpcEnvelope);
+    } else {
+      this.logger.warn("[ces-server] Unexpected message type:", msg.type);
+    }
+  }
+
+  private handleHandshake(req: HandshakeRequest): void {
+    const accepted = req.protocolVersion === CES_PROTOCOL_VERSION;
+    const ack: HandshakeAck = {
+      type: "handshake_ack",
+      protocolVersion: CES_PROTOCOL_VERSION,
+      sessionId: req.sessionId,
+      accepted,
+      ...(accepted ? {} : { reason: `Unsupported protocol version: ${req.protocolVersion}` }),
+    };
+
+    if (accepted) {
+      this.handshakeComplete = true;
+      this.sessionId = req.sessionId;
+      this.logger.log(`[ces-server] Handshake accepted for session ${req.sessionId}`);
+    } else {
+      this.logger.warn(
+        `[ces-server] Handshake rejected: version mismatch (got ${req.protocolVersion}, expected ${CES_PROTOCOL_VERSION})`,
+      );
+    }
+
+    this.sendMessage(ack);
+  }
+
+  private async handleRpcEnvelope(envelope: RpcEnvelope): Promise<void> {
+    if (!this.handshakeComplete) {
+      this.logger.warn("[ces-server] RPC received before handshake; ignoring");
+      this.sendRpcError(envelope, "HANDSHAKE_REQUIRED", "Handshake not completed");
+      return;
+    }
+
+    if (envelope.kind !== "request") {
+      // Server only processes requests; responses are ignored
+      return;
+    }
+
+    const method = envelope.method;
+    const handler = this.handlers[method];
+
+    if (!handler) {
+      this.sendRpcError(envelope, "METHOD_NOT_FOUND", `Unknown method: ${method}`);
+      return;
+    }
+
+    // Validate the request payload against the registered schema (if available)
+    const schemas = CesRpcSchemas[method as CesRpcMethod];
+    let validatedPayload = envelope.payload;
+
+    if (schemas) {
+      const parseResult = schemas.request.safeParse(envelope.payload);
+      if (!parseResult.success) {
+        this.sendRpcError(
+          envelope,
+          "INVALID_REQUEST",
+          `Invalid payload for ${method}: ${parseResult.error.message}`,
+        );
+        return;
+      }
+      validatedPayload = parseResult.data;
+    }
+
+    try {
+      const result = await handler(validatedPayload);
+      this.sendRpcResponse(envelope, result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sendRpcError(envelope, "HANDLER_ERROR", message);
+    }
+  }
+
+  private sendRpcResponse(request: RpcEnvelope, payload: unknown): void {
+    const response: RpcEnvelope & { type: "rpc" } = {
+      type: "rpc",
+      id: request.id,
+      kind: "response",
+      method: request.method,
+      payload,
+      timestamp: new Date().toISOString(),
+    };
+    this.sendMessage(response);
+  }
+
+  private sendRpcError(
+    request: RpcEnvelope,
+    code: string,
+    message: string,
+  ): void {
+    const response: RpcEnvelope & { type: "rpc" } = {
+      type: "rpc",
+      id: request.id,
+      kind: "response",
+      method: request.method,
+      payload: {
+        success: false,
+        error: { code, message },
+      },
+      timestamp: new Date().toISOString(),
+    };
+    this.sendMessage(response);
+  }
+
+  private sendMessage(msg: unknown): void {
+    if (this.closed) return;
+    const line = JSON.stringify(msg) + "\n";
+    this.output.write(line);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a CES RPC server with the given options and start serving.
+ *
+ * This is the primary entrypoint for both local and managed modes —
+ * callers just provide different input/output streams.
+ */
+export function createCesServer(options: CesServerOptions): CesRpcServer {
+  return new CesRpcServer(options);
+}


### PR DESCRIPTION
## Summary
- Add CES RPC server with local (stdio) and managed (bootstrap Unix socket) entrypoints
- Add paths.ts defining CES private data-root layout for local and managed modes
- Add tests proving managed mode uses socket-only transport and health probes on dedicated port
- Update index.ts to re-export new modules, package.json for new bin entrypoints, and Dockerfile for managed mode

Part of plan: untrusted-agent-credential-arch.md (PR 19 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
