### PR TITLE
[assistant+shared] Extract local OAuth store and token refresh primitives into `packages/credential-storage`

### DIFF
--- a/assistant/src/__tests__/credential-storage-oauth-compat.test.ts
+++ b/assistant/src/__tests__/credential-storage-oauth-compat.test.ts
@@ -1,0 +1,606 @@
+/**
+ * Compatibility tests for OAuth primitives extracted into
+ * @vellumai/credential-storage.
+ *
+ * Verifies that the shared helpers produce identical key paths, expiry
+ * calculations, circuit breaker behavior, credential error classification,
+ * and token persistence results as the original inline implementations.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeExpiresAt,
+  deleteOAuthTokens,
+  EXPIRY_BUFFER_MS,
+  getStoredAccessToken,
+  getStoredRefreshToken,
+  isCredentialError,
+  isTokenExpired,
+  oauthAppClientSecretPath,
+  oauthConnectionAccessTokenPath,
+  oauthConnectionRefreshTokenPath,
+  persistOAuthTokens,
+  persistRefreshedTokens,
+  REFRESH_FAILURE_THRESHOLD,
+  RefreshCircuitBreaker,
+  RefreshDeduplicator,
+  type SecureKeyBackend,
+  type SecureKeyDeleteResult,
+} from "@vellumai/credential-storage";
+
+// ---------------------------------------------------------------------------
+// In-memory SecureKeyBackend for testing
+// ---------------------------------------------------------------------------
+
+function createMemoryBackend(): SecureKeyBackend & {
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: async (key: string) => store.get(key),
+    set: async (key: string, value: string) => {
+      store.set(key, value);
+      return true;
+    },
+    delete: async (key: string): Promise<SecureKeyDeleteResult> => {
+      if (store.has(key)) {
+        store.delete(key);
+        return "deleted";
+      }
+      return "not-found";
+    },
+    list: async () => Array.from(store.keys()),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Secure-key path conventions
+// ---------------------------------------------------------------------------
+
+describe("OAuth secure-key path conventions", () => {
+  test("access token path matches hardcoded format", () => {
+    const connId = "conn-abc-123";
+    expect(oauthConnectionAccessTokenPath(connId)).toBe(
+      `oauth_connection/${connId}/access_token`,
+    );
+  });
+
+  test("refresh token path matches hardcoded format", () => {
+    const connId = "conn-xyz-456";
+    expect(oauthConnectionRefreshTokenPath(connId)).toBe(
+      `oauth_connection/${connId}/refresh_token`,
+    );
+  });
+
+  test("client secret path matches hardcoded format", () => {
+    const appId = "app-def-789";
+    expect(oauthAppClientSecretPath(appId)).toBe(
+      `oauth_app/${appId}/client_secret`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token expiry
+// ---------------------------------------------------------------------------
+
+describe("isTokenExpired", () => {
+  test("null expiresAt is not expired", () => {
+    expect(isTokenExpired(null)).toBe(false);
+  });
+
+  test("future expiry outside buffer is not expired", () => {
+    const future = Date.now() + EXPIRY_BUFFER_MS + 60_000;
+    expect(isTokenExpired(future)).toBe(false);
+  });
+
+  test("expiry within buffer window is expired", () => {
+    const withinBuffer = Date.now() + EXPIRY_BUFFER_MS - 1_000;
+    expect(isTokenExpired(withinBuffer)).toBe(true);
+  });
+
+  test("past expiry is expired", () => {
+    const past = Date.now() - 60_000;
+    expect(isTokenExpired(past)).toBe(true);
+  });
+
+  test("custom buffer is respected", () => {
+    const ts = Date.now() + 10_000;
+    expect(isTokenExpired(ts, 5_000)).toBe(false);
+    expect(isTokenExpired(ts, 15_000)).toBe(true);
+  });
+
+  test("EXPIRY_BUFFER_MS is 5 minutes", () => {
+    expect(EXPIRY_BUFFER_MS).toBe(5 * 60 * 1000);
+  });
+});
+
+describe("computeExpiresAt", () => {
+  test("null input returns null", () => {
+    expect(computeExpiresAt(null)).toBeNull();
+  });
+
+  test("undefined input returns null", () => {
+    expect(computeExpiresAt(undefined)).toBeNull();
+  });
+
+  test("zero returns null", () => {
+    expect(computeExpiresAt(0)).toBeNull();
+  });
+
+  test("negative returns null", () => {
+    expect(computeExpiresAt(-10)).toBeNull();
+  });
+
+  test("positive value computes future timestamp", () => {
+    const before = Date.now();
+    const result = computeExpiresAt(3600);
+    const after = Date.now();
+    expect(result).not.toBeNull();
+    expect(result!).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(result!).toBeLessThanOrEqual(after + 3600 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stored token lookup
+// ---------------------------------------------------------------------------
+
+describe("stored token lookup", () => {
+  test("getStoredAccessToken retrieves from correct path", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-1";
+    backend.store.set(
+      `oauth_connection/${connId}/access_token`,
+      "access-tok-123",
+    );
+
+    const result = await getStoredAccessToken(backend, connId);
+    expect(result).toBe("access-tok-123");
+  });
+
+  test("getStoredAccessToken returns undefined when missing", async () => {
+    const backend = createMemoryBackend();
+    const result = await getStoredAccessToken(backend, "nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  test("getStoredRefreshToken retrieves from correct path", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-2";
+    backend.store.set(
+      `oauth_connection/${connId}/refresh_token`,
+      "refresh-tok-456",
+    );
+
+    const result = await getStoredRefreshToken(backend, connId);
+    expect(result).toBe("refresh-tok-456");
+  });
+
+  test("getStoredRefreshToken returns undefined when missing", async () => {
+    const backend = createMemoryBackend();
+    const result = await getStoredRefreshToken(backend, "nonexistent");
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token persistence
+// ---------------------------------------------------------------------------
+
+describe("persistOAuthTokens", () => {
+  test("stores access and refresh tokens at correct paths", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-persist-1";
+
+    await persistOAuthTokens(backend, connId, {
+      accessToken: "access-123",
+      refreshToken: "refresh-456",
+    });
+
+    expect(backend.store.get(`oauth_connection/${connId}/access_token`)).toBe(
+      "access-123",
+    );
+    expect(backend.store.get(`oauth_connection/${connId}/refresh_token`)).toBe(
+      "refresh-456",
+    );
+  });
+
+  test("clears stale refresh token when not provided", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-persist-2";
+
+    // Pre-populate a refresh token
+    backend.store.set(
+      `oauth_connection/${connId}/refresh_token`,
+      "old-refresh",
+    );
+
+    await persistOAuthTokens(backend, connId, {
+      accessToken: "new-access",
+      // no refreshToken — should clear the old one
+    });
+
+    expect(backend.store.get(`oauth_connection/${connId}/access_token`)).toBe(
+      "new-access",
+    );
+    expect(backend.store.has(`oauth_connection/${connId}/refresh_token`)).toBe(
+      false,
+    );
+  });
+
+  test("throws when access token storage fails", async () => {
+    const backend = createMemoryBackend();
+    backend.set = async () => false; // Simulate storage failure
+    const connId = "conn-fail";
+
+    await expect(
+      persistOAuthTokens(backend, connId, { accessToken: "tok" }),
+    ).rejects.toThrow("Failed to store access token in secure storage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh-on-expiry: persistRefreshedTokens
+// ---------------------------------------------------------------------------
+
+describe("persistRefreshedTokens", () => {
+  test("persists refreshed tokens and computes expiresAt", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-refresh-1";
+
+    const before = Date.now();
+    const result = await persistRefreshedTokens(backend, connId, {
+      accessToken: "new-access-tok",
+      refreshToken: "new-refresh-tok",
+      expiresIn: 3600,
+    });
+    const after = Date.now();
+
+    expect(result.accessToken).toBe("new-access-tok");
+    expect(result.hasRefreshToken).toBe(true);
+    expect(result.expiresAt).not.toBeNull();
+    expect(result.expiresAt!).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    expect(result.expiresAt!).toBeLessThanOrEqual(after + 3600 * 1000);
+
+    expect(backend.store.get(`oauth_connection/${connId}/access_token`)).toBe(
+      "new-access-tok",
+    );
+    expect(backend.store.get(`oauth_connection/${connId}/refresh_token`)).toBe(
+      "new-refresh-tok",
+    );
+  });
+
+  test("returns null expiresAt when expiresIn is zero", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-refresh-2";
+
+    const result = await persistRefreshedTokens(backend, connId, {
+      accessToken: "tok",
+      expiresIn: 0,
+    });
+
+    expect(result.expiresAt).toBeNull();
+    expect(result.hasRefreshToken).toBe(false);
+  });
+
+  test("returns null expiresAt when expiresIn is null", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-refresh-3";
+
+    const result = await persistRefreshedTokens(backend, connId, {
+      accessToken: "tok",
+      expiresIn: null,
+    });
+
+    expect(result.expiresAt).toBeNull();
+  });
+
+  test("throws when access token storage fails", async () => {
+    const backend = createMemoryBackend();
+    backend.set = async () => false;
+
+    await expect(
+      persistRefreshedTokens(backend, "conn-x", {
+        accessToken: "tok",
+      }),
+    ).rejects.toThrow("Failed to store refreshed access token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete OAuth tokens
+// ---------------------------------------------------------------------------
+
+describe("deleteOAuthTokens", () => {
+  test("deletes both access and refresh tokens", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-del-1";
+    backend.store.set(`oauth_connection/${connId}/access_token`, "at");
+    backend.store.set(`oauth_connection/${connId}/refresh_token`, "rt");
+
+    const result = await deleteOAuthTokens(backend, connId);
+
+    expect(result.accessTokenResult).toBe("deleted");
+    expect(result.refreshTokenResult).toBe("deleted");
+    expect(backend.store.size).toBe(0);
+  });
+
+  test("returns not-found for missing tokens", async () => {
+    const backend = createMemoryBackend();
+
+    const result = await deleteOAuthTokens(backend, "nonexistent");
+
+    expect(result.accessTokenResult).toBe("not-found");
+    expect(result.refreshTokenResult).toBe("not-found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing refresh config edge case
+// ---------------------------------------------------------------------------
+
+describe("missing refresh config", () => {
+  test("getStoredRefreshToken returns undefined for connection without refresh token", async () => {
+    const backend = createMemoryBackend();
+    // Only set access token, no refresh token
+    backend.store.set("oauth_connection/conn-no-refresh/access_token", "at");
+
+    const refresh = await getStoredRefreshToken(backend, "conn-no-refresh");
+    expect(refresh).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+describe("RefreshCircuitBreaker", () => {
+  test("starts closed", () => {
+    const breaker = new RefreshCircuitBreaker();
+    expect(breaker.isOpen("service-1")).toBe(false);
+  });
+
+  test("stays closed below failure threshold", () => {
+    const breaker = new RefreshCircuitBreaker();
+    for (let i = 0; i < REFRESH_FAILURE_THRESHOLD - 1; i++) {
+      breaker.recordFailure("service-2");
+    }
+    expect(breaker.isOpen("service-2")).toBe(false);
+  });
+
+  test("opens at failure threshold", () => {
+    const breaker = new RefreshCircuitBreaker();
+    for (let i = 0; i < REFRESH_FAILURE_THRESHOLD; i++) {
+      breaker.recordFailure("service-3");
+    }
+    expect(breaker.isOpen("service-3")).toBe(true);
+  });
+
+  test("success resets the breaker", () => {
+    const breaker = new RefreshCircuitBreaker();
+    for (let i = 0; i < REFRESH_FAILURE_THRESHOLD; i++) {
+      breaker.recordFailure("service-4");
+    }
+    expect(breaker.isOpen("service-4")).toBe(true);
+
+    breaker.recordSuccess("service-4");
+    expect(breaker.isOpen("service-4")).toBe(false);
+    expect(breaker.getState("service-4")).toBeUndefined();
+  });
+
+  test("clear resets all breakers", () => {
+    const breaker = new RefreshCircuitBreaker();
+    for (let i = 0; i < REFRESH_FAILURE_THRESHOLD; i++) {
+      breaker.recordFailure("a");
+      breaker.recordFailure("b");
+    }
+    expect(breaker.isOpen("a")).toBe(true);
+    expect(breaker.isOpen("b")).toBe(true);
+
+    breaker.clear();
+    expect(breaker.isOpen("a")).toBe(false);
+    expect(breaker.isOpen("b")).toBe(false);
+  });
+
+  test("independent services don't affect each other", () => {
+    const breaker = new RefreshCircuitBreaker();
+    for (let i = 0; i < REFRESH_FAILURE_THRESHOLD; i++) {
+      breaker.recordFailure("service-x");
+    }
+    expect(breaker.isOpen("service-x")).toBe(true);
+    expect(breaker.isOpen("service-y")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refresh deduplication
+// ---------------------------------------------------------------------------
+
+describe("RefreshDeduplicator", () => {
+  test("deduplicates concurrent calls for the same key", async () => {
+    const dedup = new RefreshDeduplicator();
+    let callCount = 0;
+
+    const refreshFn = async () => {
+      callCount++;
+      return "token-abc";
+    };
+
+    const [r1, r2, r3] = await Promise.all([
+      dedup.deduplicate("conn-1", refreshFn),
+      dedup.deduplicate("conn-1", refreshFn),
+      dedup.deduplicate("conn-1", refreshFn),
+    ]);
+
+    expect(r1).toBe("token-abc");
+    expect(r2).toBe("token-abc");
+    expect(r3).toBe("token-abc");
+    expect(callCount).toBe(1);
+  });
+
+  test("different keys get independent calls", async () => {
+    const dedup = new RefreshDeduplicator();
+    let callCount = 0;
+
+    const refreshFn = async () => {
+      callCount++;
+      return `token-${callCount}`;
+    };
+
+    const [r1, r2] = await Promise.all([
+      dedup.deduplicate("conn-a", refreshFn),
+      dedup.deduplicate("conn-b", refreshFn),
+    ]);
+
+    expect(callCount).toBe(2);
+    expect(r1).not.toBe(r2);
+  });
+
+  test("propagates errors to all joined callers", async () => {
+    const dedup = new RefreshDeduplicator();
+
+    const refreshFn = async () => {
+      throw new Error("refresh failed");
+    };
+
+    const results = await Promise.allSettled([
+      dedup.deduplicate("conn-err", refreshFn),
+      dedup.deduplicate("conn-err", refreshFn),
+    ]);
+
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("rejected");
+  });
+
+  test("clears in-flight state after completion", async () => {
+    const dedup = new RefreshDeduplicator();
+    let callCount = 0;
+
+    await dedup.deduplicate("conn-c", async () => {
+      callCount++;
+      return "first";
+    });
+
+    const result = await dedup.deduplicate("conn-c", async () => {
+      callCount++;
+      return "second";
+    });
+
+    expect(callCount).toBe(2);
+    expect(result).toBe("second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential error classification
+// ---------------------------------------------------------------------------
+
+describe("isCredentialError", () => {
+  test("non-Error is not a credential error", () => {
+    expect(isCredentialError("string error")).toBe(false);
+    expect(isCredentialError(null)).toBe(false);
+    expect(isCredentialError(42)).toBe(false);
+  });
+
+  test("401 is a credential error", () => {
+    expect(isCredentialError(new Error("HTTP 401: Unauthorized"))).toBe(true);
+  });
+
+  test("403 is a credential error", () => {
+    expect(isCredentialError(new Error("HTTP 403: Forbidden"))).toBe(true);
+  });
+
+  test("400 with invalid_grant is a credential error", () => {
+    expect(
+      isCredentialError(
+        new Error("OAuth2 token refresh failed (HTTP 400: invalid_grant)"),
+      ),
+    ).toBe(true);
+  });
+
+  test("400 with invalid_client is a credential error", () => {
+    expect(
+      isCredentialError(
+        new Error("OAuth2 token refresh failed (HTTP 400: invalid_client)"),
+      ),
+    ).toBe(true);
+  });
+
+  test("400 without invalid_grant/invalid_client is transient", () => {
+    expect(
+      isCredentialError(
+        new Error("OAuth2 token refresh failed (HTTP 400: bad_request)"),
+      ),
+    ).toBe(false);
+  });
+
+  test("500 is transient (not credential error)", () => {
+    expect(
+      isCredentialError(new Error("OAuth2 token refresh failed (HTTP 500)")),
+    ).toBe(false);
+  });
+
+  test("network error is transient", () => {
+    expect(isCredentialError(new Error("fetch failed"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disconnected / local OAuth edge cases
+// ---------------------------------------------------------------------------
+
+describe("disconnected OAuth edge cases", () => {
+  test("deleteOAuthTokens gracefully handles missing tokens", async () => {
+    const backend = createMemoryBackend();
+    // Only access token exists, no refresh token
+    backend.store.set("oauth_connection/conn-partial/access_token", "at");
+
+    const result = await deleteOAuthTokens(backend, "conn-partial");
+    expect(result.accessTokenResult).toBe("deleted");
+    expect(result.refreshTokenResult).toBe("not-found");
+  });
+
+  test("persistOAuthTokens followed by deleteOAuthTokens round-trips cleanly", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-roundtrip";
+
+    // Store tokens
+    await persistOAuthTokens(backend, connId, {
+      accessToken: "at-1",
+      refreshToken: "rt-1",
+    });
+    expect(backend.store.size).toBe(2);
+
+    // Delete tokens
+    const result = await deleteOAuthTokens(backend, connId);
+    expect(result.accessTokenResult).toBe("deleted");
+    expect(result.refreshTokenResult).toBe("deleted");
+    expect(backend.store.size).toBe(0);
+  });
+
+  test("re-persist after delete stores new tokens correctly", async () => {
+    const backend = createMemoryBackend();
+    const connId = "conn-re-persist";
+
+    // First persist
+    await persistOAuthTokens(backend, connId, {
+      accessToken: "at-1",
+      refreshToken: "rt-1",
+    });
+
+    // Delete
+    await deleteOAuthTokens(backend, connId);
+
+    // Re-persist with different tokens
+    await persistOAuthTokens(backend, connId, {
+      accessToken: "at-2",
+      refreshToken: "rt-2",
+    });
+
+    expect(await getStoredAccessToken(backend, connId)).toBe("at-2");
+    expect(await getStoredRefreshToken(backend, connId)).toBe("rt-2");
+  });
+});

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -5,6 +5,12 @@
  * extra_params, granted_scopes, metadata) are stored as serialized JSON strings.
  */
 
+import {
+  deleteOAuthTokens,
+  oauthAppClientSecretPath,
+  oauthConnectionAccessTokenPath,
+  type SecureKeyBackend,
+} from "@vellumai/credential-storage";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
@@ -191,7 +197,7 @@ export async function upsertApp(
     );
   }
 
-  const defaultCredPath = (appId: string) => `oauth_app/${appId}/client_secret`;
+  const defaultCredPath = (appId: string) => oauthAppClientSecretPath(appId);
 
   // Verify the credential path points to an existing secret.
   if (clientSecretCredentialPath) {
@@ -498,7 +504,7 @@ export async function isProviderConnected(
   const conn = getConnectionByProvider(providerKey);
   if (!conn || conn.status !== "active") return false;
   return (
-    (await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)) !==
+    (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
     undefined
   );
 }
@@ -611,14 +617,21 @@ export async function disconnectOAuthProvider(
     : getConnectionByProvider(providerKey, clientId);
   if (!conn) return "not-found";
 
-  const r1 = await deleteSecureKeyAsync(
-    `oauth_connection/${conn.id}/access_token`,
-  );
-  const r2 = await deleteSecureKeyAsync(
-    `oauth_connection/${conn.id}/refresh_token`,
+  // Wrap the assistant's secure-key functions into the SecureKeyBackend
+  // interface expected by the shared deleteOAuthTokens helper.
+  const backend: SecureKeyBackend = {
+    get: (key: string) => getSecureKeyAsync(key),
+    set: (key: string, value: string) => setSecureKeyAsync(key, value),
+    delete: (key: string) => deleteSecureKeyAsync(key),
+    list: async () => [],
+  };
+
+  const { accessTokenResult, refreshTokenResult } = await deleteOAuthTokens(
+    backend,
+    conn.id,
   );
 
-  if (r1 === "error" || r2 === "error") {
+  if (accessTokenResult === "error" || refreshTokenResult === "error") {
     // Return "error" (rather than throwing like deleteApp) so the connection row
     // is preserved. This avoids orphaning secrets in secure storage — the caller
     // can retry later and the row acts as a pointer to the keys that still need
@@ -628,8 +641,8 @@ export async function disconnectOAuthProvider(
       {
         providerKey,
         connectionId: conn.id,
-        accessTokenResult: r1,
-        refreshTokenResult: r2,
+        accessTokenResult,
+        refreshTokenResult,
       },
       "Failed to delete OAuth secure keys — skipping connection row deletion to avoid orphaning secrets",
     );

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -8,11 +8,21 @@
  * Writes exclusively to the SQLite tables (oauth_app, oauth_connection)
  * and new-format secure keys (`oauth_app/{id}/...`,
  * `oauth_connection/{id}/...`).
+ *
+ * Token storage key paths and secure-key persistence are delegated to
+ * the shared `@vellumai/credential-storage` package.
  */
+
+import {
+  oauthAppClientSecretPath,
+  persistOAuthTokens,
+  type SecureKeyBackend,
+} from "@vellumai/credential-storage";
 
 import type { OAuth2FlowResult } from "../security/oauth2.js";
 import {
   deleteSecureKeyAsync,
+  getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import { runPostConnectHook } from "../tools/credentials/post-connect-hooks.js";
@@ -24,6 +34,17 @@ import {
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
+
+// ---------------------------------------------------------------------------
+// Secure-key backend adapter
+// ---------------------------------------------------------------------------
+
+const secureKeyBackend: SecureKeyBackend = {
+  get: (key: string) => getSecureKeyAsync(key),
+  set: (key: string, value: string) => setSecureKeyAsync(key, value),
+  delete: async (key: string) => deleteSecureKeyAsync(key),
+  list: async () => [],
+};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -97,7 +118,7 @@ export async function storeOAuth2Tokens(
   const app = params.oauthAppId
     ? (getApp(params.oauthAppId) ?? {
         id: params.oauthAppId,
-        clientSecretCredentialPath: `oauth_app/${params.oauthAppId}/client_secret`,
+        clientSecretCredentialPath: oauthAppClientSecretPath(params.oauthAppId),
       })
     : await upsertApp(
         service,
@@ -160,27 +181,11 @@ export async function storeOAuth2Tokens(
     connId = conn.id;
   }
 
-  // 3. Write access_token: oauth_connection/{conn.id}/access_token
-  const tokenStored = await setSecureKeyAsync(
-    `oauth_connection/${connId}/access_token`,
-    tokens.accessToken,
-  );
-  if (!tokenStored) {
-    throw new Error("Failed to store access token in secure storage");
-  }
-
-  // 4. Write or clear refresh_token: oauth_connection/{conn.id}/refresh_token
-  if (tokens.refreshToken) {
-    await setSecureKeyAsync(
-      `oauth_connection/${connId}/refresh_token`,
-      tokens.refreshToken,
-    );
-  } else {
-    // Re-auth grants that omit refresh_token must clear any stale stored
-    // token — otherwise withValidToken() will attempt refresh with invalid
-    // credentials.
-    await deleteSecureKeyAsync(`oauth_connection/${connId}/refresh_token`);
-  }
+  // 3-4. Persist access + refresh tokens via shared helper
+  await persistOAuthTokens(secureKeyBackend, connId, {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+  });
 
   // Run any provider-specific post-connect actions (e.g. Slack welcome DM)
   await runPostConnectHook({ service, rawTokenResponse });

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -5,7 +5,22 @@
  * from the SQLite oauth-store (provider + app + connection rows). After a
  * successful refresh, writes tokens to new-format secure key paths and
  * updates the oauth_connection row.
+ *
+ * Token expiry checking, circuit breaker, refresh deduplication, and
+ * credential error classification are delegated to the shared
+ * `@vellumai/credential-storage` package.
  */
+
+import {
+  isCredentialError,
+  isTokenExpired,
+  oauthConnectionAccessTokenPath,
+  oauthConnectionRefreshTokenPath,
+  persistRefreshedTokens,
+  RefreshCircuitBreaker,
+  RefreshDeduplicator,
+  type SecureKeyBackend,
+} from "@vellumai/credential-storage";
 
 import {
   getApp,
@@ -32,110 +47,20 @@ function recoveryHint(service: string): string {
   return ` Re-authorization required for ${shortName}. Do not present options or explain the error to the user.`;
 }
 
-/** Buffer before expiry to trigger proactive refresh (5 minutes). */
-const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+// ── Shared circuit breaker & deduplication instances ──────────────────
+// Backed by the portable primitives from @vellumai/credential-storage.
 
-// ── Token refresh circuit breaker ────────────────────────────────────
-// Prevents retry storms when a provider persistently rejects refresh
-// attempts (e.g. revoked refresh token returning 401 repeatedly).
-// Per-service state: after FAILURE_THRESHOLD consecutive failures, stop
-// attempting refreshes for a cooldown period that doubles on each
-// successive trip (exponential backoff), capped at MAX_COOLDOWN_MS.
-// A successful refresh resets the breaker for that service.
-
-const REFRESH_FAILURE_THRESHOLD = 3;
-const INITIAL_COOLDOWN_MS = 30_000;
-const MAX_COOLDOWN_MS = 10 * 60 * 1000;
-
-interface RefreshBreakerState {
-  consecutiveFailures: number;
-  openedAt: number;
-  cooldownMs: number;
-}
-
-const refreshBreakers = new Map<string, RefreshBreakerState>();
-
-function isRefreshBreakerOpen(service: string): boolean {
-  const state = refreshBreakers.get(service);
-  if (!state || state.consecutiveFailures < REFRESH_FAILURE_THRESHOLD)
-    return false;
-  if (Date.now() - state.openedAt < state.cooldownMs) return true;
-  // Cooldown expired — transition to half-open: reset failure count so the
-  // next batch of failures must reach the threshold again to re-trip. The
-  // existing cooldownMs is preserved so re-tripping will escalate it.
-  state.consecutiveFailures = 0;
-  return false;
-}
-
-function recordRefreshSuccess(service: string): void {
-  if (refreshBreakers.has(service)) {
-    log.info(
-      { service },
-      "Token refresh circuit breaker closed — refresh succeeded",
-    );
-    refreshBreakers.delete(service);
-  }
-}
-
-function recordRefreshFailure(service: string): void {
-  const state = refreshBreakers.get(service);
-  if (!state) {
-    refreshBreakers.set(service, {
-      consecutiveFailures: 1,
-      openedAt: 0,
-      cooldownMs: INITIAL_COOLDOWN_MS,
-    });
-    return;
-  }
-  state.consecutiveFailures++;
-  if (state.consecutiveFailures >= REFRESH_FAILURE_THRESHOLD) {
-    // Only escalate cooldown on the exact failure that trips the breaker.
-    // Concurrent in-flight failures that arrive after the threshold is
-    // already crossed must not double the cooldown again.
-    if (
-      state.consecutiveFailures === REFRESH_FAILURE_THRESHOLD &&
-      state.openedAt > 0
-    ) {
-      state.cooldownMs = Math.min(state.cooldownMs * 2, MAX_COOLDOWN_MS);
-    }
-    state.openedAt = Date.now();
-    log.warn(
-      {
-        service,
-        consecutiveFailures: state.consecutiveFailures,
-        cooldownMs: state.cooldownMs,
-      },
-      "Token refresh circuit breaker opened — skipping refresh attempts until cooldown expires",
-    );
-  }
-}
-
-// ── Per-service refresh deduplication ─────────────────────────────────
-// When multiple concurrent `withValidToken` calls detect an expired or
-// 401-rejected token for the same service, only one actual refresh
-// attempt is made. Other callers join the in-flight promise.
-
-const inflightRefreshes = new Map<string, Promise<string>>();
-
-function deduplicatedRefresh(service: string, connId: string): Promise<string> {
-  const existing = inflightRefreshes.get(connId);
-  if (existing) return existing;
-
-  const promise = doRefresh(service, connId).finally(() => {
-    inflightRefreshes.delete(connId);
-  });
-  inflightRefreshes.set(connId, promise);
-  return promise;
-}
+const circuitBreaker = new RefreshCircuitBreaker();
+const refreshDeduplicator = new RefreshDeduplicator();
 
 /** @internal Test-only: reset all circuit breaker state */
 export function _resetRefreshBreakers(): void {
-  refreshBreakers.clear();
+  circuitBreaker.clear();
 }
 
 /** @internal Test-only: reset in-flight refresh deduplication state */
 export function _resetInflightRefreshes(): void {
-  inflightRefreshes.clear();
+  refreshDeduplicator.clear();
 }
 
 export class TokenExpiredError extends Error {
@@ -150,13 +75,19 @@ export class TokenExpiredError extends Error {
   }
 }
 
-/**
- * Check whether a token is expired or will expire within the buffer window.
- */
-function isTokenExpired(expiresAt: number | null): boolean {
-  if (!expiresAt) return false;
-  return Date.now() >= expiresAt - EXPIRY_BUFFER_MS;
-}
+// ── Secure-key backend adapter ────────────────────────────────────────
+// Wraps the assistant's secure-key functions into the SecureKeyBackend
+// interface expected by @vellumai/credential-storage helpers.
+
+const secureKeyBackend: SecureKeyBackend = {
+  get: (key: string) => getSecureKeyAsync(key),
+  set: (key: string, value: string) => setSecureKeyAsync(key, value),
+  delete: async () => {
+    // Not needed in this module — refresh persistence only writes tokens.
+    return "not-found";
+  },
+  list: async () => [],
+};
 
 // ── Refresh config resolution ─────────────────────────────────────────
 
@@ -218,7 +149,7 @@ async function resolveRefreshConfig(
   const secret = await getSecureKeyAsync(app.clientSecretCredentialPath);
 
   const refreshToken = await getSecureKeyAsync(
-    `oauth_connection/${conn.id}/refresh_token`,
+    oauthConnectionRefreshTokenPath(conn.id),
   );
 
   const authMethod = provider.tokenEndpointAuthMethod as
@@ -261,8 +192,8 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     );
   }
 
-  if (isRefreshBreakerOpen(connId)) {
-    const state = refreshBreakers.get(connId)!;
+  if (circuitBreaker.isOpen(connId)) {
+    const state = circuitBreaker.getState(connId)!;
     const remainingMs = state.cooldownMs - (Date.now() - state.openedAt);
     throw new TokenExpiredError(
       service,
@@ -283,7 +214,18 @@ async function doRefresh(service: string, connId: string): Promise<string> {
       authMethod,
     );
   } catch (err) {
-    recordRefreshFailure(connId);
+    circuitBreaker.recordFailure(connId);
+    if (circuitBreaker.isOpen(connId)) {
+      const state = circuitBreaker.getState(connId)!;
+      log.warn(
+        {
+          service,
+          consecutiveFailures: state.consecutiveFailures,
+          cooldownMs: state.cooldownMs,
+        },
+        "Token refresh circuit breaker opened — skipping refresh attempts until cooldown expires",
+      );
+    }
     if (isCredentialError(err)) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new TokenExpiredError(
@@ -297,45 +239,23 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     throw err;
   }
 
-  // ----- Store refreshed access_token -----
-  if (
-    !(await setSecureKeyAsync(
-      `oauth_connection/${connId}/access_token`,
-      result.accessToken,
-    ))
-  ) {
+  // ----- Persist refreshed tokens via shared helper -----
+  let persisted;
+  try {
+    persisted = await persistRefreshedTokens(secureKeyBackend, connId, result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
     throw new TokenExpiredError(
       service,
-      `Failed to store refreshed access token for "${service}".`,
+      `Failed to store refreshed access token for "${service}": ${msg}`,
     );
   }
 
-  if (result.refreshToken) {
-    if (
-      !(await setSecureKeyAsync(
-        `oauth_connection/${connId}/refresh_token`,
-        result.refreshToken,
-      ))
-    ) {
-      throw new TokenExpiredError(
-        service,
-        `Failed to store refreshed refresh token for "${service}".`,
-      );
-    }
-  }
-
   // Update oauth_connection row with new expiry.
-  // Use null to explicitly clear a stale expiresAt when the provider omits
-  // expires_in (or returns 0), so isTokenExpired won't keep forcing refreshes.
-  const expiresAt =
-    result.expiresIn != null && result.expiresIn > 0
-      ? Date.now() + result.expiresIn * 1000
-      : null;
-
   try {
     updateConnection(connId, {
-      expiresAt,
-      hasRefreshToken: !!result.refreshToken,
+      expiresAt: persisted.expiresAt,
+      hasRefreshToken: persisted.hasRefreshToken,
     });
   } catch (err) {
     log.warn(
@@ -344,9 +264,9 @@ async function doRefresh(service: string, connId: string): Promise<string> {
     );
   }
 
-  recordRefreshSuccess(connId);
+  circuitBreaker.recordSuccess(connId);
   log.info({ service }, "OAuth2 access token refreshed successfully");
-  return result.accessToken;
+  return persisted.accessToken;
 }
 
 /**
@@ -370,7 +290,7 @@ export async function withValidToken<T>(
       ? getConnection(opts.connectionId)
       : getConnectionByProvider(service, opts);
   let token = conn
-    ? await getSecureKeyAsync(`oauth_connection/${conn.id}/access_token`)
+    ? await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))
     : undefined;
   if (!token || !conn) {
     throw new TokenExpiredError(
@@ -381,14 +301,18 @@ export async function withValidToken<T>(
 
   // Proactively refresh if expired or about to expire.
   if (isTokenExpired(conn.expiresAt)) {
-    token = await deduplicatedRefresh(service, conn.id);
+    token = await refreshDeduplicator.deduplicate(conn.id, () =>
+      doRefresh(service, conn.id),
+    );
   }
 
   try {
     return await callback(token);
   } catch (err: unknown) {
     if (is401Error(err)) {
-      token = await deduplicatedRefresh(service, conn.id);
+      token = await refreshDeduplicator.deduplicate(conn.id, () =>
+        doRefresh(service, conn.id),
+      );
       return callback(token);
     }
     throw err;
@@ -405,29 +329,5 @@ function is401Error(err: unknown): boolean {
     )
       return true;
   }
-  return false;
-}
-
-/**
- * Distinguish credential-specific refresh failures (which need reauthorization)
- * from transient errors (network timeouts, 5xx) that can be retried.
- *
- * refreshOAuth2Token() throws Error with messages like:
- *   "OAuth2 token refresh failed (HTTP 401: invalid_client)"
- *   "OAuth2 token refresh failed (HTTP 400: invalid_grant)"
- *   "OAuth2 token refresh failed (HTTP 500)"
- *
- * Credential errors: 400 with invalid_grant or invalid_client, 401, 403.
- * Everything else (5xx, network errors, non-credential 400s) is transient.
- */
-function isCredentialError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const msg = err.message;
-  // 401/403 are always credential errors
-  if (/HTTP\s+40[13]\b/.test(msg)) return true;
-  // 400 with invalid_grant means the refresh token is revoked/expired;
-  // invalid_client means client credentials are bad/rotated
-  if (/HTTP\s+400\b/.test(msg) && /invalid_grant|invalid_client/.test(msg))
-    return true;
   return false;
 }

--- a/packages/credential-storage/src/index.ts
+++ b/packages/credential-storage/src/index.ts
@@ -180,3 +180,34 @@ export function credentialKey(service: string, field: string): string {
 
 export { StaticCredentialMetadataStore } from "./static-credentials.js";
 export type { StaticCredentialPolicyInput } from "./static-credentials.js";
+
+// ---------------------------------------------------------------------------
+// OAuth runtime primitives
+// ---------------------------------------------------------------------------
+
+export {
+  // Secure-key path conventions
+  oauthConnectionAccessTokenPath,
+  oauthConnectionRefreshTokenPath,
+  oauthAppClientSecretPath,
+  // Token expiry
+  EXPIRY_BUFFER_MS,
+  isTokenExpired,
+  computeExpiresAt,
+  // Circuit breaker
+  REFRESH_FAILURE_THRESHOLD,
+  INITIAL_COOLDOWN_MS,
+  MAX_COOLDOWN_MS,
+  RefreshCircuitBreaker,
+  // Refresh deduplication
+  RefreshDeduplicator,
+  // Credential error classification
+  isCredentialError,
+  // Token persistence helpers
+  persistOAuthTokens,
+  getStoredAccessToken,
+  getStoredRefreshToken,
+  deleteOAuthTokens,
+  persistRefreshedTokens,
+} from "./oauth-runtime.js";
+export type { RefreshBreakerState } from "./oauth-runtime.js";

--- a/packages/credential-storage/src/oauth-runtime.ts
+++ b/packages/credential-storage/src/oauth-runtime.ts
@@ -1,0 +1,340 @@
+/**
+ * OAuth connection persistence, token persistence, and refresh support
+ * primitives.
+ *
+ * This module provides portable, backend-agnostic helpers for:
+ * - Secure-key path conventions for OAuth tokens and client secrets
+ * - Token expiry checking with proactive refresh buffering
+ * - Token refresh circuit breaker to prevent retry storms
+ * - Per-connection refresh deduplication
+ * - Abstract token persistence interface
+ *
+ * It has NO dependency on the assistant daemon, SQLite, Drizzle, or any
+ * service-specific module. The assistant's token-manager.ts and
+ * token-persistence.ts wire in the platform-specific backends and
+ * delegate here for shared logic.
+ */
+
+import type { SecureKeyBackend } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Secure-key path conventions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the secure-key path for an OAuth connection's access token.
+ */
+export function oauthConnectionAccessTokenPath(connectionId: string): string {
+  return `oauth_connection/${connectionId}/access_token`;
+}
+
+/**
+ * Build the secure-key path for an OAuth connection's refresh token.
+ */
+export function oauthConnectionRefreshTokenPath(connectionId: string): string {
+  return `oauth_connection/${connectionId}/refresh_token`;
+}
+
+/**
+ * Build the secure-key path for an OAuth app's client secret.
+ */
+export function oauthAppClientSecretPath(appId: string): string {
+  return `oauth_app/${appId}/client_secret`;
+}
+
+// ---------------------------------------------------------------------------
+// Token expiry
+// ---------------------------------------------------------------------------
+
+/** Buffer before expiry to trigger proactive refresh (5 minutes). */
+export const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * Check whether a token is expired or will expire within the buffer window.
+ */
+export function isTokenExpired(
+  expiresAt: number | null,
+  bufferMs: number = EXPIRY_BUFFER_MS
+): boolean {
+  if (!expiresAt) return false;
+  return Date.now() >= expiresAt - bufferMs;
+}
+
+/**
+ * Compute the absolute expiry timestamp from an `expires_in` seconds value.
+ * Returns null if the value is missing or zero.
+ */
+export function computeExpiresAt(
+  expiresIn: number | null | undefined
+): number | null {
+  if (expiresIn == null || expiresIn <= 0) return null;
+  return Date.now() + expiresIn * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Token refresh circuit breaker
+// ---------------------------------------------------------------------------
+// Prevents retry storms when a provider persistently rejects refresh
+// attempts (e.g. revoked refresh token returning 401 repeatedly).
+// Per-key state: after FAILURE_THRESHOLD consecutive failures, stop
+// attempting refreshes for a cooldown period that doubles on each
+// successive trip (exponential backoff), capped at MAX_COOLDOWN_MS.
+// A successful refresh resets the breaker for that key.
+
+export const REFRESH_FAILURE_THRESHOLD = 3;
+export const INITIAL_COOLDOWN_MS = 30_000;
+export const MAX_COOLDOWN_MS = 10 * 60 * 1000;
+
+export interface RefreshBreakerState {
+  consecutiveFailures: number;
+  openedAt: number;
+  cooldownMs: number;
+}
+
+/**
+ * In-memory token refresh circuit breaker.
+ *
+ * Tracks per-key (typically connection ID) failure state. After
+ * FAILURE_THRESHOLD consecutive failures, the breaker opens for a
+ * cooldown period that doubles on each successive trip.
+ */
+export class RefreshCircuitBreaker {
+  private breakers = new Map<string, RefreshBreakerState>();
+
+  /**
+   * Check whether the breaker is currently open (refusing refresh attempts)
+   * for the given key. If the cooldown has expired, transitions to half-open
+   * by resetting the failure count.
+   */
+  isOpen(key: string): boolean {
+    const state = this.breakers.get(key);
+    if (!state || state.consecutiveFailures < REFRESH_FAILURE_THRESHOLD)
+      return false;
+    if (Date.now() - state.openedAt < state.cooldownMs) return true;
+    // Cooldown expired — transition to half-open: reset failure count so the
+    // next batch of failures must reach the threshold again to re-trip. The
+    // existing cooldownMs is preserved so re-tripping will escalate it.
+    state.consecutiveFailures = 0;
+    return false;
+  }
+
+  /** Get the breaker state for a key, if it exists. */
+  getState(key: string): RefreshBreakerState | undefined {
+    return this.breakers.get(key);
+  }
+
+  /** Record a successful refresh, resetting the breaker for the key. */
+  recordSuccess(key: string): void {
+    this.breakers.delete(key);
+  }
+
+  /** Record a failed refresh attempt, potentially opening the breaker. */
+  recordFailure(key: string): void {
+    const state = this.breakers.get(key);
+    if (!state) {
+      this.breakers.set(key, {
+        consecutiveFailures: 1,
+        openedAt: 0,
+        cooldownMs: INITIAL_COOLDOWN_MS,
+      });
+      return;
+    }
+    state.consecutiveFailures++;
+    if (state.consecutiveFailures >= REFRESH_FAILURE_THRESHOLD) {
+      // Only escalate cooldown on the exact failure that trips the breaker.
+      // Concurrent in-flight failures that arrive after the threshold is
+      // already crossed must not double the cooldown again.
+      if (
+        state.consecutiveFailures === REFRESH_FAILURE_THRESHOLD &&
+        state.openedAt > 0
+      ) {
+        state.cooldownMs = Math.min(state.cooldownMs * 2, MAX_COOLDOWN_MS);
+      }
+      state.openedAt = Date.now();
+    }
+  }
+
+  /** Reset all breaker state (primarily for testing). */
+  clear(): void {
+    this.breakers.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refresh deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicates concurrent refresh attempts for the same key.
+ *
+ * When multiple callers detect an expired or rejected token for the same
+ * connection simultaneously, only one actual refresh attempt is made.
+ * Other callers join the in-flight promise.
+ */
+export class RefreshDeduplicator {
+  private inflight = new Map<string, Promise<string>>();
+
+  /**
+   * Execute a refresh operation, deduplicating concurrent calls for the same key.
+   * If a refresh is already in flight for the given key, returns the existing promise.
+   */
+  deduplicate(key: string, refreshFn: () => Promise<string>): Promise<string> {
+    const existing = this.inflight.get(key);
+    if (existing) return existing;
+
+    const promise = refreshFn().finally(() => {
+      this.inflight.delete(key);
+    });
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  /** Reset all in-flight state (primarily for testing). */
+  clear(): void {
+    this.inflight.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Credential error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Distinguish credential-specific refresh failures (which need reauthorization)
+ * from transient errors (network timeouts, 5xx) that can be retried.
+ *
+ * Credential errors: 400 with invalid_grant or invalid_client, 401, 403.
+ * Everything else (5xx, network errors, non-credential 400s) is transient.
+ */
+export function isCredentialError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  // 401/403 are always credential errors
+  if (/HTTP\s+40[13]\b/.test(msg)) return true;
+  // 400 with invalid_grant means the refresh token is revoked/expired;
+  // invalid_client means client credentials are bad/rotated
+  if (/HTTP\s+400\b/.test(msg) && /invalid_grant|invalid_client/.test(msg))
+    return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Token persistence helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist an OAuth access token (and optionally a refresh token) to the
+ * secure-key backend for a given connection ID.
+ *
+ * When `refreshToken` is provided, it is stored. When omitted (undefined),
+ * any existing refresh token is cleared to prevent stale token usage.
+ */
+export async function persistOAuthTokens(
+  backend: SecureKeyBackend,
+  connectionId: string,
+  tokens: {
+    accessToken: string;
+    refreshToken?: string;
+  }
+): Promise<void> {
+  const accessPath = oauthConnectionAccessTokenPath(connectionId);
+  const stored = await backend.set(accessPath, tokens.accessToken);
+  if (!stored) {
+    throw new Error("Failed to store access token in secure storage");
+  }
+
+  const refreshPath = oauthConnectionRefreshTokenPath(connectionId);
+  if (tokens.refreshToken) {
+    await backend.set(refreshPath, tokens.refreshToken);
+  } else {
+    // Re-auth grants that omit refresh_token must clear any stale stored
+    // token — otherwise refresh attempts will use invalid credentials.
+    await backend.delete(refreshPath);
+  }
+}
+
+/**
+ * Retrieve the stored access token for a connection from the secure-key backend.
+ * Returns undefined if no token is stored.
+ */
+export async function getStoredAccessToken(
+  backend: SecureKeyBackend,
+  connectionId: string
+): Promise<string | undefined> {
+  return backend.get(oauthConnectionAccessTokenPath(connectionId));
+}
+
+/**
+ * Retrieve the stored refresh token for a connection from the secure-key backend.
+ * Returns undefined if no token is stored.
+ */
+export async function getStoredRefreshToken(
+  backend: SecureKeyBackend,
+  connectionId: string
+): Promise<string | undefined> {
+  return backend.get(oauthConnectionRefreshTokenPath(connectionId));
+}
+
+/**
+ * Delete all OAuth tokens (access + refresh) for a connection from the
+ * secure-key backend. Returns the individual deletion results.
+ */
+export async function deleteOAuthTokens(
+  backend: SecureKeyBackend,
+  connectionId: string
+): Promise<{
+  accessTokenResult: "deleted" | "not-found" | "error";
+  refreshTokenResult: "deleted" | "not-found" | "error";
+}> {
+  const [accessTokenResult, refreshTokenResult] = await Promise.all([
+    backend.delete(oauthConnectionAccessTokenPath(connectionId)),
+    backend.delete(oauthConnectionRefreshTokenPath(connectionId)),
+  ]);
+  return { accessTokenResult, refreshTokenResult };
+}
+
+/**
+ * Store a refreshed access token in the secure-key backend and update
+ * connection metadata. Returns the new access token on success.
+ *
+ * This is the portable portion of the post-refresh persistence logic.
+ * Callers are responsible for updating their connection store (e.g. SQLite)
+ * with the new expiresAt and hasRefreshToken values.
+ */
+export async function persistRefreshedTokens(
+  backend: SecureKeyBackend,
+  connectionId: string,
+  result: {
+    accessToken: string;
+    refreshToken?: string;
+    expiresIn?: number | null;
+  }
+): Promise<{
+  accessToken: string;
+  expiresAt: number | null;
+  hasRefreshToken: boolean;
+}> {
+  const accessPath = oauthConnectionAccessTokenPath(connectionId);
+  if (!(await backend.set(accessPath, result.accessToken))) {
+    throw new Error(
+      `Failed to store refreshed access token for connection ${connectionId}`
+    );
+  }
+
+  if (result.refreshToken) {
+    const refreshPath = oauthConnectionRefreshTokenPath(connectionId);
+    if (!(await backend.set(refreshPath, result.refreshToken))) {
+      throw new Error(
+        `Failed to store refreshed refresh token for connection ${connectionId}`
+      );
+    }
+  }
+
+  const expiresAt = computeExpiresAt(result.expiresIn);
+
+  return {
+    accessToken: result.accessToken,
+    expiresAt,
+    hasRefreshToken: !!result.refreshToken,
+  };
+}


### PR DESCRIPTION
## Summary
- Move reusable OAuth connection persistence, token persistence, and refresh primitives into packages/credential-storage/src/oauth-runtime.ts
- Update assistant oauth-store.ts, token-persistence.ts, and token-manager.ts to consume shared implementation
- Add compatibility tests covering stored token lookup, refresh-on-expiry, missing config, and disconnected OAuth

Part of plan: untrusted-agent-credential-arch.md (PR 14 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
