### PR TITLE
fix: break circular dep in ces-contracts RpcErrorSchema import

### DIFF
--- a/packages/ces-contracts/src/error.ts
+++ b/packages/ces-contracts/src/error.ts
@@ -1,0 +1,14 @@
+/**
+ * RPC error schema — extracted to its own module to avoid circular
+ * dependencies between index.ts and rpc.ts.
+ */
+
+import { z } from "zod/v4";
+
+export const RpcErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  /** Optional structured details for debugging. */
+  details: z.record(z.string(), z.unknown()).optional(),
+});
+export type RpcError = z.infer<typeof RpcErrorSchema>;

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from "zod/v4";
+import { RpcErrorSchema } from "./error.js";
 
 // ---------------------------------------------------------------------------
 // Transport handshake
@@ -61,16 +62,10 @@ export const RpcEnvelopeSchema = z.object({
 export type RpcEnvelope = z.infer<typeof RpcEnvelopeSchema>;
 
 // ---------------------------------------------------------------------------
-// RPC error
+// RPC error (defined in error.ts to avoid circular deps with rpc.ts)
 // ---------------------------------------------------------------------------
 
-export const RpcErrorSchema = z.object({
-  code: z.string(),
-  message: z.string(),
-  /** Optional structured details for debugging. */
-  details: z.record(z.string(), z.unknown()).optional(),
-});
-export type RpcError = z.infer<typeof RpcErrorSchema>;
+export { RpcErrorSchema, type RpcError } from "./error.js";
 
 // ---------------------------------------------------------------------------
 // Tool request / response base shapes

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -31,7 +31,7 @@ import {
   PersistentGrantRecordSchema,
   TemporaryGrantDecisionSchema,
 } from "./grants.js";
-import { RpcErrorSchema } from "./index.js";
+import { RpcErrorSchema } from "./error.js";
 
 // ---------------------------------------------------------------------------
 // Method name constants


### PR DESCRIPTION
## Summary
- Extracted `RpcErrorSchema` from `index.ts` into a new `error.ts` module to break the circular dependency between `index.ts` ↔ `rpc.ts`
- `rpc.ts` now imports from `./error.js` instead of `./index.js`, eliminating the `ReferenceError: Cannot access 'RpcErrorSchema' before initialization` that was failing CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100230565/job/67099617625

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
