### PR TITLE
fix: atomic write for credential store

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -155,9 +155,11 @@ function readStore(): StoreFile | null {
 function writeStore(store: StoreFile): void {
   const path = getStorePath();
   ensureDir(dirname(path));
-  writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 });
-  // Enforce 0600 even if the file already existed with permissive bits
-  chmodSync(path, 0o600);
+  // Atomic write: write to temp file then rename to avoid partial/corrupt writes
+  const tmpPath = path + ".tmp";
+  writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 });
+  chmodSync(tmpPath, 0o600);
+  renameSync(tmpPath, path);
 }
 
 function getOrCreateStore(): StoreFile {


### PR DESCRIPTION
## Summary
- `writeStore()` in `encrypted-store.ts` now writes to a temp file and renames it into place, matching the atomic write pattern already used in `swarm/checkpoint.ts`
- Prevents credential store corruption if the process crashes mid-write

## Original prompt
Fix non-atomic write to credential store in encrypted-store.ts — use write-to-temp + renameSync pattern to prevent corruption on crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
