### PR TITLE
fix: correct off-by-one in </head> search in web-fetch

### DIFF
--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -361,7 +361,7 @@ function extractHtmlMetadata(html: string): {
   const stripped = candidate.replace(/<script[\s>][\s\S]*?<\/script>/gi, "");
   const headEnd = stripped.search(/<\/head[\s>]/i);
   const searchRegion =
-    headEnd > 0 ? stripped.slice(0, headEnd + 10) : stripped.slice(0, 50_000);
+    headEnd >= 0 ? stripped.slice(0, headEnd + 10) : stripped.slice(0, 50_000);
 
   const title = extractFirstMatch(
     searchRegion,


### PR DESCRIPTION
## Summary
- Fix off-by-one in `extractHeadMetadata`: `headEnd > 0` excluded position 0, causing the code to fall through to the 50KB fallback when `</head>` appeared at the start of the stripped HTML. Changed to `headEnd >= 0` since `String.search()` returns -1 for no match.

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)