### PR TITLE
fix: make resetRunningJobsToPending() atomic

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -345,16 +345,12 @@ export function failMemoryJob(
 
 export function resetRunningJobsToPending(): number {
   const db = getDb();
-  const runningRows = db
-    .select({ id: memoryJobs.id })
-    .from(memoryJobs)
-    .where(eq(memoryJobs.status, "running"))
-    .all();
-  db.update(memoryJobs)
+  const result = db
+    .update(memoryJobs)
     .set({ status: "pending", updatedAt: Date.now() })
     .where(eq(memoryJobs.status, "running"))
     .run();
-  return runningRows.length;
+  return result.changes;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace separate SELECT + UPDATE in `resetRunningJobsToPending()` with a single UPDATE statement, returning `result.changes` for the count
- Eliminates a theoretical race between the two statements and simplifies the code

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)