### PR TITLE
fix: stop coercing empty string to undefined in getString()

### DIFF
--- a/gateway/src/__tests__/config-file-cache.test.ts
+++ b/gateway/src/__tests__/config-file-cache.test.ts
@@ -44,10 +44,10 @@ describe("ConfigFileCache: getString", () => {
     expect(cache.getString("email", "address")).toBe("a@b.com");
   });
 
-  test("returns undefined for empty string", () => {
+  test("returns empty string as-is", () => {
     writeConfig({ email: { address: "" } });
     const cache = new ConfigFileCache();
-    expect(cache.getString("email", "address")).toBeUndefined();
+    expect(cache.getString("email", "address")).toBe("");
   });
 
   test("returns undefined for non-string value", () => {

--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -81,7 +81,7 @@ export class ConfigFileCache {
     opts?: ReadOptions,
   ): string | undefined {
     const raw = this.getRaw(section, field, opts);
-    return typeof raw === "string" ? raw || undefined : undefined;
+    return typeof raw === "string" ? raw : undefined;
   }
 
   getNumber(


### PR DESCRIPTION
## Summary
- `ConfigFileCache.getString()` used `raw || undefined` which coerced empty strings to `undefined` due to JS falsy semantics
- Changed to `raw` so empty string config values are preserved as-is
- Updated the test to assert the corrected behavior

## Original prompt
config-file-cache.ts:84 — getString() treats empty string "" as undefined. `return typeof raw === "string" ? raw || undefined : undefined;` — the || operator means an empty string returns undefined. Should be `return typeof raw === "string" ? raw : undefined;` if empty strings are valid values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)