### PR TITLE
fix: use rawChanges() in resetRunningJobsToPending

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -345,12 +345,11 @@ export function failMemoryJob(
 
 export function resetRunningJobsToPending(): number {
   const db = getDb();
-  const result = db
-    .update(memoryJobs)
+  db.update(memoryJobs)
     .set({ status: "pending", updatedAt: Date.now() })
     .where(eq(memoryJobs.status, "running"))
     .run();
-  return result.changes;
+  return rawChanges();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix TS error from #16853: Drizzle's `.run()` returns `void`, not an object with `.changes`
- Use the existing `rawChanges()` helper (already imported) to get the SQLite change count

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
