### PR TITLE
fix: replace bare .catch(() => {}) with silentlyWithLog()

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -18,6 +18,7 @@ import {
   type ProcessingStage,
   updateProcessingStage,
 } from "../../../../memory/media-store.js";
+import { silentlyWithLog } from "../../../../util/silently.js";
 import {
   FFMPEG_PALETTE_TIMEOUT_MS,
   FFMPEG_PREPROCESS_TIMEOUT_MS,
@@ -629,7 +630,10 @@ export async function preprocessForAsset(
 
     return manifest;
   } catch (err) {
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    await silentlyWithLog(
+      rm(tempDir, { recursive: true, force: true }),
+      "preprocess temp cleanup",
+    );
     const msg = (err as Error).message;
     updateProcessingStage(stage.id, {
       status: "failed",

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -16,6 +16,7 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { silentlyWithLog } from "../../../../util/silently.js";
 import {
   FFMPEG_TRANSCODE_TIMEOUT_MS,
   FFPROBE_TIMEOUT_MS,
@@ -239,7 +240,10 @@ async function transcribeViaApi(
     return parts.join(" ");
   } finally {
     const { rm } = await import("node:fs/promises");
-    await rm(chunkDir, { recursive: true, force: true }).catch(() => {});
+    await silentlyWithLog(
+      rm(chunkDir, { recursive: true, force: true }),
+      "transcribe chunk cleanup",
+    );
   }
 }
 
@@ -332,7 +336,10 @@ async function transcribeViaLocal(
     return parts.join(" ");
   } finally {
     const { rm } = await import("node:fs/promises");
-    await rm(chunkDir, { recursive: true, force: true }).catch(() => {});
+    await silentlyWithLog(
+      rm(chunkDir, { recursive: true, force: true }),
+      "transcribe chunk cleanup",
+    );
   }
 }
 

--- a/assistant/src/daemon/session-slash.ts
+++ b/assistant/src/daemon/session-slash.ts
@@ -22,6 +22,7 @@ import {
 } from "../skills/slash-commands.js";
 import { getLocalIPv4 } from "../util/network-info.js";
 import { getWorkspaceDir } from "../util/platform.js";
+import { silentlyWithLog } from "../util/silently.js";
 import { getAssistantName } from "./identity-helpers.js";
 import type { PairingStore } from "./pairing-store.js";
 
@@ -514,7 +515,10 @@ function resolvePairCommand(content: string): SlashResolution | null {
   // so the synchronous slash resolution is not blocked).
   const payloadJson = JSON.stringify(payload);
   const qrFilename = buildPairingQRCodeFilename();
-  savePairingQRCodePng(payloadJson, qrFilename).catch(() => {});
+  silentlyWithLog(
+    savePairingQRCodePng(payloadJson, qrFilename),
+    "save pairing QR code PNG",
+  );
 
   const lines = [
     "Pairing Ready\n",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -52,6 +52,7 @@ import { getConfiguredProvider } from "../../providers/provider-send-message.js"
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
+import { silentlyWithLog } from "../../util/silently.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import type { AuthContext } from "../auth/types.js";
@@ -962,7 +963,7 @@ export async function handleSendMessage(
           sessionId: conversationId,
         });
         session.processing = false;
-        session.drainQueue().catch(() => {});
+        silentlyWithLog(session.drainQueue(), "slash-command queue drain");
       }, 0);
 
       cleanupDeferred = true;
@@ -972,7 +973,7 @@ export async function handleSendMessage(
       // setTimeout above), but still needed for error paths.
       if (!cleanupDeferred && session.processing) {
         session.processing = false;
-        session.drainQueue().catch(() => {});
+        silentlyWithLog(session.drainQueue(), "error-path queue drain");
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace 6 bare `.catch(() => {})` fire-and-forget patterns in `assistant/` with `silentlyWithLog()` for debug-level error visibility
- Affected files: `conversation-routes.ts`, `session-slash.ts`, `transcribe-media.ts`, `preprocess.ts`
- Leaves structural suppression patterns (Promise.race losers, rejection chain handlers in `call-controller.ts`, `guardian-dispatch.ts`, `agent/loop.ts`, `clawhub.ts`) untouched — those rejections are handled elsewhere

## Original prompt
Replace bare `.catch(() => {})` fire-and-forget patterns with `silentlyWithLog()` in assistant code for debug-level observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
