### PR TITLE
fix: close PID file race window in daemon spawn

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -249,6 +249,11 @@ async function startDaemonFromSource(
     delete env.QDRANT_URL;
   }
 
+  // Write a sentinel PID file before spawning so concurrent hatch() calls
+  // see the file and fall through to the isDaemonResponsive() port check
+  // instead of racing to spawn a duplicate daemon.
+  writeFileSync(pidFile, "starting", "utf-8");
+
   const daemonLogFd = openLogFile("hatch.log");
   const child = spawn("bun", ["run", daemonMainPath], {
     detached: true,
@@ -260,6 +265,10 @@ async function startDaemonFromSource(
 
   if (child.pid) {
     writeFileSync(pidFile, String(child.pid), "utf-8");
+  } else {
+    try {
+      unlinkSync(pidFile);
+    } catch {}
   }
 }
 
@@ -842,6 +851,11 @@ export async function startLocalDaemon(
         delete daemonEnv.QDRANT_URL;
       }
 
+      // Write a sentinel PID file before spawning so concurrent hatch() calls
+      // see the file and fall through to the isDaemonResponsive() port check
+      // instead of racing to spawn a duplicate daemon.
+      writeFileSync(pidFile, "starting", "utf-8");
+
       const daemonLogFd = openLogFile("hatch.log");
       const child = spawn(daemonBinary, [], {
         cwd: dirname(daemonBinary),
@@ -853,10 +867,13 @@ export async function startLocalDaemon(
       child.unref();
       const daemonPid = child.pid;
 
-      // Write PID file immediately so the health monitor can find the process
-      // and concurrent hatch() calls see it as alive.
+      // Overwrite sentinel with real PID, or clean up on spawn failure.
       if (daemonPid) {
         writeFileSync(pidFile, String(daemonPid), "utf-8");
+      } else {
+        try {
+          unlinkSync(pidFile);
+        } catch {}
       }
     }
 


### PR DESCRIPTION
## Summary
- Write a `"starting"` sentinel to the PID file **before** `spawn()` in both the source-mode and binary-mode daemon launch paths
- Overwrite with the real PID on success, or clean up the sentinel on spawn failure
- Concurrent `hatch()` calls that see the sentinel (which parses as `NaN`) correctly fall through to the `isDaemonResponsive()` HTTP port check instead of racing to spawn a duplicate

## Original prompt
Fix the PID file write race condition: PID file is written after spawn() succeeds, leaving a window where the daemon is running but no PID file exists. Concurrent hatch() calls during this window could spawn duplicate daemons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
