### PR TITLE
[ces] Add CES-owned persistent and temporary grant persistence

### DIFF
--- a/credential-executor/src/__tests__/grant-store.test.ts
+++ b/credential-executor/src/__tests__/grant-store.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Tests for CES grant stores.
+ *
+ * Covers:
+ * - Persistent store: initialization, duplicate prevention by canonical grant
+ *   hash, fail-closed behavior on corrupt/unreadable files.
+ * - Temporary store: allow_once consumption, allow_10m expiry, allow_thread
+ *   scoping by conversation ID, clearConversation cleanup.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { PersistentGrantStore, type PersistentGrant } from "../grants/persistent-store.js";
+import { TemporaryGrantStore } from "../grants/temporary-store.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `ces-grant-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeGrant(overrides?: Partial<PersistentGrant>): PersistentGrant {
+  return {
+    id: overrides?.id ?? randomUUID(),
+    tool: overrides?.tool ?? "host_bash",
+    pattern: overrides?.pattern ?? "npm install",
+    scope: overrides?.scope ?? "/project",
+    createdAt: overrides?.createdAt ?? Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistent store
+// ---------------------------------------------------------------------------
+
+describe("PersistentGrantStore", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("initialization", () => {
+    test("creates grants.json when file does not exist", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const filePath = join(tmpDir, "grants.json");
+      expect(existsSync(filePath)).toBe(true);
+
+      const data = JSON.parse(readFileSync(filePath, "utf-8"));
+      expect(data.version).toBe(1);
+      expect(data.grants).toEqual([]);
+    });
+
+    test("creates parent directory if missing", () => {
+      const nestedDir = join(tmpDir, "nested", "grants");
+      const store = new PersistentGrantStore(nestedDir);
+      store.init();
+
+      expect(existsSync(join(nestedDir, "grants.json"))).toBe(true);
+    });
+
+    test("loads existing valid grants file", () => {
+      const grant = makeGrant();
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ version: 1, grants: [grant] }, null, 2),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grants = store.getAll();
+      expect(grants).toHaveLength(1);
+      expect(grants[0].id).toBe(grant.id);
+    });
+  });
+
+  describe("add and deduplication", () => {
+    test("adds a new grant and persists it", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grant = makeGrant();
+      const added = store.add(grant);
+      expect(added).toBe(true);
+
+      // Verify persisted by creating a new store instance
+      const store2 = new PersistentGrantStore(tmpDir);
+      const grants = store2.getAll();
+      expect(grants).toHaveLength(1);
+      expect(grants[0].id).toBe(grant.id);
+    });
+
+    test("deduplicates by canonical grant id", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grant = makeGrant({ id: "canonical-hash-123" });
+      expect(store.add(grant)).toBe(true);
+      expect(store.add(grant)).toBe(false); // duplicate
+
+      expect(store.getAll()).toHaveLength(1);
+    });
+
+    test("allows grants with different IDs", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "grant-a" }));
+      store.add(makeGrant({ id: "grant-b" }));
+
+      expect(store.getAll()).toHaveLength(2);
+    });
+  });
+
+  describe("getById and has", () => {
+    test("returns grant by ID", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      const grant = makeGrant({ id: "lookup-id" });
+      store.add(grant);
+
+      expect(store.getById("lookup-id")).toBeDefined();
+      expect(store.getById("lookup-id")!.tool).toBe(grant.tool);
+    });
+
+    test("returns undefined for missing ID", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      expect(store.getById("nonexistent")).toBeUndefined();
+    });
+
+    test("has() returns true for existing grant", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "exists" }));
+      expect(store.has("exists")).toBe(true);
+      expect(store.has("missing")).toBe(false);
+    });
+  });
+
+  describe("remove", () => {
+    test("removes an existing grant", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "to-remove" }));
+      expect(store.remove("to-remove")).toBe(true);
+      expect(store.has("to-remove")).toBe(false);
+    });
+
+    test("returns false for non-existent grant", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      expect(store.remove("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("clear", () => {
+    test("removes all grants", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "a" }));
+      store.add(makeGrant({ id: "b" }));
+      store.clear();
+
+      expect(store.getAll()).toHaveLength(0);
+    });
+  });
+
+  describe("fail-closed behavior", () => {
+    test("throws on malformed JSON", () => {
+      writeFileSync(join(tmpDir, "grants.json"), "not json at all");
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow();
+    });
+
+    test("throws on missing version field", () => {
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ grants: [] }),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow(/malformed/i);
+    });
+
+    test("throws on missing grants field", () => {
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ version: 1 }),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow(/malformed/i);
+    });
+
+    test("throws on unsupported version", () => {
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ version: 999, grants: [] }),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow(/unsupported version/i);
+    });
+
+    test("blocks all operations after corruption is detected", () => {
+      writeFileSync(join(tmpDir, "grants.json"), "corrupt");
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow();
+
+      // Subsequent operations should also fail
+      expect(() => store.getAll()).toThrow(/corrupt/i);
+      expect(() => store.add(makeGrant())).toThrow(/corrupt/i);
+      expect(() => store.remove("any")).toThrow(/corrupt/i);
+      expect(() => store.clear()).toThrow(/corrupt/i);
+    });
+
+    test("throws on grants field being non-array", () => {
+      writeFileSync(
+        join(tmpDir, "grants.json"),
+        JSON.stringify({ version: 1, grants: "not-an-array" }),
+      );
+
+      const store = new PersistentGrantStore(tmpDir);
+      expect(() => store.init()).toThrow(/not an array/i);
+    });
+  });
+
+  describe("atomic writes", () => {
+    test("grants.json is valid after write", () => {
+      const store = new PersistentGrantStore(tmpDir);
+      store.init();
+
+      store.add(makeGrant({ id: "atom-1" }));
+      store.add(makeGrant({ id: "atom-2" }));
+
+      const raw = readFileSync(join(tmpDir, "grants.json"), "utf-8");
+      const data = JSON.parse(raw);
+      expect(data.version).toBe(1);
+      expect(data.grants).toHaveLength(2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Temporary store
+// ---------------------------------------------------------------------------
+
+describe("TemporaryGrantStore", () => {
+  let store: TemporaryGrantStore;
+
+  beforeEach(() => {
+    store = new TemporaryGrantStore();
+  });
+
+  describe("allow_once", () => {
+    test("grant is consumed on first check", () => {
+      store.add("allow_once", "hash-abc");
+
+      expect(store.check("allow_once", "hash-abc")).toBe(true);
+      // Second check should fail — consumed
+      expect(store.check("allow_once", "hash-abc")).toBe(false);
+    });
+
+    test("different proposal hashes are independent", () => {
+      store.add("allow_once", "hash-1");
+      store.add("allow_once", "hash-2");
+
+      expect(store.check("allow_once", "hash-1")).toBe(true);
+      expect(store.check("allow_once", "hash-2")).toBe(true);
+      // Both consumed
+      expect(store.check("allow_once", "hash-1")).toBe(false);
+      expect(store.check("allow_once", "hash-2")).toBe(false);
+    });
+  });
+
+  describe("allow_10m", () => {
+    test("grant is active before expiry", () => {
+      store.add("allow_10m", "hash-timed");
+
+      expect(store.check("allow_10m", "hash-timed")).toBe(true);
+      // Can be checked multiple times (not consumed)
+      expect(store.check("allow_10m", "hash-timed")).toBe(true);
+    });
+
+    test("grant expires after TTL", () => {
+      // Add with a very short duration (1ms)
+      store.add("allow_10m", "hash-expire", { durationMs: 1 });
+
+      // Wait for expiry — use a synchronous busy-wait to avoid flakes
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        // spin
+      }
+
+      expect(store.check("allow_10m", "hash-expire")).toBe(false);
+    });
+
+    test("expired grant is lazily purged", () => {
+      store.add("allow_10m", "hash-lazy", { durationMs: 1 });
+
+      const start = Date.now();
+      while (Date.now() - start < 5) {
+        // spin
+      }
+
+      // Check triggers lazy purge
+      store.check("allow_10m", "hash-lazy");
+      expect(store.size).toBe(0);
+    });
+  });
+
+  describe("allow_thread", () => {
+    test("requires conversationId", () => {
+      expect(() => store.add("allow_thread", "hash-t", {})).toThrow(
+        /conversationId/,
+      );
+    });
+
+    test("scoped to conversation ID", () => {
+      store.add("allow_thread", "hash-t", { conversationId: "conv-1" });
+
+      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+      // Different conversation should not match
+      expect(store.check("allow_thread", "hash-t", "conv-2")).toBe(false);
+    });
+
+    test("same proposal hash in different conversations are independent", () => {
+      store.add("allow_thread", "hash-t", { conversationId: "conv-a" });
+      store.add("allow_thread", "hash-t", { conversationId: "conv-b" });
+
+      expect(store.check("allow_thread", "hash-t", "conv-a")).toBe(true);
+      expect(store.check("allow_thread", "hash-t", "conv-b")).toBe(true);
+    });
+
+    test("not consumed on check (persists within thread)", () => {
+      store.add("allow_thread", "hash-t", { conversationId: "conv-1" });
+
+      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+      expect(store.check("allow_thread", "hash-t", "conv-1")).toBe(true);
+    });
+  });
+
+  describe("checkAny", () => {
+    test("finds allow_once grant", () => {
+      store.add("allow_once", "hash-any");
+      expect(store.checkAny("hash-any")).toBe("allow_once");
+      // Consumed — should not match again
+      expect(store.checkAny("hash-any")).toBeUndefined();
+    });
+
+    test("finds allow_10m grant", () => {
+      store.add("allow_10m", "hash-any-t");
+      expect(store.checkAny("hash-any-t")).toBe("allow_10m");
+    });
+
+    test("finds allow_thread grant with conversationId", () => {
+      store.add("allow_thread", "hash-any-th", { conversationId: "conv-x" });
+      expect(store.checkAny("hash-any-th", "conv-x")).toBe("allow_thread");
+    });
+
+    test("returns undefined when no grants match", () => {
+      expect(store.checkAny("no-such-hash")).toBeUndefined();
+    });
+
+    test("prefers allow_once over allow_10m", () => {
+      store.add("allow_once", "hash-prio");
+      store.add("allow_10m", "hash-prio");
+
+      expect(store.checkAny("hash-prio")).toBe("allow_once");
+    });
+  });
+
+  describe("remove", () => {
+    test("removes a specific grant", () => {
+      store.add("allow_10m", "hash-rm");
+      expect(store.remove("allow_10m", "hash-rm")).toBe(true);
+      expect(store.check("allow_10m", "hash-rm")).toBe(false);
+    });
+
+    test("returns false for non-existent grant", () => {
+      expect(store.remove("allow_once", "nope")).toBe(false);
+    });
+  });
+
+  describe("clearConversation", () => {
+    test("removes all thread grants for a conversation", () => {
+      store.add("allow_thread", "hash-1", { conversationId: "conv-clear" });
+      store.add("allow_thread", "hash-2", { conversationId: "conv-clear" });
+      store.add("allow_thread", "hash-3", { conversationId: "conv-keep" });
+
+      store.clearConversation("conv-clear");
+
+      expect(store.check("allow_thread", "hash-1", "conv-clear")).toBe(false);
+      expect(store.check("allow_thread", "hash-2", "conv-clear")).toBe(false);
+      // Other conversation unaffected
+      expect(store.check("allow_thread", "hash-3", "conv-keep")).toBe(true);
+    });
+
+    test("does not affect non-thread grants", () => {
+      store.add("allow_once", "hash-non-thread");
+      store.add("allow_10m", "hash-non-thread-t");
+
+      store.clearConversation("any-conv");
+
+      // Non-thread grants unaffected
+      expect(store.check("allow_once", "hash-non-thread")).toBe(true);
+      expect(store.check("allow_10m", "hash-non-thread-t")).toBe(true);
+    });
+  });
+
+  describe("clear", () => {
+    test("removes all grants", () => {
+      store.add("allow_once", "h1");
+      store.add("allow_10m", "h2");
+      store.add("allow_thread", "h3", { conversationId: "c1" });
+
+      store.clear();
+      expect(store.size).toBe(0);
+    });
+  });
+
+  describe("process restart simulation", () => {
+    test("grants do not survive new store instance", () => {
+      store.add("allow_once", "hash-restart");
+      store.add("allow_10m", "hash-restart-t");
+      store.add("allow_thread", "hash-restart-th", {
+        conversationId: "conv-r",
+      });
+
+      // "Restart" — new instance
+      const newStore = new TemporaryGrantStore();
+      expect(newStore.size).toBe(0);
+      expect(newStore.checkAny("hash-restart")).toBeUndefined();
+    });
+  });
+});

--- a/credential-executor/src/grants/index.ts
+++ b/credential-executor/src/grants/index.ts
@@ -1,0 +1,17 @@
+/**
+ * CES grant stores.
+ *
+ * Re-exports the persistent and temporary grant stores used by the
+ * Credential Execution Service to track user approval decisions.
+ *
+ * - **Persistent store**: Durable grants (e.g. `always_allow`) persisted
+ *   to `grants.json` inside the CES-private data root. Survives restarts.
+ * - **Temporary store**: Ephemeral grants (`allow_once`, `allow_10m`,
+ *   `allow_thread`) held in memory. Never survives a process restart.
+ */
+
+export { PersistentGrantStore } from "./persistent-store.js";
+export type { PersistentGrant } from "./persistent-store.js";
+
+export { TemporaryGrantStore } from "./temporary-store.js";
+export type { TemporaryGrant, TemporaryGrantKind } from "./temporary-store.js";

--- a/credential-executor/src/grants/persistent-store.ts
+++ b/credential-executor/src/grants/persistent-store.ts
@@ -1,0 +1,247 @@
+/**
+ * CES persistent grant store.
+ *
+ * Stores canonical validated grants by stable ID in a `grants.json` file
+ * inside the CES-private data root. This file is never co-mingled with
+ * assistant trust files or credential metadata.
+ *
+ * Design principles:
+ * - **Fail closed**: If the store file is unreadable or malformed, all
+ *   reads return empty and all writes throw. The CES must never fall back
+ *   to a permissive default when the persistent state is corrupt.
+ * - **Atomic writes**: Uses rename-over-tmp to prevent partial writes.
+ * - **Deduplication**: Grants are keyed by a canonical hash (the `id`
+ *   field) — adding a grant with an existing ID is a no-op.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { getCesGrantsDir } from "../paths.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A canonical persistent grant stored on disk. */
+export interface PersistentGrant {
+  /** Stable canonical hash identifying this grant. */
+  id: string;
+  /** The tool or command pattern this grant authorises. */
+  tool: string;
+  /** Glob pattern scoping the grant. */
+  pattern: string;
+  /** Scope constraint (directory path or "everywhere"). */
+  scope: string;
+  /** When the grant was created (epoch ms). */
+  createdAt: number;
+}
+
+/** On-disk format for the grants file. */
+interface GrantsFile {
+  version: number;
+  grants: PersistentGrant[];
+}
+
+const GRANTS_FILE_VERSION = 1;
+const GRANTS_FILENAME = "grants.json";
+
+// ---------------------------------------------------------------------------
+// Store implementation
+// ---------------------------------------------------------------------------
+
+export class PersistentGrantStore {
+  private readonly filePath: string;
+  private cache: PersistentGrant[] | null = null;
+  /** Set to true when the store detects corruption; blocks all operations. */
+  private corrupt = false;
+
+  constructor(grantsDir?: string) {
+    const dir = grantsDir ?? getCesGrantsDir();
+    this.filePath = join(dir, GRANTS_FILENAME);
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Initialise the store, ensuring the parent directory exists and the
+   * grants file is readable. If the file does not exist it is created
+   * with an empty grant list.
+   *
+   * Throws if the directory cannot be created or an existing file is
+   * malformed (fail-closed).
+   */
+  init(): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    if (!existsSync(this.filePath)) {
+      this.writeToDisk([]);
+      return;
+    }
+
+    // Validate the existing file is readable and well-formed.
+    // If it isn't, mark corrupt and throw (fail closed).
+    this.loadFromDisk();
+  }
+
+  /**
+   * Return all persisted grants.
+   *
+   * Returns an empty array if the store has never been initialised
+   * (no file on disk). Throws if the store is corrupt.
+   */
+  getAll(): PersistentGrant[] {
+    this.assertNotCorrupt();
+    if (this.cache !== null) return [...this.cache];
+    if (!existsSync(this.filePath)) return [];
+    return [...this.loadFromDisk()];
+  }
+
+  /**
+   * Look up a grant by its canonical ID.
+   *
+   * Returns `undefined` if not found. Throws if the store is corrupt.
+   */
+  getById(id: string): PersistentGrant | undefined {
+    return this.getAll().find((g) => g.id === id);
+  }
+
+  /**
+   * Add a grant. If a grant with the same `id` already exists, this is
+   * a no-op (idempotent deduplication by canonical hash).
+   *
+   * Returns `true` if the grant was newly added, `false` if it was a
+   * duplicate.
+   */
+  add(grant: PersistentGrant): boolean {
+    this.assertNotCorrupt();
+    const grants = this.loadFromDisk();
+    if (grants.some((g) => g.id === grant.id)) {
+      return false;
+    }
+    grants.push(grant);
+    this.writeToDisk(grants);
+    return true;
+  }
+
+  /**
+   * Remove a grant by its canonical ID.
+   *
+   * Returns `true` if the grant was found and removed, `false` otherwise.
+   */
+  remove(id: string): boolean {
+    this.assertNotCorrupt();
+    const grants = this.loadFromDisk();
+    const index = grants.findIndex((g) => g.id === id);
+    if (index === -1) return false;
+    grants.splice(index, 1);
+    this.writeToDisk(grants);
+    return true;
+  }
+
+  /**
+   * Check whether a grant with the given ID exists.
+   */
+  has(id: string): boolean {
+    return this.getById(id) !== undefined;
+  }
+
+  /**
+   * Remove all grants and reset the store to an empty state.
+   */
+  clear(): void {
+    this.assertNotCorrupt();
+    this.writeToDisk([]);
+  }
+
+  // -----------------------------------------------------------------------
+  // Internals
+  // -----------------------------------------------------------------------
+
+  private assertNotCorrupt(): void {
+    if (this.corrupt) {
+      throw new Error(
+        "CES persistent grant store is corrupt — refusing to operate (fail closed)",
+      );
+    }
+  }
+
+  private loadFromDisk(): PersistentGrant[] {
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const data = JSON.parse(raw) as unknown;
+
+      if (
+        typeof data !== "object" ||
+        data === null ||
+        !("version" in data) ||
+        !("grants" in data)
+      ) {
+        this.corrupt = true;
+        throw new Error(
+          "CES grants file is malformed: missing version or grants field",
+        );
+      }
+
+      const file = data as GrantsFile;
+
+      if (file.version !== GRANTS_FILE_VERSION) {
+        this.corrupt = true;
+        throw new Error(
+          `CES grants file has unsupported version ${file.version} (expected ${GRANTS_FILE_VERSION})`,
+        );
+      }
+
+      if (!Array.isArray(file.grants)) {
+        this.corrupt = true;
+        throw new Error("CES grants file is malformed: grants is not an array");
+      }
+
+      this.cache = file.grants;
+      return [...file.grants];
+    } catch (err) {
+      if (this.corrupt) throw err;
+      // Any other read/parse error → fail closed
+      this.corrupt = true;
+      throw new Error(
+        `CES persistent grant store failed to read ${this.filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  private writeToDisk(grants: PersistentGrant[]): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const data: GrantsFile = {
+      version: GRANTS_FILE_VERSION,
+      grants,
+    };
+
+    const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+    writeFileSync(tmpPath, JSON.stringify(data, null, 2), {
+      mode: 0o600,
+    });
+    renameSync(tmpPath, this.filePath);
+    // Enforce owner-only permissions even if the file already existed
+    // with wider permissions.
+    chmodSync(this.filePath, 0o600);
+
+    this.cache = grants;
+  }
+}

--- a/credential-executor/src/grants/temporary-store.ts
+++ b/credential-executor/src/grants/temporary-store.ts
@@ -1,0 +1,219 @@
+/**
+ * CES in-memory temporary grant store.
+ *
+ * Manages grants for `allow_once`, `allow_10m`, and `allow_thread` decisions.
+ * All state is in-memory — temporary grants never survive a process restart,
+ * which is the desired behaviour for ephemeral approvals.
+ *
+ * Keying:
+ * - `allow_once`: Keyed by proposal hash. Consumed (deleted) on first use.
+ * - `allow_10m`: Keyed by proposal hash. Checked for expiry on every read;
+ *   expired entries are lazily purged.
+ * - `allow_thread`: Keyed by proposal hash + conversation ID. Scoped to a
+ *   single conversation thread.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TemporaryGrantKind = "allow_once" | "allow_10m" | "allow_thread";
+
+export interface TemporaryGrant {
+  /** The kind of temporary grant. */
+  kind: TemporaryGrantKind;
+  /** Canonical proposal hash identifying the operation being granted. */
+  proposalHash: string;
+  /** Conversation ID — required for `allow_thread`, ignored otherwise. */
+  conversationId?: string;
+  /** When the grant was created (epoch ms). */
+  createdAt: number;
+  /** When the grant expires (epoch ms). Only set for `allow_10m`. */
+  expiresAt?: number;
+}
+
+/** Default TTL for timed grants (10 minutes). */
+const DEFAULT_TIMED_DURATION_MS = 10 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Store implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the storage key for a temporary grant.
+ *
+ * - `allow_once` / `allow_10m`: keyed by proposal hash alone.
+ * - `allow_thread`: keyed by proposal hash + conversation ID.
+ */
+function storageKey(
+  kind: TemporaryGrantKind,
+  proposalHash: string,
+  conversationId?: string,
+): string {
+  if (kind === "allow_thread") {
+    if (!conversationId) {
+      throw new Error(
+        "allow_thread grants require a conversationId",
+      );
+    }
+    return `thread:${conversationId}:${proposalHash}`;
+  }
+  return `${kind}:${proposalHash}`;
+}
+
+export class TemporaryGrantStore {
+  private readonly store = new Map<string, TemporaryGrant>();
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Record a temporary grant.
+   *
+   * For `allow_once` and `allow_10m`, if a grant with the same proposal
+   * hash already exists, it is replaced (last-write-wins).
+   *
+   * @param kind - The type of temporary grant.
+   * @param proposalHash - Canonical hash of the operation proposal.
+   * @param options - Additional options (conversationId for thread grants,
+   *   custom duration for timed grants).
+   */
+  add(
+    kind: TemporaryGrantKind,
+    proposalHash: string,
+    options?: {
+      conversationId?: string;
+      durationMs?: number;
+    },
+  ): void {
+    const key = storageKey(kind, proposalHash, options?.conversationId);
+
+    const grant: TemporaryGrant = {
+      kind,
+      proposalHash,
+      createdAt: Date.now(),
+    };
+
+    if (options?.conversationId) {
+      grant.conversationId = options.conversationId;
+    }
+
+    if (kind === "allow_10m") {
+      grant.expiresAt =
+        Date.now() + (options?.durationMs ?? DEFAULT_TIMED_DURATION_MS);
+    }
+
+    this.store.set(key, grant);
+  }
+
+  /**
+   * Check whether an active temporary grant exists for the given proposal.
+   *
+   * - `allow_once`: Returns `true` and **consumes** the grant (deletes it).
+   * - `allow_10m`: Returns `true` only if the grant has not expired.
+   *   Expired grants are lazily purged.
+   * - `allow_thread`: Returns `true` only if a grant exists for the given
+   *   proposal hash scoped to the specified conversation ID.
+   *
+   * Returns `false` if no matching grant exists.
+   */
+  check(
+    kind: TemporaryGrantKind,
+    proposalHash: string,
+    conversationId?: string,
+  ): boolean {
+    const key = storageKey(kind, proposalHash, conversationId);
+    const grant = this.store.get(key);
+    if (!grant) return false;
+
+    if (grant.kind === "allow_once") {
+      // Consume on first use
+      this.store.delete(key);
+      return true;
+    }
+
+    if (grant.kind === "allow_10m") {
+      if (grant.expiresAt !== undefined && Date.now() >= grant.expiresAt) {
+        // Expired — purge and deny
+        this.store.delete(key);
+        return false;
+      }
+      return true;
+    }
+
+    // allow_thread — no expiry, just existence check
+    return true;
+  }
+
+  /**
+   * Check whether any kind of active temporary grant exists for the given
+   * proposal hash and optional conversation ID.
+   *
+   * Checks `allow_once`, `allow_10m`, and `allow_thread` in order.
+   * Returns the kind of the matched grant, or `undefined` if none match.
+   *
+   * Note: If an `allow_once` grant matches, it is consumed.
+   */
+  checkAny(
+    proposalHash: string,
+    conversationId?: string,
+  ): TemporaryGrantKind | undefined {
+    // Check allow_once first (most specific / single-use)
+    if (this.check("allow_once", proposalHash)) return "allow_once";
+
+    // Check allow_10m
+    if (this.check("allow_10m", proposalHash)) return "allow_10m";
+
+    // Check allow_thread (requires conversationId)
+    if (conversationId && this.check("allow_thread", proposalHash, conversationId)) {
+      return "allow_thread";
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Remove a specific temporary grant.
+   *
+   * Returns `true` if the grant existed and was removed.
+   */
+  remove(
+    kind: TemporaryGrantKind,
+    proposalHash: string,
+    conversationId?: string,
+  ): boolean {
+    const key = storageKey(kind, proposalHash, conversationId);
+    return this.store.delete(key);
+  }
+
+  /**
+   * Remove all temporary grants for a given conversation ID.
+   *
+   * Useful when a conversation/thread ends. Only removes `allow_thread`
+   * grants scoped to that conversation.
+   */
+  clearConversation(conversationId: string): void {
+    const prefix = `thread:${conversationId}:`;
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Remove all temporary grants. Useful for testing or full reset.
+   */
+  clear(): void {
+    this.store.clear();
+  }
+
+  /**
+   * Return the number of currently stored grants (including expired ones
+   * that haven't been lazily purged yet).
+   */
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -30,3 +30,10 @@ export {
   getHealthPort,
 } from "./paths.js";
 export type { CesMode } from "./paths.js";
+
+export { PersistentGrantStore, TemporaryGrantStore } from "./grants/index.js";
+export type {
+  PersistentGrant,
+  TemporaryGrant,
+  TemporaryGrantKind,
+} from "./grants/index.js";


### PR DESCRIPTION
## Summary
- Add persistent grant store at grants.json under CES private data root
- Add in-memory temporary grant store for allow_once, allow_10m, and allow_thread
- Add tests for initialization, deduplication, expiry, thread scoping, and fail-closed behavior

Part of plan: untrusted-agent-credential-arch.md (PR 20 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)