### PR TITLE
fix: fix two CI test failures (credentials-cli + abort-cleanup)

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -295,7 +295,11 @@ describe("assistant credentials CLI", () => {
       const result = await runCli(["list", "--json"]);
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed).toEqual({ ok: true, credentials: [] });
+      expect(parsed).toEqual({
+        ok: true,
+        credentials: [],
+        managedCredentials: [],
+      });
     });
 
     test("returns all credentials with correct shapes", async () => {
@@ -397,7 +401,11 @@ describe("assistant credentials CLI", () => {
       ]);
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed).toEqual({ ok: true, credentials: [] });
+      expect(parsed).toEqual({
+        ok: true,
+        credentials: [],
+        managedCredentials: [],
+      });
     });
 
     test("list items have the same shape as inspect output", async () => {

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -79,6 +79,7 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => "/tmp",
   getDataDir: () => "/tmp",
+  ensureDataDir: () => {},
 }));
 
 mock.module("../tools/credentials/resolve.js", () => ({


### PR DESCRIPTION
## Summary
- Update `credentials-cli.test.ts` to expect `managedCredentials: []` in list output (the credentials list command now includes managed credentials)
- Add missing `ensureDataDir` export to the platform mock in `tool-execution-abort-cleanup.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100361264/job/67099969442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
