### PR TITLE
fix: add preconnect to fetch mocks in managed-credential-catalog test

### DIFF
--- a/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
+++ b/assistant/src/__tests__/managed-credential-catalog-cli.test.ts
@@ -43,10 +43,7 @@ mock.module("../security/secure-keys.js", () => ({
 
 // Mock global fetch
 const _originalFetch = globalThis.fetch;
-globalThis.fetch = async (
-  input: string | URL | Request,
-  init?: RequestInit,
-) => {
+const mockFetch = async (input: string | URL | Request, init?: RequestInit) => {
   const url =
     typeof input === "string"
       ? input
@@ -71,6 +68,8 @@ globalThis.fetch = async (
     headers: { "Content-Type": "application/json" },
   });
 };
+mockFetch.preconnect = _originalFetch.preconnect;
+globalThis.fetch = mockFetch;
 
 // ---------------------------------------------------------------------------
 // Import after mocks are installed
@@ -241,11 +240,15 @@ describe("fetchManagedCatalog", () => {
 
     // Simulate a network error
     const savedFetch = globalThis.fetch;
-    globalThis.fetch = async () => {
-      throw new Error(
-        "Connect failed to https://platform.example.com/v1/ces/catalog with Api-Key sk-super-secret-key-12345",
-      );
-    };
+    const errorFetch: typeof fetch = Object.assign(
+      async () => {
+        throw new Error(
+          "Connect failed to https://platform.example.com/v1/ces/catalog with Api-Key sk-super-secret-key-12345",
+        );
+      },
+      { preconnect: savedFetch.preconnect },
+    );
+    globalThis.fetch = errorFetch;
 
     try {
       const result = await fetchManagedCatalog();


### PR DESCRIPTION
## Summary
- Fixed two `TS2741` errors in `managed-credential-catalog-cli.test.ts` where `globalThis.fetch` mocks were missing the `preconnect` property required by Bun's `typeof fetch`
- The top-level mock now assigns `preconnect` from the original fetch; the per-test error mock uses `Object.assign` to include it

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100361264/job/67099969446

🤖 Generated with [Claude Code](https://claude.com/claude-code)