### PR TITLE
[ces] Add managed OAuth materialization for `platform_oauth` handles

### DIFF
--- a/credential-executor/src/__tests__/managed-materializers.test.ts
+++ b/credential-executor/src/__tests__/managed-materializers.test.ts
@@ -1,0 +1,961 @@
+/**
+ * Tests for managed OAuth subject resolution and materialization.
+ *
+ * Covers:
+ * 1. Successful subject resolution from platform catalog
+ * 2. Platform HTTP error handling (401, 403, 404, 5xx)
+ * 3. Successful token materialization
+ * 4. Expired token refresh via platform re-materialization
+ * 5. Missing assistant API key behavior
+ * 6. Fail-closed behavior when platform is unreachable
+ * 7. Uniform subject shape between local and managed handles
+ * 8. Materialized tokens are never persisted
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { platformOAuthHandle } from "@vellumai/ces-contracts";
+
+import {
+  type ManagedSubject,
+  resolveManagedSubject,
+  SubjectResolutionError,
+  type PlatformCatalogEntry,
+  type ResolvedSubject,
+} from "../subjects/managed.js";
+import {
+  materializeManagedToken,
+  MaterializationError,
+  type ManagedMaterializerOptions,
+} from "../materializers/managed-platform.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PLATFORM_URL = "https://api.test-platform.vellum.ai";
+const TEST_API_KEY = "test-api-key-abc123";
+
+/**
+ * Build a mock catalog response with the given entries.
+ */
+function buildCatalogResponse(
+  entries: PlatformCatalogEntry[],
+): { connections: PlatformCatalogEntry[] } {
+  return { connections: entries };
+}
+
+/**
+ * Build a mock platform token response.
+ */
+function buildTokenResponse(overrides: {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number | null;
+} = {}) {
+  return {
+    access_token: overrides.access_token ?? "mat_token_abc123",
+    token_type: overrides.token_type ?? "Bearer",
+    expires_in: overrides.expires_in ?? 3600,
+  };
+}
+
+/**
+ * Create a mock fetch that responds based on URL path.
+ */
+function createMockFetch(handlers: {
+  catalog?: {
+    status: number;
+    body?: unknown;
+    error?: Error;
+  };
+  materialize?: {
+    status: number;
+    body?: unknown;
+    error?: Error;
+  };
+}): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/v1/ces/catalog")) {
+      if (handlers.catalog?.error) {
+        throw handlers.catalog.error;
+      }
+      return new Response(
+        JSON.stringify(handlers.catalog?.body ?? { connections: [] }),
+        {
+          status: handlers.catalog?.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (url.includes("/materialize")) {
+      if (handlers.materialize?.error) {
+        throw handlers.materialize.error;
+      }
+      return new Response(
+        JSON.stringify(handlers.materialize?.body ?? buildTokenResponse()),
+        {
+          status: handlers.materialize?.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    return new Response("Not Found", { status: 404 });
+  }) as typeof globalThis.fetch;
+}
+
+/**
+ * Build a managed subject for materialization tests.
+ */
+function buildManagedSubject(
+  overrides: Partial<ManagedSubject> = {},
+): ManagedSubject {
+  return {
+    source: "managed",
+    handle: platformOAuthHandle("conn_test123"),
+    provider: "google",
+    connectionId: "conn_test123",
+    accountInfo: "user@example.com",
+    grantedScopes: ["email", "calendar"],
+    status: "active",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Successful subject resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveManagedSubject", () => {
+  test("resolves a valid platform_oauth handle from the catalog", async () => {
+    const handle = platformOAuthHandle("conn_abc123");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          {
+            id: "conn_abc123",
+            provider: "google",
+            account_info: "user@example.com",
+            granted_scopes: ["email", "calendar"],
+            status: "active",
+          },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.subject.source).toBe("managed");
+    expect(result.subject.handle).toBe(handle);
+    expect(result.subject.provider).toBe("google");
+    expect(result.subject.connectionId).toBe("conn_abc123");
+    expect(result.subject.accountInfo).toBe("user@example.com");
+    expect(result.subject.grantedScopes).toEqual(["email", "calendar"]);
+    expect(result.subject.status).toBe("active");
+  });
+
+  test("resolves a handle when catalog has multiple connections", async () => {
+    const handle = platformOAuthHandle("conn_second");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          { id: "conn_first", provider: "slack" },
+          {
+            id: "conn_second",
+            provider: "github",
+            account_info: "dev@github.com",
+            granted_scopes: ["repo", "read:org"],
+            status: "active",
+          },
+          { id: "conn_third", provider: "google" },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.subject.provider).toBe("github");
+    expect(result.subject.connectionId).toBe("conn_second");
+  });
+
+  test("defaults account_info to null and granted_scopes to empty array", async () => {
+    const handle = platformOAuthHandle("conn_minimal");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          { id: "conn_minimal", provider: "slack" },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.subject.accountInfo).toBeNull();
+    expect(result.subject.grantedScopes).toEqual([]);
+    expect(result.subject.status).toBe("unknown");
+  });
+
+  // -------------------------------------------------------------------------
+  // Handle validation
+  // -------------------------------------------------------------------------
+
+  test("rejects an invalid handle format", async () => {
+    const result = await resolveManagedSubject("not-a-valid-handle", {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_HANDLE");
+  });
+
+  test("rejects a local_static handle", async () => {
+    const result = await resolveManagedSubject("local_static:github/api_key", {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("WRONG_HANDLE_TYPE");
+    expect(result.error.message).toContain("local_static");
+  });
+
+  test("rejects a local_oauth handle", async () => {
+    const result = await resolveManagedSubject(
+      "local_oauth:integration:google/conn_local1",
+      {
+        platformBaseUrl: TEST_PLATFORM_URL,
+        assistantApiKey: TEST_API_KEY,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("WRONG_HANDLE_TYPE");
+    expect(result.error.message).toContain("local_oauth");
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection not found in catalog
+  // -------------------------------------------------------------------------
+
+  test("returns error when connection is not in the catalog", async () => {
+    const handle = platformOAuthHandle("conn_nonexistent");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          { id: "conn_other", provider: "slack" },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("CONNECTION_NOT_FOUND");
+    expect(result.error.message).toContain("conn_nonexistent");
+  });
+
+  // -------------------------------------------------------------------------
+  // Platform HTTP errors
+  // -------------------------------------------------------------------------
+
+  test("handles platform 401 (invalid API key)", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: { status: 401 },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_HTTP_401");
+    expect(result.error.message).toContain("401");
+  });
+
+  test("handles platform 403 (forbidden)", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: { status: 403 },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_HTTP_403");
+  });
+
+  test("handles platform 404 (catalog not found)", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: { status: 404 },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_HTTP_404");
+  });
+
+  test("handles platform 500 (server error)", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: { status: 500 },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_HTTP_500");
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing prerequisites
+  // -------------------------------------------------------------------------
+
+  test("fails when assistant API key is missing", async () => {
+    const handle = platformOAuthHandle("conn_test");
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: "",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_API_KEY");
+  });
+
+  test("fails when platform base URL is missing", async () => {
+    const handle = platformOAuthHandle("conn_test");
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: "",
+      assistantApiKey: TEST_API_KEY,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_PLATFORM_URL");
+  });
+
+  // -------------------------------------------------------------------------
+  // Fail-closed behavior (network errors)
+  // -------------------------------------------------------------------------
+
+  test("fails closed when platform is unreachable", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 0,
+        error: new Error("ECONNREFUSED: Connection refused"),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_UNREACHABLE");
+    expect(result.error.message).toContain("ECONNREFUSED");
+  });
+
+  test("sanitizes API key from network error messages", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 0,
+        error: new Error(
+          `Failed to connect with Api-Key ${TEST_API_KEY} header`,
+        ),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).not.toContain(TEST_API_KEY);
+    expect(result.error.message).toContain("[REDACTED]");
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalid catalog response format
+  // -------------------------------------------------------------------------
+
+  test("handles catalog response with missing connections field", async () => {
+    const handle = platformOAuthHandle("conn_test");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: { data: [] }, // wrong shape
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_CATALOG_RESPONSE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Managed token materialization
+// ---------------------------------------------------------------------------
+
+describe("materializeManagedToken", () => {
+  test("materializes a token successfully", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 200,
+        body: buildTokenResponse({
+          access_token: "fresh_token_xyz",
+          expires_in: 1800,
+        }),
+      },
+    });
+
+    const before = Date.now();
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.token.accessToken).toBe("fresh_token_xyz");
+    expect(result.token.tokenType).toBe("Bearer");
+    expect(result.token.provider).toBe("google");
+    expect(result.token.connectionId).toBe("conn_test123");
+    // expires_in: 1800 seconds = 1,800,000 ms from now
+    expect(result.token.expiresAt).not.toBeNull();
+    expect(result.token.expiresAt!).toBeGreaterThanOrEqual(before + 1_799_000);
+    expect(result.token.expiresAt!).toBeLessThanOrEqual(
+      Date.now() + 1_801_000,
+    );
+  });
+
+  test("defaults token_type to Bearer when not provided", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 200,
+        body: { access_token: "tok_no_type" },
+      },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.token.tokenType).toBe("Bearer");
+    expect(result.token.expiresAt).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Platform error responses during materialization
+  // -------------------------------------------------------------------------
+
+  test("handles platform 401 during materialization", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: { status: 401 },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_AUTH_FAILED");
+    expect(result.error.message).toContain("401");
+  });
+
+  test("handles platform 403 during materialization", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: { status: 403 },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_FORBIDDEN");
+  });
+
+  test("handles platform 404 during materialization", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: { status: 404 },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("CONNECTION_NOT_FOUND");
+    expect(result.error.message).toContain("conn_test123");
+  });
+
+  test("handles platform 500 during materialization", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: { status: 500 },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_HTTP_500");
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing prerequisites
+  // -------------------------------------------------------------------------
+
+  test("fails when assistant API key is missing", async () => {
+    const subject = buildManagedSubject();
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: "",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_API_KEY");
+  });
+
+  test("fails when platform base URL is missing", async () => {
+    const subject = buildManagedSubject();
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: "",
+      assistantApiKey: TEST_API_KEY,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("MISSING_PLATFORM_URL");
+  });
+
+  // -------------------------------------------------------------------------
+  // Fail-closed (network errors)
+  // -------------------------------------------------------------------------
+
+  test("fails closed when platform is unreachable during materialization", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 0,
+        error: new Error("ETIMEDOUT: Connection timed out"),
+      },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PLATFORM_UNREACHABLE");
+    expect(result.error.message).toContain("ETIMEDOUT");
+  });
+
+  test("sanitizes API key from materialization error messages", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 0,
+        error: new Error(
+          `Request failed with Api-Key ${TEST_API_KEY}`,
+        ),
+      },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).not.toContain(TEST_API_KEY);
+    expect(result.error.message).toContain("[REDACTED]");
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalid token response
+  // -------------------------------------------------------------------------
+
+  test("handles response with missing access_token", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 200,
+        body: { token_type: "Bearer", expires_in: 3600 },
+      },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_TOKEN_RESPONSE");
+    expect(result.error.message).toContain("access_token");
+  });
+
+  // -------------------------------------------------------------------------
+  // Expired token refresh via re-materialization
+  // -------------------------------------------------------------------------
+
+  test("re-materialization after expiry returns a fresh token", async () => {
+    const subject = buildManagedSubject();
+    let callCount = 0;
+
+    const mockFetch = ((
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      callCount++;
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/materialize")) {
+        // Each call returns a different token to prove we got a fresh one
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              buildTokenResponse({
+                access_token: `fresh_token_${callCount}`,
+                expires_in: 3600,
+              }),
+            ),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("Not Found", { status: 404 }));
+    }) as typeof globalThis.fetch;
+
+    const opts: ManagedMaterializerOptions = {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    };
+
+    // First materialization
+    const result1 = await materializeManagedToken(subject, opts);
+    expect(result1.ok).toBe(true);
+    if (!result1.ok) return;
+    expect(result1.token.accessToken).toBe("fresh_token_1");
+
+    // Simulate expiry by re-materializing (in the real system, CES would
+    // check expiresAt and call materialize again)
+    const result2 = await materializeManagedToken(subject, opts);
+    expect(result2.ok).toBe(true);
+    if (!result2.ok) return;
+    expect(result2.token.accessToken).toBe("fresh_token_2");
+    expect(callCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Uniform subject interface
+// ---------------------------------------------------------------------------
+
+describe("uniform subject interface", () => {
+  test("managed subject conforms to ResolvedSubject interface", async () => {
+    const handle = platformOAuthHandle("conn_uniform");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          {
+            id: "conn_uniform",
+            provider: "github",
+            account_info: "dev@example.com",
+            granted_scopes: ["repo"],
+            status: "active",
+          },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // Verify the managed subject can be treated as a ResolvedSubject
+    const subject: ResolvedSubject = result.subject;
+    expect(subject.source).toBe("managed");
+    expect(subject.handle).toBe(handle);
+    expect(subject.provider).toBe("github");
+    expect(subject.connectionId).toBe("conn_uniform");
+  });
+
+  test("managed subject has 'managed' source for branching", async () => {
+    const handle = platformOAuthHandle("conn_branch");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          { id: "conn_branch", provider: "slack" },
+        ]),
+      },
+    });
+
+    const result = await resolveManagedSubject(handle, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // CES execution paths can branch on source without casting
+    const subject: ResolvedSubject = result.subject;
+    switch (subject.source) {
+      case "managed":
+        // Managed path — materialize via platform
+        expect(true).toBe(true);
+        break;
+      case "local":
+        // Local path — should not reach here
+        expect(true).toBe(false);
+        break;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Token non-persistence invariant
+// ---------------------------------------------------------------------------
+
+describe("token non-persistence invariant", () => {
+  test("materialized token is returned in-memory only — no disk writes", async () => {
+    const subject = buildManagedSubject();
+    const mockFetch = createMockFetch({
+      materialize: {
+        status: 200,
+        body: buildTokenResponse({ access_token: "ephemeral_token" }),
+      },
+    });
+
+    const result = await materializeManagedToken(subject, {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The MaterializedToken type has no persist/save methods —
+    // it is a plain data object. Verify it is a simple object.
+    expect(typeof result.token.accessToken).toBe("string");
+    expect(typeof result.token.tokenType).toBe("string");
+    expect(typeof result.token.provider).toBe("string");
+    expect(typeof result.token.connectionId).toBe("string");
+
+    // Verify no reference to storage backends, file paths, or persist calls
+    const tokenKeys = Object.keys(result.token);
+    expect(tokenKeys).toEqual([
+      "accessToken",
+      "tokenType",
+      "expiresAt",
+      "provider",
+      "connectionId",
+    ]);
+  });
+
+  test("materializer source code does not import credential-storage", async () => {
+    // Static verification: the materializer must not import from
+    // @vellumai/credential-storage, which would indicate it might
+    // persist tokens locally.
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+
+    const src = readFileSync(
+      resolve(__dirname, "..", "materializers", "managed-platform.ts"),
+      "utf-8",
+    );
+
+    expect(src).not.toContain("credential-storage");
+    expect(src).not.toContain("writeFile");
+    expect(src).not.toContain("SecureKeyBackend");
+    expect(src).not.toContain("persistOAuthTokens");
+  });
+
+  test("subject resolver source code does not import credential-storage", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+
+    const src = readFileSync(
+      resolve(__dirname, "..", "subjects", "managed.ts"),
+      "utf-8",
+    );
+
+    expect(src).not.toContain("credential-storage");
+    expect(src).not.toContain("SecureKeyBackend");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. End-to-end resolve + materialize
+// ---------------------------------------------------------------------------
+
+describe("end-to-end resolve and materialize", () => {
+  test("resolves a handle and then materializes a token", async () => {
+    const handle = platformOAuthHandle("conn_e2e");
+    const mockFetch = createMockFetch({
+      catalog: {
+        status: 200,
+        body: buildCatalogResponse([
+          {
+            id: "conn_e2e",
+            provider: "google",
+            account_info: "e2e@example.com",
+            granted_scopes: ["drive"],
+            status: "active",
+          },
+        ]),
+      },
+      materialize: {
+        status: 200,
+        body: buildTokenResponse({
+          access_token: "e2e_access_token",
+          expires_in: 7200,
+        }),
+      },
+    });
+
+    const opts = {
+      platformBaseUrl: TEST_PLATFORM_URL,
+      assistantApiKey: TEST_API_KEY,
+      fetch: mockFetch,
+    };
+
+    // Phase 1: Resolve
+    const resolveResult = await resolveManagedSubject(handle, opts);
+    expect(resolveResult.ok).toBe(true);
+    if (!resolveResult.ok) return;
+
+    // Phase 2: Materialize using the resolved subject
+    const matResult = await materializeManagedToken(
+      resolveResult.subject,
+      opts,
+    );
+    expect(matResult.ok).toBe(true);
+    if (!matResult.ok) return;
+
+    expect(matResult.token.accessToken).toBe("e2e_access_token");
+    expect(matResult.token.provider).toBe("google");
+    expect(matResult.token.connectionId).toBe("conn_e2e");
+  });
+});

--- a/credential-executor/src/materializers/managed-platform.ts
+++ b/credential-executor/src/materializers/managed-platform.ts
@@ -1,0 +1,270 @@
+/**
+ * Managed platform OAuth materializer.
+ *
+ * Materializes a `platform_oauth` handle into a short-lived access token
+ * by calling the platform's CES token-materialization endpoint. The
+ * materialized token is returned to the caller for immediate use (e.g.
+ * injection into an HTTP request or command environment) but is **never**
+ * persisted to any local storage — it exists only in memory for the
+ * duration of the execution.
+ *
+ * Security invariants:
+ * - Materialized tokens are never written to disk.
+ * - Materialized tokens are never logged (not even partially).
+ * - Platform errors are surfaced as structured errors without leaking secrets.
+ * - If the platform cannot be reached, materialization fails closed.
+ *
+ * The materializer expects a resolved `ManagedSubject` from
+ * `subjects/managed.ts`. It does not perform handle parsing or catalog
+ * lookup — that is the resolver's responsibility.
+ */
+
+import type { ManagedSubject } from "../subjects/managed.js";
+
+// ---------------------------------------------------------------------------
+// Materialization result
+// ---------------------------------------------------------------------------
+
+/**
+ * Successful materialization result.
+ *
+ * The `accessToken` field contains the short-lived token obtained from
+ * the platform. Callers MUST NOT persist this value — it should be used
+ * immediately for request injection and then discarded.
+ */
+export interface MaterializedToken {
+  /** The short-lived access token. */
+  accessToken: string;
+  /** Token type (typically "Bearer"). */
+  tokenType: string;
+  /** Epoch ms when the token expires (null if the platform didn't report expiry). */
+  expiresAt: number | null;
+  /** Provider key (mirrored from the subject for convenience). */
+  provider: string;
+  /** Connection ID (mirrored from the subject for convenience). */
+  connectionId: string;
+}
+
+export type MaterializeResult =
+  | { ok: true; token: MaterializedToken }
+  | { ok: false; error: MaterializationError };
+
+// ---------------------------------------------------------------------------
+// Materialization errors
+// ---------------------------------------------------------------------------
+
+export class MaterializationError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "MaterializationError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Platform token response shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the platform's CES token-materialization response.
+ *
+ * The platform issues a short-lived access token for the specified
+ * connection. The token is pre-authorized for the scopes granted on
+ * the connection.
+ */
+interface PlatformTokenResponse {
+  access_token: string;
+  token_type?: string;
+  /** Seconds until the token expires. */
+  expires_in?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Materializer options
+// ---------------------------------------------------------------------------
+
+export interface ManagedMaterializerOptions {
+  /**
+   * Platform base URL (without trailing slash).
+   */
+  platformBaseUrl: string;
+  /**
+   * Assistant API key for authenticating with the platform.
+   */
+  assistantApiKey: string;
+  /**
+   * Optional custom fetch implementation (for testing).
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Materializer implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Materialize a managed OAuth subject into a short-lived access token
+ * by calling the platform's token-materialization endpoint.
+ *
+ * The endpoint is:
+ *   POST {platformBaseUrl}/v1/ces/connections/{connectionId}/materialize
+ *
+ * The platform validates the assistant API key, checks that the connection
+ * is active, and returns a fresh access token (refreshing upstream if
+ * needed).
+ *
+ * Fail-closed: any error results in a structured `MaterializationError`
+ * rather than a partial or fallback result.
+ */
+export async function materializeManagedToken(
+  subject: ManagedSubject,
+  options: ManagedMaterializerOptions,
+): Promise<MaterializeResult> {
+  // -- Validate prerequisites -----------------------------------------------
+  if (!options.platformBaseUrl) {
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "MISSING_PLATFORM_URL",
+        "Platform base URL is required for managed token materialization",
+      ),
+    };
+  }
+
+  if (!options.assistantApiKey) {
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "MISSING_API_KEY",
+        "Assistant API key is required for managed token materialization",
+      ),
+    };
+  }
+
+  // -- Call platform token endpoint -----------------------------------------
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const materializeUrl =
+    `${options.platformBaseUrl}/v1/ces/connections/${subject.connectionId}/materialize`;
+
+  let response: Response;
+  try {
+    response = await fetchFn(materializeUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Api-Key ${options.assistantApiKey}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "PLATFORM_UNREACHABLE",
+        `Failed to reach platform token endpoint: ${sanitizeError(message)}`,
+      ),
+    };
+  }
+
+  // -- Handle error responses -----------------------------------------------
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: mapPlatformError(response.status, subject.connectionId),
+    };
+  }
+
+  // -- Parse token response -------------------------------------------------
+  let body: PlatformTokenResponse;
+  try {
+    body = (await response.json()) as PlatformTokenResponse;
+  } catch {
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "INVALID_TOKEN_RESPONSE",
+        "Platform token endpoint returned invalid JSON",
+      ),
+    };
+  }
+
+  if (!body.access_token || typeof body.access_token !== "string") {
+    return {
+      ok: false,
+      error: new MaterializationError(
+        "INVALID_TOKEN_RESPONSE",
+        "Platform token response missing access_token",
+      ),
+    };
+  }
+
+  // -- Build materialized token ---------------------------------------------
+  const expiresAt = computeExpiresAt(body.expires_in);
+
+  const token: MaterializedToken = {
+    accessToken: body.access_token,
+    tokenType: body.token_type ?? "Bearer",
+    expiresAt,
+    provider: subject.provider,
+    connectionId: subject.connectionId,
+  };
+
+  return { ok: true, token };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a platform HTTP error status to a structured MaterializationError.
+ */
+function mapPlatformError(
+  status: number,
+  connectionId: string,
+): MaterializationError {
+  switch (status) {
+    case 401:
+      return new MaterializationError(
+        "PLATFORM_AUTH_FAILED",
+        "Assistant API key is invalid or expired (HTTP 401)",
+      );
+    case 403:
+      return new MaterializationError(
+        "PLATFORM_FORBIDDEN",
+        "Assistant is not authorized to materialize this connection (HTTP 403)",
+      );
+    case 404:
+      return new MaterializationError(
+        "CONNECTION_NOT_FOUND",
+        `Connection ${connectionId} not found on the platform (HTTP 404)`,
+      );
+    default:
+      return new MaterializationError(
+        `PLATFORM_HTTP_${status}`,
+        `Platform token endpoint returned HTTP ${status}`,
+      );
+  }
+}
+
+/**
+ * Compute the absolute expiry timestamp from an `expires_in` seconds value.
+ * Returns null if the value is missing or zero.
+ */
+function computeExpiresAt(
+  expiresIn: number | null | undefined,
+): number | null {
+  if (expiresIn == null || expiresIn <= 0) return null;
+  return Date.now() + expiresIn * 1000;
+}
+
+/**
+ * Sanitize error messages to avoid leaking secrets.
+ */
+function sanitizeError(message: string): string {
+  return message.replace(/Api-Key\s+\S+/gi, "Api-Key [REDACTED]");
+}

--- a/credential-executor/src/subjects/managed.ts
+++ b/credential-executor/src/subjects/managed.ts
@@ -1,0 +1,290 @@
+/**
+ * Managed subject resolution for platform OAuth handles.
+ *
+ * Resolves `platform_oauth:<connection_id>` handles into a normalized
+ * subject shape that the rest of CES can treat uniformly alongside local
+ * subjects. Managed subjects never carry raw tokens — they carry only
+ * the metadata needed to call the platform's token-materialization
+ * endpoint at execution time.
+ *
+ * Subject resolution is the first phase of a two-phase credential flow:
+ *   1. **Resolution** (this module) — parse the handle, validate the
+ *      connection exists in the platform catalog, and return a subject
+ *      descriptor with provider metadata.
+ *   2. **Materialization** (`materializers/managed-platform.ts`) — use
+ *      the resolved subject to request a short-lived access token from
+ *      the platform and inject it into the execution environment.
+ *
+ * The subject shape is intentionally slim and secret-free so it can be
+ * logged, cached in memory, and passed across internal boundaries without
+ * risk of leaking credentials.
+ */
+
+import {
+  HandleType,
+  parseHandle,
+  type PlatformOAuthHandle,
+} from "@vellumai/ces-contracts";
+
+// ---------------------------------------------------------------------------
+// Common subject interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Source discriminator shared by all subject types.
+ *
+ * - `"local"` — credential lives in the local secure-key backend.
+ * - `"managed"` — credential is managed by the platform; tokens are
+ *   obtained via the platform's CES token-materialization endpoint.
+ */
+export type SubjectSource = "local" | "managed";
+
+/**
+ * Common shape that all resolved subjects expose. CES execution paths
+ * (HTTP materializer, command materializer) can branch on `source`
+ * without knowing the full subject type.
+ */
+export interface ResolvedSubject {
+  /** Source of the credential. */
+  source: SubjectSource;
+  /** The raw handle string that was resolved. */
+  handle: string;
+  /** Provider identifier (e.g. "google", "slack", "github"). */
+  provider: string;
+  /** Connection identifier on the platform (managed) or locally. */
+  connectionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Managed subject shape
+// ---------------------------------------------------------------------------
+
+/**
+ * A resolved managed subject — the output of resolving a
+ * `platform_oauth:<connection_id>` handle against the platform catalog.
+ *
+ * This shape carries zero secret material. It is safe to log, serialize,
+ * and pass across internal boundaries.
+ */
+export interface ManagedSubject extends ResolvedSubject {
+  source: "managed";
+  /** Account info as reported by the platform catalog (e.g. email). */
+  accountInfo: string | null;
+  /** Granted OAuth scopes as reported by the platform catalog. */
+  grantedScopes: string[];
+  /** Connection status from the platform catalog (e.g. "active", "expired"). */
+  status: string;
+}
+
+// ---------------------------------------------------------------------------
+// Platform catalog entry (non-secret subset from the platform response)
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a single connection entry in the platform catalog response.
+ * Only non-secret fields are parsed; token values are never included.
+ */
+export interface PlatformCatalogEntry {
+  id: string;
+  provider: string;
+  account_info?: string | null;
+  granted_scopes?: string[];
+  status?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution errors
+// ---------------------------------------------------------------------------
+
+export class SubjectResolutionError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "SubjectResolutionError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution options
+// ---------------------------------------------------------------------------
+
+export interface ManagedSubjectResolverOptions {
+  /**
+   * Platform base URL (without trailing slash).
+   * e.g. "https://api.vellum.ai"
+   */
+  platformBaseUrl: string;
+  /**
+   * Assistant API key for authenticating with the platform.
+   */
+  assistantApiKey: string;
+  /**
+   * Optional custom fetch implementation (for testing).
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution result
+// ---------------------------------------------------------------------------
+
+export type ResolveResult =
+  | { ok: true; subject: ManagedSubject }
+  | { ok: false; error: SubjectResolutionError };
+
+// ---------------------------------------------------------------------------
+// Resolver implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a `platform_oauth:<connection_id>` handle into a managed subject
+ * by looking up the connection in the platform's CES catalog.
+ *
+ * Fail-closed: if the platform cannot be reached, returns an error rather
+ * than proceeding without credential validation.
+ */
+export async function resolveManagedSubject(
+  handle: string,
+  options: ManagedSubjectResolverOptions,
+): Promise<ResolveResult> {
+  // -- Parse handle ---------------------------------------------------------
+  const parsed = parseHandle(handle);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError("INVALID_HANDLE", parsed.error),
+    };
+  }
+
+  if (parsed.handle.type !== HandleType.PlatformOAuth) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "WRONG_HANDLE_TYPE",
+        `Expected platform_oauth handle, got ${parsed.handle.type}`,
+      ),
+    };
+  }
+
+  const platformHandle = parsed.handle as PlatformOAuthHandle;
+
+  // -- Validate prerequisites -----------------------------------------------
+  if (!options.platformBaseUrl) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "MISSING_PLATFORM_URL",
+        "Platform base URL is required for managed subject resolution",
+      ),
+    };
+  }
+
+  if (!options.assistantApiKey) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "MISSING_API_KEY",
+        "Assistant API key is required for managed subject resolution",
+      ),
+    };
+  }
+
+  // -- Fetch catalog entry --------------------------------------------------
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const catalogUrl = `${options.platformBaseUrl}/v1/ces/catalog`;
+
+  let response: Response;
+  try {
+    response = await fetchFn(catalogUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Api-Key ${options.assistantApiKey}`,
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "PLATFORM_UNREACHABLE",
+        `Failed to reach platform CES catalog: ${sanitizeError(message)}`,
+      ),
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        `PLATFORM_HTTP_${response.status}`,
+        `Platform CES catalog returned HTTP ${response.status}`,
+      ),
+    };
+  }
+
+  // -- Parse response -------------------------------------------------------
+  let body: { connections?: PlatformCatalogEntry[] };
+  try {
+    body = (await response.json()) as { connections?: PlatformCatalogEntry[] };
+  } catch {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "INVALID_CATALOG_RESPONSE",
+        "Platform CES catalog returned invalid JSON",
+      ),
+    };
+  }
+
+  if (!body.connections || !Array.isArray(body.connections)) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "INVALID_CATALOG_RESPONSE",
+        "Platform CES catalog returned unexpected response format",
+      ),
+    };
+  }
+
+  // -- Find matching connection ---------------------------------------------
+  const entry = body.connections.find(
+    (c) => c.id === platformHandle.connectionId,
+  );
+
+  if (!entry) {
+    return {
+      ok: false,
+      error: new SubjectResolutionError(
+        "CONNECTION_NOT_FOUND",
+        `Connection ${platformHandle.connectionId} not found in platform catalog`,
+      ),
+    };
+  }
+
+  // -- Build managed subject ------------------------------------------------
+  const subject: ManagedSubject = {
+    source: "managed",
+    handle,
+    provider: entry.provider,
+    connectionId: entry.id,
+    accountInfo: entry.account_info ?? null,
+    grantedScopes: entry.granted_scopes ?? [],
+    status: entry.status ?? "unknown",
+  };
+
+  return { ok: true, subject };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize error messages to avoid leaking secrets (defensive).
+ */
+function sanitizeError(message: string): string {
+  return message.replace(/Api-Key\s+\S+/gi, "Api-Key [REDACTED]");
+}


### PR DESCRIPTION
## Summary
- Add managed subject resolution using platform CES catalog and token-materialization endpoints
- Normalize managed subject shape for uniform local/managed treatment in CES execution
- Add tests for materialization, platform errors, expired token refresh, and fail-closed behavior

Part of plan: untrusted-agent-credential-arch.md (PR 26 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
