### PR TITLE
[ces] Add HTTP proposal derivation, grant enforcement, and sanitized response filtering

### DIFF
--- a/credential-executor/src/__tests__/http-policy.test.ts
+++ b/credential-executor/src/__tests__/http-policy.test.ts
@@ -1,0 +1,972 @@
+/**
+ * Tests for HTTP policy evaluation, path-template derivation, and
+ * response filtering.
+ *
+ * Covers:
+ * - Path template derivation: numeric, UUID, hex placeholder replacement,
+ *   query/fragment stripping, trailing slash normalisation.
+ * - URL-to-template matching.
+ * - HTTP policy evaluation: grant matching, forbidden header rejection,
+ *   proposal generation when no grant matches.
+ * - Response filtering: header whitelisting, body clamping, secret scrubbing.
+ * - Audit summary generation: token-free output.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+
+import {
+  derivePathTemplate,
+  deriveAllowedUrlPatterns,
+  urlMatchesTemplate,
+} from "../http/path-template.js";
+import {
+  evaluateHttpPolicy,
+  detectForbiddenHeaders,
+  type HttpPolicyRequest,
+} from "../http/policy.js";
+import {
+  filterHttpResponse,
+  filterResponseHeaders,
+  clampBody,
+  scrubSecrets,
+  type RawHttpResponse,
+} from "../http/response-filter.js";
+import { generateHttpAuditSummary } from "../http/audit.js";
+import { PersistentGrantStore } from "../grants/persistent-store.js";
+import { TemporaryGrantStore } from "../grants/temporary-store.js";
+
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `ces-http-policy-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Path template derivation
+// ---------------------------------------------------------------------------
+
+describe("derivePathTemplate", () => {
+  test("preserves literal path segments", () => {
+    const result = derivePathTemplate("https://api.github.com/repos/owner/repo/pulls");
+    expect(result).toBe("https://api.github.com/repos/owner/repo/pulls");
+  });
+
+  test("replaces numeric segments with {:num}", () => {
+    const result = derivePathTemplate("https://api.example.com/users/42/posts/123");
+    expect(result).toBe("https://api.example.com/users/{:num}/posts/{:num}");
+  });
+
+  test("replaces UUID segments with {:uuid}", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const result = derivePathTemplate(`https://api.example.com/resources/${uuid}`);
+    expect(result).toBe("https://api.example.com/resources/{:uuid}");
+  });
+
+  test("replaces long hex segments with {:hex}", () => {
+    const hex = "abcdef0123456789abcdef01";
+    const result = derivePathTemplate(`https://api.example.com/commits/${hex}`);
+    expect(result).toBe("https://api.example.com/commits/{:hex}");
+  });
+
+  test("does not replace short hex-like segments", () => {
+    // "cafe" is only 4 chars — should remain literal
+    const result = derivePathTemplate("https://api.example.com/items/cafe");
+    expect(result).toBe("https://api.example.com/items/cafe");
+  });
+
+  test("strips query string", () => {
+    const result = derivePathTemplate("https://api.example.com/search?q=test&page=1");
+    expect(result).toBe("https://api.example.com/search");
+  });
+
+  test("strips fragment", () => {
+    const result = derivePathTemplate("https://api.example.com/docs#section-1");
+    expect(result).toBe("https://api.example.com/docs");
+  });
+
+  test("strips both query and fragment", () => {
+    const result = derivePathTemplate("https://api.example.com/path?q=x#frag");
+    expect(result).toBe("https://api.example.com/path");
+  });
+
+  test("normalises trailing slash", () => {
+    const result = derivePathTemplate("https://api.example.com/repos/");
+    expect(result).toBe("https://api.example.com/repos");
+  });
+
+  test("handles root path", () => {
+    const result = derivePathTemplate("https://api.example.com/");
+    expect(result).toBe("https://api.example.com/");
+  });
+
+  test("preserves port numbers", () => {
+    const result = derivePathTemplate("https://localhost:3000/api/v1/users/42");
+    expect(result).toBe("https://localhost:3000/api/v1/users/{:num}");
+  });
+
+  test("handles http scheme", () => {
+    const result = derivePathTemplate("http://internal.service/data/123");
+    expect(result).toBe("http://internal.service/data/{:num}");
+  });
+
+  test("handles mixed segment types", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const hex = "abcdef0123456789abcdef";
+    const result = derivePathTemplate(
+      `https://api.example.com/orgs/acme/repos/${uuid}/commits/${hex}/files/42`,
+    );
+    expect(result).toBe(
+      "https://api.example.com/orgs/acme/repos/{:uuid}/commits/{:hex}/files/{:num}",
+    );
+  });
+
+  test("throws on invalid URL", () => {
+    expect(() => derivePathTemplate("not-a-url")).toThrow();
+  });
+
+  test("never produces wildcard or /* patterns", () => {
+    // Verify that no possible input produces /* or host wildcards
+    const urls = [
+      "https://api.example.com/",
+      "https://api.example.com/a/b/c",
+      "https://api.example.com/users/42",
+    ];
+    for (const url of urls) {
+      const result = derivePathTemplate(url);
+      expect(result).not.toContain("/*");
+      expect(result).not.toContain("*.");
+    }
+  });
+});
+
+describe("deriveAllowedUrlPatterns", () => {
+  test("returns array with single pattern", () => {
+    const result = deriveAllowedUrlPatterns("https://api.example.com/users/42");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe("https://api.example.com/users/{:num}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL-to-template matching
+// ---------------------------------------------------------------------------
+
+describe("urlMatchesTemplate", () => {
+  test("matches literal paths exactly", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.github.com/repos/owner/repo",
+        "https://api.github.com/repos/owner/repo",
+      ),
+    ).toBe(true);
+  });
+
+  test("matches {:num} placeholder against numeric segments", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/users/42",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects non-numeric segment against {:num}", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/users/alice",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(false);
+  });
+
+  test("matches {:uuid} placeholder against UUID segments", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(
+      urlMatchesTemplate(
+        `https://api.example.com/resources/${uuid}`,
+        "https://api.example.com/resources/{:uuid}",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects non-UUID segment against {:uuid}", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/resources/not-a-uuid",
+        "https://api.example.com/resources/{:uuid}",
+      ),
+    ).toBe(false);
+  });
+
+  test("matches {:hex} placeholder against long hex segments", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/commits/abcdef0123456789abcdef01",
+        "https://api.example.com/commits/{:hex}",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects short hex against {:hex}", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/commits/abcdef",
+        "https://api.example.com/commits/{:hex}",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects different path lengths", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/users/42/extra",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects different hosts", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://evil.example.com/users/42",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects different schemes", () => {
+    expect(
+      urlMatchesTemplate(
+        "http://api.example.com/users/42",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(false);
+  });
+
+  test("host comparison is case-insensitive", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://API.Example.COM/users/42",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(true);
+  });
+
+  test("path comparison is case-sensitive for literals", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/Users/42",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(false);
+  });
+
+  test("ignores query string in the URL being matched", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/users/42?include=profile",
+        "https://api.example.com/users/{:num}",
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for invalid URL", () => {
+    expect(urlMatchesTemplate("not-a-url", "https://example.com/")).toBe(false);
+  });
+
+  test("returns false for invalid template", () => {
+    expect(urlMatchesTemplate("https://example.com/", "not-a-url")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forbidden header detection
+// ---------------------------------------------------------------------------
+
+describe("detectForbiddenHeaders", () => {
+  test("detects Authorization header", () => {
+    const result = detectForbiddenHeaders({ Authorization: "Bearer xyz" });
+    expect(result).toContain("Authorization");
+  });
+
+  test("detects Cookie header (case-insensitive)", () => {
+    const result = detectForbiddenHeaders({ cookie: "session=abc" });
+    expect(result).toContain("cookie");
+  });
+
+  test("detects Proxy-Authorization header", () => {
+    const result = detectForbiddenHeaders({
+      "Proxy-Authorization": "Basic abc",
+    });
+    expect(result).toContain("Proxy-Authorization");
+  });
+
+  test("detects X-Api-Key header", () => {
+    const result = detectForbiddenHeaders({ "X-Api-Key": "secret" });
+    expect(result).toContain("X-Api-Key");
+  });
+
+  test("detects X-Auth-Token header", () => {
+    const result = detectForbiddenHeaders({ "X-Auth-Token": "token" });
+    expect(result).toContain("X-Auth-Token");
+  });
+
+  test("returns empty array for safe headers", () => {
+    const result = detectForbiddenHeaders({
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for undefined headers", () => {
+    expect(detectForbiddenHeaders(undefined)).toEqual([]);
+  });
+
+  test("detects multiple forbidden headers", () => {
+    const result = detectForbiddenHeaders({
+      Authorization: "Bearer xyz",
+      Cookie: "session=abc",
+      "Content-Type": "application/json",
+    });
+    expect(result).toHaveLength(2);
+    expect(result).toContain("Authorization");
+    expect(result).toContain("Cookie");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP policy evaluation
+// ---------------------------------------------------------------------------
+
+describe("evaluateHttpPolicy", () => {
+  let tmpDir: string;
+  let persistentStore: PersistentGrantStore;
+  let temporaryStore: TemporaryGrantStore;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    persistentStore = new PersistentGrantStore(tmpDir);
+    persistentStore.init();
+    temporaryStore = new TemporaryGrantStore();
+  });
+
+  test("blocks requests with forbidden auth headers", () => {
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo",
+      headers: { Authorization: "Bearer smuggled-token" },
+      purpose: "List repos",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBe("forbidden_headers");
+    }
+  });
+
+  test("allows request with matching persistent grant", () => {
+    persistentStore.add({
+      id: "grant-1",
+      tool: "http",
+      pattern: "GET https://api.github.com/repos/owner/repo",
+      scope: "local_static:github/api_key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo",
+      purpose: "List repos",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.grantId).toBe("grant-1");
+      expect(result.grantSource).toBe("persistent");
+    }
+  });
+
+  test("allows request with explicit grantId", () => {
+    persistentStore.add({
+      id: "explicit-grant",
+      tool: "http",
+      pattern: "POST https://api.example.com/data",
+      scope: "local_static:svc/key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "POST",
+      url: "https://api.example.com/data",
+      purpose: "Post data",
+      grantId: "explicit-grant",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.grantId).toBe("explicit-grant");
+    }
+  });
+
+  test("matches persistent grant with templated URL patterns", () => {
+    persistentStore.add({
+      id: "templated-grant",
+      tool: "http",
+      pattern: "GET https://api.example.com/users/{:num}/posts",
+      scope: "local_static:svc/key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "GET",
+      url: "https://api.example.com/users/42/posts",
+      purpose: "List posts",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(true);
+    if (result.allowed) {
+      expect(result.grantId).toBe("templated-grant");
+    }
+  });
+
+  test("returns approval_required when no grant matches", () => {
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:github/api_key",
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/pulls/42",
+      purpose: "List pull requests",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBe("approval_required");
+      expect(result.proposal.type).toBe("http");
+      expect(result.proposal.credentialHandle).toBe(
+        "local_static:github/api_key",
+      );
+      expect(result.proposal.method).toBe("GET");
+      // Proposal should have allowedUrlPatterns with templated path
+      expect(result.proposal.allowedUrlPatterns).toBeDefined();
+      expect(result.proposal.allowedUrlPatterns![0]).toBe(
+        "https://api.github.com/repos/owner/repo/pulls/{:num}",
+      );
+    }
+  });
+
+  test("proposal derivation never produces wildcards", () => {
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "GET",
+      url: "https://api.example.com/resources/42",
+      purpose: "Get resource",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed && result.reason === "approval_required") {
+      for (const pattern of result.proposal.allowedUrlPatterns ?? []) {
+        expect(pattern).not.toContain("/*");
+        expect(pattern).not.toContain("*.");
+      }
+    }
+  });
+
+  test("does not match grant with different credential handle", () => {
+    persistentStore.add({
+      id: "wrong-cred-grant",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: "local_static:other/key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "GET",
+      url: "https://api.example.com/data",
+      purpose: "Get data",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+  });
+
+  test("does not match grant with different HTTP method", () => {
+    persistentStore.add({
+      id: "get-only-grant",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: "local_static:svc/key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "POST",
+      url: "https://api.example.com/data",
+      purpose: "Post data",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+  });
+
+  test("checks forbidden headers before grants", () => {
+    // Even with a matching grant, forbidden headers should block
+    persistentStore.add({
+      id: "valid-grant",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: "local_static:svc/key",
+      createdAt: Date.now(),
+    });
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:svc/key",
+      method: "GET",
+      url: "https://api.example.com/data",
+      headers: { Authorization: "Bearer smuggled" },
+      purpose: "Get data",
+    };
+
+    const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.reason).toBe("forbidden_headers");
+    }
+  });
+
+  // Cleanup
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response header filtering
+// ---------------------------------------------------------------------------
+
+describe("filterResponseHeaders", () => {
+  test("passes through whitelisted headers", () => {
+    const result = filterResponseHeaders({
+      "Content-Type": "application/json",
+      "X-Request-Id": "abc-123",
+      ETag: '"abc"',
+    });
+
+    expect(result["content-type"]).toBe("application/json");
+    expect(result["x-request-id"]).toBe("abc-123");
+    expect(result["etag"]).toBe('"abc"');
+  });
+
+  test("strips set-cookie header", () => {
+    const result = filterResponseHeaders({
+      "Content-Type": "text/html",
+      "Set-Cookie": "session=secret; HttpOnly",
+    });
+
+    expect(result["content-type"]).toBe("text/html");
+    expect(result["set-cookie"]).toBeUndefined();
+  });
+
+  test("strips www-authenticate header", () => {
+    const result = filterResponseHeaders({
+      "WWW-Authenticate": "Bearer realm=api",
+      "Content-Type": "application/json",
+    });
+
+    expect(result["www-authenticate"]).toBeUndefined();
+  });
+
+  test("strips arbitrary non-whitelisted headers", () => {
+    const result = filterResponseHeaders({
+      "X-Custom-Secret": "secret-value",
+      "Content-Type": "text/plain",
+    });
+
+    expect(result["x-custom-secret"]).toBeUndefined();
+    expect(result["content-type"]).toBe("text/plain");
+  });
+
+  test("lowercases header keys in output", () => {
+    const result = filterResponseHeaders({
+      "Content-Type": "text/html",
+      "Cache-Control": "no-cache",
+    });
+
+    expect(Object.keys(result).every((k) => k === k.toLowerCase())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Body clamping
+// ---------------------------------------------------------------------------
+
+describe("clampBody", () => {
+  test("passes through small bodies unchanged", () => {
+    const body = "Hello, world!";
+    const result = clampBody(body);
+
+    expect(result.clampedBody).toBe(body);
+    expect(result.truncated).toBe(false);
+    expect(result.originalBytes).toBe(Buffer.byteLength(body));
+  });
+
+  test("truncates bodies exceeding max size", () => {
+    // Create a body larger than 256KB
+    const body = "x".repeat(300 * 1024);
+    const result = clampBody(body);
+
+    expect(result.truncated).toBe(true);
+    expect(result.originalBytes).toBe(Buffer.byteLength(body));
+    expect(result.clampedBody).toContain("[CES: Response truncated");
+    // The clamped body should be smaller than the original
+    expect(Buffer.byteLength(result.clampedBody)).toBeLessThan(
+      Buffer.byteLength(body),
+    );
+  });
+
+  test("reports original byte size", () => {
+    const body = "a".repeat(100);
+    const result = clampBody(body);
+
+    expect(result.originalBytes).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secret scrubbing
+// ---------------------------------------------------------------------------
+
+describe("scrubSecrets", () => {
+  test("replaces exact secret occurrences", () => {
+    const secret = "sk-abc123456789xyz";
+    const body = `Response: {"api_key": "${secret}", "status": "ok"}`;
+    const result = scrubSecrets(body, [secret]);
+
+    expect(result).not.toContain(secret);
+    expect(result).toContain("[CES:REDACTED]");
+  });
+
+  test("replaces multiple occurrences of the same secret", () => {
+    const secret = "ghp_1234567890abcdef";
+    const body = `token: ${secret}, again: ${secret}`;
+    const result = scrubSecrets(body, [secret]);
+
+    expect(result).not.toContain(secret);
+    expect(result.match(/\[CES:REDACTED\]/g)?.length).toBe(2);
+  });
+
+  test("scrubs multiple different secrets", () => {
+    const secret1 = "sk-prod-abcdefgh";
+    const secret2 = "ghp_testtoken123";
+    const body = `key1=${secret1}&key2=${secret2}`;
+    const result = scrubSecrets(body, [secret1, secret2]);
+
+    expect(result).not.toContain(secret1);
+    expect(result).not.toContain(secret2);
+  });
+
+  test("skips short secrets to avoid false positives", () => {
+    const shortSecret = "abc";
+    const body = "abc is a common substring in abcdef";
+    const result = scrubSecrets(body, [shortSecret]);
+
+    // Short secret should not be scrubbed
+    expect(result).toBe(body);
+  });
+
+  test("handles empty secrets array", () => {
+    const body = "no secrets here";
+    const result = scrubSecrets(body, []);
+
+    expect(result).toBe(body);
+  });
+
+  test("handles body with no matching secrets", () => {
+    const body = "clean response body";
+    const result = scrubSecrets(body, ["nonexistent-secret-value"]);
+
+    expect(result).toBe(body);
+  });
+
+  test("handles secrets with regex metacharacters", () => {
+    const secret = "secret+value.with$special(chars)";
+    const body = `Found: ${secret}`;
+    const result = scrubSecrets(body, [secret]);
+
+    expect(result).not.toContain(secret);
+    expect(result).toContain("[CES:REDACTED]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full response filter
+// ---------------------------------------------------------------------------
+
+describe("filterHttpResponse", () => {
+  test("combines header filtering, body clamping, and secret scrubbing", () => {
+    const secret = "sk-live-1234567890abcdef";
+    const raw: RawHttpResponse = {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Set-Cookie": "session=abc; HttpOnly",
+        "X-Request-Id": "req-123",
+      },
+      body: `{"data": "value", "echo": "${secret}"}`,
+    };
+
+    const result = filterHttpResponse(raw, [secret]);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["content-type"]).toBe("application/json");
+    expect(result.headers["x-request-id"]).toBe("req-123");
+    expect(result.headers["set-cookie"]).toBeUndefined();
+    expect(result.body).not.toContain(secret);
+    expect(result.body).toContain("[CES:REDACTED]");
+    expect(result.truncated).toBe(false);
+  });
+
+  test("works with no secrets provided", () => {
+    const raw: RawHttpResponse = {
+      statusCode: 404,
+      headers: { "Content-Type": "text/plain" },
+      body: "Not found",
+    };
+
+    const result = filterHttpResponse(raw);
+
+    expect(result.statusCode).toBe(404);
+    expect(result.body).toBe("Not found");
+    expect(result.truncated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit summary generation
+// ---------------------------------------------------------------------------
+
+describe("generateHttpAuditSummary", () => {
+  test("produces token-free summary with templated URL", () => {
+    const summary = generateHttpAuditSummary({
+      credentialHandle: "local_static:github/api_key",
+      grantId: "grant-1",
+      sessionId: "sess-1",
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/pulls/42",
+      success: true,
+      statusCode: 200,
+    });
+
+    expect(summary.auditId).toBeDefined();
+    expect(summary.grantId).toBe("grant-1");
+    expect(summary.credentialHandle).toBe("local_static:github/api_key");
+    expect(summary.toolName).toBe("http");
+    expect(summary.sessionId).toBe("sess-1");
+    expect(summary.success).toBe(true);
+    expect(summary.timestamp).toBeDefined();
+
+    // Target should use templated path, not raw URL
+    expect(summary.target).toContain("GET");
+    expect(summary.target).toContain("{:num}");
+    expect(summary.target).toContain("-> 200");
+    // Must not contain the raw numeric ID
+    expect(summary.target).not.toContain("/42");
+  });
+
+  test("includes error message on failure", () => {
+    const summary = generateHttpAuditSummary({
+      credentialHandle: "local_static:svc/key",
+      grantId: "grant-2",
+      sessionId: "sess-2",
+      method: "POST",
+      url: "https://api.example.com/data",
+      success: false,
+      errorMessage: "Connection refused",
+    });
+
+    expect(summary.success).toBe(false);
+    expect(summary.errorMessage).toBe("Connection refused");
+  });
+
+  test("handles invalid URL gracefully in target", () => {
+    const summary = generateHttpAuditSummary({
+      credentialHandle: "local_static:svc/key",
+      grantId: "grant-3",
+      sessionId: "sess-3",
+      method: "GET",
+      url: "not-a-valid-url",
+      success: false,
+      errorMessage: "Invalid URL",
+    });
+
+    expect(summary.target).toContain("[invalid-url]");
+  });
+
+  test("omits errorMessage when not provided", () => {
+    const summary = generateHttpAuditSummary({
+      credentialHandle: "local_static:svc/key",
+      grantId: "grant-4",
+      sessionId: "sess-4",
+      method: "GET",
+      url: "https://api.example.com/health",
+      success: true,
+    });
+
+    expect(summary.errorMessage).toBeUndefined();
+  });
+
+  test("audit summary never contains secret values", () => {
+    // Even if someone accidentally passes secret-looking data,
+    // the summary only contains metadata fields
+    const summary = generateHttpAuditSummary({
+      credentialHandle: "local_static:github/api_key",
+      grantId: "grant-5",
+      sessionId: "sess-5",
+      method: "GET",
+      url: "https://api.github.com/user",
+      success: true,
+      statusCode: 200,
+    });
+
+    const serialized = JSON.stringify(summary);
+    // The summary should not contain any field that could hold a raw token
+    expect(serialized).not.toContain("Bearer");
+    expect(serialized).not.toContain("ghp_");
+    expect(serialized).not.toContain("sk-");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: end-to-end policy → filter → audit
+// ---------------------------------------------------------------------------
+
+describe("end-to-end: policy evaluation → response filter → audit", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("off-grant request is blocked, returns proposal, never reaches network", () => {
+    const persistentStore = new PersistentGrantStore(tmpDir);
+    persistentStore.init();
+    const temporaryStore = new TemporaryGrantStore();
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:stripe/api_key",
+      method: "POST",
+      url: "https://api.stripe.com/v1/charges",
+      purpose: "Create a charge",
+    };
+
+    const policyResult = evaluateHttpPolicy(
+      request,
+      persistentStore,
+      temporaryStore,
+    );
+
+    // Must be blocked
+    expect(policyResult.allowed).toBe(false);
+    if (!policyResult.allowed) {
+      expect(policyResult.reason).toBe("approval_required");
+      expect(policyResult.proposal.type).toBe("http");
+      expect(policyResult.proposal.credentialHandle).toBe(
+        "local_static:stripe/api_key",
+      );
+      // Must have specific URL pattern, not wildcard
+      expect(policyResult.proposal.allowedUrlPatterns).toBeDefined();
+      expect(policyResult.proposal.allowedUrlPatterns!.length).toBeGreaterThan(0);
+      for (const pattern of policyResult.proposal.allowedUrlPatterns!) {
+        expect(pattern).not.toBe("/*");
+        expect(pattern).not.toContain("*");
+      }
+    }
+  });
+
+  test("granted request produces sanitised response and clean audit summary", () => {
+    const persistentStore = new PersistentGrantStore(tmpDir);
+    persistentStore.init();
+    persistentStore.add({
+      id: "stripe-charge-grant",
+      tool: "http",
+      pattern: "GET https://api.stripe.com/v1/charges/{:num}",
+      scope: "local_static:stripe/api_key",
+      createdAt: Date.now(),
+    });
+    const temporaryStore = new TemporaryGrantStore();
+
+    const request: HttpPolicyRequest = {
+      credentialHandle: "local_static:stripe/api_key",
+      method: "GET",
+      url: "https://api.stripe.com/v1/charges/123",
+      purpose: "Get charge details",
+    };
+
+    // Policy allows
+    const policyResult = evaluateHttpPolicy(
+      request,
+      persistentStore,
+      temporaryStore,
+    );
+    expect(policyResult.allowed).toBe(true);
+
+    // Simulate HTTP response filtering
+    const secret = "sk_live_abcdefghijklmnop";
+    const raw: RawHttpResponse = {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Set-Cookie": "stripe_session=xyz",
+      },
+      body: `{"id": "ch_123", "key_echo": "${secret}"}`,
+    };
+
+    const filtered = filterHttpResponse(raw, [secret]);
+    expect(filtered.headers["set-cookie"]).toBeUndefined();
+    expect(filtered.body).not.toContain(secret);
+
+    // Generate audit summary
+    if (policyResult.allowed) {
+      const audit = generateHttpAuditSummary({
+        credentialHandle: request.credentialHandle,
+        grantId: policyResult.grantId,
+        sessionId: "test-session",
+        method: request.method,
+        url: request.url,
+        success: true,
+        statusCode: 200,
+      });
+
+      expect(audit.success).toBe(true);
+      expect(audit.target).toContain("{:num}");
+      expect(audit.target).not.toContain("123");
+      const auditStr = JSON.stringify(audit);
+      expect(auditStr).not.toContain(secret);
+    }
+  });
+});

--- a/credential-executor/src/http/audit.ts
+++ b/credential-executor/src/http/audit.ts
@@ -1,0 +1,84 @@
+/**
+ * HTTP audit summary generation for the Credential Execution Service.
+ *
+ * Produces token-free audit summaries of credentialed HTTP operations.
+ * These summaries are stored in the CES audit log and may be exposed
+ * to the assistant runtime for observability — they must never contain
+ * secret values, auth tokens, or raw credential material.
+ *
+ * Audit summaries capture:
+ * - What was accessed (method, URL template, status code)
+ * - Which credential and grant were used
+ * - Whether the operation succeeded
+ * - Timing metadata
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { AuditRecordSummary } from "@vellumai/ces-contracts";
+import { derivePathTemplate } from "./path-template.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HttpAuditInput {
+  /** CES credential handle used for this request. */
+  credentialHandle: string;
+  /** Grant ID that authorised this request. */
+  grantId: string;
+  /** CES session ID. */
+  sessionId: string;
+  /** HTTP method. */
+  method: string;
+  /** Raw target URL (will be templated for the audit record). */
+  url: string;
+  /** Whether the HTTP operation succeeded. */
+  success: boolean;
+  /** HTTP status code (if available). */
+  statusCode?: number;
+  /** Error message if the operation failed (must not contain secrets). */
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Summary generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a token-free audit record summary for an HTTP operation.
+ *
+ * The `target` field uses the path template (with placeholders) rather
+ * than the raw URL to avoid leaking path-level identifiers that might
+ * be sensitive (e.g. personal resource IDs). The method is prepended
+ * for readability: `GET https://api.example.com/users/{:num}`.
+ */
+export function generateHttpAuditSummary(
+  input: HttpAuditInput,
+): AuditRecordSummary {
+  let target: string;
+  try {
+    const template = derivePathTemplate(input.url);
+    target = `${input.method.toUpperCase()} ${template}`;
+  } catch {
+    // If URL parsing fails, use a safe redacted placeholder
+    target = `${input.method.toUpperCase()} [invalid-url]`;
+  }
+
+  // Append status code if available
+  if (input.statusCode !== undefined) {
+    target += ` -> ${input.statusCode}`;
+  }
+
+  return {
+    auditId: randomUUID(),
+    grantId: input.grantId,
+    credentialHandle: input.credentialHandle,
+    toolName: "http",
+    target,
+    sessionId: input.sessionId,
+    success: input.success,
+    ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/credential-executor/src/http/path-template.ts
+++ b/credential-executor/src/http/path-template.ts
@@ -1,0 +1,176 @@
+/**
+ * Deterministic path-template derivation for HTTP grant proposals.
+ *
+ * Normalises URLs and replaces only well-known dynamic segments (numeric IDs,
+ * UUIDs, and long hex strings) with typed placeholders while keeping every
+ * other path segment literal. This ensures that proposals are specific enough
+ * to be meaningful ("allow GET on /repos/{owner}/pulls/{:num}") without
+ * over-expanding to wildcard patterns that would be too permissive.
+ *
+ * Design invariants:
+ * - Query strings and fragments are stripped — only scheme + host + path matter.
+ * - Host is preserved literally (no wildcard expansion).
+ * - Path never collapses to `/*`.
+ * - Trailing slashes are normalised away.
+ */
+
+// ---------------------------------------------------------------------------
+// Segment classification patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * UUID v4 pattern (case-insensitive): 8-4-4-4-12 hex digits with hyphens.
+ */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Purely numeric segments (e.g. resource IDs like `/users/42`).
+ */
+const NUMERIC_RE = /^[0-9]+$/;
+
+/**
+ * Hex-like strings of 16+ characters — commonly used for opaque identifiers,
+ * commit SHAs, object IDs, etc. Must be at least 16 chars to avoid matching
+ * short, human-meaningful slugs that happen to be hex-only (e.g. "cafe",
+ * "dead", "beef").
+ */
+const HEX_LONG_RE = /^[0-9a-f]{16,}$/i;
+
+// ---------------------------------------------------------------------------
+// Placeholder types
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace a path segment with a typed placeholder if it matches a known
+ * dynamic pattern. Returns the original segment if it does not match.
+ */
+function classifySegment(segment: string): string {
+  if (UUID_RE.test(segment)) return "{:uuid}";
+  if (NUMERIC_RE.test(segment)) return "{:num}";
+  if (HEX_LONG_RE.test(segment)) return "{:hex}";
+  return segment;
+}
+
+// ---------------------------------------------------------------------------
+// Path template derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a deterministic path template from a raw URL.
+ *
+ * 1. Parse the URL to extract scheme, host, and pathname.
+ * 2. Strip query string and fragment.
+ * 3. Split the pathname into segments and classify each one.
+ * 4. Reassemble into `scheme://host/path/with/{placeholders}`.
+ *
+ * Throws if `rawUrl` is not a valid absolute URL.
+ */
+export function derivePathTemplate(rawUrl: string): string {
+  const parsed = new URL(rawUrl);
+
+  // Normalise: strip query and fragment, lowercase the host
+  const scheme = parsed.protocol.replace(/:$/, "");
+  const host = parsed.hostname + (parsed.port ? `:${parsed.port}` : "");
+
+  // Split path into segments, dropping empty segments from leading/trailing slashes
+  const segments = parsed.pathname
+    .split("/")
+    .filter((s) => s.length > 0);
+
+  const templatedSegments = segments.map(classifySegment);
+
+  const path =
+    templatedSegments.length > 0
+      ? "/" + templatedSegments.join("/")
+      : "/";
+
+  return `${scheme}://${host}${path}`;
+}
+
+/**
+ * Derive the allowed URL pattern for an HTTP grant proposal.
+ *
+ * Returns an array with a single pattern string — the path template.
+ * The caller uses this to populate `allowedUrlPatterns` on the proposal.
+ *
+ * This is a thin wrapper around `derivePathTemplate` that returns an array
+ * for direct use in proposal construction.
+ */
+export function deriveAllowedUrlPatterns(rawUrl: string): string[] {
+  return [derivePathTemplate(rawUrl)];
+}
+
+/**
+ * Check whether a concrete URL matches a path template pattern.
+ *
+ * Used during grant evaluation to determine whether a stored
+ * `allowedUrlPatterns` entry covers a requested URL.
+ *
+ * Matching rules:
+ * - Scheme and host must match exactly (case-insensitive).
+ * - Path segments must match positionally.
+ * - A `{:num}` placeholder matches any purely numeric segment.
+ * - A `{:uuid}` placeholder matches any UUID v4 segment.
+ * - A `{:hex}` placeholder matches any 16+-char hex segment.
+ * - Literal segments must match exactly (case-sensitive — URL paths are
+ *   case-sensitive per RFC 3986).
+ */
+export function urlMatchesTemplate(
+  rawUrl: string,
+  template: string,
+): boolean {
+  let parsedUrl: URL;
+  let parsedTemplate: URL;
+
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  try {
+    parsedTemplate = new URL(template);
+  } catch {
+    return false;
+  }
+
+  // Scheme must match
+  if (parsedUrl.protocol !== parsedTemplate.protocol) return false;
+
+  // Host must match (case-insensitive)
+  const urlHost =
+    parsedUrl.hostname.toLowerCase() +
+    (parsedUrl.port ? `:${parsedUrl.port}` : "");
+  const templateHost =
+    parsedTemplate.hostname.toLowerCase() +
+    (parsedTemplate.port ? `:${parsedTemplate.port}` : "");
+  if (urlHost !== templateHost) return false;
+
+  // Split paths and compare segment-by-segment
+  const urlSegments = parsedUrl.pathname
+    .split("/")
+    .filter((s) => s.length > 0);
+  const templateSegments = parsedTemplate.pathname
+    .split("/")
+    .filter((s) => s.length > 0);
+
+  if (urlSegments.length !== templateSegments.length) return false;
+
+  for (let i = 0; i < templateSegments.length; i++) {
+    const tSeg = templateSegments[i];
+    const uSeg = urlSegments[i];
+
+    if (tSeg === "{:num}") {
+      if (!NUMERIC_RE.test(uSeg)) return false;
+    } else if (tSeg === "{:uuid}") {
+      if (!UUID_RE.test(uSeg)) return false;
+    } else if (tSeg === "{:hex}") {
+      if (!HEX_LONG_RE.test(uSeg)) return false;
+    } else {
+      // Literal match (case-sensitive)
+      if (tSeg !== uSeg) return false;
+    }
+  }
+
+  return true;
+}

--- a/credential-executor/src/http/policy.ts
+++ b/credential-executor/src/http/policy.ts
@@ -1,0 +1,256 @@
+/**
+ * HTTP policy evaluation for the Credential Execution Service.
+ *
+ * Evaluates incoming HTTP requests against the CES grant stores before any
+ * outbound network call is made. If no active grant covers the request, the
+ * policy engine blocks the call and returns an `approval_required` result
+ * containing the minimal reusable HTTP capability proposal.
+ *
+ * Security invariants:
+ * - **Off-grant requests are blocked before any network call.** The CES must
+ *   never make an authenticated outbound HTTP request without a matching grant.
+ * - **Proposal derivation never auto-expands.** Proposals use the concrete
+ *   path template (with typed placeholders for dynamic segments), never host
+ *   wildcards or `/*`.
+ * - **Caller-supplied auth headers are rejected.** The untrusted agent must
+ *   not be able to smuggle raw `Authorization`, `Cookie`, or other auth
+ *   headers in the request — CES injects those from the materialised
+ *   credential.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { HttpGrantProposal } from "@vellumai/ces-contracts";
+
+import type { PersistentGrant, PersistentGrantStore } from "../grants/persistent-store.js";
+import type { TemporaryGrantStore } from "../grants/temporary-store.js";
+import {
+  deriveAllowedUrlPatterns,
+  derivePathTemplate,
+  urlMatchesTemplate,
+} from "./path-template.js";
+
+// ---------------------------------------------------------------------------
+// Auth header rejection
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers that the untrusted agent is forbidden from setting on credentialed
+ * requests. CES injects authentication; the caller must not override it.
+ */
+const FORBIDDEN_CALLER_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-api-key",
+  "x-auth-token",
+]);
+
+/**
+ * Returns the list of forbidden header names present in the caller-supplied
+ * headers, or an empty array if none are present.
+ */
+export function detectForbiddenHeaders(
+  headers: Record<string, string> | undefined,
+): string[] {
+  if (!headers) return [];
+  const forbidden: string[] = [];
+  for (const key of Object.keys(headers)) {
+    if (FORBIDDEN_CALLER_HEADERS.has(key.toLowerCase())) {
+      forbidden.push(key);
+    }
+  }
+  return forbidden;
+}
+
+// ---------------------------------------------------------------------------
+// Policy evaluation result
+// ---------------------------------------------------------------------------
+
+export type PolicyResult =
+  | { allowed: true; grantId: string; grantSource: "persistent" | "temporary" }
+  | { allowed: false; reason: "forbidden_headers"; forbiddenHeaders: string[] }
+  | {
+      allowed: false;
+      reason: "approval_required";
+      proposal: HttpGrantProposal;
+    };
+
+// ---------------------------------------------------------------------------
+// Policy evaluation request
+// ---------------------------------------------------------------------------
+
+export interface HttpPolicyRequest {
+  /** CES credential handle identifying which credential to use. */
+  credentialHandle: string;
+  /** HTTP method (e.g. "GET", "POST"). */
+  method: string;
+  /** Target URL. */
+  url: string;
+  /** Caller-supplied headers (before credential injection). */
+  headers?: Record<string, string>;
+  /** Human-readable purpose for the audit trail. */
+  purpose: string;
+  /** Explicit grant ID the caller claims to hold. */
+  grantId?: string;
+  /** Conversation ID for thread-scoped temporary grants. */
+  conversationId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Policy evaluator
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether an HTTP request is covered by an existing grant.
+ *
+ * Evaluation order:
+ * 1. Reject forbidden caller-supplied auth headers.
+ * 2. If an explicit `grantId` is provided, look it up in the persistent store.
+ * 3. Check the persistent grant store for a matching active grant.
+ * 4. Check the temporary grant store for a matching temporary grant.
+ * 5. If no grant matches, derive a minimal proposal and return `approval_required`.
+ */
+export function evaluateHttpPolicy(
+  request: HttpPolicyRequest,
+  persistentStore: PersistentGrantStore,
+  temporaryStore: TemporaryGrantStore,
+): PolicyResult {
+  // 1. Reject forbidden caller-supplied auth headers
+  const forbidden = detectForbiddenHeaders(request.headers);
+  if (forbidden.length > 0) {
+    return {
+      allowed: false,
+      reason: "forbidden_headers",
+      forbiddenHeaders: forbidden,
+    };
+  }
+
+  // 2. Check explicit grantId in persistent store
+  if (request.grantId) {
+    const grant = persistentStore.getById(request.grantId);
+    if (grant) {
+      return { allowed: true, grantId: grant.id, grantSource: "persistent" };
+    }
+    // Explicit grant not found — fall through to pattern matching
+  }
+
+  // 3. Check persistent grants for pattern match
+  const pathTemplate = derivePathTemplate(request.url);
+  const allGrants = persistentStore.getAll();
+  for (const grant of allGrants) {
+    if (
+      grant.tool === "http" &&
+      grantCoversRequest(grant, request.credentialHandle, request.method, request.url, pathTemplate)
+    ) {
+      return { allowed: true, grantId: grant.id, grantSource: "persistent" };
+    }
+  }
+
+  // 4. Check temporary grants
+  // Build a proposal hash key from the canonical request shape
+  const proposal = buildProposal(request, pathTemplate);
+  const proposalHash = hashProposalForLookup(proposal);
+
+  const tempKind = temporaryStore.checkAny(
+    proposalHash,
+    request.conversationId,
+  );
+  if (tempKind) {
+    return {
+      allowed: true,
+      grantId: `temp:${tempKind}:${proposalHash}`,
+      grantSource: "temporary",
+    };
+  }
+
+  // 5. No grant matches — derive proposal
+  return {
+    allowed: false,
+    reason: "approval_required",
+    proposal,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grant matching helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a persistent grant covers a specific HTTP request.
+ *
+ * A grant covers a request when:
+ * - The grant's `pattern` field contains an `allowedUrlPatterns`-style
+ *   entry that matches the request URL's path template.
+ * - The grant's `scope` field matches the credential handle.
+ * - The grant is for the `http` tool type.
+ */
+function grantCoversRequest(
+  grant: PersistentGrant,
+  credentialHandle: string,
+  method: string,
+  rawUrl: string,
+  _pathTemplate: string,
+): boolean {
+  // Scope must match the credential handle
+  if (grant.scope !== credentialHandle) return false;
+
+  // The pattern field encodes "METHOD pattern", e.g. "GET https://api.github.com/repos/{:uuid}/pulls"
+  // Parse out the method and URL pattern
+  const spaceIdx = grant.pattern.indexOf(" ");
+  if (spaceIdx === -1) {
+    // Pattern without method — match URL only
+    return urlMatchesTemplate(rawUrl, grant.pattern);
+  }
+
+  const grantMethod = grant.pattern.slice(0, spaceIdx).toUpperCase();
+  const grantUrlPattern = grant.pattern.slice(spaceIdx + 1);
+
+  if (grantMethod !== method.toUpperCase()) return false;
+  return urlMatchesTemplate(rawUrl, grantUrlPattern);
+}
+
+// ---------------------------------------------------------------------------
+// Proposal construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the minimal HTTP grant proposal for an unapproved request.
+ *
+ * The proposal uses the derived path template as the `allowedUrlPatterns`
+ * entry — never `/*` or host-level wildcards.
+ */
+function buildProposal(
+  request: HttpPolicyRequest,
+  _pathTemplate: string,
+): HttpGrantProposal {
+  return {
+    type: "http",
+    credentialHandle: request.credentialHandle,
+    method: request.method.toUpperCase(),
+    url: request.url,
+    purpose: request.purpose,
+    allowedUrlPatterns: deriveAllowedUrlPatterns(request.url),
+  };
+}
+
+/**
+ * Compute a deterministic hash key for temporary grant lookup.
+ *
+ * Uses the same canonical JSON → SHA-256 approach as the contracts package
+ * `hashProposal`, but we use a simplified inline version here to avoid
+ * importing the full contracts rendering module into the policy hot path.
+ */
+function hashProposalForLookup(proposal: HttpGrantProposal): string {
+  // Build a canonical key from the proposal's stable fields:
+  // type + credentialHandle + method + allowedUrlPatterns (sorted)
+  const parts = [
+    proposal.type,
+    proposal.credentialHandle,
+    proposal.method.toUpperCase(),
+    ...(proposal.allowedUrlPatterns ?? []).slice().sort(),
+  ];
+  const canonical = JSON.stringify(parts);
+
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}

--- a/credential-executor/src/http/response-filter.ts
+++ b/credential-executor/src/http/response-filter.ts
@@ -1,0 +1,233 @@
+/**
+ * HTTP response filtering for the Credential Execution Service.
+ *
+ * Sanitises raw HTTP responses before returning them to the untrusted
+ * assistant runtime. The assistant must never receive:
+ * - Raw auth-bearing response headers (e.g. `set-cookie`, `www-authenticate`)
+ * - Echoed secret values in response bodies (defense-in-depth scrubbing)
+ * - Unbounded response bodies that could exhaust memory
+ *
+ * The filter also produces a token-free audit summary of every HTTP
+ * interaction for the CES audit log.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum response body size returned to the assistant (256 KB).
+ *
+ * Responses larger than this are truncated with a suffix indicating
+ * the original size. The full body is never stored — this is a hard
+ * clamp, not a soft limit.
+ */
+const MAX_BODY_BYTES = 256 * 1024;
+
+/**
+ * Response headers that are safe to pass through to the assistant.
+ *
+ * Only these headers are included in the sanitised response.
+ * Everything else is stripped — especially `set-cookie`,
+ * `www-authenticate`, and any custom auth headers.
+ */
+const ALLOWED_RESPONSE_HEADERS = new Set([
+  "content-type",
+  "content-length",
+  "content-encoding",
+  "content-language",
+  "content-disposition",
+  "cache-control",
+  "etag",
+  "last-modified",
+  "date",
+  "x-request-id",
+  "x-ratelimit-limit",
+  "x-ratelimit-remaining",
+  "x-ratelimit-reset",
+  "retry-after",
+  "link",
+  "location",
+  "vary",
+  "accept-ranges",
+  "access-control-allow-origin",
+  "access-control-allow-methods",
+  "access-control-allow-headers",
+  "access-control-expose-headers",
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Raw HTTP response from the outbound call. */
+export interface RawHttpResponse {
+  /** HTTP status code. */
+  statusCode: number;
+  /** Raw response headers (key-value pairs, header names may be mixed case). */
+  headers: Record<string, string>;
+  /** Response body as a string. */
+  body: string;
+}
+
+/** Sanitised HTTP response safe for the assistant runtime. */
+export interface SanitisedHttpResponse {
+  /** HTTP status code (passed through). */
+  statusCode: number;
+  /** Whitelisted response headers (lowercased keys). */
+  headers: Record<string, string>;
+  /** Body clamped to MAX_BODY_BYTES with secrets scrubbed. */
+  body: string;
+  /** Whether the body was truncated. */
+  truncated: boolean;
+  /** Original body size in bytes (before truncation). */
+  originalBodyBytes: number;
+}
+
+// ---------------------------------------------------------------------------
+// Header filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter response headers to only include whitelisted safe headers.
+ *
+ * All header names are lowercased for consistent comparison.
+ */
+export function filterResponseHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (ALLOWED_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      filtered[key.toLowerCase()] = value;
+    }
+  }
+  return filtered;
+}
+
+// ---------------------------------------------------------------------------
+// Body clamping
+// ---------------------------------------------------------------------------
+
+/**
+ * Clamp the response body to the maximum allowed size.
+ *
+ * Returns the (possibly truncated) body and metadata about truncation.
+ */
+export function clampBody(body: string): {
+  clampedBody: string;
+  truncated: boolean;
+  originalBytes: number;
+} {
+  const bodyBytes = Buffer.byteLength(body, "utf-8");
+
+  if (bodyBytes <= MAX_BODY_BYTES) {
+    return {
+      clampedBody: body,
+      truncated: false,
+      originalBytes: bodyBytes,
+    };
+  }
+
+  // Truncate to MAX_BODY_BYTES. We use Buffer to handle multi-byte characters
+  // correctly — slice at byte boundaries and convert back to string.
+  const buf = Buffer.from(body, "utf-8");
+  const truncatedBuf = buf.subarray(0, MAX_BODY_BYTES);
+
+  // Decode back to string; incomplete multi-byte sequences at the end are
+  // replaced with the Unicode replacement character, which is acceptable
+  // for a truncated preview.
+  const truncatedBody = truncatedBuf.toString("utf-8");
+
+  return {
+    clampedBody:
+      truncatedBody +
+      `\n\n[CES: Response truncated from ${bodyBytes} bytes to ${MAX_BODY_BYTES} bytes]`,
+    truncated: true,
+    originalBytes: bodyBytes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Secret scrubbing (defense-in-depth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scrub exact occurrences of known secret values from a response body.
+ *
+ * This is a defense-in-depth measure for APIs that echo back auth tokens
+ * or API keys in their response bodies. The scrubbing replaces exact
+ * matches of the secret with a redacted placeholder.
+ *
+ * Limitations:
+ * - Only scrubs exact matches (no partial or encoded variants).
+ * - Short secrets (< 8 characters) are skipped to avoid false positives.
+ * - This is NOT a primary security control — the grant system and
+ *   credential isolation are the real boundaries.
+ */
+export function scrubSecrets(body: string, secrets: string[]): string {
+  let result = body;
+  for (const secret of secrets) {
+    // Skip short secrets to avoid false positives with common substrings
+    if (secret.length < 8) continue;
+    // Use a simple global replace — secrets are treated as literal strings
+    result = replaceAll(result, secret, "[CES:REDACTED]");
+  }
+  return result;
+}
+
+/**
+ * Replace all occurrences of `search` in `str` with `replacement`.
+ *
+ * Uses a simple loop to avoid regex special-character escaping issues
+ * with secret values that may contain regex metacharacters.
+ */
+function replaceAll(str: string, search: string, replacement: string): string {
+  if (search.length === 0) return str;
+
+  let result = "";
+  let idx = 0;
+  while (idx < str.length) {
+    const foundAt = str.indexOf(search, idx);
+    if (foundAt === -1) {
+      result += str.slice(idx);
+      break;
+    }
+    result += str.slice(idx, foundAt) + replacement;
+    idx = foundAt + search.length;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Full response filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the full sanitisation pipeline to a raw HTTP response.
+ *
+ * Pipeline:
+ * 1. Filter response headers to the whitelist.
+ * 2. Clamp the body to MAX_BODY_BYTES.
+ * 3. Scrub known secrets from the (already clamped) body.
+ *
+ * @param raw - The raw HTTP response from the outbound call.
+ * @param secrets - Known secret values to scrub from the body.
+ * @returns Sanitised response safe for the assistant runtime.
+ */
+export function filterHttpResponse(
+  raw: RawHttpResponse,
+  secrets: string[] = [],
+): SanitisedHttpResponse {
+  const filteredHeaders = filterResponseHeaders(raw.headers);
+  const { clampedBody, truncated, originalBytes } = clampBody(raw.body);
+  const scrubbedBody = scrubSecrets(clampedBody, secrets);
+
+  return {
+    statusCode: raw.statusCode,
+    headers: filteredHeaders,
+    body: scrubbedBody,
+    truncated,
+    originalBodyBytes: originalBytes,
+  };
+}


### PR DESCRIPTION
## Summary
- Add deterministic path-template derivation with typed placeholders for numeric/UUID/hex segments
- Add HTTP policy evaluation blocking off-grant requests before network calls
- Add response filtering with body clamping, header whitelisting, secret scrubbing, and audit summaries

Part of plan: untrusted-agent-credential-arch.md (PR 21 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
