### PR TITLE
fix: align guardian DDL timestamp column types with Drizzle schema

### DIFF
--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -79,6 +79,7 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => "/tmp",
   getDataDir: () => "/tmp",
+  getDbPath: () => "/tmp/assistant.db",
   ensureDataDir: () => {},
 }));
 

--- a/assistant/src/memory/migrations/033-scoped-approval-grants.ts
+++ b/assistant/src/memory/migrations/033-scoped-approval-grants.ts
@@ -26,11 +26,11 @@ export function createScopedApprovalGrantsTable(database: DrizzleDb): void {
       requester_external_user_id TEXT,
       guardian_external_user_id TEXT,
       status TEXT NOT NULL,
-      expires_at TEXT NOT NULL,
-      consumed_at TEXT,
+      expires_at INTEGER NOT NULL,
+      consumed_at INTEGER,
       consumed_by_request_id TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
     )
   `);
 

--- a/assistant/src/memory/migrations/121-canonical-guardian-requests.ts
+++ b/assistant/src/memory/migrations/121-canonical-guardian-requests.ts
@@ -27,9 +27,9 @@ export function createCanonicalGuardianTables(database: DrizzleDb): void {
       answer_text TEXT,
       decided_by_external_user_id TEXT,
       followup_state TEXT,
-      expires_at TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
+      expires_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
     )
   `);
 
@@ -61,8 +61,8 @@ export function createCanonicalGuardianTables(database: DrizzleDb): void {
       destination_chat_id TEXT,
       destination_message_id TEXT,
       status TEXT NOT NULL DEFAULT 'pending',
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
     )
   `);
 


### PR DESCRIPTION
## Summary
- Updated `CREATE TABLE IF NOT EXISTS` DDLs in migrations 121 (canonical guardian tables) and 033 (scoped approval grants) to declare timestamp columns as `INTEGER` instead of `TEXT`, matching the Drizzle schema changed in #16867
- Added missing `getDbPath` export to the `platform.js` mock in `tool-execution-abort-cleanup.test.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100574825/job/67100519906

🤖 Generated with [Claude Code](https://claude.com/claude-code)