### PR TITLE
[ces] Wire authenticated HTTP execution across local and managed handles

### DIFF
--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -1,0 +1,1234 @@
+/**
+ * Integration tests for the CES HTTP executor.
+ *
+ * Covers:
+ * 1. Local static secret flow — resolve, grant-check, materialise, execute, filter
+ * 2. Local OAuth flow — resolve, grant-check, materialise (with token), execute, filter
+ * 3. platform_oauth:<connection_id> flow — resolve, grant-check, materialise via
+ *    platform, execute, filter
+ * 4. Approval-required short-circuit — off-grant requests return a proposal
+ *    without making any network call
+ * 5. Forbidden header rejection — caller-supplied auth headers are blocked
+ * 6. Redirect denial — redirect hops that violate grant policy are blocked
+ * 7. Filtered response behaviour — secret scrubbing, header stripping, body clamping
+ * 8. Audit summaries are token-free
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  localStaticHandle,
+  localOAuthHandle,
+  platformOAuthHandle,
+} from "@vellumai/ces-contracts";
+import {
+  type OAuthConnectionRecord,
+  type SecureKeyBackend,
+  type SecureKeyDeleteResult,
+  type StaticCredentialRecord,
+  StaticCredentialMetadataStore,
+  oauthConnectionAccessTokenPath,
+  credentialKey,
+} from "@vellumai/credential-storage";
+
+import {
+  executeAuthenticatedHttpRequest,
+  type HttpExecutorDeps,
+} from "../http/executor.js";
+import { PersistentGrantStore } from "../grants/persistent-store.js";
+import { TemporaryGrantStore } from "../grants/temporary-store.js";
+import { LocalMaterialiser } from "../materializers/local.js";
+import type { OAuthConnectionLookup, LocalSubjectResolverDeps } from "../subjects/local.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `ces-http-executor-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * In-memory secure-key backend for testing.
+ */
+function createMemoryBackend(
+  initial: Record<string, string> = {},
+): SecureKeyBackend {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    async get(key: string): Promise<string | undefined> {
+      return store.get(key);
+    },
+    async set(key: string, value: string): Promise<boolean> {
+      store.set(key, value);
+      return true;
+    },
+    async delete(key: string): Promise<SecureKeyDeleteResult> {
+      if (store.has(key)) {
+        store.delete(key);
+        return "deleted";
+      }
+      return "not-found";
+    },
+    async list(): Promise<string[]> {
+      return Array.from(store.keys());
+    },
+  };
+}
+
+function buildStaticRecord(
+  overrides: Partial<StaticCredentialRecord> = {},
+): StaticCredentialRecord {
+  return {
+    credentialId: overrides.credentialId ?? "cred-uuid-1",
+    service: overrides.service ?? "github",
+    field: overrides.field ?? "api_key",
+    allowedTools: overrides.allowedTools ?? [],
+    allowedDomains: overrides.allowedDomains ?? [],
+    createdAt: overrides.createdAt ?? Date.now(),
+    updatedAt: overrides.updatedAt ?? Date.now(),
+  };
+}
+
+function buildOAuthConnection(
+  overrides: Partial<OAuthConnectionRecord> = {},
+): OAuthConnectionRecord {
+  return {
+    id: overrides.id ?? "conn-uuid-1",
+    providerKey: overrides.providerKey ?? "integration:google",
+    accountInfo: overrides.accountInfo ?? "user@example.com",
+    grantedScopes: overrides.grantedScopes ?? ["openid", "email"],
+    accessTokenPath: overrides.accessTokenPath ??
+      oauthConnectionAccessTokenPath(overrides.id ?? "conn-uuid-1"),
+    hasRefreshToken: overrides.hasRefreshToken ?? true,
+    expiresAt: overrides.expiresAt ?? null,
+    createdAt: overrides.createdAt ?? Date.now(),
+    updatedAt: overrides.updatedAt ?? Date.now(),
+  };
+}
+
+function createOAuthLookup(
+  connections: OAuthConnectionRecord[] = [],
+): OAuthConnectionLookup {
+  const byId = new Map(connections.map((c) => [c.id, c]));
+  return {
+    getById(id: string) {
+      return byId.get(id);
+    },
+  };
+}
+
+/**
+ * Build a mock fetch that returns a predetermined response.
+ */
+function mockFetch(
+  statusCode: number,
+  body: string,
+  headers?: Record<string, string>,
+): typeof globalThis.fetch {
+  return async (_url: string | URL | Request, _init?: RequestInit) => {
+    const responseHeaders = new Headers(headers ?? {});
+    if (!responseHeaders.has("content-type")) {
+      responseHeaders.set("content-type", "application/json");
+    }
+    return new Response(body, {
+      status: statusCode,
+      headers: responseHeaders,
+    });
+  };
+}
+
+/**
+ * Build a mock fetch that records requests for inspection.
+ */
+function mockFetchRecorder(
+  statusCode: number,
+  body: string,
+  headers?: Record<string, string>,
+): {
+  fetch: typeof globalThis.fetch;
+  requests: Array<{ url: string; init?: RequestInit }>;
+} {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchFn = async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    requests.push({ url: url.toString(), init });
+    const responseHeaders = new Headers(headers ?? {});
+    if (!responseHeaders.has("content-type")) {
+      responseHeaders.set("content-type", "application/json");
+    }
+    return new Response(body, {
+      status: statusCode,
+      headers: responseHeaders,
+    });
+  };
+  return { fetch: fetchFn, requests };
+}
+
+/**
+ * Build a mock fetch that returns a redirect on first call, then a real
+ * response on subsequent calls.
+ */
+function mockFetchRedirect(
+  redirectUrl: string,
+  redirectStatus: number,
+  finalStatusCode: number,
+  finalBody: string,
+): typeof globalThis.fetch {
+  let callCount = 0;
+  return async (_url: string | URL | Request, _init?: RequestInit) => {
+    callCount++;
+    if (callCount === 1) {
+      return new Response(null, {
+        status: redirectStatus,
+        headers: { Location: redirectUrl },
+      });
+    }
+    return new Response(finalBody, {
+      status: finalStatusCode,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+/** Silent logger that suppresses output during tests. */
+const silentLogger: Pick<Console, "log" | "warn" | "error"> = {
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+interface TestFixture {
+  tmpDir: string;
+  persistentStore: PersistentGrantStore;
+  temporaryStore: TemporaryGrantStore;
+  backend: SecureKeyBackend;
+  metadataStore: StaticCredentialMetadataStore;
+  localMaterialiser: LocalMaterialiser;
+}
+
+function createFixture(
+  secretEntries: Record<string, string> = {},
+  staticRecords: StaticCredentialRecord[] = [],
+  oauthConnections: OAuthConnectionRecord[] = [],
+): TestFixture {
+  const tmpDir = makeTmpDir();
+  const persistentStore = new PersistentGrantStore(tmpDir);
+  persistentStore.init();
+  const temporaryStore = new TemporaryGrantStore();
+
+  const backend = createMemoryBackend(secretEntries);
+  const metadataStore = new StaticCredentialMetadataStore();
+  for (const record of staticRecords) {
+    metadataStore.upsert(record);
+  }
+
+  const oauthLookup = createOAuthLookup(oauthConnections);
+
+  const localMaterialiser = new LocalMaterialiser({
+    secureKeyBackend: backend,
+  });
+
+  return {
+    tmpDir,
+    persistentStore,
+    temporaryStore,
+    backend,
+    metadataStore,
+    localMaterialiser,
+  };
+}
+
+function buildDeps(
+  fixture: TestFixture,
+  oauthConnections: OAuthConnectionRecord[] = [],
+  overrides: Partial<HttpExecutorDeps> = {},
+): HttpExecutorDeps {
+  return {
+    persistentGrantStore: fixture.persistentStore,
+    temporaryGrantStore: fixture.temporaryStore,
+    localMaterialiser: fixture.localMaterialiser,
+    localSubjectDeps: {
+      metadataStore: fixture.metadataStore,
+      oauthConnections: createOAuthLookup(oauthConnections),
+    },
+    sessionId: "test-session",
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Local static secrets
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: local static secrets", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const handle = localStaticHandle("github", "api_key");
+    const storageKey = credentialKey("github", "api_key");
+    fixture = createFixture(
+      { [storageKey]: "ghp_testtoken_12345678" },
+      [buildStaticRecord({ service: "github", field: "api_key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("successful request with matching grant", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Add a matching grant
+    fixture.persistentStore.add({
+      id: "grant-github-repos",
+      tool: "http",
+      pattern: "GET https://api.github.com/repos/owner/repo",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const { fetch: fetchFn, requests } = mockFetchRecorder(
+      200,
+      '{"name": "repo", "full_name": "owner/repo"}',
+    );
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/repos/owner/repo",
+        purpose: "Get repo info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.responseBody).toContain("owner/repo");
+    expect(result.auditId).toBeDefined();
+
+    // Verify the outbound request had auth injected
+    expect(requests).toHaveLength(1);
+    const outboundHeaders = requests[0].init?.headers as Record<string, string>;
+    expect(outboundHeaders?.["Authorization"]).toContain("Bearer");
+    expect(outboundHeaders?.["Authorization"]).toContain("ghp_testtoken_12345678");
+  });
+
+  test("response body is scrubbed of secret values", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-github-user",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Simulate API echoing back the token in response
+    const fetchFn = mockFetch(
+      200,
+      '{"token_echo": "ghp_testtoken_12345678", "name": "octocat"}',
+    );
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseBody).not.toContain("ghp_testtoken_12345678");
+    expect(result.responseBody).toContain("[CES:REDACTED]");
+    expect(result.responseBody).toContain("octocat");
+  });
+
+  test("response headers are filtered (set-cookie stripped)", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-github-data",
+      tool: "http",
+      pattern: "GET https://api.github.com/data",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn = mockFetch(200, '{"ok": true}', {
+      "content-type": "application/json",
+      "set-cookie": "session=secret; HttpOnly",
+      "x-request-id": "req-123",
+    });
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseHeaders).toBeDefined();
+    expect(result.responseHeaders!["content-type"]).toBe("application/json");
+    expect(result.responseHeaders!["x-request-id"]).toBe("req-123");
+    // set-cookie must be stripped
+    expect(result.responseHeaders!["set-cookie"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Local OAuth
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: local OAuth", () => {
+  let fixture: TestFixture;
+  let connection: OAuthConnectionRecord;
+
+  beforeEach(() => {
+    connection = buildOAuthConnection({
+      id: "conn-google-1",
+      providerKey: "integration:google",
+      expiresAt: Date.now() + 3600000, // valid for 1 hour
+    });
+
+    const accessTokenPath = oauthConnectionAccessTokenPath("conn-google-1");
+    fixture = createFixture(
+      { [accessTokenPath]: "ya29.test-google-token-abc123" },
+      [],
+      [connection],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("successful OAuth request with matching grant", async () => {
+    const handle = localOAuthHandle("integration:google", "conn-google-1");
+
+    fixture.persistentStore.add({
+      id: "grant-google-calendar",
+      tool: "http",
+      pattern: "GET https://www.googleapis.com/calendar/v3/calendars/primary/events",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const { fetch: fetchFn, requests } = mockFetchRecorder(
+      200,
+      '{"items": [{"summary": "Meeting"}]}',
+    );
+
+    const deps = buildDeps(fixture, [connection], { fetch: fetchFn });
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+        purpose: "List calendar events",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.responseBody).toContain("Meeting");
+    expect(result.auditId).toBeDefined();
+
+    // Verify Bearer token was injected
+    expect(requests).toHaveLength(1);
+    const outboundHeaders = requests[0].init?.headers as Record<string, string>;
+    expect(outboundHeaders?.["Authorization"]).toBe(
+      "Bearer ya29.test-google-token-abc123",
+    );
+  });
+
+  test("OAuth token scrubbed from response body", async () => {
+    const handle = localOAuthHandle("integration:google", "conn-google-1");
+
+    fixture.persistentStore.add({
+      id: "grant-google-debug",
+      tool: "http",
+      pattern: "GET https://www.googleapis.com/oauth2/v1/tokeninfo",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Simulate tokeninfo endpoint echoing the token
+    const fetchFn = mockFetch(
+      200,
+      '{"access_token": "ya29.test-google-token-abc123", "expires_in": 3600}',
+    );
+
+    const deps = buildDeps(fixture, [connection], { fetch: fetchFn });
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://www.googleapis.com/oauth2/v1/tokeninfo",
+        purpose: "Check token info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseBody).not.toContain("ya29.test-google-token-abc123");
+    expect(result.responseBody).toContain("[CES:REDACTED]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Managed (platform_oauth) handles
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: platform_oauth handles", () => {
+  let fixture: TestFixture;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    fixture = createFixture();
+    tmpDir = fixture.tmpDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("successful platform OAuth request", async () => {
+    const handle = platformOAuthHandle("conn-platform-1");
+
+    fixture.persistentStore.add({
+      id: "grant-platform-api",
+      tool: "http",
+      pattern: "GET https://api.slack.com/api/conversations.list",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Mock the platform catalog response
+    const platformCatalogFetch = async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const urlStr = url.toString();
+
+      // Platform catalog
+      if (urlStr.includes("/v1/ces/catalog")) {
+        return new Response(
+          JSON.stringify({
+            connections: [
+              {
+                id: "conn-platform-1",
+                provider: "slack",
+                account_info: "workspace@slack.com",
+                granted_scopes: ["channels:read"],
+                status: "active",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // Platform token materialization
+      if (urlStr.includes("/v1/ces/connections/conn-platform-1/materialize")) {
+        return new Response(
+          JSON.stringify({
+            access_token: "xoxp-platform-token-12345678",
+            token_type: "Bearer",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // The actual outbound Slack API call
+      if (urlStr.includes("api.slack.com")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            channels: [{ name: "general" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("Not found", { status: 404 });
+    };
+
+    const deps = buildDeps(fixture, [], {
+      fetch: platformCatalogFetch,
+      managedSubjectOptions: {
+        platformBaseUrl: "https://api.vellum.ai",
+        assistantApiKey: "test-api-key",
+        fetch: platformCatalogFetch,
+      },
+      managedMaterializerOptions: {
+        platformBaseUrl: "https://api.vellum.ai",
+        assistantApiKey: "test-api-key",
+        fetch: platformCatalogFetch,
+      },
+    });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.slack.com/api/conversations.list",
+        purpose: "List Slack channels",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.responseBody).toContain("general");
+    expect(result.auditId).toBeDefined();
+
+    // Token should be scrubbed from body
+    expect(result.responseBody).not.toContain("xoxp-platform-token-12345678");
+  });
+
+  test("fails when managed mode is not configured", async () => {
+    const handle = platformOAuthHandle("conn-platform-1");
+
+    fixture.persistentStore.add({
+      id: "grant-platform-unconfigured",
+      tool: "http",
+      pattern: "GET https://api.slack.com/data",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // No managedSubjectOptions or managedMaterializerOptions
+    const deps = buildDeps(fixture, []);
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.slack.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe("MATERIALISATION_FAILED");
+    expect(result.error!.message).toContain("not configured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Approval required short-circuit
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: approval-required short-circuit", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("stripe", "api_key");
+    fixture = createFixture(
+      { [storageKey]: "sk_test_abcdefghijklmnop" },
+      [buildStaticRecord({ service: "stripe", field: "api_key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("off-grant request returns approval_required without network call", async () => {
+    const handle = localStaticHandle("stripe", "api_key");
+    // No grant added — should be blocked
+
+    const { fetch: fetchFn, requests } = mockFetchRecorder(200, '{"ok": true}');
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "POST",
+        url: "https://api.stripe.com/v1/charges",
+        purpose: "Create a charge",
+      },
+      deps,
+    );
+
+    // Request must be blocked
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe("APPROVAL_REQUIRED");
+    expect(result.error!.details).toBeDefined();
+    expect((result.error!.details as Record<string, unknown>).proposal).toBeDefined();
+    expect((result.error!.details as Record<string, unknown>).proposalHash).toBeDefined();
+
+    // No network call should have been made
+    expect(requests).toHaveLength(0);
+  });
+
+  test("proposal contains specific URL pattern (no wildcards)", async () => {
+    const handle = localStaticHandle("stripe", "api_key");
+
+    const deps = buildDeps(fixture, []);
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.stripe.com/v1/charges/123",
+        purpose: "Get charge",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("APPROVAL_REQUIRED");
+
+    const proposal = (result.error!.details as Record<string, unknown>)
+      .proposal as Record<string, unknown>;
+    const allowedPatterns = proposal.allowedUrlPatterns as string[];
+    expect(allowedPatterns).toBeDefined();
+    expect(allowedPatterns.length).toBeGreaterThan(0);
+
+    for (const pattern of allowedPatterns) {
+      expect(pattern).not.toContain("/*");
+      expect(pattern).not.toContain("*.");
+      // Should have {:num} for the charge ID
+      expect(pattern).toContain("{:num}");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Forbidden header rejection
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: forbidden header rejection", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("github", "api_key");
+    fixture = createFixture(
+      { [storageKey]: "ghp_testtoken_12345678" },
+      [buildStaticRecord({ service: "github", field: "api_key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("rejects request with Authorization header", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Even with a matching grant, should be rejected
+    fixture.persistentStore.add({
+      id: "grant-with-auth",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const { fetch: fetchFn, requests } = mockFetchRecorder(200, '{"ok": true}');
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        headers: { Authorization: "Bearer smuggled-token" },
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("FORBIDDEN_HEADERS");
+    expect(result.error!.message).toContain("Authorization");
+    expect(requests).toHaveLength(0);
+  });
+
+  test("rejects request with Cookie header", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-with-cookie",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const { fetch: fetchFn, requests } = mockFetchRecorder(200, '{"ok": true}');
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        headers: { Cookie: "session=hijacked" },
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("FORBIDDEN_HEADERS");
+    expect(requests).toHaveLength(0);
+  });
+
+  test("rejects request with X-Api-Key header", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-with-xapikey",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const deps = buildDeps(fixture, []);
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        headers: { "X-Api-Key": "smuggled-key" },
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("FORBIDDEN_HEADERS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Redirect denial
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: redirect denial", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("github", "api_key");
+    fixture = createFixture(
+      { [storageKey]: "ghp_testtoken_12345678" },
+      [buildStaticRecord({ service: "github", field: "api_key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("blocks redirect to domain not covered by grant", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Grant only covers api.github.com
+    fixture.persistentStore.add({
+      id: "grant-github-only",
+      tool: "http",
+      pattern: "GET https://api.github.com/repos/owner/repo",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Redirect to an evil domain
+    const fetchFn = mockFetchRedirect(
+      "https://evil.example.com/steal-token",
+      302,
+      200,
+      '{"stolen": true}',
+    );
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/repos/owner/repo",
+        purpose: "Get repo info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("HTTP_REQUEST_FAILED");
+    expect(result.error!.message).toContain("redirect");
+    expect(result.error!.message).toContain("denied");
+  });
+
+  test("allows redirect to path covered by same grant", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Grant covers a template that matches both source and redirect target
+    fixture.persistentStore.add({
+      id: "grant-github-repos-template",
+      tool: "http",
+      pattern: "GET https://api.github.com/repos/owner/repo",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Redirect to the same domain/path that matches the grant
+    let callCount = 0;
+    const fetchFn: typeof globalThis.fetch = async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(null, {
+          status: 301,
+          headers: { Location: "https://api.github.com/repos/owner/repo" },
+        });
+      }
+      return new Response('{"name": "repo"}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/repos/owner/repo",
+        purpose: "Get repo info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Filtered response behaviour
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: filtered response behaviour", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("example", "key");
+    fixture = createFixture(
+      { [storageKey]: "secret-key-value-12345678" },
+      [buildStaticRecord({ service: "example", field: "key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("strips www-authenticate from response headers", async () => {
+    const handle = localStaticHandle("example", "key");
+
+    fixture.persistentStore.add({
+      id: "grant-example",
+      tool: "http",
+      pattern: "GET https://api.example.com/protected",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn = mockFetch(401, '{"error": "unauthorized"}', {
+      "www-authenticate": "Bearer realm=api",
+      "content-type": "application/json",
+    });
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.example.com/protected",
+        purpose: "Access protected resource",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(401);
+    expect(result.responseHeaders!["www-authenticate"]).toBeUndefined();
+    expect(result.responseHeaders!["content-type"]).toBe("application/json");
+  });
+
+  test("passes through safe response headers", async () => {
+    const handle = localStaticHandle("example", "key");
+
+    fixture.persistentStore.add({
+      id: "grant-example-safe",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn = mockFetch(200, '{"ok": true}', {
+      "content-type": "application/json",
+      "x-ratelimit-remaining": "42",
+      "x-request-id": "abc-def",
+      "etag": '"v1"',
+    });
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.example.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseHeaders!["content-type"]).toBe("application/json");
+    expect(result.responseHeaders!["x-ratelimit-remaining"]).toBe("42");
+    expect(result.responseHeaders!["x-request-id"]).toBe("abc-def");
+    expect(result.responseHeaders!["etag"]).toBe('"v1"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Audit summaries are token-free
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: audit summary integrity", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("github", "api_key");
+    fixture = createFixture(
+      { [storageKey]: "ghp_secrettoken_12345678" },
+      [buildStaticRecord({ service: "github", field: "api_key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("audit ID is returned on successful request", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-audit-test",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn = mockFetch(200, '{"login": "octocat"}');
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.auditId).toBeDefined();
+    expect(typeof result.auditId).toBe("string");
+    expect(result.auditId!.length).toBeGreaterThan(0);
+  });
+
+  test("audit ID is returned on materialisation failure", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Grant exists but we'll break materialisation by using a handle that
+    // won't resolve (wrong service)
+    const badHandle = localStaticHandle("nonexistent", "key");
+    fixture.persistentStore.add({
+      id: "grant-bad-cred",
+      tool: "http",
+      pattern: "GET https://api.github.com/user",
+      scope: badHandle,
+      createdAt: Date.now(),
+    });
+
+    const deps = buildDeps(fixture, []);
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: badHandle,
+        method: "GET",
+        url: "https://api.github.com/user",
+        purpose: "Get user info",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("MATERIALISATION_FAILED");
+    expect(result.auditId).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Invalid handle
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: invalid handle", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = createFixture();
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("rejects completely invalid handle format", async () => {
+    const deps = buildDeps(fixture, []);
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: "not-a-valid-handle",
+        method: "GET",
+        url: "https://api.example.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("INVALID_HANDLE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Network error handling
+// ---------------------------------------------------------------------------
+
+describe("HTTP executor: network error handling", () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    const storageKey = credentialKey("example", "key");
+    fixture = createFixture(
+      { [storageKey]: "secret-key-value-12345678" },
+      [buildStaticRecord({ service: "example", field: "key" })],
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture.tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns error when fetch fails", async () => {
+    const handle = localStaticHandle("example", "key");
+
+    fixture.persistentStore.add({
+      id: "grant-network-fail",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn: typeof globalThis.fetch = async () => {
+      throw new Error("Connection refused");
+    };
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.example.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe("HTTP_REQUEST_FAILED");
+    expect(result.error!.message).toContain("Connection refused");
+    expect(result.auditId).toBeDefined();
+  });
+
+  test("error message is scrubbed of secret values", async () => {
+    const handle = localStaticHandle("example", "key");
+
+    fixture.persistentStore.add({
+      id: "grant-error-scrub",
+      tool: "http",
+      pattern: "GET https://api.example.com/data",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    const fetchFn: typeof globalThis.fetch = async () => {
+      throw new Error(
+        "Failed to connect with token secret-key-value-12345678 to api.example.com",
+      );
+    };
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.example.com/data",
+        purpose: "Get data",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.message).not.toContain("secret-key-value-12345678");
+    expect(result.error!.message).toContain("[CES:REDACTED]");
+  });
+});

--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -1,0 +1,540 @@
+/**
+ * HTTP executor for the Credential Execution Service.
+ *
+ * Implements the full `make_authenticated_request` flow:
+ *
+ * 1. Resolve the credential handle to a local or managed subject.
+ * 2. Check grants (policy evaluation) — block off-grant requests before
+ *    any network call.
+ * 3. Materialise the credential through the appropriate backend.
+ * 4. Inject auth into the outbound request according to the subject's
+ *    handle type.
+ * 5. Perform the HTTP request.
+ * 6. Reject redirect hops that would violate the grant policy.
+ * 7. Filter the response through the PR 21 sanitisation pipeline.
+ * 8. Generate a token-free audit summary.
+ *
+ * Security invariants:
+ * - Off-grant requests never reach the network.
+ * - Caller-supplied raw auth headers are rejected.
+ * - Redirect hops to domains/paths outside the grant's scope are blocked.
+ * - The assistant runtime only sees sanitised HTTP results and audit
+ *   summaries — never raw tokens or secrets.
+ * - Audit summaries are always token-free.
+ */
+
+import type {
+  MakeAuthenticatedRequest,
+  MakeAuthenticatedRequestResponse,
+} from "@vellumai/ces-contracts";
+import { HandleType, parseHandle, hashProposal } from "@vellumai/ces-contracts";
+
+import { evaluateHttpPolicy, type PolicyResult } from "./policy.js";
+import { filterHttpResponse, type RawHttpResponse } from "./response-filter.js";
+import { generateHttpAuditSummary } from "./audit.js";
+
+import type { PersistentGrantStore } from "../grants/persistent-store.js";
+import type { TemporaryGrantStore } from "../grants/temporary-store.js";
+
+import type { LocalMaterialiser, MaterialisedCredential } from "../materializers/local.js";
+import { materializeManagedToken, type ManagedMaterializerOptions } from "../materializers/managed-platform.js";
+import { resolveLocalSubject, type LocalSubjectResolverDeps } from "../subjects/local.js";
+import { resolveManagedSubject, type ManagedSubjectResolverOptions } from "../subjects/managed.js";
+
+// ---------------------------------------------------------------------------
+// Auth injection constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers that are forbidden in caller-supplied requests. This is
+ * enforced at the policy layer, but we double-check before injection
+ * as defense-in-depth.
+ */
+const AUTH_HEADERS_TO_STRIP = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-api-key",
+  "x-auth-token",
+]);
+
+// ---------------------------------------------------------------------------
+// Executor dependencies
+// ---------------------------------------------------------------------------
+
+export interface HttpExecutorDeps {
+  /** Persistent grant store for policy evaluation. */
+  persistentGrantStore: PersistentGrantStore;
+  /** Temporary grant store for policy evaluation. */
+  temporaryGrantStore: TemporaryGrantStore;
+  /** Local materialiser for local_static and local_oauth handles. */
+  localMaterialiser: LocalMaterialiser;
+  /** Dependencies for local subject resolution. */
+  localSubjectDeps: LocalSubjectResolverDeps;
+  /** Options for managed subject resolution (null if managed mode is unavailable). */
+  managedSubjectOptions?: ManagedSubjectResolverOptions;
+  /** Options for managed token materialisation (null if managed mode is unavailable). */
+  managedMaterializerOptions?: ManagedMaterializerOptions;
+  /** Session ID for audit records. */
+  sessionId: string;
+  /** Optional custom fetch implementation (for testing). */
+  fetch?: typeof globalThis.fetch;
+  /** Optional logger. */
+  logger?: Pick<Console, "log" | "warn" | "error">;
+}
+
+// ---------------------------------------------------------------------------
+// Redirect policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of redirects to follow before aborting.
+ */
+const MAX_REDIRECTS = 5;
+
+/**
+ * HTTP status codes that indicate a redirect.
+ */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+// ---------------------------------------------------------------------------
+// Executor implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute an authenticated HTTP request through the full CES pipeline.
+ *
+ * This is the handler implementation for the `make_authenticated_request`
+ * RPC method. It is pure logic with injected dependencies, making it
+ * testable without real network calls or credential stores.
+ */
+export async function executeAuthenticatedHttpRequest(
+  request: MakeAuthenticatedRequest,
+  deps: HttpExecutorDeps,
+): Promise<MakeAuthenticatedRequestResponse> {
+  const logger = deps.logger ?? console;
+
+  // 1. Parse the handle to determine source (local vs managed)
+  const parseResult = parseHandle(request.credentialHandle);
+  if (!parseResult.ok) {
+    return {
+      success: false,
+      error: {
+        code: "INVALID_HANDLE",
+        message: parseResult.error,
+      },
+    };
+  }
+
+  // 2. Evaluate grant policy — blocks off-grant requests before network
+  const policyResult = evaluateHttpPolicy(
+    {
+      credentialHandle: request.credentialHandle,
+      method: request.method,
+      url: request.url,
+      headers: request.headers,
+      purpose: request.purpose,
+      grantId: request.grantId,
+    },
+    deps.persistentGrantStore,
+    deps.temporaryGrantStore,
+  );
+
+  if (!policyResult.allowed) {
+    if (policyResult.reason === "forbidden_headers") {
+      return {
+        success: false,
+        error: {
+          code: "FORBIDDEN_HEADERS",
+          message: `Request contains forbidden auth headers that the agent must not set: ${policyResult.forbiddenHeaders.join(", ")}. CES injects authentication — the caller must not supply raw auth headers.`,
+        },
+      };
+    }
+
+    // approval_required — return the proposal so the assistant can prompt
+    return {
+      success: false,
+      error: {
+        code: "APPROVAL_REQUIRED",
+        message: `No active grant covers this request. Approval is required.`,
+        details: {
+          proposal: policyResult.proposal,
+          proposalHash: hashProposal(policyResult.proposal),
+        },
+      },
+    };
+  }
+
+  const grantId = policyResult.grantId;
+
+  // 3. Materialise the credential
+  const materialiseResult = await materialiseCredential(
+    parseResult.handle.type,
+    request.credentialHandle,
+    deps,
+  );
+
+  if (!materialiseResult.ok) {
+    const audit = generateHttpAuditSummary({
+      credentialHandle: request.credentialHandle,
+      grantId,
+      sessionId: deps.sessionId,
+      method: request.method,
+      url: request.url,
+      success: false,
+      errorMessage: materialiseResult.error,
+    });
+
+    return {
+      success: false,
+      error: {
+        code: "MATERIALISATION_FAILED",
+        message: materialiseResult.error,
+      },
+      auditId: audit.auditId,
+    };
+  }
+
+  const { credential, secrets } = materialiseResult;
+
+  // 4. Build the outbound request with injected auth
+  const outboundHeaders = buildOutboundHeaders(
+    request.headers ?? {},
+    credential,
+  );
+
+  // 5. Perform the HTTP request with redirect enforcement
+  let rawResponse: RawHttpResponse;
+  try {
+    rawResponse = await performHttpRequest(
+      request.method,
+      request.url,
+      outboundHeaders,
+      request.body,
+      policyResult,
+      request.credentialHandle,
+      deps,
+    );
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    // Sanitise error messages to avoid leaking secrets
+    const safeError = sanitiseErrorMessage(errorMessage, secrets);
+
+    const audit = generateHttpAuditSummary({
+      credentialHandle: request.credentialHandle,
+      grantId,
+      sessionId: deps.sessionId,
+      method: request.method,
+      url: request.url,
+      success: false,
+      errorMessage: safeError,
+    });
+
+    return {
+      success: false,
+      error: {
+        code: "HTTP_REQUEST_FAILED",
+        message: safeError,
+      },
+      auditId: audit.auditId,
+    };
+  }
+
+  // 6. Filter the response through the sanitisation pipeline
+  const filtered = filterHttpResponse(rawResponse, secrets);
+
+  // 7. Generate audit summary
+  const audit = generateHttpAuditSummary({
+    credentialHandle: request.credentialHandle,
+    grantId,
+    sessionId: deps.sessionId,
+    method: request.method,
+    url: request.url,
+    success: true,
+    statusCode: rawResponse.statusCode,
+  });
+
+  logger.log(
+    `[ces-http] ${request.method} ${request.url} -> ${rawResponse.statusCode} (grant=${grantId})`,
+  );
+
+  return {
+    success: true,
+    statusCode: filtered.statusCode,
+    responseHeaders: filtered.headers,
+    responseBody: filtered.body,
+    auditId: audit.auditId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credential materialisation dispatch
+// ---------------------------------------------------------------------------
+
+interface MaterialiseSuccess {
+  ok: true;
+  credential: MaterialisedCredential;
+  /** Secret values to scrub from response bodies (defense-in-depth). */
+  secrets: string[];
+}
+
+interface MaterialiseFailure {
+  ok: false;
+  error: string;
+}
+
+type MaterialiseResult = MaterialiseSuccess | MaterialiseFailure;
+
+async function materialiseCredential(
+  handleType: string,
+  rawHandle: string,
+  deps: HttpExecutorDeps,
+): Promise<MaterialiseResult> {
+  switch (handleType) {
+    case HandleType.LocalStatic:
+    case HandleType.LocalOAuth: {
+      // Resolve local subject
+      const subjectResult = resolveLocalSubject(rawHandle, deps.localSubjectDeps);
+      if (!subjectResult.ok) {
+        return { ok: false, error: subjectResult.error };
+      }
+
+      // Materialise through the local materialiser
+      const matResult = await deps.localMaterialiser.materialise(subjectResult.subject);
+      if (!matResult.ok) {
+        return { ok: false, error: matResult.error };
+      }
+
+      return {
+        ok: true,
+        credential: matResult.credential,
+        secrets: [matResult.credential.value],
+      };
+    }
+
+    case HandleType.PlatformOAuth: {
+      if (!deps.managedSubjectOptions || !deps.managedMaterializerOptions) {
+        return {
+          ok: false,
+          error: "Managed OAuth is not configured. Platform URL and API key are required.",
+        };
+      }
+
+      // Resolve managed subject
+      const subjectResult = await resolveManagedSubject(
+        rawHandle,
+        deps.managedSubjectOptions,
+      );
+      if (!subjectResult.ok) {
+        return { ok: false, error: subjectResult.error.message };
+      }
+
+      // Materialise through the managed materialiser
+      const matResult = await materializeManagedToken(
+        subjectResult.subject,
+        deps.managedMaterializerOptions,
+      );
+      if (!matResult.ok) {
+        return { ok: false, error: matResult.error.message };
+      }
+
+      return {
+        ok: true,
+        credential: {
+          value: matResult.token.accessToken,
+          handleType: HandleType.PlatformOAuth,
+          expiresAt: matResult.token.expiresAt,
+        },
+        secrets: [matResult.token.accessToken],
+      };
+    }
+
+    default:
+      return {
+        ok: false,
+        error: `Unsupported handle type "${handleType}" for HTTP execution`,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth header injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the outbound request headers by:
+ * 1. Stripping any caller-supplied auth headers (defense-in-depth).
+ * 2. Injecting the credential as an Authorization header.
+ */
+function buildOutboundHeaders(
+  callerHeaders: Record<string, string>,
+  credential: MaterialisedCredential,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  // Copy caller headers, stripping any auth headers
+  for (const [key, value] of Object.entries(callerHeaders)) {
+    if (!AUTH_HEADERS_TO_STRIP.has(key.toLowerCase())) {
+      headers[key] = value;
+    }
+  }
+
+  // Inject credential based on handle type
+  switch (credential.handleType) {
+    case HandleType.LocalStatic:
+      // Static secrets are injected as Bearer tokens by default.
+      // The subject metadata could specify a different injection strategy
+      // in the future, but for now Bearer is the safe default.
+      headers["Authorization"] = `Bearer ${credential.value}`;
+      break;
+
+    case HandleType.LocalOAuth:
+    case HandleType.PlatformOAuth:
+      // OAuth tokens are always Bearer tokens.
+      headers["Authorization"] = `Bearer ${credential.value}`;
+      break;
+
+    default:
+      // Unknown type — inject as Bearer (fail-open on injection is OK
+      // because the grant policy already vetted the request).
+      headers["Authorization"] = `Bearer ${credential.value}`;
+      break;
+  }
+
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP request execution with redirect enforcement
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform an HTTP request, following redirects only when each hop
+ * independently satisfies the grant policy.
+ */
+async function performHttpRequest(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body: unknown | undefined,
+  originalPolicy: PolicyResult & { allowed: true },
+  credentialHandle: string,
+  deps: HttpExecutorDeps,
+): Promise<RawHttpResponse> {
+  const fetchFn = deps.fetch ?? globalThis.fetch;
+
+  let currentUrl = url;
+  let currentMethod = method;
+  let currentHeaders = headers;
+  let currentBody = body;
+  let redirectCount = 0;
+
+  while (true) {
+    // Build fetch options — disable automatic redirect following so we
+    // can enforce grant policy on each hop.
+    const fetchOptions: RequestInit = {
+      method: currentMethod,
+      headers: currentHeaders,
+      redirect: "manual",
+    };
+
+    if (currentBody !== undefined && currentBody !== null) {
+      fetchOptions.body =
+        typeof currentBody === "string"
+          ? currentBody
+          : JSON.stringify(currentBody);
+    }
+
+    const response = await fetchFn(currentUrl, fetchOptions);
+
+    // Check for redirect
+    if (REDIRECT_STATUSES.has(response.status)) {
+      redirectCount++;
+      if (redirectCount > MAX_REDIRECTS) {
+        throw new Error(
+          `Too many redirects (exceeded ${MAX_REDIRECTS}). Aborting.`,
+        );
+      }
+
+      const locationHeader = response.headers.get("location");
+      if (!locationHeader) {
+        throw new Error(
+          `Redirect response (${response.status}) missing Location header.`,
+        );
+      }
+
+      // Resolve the redirect URL (may be relative)
+      const redirectUrl = new URL(locationHeader, currentUrl).toString();
+
+      // Enforce grant policy on the redirect target — the redirect must
+      // independently satisfy the same credential handle's grant policy.
+      const redirectPolicy = evaluateHttpPolicy(
+        {
+          credentialHandle,
+          method: currentMethod,
+          url: redirectUrl,
+          purpose: `redirect from ${currentUrl}`,
+        },
+        deps.persistentGrantStore,
+        deps.temporaryGrantStore,
+      );
+
+      if (!redirectPolicy.allowed) {
+        throw new Error(
+          `Redirect to ${sanitiseUrl(redirectUrl)} denied: the redirect target does not satisfy the grant policy for credential handle "${credentialHandle}".`,
+        );
+      }
+
+      // For 303 redirects, convert to GET
+      if (response.status === 303) {
+        currentMethod = "GET";
+        currentBody = undefined;
+      }
+
+      currentUrl = redirectUrl;
+      continue;
+    }
+
+    // Not a redirect — read the response
+    const responseBody = await response.text();
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    return {
+      statusCode: response.status,
+      headers: responseHeaders,
+      body: responseBody,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitise a URL for error messages by stripping query parameters
+ * (which may contain sensitive values).
+ */
+function sanitiseUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "[invalid-url]";
+  }
+}
+
+/**
+ * Sanitise error messages to avoid leaking secret values.
+ */
+function sanitiseErrorMessage(message: string, secrets: string[]): string {
+  let result = message;
+  for (const secret of secrets) {
+    if (secret.length < 8) continue;
+    result = result.replaceAll(secret, "[CES:REDACTED]");
+  }
+  return result;
+}

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -13,7 +13,12 @@
  * - `managed-main.ts` — managed mode (Unix socket transport, sidecar)
  */
 
-export { CesRpcServer, createCesServer } from "./server.js";
+export {
+  CesRpcServer,
+  createCesServer,
+  createMakeAuthenticatedRequestHandler,
+  buildHandlersWithHttp,
+} from "./server.js";
 export type {
   CesServerOptions,
   RpcHandlerRegistry,
@@ -81,3 +86,6 @@ export type {
   TokenRefreshFn,
   LocalMaterialiserDeps,
 } from "./materializers/local.js";
+
+export { executeAuthenticatedHttpRequest } from "./http/executor.js";
+export type { HttpExecutorDeps } from "./http/executor.js";

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -18,14 +18,21 @@ import type { Readable, Writable } from "node:stream";
 
 import {
   CES_PROTOCOL_VERSION,
+  CesRpcMethod as CesRpcMethodEnum,
   type CesRpcMethod,
   CesRpcSchemas,
   type HandshakeAck,
   type HandshakeRequest,
+  type MakeAuthenticatedRequest,
   type RpcEnvelope,
   type TransportMessage,
   TransportMessageSchema,
 } from "@vellumai/ces-contracts";
+
+import {
+  executeAuthenticatedHttpRequest,
+  type HttpExecutorDeps,
+} from "./http/executor.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -292,6 +299,45 @@ export class CesRpcServer {
     const line = JSON.stringify(msg) + "\n";
     this.output.write(line);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory: make_authenticated_request
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a handler function for the `make_authenticated_request` RPC method.
+ *
+ * Binds the executor to the provided dependencies so it can be registered
+ * in the RPC handler registry.
+ */
+export function createMakeAuthenticatedRequestHandler(
+  deps: HttpExecutorDeps,
+): RpcMethodHandler {
+  return async (request: unknown) => {
+    return executeAuthenticatedHttpRequest(
+      request as MakeAuthenticatedRequest,
+      deps,
+    );
+  };
+}
+
+/**
+ * Build an RPC handler registry that includes the `make_authenticated_request`
+ * handler alongside any additional handlers.
+ *
+ * This is a convenience helper for callers that want to wire up the HTTP
+ * executor without manually constructing the registry.
+ */
+export function buildHandlersWithHttp(
+  httpDeps: HttpExecutorDeps,
+  additionalHandlers?: RpcHandlerRegistry,
+): RpcHandlerRegistry {
+  return {
+    ...additionalHandlers,
+    [CesRpcMethodEnum.MakeAuthenticatedRequest]:
+      createMakeAuthenticatedRequestHandler(httpDeps),
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add http/executor.ts resolving handles, checking grants, materializing credentials, and making outbound requests
- Reject caller-supplied auth headers and off-policy redirect hops
- Wire make_authenticated_request handler in CES server
- Add integration tests for local static, local OAuth, and platform_oauth handles

Part of plan: untrusted-agent-credential-arch.md (PR 27 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)