### PR TITLE
fix: use gateway URL in avatar SKILL.md

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -112,10 +112,10 @@ Tell the user their avatar has been updated. The client will pick up the new ima
 
 ## Mode 3: AI-Generated Image
 
-The user describes what they want their avatar to look like. Use `bash` to call the daemon's avatar generation HTTP endpoint:
+The user describes what they want their avatar to look like. Use `bash` to call the gateway's avatar generation endpoint:
 
 ```bash
-curl -s -X POST http://localhost:${VELLUM_DAEMON_PORT:-9320}/v1/settings/avatar/generate \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/settings/avatar/generate" \
   -H "Content-Type: application/json" \
   -d '{"description": "<user'\''s description>"}'
 ```


### PR DESCRIPTION
## Summary
- Replace direct daemon URL (`http://localhost:${VELLUM_DAEMON_PORT:-9320}/v1/...`) with `$INTERNAL_GATEWAY_BASE_URL` in `skills/vellum-avatar/SKILL.md`
- Fixes CI failure in `gateway-only-guard.test.ts` which enforces all API requests go through the gateway

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100733118/job/67100930972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
