### PR TITLE
fix: resolve TypeScript errors in CES command executor

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -228,7 +228,7 @@ function addTemporaryCommandGrant(
   const parts = ["command", credentialHandle, bundleId, profileName];
   const canonical = JSON.stringify(parts);
   const proposalHash = createHash("sha256").update(canonical, "utf8").digest("hex");
-  store.record(kind, proposalHash, { conversationId });
+  store.add(kind, proposalHash, { conversationId });
 }
 
 // ---------------------------------------------------------------------------

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -409,12 +409,9 @@ export async function executeAuthenticatedCommand(
 // Internal: Bundle resolution
 // ---------------------------------------------------------------------------
 
-interface BundleResolutionResult {
-  ok: boolean;
-  manifest?: SecureCommandManifest;
-  toolstoreDir?: string;
-  error?: string;
-}
+type BundleResolutionResult =
+  | { ok: true; manifest: SecureCommandManifest; toolstoreDir: string }
+  | { ok: false; error: string };
 
 function resolveBundle(
   bundleDigest: string,


### PR DESCRIPTION
## Summary
- Convert `BundleResolutionResult` from a plain interface to a discriminated union type so TypeScript properly narrows `manifest` and `toolstoreDir` after the `!ok` early return
- Fix test helper calling `store.record()` → `store.add()` to match the actual `TemporaryGrantStore` API

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100828669/job/67101193731

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
