### PR TITLE
fix: resolve remaining TypeScript errors in CES command executor

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -228,7 +228,7 @@ function addTemporaryCommandGrant(
   const parts = ["command", credentialHandle, bundleId, profileName];
   const canonical = JSON.stringify(parts);
   const proposalHash = createHash("sha256").update(canonical, "utf8").digest("hex");
-  store.record(kind, proposalHash, { conversationId });
+  store.add(kind, proposalHash, { conversationId });
 }
 
 // ---------------------------------------------------------------------------

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -409,12 +409,9 @@ export async function executeAuthenticatedCommand(
 // Internal: Bundle resolution
 // ---------------------------------------------------------------------------
 
-interface BundleResolutionResult {
-  ok: boolean;
-  manifest?: SecureCommandManifest;
-  toolstoreDir?: string;
-  error?: string;
-}
+type BundleResolutionResult =
+  | { ok: true; manifest: SecureCommandManifest; toolstoreDir: string }
+  | { ok: false; error: string };
 
 function resolveBundle(
   bundleDigest: string,


### PR DESCRIPTION
## Summary
- Fixed `store.record()` → `store.add()` in the command-executor test helper to match `TemporaryGrantStore`'s actual API
- Converted `BundleResolutionResult` from a plain interface with optional fields to a proper discriminated union, enabling TypeScript to narrow `manifest` and `toolstoreDir` after `ok` checks

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100792886/job/67101093976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
