### PR TITLE
[assistant] Register CES tools for authenticated HTTP, secure commands, and secure bundle installation

### DIFF
--- a/assistant/src/__tests__/credential-execution-tools.test.ts
+++ b/assistant/src/__tests__/credential-execution-tools.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test";
+
+import { makeAuthenticatedRequestTool } from "../tools/credential-execution/make-authenticated-request.js";
+import { manageSecureCommandTool } from "../tools/credential-execution/manage-secure-command-tool.js";
+import { runAuthenticatedCommandTool } from "../tools/credential-execution/run-authenticated-command.js";
+import { cesTools, getCesToolsIfEnabled } from "../tools/tool-manifest.js";
+import type { Tool } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Schema shape tests
+// ---------------------------------------------------------------------------
+
+describe("CES tool schema shapes", () => {
+  test("make_authenticated_request has correct name and required fields", () => {
+    const def = makeAuthenticatedRequestTool.getDefinition();
+    expect(def.name).toBe("make_authenticated_request");
+    const schema = def.input_schema as {
+      required: string[];
+      properties: Record<string, unknown>;
+    };
+    expect(schema.required).toContain("credentialHandle");
+    expect(schema.required).toContain("method");
+    expect(schema.required).toContain("url");
+    expect(schema.required).toContain("purpose");
+    // Should include optional grantId for re-use of prior approvals
+    expect(schema.properties).toHaveProperty("grantId");
+  });
+
+  test("run_authenticated_command has correct name and required fields", () => {
+    const def = runAuthenticatedCommandTool.getDefinition();
+    expect(def.name).toBe("run_authenticated_command");
+    const schema = def.input_schema as {
+      required: string[];
+      properties: Record<string, unknown>;
+    };
+    expect(schema.required).toContain("credentialHandle");
+    expect(schema.required).toContain("command");
+    expect(schema.required).toContain("purpose");
+    // Should include optional fields
+    expect(schema.properties).toHaveProperty("envMappings");
+    expect(schema.properties).toHaveProperty("cwd");
+    expect(schema.properties).toHaveProperty("grantId");
+  });
+
+  test("manage_secure_command_tool has correct name and required fields", () => {
+    const def = manageSecureCommandTool.getDefinition();
+    expect(def.name).toBe("manage_secure_command_tool");
+    const schema = def.input_schema as {
+      required: string[];
+      properties: Record<string, unknown>;
+    };
+    expect(schema.required).toContain("action");
+    expect(schema.required).toContain("toolName");
+    // Bundle metadata fields must be exposed for guardian review
+    expect(schema.properties).toHaveProperty("bundleId");
+    expect(schema.properties).toHaveProperty("version");
+    expect(schema.properties).toHaveProperty("sourceUrl");
+    expect(schema.properties).toHaveProperty("sha256");
+    expect(schema.properties).toHaveProperty("profiles");
+  });
+
+  test("all CES tools are high risk", () => {
+    for (const tool of cesTools) {
+      expect(tool.defaultRiskLevel).toBe("high");
+    }
+  });
+
+  test("all CES tools belong to credential-execution category", () => {
+    for (const tool of cesTools) {
+      expect(tool.category).toBe("credential-execution");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool manifest / registration tests
+// ---------------------------------------------------------------------------
+
+describe("CES tool manifest registration", () => {
+  test("cesTools contains exactly three CES tools", () => {
+    expect(cesTools).toHaveLength(3);
+    const names = cesTools.map((t: Tool) => t.name);
+    expect(names).toContain("make_authenticated_request");
+    expect(names).toContain("run_authenticated_command");
+    expect(names).toContain("manage_secure_command_tool");
+  });
+
+  test("getCesToolsIfEnabled returns empty when flag is disabled", () => {
+    // The CES feature flag defaults to disabled in the registry
+    // (defaultEnabled: false), so without an explicit override
+    // getCesToolsIfEnabled should return an empty array.
+    const tools = getCesToolsIfEnabled();
+    expect(tools).toHaveLength(0);
+  });
+
+  test("no CES tool exposes raw secret values in its schema", () => {
+    for (const tool of cesTools) {
+      const def = tool.getDefinition();
+      const schema = def.input_schema as {
+        properties: Record<string, { type?: string; description?: string }>;
+      };
+      // No field should accept a secret/password/token value directly
+      for (const [key, prop] of Object.entries(schema.properties)) {
+        const desc = (prop.description ?? "").toLowerCase();
+        expect(key === "value" && desc.includes("secret")).toBe(false);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secure tool installation separation tests
+// ---------------------------------------------------------------------------
+
+describe("secure tool installation is separate from credential grants", () => {
+  test("manage_secure_command_tool accepts only bundle metadata, not raw bytes", () => {
+    const def = manageSecureCommandTool.getDefinition();
+    const schema = def.input_schema as {
+      properties: Record<string, unknown>;
+    };
+    const propertyNames = Object.keys(schema.properties);
+    // Must NOT have fields for raw content or file paths
+    expect(propertyNames).not.toContain("content");
+    expect(propertyNames).not.toContain("bytes");
+    expect(propertyNames).not.toContain("filePath");
+    expect(propertyNames).not.toContain("workspacePath");
+    expect(propertyNames).not.toContain("data");
+    // Must have the user-reviewable metadata fields
+    expect(propertyNames).toContain("bundleId");
+    expect(propertyNames).toContain("version");
+    expect(propertyNames).toContain("sourceUrl");
+    expect(propertyNames).toContain("sha256");
+  });
+
+  test("manage_secure_command_tool does not share tool name with grant tools", () => {
+    // The tool name must not collide with existing credential grant tools
+    const grantToolNames = [
+      "credential_store",
+      "credential_grant",
+      "credential_revoke",
+      "credential_list",
+    ];
+    expect(grantToolNames).not.toContain(manageSecureCommandTool.name);
+  });
+
+  test("manage_secure_command_tool action enum does not include grant actions", () => {
+    const def = manageSecureCommandTool.getDefinition();
+    const schema = def.input_schema as {
+      properties: {
+        action: { enum?: string[] };
+      };
+    };
+    const actionEnum = schema.properties.action.enum ?? [];
+    // Should only have register/unregister, not grant-related actions
+    expect(actionEnum).toEqual(["register", "unregister"]);
+    expect(actionEnum).not.toContain("grant");
+    expect(actionEnum).not.toContain("revoke");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Execution tests (CES client not available)
+// ---------------------------------------------------------------------------
+
+describe("CES tool execution without client", () => {
+  const minimalContext = {
+    workingDir: "/tmp",
+    sessionId: "test-session",
+    conversationId: "test-conversation",
+    trustClass: "guardian" as const,
+  };
+
+  test("make_authenticated_request fails gracefully when CES client is absent", async () => {
+    const result = await makeAuthenticatedRequestTool.execute(
+      {
+        credentialHandle: "local_static:test/key",
+        method: "GET",
+        url: "https://example.com",
+        purpose: "test",
+      },
+      minimalContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("CES client is not available");
+  });
+
+  test("run_authenticated_command fails gracefully when CES client is absent", async () => {
+    const result = await runAuthenticatedCommandTool.execute(
+      {
+        credentialHandle: "local_static:test/key",
+        command: "echo hello",
+        purpose: "test",
+      },
+      minimalContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("CES client is not available");
+  });
+
+  test("manage_secure_command_tool fails gracefully when CES client is absent", async () => {
+    const result = await manageSecureCommandTool.execute(
+      {
+        action: "register",
+        toolName: "test-tool",
+        bundleId: "test-bundle",
+        version: "1.0.0",
+        sourceUrl: "https://example.com/bundle.tar.gz",
+        sha256: "abc123",
+        credentialHandle: "local_static:test/key",
+      },
+      minimalContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("CES client is not available");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// manage_secure_command_tool input validation tests
+// ---------------------------------------------------------------------------
+
+describe("manage_secure_command_tool input validation", () => {
+  const contextWithMockCes = {
+    workingDir: "/tmp",
+    sessionId: "test-session",
+    conversationId: "test-conversation",
+    trustClass: "guardian" as const,
+    cesClient: {
+      isReady: () => true,
+      handshake: async () => ({ accepted: true }),
+      call: async () => ({ success: true }),
+      close: () => {},
+    },
+  };
+
+  test("rejects register without required bundle metadata", async () => {
+    const result = await manageSecureCommandTool.execute(
+      {
+        action: "register",
+        toolName: "test-tool",
+        // Missing bundleId, version, sourceUrl, sha256, credentialHandle
+      },
+      contextWithMockCes,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("bundleId");
+    expect(result.content).toContain("version");
+    expect(result.content).toContain("sourceUrl");
+    expect(result.content).toContain("sha256");
+    expect(result.content).toContain("credentialHandle");
+  });
+
+  test("rejects non-HTTPS sourceUrl", async () => {
+    const result = await manageSecureCommandTool.execute(
+      {
+        action: "register",
+        toolName: "test-tool",
+        bundleId: "test-bundle",
+        version: "1.0.0",
+        sourceUrl: "http://insecure.example.com/bundle.tar.gz",
+        sha256: "abc123",
+        credentialHandle: "local_static:test/key",
+      },
+      contextWithMockCes,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("HTTPS");
+  });
+});

--- a/assistant/src/tools/credential-execution/make-authenticated-request.ts
+++ b/assistant/src/tools/credential-execution/make-authenticated-request.ts
@@ -1,0 +1,161 @@
+/**
+ * CES tool: make_authenticated_request
+ *
+ * Delegates an authenticated HTTP request to the Credential Execution Service.
+ * The assistant never sees raw credentials — CES injects the credential into
+ * the outbound request internally and returns the sanitised response.
+ *
+ * The input schema matches the `MakeAuthenticatedRequestSchema` from
+ * `@vellumai/ces-contracts` exactly so the LLM-produced parameters pass
+ * straight through to the CES RPC call with no transformation.
+ */
+
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("ces-tool:make-authenticated-request");
+
+class MakeAuthenticatedRequestTool implements Tool {
+  name = "make_authenticated_request";
+  description =
+    "Execute an authenticated HTTP request through CES. CES injects the credential and returns the response — the assistant never sees raw secrets.";
+  category = "credential-execution";
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          credentialHandle: {
+            type: "string",
+            description:
+              "CES credential handle to use for authentication (e.g. local_static:github/api_key).",
+          },
+          method: {
+            type: "string",
+            description: "HTTP method (GET, POST, PUT, DELETE, PATCH, etc.).",
+          },
+          url: {
+            type: "string",
+            description: "Target URL for the request.",
+          },
+          headers: {
+            type: "object",
+            additionalProperties: { type: "string" },
+            description:
+              "Optional request headers. Credential headers are injected by CES — do not include secrets here.",
+          },
+          body: {
+            description:
+              "Optional request body (string or JSON-serialisable object).",
+          },
+          purpose: {
+            type: "string",
+            description:
+              "Human-readable purpose for this request, shown in audit logs and approval prompts.",
+          },
+          grantId: {
+            type: "string",
+            description:
+              "Existing grant ID to consume, if the caller holds one from a prior approval.",
+          },
+        },
+        required: ["credentialHandle", "method", "url", "purpose"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const cesClient = context.cesClient;
+    if (!cesClient) {
+      return {
+        content:
+          "Error: CES client is not available. The Credential Execution Service must be running.",
+        isError: true,
+      };
+    }
+
+    if (!cesClient.isReady()) {
+      return {
+        content:
+          "Error: CES client has not completed handshake. Cannot execute authenticated requests.",
+        isError: true,
+      };
+    }
+
+    const credentialHandle = input.credentialHandle as string;
+    const method = input.method as string;
+    const url = input.url as string;
+    const purpose = input.purpose as string;
+    const headers = input.headers as Record<string, string> | undefined;
+    const body = input.body;
+    const grantId = input.grantId as string | undefined;
+
+    try {
+      const response = await cesClient.call("make_authenticated_request", {
+        credentialHandle,
+        method,
+        url,
+        purpose,
+        ...(headers ? { headers } : {}),
+        ...(body !== undefined ? { body } : {}),
+        ...(grantId ? { grantId } : {}),
+      });
+
+      if (!response.success) {
+        const errorMsg =
+          response.error?.message ?? "Authenticated request failed";
+        log.warn(
+          { credentialHandle, method, url, error: errorMsg },
+          "CES make_authenticated_request failed",
+        );
+        return {
+          content: `Error: ${errorMsg}`,
+          isError: true,
+          cesApprovalRequired:
+            response.error?.code === "APPROVAL_REQUIRED"
+              ? ((response as unknown as Record<string, unknown>)
+                  .approvalRequired as ToolExecutionResult["cesApprovalRequired"])
+              : undefined,
+        };
+      }
+
+      // Build a human-readable result
+      const parts: string[] = [];
+      if (response.statusCode !== undefined) {
+        parts.push(`HTTP ${response.statusCode}`);
+      }
+      if (response.responseBody) {
+        parts.push(response.responseBody);
+      }
+      if (response.auditId) {
+        parts.push(`[audit: ${response.auditId}]`);
+      }
+
+      return {
+        content: parts.join("\n\n"),
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(
+        { credentialHandle, method, url, error: msg },
+        "CES make_authenticated_request RPC error",
+      );
+      return {
+        content: `Error: CES RPC call failed — ${msg}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+export const makeAuthenticatedRequestTool = new MakeAuthenticatedRequestTool();

--- a/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
+++ b/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
@@ -1,0 +1,213 @@
+/**
+ * CES tool: manage_secure_command_tool
+ *
+ * The only assistant-facing way to request secure bundle installation or
+ * update. This tool deliberately accepts only user-reviewable bundle
+ * metadata (bundleId, version, sourceUrl, sha256, declared profiles) —
+ * never raw bytes, workspace file paths, or executable content.
+ *
+ * Every invocation forces a fresh approval prompt without creating
+ * persistent grants, so the guardian reviews each installation request
+ * individually.
+ *
+ * The tool translates the bundle metadata into the CES
+ * `manage_secure_command_tool` RPC, which handles download, integrity
+ * verification, and installation inside the CES sandbox.
+ */
+
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("ces-tool:manage-secure-command-tool");
+
+class ManageSecureCommandToolImpl implements Tool {
+  name = "manage_secure_command_tool";
+  description =
+    "Request installation, update, or removal of a secure command tool bundle. " +
+    "Accepts only bundle metadata for guardian review — never raw bytes or file paths. " +
+    "Each invocation requires fresh approval.";
+  category = "credential-execution";
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: ["register", "unregister"],
+            description:
+              'Whether to install/update ("register") or remove ("unregister") the secure command tool.',
+          },
+          toolName: {
+            type: "string",
+            description:
+              "Unique tool name for the secure command (e.g. aws-cli, kubectl).",
+          },
+          bundleId: {
+            type: "string",
+            description:
+              "Bundle identifier for the secure command package (required for register).",
+          },
+          version: {
+            type: "string",
+            description:
+              "Semantic version of the bundle to install (required for register).",
+          },
+          sourceUrl: {
+            type: "string",
+            description:
+              "URL from which CES will download the bundle (required for register). Must be HTTPS.",
+          },
+          sha256: {
+            type: "string",
+            description:
+              "SHA-256 hash of the bundle for integrity verification (required for register).",
+          },
+          profiles: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              'Declared credential profiles the bundle requires (e.g. ["aws", "github"]). Shown to the guardian during approval.',
+          },
+          credentialHandle: {
+            type: "string",
+            description:
+              "CES credential handle the tool should use (required for register).",
+          },
+          description: {
+            type: "string",
+            description:
+              "Human-readable description of what the secure command tool does (required for register).",
+          },
+        },
+        required: ["action", "toolName"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const cesClient = context.cesClient;
+    if (!cesClient) {
+      return {
+        content:
+          "Error: CES client is not available. The Credential Execution Service must be running.",
+        isError: true,
+      };
+    }
+
+    if (!cesClient.isReady()) {
+      return {
+        content:
+          "Error: CES client has not completed handshake. Cannot manage secure command tools.",
+        isError: true,
+      };
+    }
+
+    const action = input.action as "register" | "unregister";
+    const toolName = input.toolName as string;
+
+    // Validate that register actions include the required bundle metadata
+    if (action === "register") {
+      const bundleId = input.bundleId as string | undefined;
+      const version = input.version as string | undefined;
+      const sourceUrl = input.sourceUrl as string | undefined;
+      const sha256 = input.sha256 as string | undefined;
+      const credentialHandle = input.credentialHandle as string | undefined;
+
+      const missing: string[] = [];
+      if (!bundleId) missing.push("bundleId");
+      if (!version) missing.push("version");
+      if (!sourceUrl) missing.push("sourceUrl");
+      if (!sha256) missing.push("sha256");
+      if (!credentialHandle) missing.push("credentialHandle");
+
+      if (missing.length > 0) {
+        return {
+          content: `Error: register action requires: ${missing.join(", ")}`,
+          isError: true,
+        };
+      }
+
+      // Reject non-HTTPS source URLs to prevent insecure downloads
+      if (sourceUrl && !sourceUrl.startsWith("https://")) {
+        return {
+          content:
+            "Error: sourceUrl must use HTTPS for secure bundle downloads.",
+          isError: true,
+        };
+      }
+    }
+
+    // Build the CES RPC request. The CES `manage_secure_command_tool` RPC
+    // schema accepts the tool registration fields; the bundle metadata
+    // (bundleId, version, sourceUrl, sha256, profiles) is passed via the
+    // commandTemplate field as structured JSON that CES parses internally.
+    const commandTemplate =
+      action === "register"
+        ? JSON.stringify({
+            bundleId: input.bundleId,
+            version: input.version,
+            sourceUrl: input.sourceUrl,
+            sha256: input.sha256,
+            profiles: input.profiles,
+          })
+        : undefined;
+
+    try {
+      const response = await cesClient.call("manage_secure_command_tool", {
+        action,
+        toolName,
+        ...(input.credentialHandle
+          ? { credentialHandle: input.credentialHandle as string }
+          : {}),
+        ...(commandTemplate ? { commandTemplate } : {}),
+        ...(input.description
+          ? { description: input.description as string }
+          : {}),
+      });
+
+      if (!response.success) {
+        const errorMsg =
+          response.error?.message ?? `Failed to ${action} secure command tool`;
+        log.warn(
+          { toolName, action, error: errorMsg },
+          "CES manage_secure_command_tool failed",
+        );
+        return { content: `Error: ${errorMsg}`, isError: true };
+      }
+
+      if (action === "register") {
+        return {
+          content: `Secure command tool "${toolName}" registered successfully (bundle: ${input.bundleId}@${input.version}).`,
+          isError: false,
+        };
+      }
+
+      return {
+        content: `Secure command tool "${toolName}" unregistered successfully.`,
+        isError: false,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(
+        { toolName, action, error: msg },
+        "CES manage_secure_command_tool RPC error",
+      );
+      return {
+        content: `Error: CES RPC call failed — ${msg}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+export const manageSecureCommandTool = new ManageSecureCommandToolImpl();

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -1,0 +1,158 @@
+/**
+ * CES tool: run_authenticated_command
+ *
+ * Delegates an authenticated command execution to the Credential Execution
+ * Service. CES injects credential values into the command's environment and
+ * runs it inside the CES sandbox — the assistant never sees raw secrets.
+ *
+ * The input schema matches the `RunAuthenticatedCommandSchema` from
+ * `@vellumai/ces-contracts` exactly so the LLM-produced parameters pass
+ * straight through to the CES RPC call with no transformation.
+ */
+
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("ces-tool:run-authenticated-command");
+
+class RunAuthenticatedCommandTool implements Tool {
+  name = "run_authenticated_command";
+  description =
+    "Execute a command with credential environment variables injected by CES. The command runs inside the CES sandbox — the assistant never sees raw secrets.";
+  category = "credential-execution";
+  defaultRiskLevel = RiskLevel.High;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          credentialHandle: {
+            type: "string",
+            description:
+              "CES credential handle to use for environment injection (e.g. local_static:aws/key).",
+          },
+          command: {
+            type: "string",
+            description: "The command to execute.",
+          },
+          envMappings: {
+            type: "object",
+            additionalProperties: { type: "string" },
+            description:
+              "Optional mapping of environment variable names to credential field paths for injection.",
+          },
+          cwd: {
+            type: "string",
+            description: "Optional working directory for command execution.",
+          },
+          purpose: {
+            type: "string",
+            description:
+              "Human-readable purpose for this command, shown in audit logs and approval prompts.",
+          },
+          grantId: {
+            type: "string",
+            description:
+              "Existing grant ID to consume, if the caller holds one from a prior approval.",
+          },
+        },
+        required: ["credentialHandle", "command", "purpose"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const cesClient = context.cesClient;
+    if (!cesClient) {
+      return {
+        content:
+          "Error: CES client is not available. The Credential Execution Service must be running.",
+        isError: true,
+      };
+    }
+
+    if (!cesClient.isReady()) {
+      return {
+        content:
+          "Error: CES client has not completed handshake. Cannot execute authenticated commands.",
+        isError: true,
+      };
+    }
+
+    const credentialHandle = input.credentialHandle as string;
+    const command = input.command as string;
+    const purpose = input.purpose as string;
+    const envMappings = input.envMappings as Record<string, string> | undefined;
+    const cwd = input.cwd as string | undefined;
+    const grantId = input.grantId as string | undefined;
+
+    try {
+      const response = await cesClient.call("run_authenticated_command", {
+        credentialHandle,
+        command,
+        purpose,
+        ...(envMappings ? { envMappings } : {}),
+        ...(cwd ? { cwd } : {}),
+        ...(grantId ? { grantId } : {}),
+      });
+
+      if (!response.success) {
+        const errorMsg =
+          response.error?.message ?? "Authenticated command failed";
+        log.warn(
+          { credentialHandle, command, error: errorMsg },
+          "CES run_authenticated_command failed",
+        );
+        return {
+          content: `Error: ${errorMsg}`,
+          isError: true,
+          cesApprovalRequired:
+            response.error?.code === "APPROVAL_REQUIRED"
+              ? ((response as unknown as Record<string, unknown>)
+                  .approvalRequired as ToolExecutionResult["cesApprovalRequired"])
+              : undefined,
+        };
+      }
+
+      // Build a human-readable result
+      const parts: string[] = [];
+      if (response.exitCode !== undefined) {
+        parts.push(`Exit code: ${response.exitCode}`);
+      }
+      if (response.stdout) {
+        parts.push(response.stdout);
+      }
+      if (response.stderr) {
+        parts.push(`stderr:\n${response.stderr}`);
+      }
+      if (response.auditId) {
+        parts.push(`[audit: ${response.auditId}]`);
+      }
+
+      return {
+        content: parts.join("\n\n"),
+        isError: response.exitCode !== undefined && response.exitCode !== 0,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(
+        { credentialHandle, command, error: msg },
+        "CES run_authenticated_command RPC error",
+      );
+      return {
+        content: `Error: CES RPC call failed — ${msg}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+export const runAuthenticatedCommandTool = new RunAuthenticatedCommandTool();

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -223,8 +223,13 @@ export function getAllToolDefinitions(): ToolDefinition[] {
 }
 
 export async function initializeTools(): Promise<void> {
-  const { loadEagerModules, eagerModuleToolNames, explicitTools } =
-    await import("./tool-manifest.js");
+  const {
+    loadEagerModules,
+    eagerModuleToolNames,
+    explicitTools,
+    getCesToolsIfEnabled,
+    cesTools,
+  } = await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
   // registrations.  In production this is empty; in tests a non-skill tool
@@ -251,6 +256,12 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
+  // CES tools — registered only when the CES feature flag is enabled.
+  const activeCesTools = getCesToolsIfEnabled();
+  for (const tool of activeCesTools) {
+    registerTool(tool);
+  }
+
   registerUiSurfaceTools();
   registerAppTools();
 
@@ -267,6 +278,7 @@ export async function initializeTools(): Promise<void> {
       ...eagerModuleToolNames,
       ...explicitTools.map((t: Tool) => t.name),
       ...hostTools.map((t: Tool) => t.name),
+      ...cesTools.map((t: Tool) => t.name),
       ...allComputerUseTools.map((t: Tool) => t.name),
       ...allUiSurfaceTools.map((t: Tool) => t.name),
       ...coreAppProxyTools.map((t: Tool) => t.name),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,8 +6,13 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
+import { getConfig } from "../config/loader.js";
+import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
 import { assetMaterializeTool } from "./assets/materialize.js";
 import { assetSearchTool } from "./assets/search.js";
+import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
+import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
+import { runAuthenticatedCommandTool } from "./credential-execution/run-authenticated-command.js";
 import { credentialStoreTool } from "./credentials/vault.js";
 import { fileEditTool } from "./filesystem/edit.js";
 import { fileReadTool } from "./filesystem/read.js";
@@ -84,3 +89,33 @@ export const explicitTools: Tool[] = [
   memoryRecallTool,
   credentialStoreTool,
 ];
+
+// ── CES tools (feature-flag gated) ──────────────────────────────────
+// Credential Execution Service tools are only registered when the
+// CES feature flag (`feature_flags.ces-tools.enabled`) is enabled.
+// This list is intentionally separate from `explicitTools` so that
+// initializeTools() in registry.ts can conditionally include them.
+
+/** All CES tools — stable references for the manifest snapshot. */
+export const cesTools: Tool[] = [
+  makeAuthenticatedRequestTool,
+  runAuthenticatedCommandTool,
+  manageSecureCommandTool,
+];
+
+/**
+ * Return CES tools only if the CES feature flag is enabled.
+ * Returns an empty array when the flag is disabled so callers can
+ * unconditionally iterate the result.
+ */
+export function getCesToolsIfEnabled(): Tool[] {
+  try {
+    const config = getConfig();
+    if (isCesToolsEnabled(config)) {
+      return cesTools;
+    }
+  } catch {
+    // Config not yet loaded (e.g. during test setup) — CES tools stay off.
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- Add `make_authenticated_request` and `run_authenticated_command` tool implementations that delegate to CES via the RPC client — the assistant never sees raw credentials
- Add `manage_secure_command_tool` accepting only user-reviewable bundle metadata (bundleId, version, sourceUrl, sha256, profiles), never raw bytes or file paths, with HTTPS-only enforcement
- Register all three CES tools behind the `feature_flags.ces-tools.enabled` feature flag in tool-manifest.ts and registry.ts
- Add tests covering schema shape, flag-based registration, installation/grant separation, input validation, and graceful failure without CES client

Part of plan: untrusted-agent-credential-arch.md (PR 30 of 35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
