### PR TITLE
fix: use RiskLevel enum in CES tools test

### DIFF
--- a/assistant/src/__tests__/credential-execution-tools.test.ts
+++ b/assistant/src/__tests__/credential-execution-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { RiskLevel } from "../permissions/types.js";
 import { makeAuthenticatedRequestTool } from "../tools/credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "../tools/credential-execution/manage-secure-command-tool.js";
 import { runAuthenticatedCommandTool } from "../tools/credential-execution/run-authenticated-command.js";
@@ -61,7 +62,7 @@ describe("CES tool schema shapes", () => {
 
   test("all CES tools are high risk", () => {
     for (const tool of cesTools) {
-      expect(tool.defaultRiskLevel).toBe("high");
+      expect(tool.defaultRiskLevel).toBe(RiskLevel.High);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fix TypeScript error in `credential-execution-tools.test.ts` where `"high"` string literal was used instead of `RiskLevel.High` enum value, causing CI type-check failure

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100894002/job/67101364500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
