### PR TITLE
fix: use VELLUM_WORKSPACE_DIR and INTERNAL_GATEWAY_BASE_URL in vellum-avatar SKILL.md

### DIFF
--- a/skills/vellum-avatar/SKILL.md
+++ b/skills/vellum-avatar/SKILL.md
@@ -77,8 +77,8 @@ After the user chooses, write the selection to `data/avatar/character-traits.jso
 ```
 
 ```bash
-mkdir -p "$(assistant workspace-dir)/data/avatar"
-cat > "$(assistant workspace-dir)/data/avatar/character-traits.json" << 'TRAITS'
+mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
+cat > "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json" << 'TRAITS'
 { "bodyShape": "<value>", "eyeStyle": "<value>", "color": "<value>" }
 TRAITS
 ```
@@ -86,7 +86,7 @@ TRAITS
 Then remove the custom image file if it exists, since native character mode takes precedence:
 
 ```bash
-rm -f "$(assistant workspace-dir)/data/avatar/avatar-image.png"
+rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png"
 ```
 
 The client will detect the traits file and render the animated character.
@@ -98,14 +98,14 @@ The user provides a file path to an image they want to use as their avatar.
 Copy the image to the avatar location:
 
 ```bash
-mkdir -p "$(assistant workspace-dir)/data/avatar"
-cp "<user-provided-path>" "$(assistant workspace-dir)/data/avatar/avatar-image.png"
+mkdir -p "$VELLUM_WORKSPACE_DIR/data/avatar"
+cp "<user-provided-path>" "$VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png"
 ```
 
 Then remove the character traits file, since a custom image overrides the native character:
 
 ```bash
-rm -f "$(assistant workspace-dir)/data/avatar/character-traits.json"
+rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
 ```
 
 Tell the user their avatar has been updated. The client will pick up the new image automatically.
@@ -123,7 +123,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/settings/avatar/generate" \
 This generates an image using AI and saves it to `data/avatar/avatar-image.png`. After the image is generated, remove the character traits file:
 
 ```bash
-rm -f "$(assistant workspace-dir)/data/avatar/character-traits.json"
+rm -f "$VELLUM_WORKSPACE_DIR/data/avatar/character-traits.json"
 ```
 
 The generated avatar will appear automatically in the client.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-skill-refactor.md.

- Replace `$(assistant workspace-dir)` with `$VELLUM_WORKSPACE_DIR` (the CLI subcommand doesn't exist)
- Replace hardcoded `localhost:${VELLUM_DAEMON_PORT:-9320}` with `$INTERNAL_GATEWAY_BASE_URL` to comply with gateway-only API consumption policy and fix the gateway-only-guard CI test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
