### PR TITLE
fix: CES URL template matching and test assertion safety

### DIFF
--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -493,7 +493,7 @@ describe("executeAuthenticatedCommand — grant enforcement", () => {
 
     // The command itself may fail (since the entrypoint is a test script),
     // but it should get past the grant check
-    expect(result.error).not.toContain("No active grant");
+    expect(result.error ?? "").not.toContain("No active grant");
   });
 
   test("allows command with a temporary grant", async () => {
@@ -538,7 +538,7 @@ describe("executeAuthenticatedCommand — grant enforcement", () => {
     const result = await executeAuthenticatedCommand(request, deps);
 
     // Should get past the grant check
-    expect(result.error).not.toContain("No active grant");
+    expect(result.error ?? "").not.toContain("No active grant");
   });
 });
 
@@ -651,7 +651,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     }
     // If the script can't execute (path issues in test), verify we got past
     // the adapter phase
-    expect(result.error).not.toContain("Auth adapter");
+    expect(result.error ?? "").not.toContain("Auth adapter");
   });
 
   test("env_var adapter applies valuePrefix", async () => {
@@ -705,7 +705,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     if (result.exitCode === 0) {
       expect(result.stdout?.trim()).toBe("Bearer my-oauth-token");
     }
-    expect(result.error).not.toContain("Auth adapter");
+    expect(result.error ?? "").not.toContain("Auth adapter");
   });
 
   test("temp_file adapter writes credential to a file", async () => {
@@ -761,7 +761,7 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
       expect(result.stdout?.trim()).toBe('{"key":"test-secret"}');
     }
     // Verify we got past the adapter phase
-    expect(result.error).not.toContain("Auth adapter");
+    expect(result.error ?? "").not.toContain("Auth adapter");
   });
 });
 
@@ -844,8 +844,8 @@ describe("executeAuthenticatedCommand — egress enforcement", () => {
     const result = await executeAuthenticatedCommand(request, deps);
 
     // Should get past egress check
-    expect(result.error).not.toContain("proxy_required");
-    expect(result.error).not.toContain("egress");
+    expect(result.error ?? "").not.toContain("proxy_required");
+    expect(result.error ?? "").not.toContain("egress");
   });
 });
 

--- a/credential-executor/src/http/path-template.ts
+++ b/credential-executor/src/http/path-template.ts
@@ -146,13 +146,16 @@ export function urlMatchesTemplate(
     (parsedTemplate.port ? `:${parsedTemplate.port}` : "");
   if (urlHost !== templateHost) return false;
 
-  // Split paths and compare segment-by-segment
+  // Split paths and compare segment-by-segment.
+  // decodeURIComponent is needed because the URL constructor percent-encodes
+  // curly braces ({, }) in paths — placeholders like {:num} become %7B:num%7D.
   const urlSegments = parsedUrl.pathname
     .split("/")
     .filter((s) => s.length > 0);
   const templateSegments = parsedTemplate.pathname
     .split("/")
-    .filter((s) => s.length > 0);
+    .filter((s) => s.length > 0)
+    .map((s) => decodeURIComponent(s));
 
   if (urlSegments.length !== templateSegments.length) return false;
 


### PR DESCRIPTION
## Summary
- Decode percent-encoded path segments in `urlMatchesTemplate` so `{:num}`, `{:uuid}`, and `{:hex}` placeholders are correctly matched after `new URL()` encodes curly braces
- Use `result.error ?? ""` in command-executor test assertions to handle the case where `result.error` is `undefined` (Bun's `.toContain()` requires a string or array)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100876898/job/67101319191

🤖 Generated with [Claude Code](https://claude.com/claude-code)