### PR TITLE
fix: sync CLI_HELP_REFERENCE with credential-execution command

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -15,6 +15,7 @@ Commands:
   config                                   Manage configuration
   keys                                     Manage API keys in secure storage
   credentials [options]                    Manage credentials in the encrypted vault (API keys, tokens, passwords)
+  credential-execution [options]           Inspect and manage Credential Execution Service (CES) grants and audit records
   trust                                    Manage trust rules
   memory                                   Manage long-term memory indexing/retrieval
   audit [options]                          Show recent tool invocations


### PR DESCRIPTION
## Summary
- Add the `credential-execution` CLI command to the `CLI_HELP_REFERENCE` static snapshot in `assistant/src/cli/reference.ts`
- The CES CLI command was registered in recent PRs but the reference string was not updated, causing `cli-help-reference-sync.test.ts` to fail in CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23100929961/job/67101458012

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
