### PR TITLE
fix: remove dead set_avatar hook, add avatar_updated broadcast to HTTP route

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -15,7 +15,6 @@ import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
 import { isDoordashCommand, updateDoordashProgress } from "./doordash-steps.js";
 import type { ServerMessage } from "./message-protocol.js";
 import { refreshSurfacesForApp } from "./session-surfaces.js";
@@ -191,21 +190,6 @@ registerHook(
         status,
       });
     }
-  },
-);
-
-// Broadcast avatar change to all connected clients so every
-// macOS/iOS instance reloads the avatar image.
-registerHook(
-  "set_avatar",
-  (_name, _input, _result, { broadcastToAllClients }) => {
-    const avatarPath = join(
-      getWorkspaceDir(),
-      "data",
-      "avatar",
-      "avatar-image.png",
-    );
-    broadcastToAllClients?.({ type: "avatar_updated", avatarPath });
   },
 );
 

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -103,6 +103,20 @@ async function handleGenerateAvatar(description: string): Promise<Response> {
       "avatar",
       "avatar-image.png",
     );
+
+    // Notify all connected SSE clients so every macOS/iOS instance
+    // reloads the avatar image immediately.
+    assistantEventHub
+      .publish(
+        buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+          type: "avatar_updated",
+          avatarPath,
+        }),
+      )
+      .catch((err) => {
+        log.warn({ err }, "Failed to publish avatar_updated event");
+      });
+
     return Response.json({ ok: true, avatarPath });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -88,8 +88,6 @@ export const setAvatarTool: Tool = {
 
       log.info({ avatarPath }, "Avatar saved successfully");
 
-      // Side-effect hook in tool-side-effects.ts broadcasts avatar_updated to all clients.
-
       return {
         content: "Avatar updated! Your new avatar will appear shortly.",
         isError: false,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for avatar-skill-refactor.md.

- Remove dead `registerHook("set_avatar", ...)` from tool-side-effects.ts (tool was removed from registry, hook never fires)
- Remove stale `getWorkspaceDir` import from tool-side-effects.ts
- Remove stale comment referencing the side-effect hook from avatar-generator.ts
- Add `avatar_updated` broadcast to the HTTP avatar generation handler in settings-routes.ts so clients are still notified when avatars are generated via the HTTP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
