### PR TITLE
fix: move host_bash forcePromptSideEffects before permission check for CES lockdown

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -2,9 +2,11 @@ import { readFileSync } from "node:fs";
 
 import { getConfig } from "../config/loader.js";
 import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
+import { isCesShellLockdownEnabled } from "../credential-execution/feature-gates.js";
 import { getHookManager } from "../hooks/manager.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
+import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { TokenExpiredError } from "../security/token-manager.js";
 import { PermissionDeniedError, ToolError } from "../util/errors.js";
@@ -85,6 +87,19 @@ export class ToolExecutor {
       // interactive permission/prompt flow so non-interactive sessions
       // don't auto-deny prompt-gated tools and burn the one-time grant.
       if (!gateResult.grantConsumed) {
+        // CES shell lockdown: set forcePromptSideEffects BEFORE the
+        // permission check so the PermissionChecker sees it and promotes
+        // any "allow" trust-rule decision to "prompt". Previously this
+        // flag was set inside host-shell.ts execute(), which runs AFTER
+        // the permission check and therefore had no effect.
+        if (
+          name === "host_bash" &&
+          isCesShellLockdownEnabled(getConfig()) &&
+          isUntrustedTrustClass(context.trustClass)
+        ) {
+          context.forcePromptSideEffects = true;
+        }
+
         // Check permissions via the extracted PermissionChecker
         const permResult = await this.permissionChecker.checkPermission(
           name,

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -163,18 +163,13 @@ class HostShellTool implements Tool {
     // VELLUM_UNTRUSTED_SHELL flag is injected to self-deny raw-secret CLI
     // commands. This does NOT provide the strong CES secrecy guarantee —
     // the subprocess runs unsandboxed and could access protected paths.
+    //
+    // NOTE: forcePromptSideEffects is set in executor.ts BEFORE the
+    // permission check runs, not here. Setting it here would be too late
+    // because execute() is called after permissions have already been evaluated.
     const hostLockdownActive =
       isCesShellLockdownEnabled(config) &&
       isUntrustedTrustClass(context.trustClass);
-
-    // Disable persistent approvals for untrusted sessions under CES lockdown.
-    // The permission checker reads this from the context, so we set it before
-    // we reach the execution path. This is a signal — the permission checker
-    // consumes it upstream, but we also set forcePromptSideEffects to ensure
-    // every invocation prompts.
-    if (hostLockdownActive) {
-      context.forcePromptSideEffects = true;
-    }
 
     log.info(
       {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for untrusted-agent-credential-arch.md.

**Gap:** Shell lockdown forcePromptSideEffects set too late
**What was expected:** host_bash should always prompt when CES lockdown active for untrusted actors
**What was found:** Flag is set in execute() after permission check has already run

- Moved `context.forcePromptSideEffects = true` from `host-shell.ts execute()` to `executor.ts`, right before `permissionChecker.checkPermission()` is called
- Condition: tool is `host_bash` AND CES shell lockdown is enabled AND actor is untrusted
- Removed the now-redundant flag assignment from `host-shell.ts` and updated the comment to explain why it lives in the executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
