### PR TITLE
fix: extract CES approval data from error.details instead of response.approvalRequired

### DIFF
--- a/assistant/src/tools/credential-execution/make-authenticated-request.ts
+++ b/assistant/src/tools/credential-execution/make-authenticated-request.ts
@@ -10,6 +10,8 @@
  * straight through to the CES RPC call with no transformation.
  */
 
+import { GrantProposalSchema, renderProposal } from "@vellumai/ces-contracts";
+
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -117,14 +119,44 @@ class MakeAuthenticatedRequestTool implements Tool {
           { credentialHandle, method, url, error: errorMsg },
           "CES make_authenticated_request failed",
         );
+
+        // Extract CES approval data from error.details when approval is required.
+        // CES returns the proposal and proposalHash inside error.details, not as
+        // a top-level response field.
+        let cesApprovalRequired: ToolExecutionResult["cesApprovalRequired"];
+        if (
+          response.error?.code === "APPROVAL_REQUIRED" &&
+          response.error.details
+        ) {
+          const details = response.error.details as Record<string, unknown>;
+          const proposalParseResult = GrantProposalSchema.safeParse(
+            details.proposal,
+          );
+          if (proposalParseResult.success) {
+            const proposal = proposalParseResult.data;
+            cesApprovalRequired = {
+              proposal,
+              proposalHash: (details.proposalHash as string) ?? "",
+              renderedProposal: renderProposal(proposal),
+              sessionId: context.sessionId,
+            };
+          } else {
+            log.warn(
+              {
+                credentialHandle,
+                method,
+                url,
+                parseError: proposalParseResult.error,
+              },
+              "CES APPROVAL_REQUIRED response has invalid proposal in error.details",
+            );
+          }
+        }
+
         return {
           content: `Error: ${errorMsg}`,
           isError: true,
-          cesApprovalRequired:
-            response.error?.code === "APPROVAL_REQUIRED"
-              ? ((response as unknown as Record<string, unknown>)
-                  .approvalRequired as ToolExecutionResult["cesApprovalRequired"])
-              : undefined,
+          cesApprovalRequired,
         };
       }
 

--- a/assistant/src/tools/credential-execution/run-authenticated-command.ts
+++ b/assistant/src/tools/credential-execution/run-authenticated-command.ts
@@ -10,6 +10,8 @@
  * straight through to the CES RPC call with no transformation.
  */
 
+import { GrantProposalSchema, renderProposal } from "@vellumai/ces-contracts";
+
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -111,14 +113,43 @@ class RunAuthenticatedCommandTool implements Tool {
           { credentialHandle, command, error: errorMsg },
           "CES run_authenticated_command failed",
         );
+
+        // Extract CES approval data from error.details when approval is required.
+        // CES returns the proposal and proposalHash inside error.details, not as
+        // a top-level response field.
+        let cesApprovalRequired: ToolExecutionResult["cesApprovalRequired"];
+        if (
+          response.error?.code === "APPROVAL_REQUIRED" &&
+          response.error.details
+        ) {
+          const details = response.error.details as Record<string, unknown>;
+          const proposalParseResult = GrantProposalSchema.safeParse(
+            details.proposal,
+          );
+          if (proposalParseResult.success) {
+            const proposal = proposalParseResult.data;
+            cesApprovalRequired = {
+              proposal,
+              proposalHash: (details.proposalHash as string) ?? "",
+              renderedProposal: renderProposal(proposal),
+              sessionId: context.sessionId,
+            };
+          } else {
+            log.warn(
+              {
+                credentialHandle,
+                command,
+                parseError: proposalParseResult.error,
+              },
+              "CES APPROVAL_REQUIRED response has invalid proposal in error.details",
+            );
+          }
+        }
+
         return {
           content: `Error: ${errorMsg}`,
           isError: true,
-          cesApprovalRequired:
-            response.error?.code === "APPROVAL_REQUIRED"
-              ? ((response as unknown as Record<string, unknown>)
-                  .approvalRequired as ToolExecutionResult["cesApprovalRequired"])
-              : undefined,
+          cesApprovalRequired,
         };
       }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for untrusted-agent-credential-arch.md.

**Gap:** CES approval flow broken — wrong property path
**What was expected:** Tools should extract proposal from CES error details
**What was found:** Tools read non-existent response.approvalRequired, approval bridge never fires

- Both `make-authenticated-request.ts` and `run-authenticated-command.ts` now extract approval data from `response.error.details.proposal` and `response.error.details.proposalHash`
- Proposal is validated through `GrantProposalSchema.safeParse()` for type safety
- `renderedProposal` is generated using the shared `renderProposal()` from `@vellumai/ces-contracts`
- `sessionId` is sourced from the tool execution context

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
