### PR TITLE
fix: add proper bundle metadata fields to manage_secure_command_tool RPC schema

### DIFF
--- a/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
+++ b/assistant/src/tools/credential-execution/manage-secure-command-tool.ts
@@ -147,21 +147,8 @@ class ManageSecureCommandToolImpl implements Tool {
       }
     }
 
-    // Build the CES RPC request. The CES `manage_secure_command_tool` RPC
-    // schema accepts the tool registration fields; the bundle metadata
-    // (bundleId, version, sourceUrl, sha256, profiles) is passed via the
-    // commandTemplate field as structured JSON that CES parses internally.
-    const commandTemplate =
-      action === "register"
-        ? JSON.stringify({
-            bundleId: input.bundleId,
-            version: input.version,
-            sourceUrl: input.sourceUrl,
-            sha256: input.sha256,
-            profiles: input.profiles,
-          })
-        : undefined;
-
+    // Build the CES RPC request. Bundle metadata fields are sent directly
+    // as proper schema fields on the RPC payload.
     try {
       const response = await cesClient.call("manage_secure_command_tool", {
         action,
@@ -169,9 +156,19 @@ class ManageSecureCommandToolImpl implements Tool {
         ...(input.credentialHandle
           ? { credentialHandle: input.credentialHandle as string }
           : {}),
-        ...(commandTemplate ? { commandTemplate } : {}),
         ...(input.description
           ? { description: input.description as string }
+          : {}),
+        ...(action === "register"
+          ? {
+              bundleId: input.bundleId as string,
+              version: input.version as string,
+              sourceUrl: input.sourceUrl as string,
+              sha256: input.sha256 as string,
+              ...(input.profiles
+                ? { profiles: input.profiles as string[] }
+                : {}),
+            }
           : {}),
       });
 

--- a/credential-executor/src/index.ts
+++ b/credential-executor/src/index.ts
@@ -19,10 +19,13 @@ export {
   createRunAuthenticatedCommandHandler,
   registerCommandExecutionHandler,
   createMakeAuthenticatedRequestHandler,
+  createManageSecureCommandToolHandler,
+  registerManageSecureCommandToolHandler,
   buildHandlersWithHttp,
 } from "./server.js";
 export type {
   CesServerOptions,
+  ManageSecureCommandToolHandlerDeps,
   RpcHandlerRegistry,
   RpcMethodHandler,
   RunAuthenticatedCommandHandlerOptions,

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -23,6 +23,8 @@ import {
   type HandshakeAck,
   type HandshakeRequest,
   type MakeAuthenticatedRequest,
+  type ManageSecureCommandTool,
+  type ManageSecureCommandToolResponse,
   type RpcEnvelope,
   type RunAuthenticatedCommand,
   type RunAuthenticatedCommandResponse,
@@ -483,4 +485,152 @@ export function registerCommandExecutionHandler(
 ): void {
   registry[CesRpcMethod.RunAuthenticatedCommand] =
     createRunAuthenticatedCommandHandler(options) as RpcMethodHandler;
+}
+
+// ---------------------------------------------------------------------------
+// manage_secure_command_tool handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies for the `manage_secure_command_tool` handler.
+ */
+export interface ManageSecureCommandToolHandlerDeps {
+  /**
+   * Download bundle bytes from the given HTTPS URL.
+   * Implementations should enforce size limits and timeouts.
+   */
+  downloadBundle: (sourceUrl: string) => Promise<Buffer | Uint8Array>;
+
+  /**
+   * Publish a bundle into the CES-private toolstore.
+   * Typically delegates to `publishBundle()` from `./toolstore/publish.js`.
+   */
+  publishBundle: (request: import("./toolstore/publish.js").PublishRequest) => import("./toolstore/publish.js").PublishResult;
+
+  /**
+   * Unregister/remove a tool from the tool registry by name.
+   * Returns true if the tool was found and removed.
+   */
+  unregisterTool: (toolName: string) => boolean;
+
+  /**
+   * Register a tool in the tool registry after successful publication.
+   * Called with the tool name, credential handle, description, and the
+   * bundle digest for runtime lookup.
+   */
+  registerTool: (entry: {
+    toolName: string;
+    credentialHandle: string;
+    description: string;
+    bundleDigest: string;
+  }) => void;
+}
+
+/**
+ * Create an RPC handler for the `manage_secure_command_tool` method.
+ *
+ * This handler:
+ * 1. For "register" actions: validates required bundle metadata fields,
+ *    downloads the bundle from `sourceUrl`, publishes it into the
+ *    immutable toolstore with digest verification, and registers
+ *    the tool entry.
+ * 2. For "unregister" actions: removes the tool from the registry.
+ */
+export function createManageSecureCommandToolHandler(
+  deps: ManageSecureCommandToolHandlerDeps,
+): RpcMethodHandler<ManageSecureCommandTool, ManageSecureCommandToolResponse> {
+  return async (request) => {
+    if (request.action === "unregister") {
+      const removed = deps.unregisterTool(request.toolName);
+      if (!removed) {
+        return {
+          success: false,
+          error: {
+            code: "TOOL_NOT_FOUND",
+            message: `Tool "${request.toolName}" is not registered.`,
+          },
+        };
+      }
+      return { success: true };
+    }
+
+    // action === "register"
+    const missing: string[] = [];
+    if (!request.bundleId) missing.push("bundleId");
+    if (!request.version) missing.push("version");
+    if (!request.sourceUrl) missing.push("sourceUrl");
+    if (!request.sha256) missing.push("sha256");
+    if (!request.credentialHandle) missing.push("credentialHandle");
+    if (missing.length > 0) {
+      return {
+        success: false,
+        error: {
+          code: "MISSING_FIELDS",
+          message: `Register action requires: ${missing.join(", ")}`,
+        },
+      };
+    }
+
+    // Download the bundle
+    let bundleBytes: Buffer | Uint8Array;
+    try {
+      bundleBytes = await deps.downloadBundle(request.sourceUrl!);
+    } catch (err) {
+      return {
+        success: false,
+        error: {
+          code: "DOWNLOAD_FAILED",
+          message: `Failed to download bundle from ${request.sourceUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
+    }
+
+    // Publish into the immutable toolstore (includes digest verification)
+    const publishResult = deps.publishBundle({
+      bundleBytes,
+      expectedDigest: request.sha256!,
+      bundleId: request.bundleId!,
+      version: request.version!,
+      sourceUrl: request.sourceUrl!,
+      // The secure command manifest is embedded in the bundle; for now
+      // pass a minimal manifest with declared profiles.
+      secureCommandManifest: {
+        commandProfiles: Object.fromEntries(
+          (request.profiles ?? []).map((p) => [p, { command: request.toolName }]),
+        ),
+      } as import("./commands/profiles.js").SecureCommandManifest,
+    });
+
+    if (!publishResult.success) {
+      return {
+        success: false,
+        error: {
+          code: "PUBLISH_FAILED",
+          message: publishResult.error ?? "Unknown publish error",
+        },
+      };
+    }
+
+    // Register the tool entry for runtime lookup
+    deps.registerTool({
+      toolName: request.toolName,
+      credentialHandle: request.credentialHandle!,
+      description: request.description ?? "",
+      bundleDigest: request.sha256!,
+    });
+
+    return { success: true };
+  };
+}
+
+/**
+ * Convenience helper to register the `manage_secure_command_tool` handler
+ * into an RPC handler registry.
+ */
+export function registerManageSecureCommandToolHandler(
+  registry: RpcHandlerRegistry,
+  deps: ManageSecureCommandToolHandlerDeps,
+): void {
+  registry[CesRpcMethod.ManageSecureCommandTool] =
+    createManageSecureCommandToolHandler(deps) as RpcMethodHandler;
 }

--- a/packages/ces-contracts/src/__tests__/grants.test.ts
+++ b/packages/ces-contracts/src/__tests__/grants.test.ts
@@ -534,10 +534,19 @@ describe("RPC schemas", () => {
       action: "register",
       toolName: "aws-cli",
       credentialHandle: "local_static:aws/key",
-      commandTemplate: "aws {{credential}} s3 ls",
       description: "AWS CLI with credentials",
+      bundleId: "aws-cli",
+      version: "2.15.0",
+      sourceUrl: "https://bundles.example.com/aws-cli-2.15.0.vbundle",
+      sha256: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      profiles: ["aws"],
     });
     expect(result.action).toBe("register");
+    expect(result.bundleId).toBe("aws-cli");
+    expect(result.version).toBe("2.15.0");
+    expect(result.sourceUrl).toBe("https://bundles.example.com/aws-cli-2.15.0.vbundle");
+    expect(result.sha256).toBe("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+    expect(result.profiles).toEqual(["aws"]);
   });
 
   test("ManageSecureCommandToolSchema parses unregister action", () => {

--- a/packages/ces-contracts/src/rpc.ts
+++ b/packages/ces-contracts/src/rpc.ts
@@ -152,10 +152,18 @@ export const ManageSecureCommandToolSchema = z.object({
   toolName: z.string(),
   /** CES credential handle the tool should use (required for register). */
   credentialHandle: z.string().optional(),
-  /** Command template with `{{credential}}` placeholders (required for register). */
-  commandTemplate: z.string().optional(),
   /** Human-readable description of the tool (required for register). */
   description: z.string().optional(),
+  /** Bundle identifier for the secure command package (required for register). */
+  bundleId: z.string().optional(),
+  /** Semantic version of the bundle to install (required for register). */
+  version: z.string().optional(),
+  /** HTTPS URL from which CES will download the bundle (required for register). */
+  sourceUrl: z.string().optional(),
+  /** SHA-256 hex digest of the bundle for integrity verification (required for register). */
+  sha256: z.string().optional(),
+  /** Declared credential profiles the bundle requires (e.g. ["aws", "github"]). */
+  profiles: z.array(z.string()).optional(),
 });
 export type ManageSecureCommandTool = z.infer<
   typeof ManageSecureCommandToolSchema


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for untrusted-agent-credential-arch.md.

**Gap:** manage_secure_command_tool RPC schema mismatch
**What was expected:** Proper schema fields for bundle metadata
**What was found:** Bundle metadata JSON-stringified into commandTemplate field meant for something else

- Extended `ManageSecureCommandToolSchema` with proper fields: `bundleId`, `version`, `sourceUrl`, `sha256`, `profiles`
- Removed the old `commandTemplate` field that was being misused for JSON-encoded bundle metadata
- Updated tool implementation to send bundle metadata as proper schema fields
- Added `createManageSecureCommandToolHandler` server-side handler with download, publish, and registration logic
- Updated test to validate new schema fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
