### PR TITLE
fix: wire CES client into tool context for CES tool execution

### DIFF
--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -7,6 +7,7 @@
  */
 
 import { isHttpAuthDisabled } from "../config/env.js";
+import type { CesClient } from "../credential-execution/client.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import {
   generateAllowlistOptions,
@@ -108,6 +109,8 @@ export interface ToolSetupContext extends SurfaceSessionContext {
   hostBashProxy?: import("./host-bash-proxy.js").HostBashProxy;
   /** Optional proxy for delegating host_file_read/write/edit execution to a connected client. */
   hostFileProxy?: import("./host-file-proxy.js").HostFileProxy;
+  /** CES RPC client for credential execution operations. Injected when CES tools are enabled and the CES process is available. */
+  cesClient?: CesClient;
 }
 
 // ── buildToolDefinitions ─────────────────────────────────────────────
@@ -187,6 +190,7 @@ export function createToolExecutor(
       toolUseId,
       hostBashProxy: ctx.hostBashProxy,
       hostFileProxy: ctx.hostFileProxy,
+      cesClient: ctx.cesClient,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -23,6 +23,14 @@ import type {
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { ContextWindowManager } from "../context/window-manager.js";
+import type { CesClient } from "../credential-execution/client.js";
+import { createCesClient } from "../credential-execution/client.js";
+import { isCesToolsEnabled } from "../credential-execution/feature-gates.js";
+import {
+  type CesProcessManager,
+  CesUnavailableError,
+  createCesProcessManager,
+} from "../credential-execution/process-manager.js";
 import { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
@@ -48,6 +56,7 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
+import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
 import type { CuObservationResult } from "./host-cu-proxy.js";
@@ -116,6 +125,8 @@ export interface SessionMemoryPolicy {
   strictSideEffects: boolean;
 }
 
+const log = getLogger("session");
+
 export const DEFAULT_MEMORY_POLICY: Readonly<SessionMemoryPolicy> =
   Object.freeze({
     scopeId: "default",
@@ -166,6 +177,8 @@ export class Session {
   /** @internal */ hostBashProxy?: HostBashProxy;
   /** @internal */ hostCuProxy?: HostCuProxy;
   /** @internal */ hostFileProxy?: HostFileProxy;
+  /** @internal */ cesProcessManager?: CesProcessManager;
+  /** @internal */ cesClient?: CesClient;
   /** @internal */ readonly queue = new MessageQueue();
   /** @internal */ currentActiveSurfaceId?: string;
   /** @internal */ currentPage?: string;
@@ -312,6 +325,46 @@ export class Session {
 
     const config = getConfig();
     this.streamThinking = config.thinking.streamThinking ?? false;
+
+    // CES (Credential Execution Service) lifecycle — conditionally start the
+    // CES process and perform the RPC handshake when CES tools are enabled.
+    // The initialization is async; cesClient is set once the handshake
+    // completes. Tools reading context.cesClient tolerate it being undefined
+    // until then (they return a graceful error).
+    if (isCesToolsEnabled(config)) {
+      const pm = createCesProcessManager({ assistantConfig: config });
+      this.cesProcessManager = pm;
+      void (async () => {
+        try {
+          const transport = await pm.start();
+          const client = createCesClient(transport);
+          const { accepted, reason } = await client.handshake();
+          if (accepted) {
+            this.cesClient = client;
+            log.info("CES client initialized and handshake accepted");
+          } else {
+            log.warn(
+              { reason },
+              "CES handshake rejected — CES tools will be unavailable",
+            );
+            client.close();
+          }
+        } catch (err) {
+          if (err instanceof CesUnavailableError) {
+            log.info(
+              { reason: err.message },
+              "CES is not available — CES tools will be unavailable",
+            );
+          } else {
+            log.warn(
+              { error: err instanceof Error ? err.message : String(err) },
+              "Failed to initialize CES client — CES tools will be unavailable",
+            );
+          }
+        }
+      })();
+    }
+
     const resolveTools = createResolveToolsCallback(toolDefs, this);
 
     const configuredMaxTokens = maxTokens;
@@ -445,6 +498,15 @@ export class Session {
     this.hostBashProxy?.dispose();
     this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
+    // Gracefully shut down the CES client and process manager
+    if (this.cesClient) {
+      this.cesClient.close();
+      this.cesClient = undefined;
+    }
+    if (this.cesProcessManager) {
+      void this.cesProcessManager.stop();
+      this.cesProcessManager = undefined;
+    }
     disposeSession(this);
   }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for untrusted-agent-credential-arch.md.

**Gap:** Daemon never populates cesClient on ToolContext
**What was expected:** CES client should be launched and injected into tool context
**What was found:** cesClient is always undefined, making all CES tools non-functional

- Adds `cesClient` to `ToolSetupContext` interface and wires it into `ToolContext` construction in `createToolExecutor`
- In the `Session` constructor, conditionally (behind `isCesToolsEnabled`) creates a `CesProcessManager`, starts it, creates a `CesClient`, performs the RPC handshake, and sets the client on the session
- Gracefully shuts down the CES client and process manager in `Session.dispose()`
- CES tools now receive a live `cesClient` on the tool context once handshake completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
