### PR TITLE
fix: wire CES RPC handler registries in local and managed entrypoints

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -20,16 +20,34 @@
  */
 
 import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
-import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+import { CES_PROTOCOL_VERSION, CesRpcMethod } from "@vellumai/ces-contracts";
+import { StaticCredentialMetadataStore } from "@vellumai/credential-storage";
 
+import { AuditStore } from "./audit/store.js";
+import { PersistentGrantStore } from "./grants/persistent-store.js";
+import {
+  createListAuditRecordsHandler,
+  createListGrantsHandler,
+  createRevokeGrantHandler,
+} from "./grants/rpc-handlers.js";
+import { TemporaryGrantStore } from "./grants/temporary-store.js";
+import { LocalMaterialiser } from "./materializers/local.js";
 import {
   getCesAuditDir,
   getCesDataRoot,
   getCesGrantsDir,
   getCesToolStoreDir,
 } from "./paths.js";
-import { CesRpcServer, type RpcHandlerRegistry } from "./server.js";
+import {
+  buildHandlersWithHttp,
+  CesRpcServer,
+  registerCommandExecutionHandler,
+  type RpcHandlerRegistry,
+} from "./server.js";
+import type { OAuthConnectionLookup } from "./subjects/local.js";
 
 // ---------------------------------------------------------------------------
 // Data directory bootstrap
@@ -48,13 +66,123 @@ function ensureDataDirs(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Stub RPC handlers (real implementations will be added in subsequent PRs)
+// Vellum root resolution (mirrors assistant/src/util/platform.ts)
 // ---------------------------------------------------------------------------
 
-const handlers: RpcHandlerRegistry = {
-  // Placeholder — each RPC method will be wired to its implementation
-  // as the respective PRs land.
-};
+function getVellumRootDir(): string {
+  const baseDataDir = process.env["BASE_DATA_DIR"]?.trim();
+  return join(baseDataDir || homedir(), ".vellum");
+}
+
+// ---------------------------------------------------------------------------
+// Build RPC handler registry
+// ---------------------------------------------------------------------------
+
+function buildHandlers(sessionId: string): RpcHandlerRegistry {
+  // -- Grant stores ----------------------------------------------------------
+  const persistentGrantStore = new PersistentGrantStore(
+    getCesGrantsDir("local"),
+  );
+  persistentGrantStore.init();
+
+  const temporaryGrantStore = new TemporaryGrantStore();
+
+  // -- Audit store -----------------------------------------------------------
+  const auditStore = new AuditStore(getCesAuditDir("local"));
+  auditStore.init();
+
+  // -- Credential backend (local) --------------------------------------------
+  // In local mode CES shares the filesystem with the assistant and can access
+  // the same credential metadata and secure-key stores.
+  const vellumRoot = getVellumRootDir();
+  const credentialMetadataPath = join(
+    vellumRoot,
+    "data",
+    "credential-metadata.json",
+  );
+  const metadataStore = new StaticCredentialMetadataStore(
+    credentialMetadataPath,
+  );
+
+  // Stub OAuth connection lookup — local OAuth connections are resolved from
+  // the assistant's SQLite database which CES cannot access directly. When
+  // local OAuth execution is needed, a connection bridge must be added.
+  const oauthConnections: OAuthConnectionLookup = {
+    getById: () => undefined,
+  };
+
+  // Stub SecureKeyBackend — in local mode the backend implementation lives in
+  // the assistant process (keychain or encrypted file store). CES cannot import
+  // it directly. HTTP/command handlers that require credential materialisation
+  // will return a structured error until a CES-native backend is wired in.
+  const stubSecureKeyBackend = {
+    async get(_key: string) {
+      return undefined;
+    },
+    async set(_key: string, _value: string) {
+      return false;
+    },
+    async delete(_key: string) {
+      return "error" as const;
+    },
+    async list() {
+      return [];
+    },
+  };
+
+  const localMaterialiser = new LocalMaterialiser({
+    secureKeyBackend: stubSecureKeyBackend,
+  });
+
+  // -- Build handler registry ------------------------------------------------
+
+  // Start with the HTTP handler (make_authenticated_request)
+  const handlers = buildHandlersWithHttp(
+    {
+      persistentGrantStore,
+      temporaryGrantStore,
+      localMaterialiser,
+      localSubjectDeps: {
+        metadataStore,
+        oauthConnections,
+      },
+      sessionId,
+    },
+  );
+
+  // Register run_authenticated_command handler
+  registerCommandExecutionHandler(handlers, {
+    executorDeps: {
+      persistentStore: persistentGrantStore,
+      temporaryStore: temporaryGrantStore,
+      materializeCredential: async (_handle) => ({
+        ok: false as const,
+        error:
+          "CES local credential materialisation not yet available. " +
+          "A CES-native secure-key backend must be configured.",
+      }),
+      cesMode: "local",
+    },
+    defaultWorkspaceDir: join(vellumRoot, "workspace"),
+  });
+
+  // Register grant management handlers
+  handlers[CesRpcMethod.ListGrants] = createListGrantsHandler({
+    persistentGrantStore,
+    sessionId,
+  }) as typeof handlers[string];
+
+  handlers[CesRpcMethod.RevokeGrant] = createRevokeGrantHandler({
+    persistentGrantStore,
+  }) as typeof handlers[string];
+
+  // Register audit record handler
+  handlers[CesRpcMethod.ListAuditRecords] = createListAuditRecordsHandler({
+    auditStore,
+  }) as typeof handlers[string];
+
+  return handlers;
+}
 
 // ---------------------------------------------------------------------------
 // Main
@@ -77,6 +205,10 @@ async function main(): Promise<void> {
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+
+  // Build the handler registry with all available RPC implementations
+  const sessionId = `ces-local-${Date.now()}`;
+  const handlers = buildHandlers(sessionId);
 
   const server = new CesRpcServer({
     input: process.stdin,

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -22,8 +22,16 @@ import { createServer as createNetServer, type Socket } from "node:net";
 import { dirname } from "node:path";
 import { Readable, Writable } from "node:stream";
 
-import { CES_PROTOCOL_VERSION } from "@vellumai/ces-contracts";
+import { CES_PROTOCOL_VERSION, CesRpcMethod } from "@vellumai/ces-contracts";
 
+import { AuditStore } from "./audit/store.js";
+import { PersistentGrantStore } from "./grants/persistent-store.js";
+import {
+  createListAuditRecordsHandler,
+  createListGrantsHandler,
+  createRevokeGrantHandler,
+} from "./grants/rpc-handlers.js";
+import { TemporaryGrantStore } from "./grants/temporary-store.js";
 import {
   getBootstrapSocketPath,
   getCesAuditDir,
@@ -32,7 +40,14 @@ import {
   getCesToolStoreDir,
   getHealthPort,
 } from "./paths.js";
-import { CesRpcServer, type RpcHandlerRegistry } from "./server.js";
+import {
+  buildHandlersWithHttp,
+  CesRpcServer,
+  registerCommandExecutionHandler,
+  type RpcHandlerRegistry,
+} from "./server.js";
+import type { ManagedSubjectResolverOptions } from "./subjects/managed.js";
+import type { ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 
 // ---------------------------------------------------------------------------
 // Logging (managed always logs to stderr)
@@ -61,10 +76,110 @@ function ensureDataDirs(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Stub RPC handlers (real implementations added in subsequent PRs)
+// Build RPC handler registry (managed mode)
 // ---------------------------------------------------------------------------
 
-const handlers: RpcHandlerRegistry = {};
+function buildHandlers(sessionId: string): RpcHandlerRegistry {
+  // -- Grant stores ----------------------------------------------------------
+  const persistentGrantStore = new PersistentGrantStore(
+    getCesGrantsDir("managed"),
+  );
+  persistentGrantStore.init();
+
+  const temporaryGrantStore = new TemporaryGrantStore();
+
+  // -- Audit store -----------------------------------------------------------
+  const auditStore = new AuditStore(getCesAuditDir("managed"));
+  auditStore.init();
+
+  // -- Managed credential options --------------------------------------------
+  // In managed mode, credentials are obtained from the platform via its
+  // token-materialization endpoint. The platform URL and API key are provided
+  // through environment variables set by the orchestration layer.
+  const platformBaseUrl = process.env["PLATFORM_BASE_URL"] ?? "";
+  const assistantApiKey = process.env["ASSISTANT_API_KEY"] ?? "";
+
+  const managedSubjectOptions: ManagedSubjectResolverOptions | undefined =
+    platformBaseUrl && assistantApiKey
+      ? { platformBaseUrl, assistantApiKey }
+      : undefined;
+
+  const managedMaterializerOptions: ManagedMaterializerOptions | undefined =
+    platformBaseUrl && assistantApiKey
+      ? { platformBaseUrl, assistantApiKey }
+      : undefined;
+
+  if (!managedSubjectOptions) {
+    warn(
+      "PLATFORM_BASE_URL and/or ASSISTANT_API_KEY not set. " +
+        "Managed credential materialisation will not be available.",
+    );
+  }
+
+  // -- Build handler registry ------------------------------------------------
+
+  // In managed mode there is no local secure-key backend. The HTTP handler
+  // uses managed subject resolution and managed materialisation instead.
+  // The localMaterialiser and localSubjectDeps are required by HttpExecutorDeps
+  // but will only be reached for local_static/local_oauth handles (which are
+  // not expected in managed deployments). We stub them to fail closed.
+  const stubLocalMaterialiser = {
+    async materialise() {
+      return {
+        ok: false as const,
+        error: "Local credential materialisation is not available in managed mode.",
+      };
+    },
+    reset() {},
+  };
+
+  const handlers = buildHandlersWithHttp(
+    {
+      persistentGrantStore,
+      temporaryGrantStore,
+      localMaterialiser: stubLocalMaterialiser as any,
+      localSubjectDeps: {
+        metadataStore: { getByServiceField: () => undefined } as any,
+        oauthConnections: { getById: () => undefined },
+      },
+      managedSubjectOptions,
+      managedMaterializerOptions,
+      sessionId,
+    },
+  );
+
+  // Register run_authenticated_command handler
+  registerCommandExecutionHandler(handlers, {
+    executorDeps: {
+      persistentStore: persistentGrantStore,
+      temporaryStore: temporaryGrantStore,
+      materializeCredential: async (_handle) => ({
+        ok: false as const,
+        error:
+          "Command credential materialisation in managed mode is not yet available.",
+      }),
+      cesMode: "managed",
+    },
+    defaultWorkspaceDir: "/workspace",
+  });
+
+  // Register grant management handlers
+  handlers[CesRpcMethod.ListGrants] = createListGrantsHandler({
+    persistentGrantStore,
+    sessionId,
+  }) as typeof handlers[string];
+
+  handlers[CesRpcMethod.RevokeGrant] = createRevokeGrantHandler({
+    persistentGrantStore,
+  }) as typeof handlers[string];
+
+  // Register audit record handler
+  handlers[CesRpcMethod.ListAuditRecords] = createListAuditRecordsHandler({
+    auditStore,
+  }) as typeof handlers[string];
+
+  return handlers;
+}
 
 // ---------------------------------------------------------------------------
 // Health server
@@ -244,6 +359,10 @@ async function main(): Promise<void> {
   }
 
   rpcConnected = true;
+
+  // Build the handler registry with all available RPC implementations
+  const sessionId = `ces-managed-${Date.now()}`;
+  const handlers = buildHandlers(sessionId);
 
   const server = new CesRpcServer({
     input: connection.readable,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for untrusted-agent-credential-arch.md.

**Gap:** CES entrypoints have empty RPC handler registries
**What was expected:** Entrypoints should use handler factories to build functional registries
**What was found:** Empty stub registries causing METHOD_NOT_FOUND for all RPC calls

### Changes

- **`main.ts` (local mode):** Replaced empty `handlers` object with `buildHandlers()` that instantiates `PersistentGrantStore`, `TemporaryGrantStore`, `AuditStore`, `StaticCredentialMetadataStore`, and `LocalMaterialiser`, then wires them into `buildHandlersWithHttp()`, `registerCommandExecutionHandler()`, and the grant/audit RPC handler factories.

- **`managed-main.ts` (managed mode):** Same pattern but uses managed-mode paths, reads `PLATFORM_BASE_URL`/`ASSISTANT_API_KEY` from env for managed credential options, and stubs local materialiser (not applicable in managed deployments).

### Handler registry now includes:
- `make_authenticated_request` (via `buildHandlersWithHttp`)
- `run_authenticated_command` (via `registerCommandExecutionHandler`)
- `list_grants` (via `createListGrantsHandler`)
- `revoke_grant` (via `createRevokeGrantHandler`)
- `list_audit_records` (via `createListAuditRecordsHandler`)

### Notes
- HTTP/command handlers use stub backends for credential materialisation since `SecureKeyBackend` implementation is not available in the CES package (lives in assistant's security module). They return structured errors instead of METHOD_NOT_FOUND.
- Grant and audit handlers are fully functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)