### PR TITLE
fix: use unknown intermediate cast for stub SecureCommandManifest

### DIFF
--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -598,7 +598,7 @@ export function createManageSecureCommandToolHandler(
         commandProfiles: Object.fromEntries(
           (request.profiles ?? []).map((p) => [p, { command: request.toolName }]),
         ),
-      } as import("./commands/profiles.js").SecureCommandManifest,
+      } as unknown as import("./commands/profiles.js").SecureCommandManifest,
     });
 
     if (!publishResult.success) {


### PR DESCRIPTION
## Summary
- Fix TS2352 type error in `credential-executor/src/server.ts` where a minimal stub manifest (only `commandProfiles`) was cast directly to `SecureCommandManifest`, which now requires 7+ additional fields
- Changed `as SecureCommandManifest` to `as unknown as SecureCommandManifest` since the code is an intentional stub ("for now pass a minimal manifest with declared profiles")

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23101460448/job/67102842134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
