### PR TITLE
fix: harden enrichment test createCommit against index.lock race

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -59,9 +65,34 @@ describe("CommitEnrichmentService", () => {
   }
 
   async function createCommit(): Promise<string> {
-    writeFileSync(join(testDir, `file-${Date.now()}.txt`), "content");
-    await gitService.commitChanges("test commit");
-    return await gitService.getHeadHash();
+    const filename = `file-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`;
+    writeFileSync(join(testDir, filename), "content");
+    // Use execFileSync directly for test setup commits to avoid async
+    // timing issues that can leave stale index.lock files on loaded CI runners.
+    const lockPath = join(testDir, ".git", "index.lock");
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      /* no lock to clean */
+    }
+    execFileSync("git", ["add", "-A"], { cwd: testDir });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "core.hooksPath=/dev/null",
+        "commit",
+        "--no-verify",
+        "-m",
+        "test commit",
+        "--allow-empty",
+      ],
+      { cwd: testDir },
+    );
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: testDir,
+      encoding: "utf-8",
+    }).trim();
   }
 
   async function waitForDrain(


### PR DESCRIPTION
## Summary
- Switch `createCommit()` test helper from async `gitService.commitChanges()` to synchronous `execFileSync` git commands, eliminating async timing issues that can leave stale `index.lock` files on loaded CI runners
- Add defensive `index.lock` cleanup before each commit and unique filename suffixes to prevent collisions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23101192116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
