### PR TITLE
fix: register manage_secure_command_tool handler in CES entrypoints

### DIFF
--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -45,8 +45,10 @@ import {
   buildHandlersWithHttp,
   CesRpcServer,
   registerCommandExecutionHandler,
+  registerManageSecureCommandToolHandler,
   type RpcHandlerRegistry,
 } from "./server.js";
+import { publishBundle } from "./toolstore/publish.js";
 import type { OAuthConnectionLookup } from "./subjects/local.js";
 
 // ---------------------------------------------------------------------------
@@ -164,6 +166,26 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       cesMode: "local",
     },
     defaultWorkspaceDir: join(vellumRoot, "workspace"),
+  });
+
+  // Register manage_secure_command_tool handler
+  const toolRegistry = new Map<string, { toolName: string; credentialHandle: string; description: string; bundleDigest: string }>();
+
+  registerManageSecureCommandToolHandler(handlers, {
+    downloadBundle: async (sourceUrl: string) => {
+      const resp = await fetch(sourceUrl);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+      }
+      return Buffer.from(await resp.arrayBuffer());
+    },
+    publishBundle: (request) => publishBundle({ ...request, cesMode: "local" }),
+    unregisterTool: (toolName: string) => {
+      return toolRegistry.delete(toolName);
+    },
+    registerTool: (entry) => {
+      toolRegistry.set(entry.toolName, entry);
+    },
   });
 
   // Register grant management handlers

--- a/credential-executor/src/managed-main.ts
+++ b/credential-executor/src/managed-main.ts
@@ -44,8 +44,10 @@ import {
   buildHandlersWithHttp,
   CesRpcServer,
   registerCommandExecutionHandler,
+  registerManageSecureCommandToolHandler,
   type RpcHandlerRegistry,
 } from "./server.js";
+import { publishBundle } from "./toolstore/publish.js";
 import type { ManagedSubjectResolverOptions } from "./subjects/managed.js";
 import type { ManagedMaterializerOptions } from "./materializers/managed-platform.js";
 
@@ -161,6 +163,26 @@ function buildHandlers(sessionId: string): RpcHandlerRegistry {
       cesMode: "managed",
     },
     defaultWorkspaceDir: "/workspace",
+  });
+
+  // Register manage_secure_command_tool handler
+  const toolRegistry = new Map<string, { toolName: string; credentialHandle: string; description: string; bundleDigest: string }>();
+
+  registerManageSecureCommandToolHandler(handlers, {
+    downloadBundle: async (sourceUrl: string) => {
+      const resp = await fetch(sourceUrl);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+      }
+      return Buffer.from(await resp.arrayBuffer());
+    },
+    publishBundle: (request) => publishBundle({ ...request, cesMode: "managed" }),
+    unregisterTool: (toolName: string) => {
+      return toolRegistry.delete(toolName);
+    },
+    registerTool: (entry) => {
+      toolRegistry.set(entry.toolName, entry);
+    },
   });
 
   // Register grant management handlers


### PR DESCRIPTION
## Summary
Fixes gap: manage_secure_command_tool handler not registered in CES entrypoints.

The handler factory existed but was never called from either main.ts or managed-main.ts, causing METHOD_NOT_FOUND for secure tool management RPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
