### PR TITLE
fix: correct record_grant handler tool/scope/pattern field mapping for persistent grants

### DIFF
--- a/credential-executor/src/grants/rpc-handlers.ts
+++ b/credential-executor/src/grants/rpc-handlers.ts
@@ -49,8 +49,8 @@ function projectGrant(
   return {
     grantId: grant.id,
     sessionId,
-    credentialHandle: grant.tool,
-    proposalType: "http",
+    credentialHandle: grant.scope,
+    proposalType: grant.tool as "http" | "command",
     proposalHash: grant.id,
     allowedPurposes: [grant.pattern],
     status: "active",
@@ -101,12 +101,12 @@ export function createRecordGrantHandler(
 
     const persistentGrant: PersistentGrant = {
       id: grantId,
-      tool: proposal.credentialHandle,
+      tool: proposal.type,
       pattern:
         proposal.type === "http"
           ? `${proposal.method} ${proposal.url}`
           : proposal.command,
-      scope: "everywhere",
+      scope: proposal.credentialHandle,
       createdAt: now,
     };
 


### PR DESCRIPTION
## Summary
Fixes persistent grant matching bug in record_grant handler.

**What was wrong:** `tool` was set to `credentialHandle` and `scope` to `'everywhere'`, but policy evaluators expect `tool='http'|'command'` and `scope=credentialHandle`. Additionally, the `projectGrant` function had mirrored bugs: it mapped `grant.tool` to `credentialHandle` (wrong after the semantic change) and hardcoded `proposalType: "http"` instead of reading from `grant.tool`.

**Fix:**
- `record_grant` handler: Map `proposal.type` to `tool`, `proposal.credentialHandle` to `scope`
- `projectGrant`: Map `grant.scope` to `credentialHandle`, `grant.tool` to `proposalType`

🤖 Generated with [Claude Code](https://claude.com/claude-code)