### PR TITLE
feat: report user turn counts in anonymous telemetry

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -1,0 +1,42 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+
+import { getDb } from "./db.js";
+import { messages } from "./schema.js";
+
+export interface TurnEvent {
+  id: string;
+  createdAt: number;
+}
+
+/**
+ * Query user messages (turns) that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedTurnEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): TurnEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.role, "user"),
+        afterId
+          ? or(
+              gt(messages.createdAt, afterCreatedAt),
+              and(
+                eq(messages.createdAt, afterCreatedAt),
+                gt(messages.id, afterId),
+              ),
+            )
+          : gt(messages.createdAt, afterCreatedAt),
+      ),
+    )
+    .orderBy(asc(messages.createdAt), asc(messages.id))
+    .limit(limit)
+    .all();
+  return rows;
+}

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -1,8 +1,8 @@
 /**
  * Usage telemetry reporter.
  *
- * Periodically flushes LLM usage events from the local SQLite
- * `llm_usage_events` table and POSTs them to the platform telemetry endpoint.
+ * Periodically flushes LLM usage events and turn events (user messages) from
+ * the local SQLite database and POSTs them to the platform telemetry endpoint.
  *
  * Two auth modes:
  * - Authenticated: Api-Key header via managed proxy context
@@ -20,6 +20,7 @@ import {
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
+import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { getLogger } from "../util/logger.js";
 
@@ -31,6 +32,8 @@ const log = getLogger("usage-telemetry");
 
 const CHECKPOINT_KEY_WATERMARK = "telemetry:usage:last_reported_at";
 const CHECKPOINT_KEY_WATERMARK_ID = "telemetry:usage:last_reported_id";
+const CHECKPOINT_KEY_TURN_WATERMARK = "telemetry:turns:last_reported_at";
+const CHECKPOINT_KEY_TURN_WATERMARK_ID = "telemetry:turns:last_reported_id";
 const CHECKPOINT_KEY_INSTALL_ID = "telemetry:installation_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const BATCH_SIZE = 500;
@@ -94,12 +97,19 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
-      // Read watermark (compound cursor: createdAt + id)
+      // Read usage watermark (compound cursor: createdAt + id)
       const watermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK) ?? "0",
       );
       const watermarkId =
         getMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID) ?? undefined;
+
+      // Read turn watermark (compound cursor: createdAt + id)
+      const turnWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK) ?? "0",
+      );
+      const turnWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID) ?? undefined;
 
       // Query unreported events
       const events = queryUnreportedUsageEvents(
@@ -107,7 +117,13 @@ export class UsageTelemetryReporter {
         watermarkId,
         BATCH_SIZE,
       );
-      if (events.length === 0) return;
+      const turnEvents = queryUnreportedTurnEvents(
+        turnWatermark,
+        turnWatermarkId,
+        BATCH_SIZE,
+      );
+
+      if (events.length === 0 && turnEvents.length === 0) return;
 
       // Resolve auth context — skip flush when neither auth mode is viable
       const proxyCtx = await resolveManagedProxyContext();
@@ -140,6 +156,10 @@ export class UsageTelemetryReporter {
           actor: e.actor,
           recorded_at: e.createdAt,
         })),
+        turn_events: turnEvents.map((e) => ({
+          daemon_event_id: e.id,
+          recorded_at: e.createdAt,
+        })),
       };
 
       // Send
@@ -162,16 +182,28 @@ export class UsageTelemetryReporter {
       }
       await resp.text(); // consume body to release connection
 
-      // Advance watermark (compound cursor)
-      const lastEvent = events[events.length - 1];
-      setMemoryCheckpoint(
-        CHECKPOINT_KEY_WATERMARK,
-        String(lastEvent.createdAt),
-      );
-      setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, lastEvent.id);
+      // Advance usage watermark (compound cursor)
+      if (events.length > 0) {
+        const lastEvent = events[events.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_WATERMARK,
+          String(lastEvent.createdAt),
+        );
+        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, lastEvent.id);
+      }
 
-      // If we got a full batch, there may be more events — recurse
-      if (events.length === BATCH_SIZE) {
+      // Advance turn watermark (compound cursor)
+      if (turnEvents.length > 0) {
+        const lastTurn = turnEvents[turnEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TURN_WATERMARK,
+          String(lastTurn.createdAt),
+        );
+        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID, lastTurn.id);
+      }
+
+      // If we got a full batch of either type, there may be more — recurse
+      if (events.length === BATCH_SIZE || turnEvents.length === BATCH_SIZE) {
         await this._doFlush(batchCount + 1);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Added `turn_events` array to the telemetry payload sent to the platform, reporting each user message as a lightweight event (ID + timestamp only, no content)
- Added `turn-events-store.ts` with a Drizzle query against the `messages` table using the same compound-cursor watermark pattern as usage events
- Turn events use independent watermark checkpoints (`telemetry:turns:last_reported_at/id`) so the two streams don't interfere

## Original prompt
For the anonymous telemetry that gets sent back to the platform, instead of just token counts, I also want to report number of turns (aka number of messages sent by the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
