### PR TITLE
fix: remove CES executable search path inside sandbox boundary

### DIFF
--- a/assistant/src/credential-execution/executable-discovery.ts
+++ b/assistant/src/credential-execution/executable-discovery.ts
@@ -22,7 +22,7 @@ import { join } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
-import { getDataDir, getRootDir } from "../util/platform.js";
+import { getRootDir } from "../util/platform.js";
 
 const log = getLogger("ces-discovery");
 
@@ -40,15 +40,13 @@ const MANAGED_BOOTSTRAP_SOCKET_PATH = "/run/ces/ces.sock";
  * Candidate locations for the local credential-executor binary, checked
  * in order. The first existing path wins.
  *
- * 1. `~/.vellum/bin/credential-executor` — installed alongside the assistant
- * 2. Relative to the repo root (development) — `credential-executor/src/index.ts`
- *    run via `bun run`.
+ * Only paths outside the sandbox working directory are eligible.
+ * `getDataDir()` (under `~/.vellum/workspace/data`) was previously included
+ * but is inside the sandbox write boundary, so a sandboxed tool could plant
+ * a malicious binary there. Removed to close the sandbox-escape vector.
  */
 function getLocalBinarySearchPaths(): string[] {
-  return [
-    join(getRootDir(), "bin", "credential-executor"),
-    join(getDataDir(), "bin", "credential-executor"),
-  ];
+  return [join(getRootDir(), "bin", "credential-executor")];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed `getDataDir()/bin/credential-executor` from the CES local discovery search paths
- This path (`~/.vellum/workspace/data/bin/`) is inside the sandbox working directory (`~/.vellum/workspace/`), meaning sandboxed tools could write a malicious binary there
- Only `getRootDir()/bin/credential-executor` (`~/.vellum/bin/`) — which is outside the sandbox — is now searched

## Original prompt
the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
