### PR TITLE
fix: tighten credential-storage package boundary regex

### DIFF
--- a/packages/credential-storage/src/__tests__/package-boundary.test.ts
+++ b/packages/credential-storage/src/__tests__/package-boundary.test.ts
@@ -38,9 +38,9 @@ function collectSourceFiles(dir: string): string[] {
  * or other modules this package should never depend on.
  */
 const FORBIDDEN_IMPORT_PATTERNS = [
-  // Assistant daemon internals
-  /from\s+["'](?:\.\.\/)*(?:assistant|@vellumai\/assistant)\//,
-  /require\s*\(\s*["'](?:\.\.\/)*(?:assistant|@vellumai\/assistant)\//,
+  // Assistant daemon internals (blocks both sub-path and root entrypoint imports)
+  /from\s+["'](?:\.\.\/)*(?:assistant|@vellumai\/assistant)(?:\/|["'])/,
+  /require\s*\(\s*["'](?:\.\.\/)*(?:assistant|@vellumai\/assistant)(?:\/|["'])/,
 
   // CES modules (credential execution service)
   /from\s+["'].*\/ces\//,


### PR DESCRIPTION
Address review feedback from PR #16812. Update package-boundary.test.ts to block root assistant imports (e.g. `from "@vellumai/assistant"`) in the boundary regex, not just sub-path imports (e.g. `from "@vellumai/assistant/foo"`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
