### PR TITLE
fix: preserve Telegram URL fallback for blank config values

### DIFF
--- a/gateway/src/__tests__/config-file-cache.test.ts
+++ b/gateway/src/__tests__/config-file-cache.test.ts
@@ -44,10 +44,10 @@ describe("ConfigFileCache: getString", () => {
     expect(cache.getString("email", "address")).toBe("a@b.com");
   });
 
-  test("returns empty string as-is", () => {
+  test("returns undefined for empty string value", () => {
     writeConfig({ email: { address: "" } });
     const cache = new ConfigFileCache();
-    expect(cache.getString("email", "address")).toBe("");
+    expect(cache.getString("email", "address")).toBeUndefined();
   });
 
   test("returns undefined for non-string value", () => {

--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -81,7 +81,7 @@ export class ConfigFileCache {
     opts?: ReadOptions,
   ): string | undefined {
     const raw = this.getRaw(section, field, opts);
-    return typeof raw === "string" ? raw : undefined;
+    return typeof raw === "string" ? raw || undefined : undefined;
   }
 
   getNumber(


### PR DESCRIPTION
Address review feedback from PR #16854. Restore empty-string-to-undefined coercion in `getString()` so that `??` fallback logic in Telegram API callers (`callTelegramApi`, `downloadTelegramFile`) continues to produce valid URLs when config values are blank.

Closes feedback on #16854.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
