### PR TITLE
fix: ensure silentlyWithLog suppresses cleanup errors

### DIFF
--- a/assistant/src/util/silently.ts
+++ b/assistant/src/util/silently.ts
@@ -3,22 +3,21 @@ import { getLogger } from "./logger.js";
 const log = getLogger("silently");
 
 /**
- * Attaches a `.catch()` to `promise` that emits a debug-level log instead of
- * swallowing the rejection completely.  Use this in place of bare
- * `.catch(() => {})` when you need fire-and-forget semantics but still want
- * visibility into unexpected errors during debugging.
+ * Suppresses rejections from `promise`, logging them at debug level instead.
+ * Use this in place of bare `.catch(() => {})` when you need fire-and-forget
+ * semantics but still want visibility into unexpected errors during debugging.
  *
- * The original promise is returned unchanged so callers can still chain it.
+ * Returns the caught promise so `await silentlyWithLog(...)` never throws.
  *
  * @example
  *   silentlyWithLog(stopSession(id), 'idle session cleanup');
+ *   await silentlyWithLog(rm(dir, { recursive: true }), 'cleanup');
  */
 export function silentlyWithLog<T>(
   promise: Promise<T>,
   context: string,
-): Promise<T> {
-  promise.catch((err: unknown) => {
+): Promise<T | void> {
+  return promise.catch((err: unknown) => {
     log.debug({ err, context }, "Suppressed async error");
   });
-  return promise;
 }


### PR DESCRIPTION
Address review feedback from PR #16858.

`silentlyWithLog()` was returning the original promise, so `await silentlyWithLog(...)` still threw on rejection. This caused cleanup errors (e.g. from `rm()`) to propagate and mask the original error in catch/finally blocks in preprocess and transcribe paths.

Fix: return the caught promise chain from `silentlyWithLog()` so rejections are always suppressed. The return type changes to `Promise<T | void>` to reflect that a caught rejection resolves to `undefined`.

Affected call sites (no changes needed — the fix is at the source):
- `assistant/src/config/bundled-skills/media-processing/services/preprocess.ts` (catch block cleanup)
- `assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts` (two finally block cleanups)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
