### PR TITLE
fix: model CES tool responses as discriminated union and list packages/ in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Bun + TypeScript monorepo with multiple packages:
 - `cli/` — Multi-assistant management CLI (Bun + TypeScript). See `cli/AGENTS.md`.
 - `clients/` — Client apps (macOS/iOS/etc). See `clients/AGENTS.md` and platform docs like `clients/macos/CLAUDE.md`.
 - `gateway/` — Channel ingress gateway (Bun + TypeScript)
+- `packages/` — Shared internal packages (e.g. `ces-contracts` for CES wire-protocol schemas)
 - `scripts/` — Utility scripts
 - `skills/` — First-party skill catalog (portable skill packages). See `skills/AGENTS.md`.
 - `.claude/` — Claude Code slash commands and helper scripts (see `.claude/README.md`). Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks; repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/` as local skill directories. The `/update` command uses `vellum ps`, `vellum sleep`, and `vellum wake` to manage assistant lifecycle.

--- a/packages/ces-contracts/src/__tests__/contracts.test.ts
+++ b/packages/ces-contracts/src/__tests__/contracts.test.ts
@@ -218,6 +218,13 @@ describe("ToolResponseBaseSchema", () => {
     expect(result.result).toEqual({ html: "<html></html>" });
   });
 
+  test("parses a successful response without result", () => {
+    const result = ToolResponseBaseSchema.parse({
+      success: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
   test("parses a failed response with error", () => {
     const result = ToolResponseBaseSchema.parse({
       success: false,
@@ -227,7 +234,15 @@ describe("ToolResponseBaseSchema", () => {
       },
     });
     expect(result.success).toBe(false);
-    expect(result.error?.code).toBe("TOOL_FAILED");
+    expect(result.error.code).toBe("TOOL_FAILED");
+  });
+
+  test("rejects a failed response without error", () => {
+    expect(() =>
+      ToolResponseBaseSchema.parse({
+        success: false,
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/ces-contracts/src/index.ts
+++ b/packages/ces-contracts/src/index.ts
@@ -87,16 +87,26 @@ export type ToolRequestBase = z.infer<typeof ToolRequestBaseSchema>;
 
 /**
  * Base shape for a tool execution response sent from CES back to the
- * assistant.
+ * assistant. Modeled as a discriminated union on `success` so malformed
+ * payloads (e.g. `success: false` without `error`, or `success: true`
+ * with `error`) are rejected at parse time.
  */
-export const ToolResponseBaseSchema = z.object({
-  /** Whether the tool executed successfully. */
-  success: z.boolean(),
-  /** Tool output when `success` is true. */
+const ToolResponseSuccessSchema = z.object({
+  success: z.literal(true),
+  /** Tool output. */
   result: z.unknown().optional(),
-  /** Structured error when `success` is false. */
-  error: RpcErrorSchema.optional(),
 });
+
+const ToolResponseErrorSchema = z.object({
+  success: z.literal(false),
+  /** Structured error describing the failure. */
+  error: RpcErrorSchema,
+});
+
+export const ToolResponseBaseSchema = z.discriminatedUnion("success", [
+  ToolResponseSuccessSchema,
+  ToolResponseErrorSchema,
+]);
 export type ToolResponseBase = z.infer<typeof ToolResponseBaseSchema>;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Address review feedback from PR #16810.

- Refactor `ToolResponseBaseSchema` to use a discriminated union keyed by `success`, so malformed payloads like `{success: false}` (missing error) or contradictory payloads are rejected at parse time
- Add `packages/` to AGENTS.md Project Structure section for discoverability
- Update tests to verify the discriminated union rejects invalid payloads
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
