### PR TITLE
fix: log errors in egress-proxy stopAllSessions

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -459,5 +459,7 @@ export function getSessionsForConversation(
  * Stop all sessions and clear internal state. Useful for daemon shutdown.
  */
 export async function stopAllSessions(): Promise<void> {
-  return coreStopAllSessions(store);
+  return coreStopAllSessions(store, (id, err) => {
+    log.debug({ err, id }, "session shutdown error");
+  });
 }

--- a/packages/egress-proxy/src/session-core.ts
+++ b/packages/egress-proxy/src/session-core.ts
@@ -441,12 +441,21 @@ export async function getOrStartSession(
 
 /**
  * Stop all sessions and clear internal state. Useful for daemon shutdown.
+ *
+ * @param onError — optional callback invoked for each session that fails to
+ *   stop.  When omitted, errors are silently swallowed so shutdown always
+ *   completes.
  */
-export async function stopAllSessions(store: SessionStore): Promise<void> {
+export async function stopAllSessions(
+  store: SessionStore,
+  onError?: (sessionId: ProxySessionId, err: unknown) => void,
+): Promise<void> {
   const ids = [...store.sessions.keys()];
   await Promise.all(
     ids.map((id) =>
-      stopSession(id, store).catch(() => {}),
+      stopSession(id, store).catch((err) => {
+        onError?.(id, err);
+      }),
     ),
   );
   store.sessions.clear();


### PR DESCRIPTION
Address review feedback from PR #16833.

`stopAllSessions` in the egress-proxy package was silently swallowing errors with `.catch(() => {})`. Added an optional `onError` callback parameter so callers can handle shutdown errors. The assistant's `session-manager.ts` now passes a logging callback to restore the `log.debug` behavior that existed before the extraction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
