### PR TITLE
fix: rebuild guardian timestamp columns with INTEGER affinity

### DIFF
--- a/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
+++ b/assistant/src/memory/migrations/162-guardian-timestamps-epoch-ms.ts
@@ -5,15 +5,19 @@ import { withCrashRecovery } from "./validate-migration-state.js";
 const log = getLogger("migration-162");
 
 /**
- * Convert guardian table timestamps from ISO 8601 text to epoch ms integers.
+ * Convert guardian table timestamps from ISO 8601 text to epoch ms integers,
+ * then rebuild the tables so that timestamp columns have INTEGER affinity.
  *
  * The `canonical_guardian_requests`, `canonical_guardian_deliveries`, and
- * `scoped_approval_grants` tables originally used TEXT for timestamp columns
- * while all other tables use INTEGER (epoch ms). This migration converts
- * existing data in-place — SQLite's dynamic typing allows storing integers
- * in columns declared as TEXT without a table rebuild.
+ * `scoped_approval_grants` tables were originally created with TEXT columns
+ * for timestamps. Migration step 1 converts existing data values in-place,
+ * and step 2 rebuilds the tables so the column declarations use INTEGER.
+ * Without the rebuild, SQLite's TEXT affinity coerces the integer values
+ * back to text strings on read, causing downstream code (e.g.
+ * `new Date(req.expiresAt).getTime()`) to produce NaN.
  */
 export function migrateGuardianTimestampsEpochMs(database: DrizzleDb): void {
+  // Step 1: Convert existing text timestamps to integer epoch ms values.
   withCrashRecovery(
     database,
     "migration_guardian_timestamps_epoch_ms_v1",
@@ -60,4 +64,220 @@ export function migrateGuardianTimestampsEpochMs(database: DrizzleDb): void {
       );
     },
   );
+
+  // Step 2: Rebuild tables so timestamp columns have INTEGER affinity.
+  // Databases created before the CREATE TABLE migrations were updated still
+  // have TEXT affinity on these columns, which coerces integer values back
+  // to text strings on read.
+  withCrashRecovery(
+    database,
+    "migration_guardian_timestamps_rebuild_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      rebuildCanonicalGuardianRequests(raw);
+      rebuildCanonicalGuardianDeliveries(raw);
+      rebuildScopedApprovalGrants(raw);
+
+      log.info(
+        "Rebuilt guardian tables with INTEGER affinity on timestamp columns",
+      );
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table rebuild helpers
+// ---------------------------------------------------------------------------
+
+type RawDb = ReturnType<typeof getSqliteFrom>;
+
+function hasIntegerAffinity(
+  raw: RawDb,
+  table: string,
+  column: string,
+): boolean {
+  const row = raw
+    .query(
+      `SELECT type FROM pragma_table_info('${table}') WHERE name = '${column}'`,
+    )
+    .get() as { type: string } | null;
+  if (!row) return true; // column doesn't exist — nothing to fix
+  return row.type.toUpperCase() === "INTEGER";
+}
+
+function rebuildCanonicalGuardianRequests(raw: RawDb): void {
+  if (hasIntegerAffinity(raw, "canonical_guardian_requests", "created_at"))
+    return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+
+      CREATE TABLE canonical_guardian_requests_new (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        source_channel TEXT,
+        conversation_id TEXT,
+        requester_external_user_id TEXT,
+        requester_chat_id TEXT,
+        guardian_external_user_id TEXT,
+        guardian_principal_id TEXT,
+        call_session_id TEXT,
+        pending_question_id TEXT,
+        question_text TEXT,
+        request_code TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        answer_text TEXT,
+        decided_by_external_user_id TEXT,
+        decided_by_principal_id TEXT,
+        followup_state TEXT,
+        expires_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      INSERT INTO canonical_guardian_requests_new
+      SELECT id, kind, source_type, source_channel, conversation_id,
+             requester_external_user_id, requester_chat_id,
+             guardian_external_user_id, guardian_principal_id,
+             call_session_id, pending_question_id, question_text,
+             request_code, tool_name, input_digest, status, answer_text,
+             decided_by_external_user_id, decided_by_principal_id,
+             followup_state, expires_at, created_at, updated_at
+      FROM canonical_guardian_requests;
+
+      DROP TABLE canonical_guardian_requests;
+      ALTER TABLE canonical_guardian_requests_new RENAME TO canonical_guardian_requests;
+
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_status ON canonical_guardian_requests(status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_guardian ON canonical_guardian_requests(guardian_external_user_id, status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_conversation ON canonical_guardian_requests(conversation_id, status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_source ON canonical_guardian_requests(source_type, status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_kind ON canonical_guardian_requests(kind, status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_requests_request_code ON canonical_guardian_requests(request_code);
+
+      COMMIT;
+    `);
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildCanonicalGuardianDeliveries(raw: RawDb): void {
+  if (hasIntegerAffinity(raw, "canonical_guardian_deliveries", "created_at"))
+    return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+
+      CREATE TABLE canonical_guardian_deliveries_new (
+        id TEXT PRIMARY KEY,
+        request_id TEXT NOT NULL REFERENCES canonical_guardian_requests(id) ON DELETE CASCADE,
+        destination_channel TEXT NOT NULL,
+        destination_conversation_id TEXT,
+        destination_chat_id TEXT,
+        destination_message_id TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      INSERT INTO canonical_guardian_deliveries_new
+      SELECT id, request_id, destination_channel, destination_conversation_id,
+             destination_chat_id, destination_message_id, status,
+             created_at, updated_at
+      FROM canonical_guardian_deliveries;
+
+      DROP TABLE canonical_guardian_deliveries;
+      ALTER TABLE canonical_guardian_deliveries_new RENAME TO canonical_guardian_deliveries;
+
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_request_id ON canonical_guardian_deliveries(request_id);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_status ON canonical_guardian_deliveries(status);
+      CREATE INDEX IF NOT EXISTS idx_canonical_guardian_deliveries_destination ON canonical_guardian_deliveries(destination_channel, destination_chat_id);
+
+      COMMIT;
+    `);
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
+}
+
+function rebuildScopedApprovalGrants(raw: RawDb): void {
+  if (hasIntegerAffinity(raw, "scoped_approval_grants", "created_at")) return;
+
+  raw.exec("PRAGMA foreign_keys = OFF");
+  try {
+    raw.exec(/*sql*/ `
+      BEGIN;
+
+      CREATE TABLE scoped_approval_grants_new (
+        id TEXT PRIMARY KEY,
+        scope_mode TEXT NOT NULL,
+        request_id TEXT,
+        tool_name TEXT,
+        input_digest TEXT,
+        request_channel TEXT NOT NULL,
+        decision_channel TEXT NOT NULL,
+        execution_channel TEXT,
+        conversation_id TEXT,
+        call_session_id TEXT,
+        requester_external_user_id TEXT,
+        guardian_external_user_id TEXT,
+        status TEXT NOT NULL,
+        expires_at INTEGER NOT NULL,
+        consumed_at INTEGER,
+        consumed_by_request_id TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      INSERT INTO scoped_approval_grants_new
+      SELECT id, scope_mode, request_id, tool_name, input_digest,
+             request_channel, decision_channel, execution_channel,
+             conversation_id, call_session_id,
+             requester_external_user_id, guardian_external_user_id,
+             status, expires_at, consumed_at, consumed_by_request_id,
+             created_at, updated_at
+      FROM scoped_approval_grants;
+
+      DROP TABLE scoped_approval_grants;
+      ALTER TABLE scoped_approval_grants_new RENAME TO scoped_approval_grants;
+
+      CREATE INDEX IF NOT EXISTS idx_scoped_grants_request_id ON scoped_approval_grants(request_id) WHERE request_id IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_scoped_grants_tool_sig ON scoped_approval_grants(tool_name, input_digest) WHERE tool_name IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_scoped_grants_status_expires ON scoped_approval_grants(status, expires_at);
+
+      COMMIT;
+    `);
+  } catch (e) {
+    try {
+      raw.exec("ROLLBACK");
+    } catch {
+      /* no active transaction */
+    }
+    throw e;
+  } finally {
+    raw.exec("PRAGMA foreign_keys = ON");
+  }
 }

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -202,6 +202,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Convert guardian table timestamps from ISO 8601 text to epoch ms integers for consistency with all other tables",
   },
+  {
+    key: "migration_guardian_timestamps_rebuild_v1",
+    version: 30,
+    dependsOn: ["migration_guardian_timestamps_epoch_ms_v1"],
+    description:
+      "Rebuild guardian tables so timestamp columns have INTEGER affinity instead of TEXT",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
Address review feedback from PR #16867.

The original migration only converted timestamp values via UPDATE but left the column declarations as TEXT. In SQLite, TEXT affinity coerces stored integers back to text strings on read, causing `new Date(req.expiresAt).getTime()` to return NaN and breaking expiry filtering.

This adds a table rebuild step (using the standard RENAME/CREATE/INSERT/DROP pattern) for `canonical_guardian_requests`, `canonical_guardian_deliveries`, and `scoped_approval_grants` so that timestamp columns (`created_at`, `updated_at`, `expires_at`, `consumed_at`) have INTEGER affinity. The rebuild is idempotent — it checks `pragma_table_info` and skips tables that already have INTEGER affinity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
