### PR TITLE
fix: exclude non-user-origin rows from turn telemetry count

### DIFF
--- a/assistant/src/memory/turn-events-store.ts
+++ b/assistant/src/memory/turn-events-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq, gt, notLike, or } from "drizzle-orm";
 
 import { getDb } from "./db.js";
 import { messages } from "./schema.js";
@@ -24,6 +24,9 @@ export function queryUnreportedTurnEvents(
     .where(
       and(
         eq(messages.role, "user"),
+        // Exclude tool-result rows persisted with role "user" — these are
+        // system-generated and should not count as user turns.
+        notLike(messages.content, '%"type":"tool_result"%'),
         afterId
           ? or(
               gt(messages.createdAt, afterCreatedAt),


### PR DESCRIPTION
Address review feedback from PR #16911. The `queryUnreportedTurnEvents` query was counting all `role = "user"` messages, but the daemon also persists tool-result blocks with role "user" (in `session-agent-loop-handlers.ts` and `session-agent-loop.ts`). These synthetic rows inflated user-turn counts in telemetry.

Added a `notLike` filter to exclude messages containing `"type":"tool_result"` content, so only actual user-authored messages are counted as turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
