### PR TITLE
fix: block concurrent hatch while PID file is in starting state

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -207,7 +207,25 @@ async function startDaemonFromSource(
   // --- Lifecycle guard: prevent split-brain daemon state ---
   if (existsSync(pidFile)) {
     try {
-      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      const content = readFileSync(pidFile, "utf-8").trim();
+
+      // Another caller is already spawning the daemon — wait for it
+      // instead of racing to spawn a duplicate.
+      if (content === "starting") {
+        console.log(
+          "   Assistant is starting — waiting for it to become ready...",
+        );
+        if (await waitForDaemonReady(resources.daemonPort, 60000)) {
+          console.log("   Assistant is ready\n");
+          return;
+        }
+        // The other spawn may have failed; clean up and proceed to spawn.
+        try {
+          unlinkSync(pidFile);
+        } catch {}
+      }
+
+      const pid = parseInt(content, 10);
       if (!isNaN(pid)) {
         try {
           process.kill(pid, 0);
@@ -250,8 +268,7 @@ async function startDaemonFromSource(
   }
 
   // Write a sentinel PID file before spawning so concurrent hatch() calls
-  // see the file and fall through to the isDaemonResponsive() port check
-  // instead of racing to spawn a duplicate daemon.
+  // detect the in-progress spawn and wait instead of racing.
   writeFileSync(pidFile, "starting", "utf-8");
 
   const daemonLogFd = openLogFile("hatch.log");
@@ -293,7 +310,25 @@ async function startDaemonWatchFromSource(
   // If a daemon is already running, skip spawning a new one.
   if (existsSync(pidFile)) {
     try {
-      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      const content = readFileSync(pidFile, "utf-8").trim();
+
+      // Another caller is already spawning the daemon — wait for it
+      // instead of racing to spawn a duplicate.
+      if (content === "starting") {
+        console.log(
+          "   Assistant is starting — waiting for it to become ready...",
+        );
+        if (await waitForDaemonReady(resources.daemonPort, 60000)) {
+          console.log("   Assistant is ready\n");
+          return;
+        }
+        // The other spawn may have failed; clean up and proceed to spawn.
+        try {
+          unlinkSync(pidFile);
+        } catch {}
+      }
+
+      const pid = parseInt(content, 10);
       if (!isNaN(pid)) {
         try {
           process.kill(pid, 0); // Check if alive
@@ -763,7 +798,26 @@ export async function startLocalDaemon(
     let daemonAlive = false;
     if (existsSync(pidFile)) {
       try {
-        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+        const content = readFileSync(pidFile, "utf-8").trim();
+
+        // Another caller is already spawning the daemon — wait for it
+        // instead of racing to spawn a duplicate.
+        if (content === "starting") {
+          console.log(
+            "   Assistant is starting — waiting for it to become ready...",
+          );
+          if (await waitForDaemonReady(resources.daemonPort, 60000)) {
+            console.log("   Assistant is ready\n");
+            ensureBunInstalled();
+            return;
+          }
+          // The other spawn may have failed; clean up and proceed to spawn.
+          try {
+            unlinkSync(pidFile);
+          } catch {}
+        }
+
+        const pid = parseInt(content, 10);
         if (!isNaN(pid)) {
           try {
             process.kill(pid, 0); // Check if alive


### PR DESCRIPTION
Address review feedback from PR #16859. The sentinel PID file (containing "starting") was not actually blocking concurrent daemon spawns — `parseInt("starting", 10)` returns `NaN`, causing the lifecycle guard to skip and fall through to `isDaemonResponsive()`, which also returns false during startup. Now all three lifecycle guards explicitly check for the "starting" sentinel and wait for the daemon to become responsive via `waitForDaemonReady()` instead of racing to spawn a duplicate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
