### PR TITLE
fix: use unique temp path for each credential store write

### DIFF
--- a/assistant/src/security/encrypted-store.ts
+++ b/assistant/src/security/encrypted-store.ts
@@ -155,8 +155,9 @@ function readStore(): StoreFile | null {
 function writeStore(store: StoreFile): void {
   const path = getStorePath();
   ensureDir(dirname(path));
-  // Atomic write: write to temp file then rename to avoid partial/corrupt writes
-  const tmpPath = path + ".tmp";
+  // Atomic write: write to temp file then rename to avoid partial/corrupt writes.
+  // Use a unique suffix per write to prevent collisions under concurrent writes.
+  const tmpPath = path + `.tmp.${randomBytes(6).toString("hex")}`;
   writeFileSync(tmpPath, JSON.stringify(store, null, 2), { mode: 0o600 });
   chmodSync(tmpPath, 0o600);
   renameSync(tmpPath, path);


### PR DESCRIPTION
Address review feedback from PR #16848. Generate a unique temp path for each write to avoid concurrent write conflicts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
