### PR TITLE
fix: use bootstrap-returned assistant and check upsertManagedEntry in transfer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -138,11 +138,14 @@ struct AssistantTransferSection: View {
             case .createdNew(let assistant):
                 platformAssistant = assistant
             }
-            LockfileAssistant.upsertManagedEntry(
+            let lockfileSuccess = LockfileAssistant.upsertManagedEntry(
                 assistantId: platformAssistant.id,
                 runtimeUrl: AuthService.shared.baseURL,
                 hatchedAt: platformAssistant.created_at ?? ISO8601DateFormatter().string(from: Date())
             )
+            guard lockfileSuccess else {
+                throw TransferError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
+            }
 
             // Step 3 — Import bundle to managed assistant
             currentStep = "Importing data to cloud..."
@@ -150,7 +153,7 @@ struct AssistantTransferSection: View {
 
             // Step 4 — Switch to managed assistant
             currentStep = "Switching to cloud assistant..."
-            guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.isManaged }) else {
+            guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
                 throw TransferError.managedEntryNotFound
             }
             AppDelegate.shared?.performSwitchAssistant(to: managedAssistant)


### PR DESCRIPTION
Address review feedback from PR #16807. Use the platformAssistant.id returned by ensureManagedAssistant() instead of querying lockfile for any managed entry, and check upsertManagedEntry return value to abort before cloud import on lockfile write failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
