### PR TITLE
fix: avoid pipefail/SIGPIPE in credential-executor CI

### DIFF
--- a/.github/workflows/ci-main-credential-executor.yaml
+++ b/.github/workflows/ci-main-credential-executor.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Test
         run: |
-          if find src/ -name '*.test.*' -o -name '*.spec.*' | grep -q .; then
+          if [ -n "$(find src/ -name '*.test.*' -o -name '*.spec.*' -print -quit)" ]; then
             bun run test
           else
             echo "No test files found, skipping"

--- a/.github/workflows/pr-credential-executor.yaml
+++ b/.github/workflows/pr-credential-executor.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test
         run: |
-          if find src/ -name '*.test.*' -o -name '*.spec.*' | grep -q .; then
+          if [ -n "$(find src/ -name '*.test.*' -o -name '*.spec.*' -print -quit)" ]; then
             bun run test
           else
             echo "No test files found, skipping"


### PR DESCRIPTION
## Summary
- Replace `find ... | grep -q .` with `find ... -print -quit` in a subshell to avoid SIGPIPE false negatives under `pipefail`
- When `grep -q` exits early after the first match, `find` can receive SIGPIPE (exit 141), causing the pipeline to fail under `set -o pipefail` (GitHub Actions default) — incorrectly skipping tests
- Fixed in both `ci-main-credential-executor.yaml` and `pr-credential-executor.yaml`

Addresses review feedback from PR #16834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
