### PR TITLE
fix: validate grantId scope and fix hash consistency in CES policy

### DIFF
--- a/credential-executor/src/http/policy.ts
+++ b/credential-executor/src/http/policy.ts
@@ -18,9 +18,7 @@
  *   credential.
  */
 
-import { createHash } from "node:crypto";
-
-import type { HttpGrantProposal } from "@vellumai/ces-contracts";
+import { hashProposal, type HttpGrantProposal } from "@vellumai/ces-contracts";
 
 import type { PersistentGrant, PersistentGrantStore } from "../grants/persistent-store.js";
 import type { TemporaryGrantStore } from "../grants/temporary-store.js";
@@ -129,10 +127,14 @@ export function evaluateHttpPolicy(
   // 2. Check explicit grantId in persistent store
   if (request.grantId) {
     const grant = persistentStore.getById(request.grantId);
-    if (grant) {
+    if (
+      grant &&
+      grant.tool === "http" &&
+      grantCoversRequest(grant, request.credentialHandle, request.method, request.url, "")
+    ) {
       return { allowed: true, grantId: grant.id, grantSource: "persistent" };
     }
-    // Explicit grant not found — fall through to pattern matching
+    // Explicit grant not found or does not cover this request — fall through to pattern matching
   }
 
   // 3. Check persistent grants for pattern match
@@ -150,7 +152,7 @@ export function evaluateHttpPolicy(
   // 4. Check temporary grants
   // Build a proposal hash key from the canonical request shape
   const proposal = buildProposal(request, pathTemplate);
-  const proposalHash = hashProposalForLookup(proposal);
+  const proposalHash = hashProposal(proposal);
 
   const tempKind = temporaryStore.checkAny(
     proposalHash,
@@ -234,23 +236,3 @@ function buildProposal(
   };
 }
 
-/**
- * Compute a deterministic hash key for temporary grant lookup.
- *
- * Uses the same canonical JSON → SHA-256 approach as the contracts package
- * `hashProposal`, but we use a simplified inline version here to avoid
- * importing the full contracts rendering module into the policy hot path.
- */
-function hashProposalForLookup(proposal: HttpGrantProposal): string {
-  // Build a canonical key from the proposal's stable fields:
-  // type + credentialHandle + method + allowedUrlPatterns (sorted)
-  const parts = [
-    proposal.type,
-    proposal.credentialHandle,
-    proposal.method.toUpperCase(),
-    ...(proposal.allowedUrlPatterns ?? []).slice().sort(),
-  ];
-  const canonical = JSON.stringify(parts);
-
-  return createHash("sha256").update(canonical, "utf8").digest("hex");
-}


### PR DESCRIPTION
## Summary
- **P0 security fix**: The explicit `grantId` path in `evaluateHttpPolicy` now validates `grant.tool === "http"` and calls `grantCoversRequest()` to verify scope, method, and URL pattern match — preventing grant ID replay attacks across different credentials or endpoints
- **Hash consistency fix**: Replaced the inline `hashProposalForLookup` (which hashed a flat array of selected fields) with the canonical `hashProposal` from `@vellumai/ces-contracts` (which hashes the full proposal with recursively sorted keys) — fixing temporary grant matching that was broken due to hash mismatch
- **Dead code removal**: Removed `hashProposalForLookup` and unused `node:crypto` import

The `path-template.ts` `decodeURIComponent` fix for URL template matching was already present in the merged PR.

Addresses feedback from #16868.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
