### PR TITLE
fix: include credential-executor and packages in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,18 @@
-# Build the assistant image from the repository root but keep context minimal.
+# Build images from the repository root but keep context minimal.
 **
 !assistant/
 !assistant/**
-# Exclude local dependencies and build outputs from included packages.
+!credential-executor/
+!credential-executor/**
+!packages/
+!packages/**
+
+# Exclude local dependencies and build outputs from included directories.
 assistant/node_modules/
 assistant/dist/
 assistant/out/
 assistant/build/
 assistant/.env
 assistant/.env.*
+credential-executor/node_modules/
+packages/*/node_modules/


### PR DESCRIPTION
Address review feedback from PR #16838. The root .dockerignore excluded everything except assistant/, causing Docker builds that use context: . to miss credential-executor/ and packages/ directories needed by COPY instructions in both the credential-executor and assistant Dockerfiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
