### PR TITLE
fix: remove tsconfig path mapping that escapes rootDir

### DIFF
--- a/assistant/tsconfig.json
+++ b/assistant/tsconfig.json
@@ -13,12 +13,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "jsx": "react-jsx",
-    "types": ["bun-types"],
-    "paths": {
-      "@vellumai/credential-storage": [
-        "../packages/credential-storage/src/index.ts"
-      ]
-    }
+    "types": ["bun-types"]
   },
   "include": ["src/**/*", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist", "drizzle"]


### PR DESCRIPTION
Address review feedback from PR #16831.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
