### PR TITLE
fix: delete OAuth token keys sequentially

### DIFF
--- a/packages/credential-storage/src/oauth-runtime.ts
+++ b/packages/credential-storage/src/oauth-runtime.ts
@@ -286,10 +286,10 @@ export async function deleteOAuthTokens(
   accessTokenResult: "deleted" | "not-found" | "error";
   refreshTokenResult: "deleted" | "not-found" | "error";
 }> {
-  const [accessTokenResult, refreshTokenResult] = await Promise.all([
-    backend.delete(oauthConnectionAccessTokenPath(connectionId)),
-    backend.delete(oauthConnectionRefreshTokenPath(connectionId)),
-  ]);
+  // Delete sequentially to avoid lost updates — the encrypted store uses
+  // read-modify-write, so concurrent deletes can restore a deleted key.
+  const accessTokenResult = await backend.delete(oauthConnectionAccessTokenPath(connectionId));
+  const refreshTokenResult = await backend.delete(oauthConnectionRefreshTokenPath(connectionId));
   return { accessTokenResult, refreshTokenResult };
 }
 


### PR DESCRIPTION
Address review feedback from PR #16844. Sequential deletion prevents concurrent write conflicts in the encrypted store.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
