### PR TITLE
fix: apply managed-sidecar feature gate in CES process manager

### DIFF
--- a/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-e2e.test.ts
@@ -183,21 +183,21 @@ describe("process manager config wiring", () => {
     expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(true);
   });
 
-  test("CesProcessManagerConfig allows omitting assistantConfig for backward compat", () => {
-    const config: CesProcessManagerConfig = {};
-    expect(config.assistantConfig).toBeUndefined();
+  test("CesProcessManagerConfig requires assistantConfig for feature-flag gate", () => {
+    const config: CesProcessManagerConfig = {
+      assistantConfig: makeConfig({}),
+    };
+    expect(config.assistantConfig).toBeDefined();
   });
 
-  test("when flag is off and config is provided, managed discovery is skipped", () => {
-    // This validates the contract: createCesProcessManager with a config
-    // where the flag is off should fall back to local discovery.
+  test("when flag is off, managed discovery is skipped", () => {
     const config: CesProcessManagerConfig = {
       assistantConfig: makeConfig({
         "feature_flags.ces-managed-sidecar.enabled": false,
       }),
     };
     // The managed path should be gated
-    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(false);
+    expect(isCesManagedSidecarEnabled(config.assistantConfig)).toBe(false);
   });
 });
 

--- a/assistant/src/cli/commands/credential-execution.ts
+++ b/assistant/src/cli/commands/credential-execution.ts
@@ -22,6 +22,7 @@ import {
 } from "@vellumai/ces-contracts";
 import type { Command } from "commander";
 
+import { getConfig } from "../../config/loader.js";
 import {
   type CesClient,
   createCesClient,
@@ -42,7 +43,7 @@ async function acquireCesClient(): Promise<{
   client: CesClient;
   cleanup: () => Promise<void>;
 }> {
-  const pm = createCesProcessManager();
+  const pm = createCesProcessManager({ assistantConfig: getConfig() });
   const transport = await pm.start();
   const client = createCesClient(transport);
   const hs = await client.handshake();

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -13,11 +13,10 @@
  * lifecycle; the process manager only manages the transport connection.
  *
  * Feature-flag gate: Managed sidecar mode is controlled by the
- * `ces-managed-sidecar` feature flag. When the flag is off, the process
- * manager skips managed discovery even in containerized environments,
- * ensuring rollback safety. Non-CES internal consumers continue working
- * unchanged because the process manager never alters the local code path
- * when the flag is disabled.
+ * `ces-managed-sidecar` feature flag (checked via the required
+ * AssistantConfig). When the flag is off, the process manager skips
+ * managed discovery even in containerized environments, ensuring
+ * rollback safety.
  *
  * Managed env contract:
  * - CES_BOOTSTRAP_SOCKET  — Path to the bootstrap Unix socket (shared emptyDir)
@@ -70,11 +69,10 @@ export const CES_PRIVATE_DATA_DIR = "/ces-data";
 export interface CesProcessManagerConfig {
   /**
    * Assistant configuration for feature-flag checks.
-   * When provided, the managed sidecar path is gated behind the
-   * `ces-managed-sidecar` feature flag. When omitted, managed mode
-   * is allowed unconditionally (for backward compat with CLI callers).
+   * The managed sidecar path is gated behind the `ces-managed-sidecar`
+   * feature flag via this config.
    */
-  assistantConfig?: AssistantConfig;
+  assistantConfig: AssistantConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,9 +84,9 @@ export interface CesProcessManager {
    * Start the CES process (local) or connect to the sidecar (managed).
    * Returns a CesTransport ready for use with createCesClient().
    *
-   * When an AssistantConfig is provided and the `ces-managed-sidecar`
-   * feature flag is off, managed mode is skipped even in containerized
-   * environments — the process manager falls back to local discovery.
+   * When the `ces-managed-sidecar` feature flag is off, managed mode
+   * is skipped even in containerized environments — the process manager
+   * falls back to local discovery.
    *
    * Throws if CES is unavailable.
    */
@@ -109,7 +107,7 @@ export interface CesProcessManager {
 // ---------------------------------------------------------------------------
 
 export function createCesProcessManager(
-  config?: CesProcessManagerConfig,
+  config: CesProcessManagerConfig,
 ): CesProcessManager {
   let childProcess: Subprocess | null = null;
   let managedSocket: Socket | null = null;
@@ -122,13 +120,11 @@ export function createCesProcessManager(
         throw new Error("CES process manager is already running");
       }
 
-      // Feature-flag gate: when the managed sidecar flag is off and we
-      // have a config to check, skip managed discovery entirely.
-      // This ensures rollback safety — disabling the flag leaves existing
-      // non-agent platform consumers intact.
-      const managedAllowed =
-        !config?.assistantConfig ||
-        isCesManagedSidecarEnabled(config.assistantConfig);
+      // Feature-flag gate: when the managed sidecar flag is off, skip
+      // managed discovery entirely. This ensures rollback safety —
+      // disabling the flag leaves existing non-agent platform consumers
+      // intact.
+      const managedAllowed = isCesManagedSidecarEnabled(config.assistantConfig);
 
       if (managedAllowed) {
         discoveryResult = await discoverCes();


### PR DESCRIPTION
Address review feedback from PR #16891 (P1).

The `ces-managed-sidecar` feature flag gate was bypassed in practice because
`managedAllowed` defaulted to `true` when `assistantConfig` was omitted, and
the CLI caller (`credential-execution.ts`) constructed the process manager
with no config.

Fix:
- Make `assistantConfig` required in `CesProcessManagerConfig` so the feature
  flag is always checked — no caller can accidentally bypass the gate.
- Update the CLI `acquireCesClient()` to pass `getConfig()`.
- Simplify the `managedAllowed` check (no longer needs the `!config?.` guard).
- Update managed e2e test to reflect the required config contract.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
