### PR TITLE
fix: reload CES grants from disk before returning

### DIFF
--- a/credential-executor/src/grants/persistent-store.ts
+++ b/credential-executor/src/grants/persistent-store.ts
@@ -105,7 +105,6 @@ export class PersistentGrantStore {
    */
   getAll(): PersistentGrant[] {
     this.assertNotCorrupt();
-    if (this.cache !== null) return [...this.cache];
     if (!existsSync(this.filePath)) return [];
     return [...this.loadFromDisk()];
   }


### PR DESCRIPTION
Address review feedback from PR #16860.

getAll() was returning cached grants without re-reading from disk, so external modifications (revocations, corruption) would not be detected. Now always reloads from disk to maintain fail-closed behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
