### PR TITLE
fix: CES RPC client robustness improvements

### DIFF
--- a/assistant/src/credential-execution/client.ts
+++ b/assistant/src/credential-execution/client.ts
@@ -205,11 +205,20 @@ export function createCesClient(
         });
       });
 
-      sendLine({
-        type: "handshake_request",
-        protocolVersion: CES_PROTOCOL_VERSION,
-        sessionId,
-      });
+      try {
+        sendLine({
+          type: "handshake_request",
+          protocolVersion: CES_PROTOCOL_VERSION,
+          sessionId,
+        });
+      } catch (err) {
+        const entry = pending.get("handshake");
+        if (entry) {
+          clearTimeout(entry.timer);
+          pending.delete("handshake");
+        }
+        throw err;
+      }
 
       const ack = await ackPromise;
 
@@ -276,7 +285,16 @@ export function createCesClient(
         timestamp: new Date().toISOString(),
       };
 
-      sendLine({ type: "rpc", ...envelope });
+      try {
+        sendLine({ type: "rpc", ...envelope });
+      } catch (err) {
+        const entry = pending.get(id);
+        if (entry) {
+          clearTimeout(entry.timer);
+          pending.delete(id);
+        }
+        throw err;
+      }
 
       const rawResponse = await responsePromise;
 

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -27,6 +27,7 @@
  */
 
 import { createConnection, type Socket } from "node:net";
+import { StringDecoder } from "node:string_decoder";
 
 import type { Subprocess } from "bun";
 
@@ -248,6 +249,7 @@ function createStdioTransport(proc: Subprocess): CesTransport {
   // Read stdout line by line — narrow past `number` union arm from Subprocess type
   if (proc.stdout && typeof proc.stdout !== "number") {
     const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
 
     void (async () => {
       try {
@@ -255,7 +257,7 @@ function createStdioTransport(proc: Subprocess): CesTransport {
           const { value, done } = await reader.read();
           if (done) break;
 
-          buffer += new TextDecoder().decode(value);
+          buffer += decoder.decode(value, { stream: true });
           let newlineIdx: number;
           while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
             const line = buffer.slice(0, newlineIdx).trim();
@@ -314,8 +316,10 @@ function createSocketTransport(socket: Socket): CesTransport {
   let buffer = "";
   let alive = true;
 
+  const decoder = new StringDecoder("utf8");
+
   socket.on("data", (chunk: Buffer | string) => {
-    buffer += chunk.toString();
+    buffer += typeof chunk === "string" ? chunk : decoder.write(chunk);
     let newlineIdx: number;
     while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
       const line = buffer.slice(0, newlineIdx).trim();


### PR DESCRIPTION
Address review feedback from PR #16839.

- Clear pending call state (timer + map entry) when transport write fails in both `call()` and `handshake()`, preventing leaked timers and unhandled promise rejections
- Reuse a single `TextDecoder` instance with `{ stream: true }` in stdio transport to avoid corrupting multi-byte UTF-8 characters split across chunk boundaries
- Use `StringDecoder` in socket transport for the same multi-byte safety
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
