### PR TITLE
fix: move http-policy test assertions outside type guards

### DIFF
--- a/credential-executor/src/__tests__/http-policy.test.ts
+++ b/credential-executor/src/__tests__/http-policy.test.ts
@@ -457,17 +457,20 @@ describe("evaluateHttpPolicy", () => {
 
     const result = evaluateHttpPolicy(request, persistentStore, temporaryStore);
     expect(result.allowed).toBe(false);
-    if (!result.allowed && result.reason === "approval_required") {
-      expect(result.proposal.type).toBe("http");
-      expect(result.proposal.credentialHandle).toBe(
-        "local_static:github/api_key",
-      );
-      expect(result.proposal.method).toBe("GET");
-      // Proposal should have allowedUrlPatterns with templated path
-      expect(result.proposal.allowedUrlPatterns).toBeDefined();
-      expect(result.proposal.allowedUrlPatterns![0]).toBe(
-        "https://api.github.com/repos/owner/repo/pulls/{:num}",
-      );
+    if (!result.allowed) {
+      expect(result.reason).toBe("approval_required");
+      if (result.reason === "approval_required") {
+        expect(result.proposal.type).toBe("http");
+        expect(result.proposal.credentialHandle).toBe(
+          "local_static:github/api_key",
+        );
+        expect(result.proposal.method).toBe("GET");
+        // Proposal should have allowedUrlPatterns with templated path
+        expect(result.proposal.allowedUrlPatterns).toBeDefined();
+        expect(result.proposal.allowedUrlPatterns![0]).toBe(
+          "https://api.github.com/repos/owner/repo/pulls/{:num}",
+        );
+      }
     }
   });
 
@@ -891,17 +894,20 @@ describe("end-to-end: policy evaluation → response filter → audit", () => {
 
     // Must be blocked
     expect(policyResult.allowed).toBe(false);
-    if (!policyResult.allowed && policyResult.reason === "approval_required") {
-      expect(policyResult.proposal.type).toBe("http");
-      expect(policyResult.proposal.credentialHandle).toBe(
-        "local_static:stripe/api_key",
-      );
-      // Must have specific URL pattern, not wildcard
-      expect(policyResult.proposal.allowedUrlPatterns).toBeDefined();
-      expect(policyResult.proposal.allowedUrlPatterns!.length).toBeGreaterThan(0);
-      for (const pattern of policyResult.proposal.allowedUrlPatterns!) {
-        expect(pattern).not.toBe("/*");
-        expect(pattern).not.toContain("*");
+    if (!policyResult.allowed) {
+      expect(policyResult.reason).toBe("approval_required");
+      if (policyResult.reason === "approval_required") {
+        expect(policyResult.proposal.type).toBe("http");
+        expect(policyResult.proposal.credentialHandle).toBe(
+          "local_static:stripe/api_key",
+        );
+        // Must have specific URL pattern, not wildcard
+        expect(policyResult.proposal.allowedUrlPatterns).toBeDefined();
+        expect(policyResult.proposal.allowedUrlPatterns!.length).toBeGreaterThan(0);
+        for (const pattern of policyResult.proposal.allowedUrlPatterns!) {
+          expect(pattern).not.toBe("/*");
+          expect(pattern).not.toContain("*");
+        }
       }
     }
   });


### PR DESCRIPTION
Address review feedback from PR #16870.

Moves `reason` assertions outside the type-narrowing `if` guard so they are always evaluated when `allowed === false`. Previously, the `reason === "approval_required"` check was part of the guard condition itself, meaning a regression to a different blocking reason would silently skip all inner assertions. Now the reason is asserted as a hard expectation, and the inner `if` exists only for TypeScript type narrowing.

Closes #16870 feedback threads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
