### PR TITLE
fix: propagate untrusted-shell flag to proxied host_bash

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -67,6 +67,55 @@ describe("HostBashProxy", () => {
       expect(proxy.hasPendingRequest(requestId)).toBe(false);
     });
 
+    test("forwards env field in host_bash_request message", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          command: "echo locked",
+          env: { VELLUM_UNTRUSTED_SHELL: "1" },
+        },
+        "session-1",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.env).toEqual({ VELLUM_UNTRUSTED_SHELL: "1" });
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        stdout: "locked\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      await resultPromise;
+    });
+
+    test("omits env field when not provided", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { command: "echo normal" },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.env).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        stdout: "normal\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+
+      await resultPromise;
+    });
+
     test("formats error output correctly", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -698,6 +698,7 @@ describe("host_bash — proxy delegation", () => {
         command: string;
         working_dir?: string;
         timeout_seconds?: number;
+        env?: Record<string, string>;
       };
       sessionId: string;
     }> = [];
@@ -710,6 +711,7 @@ describe("host_bash — proxy delegation", () => {
             command: string;
             working_dir?: string;
             timeout_seconds?: number;
+            env?: Record<string, string>;
           },
           sessionId: string,
           _signal?: AbortSignal,
@@ -842,5 +844,63 @@ describe("host_bash — proxy delegation", () => {
     expect(result.isError).toBe(false);
     expect(result.content.trim()).toBe("no-proxy");
     expect(spawnCalls.length).toBe(1);
+  });
+
+  test("propagates VELLUM_UNTRUSTED_SHELL env to proxy under CES lockdown", async () => {
+    // Enable CES shell lockdown
+    const origFlags = (mockConfig as Record<string, unknown>)
+      .assistantFeatureFlagValues;
+    (mockConfig as Record<string, unknown>).assistantFeatureFlagValues = {
+      "feature_flags.ces-shell-lockdown.enabled": true,
+    };
+
+    try {
+      const proxyResult: ToolExecutionResult = {
+        content: "proxied",
+        isError: false,
+      };
+      const { proxy, calls } = makeMockProxy(proxyResult);
+
+      const ctx: ToolContext = {
+        ...makeContext(),
+        trustClass: "trusted_contact", // untrusted actor
+        hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+      };
+
+      const result = await hostShellTool.execute(
+        { command: "echo lockdown" },
+        ctx,
+      );
+
+      expect(result).toBe(proxyResult);
+      expect(calls.length).toBe(1);
+      expect(calls[0].input.env).toEqual({ VELLUM_UNTRUSTED_SHELL: "1" });
+    } finally {
+      (mockConfig as Record<string, unknown>).assistantFeatureFlagValues =
+        origFlags;
+    }
+  });
+
+  test("does not propagate env to proxy when CES lockdown is inactive", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxied",
+      isError: false,
+    };
+    const { proxy, calls } = makeMockProxy(proxyResult);
+
+    const ctx: ToolContext = {
+      ...makeContext(),
+      trustClass: "guardian", // trusted actor — no lockdown
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    };
+
+    const result = await hostShellTool.execute(
+      { command: "echo no-lockdown" },
+      ctx,
+    );
+
+    expect(result).toBe(proxyResult);
+    expect(calls.length).toBe(1);
+    expect(calls[0].input.env).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -39,7 +39,12 @@ export class HostBashProxy {
   }
 
   request(
-    input: { command: string; working_dir?: string; timeout_seconds?: number },
+    input: {
+      command: string;
+      working_dir?: string;
+      timeout_seconds?: number;
+      env?: Record<string, string>;
+    },
     sessionId: string,
     signal?: AbortSignal,
   ): Promise<ToolExecutionResult> {
@@ -94,6 +99,9 @@ export class HostBashProxy {
         command: input.command,
         working_dir: input.working_dir,
         timeout_seconds: input.timeout_seconds,
+        ...(input.env && Object.keys(input.env).length > 0
+          ? { env: input.env }
+          : {}),
       } as ServerMessage);
     });
   }

--- a/assistant/src/daemon/message-types/host-bash.ts
+++ b/assistant/src/daemon/message-types/host-bash.ts
@@ -11,6 +11,8 @@ export interface HostBashRequest {
   command: string;
   working_dir?: string;
   timeout_seconds?: number;
+  /** Extra environment variables to inject into the subprocess (e.g. VELLUM_UNTRUSTED_SHELL). */
+  env?: Record<string, string>;
 }
 
 // --- Domain-level union aliases (consumed by the barrel file) ---

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -121,41 +121,8 @@ class HostShellTool implements Tool {
         isError: true,
       };
     }
-    // Proxy to connected client for execution on the user's machine
-    // when a capable client is available (managed/cloud-hosted mode).
-    if (context.hostBashProxy?.isAvailable()) {
-      const { shellDefaultTimeoutSec, shellMaxTimeoutSec } =
-        getConfig().timeouts;
-      const rawSec =
-        typeof input.timeout_seconds === "number"
-          ? input.timeout_seconds
-          : shellDefaultTimeoutSec;
-      const normalizedTimeout = Math.max(
-        1,
-        Math.min(rawSec, shellMaxTimeoutSec),
-      );
-      return context.hostBashProxy.request(
-        {
-          command,
-          working_dir: rawWorkingDir as string | undefined,
-          timeout_seconds: normalizedTimeout,
-        },
-        context.sessionId,
-        context.signal,
-      );
-    }
-
-    const workingDir =
-      typeof rawWorkingDir === "string" ? rawWorkingDir : homedir();
-
     const config = getConfig();
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
-    const requestedSec =
-      typeof input.timeout_seconds === "number"
-        ? input.timeout_seconds
-        : shellDefaultTimeoutSec;
-    const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
-    const timeoutMs = timeoutSec * 1000;
 
     // CES shell lockdown: host_bash is the weaker-tier escape hatch. When
     // lockdown is active for untrusted actors, persistent approvals are
@@ -170,6 +137,44 @@ class HostShellTool implements Tool {
     const hostLockdownActive =
       isCesShellLockdownEnabled(config) &&
       isUntrustedTrustClass(context.trustClass);
+
+    // Proxy to connected client for execution on the user's machine
+    // when a capable client is available (managed/cloud-hosted mode).
+    if (context.hostBashProxy?.isAvailable()) {
+      const rawSec =
+        typeof input.timeout_seconds === "number"
+          ? input.timeout_seconds
+          : shellDefaultTimeoutSec;
+      const normalizedTimeout = Math.max(
+        1,
+        Math.min(rawSec, shellMaxTimeoutSec),
+      );
+      // Propagate VELLUM_UNTRUSTED_SHELL to the proxied client so CLI
+      // commands self-deny raw-secret flows even when executed remotely.
+      const proxyEnv: Record<string, string> | undefined = hostLockdownActive
+        ? { VELLUM_UNTRUSTED_SHELL: "1" }
+        : undefined;
+      return context.hostBashProxy.request(
+        {
+          command,
+          working_dir: rawWorkingDir as string | undefined,
+          timeout_seconds: normalizedTimeout,
+          env: proxyEnv,
+        },
+        context.sessionId,
+        context.signal,
+      );
+    }
+
+    const workingDir =
+      typeof rawWorkingDir === "string" ? rawWorkingDir : homedir();
+
+    const requestedSec =
+      typeof input.timeout_seconds === "number"
+        ? input.timeout_seconds
+        : shellDefaultTimeoutSec;
+    const timeoutSec = Math.max(1, Math.min(requestedSec, shellMaxTimeoutSec));
+    const timeoutMs = timeoutSec * 1000;
 
     log.info(
       {

--- a/clients/shared/Network/HTTPDaemonClient+HostBash.swift
+++ b/clients/shared/Network/HTTPDaemonClient+HostBash.swift
@@ -62,6 +62,16 @@ extension HTTPTransport {
                 process.currentDirectoryURL = FileManager.default.homeDirectoryForCurrentUser
             }
 
+            // Inject extra environment variables from the daemon (e.g. VELLUM_UNTRUSTED_SHELL)
+            // into the subprocess. Merge with the inherited environment so existing vars are preserved.
+            if let extraEnv = request.env, !extraEnv.isEmpty {
+                var env = ProcessInfo.processInfo.environment
+                for (key, value) in extraEnv {
+                    env[key] = value
+                }
+                process.environment = env
+            }
+
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
             process.standardOutput = stdoutPipe

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1370,6 +1370,8 @@ public struct HostBashRequest: Decodable, Sendable {
     public let command: String
     public let workingDir: String?
     public let timeoutSeconds: Double?
+    /// Extra environment variables to inject into the subprocess (e.g. VELLUM_UNTRUSTED_SHELL).
+    public let env: [String: String]?
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -1378,6 +1380,7 @@ public struct HostBashRequest: Decodable, Sendable {
         case command
         case workingDir = "working_dir"
         case timeoutSeconds = "timeout_seconds"
+        case env
     }
 }
 


### PR DESCRIPTION
Address remaining review feedback from PR #16850.

When CES shell lockdown is active for untrusted actors, the VELLUM_UNTRUSTED_SHELL=1 env flag was only injected into the local spawn path. The proxy path (managed/cloud-hosted mode) returned early without applying this marker, allowing proxied shell commands to run raw-secret CLI flows without hitting the untrusted-shell guards.

Changes:
- Compute hostLockdownActive before the proxy branch in host-shell.ts
- Pass env: { VELLUM_UNTRUSTED_SHELL: '1' } through the proxy request when lockdown is active
- Add env field to HostBashRequest message type and HostBashProxy.request()
- Update Swift client to decode and inject env vars into the subprocess
- Add tests for proxy env propagation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
