### PR TITLE
fix: validate deniedSubcommands and fileMode bitmask

### DIFF
--- a/credential-executor/src/commands/auth-adapters.ts
+++ b/credential-executor/src/commands/auth-adapters.ts
@@ -143,10 +143,10 @@ export function validateAuthAdapterConfig(
     case AuthAdapterType.TempFile:
       if (
         config.fileMode !== undefined &&
-        config.fileMode > 0o600
+        (config.fileMode > 0o600 || (config.fileMode & 0o077) !== 0)
       ) {
         errors.push(
-          `temp_file adapter fileMode must be <= 0600 (owner-only), got ${config.fileMode.toString(8)}`,
+          `temp_file adapter fileMode must be <= 0600 (owner-only) with no group/other bits, got ${config.fileMode.toString(8)}`,
         );
       }
       break;

--- a/credential-executor/src/commands/validator.ts
+++ b/credential-executor/src/commands/validator.ts
@@ -179,8 +179,13 @@ function validateProfile(
     }
   }
 
-  // -- Denied subcommands (optional but must be an array)
-  if (profile.deniedSubcommands) {
+  // -- Denied subcommands (required — runtime iterates unconditionally)
+  if (!profile.deniedSubcommands || !Array.isArray(profile.deniedSubcommands)) {
+    errors.push(
+      `${prefix}: deniedSubcommands is required and must be an array. ` +
+        "Use an empty array if no subcommands need to be denied.",
+    );
+  } else {
     for (const sub of profile.deniedSubcommands) {
       if (!sub || sub.trim().length === 0) {
         errors.push(


### PR DESCRIPTION
Address review feedback from PR #16841.

- **validator.ts**: Make `deniedSubcommands` required in `validateProfile` — the runtime (`validateCommand`) iterates it unconditionally, so a missing field causes a runtime crash instead of a registration-time validation error.
- **auth-adapters.ts**: Add bitmask check `(fileMode & 0o077) !== 0` to reject modes with group/other permission bits (e.g. `0o006`, `0o077`) that pass the simple numeric `> 0o600` comparison but leave credential temp files world-readable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
