### PR TITLE
fix: CES RPC server robustness improvements

### DIFF
--- a/credential-executor/src/paths.ts
+++ b/credential-executor/src/paths.ts
@@ -51,8 +51,14 @@ function getVellumRootDir(): string {
   return join(baseDataDir || homedir(), ".vellum");
 }
 
-/** Well-known managed CES data root (dedicated volume mount). */
-const MANAGED_CES_DATA_ROOT = "/ces-data";
+/**
+ * Well-known managed CES data root.
+ *
+ * Defaults to `/home/ces/.ces-data` so the non-root `ces` user (uid 1001)
+ * can write without extra chown/mkdir in the Dockerfile. Can be overridden
+ * via `CES_DATA_ROOT` for custom volume mounts.
+ */
+const MANAGED_CES_DATA_ROOT = process.env["CES_DATA_ROOT"] ?? "/home/ces/.ces-data";
 
 /**
  * Return the CES-private data root.

--- a/credential-executor/src/server.ts
+++ b/credential-executor/src/server.ts
@@ -154,9 +154,14 @@ export class CesRpcServer {
     return this.sessionId;
   }
 
-  /** Shut down the server gracefully. */
+  /** Shut down the server gracefully, destroying transport streams. */
   close(): void {
+    if (this.closed) return;
     this.closed = true;
+    this.input.destroy();
+    if (typeof (this.output as any).destroy === "function") {
+      this.output.destroy();
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -197,7 +202,9 @@ export class CesRpcServer {
     if (msg.type === "handshake_request") {
       this.handleHandshake(msg as HandshakeRequest);
     } else if (msg.type === "rpc") {
-      this.handleRpcEnvelope(msg as unknown as RpcEnvelope);
+      this.handleRpcEnvelope(msg as unknown as RpcEnvelope).catch((err) => {
+        this.logger.error(`[ces-server] Unhandled error in RPC handler: ${err}`);
+      });
     } else {
       this.logger.warn("[ces-server] Unexpected message type:", msg.type);
     }


### PR DESCRIPTION
Address review feedback from PR #16843.

- **paths.ts**: Change managed CES data root from `/ces-data` (root-owned) to `/home/ces/.ces-data` (writable by `ces` user). Add `CES_DATA_ROOT` env var override.
- **server.ts**: Destroy input/output streams in `close()` so abort/SIGTERM actually tears down transport handles.
- **server.ts**: Add `.catch()` to fire-and-forget `handleRpcEnvelope()` call to prevent unhandled promise rejections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
