### PR TITLE
fix: prevent symlink escape in CES workspace validation

### DIFF
--- a/credential-executor/src/commands/workspace.ts
+++ b/credential-executor/src/commands/workspace.ts
@@ -31,7 +31,6 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
-  readlinkSync,
   realpathSync,
   rmSync,
 } from "node:fs";
@@ -163,27 +162,46 @@ export function validateRelativePath(
 
 /**
  * Verify that a resolved path is contained within the expected root
- * directory. Returns an error string if the path escapes.
+ * directory. When the path exists on disk, symlinks are fully resolved
+ * via `realpathSync` so that symlinked segments cannot escape the root.
+ * Falls back to lexical `resolve()` for paths that don't exist yet.
  */
 export function validateContainedPath(
   resolvedPath: string,
   rootDir: string,
   label: string,
 ): string | undefined {
-  const normalizedRoot = resolve(rootDir) + "/";
-  const normalizedPath = resolve(resolvedPath);
+  // Resolve symlinks when path exists; fall back to lexical resolve
+  let normalizedRoot: string;
+  let normalizedPath: string;
+  try {
+    normalizedRoot = realpathSync(rootDir);
+  } catch {
+    normalizedRoot = resolve(rootDir);
+  }
+  try {
+    normalizedPath = realpathSync(resolvedPath);
+  } catch {
+    normalizedPath = resolve(resolvedPath);
+  }
+
+  const rootPrefix = normalizedRoot + "/";
 
   // The path must start with the root directory prefix
   // (or be the root directory itself, though that's unusual for files)
-  if (!normalizedPath.startsWith(normalizedRoot) && normalizedPath !== resolve(rootDir)) {
-    return `${label}: resolved path "${normalizedPath}" escapes the root directory "${resolve(rootDir)}".`;
+  if (!normalizedPath.startsWith(rootPrefix) && normalizedPath !== normalizedRoot) {
+    return `${label}: resolved path "${normalizedPath}" escapes the root directory "${normalizedRoot}".`;
   }
   return undefined;
 }
 
 /**
- * Check if a path is a symlink that points outside the given root.
- * Returns an error string if it's an escaping symlink, undefined if safe.
+ * Check if a path (or any of its parent components) involves symlinks
+ * that resolve outside the given root directory.
+ *
+ * Uses `realpathSync` to fully resolve all symlink chains (including
+ * chained symlinks and symlinked parent directories) and then validates
+ * that the fully-resolved path is still within the root.
  */
 export function checkSymlinkEscape(
   filePath: string,
@@ -191,24 +209,20 @@ export function checkSymlinkEscape(
   label: string,
 ): string | undefined {
   try {
-    const stat = lstatSync(filePath);
-    if (!stat.isSymbolicLink()) {
-      return undefined; // Not a symlink — safe
-    }
-
-    // Resolve the symlink target
-    const target = readlinkSync(filePath);
-    const resolvedTarget = resolve(dirname(filePath), target);
-    const normalizedRoot = resolve(rootDir) + "/";
+    // Fully resolve all symlinks (handles chained symlinks and
+    // symlinked parent directories in a single call)
+    const resolvedTarget = realpathSync(filePath);
+    const resolvedRoot = realpathSync(rootDir);
+    const rootPrefix = resolvedRoot + "/";
 
     if (
-      !resolvedTarget.startsWith(normalizedRoot) &&
-      resolvedTarget !== resolve(rootDir)
+      !resolvedTarget.startsWith(rootPrefix) &&
+      resolvedTarget !== resolvedRoot
     ) {
-      return `${label}: symlink "${filePath}" points to "${resolvedTarget}" which is outside the scratch directory "${resolve(rootDir)}".`;
+      return `${label}: path "${filePath}" resolves to "${resolvedTarget}" which is outside the scratch directory "${resolvedRoot}".`;
     }
   } catch {
-    // If we can't stat the file, it doesn't exist yet or is inaccessible.
+    // If we can't resolve the file, it doesn't exist yet or is inaccessible.
     // This will be caught later during the actual copy.
     return undefined;
   }


### PR DESCRIPTION
Address review feedback from PR #16864. Security hardening for workspace containment checks.

- `validateContainedPath`: Use `realpathSync` instead of lexical `resolve()` to dereference symlinks when checking path containment. Falls back to `resolve()` for paths that don't exist yet.
- `checkSymlinkEscape`: Replace single-level `readlinkSync` with `realpathSync` to fully resolve chained symlinks and symlinked parent directories in one call.
- Remove unused `readlinkSync` import.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
