### PR TITLE
fix: normalize provider key before filtering managed connections

### DIFF
--- a/assistant/src/cli/commands/oauth/connections.ts
+++ b/assistant/src/cli/commands/oauth/connections.ts
@@ -182,9 +182,14 @@ Examples:
           let managedEntries: Array<Record<string, unknown>> = [];
           if (managedResult.ok && managedResult.descriptors.length > 0) {
             let descriptors = managedResult.descriptors;
-            // Apply provider filter if specified
+            // Apply provider filter if specified.  Managed descriptors use
+            // plain slugs (e.g. "google") while the CLI --provider flag uses
+            // the canonical "integration:google" format.  Strip the prefix
+            // before comparing so both forms match.
             if (opts.provider) {
-              const filterKey = opts.provider.toLowerCase();
+              const filterKey = opts.provider
+                .replace(/^integration:/, "")
+                .toLowerCase();
               descriptors = descriptors.filter(
                 (d) => d.provider.toLowerCase() === filterKey,
               );


### PR DESCRIPTION
Address review feedback from PR #16840. Strips the `integration:` prefix from the `--provider` CLI flag before comparing with platform managed catalog descriptors (which use plain slugs like `google`). Without this, `assistant oauth connections list --provider integration:google` would incorrectly hide matching managed connections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
