### PR TITLE
fix: evaluate 303 redirect grant against post-redirect method

### DIFF
--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -910,6 +910,71 @@ describe("HTTP executor: redirect denial", () => {
     expect(result.error!.message).toContain("denied");
   });
 
+  test("303 redirect evaluates policy against GET, not original method", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    // Grant only covers GET — no POST grant exists
+    fixture.persistentStore.add({
+      id: "grant-github-get-only",
+      tool: "http",
+      pattern: "GET https://api.github.com/repos/owner/repo/result",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // Also add a grant for the original POST endpoint
+    fixture.persistentStore.add({
+      id: "grant-github-post",
+      tool: "http",
+      pattern: "POST https://api.github.com/repos/owner/repo/action",
+      scope: handle,
+      createdAt: Date.now(),
+    });
+
+    // POST -> 303 redirect to a GET-only granted endpoint
+    let callCount = 0;
+    const requests: Array<{ url: string; method: string }> = [];
+    const fetchFn = asFetch(async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      callCount++;
+      requests.push({ url: url.toString(), method: init?.method ?? "GET" });
+      if (callCount === 1) {
+        return new Response(null, {
+          status: 303,
+          headers: { Location: "https://api.github.com/repos/owner/repo/result" },
+        });
+      }
+      return new Response('{"status": "done"}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const deps = buildDeps(fixture, [], { fetch: fetchFn });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "POST",
+        url: "https://api.github.com/repos/owner/repo/action",
+        body: '{"trigger": true}',
+        purpose: "Trigger action",
+      },
+      deps,
+    );
+
+    // Should succeed — policy evaluates GET (post-303 method) against the grant
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+
+    // Verify the redirect hop actually used GET
+    expect(requests).toHaveLength(2);
+    expect(requests[0].method).toBe("POST");
+    expect(requests[1].method).toBe("GET");
+  });
+
   test("allows redirect to path covered by same grant", async () => {
     const handle = localStaticHandle("github", "api_key");
 

--- a/credential-executor/src/http/executor.ts
+++ b/credential-executor/src/http/executor.ts
@@ -466,12 +466,18 @@ async function performHttpRequest(
       // Resolve the redirect URL (may be relative)
       const redirectUrl = new URL(locationHeader, currentUrl).toString();
 
+      // Determine the method that will actually be used on the next hop.
+      // 303 converts any method to GET (per RFC 9110 §15.4.4); other
+      // redirect statuses preserve the method.
+      const nextMethod = response.status === 303 ? "GET" : currentMethod;
+
       // Enforce grant policy on the redirect target — the redirect must
-      // independently satisfy the same credential handle's grant policy.
+      // independently satisfy the same credential handle's grant policy
+      // using the method we will actually send.
       const redirectPolicy = evaluateHttpPolicy(
         {
           credentialHandle,
-          method: currentMethod,
+          method: nextMethod,
           url: redirectUrl,
           purpose: `redirect from ${currentUrl}`,
         },
@@ -485,7 +491,7 @@ async function performHttpRequest(
         );
       }
 
-      // For 303 redirects, convert to GET
+      // Apply the method/body changes for 303 redirects
       if (response.status === 303) {
         currentMethod = "GET";
         currentBody = undefined;


### PR DESCRIPTION
## Summary
- Fix redirect policy evaluation in CES HTTP executor to use the post-redirect method for 303 responses
- Previously, `evaluateHttpPolicy` was called with `currentMethod` (e.g. POST) before the 303 handler converted it to GET, so the grant check ran against the wrong method
- Now computes `nextMethod` (GET for 303, unchanged for others) before the policy check, matching the method actually sent on the next hop
- Add regression test: POST→303→GET flow with a GET-only grant now succeeds correctly

Addresses Codex P1 review feedback on #16875.

## Test plan
- [x] New test: `303 redirect evaluates policy against GET, not original method`
- [x] All 22 http-executor tests pass
- [x] Type-check clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
