### PR TITLE
fix: guard decodeURIComponent for malformed escapes in URL template matching

### DIFF
--- a/credential-executor/src/__tests__/http-policy.test.ts
+++ b/credential-executor/src/__tests__/http-policy.test.ts
@@ -286,6 +286,36 @@ describe("urlMatchesTemplate", () => {
   test("returns false for invalid template", () => {
     expect(urlMatchesTemplate("https://example.com/", "not-a-url")).toBe(false);
   });
+
+  test("returns false (not throw) for malformed percent escapes in template", () => {
+    // A bare % or %zz would cause decodeURIComponent to throw URIError
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/users/42",
+        "https://api.example.com/users/%zz",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false (not throw) for malformed percent escapes in URL", () => {
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/data/%zz",
+        "https://api.example.com/data/foo",
+      ),
+    ).toBe(false);
+  });
+
+  test("matches literal segments consistently when both are percent-encoded", () => {
+    // Both sides should be decoded before comparison, so %20 in the URL
+    // matches a space in a literal template segment (and vice versa).
+    expect(
+      urlMatchesTemplate(
+        "https://api.example.com/hello%20world",
+        "https://api.example.com/hello%20world",
+      ),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/credential-executor/src/http/path-template.ts
+++ b/credential-executor/src/http/path-template.ts
@@ -15,6 +15,23 @@
  */
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely decode a percent-encoded path segment. Falls back to the raw
+ * segment when it contains malformed escapes (e.g. bare `%` or `%zz`)
+ * that would cause `decodeURIComponent` to throw a `URIError`.
+ */
+function safeDecodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Segment classification patterns
 // ---------------------------------------------------------------------------
 
@@ -147,15 +164,17 @@ export function urlMatchesTemplate(
   if (urlHost !== templateHost) return false;
 
   // Split paths and compare segment-by-segment.
-  // decodeURIComponent is needed because the URL constructor percent-encodes
-  // curly braces ({, }) in paths — placeholders like {:num} become %7B:num%7D.
+  // safeDecodeSegment is applied to both sides so that percent-encoded bytes
+  // (e.g. %20, %7B) are compared consistently and so that the URL constructor's
+  // encoding of curly braces ({, }) in template placeholders is reversed.
   const urlSegments = parsedUrl.pathname
     .split("/")
-    .filter((s) => s.length > 0);
+    .filter((s) => s.length > 0)
+    .map(safeDecodeSegment);
   const templateSegments = parsedTemplate.pathname
     .split("/")
     .filter((s) => s.length > 0)
-    .map((s) => decodeURIComponent(s));
+    .map(safeDecodeSegment);
 
   if (urlSegments.length !== templateSegments.length) return false;
 


### PR DESCRIPTION
## Summary
- Addresses Codex P1+P2 review feedback on #16886
- Wraps `decodeURIComponent` in a `safeDecodeSegment` helper with try/catch to prevent `URIError` from malformed percent escapes (e.g. bare `%` or `%zz`) crashing policy evaluation
- Decodes both `urlSegments` and `templateSegments` for consistent comparison — previously only template segments were decoded, breaking literal-path matches when URLs contained percent-encoded bytes

## Test plan
- [x] Added test: malformed percent escapes in template return false (not throw)
- [x] Added test: malformed percent escapes in URL return false (not throw)
- [x] Added test: percent-encoded literal segments match consistently on both sides
- [x] All 75 existing http-policy tests continue to pass
- [x] Type-check passes

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/16948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
